### PR TITLE
tweaks to the flutter settings page

### DIFF
--- a/src/io/flutter/FlutterBundle.properties
+++ b/src/io/flutter/FlutterBundle.properties
@@ -7,7 +7,7 @@ runner.flutter.configuration.name=Flutter
 runner.flutter.configuration.description=Flutter run configuration
 flutter.project.description=Flutter modules are used to build high-performance, high-fidelity, mobile apps for iOS \
   and Android using the Flutter framework.
-flutter.sdk.path.label=Flutter &SDK Path:
+flutter.sdk.path.label=Flutter &SDK path:
 flutter.sdk.browse.path.label=Select Flutter SDK Path
 flutter.sdk.is.not.configured=The Flutter SDK is not configured
 flutter.title=Flutter

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.form
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="io.flutter.sdk.FlutterSettingsConfigurable">
-  <grid id="27dc6" binding="mainPanel" layout-manager="GridLayoutManager" row-count="3" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="mainPanel" layout-manager="GridLayoutManager" row-count="4" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="500" height="400"/>
@@ -8,7 +8,7 @@
     <properties/>
     <border type="none"/>
     <children>
-      <grid id="6d822" binding="sdkSettings" layout-manager="GridLayoutManager" row-count="2" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="6d822" binding="sdkSettings" layout-manager="GridLayoutManager" row-count="1" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -24,11 +24,6 @@
               <text resource-bundle="io/flutter/FlutterBundle" key="flutter.sdk.path.label"/>
             </properties>
           </component>
-          <vspacer id="6fe02">
-            <constraints>
-              <grid row="1" column="1" row-span="1" col-span="2" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
-            </constraints>
-          </vspacer>
           <component id="83a87" class="com.intellij.ui.ComboboxWithBrowseButton" binding="sdkCombo" custom-create="true">
             <constraints>
               <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
@@ -41,7 +36,7 @@
       </grid>
       <component id="f16d5" class="com.intellij.ui.components.JBLabel" binding="errorLabel">
         <constraints>
-          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text resource-bundle="io/flutter/FlutterBundle" key="error.path.to.sdk.not.specified"/>
@@ -49,7 +44,7 @@
       </component>
       <component id="5a409" class="javax.swing.JTextArea" binding="versionDetails">
         <constraints>
-          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="6" anchor="0" fill="3" indent="0" use-parent-layout="false">
+          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="6" anchor="0" fill="3" indent="0" use-parent-layout="false">
             <preferred-size width="150" height="50"/>
           </grid>
         </constraints>
@@ -58,7 +53,16 @@
           <background color="-12828863"/>
           <editable value="false"/>
           <enabled value="false"/>
+          <margin top="8" left="8" bottom="8" right="8"/>
           <text value=""/>
+        </properties>
+      </component>
+      <component id="a59e7" class="javax.swing.JLabel">
+        <constraints>
+          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="Version details:"/>
         </properties>
       </component>
     </children>


### PR DESCRIPTION
- some tweaks to the flutter settings page (an additional label, and a margin for the version text area)

<img width="730" alt="screen shot 2016-09-07 at 9 09 22 pm" src="https://cloud.githubusercontent.com/assets/1269969/18338096/20a19c44-754b-11e6-986e-2dcc33949425.png">

@pq