### PR TITLE
Set Dart SDK location w/ Flutter configuration (#121).

### DIFF
--- a/src/io/flutter/module/FlutterGeneratorPeer.java
+++ b/src/io/flutter/module/FlutterGeneratorPeer.java
@@ -96,6 +96,7 @@ public class FlutterGeneratorPeer {
         FileUtilRt.toSystemIndependentName(getSdkComboPath());
       if (FlutterSdkUtil.isFlutterSdkHome(sdkHomePath)) {
         FlutterSdkGlobalLibUtil.ensureFlutterSdkConfigured(sdkHomePath);
+        FlutterSdkUtil.setDartSdkPathIfUnset(sdkHomePath);
       }
     };
 

--- a/src/io/flutter/sdk/FlutterSdkUtil.java
+++ b/src/io/flutter/sdk/FlutterSdkUtil.java
@@ -16,7 +16,9 @@ import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.util.ArrayUtil;
+import com.jetbrains.lang.dart.sdk.DartSdk;
 import com.jetbrains.lang.dart.sdk.DartSdkGlobalLibUtil;
+import com.jetbrains.lang.dart.sdk.DartSdkUpdateOption;
 import gnu.trove.THashSet;
 import io.flutter.FlutterBundle;
 import org.jetbrains.annotations.NotNull;
@@ -175,5 +177,26 @@ public class FlutterSdkUtil {
 
   public static void enableDartSupport(Module module) {
     ApplicationManager.getApplication().runWriteAction(() -> DartSdkGlobalLibUtil.enableDartSdk(module));
+  }
+
+  /**
+   * If there is no configured Dart SDK, update it to the one relative to the given Flutter SDK.
+   *
+   * @param flutterSdkPath the Flutter SDK path
+   */
+  public static void setDartSdkPathIfUnset(@NotNull String flutterSdkPath) {
+    final DartSdk globalDartSdk = DartSdk.getGlobalDartSdk();
+    if (globalDartSdk != null) {
+      return;
+    }
+    try {
+      final String dartSdk = FlutterSdkUtil.pathToDartSdk(flutterSdkPath);
+      DartSdkGlobalLibUtil.ensureDartSdkConfigured(dartSdk);
+      // Checking for updates doesn't make sense since the channels don't correspond to Flutter...
+      DartSdkUpdateOption.setDartSdkUpdateOption(DartSdkUpdateOption.DoNotCheck);
+    }
+    catch (ExecutionException e) {
+      LOG.error(e);
+    }
   }
 }

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.java
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.java
@@ -26,6 +26,8 @@ import com.intellij.ui.DocumentAdapter;
 import com.intellij.ui.JBColor;
 import com.intellij.ui.components.JBLabel;
 import com.intellij.xml.util.XmlStringUtil;
+import com.jetbrains.lang.dart.sdk.DartSdk;
+import com.jetbrains.lang.dart.sdk.DartSdkGlobalLibUtil;
 import io.flutter.FlutterBundle;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
@@ -131,6 +133,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
         FileUtilRt.toSystemIndependentName(getSdkPathText());
       if (FlutterSdkUtil.isFlutterSdkHome(sdkHomePath)) {
         FlutterSdkGlobalLibUtil.ensureFlutterSdkConfigured(sdkHomePath);
+        FlutterSdkUtil.setDartSdkPathIfUnset(sdkHomePath);
       }
     };
 


### PR DESCRIPTION
* updates Dart SDK location when the Flutter SDK is configured.
* disables Dart SDK update checking (since there’s no Flutter channel).

Fixes: https://github.com/flutter/flutter-intellij/issues/121.

/cc @devoncarew @stevemessick 