### PR TITLE
Device Selector toolbar contribution UI (#137).

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -15,7 +15,21 @@
   <!-- Everything following should be SmallIDE-friendly.-->
   <!-- See: http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html -->
 
+  <actions>
+    <group id="Flutter.MainToolbarActions">
+      <separator/>
+
+      <action id="Flutter.DeviceSelector" class="io.flutter.actions.DeviceSelectorAction" text="devices"
+              description="Select a device to connect"
+              icon="FlutterIcons.Flutter_16"/>
+    <separator/>
+      <add-to-group anchor="before" group-id="RunContextGroup" relative-to-action="RunConfiguration"/>
+      <add-to-group anchor="before" group-id="ToolbarRunGroup" relative-to-action="RunConfiguration"/>
+    </group>
+  </actions>
+
   <extensions defaultExtensionNs="com.intellij">
+
     <configurationType implementation="io.flutter.run.FlutterRunConfigurationType"/>
     <runConfigurationProducer implementation="io.flutter.run.FlutterRunConfigurationProducer"/>
     <programRunner implementation="io.flutter.run.FlutterRunner"/>

--- a/src/io/flutter/actions/DeviceSelectorAction.java
+++ b/src/io/flutter/actions/DeviceSelectorAction.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2016 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
 package io.flutter.actions;
 
 import com.intellij.openapi.actionSystem.AnAction;
@@ -13,17 +18,11 @@ import javax.swing.*;
 
 public class DeviceSelectorAction extends ComboBoxAction implements DumbAware {
 
-    @Override
-    public void actionPerformed(AnActionEvent e) {
-        //TODO: fill in.
-    }
-
     @NotNull
     @Override
     protected DefaultActionGroup createPopupActionGroup(JComponent button) {
         DefaultActionGroup group = new DefaultActionGroup();
-        group.add(new SelectDeviceAction("iPhone 6"));
-        group.add(new SelectDeviceAction("Nexus 5"));
+        //TODO: fill in from DaemonManager.
         return group;
     }
 

--- a/src/io/flutter/actions/DeviceSelectorAction.java
+++ b/src/io/flutter/actions/DeviceSelectorAction.java
@@ -1,0 +1,47 @@
+package io.flutter.actions;
+
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.DefaultActionGroup;
+import com.intellij.openapi.actionSystem.ex.ComboBoxAction;
+import com.intellij.openapi.project.DumbAware;
+import icons.FlutterIcons;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+
+
+public class DeviceSelectorAction extends ComboBoxAction implements DumbAware {
+
+    @Override
+    public void actionPerformed(AnActionEvent e) {
+        //TODO: fill in.
+    }
+
+    @NotNull
+    @Override
+    protected DefaultActionGroup createPopupActionGroup(JComponent button) {
+        DefaultActionGroup group = new DefaultActionGroup();
+        group.add(new SelectDeviceAction("iPhone 6"));
+        group.add(new SelectDeviceAction("Nexus 5"));
+        return group;
+    }
+
+    @Override
+    public void update(AnActionEvent e) {
+        //TODO: fill in.
+    }
+
+
+    private static class SelectDeviceAction extends AnAction {
+
+        SelectDeviceAction(String deviceName) {
+            super(deviceName, null, FlutterIcons.Flutter_16);
+        }
+
+        @Override
+        public void actionPerformed(AnActionEvent e) {
+            //TODO: fill in.
+        }
+    }
+}

--- a/src/io/flutter/run/FlutterRunConfiguration.java
+++ b/src/io/flutter/run/FlutterRunConfiguration.java
@@ -39,7 +39,8 @@ public class FlutterRunConfiguration extends DartRunConfigurationBase {
   @Nullable
   @Override
   public RunProfileState getState(@NotNull Executor executor, @NotNull ExecutionEnvironment environment) throws ExecutionException {
-    return new FlutterDaemonRunState(environment);
+    return new FlutterRunningState(environment);
+    //return new FlutterDaemonRunState(environment);
   }
 
   @Nullable


### PR DESCRIPTION
Adds a Flutter toolbar group and contributes a stubbed out device selector combobox to the navbar and toolbar.

<img width="308" alt="screen shot 2016-09-23 at 2 14 28 pm" src="https://cloud.githubusercontent.com/assets/67586/18801797/da4522ce-8199-11e6-8181-574fe1440e56.png">

<img width="457" alt="screen shot 2016-09-23 at 2 27 48 pm" src="https://cloud.githubusercontent.com/assets/67586/18801822/fd500464-8199-11e6-9573-c20e166949a0.png">

To be wired up when the daemon-mode bits land.

Obviously some proper device icons would be great.  Flutter is just a stand-in.