### PR TITLE
Rename copy of debug service and make it a subclass of the real one

### DIFF
--- a/third_party/intellij-plugins-dart/src/com/jetbrains/lang/dart/ide/runner/DartRunner.java
+++ b/third_party/intellij-plugins-dart/src/com/jetbrains/lang/dart/ide/runner/DartRunner.java
@@ -26,7 +26,7 @@ import com.jetbrains.lang.dart.ide.runner.base.DartRunConfigurationBase;
 import com.jetbrains.lang.dart.ide.runner.server.DartCommandLineRunConfiguration;
 import com.jetbrains.lang.dart.ide.runner.server.DartCommandLineRunningState;
 import com.jetbrains.lang.dart.ide.runner.server.DartRemoteDebugConfiguration;
-import com.jetbrains.lang.dart.ide.runner.server.vmService.DartVmServiceDebugProcess;
+import com.jetbrains.lang.dart.ide.runner.server.vmService.DartVmServiceDebugProcessZ;
 import com.jetbrains.lang.dart.ide.runner.test.DartTestRunnerParameters;
 import com.jetbrains.lang.dart.sdk.DartSdk;
 import com.jetbrains.lang.dart.util.DartUrlResolver;
@@ -152,16 +152,16 @@ public class DartRunner extends DefaultProgramRunner {
       @NotNull
       public XDebugProcess start(@NotNull final XDebugSession session) {
         final DartUrlResolver dartUrlResolver = getDartUrlResolver(env.getProject(), contextFileOrDir);
-        return new DartVmServiceDebugProcess(session,
-                                             StringUtil.notNullize(debuggingHost, "localhost"),
-                                             observatoryPort,
-                                             executionResult,
-                                             dartUrlResolver,
-                                             dasExecutionContextId,
-                                             runConfiguration instanceof DartRemoteDebugConfiguration,
-                                             entryPointInLibFolder,
-                                             getTimeout(),
-                                             getConnector());
+        return new DartVmServiceDebugProcessZ(session,
+                                              StringUtil.notNullize(debuggingHost, "localhost"),
+                                              observatoryPort,
+                                              executionResult,
+                                              dartUrlResolver,
+                                              dasExecutionContextId,
+                                              runConfiguration instanceof DartRemoteDebugConfiguration,
+                                              entryPointInLibFolder,
+                                              getTimeout(),
+                                              getConnector());
       }
     });
 

--- a/third_party/intellij-plugins-dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceBreakpointHandlerZ.java
+++ b/third_party/intellij-plugins-dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceBreakpointHandlerZ.java
@@ -3,7 +3,7 @@ package com.jetbrains.lang.dart.ide.runner.server.vmService;
 import org.jetbrains.annotations.NotNull;
 
 public class DartVmServiceBreakpointHandlerZ extends DartVmServiceBreakpointHandler {
-  protected DartVmServiceBreakpointHandlerZ(@NotNull DartVmServiceDebugProcess debugProcess) {
+  protected DartVmServiceBreakpointHandlerZ(@NotNull DartVmServiceDebugProcessZ debugProcess) {
     super(debugProcess);
   }
 }

--- a/third_party/intellij-plugins-dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcessZ.java
+++ b/third_party/intellij-plugins-dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcessZ.java
@@ -50,8 +50,8 @@ import java.io.IOException;
 import java.util.*;
 
 @SuppressWarnings("Duplicates")
-public class DartVmServiceDebugProcess extends XDebugProcess {
-  private static final Logger LOG = Logger.getInstance(DartVmServiceDebugProcess.class.getName());
+public class DartVmServiceDebugProcessZ extends DartVmServiceDebugProcess {
+  private static final Logger LOG = Logger.getInstance(DartVmServiceDebugProcessZ.class.getName());
 
   @Nullable private final ExecutionResult myExecutionResult;
   @NotNull private final DartUrlResolver myDartUrlResolver;
@@ -79,17 +79,17 @@ public class DartVmServiceDebugProcess extends XDebugProcess {
   @Nullable String myRemoteProjectRootUri;
   @Nullable private ObservatoryConnector myConnector;
 
-  public DartVmServiceDebugProcess(@NotNull final XDebugSession session,
-                                   @NotNull final String debuggingHost,
-                                   final int observatoryPort,
-                                   @Nullable final ExecutionResult executionResult,
-                                   @NotNull final DartUrlResolver dartUrlResolver,
-                                   @Nullable final String dasExecutionContextId,
-                                   final boolean remoteDebug,
-                                   final boolean entryPointInLibFolder,
-                                   final int timeout,
-                                   final ObservatoryConnector connector) {
-    super(session);
+  public DartVmServiceDebugProcessZ(@NotNull final XDebugSession session,
+                                    @NotNull final String debuggingHost,
+                                    final int observatoryPort,
+                                    @Nullable final ExecutionResult executionResult,
+                                    @NotNull final DartUrlResolver dartUrlResolver,
+                                    @Nullable final String dasExecutionContextId,
+                                    final boolean remoteDebug,
+                                    final boolean entryPointInLibFolder,
+                                    final int timeout,
+                                    @Nullable final ObservatoryConnector connector) {
+    super(session, debuggingHost, observatoryPort, executionResult, dartUrlResolver, dasExecutionContextId, remoteDebug, entryPointInLibFolder, timeout);
     myDebuggingHost = debuggingHost;
     myObservatoryPort = observatoryPort;
     myExecutionResult = executionResult;


### PR DESCRIPTION
@devoncarew See if this fixes your latest class loader problem with the built plugin.