### PR TITLE
fix the built plugin jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ allprojects {
   sourceSets {
     main {
       java.srcDirs 'src', 'gen', 'third_party/intellij-plugins-dart/src'
-      // resources.srcDir 'resources'
+      resources.srcDirs 'resources', 'src'
     }
     test {
       java.srcDirs 'testSrc', 'third_party/intellij-plugins-dart/testSrc'


### PR DESCRIPTION
Fix an issue w/ the built plugin (`flutter-intellij-0.0.1.jar`) - it wasn't including its resources.

@pq @stevemessick 