### PR TITLE
Wire up restart commands

### DIFF
--- a/src/io/flutter/FlutterBundle.properties
+++ b/src/io/flutter/FlutterBundle.properties
@@ -2,6 +2,11 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+app.restart.action.text=Restart
+app.restart.action.description=Restart the Flutter app
+app.reload.action.text=Reload
+app.reload.action.description=Reload changes to the running Flutter app
+
 config.progargs.caption=Program Arguments
 
 dart.sdk.configuration.action.label=Configure Dart SDK
@@ -24,9 +29,6 @@ flutter.wrong.dart.sdk.warning=The Dart SDK for this module is not the same as F
 
 no.project.dir=Project directory not given
 no.socket.for.debugging=The debugger cannot find an available socket for the Observatory connection
-
-open.observatory.action.text=Open Observatory
-open.observatory.action.description=Open Observatory
 
 runner.flutter.configuration.description=Flutter run configuration
 runner.flutter.configuration.name=Flutter

--- a/src/io/flutter/actions/FlutterAppAction.java
+++ b/src/io/flutter/actions/FlutterAppAction.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2016 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.actions;
+
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.project.DumbAwareAction;
+import com.jetbrains.lang.dart.DartBundle;
+import com.jetbrains.lang.dart.ide.runner.ObservatoryConnector;
+import icons.FlutterIcons;
+import io.flutter.run.daemon.FlutterApp;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+
+abstract public class FlutterAppAction extends DumbAwareAction {
+
+  private final ObservatoryConnector myConnector;
+
+  public FlutterAppAction(ObservatoryConnector connector, String text, String description, Icon icon) {
+    super(text, description, icon);
+    myConnector = connector;
+  }
+
+  @Override
+  public void update(@NotNull final AnActionEvent e) {
+    e.getPresentation().setEnabled(myConnector.isConnectionReady());
+  }
+
+  boolean isConnectionReady() {
+    return myConnector.isConnectionReady();
+  }
+
+  FlutterApp getApp() {
+    return myConnector.getApp();
+  }
+
+  void ifReadyThen(Runnable x) {
+    if (isConnectionReady()) {
+      x.run();
+    }
+  }
+}

--- a/src/io/flutter/actions/OpenComputedUrlAction.java
+++ b/src/io/flutter/actions/OpenComputedUrlAction.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.actions;
+
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.project.DumbAwareAction;
+import com.intellij.openapi.util.Computable;
+import com.jetbrains.lang.dart.DartBundle;
+import com.jetbrains.lang.dart.ide.runner.server.OpenDartObservatoryUrlAction;
+import icons.DartIcons;
+import org.jetbrains.annotations.NotNull;
+
+public class OpenComputedUrlAction extends DumbAwareAction {
+  private Computable<String> myUrl;
+  private Computable<Boolean> myIsApplicable;
+
+  public OpenComputedUrlAction(@NotNull final Computable<String> url, @NotNull final Computable<Boolean> isApplicable) {
+    super(DartBundle.message("open.observatory.action.text"), DartBundle.message("open.observatory.action.description"), DartIcons.Dart_16);
+    myUrl = url;
+    myIsApplicable = isApplicable;
+  }
+
+  @Override
+  public void update(@NotNull final AnActionEvent e) {
+    e.getPresentation().setEnabled(myIsApplicable.compute());
+  }
+
+  @Override
+  public void actionPerformed(@NotNull final AnActionEvent e) {
+    OpenDartObservatoryUrlAction.openUrlInChromeFamilyBrowser(myUrl.compute());
+  }
+}

--- a/src/io/flutter/actions/ReloadFlutterApp.java
+++ b/src/io/flutter/actions/ReloadFlutterApp.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2016 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.actions;
+
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.jetbrains.lang.dart.ide.runner.ObservatoryConnector;
+import icons.FlutterIcons;
+import io.flutter.FlutterBundle;
+
+public class ReloadFlutterApp extends FlutterAppAction {
+
+  public ReloadFlutterApp(ObservatoryConnector connector) {
+    super(connector, FlutterBundle.message("app.reload.action.text"), FlutterBundle.message("app.reload.action.description"),
+          FlutterIcons.Flutter);
+  }
+
+  @Override
+  public void actionPerformed(AnActionEvent e) {
+    ifReadyThen(() -> getApp().performReload());
+  }
+}

--- a/src/io/flutter/actions/RestartFlutterApp.java
+++ b/src/io/flutter/actions/RestartFlutterApp.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2016 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.actions;
+
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.jetbrains.lang.dart.ide.runner.ObservatoryConnector;
+import icons.FlutterIcons;
+import io.flutter.FlutterBundle;
+
+public class RestartFlutterApp extends FlutterAppAction {
+
+  public RestartFlutterApp(ObservatoryConnector connector) {
+    super(connector, FlutterBundle.message("app.restart.action.text"), FlutterBundle.message("app.restart.action.description"),
+          FlutterIcons.Flutter);
+  }
+
+  @Override
+  public void actionPerformed(AnActionEvent e) {
+    ifReadyThen(() -> getApp().performRestart());
+  }
+}

--- a/src/io/flutter/run/FlutterAppState.java
+++ b/src/io/flutter/run/FlutterAppState.java
@@ -14,7 +14,9 @@ import com.intellij.execution.ui.ConsoleView;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.Separator;
 import com.intellij.openapi.project.Project;
+import com.intellij.util.net.NetUtils;
 import com.jetbrains.lang.dart.ide.runner.server.DartCommandLineRunningState;
+import com.jetbrains.lang.dart.ide.runner.server.OpenDartObservatoryUrlAction;
 import io.flutter.run.daemon.ConnectedDevice;
 import io.flutter.run.daemon.FlutterApp;
 import io.flutter.run.daemon.FlutterDaemonService;
@@ -70,9 +72,9 @@ public class FlutterAppState extends DartCommandLineRunningState {
 
   protected void addObservatoryActions(List<AnAction> actions, final ProcessHandler processHandler) {
     actions.add(new Separator());
-    //actions.add(new OpenDartObservatoryUrlAction(
-    //  "http://" + NetUtils.getLocalHostString() + ":" + myObservatoryPort,
-    //  () -> !processHandler.isProcessTerminated()));
+    actions.add(new OpenDartObservatoryUrlAction(
+      "http://" + NetUtils.getLocalHostString() + ":" + myApp.port(),
+      () -> !processHandler.isProcessTerminated()));
   }
 
   public boolean isConnectionReady() {
@@ -81,5 +83,9 @@ public class FlutterAppState extends DartCommandLineRunningState {
 
   public int getObservatoryPort() {
     return myApp.port();
+  }
+
+  public FlutterApp getApp() {
+    return myApp;
   }
 }

--- a/src/io/flutter/run/FlutterRunner.java
+++ b/src/io/flutter/run/FlutterRunner.java
@@ -21,6 +21,7 @@ import com.jetbrains.lang.dart.ide.runner.DartRunner;
 import com.jetbrains.lang.dart.ide.runner.ObservatoryConnector;
 import com.jetbrains.lang.dart.util.DartUrlResolver;
 import com.jetbrains.lang.dart.util.DartUrlResolverImpl;
+import io.flutter.run.daemon.FlutterApp;
 import io.flutter.run.daemon.FlutterDaemonService;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -61,6 +62,11 @@ public class FlutterRunner extends DartRunner {
         @Override
         public int getPort() {
           return appState.getObservatoryPort();
+        }
+
+        @Override
+        public FlutterApp getApp() {
+          return appState.getApp();
         }
       };
     }

--- a/src/io/flutter/run/daemon/FlutterApp.java
+++ b/src/io/flutter/run/daemon/FlutterApp.java
@@ -89,8 +89,7 @@ public interface FlutterApp {
   /**
    * Refresh the app.
    */
-  void performRefresh();
-
+  void performReload();
   /**
    * Fetch the widget hierarchy.
    *
@@ -209,16 +208,12 @@ class RunningFlutterApp implements FlutterApp {
 
   @Override
   public void performRestart() {
-    myManager.restartApp(this, false);
-  }
-
-  void fullRestartApp() {
     myManager.restartApp(this, true);
   }
 
   @Override
-  public void performRefresh() {
-    throw new NotImplementedException();
+  public void performReload() {
+    myManager.restartApp(this, true);
   }
 
   @Override

--- a/src/io/flutter/run/daemon/FlutterAppManager.java
+++ b/src/io/flutter/run/daemon/FlutterAppManager.java
@@ -194,7 +194,9 @@ public class FlutterAppManager {
   }
 
   void restartApp(@NotNull RunningFlutterApp app, boolean isFullRestart) {
-    // TODO send app.restart command
+    AppRestart appStart = new AppRestart(app.appId(), isFullRestart);
+    Method cmd = makeMethod(CMD_APP_RESTART, appStart);
+    sendCommand(app.getController(), cmd);
   }
 
   void enableDevicePolling(@NotNull FlutterDaemonController controller) {
@@ -403,6 +405,20 @@ public class FlutterAppManager {
       app.directory = result.getAsJsonPrimitive("directory").getAsString();
       app.supportsRestart = result.getAsJsonPrimitive("supportsRestart").getAsBoolean();
       manager.eventAppStarted(app, controller);
+    }
+  }
+
+  private static class AppRestart extends Params {
+    // "method":"app.restart"
+    AppRestart(String appId, boolean fullRestart) {
+      this.appId = appId;
+      this.fullRestart = fullRestart;
+    }
+
+    @SuppressWarnings("unused") private String appId;
+    @SuppressWarnings("unused") private boolean fullRestart;
+
+    void process(JsonObject obj, FlutterAppManager manager, FlutterDaemonController controller) {
     }
   }
 

--- a/src/io/flutter/run/daemon/FlutterDaemonService.java
+++ b/src/io/flutter/run/daemon/FlutterDaemonService.java
@@ -24,7 +24,7 @@ import java.util.*;
 public class FlutterDaemonService {
 
   private static final Logger LOG = Logger.getInstance("#io.flutter.run.daemon.FlutterDaemonService");
-  private static final boolean HOT_MODE_DEFAULT = false;
+  private static final boolean HOT_MODE_DEFAULT = true;
   private static final String TARGET_DEFAULT = null;
   private static final String ROUTE_DEFAULT = null;
 

--- a/third_party/intellij-plugins-dart/src/com/jetbrains/lang/dart/ide/runner/ObservatoryConnector.java
+++ b/third_party/intellij-plugins-dart/src/com/jetbrains/lang/dart/ide/runner/ObservatoryConnector.java
@@ -1,5 +1,7 @@
 package com.jetbrains.lang.dart.ide.runner;
 
+import io.flutter.run.daemon.FlutterApp;
+
 public interface ObservatoryConnector {
 
   /**
@@ -11,4 +13,9 @@ public interface ObservatoryConnector {
    * Return the port used by the observatory.
    */
   int getPort();
+
+  /**
+   * Return the FlutterApp used to control the running app.
+   */
+  FlutterApp getApp();
 }

--- a/third_party/intellij-plugins-dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcessZ.java
+++ b/third_party/intellij-plugins-dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcessZ.java
@@ -30,15 +30,16 @@ import com.jetbrains.lang.dart.DartFileType;
 import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService;
 import com.jetbrains.lang.dart.ide.runner.ObservatoryConnector;
 import com.jetbrains.lang.dart.ide.runner.base.DartDebuggerEditorsProvider;
-import com.jetbrains.lang.dart.ide.runner.server.OpenDartObservatoryUrlAction;
+import io.flutter.actions.OpenComputedUrlAction;
 import com.jetbrains.lang.dart.ide.runner.server.vmService.frame.DartVmServiceStackFrame;
-import com.jetbrains.lang.dart.ide.runner.server.vmService.frame.DartVmServiceSuspendContext;
 import com.jetbrains.lang.dart.util.DartResolveUtil;
 import com.jetbrains.lang.dart.util.DartUrlResolver;
 import gnu.trove.THashMap;
 import gnu.trove.THashSet;
 import gnu.trove.TIntObjectHashMap;
 import io.flutter.FlutterBundle;
+import io.flutter.actions.ReloadFlutterApp;
+import io.flutter.actions.RestartFlutterApp;
 import org.dartlang.vm.service.VmService;
 import org.dartlang.vm.service.element.*;
 import org.dartlang.vm.service.logging.Logging;
@@ -93,7 +94,8 @@ public class DartVmServiceDebugProcessZ extends DartVmServiceDebugProcess {
                                     @Nullable final VirtualFile currentWorkingDirectory,
                                     @Nullable final ObservatoryConnector connector) {
     // TODO Delete <code>true</code>, add <code>currentWorkingDirectory</code> to work with EAP version
-    super(session, debuggingHost, observatoryPort, executionResult, dartUrlResolver, dasExecutionContextId, remoteDebug, true, timeout);
+    super(session, debuggingHost, observatoryPort, executionResult, dartUrlResolver, dasExecutionContextId, remoteDebug, timeout,
+          currentWorkingDirectory);
     myDebuggingHost = debuggingHost;
     myObservatoryPort = observatoryPort;
     myExecutionResult = executionResult;
@@ -246,7 +248,7 @@ public class DartVmServiceDebugProcessZ extends DartVmServiceDebugProcess {
     vmService.addVmServiceListener(vmServiceListener);
 
     myVmServiceWrapper =
-      new VmServiceWrapper(this, vmService, myIsolatesInfo, (DartVmServiceBreakpointHandler)myBreakpointHandlers[0]);
+      new VmServiceWrapper(this, vmService, vmServiceListener, myIsolatesInfo, (DartVmServiceBreakpointHandler)myBreakpointHandlers[0]);
     myVmServiceWrapper.handleDebuggerConnected();
 
     myVmConnected = true;
@@ -323,10 +325,9 @@ public class DartVmServiceDebugProcessZ extends DartVmServiceDebugProcess {
 
   @Override
   public void startStepOver(@Nullable XSuspendContext context) {
-    if(this.myLatestCurrentIsolateId != null && this.mySuspendedIsolateIds.contains(this.myLatestCurrentIsolateId)) {
+    if (this.myLatestCurrentIsolateId != null && this.mySuspendedIsolateIds.contains(this.myLatestCurrentIsolateId)) {
       this.myVmServiceWrapper.resumeIsolate(this.myLatestCurrentIsolateId, StepOption.Over);
     }
-
   }
 
   @Override
@@ -360,6 +361,24 @@ public class DartVmServiceDebugProcessZ extends DartVmServiceDebugProcess {
   public void resume(@Nullable XSuspendContext context) {
     for (String isolateId : new ArrayList<>(mySuspendedIsolateIds)) {
       myVmServiceWrapper.resumeIsolate(isolateId, null);
+    }
+  }
+
+  @Override
+  public void startPausing() {
+    for (IsolatesInfo.IsolateInfo info : getIsolateInfos()) {
+      if (!mySuspendedIsolateIds.contains(info.getIsolateId())) {
+        myVmServiceWrapper.pauseIsolate(info.getIsolateId());
+      }
+    }
+  }
+
+  @Override
+  public void runToPosition(@NotNull XSourcePosition position, @Nullable XSuspendContext context) {
+    if (myLatestCurrentIsolateId != null && mySuspendedIsolateIds.contains(myLatestCurrentIsolateId)) {
+      // Set a temporary breakpoint and resume.
+      myVmServiceWrapper.addTemporaryBreakpoint(position, myLatestCurrentIsolateId);
+      myVmServiceWrapper.resumeIsolate(myLatestCurrentIsolateId, null);
     }
   }
 
@@ -414,10 +433,16 @@ public class DartVmServiceDebugProcessZ extends DartVmServiceDebugProcess {
     // For Run tool window this action is added in DartCommandLineRunningState.createActions()
     topToolbar.addSeparator();
 
-    if (myObservatoryPort > 0) {
-      topToolbar.addAction(new OpenDartObservatoryUrlAction(getObservatoryUrl("http", null),
-                                                            () -> myVmConnected && !getSession().isStopped()));
-    }
+    topToolbar.addAction(new OpenComputedUrlAction(() -> computeObservatoryUrl(),
+                                                   () -> myConnector.isConnectionReady() && myVmConnected && !getSession().isStopped()));
+    topToolbar.addAction(new RestartFlutterApp(myConnector));
+    topToolbar.addAction(new ReloadFlutterApp(myConnector));
+  }
+
+  private String computeObservatoryUrl() {
+    assert myConnector != null;
+    myObservatoryPort = myConnector.getPort();
+    return getObservatoryUrl("http", null);
   }
 
   @NotNull


### PR DESCRIPTION
@pq @devoncarew This adds Restart and Reload commands, as well as restoring the observatory connection. At least one, maybe both, need new icons. Reload does not seem to be working but restart does what's expected. It may be a problem in flutter. I notice that when I start the daemon in hot mode there are a lot more log messages printed than before, so I think hot mode is selected correctly.