### PR TITLE
adjust the flutter preference page layout

### DIFF
--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.form
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="io.flutter.sdk.FlutterSettingsConfigurable">
-  <grid id="27dc6" binding="mainPanel" layout-manager="GridLayoutManager" row-count="4" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="mainPanel" layout-manager="GridLayoutManager" row-count="5" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="500" height="400"/>
@@ -36,7 +36,7 @@
       </grid>
       <component id="f16d5" class="com.intellij.ui.components.JBLabel" binding="errorLabel">
         <constraints>
-          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text resource-bundle="io/flutter/FlutterBundle" key="error.path.to.sdk.not.specified"/>
@@ -44,8 +44,8 @@
       </component>
       <component id="5a409" class="javax.swing.JTextArea" binding="versionDetails">
         <constraints>
-          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="6" anchor="0" fill="3" indent="0" use-parent-layout="false">
-            <preferred-size width="150" height="50"/>
+          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="3" indent="0" use-parent-layout="false">
+            <preferred-size width="150" height="150"/>
           </grid>
         </constraints>
         <properties>
@@ -65,6 +65,11 @@
           <text value="Version details:"/>
         </properties>
       </component>
+      <vspacer id="b5ec9">
+        <constraints>
+          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+        </constraints>
+      </vspacer>
     </children>
   </grid>
 </form>


### PR DESCRIPTION
Adjust the flutter preference page layout; add a spring to the bottom, and fix the version textbox height so it doesn't resize when the content changes.

<img width="795" alt="screen shot 2016-09-13 at 9 27 40 pm" src="https://cloud.githubusercontent.com/assets/1269969/18500097/5ead37ca-79f9-11e6-8133-d72f161df0d5.png">

@pq