### PR TITLE
add meta-data for an update site

### DIFF
--- a/docs/alpha/updatePlugins.xml
+++ b/docs/alpha/updatePlugins.xml
@@ -1,0 +1,6 @@
+<plugins>
+  <plugin
+      id="io.flutter"
+      url="https://github.com/flutter/flutter-intellij/files/460171/Flutter-0.0.1.zip"
+      version="0.0.1"/>
+</plugins>


### PR DESCRIPTION
- add meta-data for an update site

Trial run for an update site; definitely not something for users to consume!

@pq @stevemessick 