### PR TITLE
Make flutter home testing less prescriptive (#87).

### DIFF
--- a/src/io/flutter/sdk/FlutterSdk.java
+++ b/src/io/flutter/sdk/FlutterSdk.java
@@ -126,7 +126,7 @@ public class FlutterSdk {
       parent = parent.getParent();
     }
     while (parent != null && --count > 0);
-    return parent != null && parent.getName().equals("flutter") ? parent : null;
+    return parent;
   }
 
   public void run(@NotNull Command cmd,


### PR DESCRIPTION
There’s no reason the flutter repo couldn’t be cloned into a directoring _not_ called `flutter`.

Fixes https://github.com/flutter/flutter-intellij/issues/87.

/cc @devoncarew @stevemessick 