### PR TITLE
fold 'flutter run' in the flutter console

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -28,6 +28,8 @@
     <projectService serviceInterface="io.flutter.sdk.FlutterSdkService" serviceImplementation="io.flutter.sdk.FlutterSmallIDESdkService"
                     overrides="false"/>
 
+    <console.folding implementation="io.flutter.console.FlutterConsoleFolding"/>
+
     <applicationConfigurable groupId="language" instance="io.flutter.sdk.FlutterSettingsConfigurable"
                              id="flutter.settings" key="flutter.title" bundle="io.flutter.FlutterBundle" nonDefaultProject="true"/>
   </extensions>

--- a/src/io/flutter/console/FlutterConsoleFolding.java
+++ b/src/io/flutter/console/FlutterConsoleFolding.java
@@ -21,11 +21,9 @@ public class FlutterConsoleFolding extends ConsoleFolding {
     if (!line.contains("flutter run")) return false;
 
     try {
-      final String homePath = FlutterSdk.getGlobalFlutterSdk().getHomePath();
-      if (homePath == null) {
-        return false;
-      }
-      final String flutterPath = FlutterSdkUtil.pathToFlutterTool(homePath);
+      FlutterSdk sdk = FlutterSdk.getGlobalFlutterSdk();
+      if (sdk == null) return false;
+      final String flutterPath = FlutterSdkUtil.pathToFlutterTool(sdk.getHomePath());
       return line.startsWith(flutterPath + " run");
     }
     catch (ExecutionException e) {

--- a/src/io/flutter/console/FlutterConsoleFolding.java
+++ b/src/io/flutter/console/FlutterConsoleFolding.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2016 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.console;
+
+import com.intellij.execution.ConsoleFolding;
+import com.intellij.execution.ExecutionException;
+import com.intellij.execution.configurations.CommandLineTokenizer;
+import com.intellij.openapi.util.text.StringUtil;
+import io.flutter.sdk.FlutterSdk;
+import io.flutter.sdk.FlutterSdkUtil;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+public class FlutterConsoleFolding extends ConsoleFolding {
+  @Override
+  public boolean shouldFoldLine(String line) {
+    if (!line.contains("flutter run")) return false;
+
+    try {
+      final String homePath = FlutterSdk.getGlobalFlutterSdk().getHomePath();
+      if (homePath == null) {
+        return false;
+      }
+      final String flutterPath = FlutterSdkUtil.pathToFlutterTool(homePath);
+      return line.startsWith(flutterPath + " run");
+    }
+    catch (ExecutionException e) {
+      return false;
+    }
+  }
+
+  @Nullable
+  @Override
+  public String getPlaceholderText(List<String> lines) {
+    // /Users/.../flutter/bin/flutter run --start-paused --debug-port 50354
+
+    String fullText = StringUtil.join(lines, "\n");
+
+    final CommandLineTokenizer tok = new CommandLineTokenizer(fullText);
+    if (!tok.hasMoreTokens()) return fullText;
+
+    final String filePath = tok.nextToken();
+
+    final StringBuilder builder = new StringBuilder();
+    builder.append("flutter");
+
+    while (tok.hasMoreTokens()) {
+      String token = tok.nextToken();
+
+      // strip off --start-paused
+      if (token.equals("--start-paused")) continue;
+
+      // strip off --debug-port 50354
+      if (token.equals("--debug-port")) {
+        if (tok.hasMoreTokens()) tok.nextToken();
+        continue;
+      }
+
+      builder.append(" ").append(token);
+    }
+
+    return builder.toString();
+  }
+}


### PR DESCRIPTION
- this folds the `flutter run` line in the console when running flutter apps

this:
<img width="618" alt="screen shot 2016-09-02 at 5 22 16 pm" src="https://cloud.githubusercontent.com/assets/1269969/18221422/e78bec88-7131-11e6-94db-a8be70959aad.png">

becomes this:
<img width="343" alt="screen shot 2016-09-02 at 5 21 55 pm" src="https://cloud.githubusercontent.com/assets/1269969/18221426/f0df27c8-7131-11e6-9470-72ddff09e6ea.png">

and on hover:
<img width="607" alt="screen shot 2016-09-02 at 5 22 10 pm" src="https://cloud.githubusercontent.com/assets/1269969/18221432/fa3f9e38-7131-11e6-98fb-027d84376deb.png">

@pq @stevemessick 

@stevemessick, we can adjust this as the daemon run changes change the console output -