### PR TITLE
Add Flutter SDK configuration to project creation (#45).

### DIFF
--- a/src/io/flutter/FlutterBundle.properties
+++ b/src/io/flutter/FlutterBundle.properties
@@ -8,6 +8,7 @@ runner.flutter.configuration.description=Flutter run configuration
 flutter.project.description=Flutter modules are used to build high-performance, high-fidelity, mobile apps for iOS \
   and Android using the Flutter framework.
 flutter.sdk.path.label=Flutter &SDK Path:
+flutter.sdk.browse.path.label=Select Flutter SDK Path
 flutter.sdk.is.not.configured=The Flutter SDK is not configured
 flutter.title=Flutter
 error.path.to.sdk.not.specified=Error: path to the Flutter SDK is not specified.
@@ -17,6 +18,5 @@ flutter.module.name=Flutter
 flutter.command.exception=Flutter Command Exception: {0}
 no.socket.for.debugging=The debugger cannot find an available socket for the Observatory connection
 no.project.dir=Project directory not given
-flutter.sdk.name=Flutter SDK
 dart.sdk.configuration.action.label=Configure Dart SDK
 flutter.wrong.dart.sdk.warning=The Dart SDK for this module is not the same as Flutter's.  Setting Dart to use the Flutter vended SDK is strongly recommended.

--- a/src/io/flutter/module/FlutterGeneratorPeer.form
+++ b/src/io/flutter/module/FlutterGeneratorPeer.form
@@ -8,7 +8,7 @@
     <properties/>
     <border type="none"/>
     <children>
-      <component id="ad4af" class="com.intellij.ui.components.JBLabel">
+      <component id="ad4af" class="com.intellij.ui.components.JBLabel" binding="myVersionLabel">
         <constraints>
           <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
@@ -31,12 +31,12 @@
         </constraints>
         <properties/>
       </component>
-      <component id="2c07c" class="com.intellij.ui.components.JBLabel" binding="myVersionLabel">
+      <component id="2c07c" class="com.intellij.ui.components.JBLabel" binding="myVersionContent">
         <constraints>
           <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
-          <text value="1.0"/>
+          <text value=""/>
         </properties>
       </component>
       <vspacer id="e8033">

--- a/src/io/flutter/module/FlutterGeneratorPeer.java
+++ b/src/io/flutter/module/FlutterGeneratorPeer.java
@@ -5,19 +5,104 @@
  */
 package io.flutter.module;
 
+import com.intellij.icons.AllIcons;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory;
 import com.intellij.openapi.ui.ComboBox;
+import com.intellij.openapi.ui.ComponentWithBrowseButton;
+import com.intellij.openapi.ui.TextComponentAccessor;
+import com.intellij.openapi.ui.ValidationInfo;
+import com.intellij.openapi.util.io.FileUtil;
+import com.intellij.openapi.util.io.FileUtilRt;
+import com.intellij.ui.ColorUtil;
 import com.intellij.ui.ComboboxWithBrowseButton;
+import com.intellij.ui.DocumentAdapter;
+import com.intellij.ui.JBColor;
 import com.intellij.ui.components.JBLabel;
+import com.intellij.xml.util.XmlStringUtil;
+import io.flutter.FlutterBundle;
+import io.flutter.sdk.FlutterSdk;
+import io.flutter.sdk.FlutterSdkGlobalLibUtil;
+import io.flutter.sdk.FlutterSdkUtil;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
+import javax.swing.event.DocumentEvent;
+import javax.swing.text.JTextComponent;
 
 public class FlutterGeneratorPeer {
 
   private JPanel myMainPanel;
   private ComboboxWithBrowseButton mySdkPathComboWithBrowse;
   private JBLabel myVersionLabel;
+  private JBLabel myVersionContent;
   private JBLabel myErrorLabel; // shown in IntelliJ IDEA only
+
+  public FlutterGeneratorPeer() {
+    myErrorLabel.setIcon(AllIcons.Actions.Lightning);
+    myErrorLabel.setVisible(false);
+
+    // Hide pending real content -- TODO: #83.
+    myVersionLabel.setVisible(false);
+    myVersionContent.setVisible(false);
+
+    initSdkCombo();
+    validate();
+  }
+
+  private void initSdkCombo() {
+
+    final FlutterSdk sdkInitial = FlutterSdk.getGlobalFlutterSdk();
+    final String sdkPathInitial = sdkInitial == null ? "" : FileUtil.toSystemDependentName(sdkInitial.getHomePath());
+
+    mySdkPathComboWithBrowse.getComboBox().setEditable(true);
+    mySdkPathComboWithBrowse.getComboBox().getEditor().setItem(sdkPathInitial);
+
+    final TextComponentAccessor<JComboBox> textComponentAccessor = new TextComponentAccessor<JComboBox>() {
+      @Override
+      public String getText(final JComboBox component) {
+        return component.getEditor().getItem().toString();
+      }
+
+      @Override
+      public void setText(@NotNull final JComboBox component, @NotNull final String text) {
+        if (text.isEmpty() || FlutterSdkUtil.isFlutterSdkHome(text)) {
+          component.getEditor().setItem(FileUtilRt.toSystemDependentName(text));
+        }
+        validate();
+      }
+    };
+
+    final ComponentWithBrowseButton.BrowseFolderActionListener<JComboBox> browseFolderListener =
+      new ComponentWithBrowseButton.BrowseFolderActionListener<>(FlutterBundle.message("flutter.sdk.browse.path.label"), null,
+                                                                 mySdkPathComboWithBrowse, null,
+                                                                 FileChooserDescriptorFactory.createSingleFolderDescriptor(),
+                                                                 textComponentAccessor);
+    mySdkPathComboWithBrowse.addBrowseFolderListener(null, browseFolderListener);
+
+    final JTextComponent editorComponent = (JTextComponent)mySdkPathComboWithBrowse.getComboBox().getEditor().getEditorComponent();
+    editorComponent.getDocument().addDocumentListener(new DocumentAdapter() {
+      @Override
+      protected void textChanged(DocumentEvent e) {
+        validate();
+      }
+    });
+  }
+
+  void apply() {
+    final Runnable runnable = () -> {
+      final String sdkHomePath =
+        FileUtilRt.toSystemIndependentName(getSdkComboPath());
+      if (FlutterSdkUtil.isFlutterSdkHome(sdkHomePath)) {
+        FlutterSdkGlobalLibUtil.ensureFlutterSdkConfigured(sdkHomePath);
+      }
+    };
+
+    ApplicationManager.getApplication().runWriteAction(runnable);
+  }
+
+
 
   @NotNull
   public JComponent getComponent() {
@@ -26,5 +111,35 @@ public class FlutterGeneratorPeer {
 
   private void createUIComponents() {
     mySdkPathComboWithBrowse = new ComboboxWithBrowseButton(new ComboBox<>());
+  }
+
+  public boolean validate() {
+    final ValidationInfo info = validateSdk();
+    if (info == null) {
+      myErrorLabel.setVisible(false);
+      return true;
+    }
+    else {
+      myErrorLabel.setVisible(true);
+      myErrorLabel
+        .setText(XmlStringUtil.wrapInHtml("<font color='#" + ColorUtil.toHex(JBColor.RED) + "'><left>" + info.message + "</left></font>"));
+      return false;
+    }
+  }
+
+  @Nullable
+  private ValidationInfo validateSdk() {
+    final String sdkPath = getSdkComboPath();
+    final String message = FlutterSdkUtil.getErrorMessageIfWrongSdkRootPath(sdkPath);
+    if (message != null) {
+      return new ValidationInfo(message, mySdkPathComboWithBrowse);
+    }
+
+    return null;
+  }
+
+  @NotNull
+  private String getSdkComboPath() {
+    return mySdkPathComboWithBrowse.getComboBox().getEditor().getItem().toString().trim();
   }
 }

--- a/src/io/flutter/sdk/FlutterSdk.java
+++ b/src/io/flutter/sdk/FlutterSdk.java
@@ -129,7 +129,10 @@ public class FlutterSdk {
     return parent != null && parent.getName().equals("flutter") ? parent : null;
   }
 
-  public void run(@NotNull Command cmd, @NotNull Module module, @NotNull VirtualFile workingDir, @NotNull String... args)
+  public void run(@NotNull Command cmd,
+                  @NotNull Module module,
+                  @NotNull VirtualFile workingDir,
+                  @NotNull String... args)
     throws ExecutionException {
     final String flutterPath = FlutterSdkUtil.pathToFlutterTool(getHomePath());
     final GeneralCommandLine command = new GeneralCommandLine().withWorkDirectory(workingDir.getPath());

--- a/src/io/flutter/sdk/FlutterSdkGlobalLibUtil.java
+++ b/src/io/flutter/sdk/FlutterSdkGlobalLibUtil.java
@@ -54,7 +54,10 @@ public class FlutterSdkGlobalLibUtil {
   @SuppressWarnings("Duplicates")
   private static void setupFlutterSdkRoots(@NotNull final Library library, @NotNull final String sdkHomePath) {
     final VirtualFile libRoot = LocalFileSystem.getInstance().refreshAndFindFileByPath(sdkHomePath + "/bin/cache/dart-sdk/lib");
-    if (libRoot != null && libRoot.isDirectory()) {
+    if (libRoot == null || !libRoot.isDirectory()) {
+      LOG.warn("No Dart SDK found in Flutter install, Flutter SDK library root setup skipped");
+    }
+    else {
       final LibraryEx.ModifiableModelEx libModifiableModel = (LibraryEx.ModifiableModelEx)library.getModifiableModel();
       try {
         // remove old


### PR DESCRIPTION
Adds a Flutter SDK Configuration page to the New Flutter Project Wizard w/ SDK validation (see #45 for screenshots).  Validation ensures that a project cannot be created without a Flutter SDK set (#80).

Fixes: https://github.com/flutter/flutter-intellij/issues/45
Fixes: https://github.com/flutter/flutter-intellij/issues/80

/cc @stevemessick @devoncarew 