### PR TITLE
add emulator info to devices

### DIFF
--- a/src/io/flutter/run/daemon/ConnectedDevice.java
+++ b/src/io/flutter/run/daemon/ConnectedDevice.java
@@ -32,11 +32,13 @@ class FlutterDevice implements ConnectedDevice {
   private final String myDeviceName;
   private final String myDeviceId;
   private final String myPlatform;
+  @SuppressWarnings("unused") private final boolean myEmulator;
 
-  FlutterDevice(String deviceName, String deviceId, String platform) {
+  FlutterDevice(String deviceName, String deviceId, String platform, boolean emulator) {
     myDeviceName = deviceName;
     myDeviceId = deviceId;
     myPlatform = platform;
+    myEmulator = emulator;
   }
 
   @Override

--- a/src/io/flutter/run/daemon/FlutterAppManager.java
+++ b/src/io/flutter/run/daemon/FlutterAppManager.java
@@ -283,7 +283,7 @@ public class FlutterAppManager {
   }
 
   private void eventDeviceAdded(@NotNull DeviceAdded added, @NotNull FlutterDaemonController controller) {
-    myService.addConnectedDevice(new FlutterDevice(added.name, added.id, added.platform));
+    myService.addConnectedDevice(new FlutterDevice(added.name, added.id, added.platform, added.emulator));
   }
 
   private void eventDeviceRemoved(@NotNull DeviceRemoved removed, @NotNull FlutterDaemonController controller) {
@@ -313,6 +313,8 @@ public class FlutterAppManager {
   }
 
   private void eventAppStopped(@NotNull AppStopped stopped, @NotNull FlutterDaemonController controller) {
+    // TODO(devoncarew): Terminate the launch.
+
   }
 
   private void eventDebugPort(@NotNull AppDebugPort port, @NotNull FlutterDaemonController controller) {
@@ -457,6 +459,7 @@ public class FlutterAppManager {
     @SuppressWarnings("unused") private String id;
     @SuppressWarnings("unused") private String name;
     @SuppressWarnings("unused") private String platform;
+    @SuppressWarnings("unused") private boolean emulator;
 
     void process(FlutterAppManager manager, FlutterDaemonController controller) {
       manager.eventDeviceAdded(this, controller);
@@ -468,6 +471,7 @@ public class FlutterAppManager {
     @SuppressWarnings("unused") private String id;
     @SuppressWarnings("unused") private String name;
     @SuppressWarnings("unused") private String platform;
+    @SuppressWarnings("unused") private boolean emulator;
 
     void process(FlutterAppManager manager, FlutterDaemonController controller) {
       manager.eventDeviceRemoved(this, controller);


### PR DESCRIPTION
This will let us know things like if the ios simulator is already running.

https://github.com/flutter/flutter/pull/6114 will need to land before this.

@stevemessick @pq