### PR TITLE
changes to reload and restart

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -39,7 +39,7 @@
 
   <extensions defaultExtensionNs="com.intellij">
     
-    <postStartupActivity implementation="io.flutter.FlutterInitializer"></postStartupActivity>
+    <postStartupActivity implementation="io.flutter.FlutterInitializer"/>
     <applicationService serviceInterface="io.flutter.run.daemon.FlutterDaemonService"
                         serviceImplementation="io.flutter.run.daemon.FlutterDaemonService"/>
 

--- a/src/io/flutter/FlutterBundle.properties
+++ b/src/io/flutter/FlutterBundle.properties
@@ -2,10 +2,10 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-app.restart.action.text=Restart
+app.restart.action.text=Full Application Restart
 app.restart.action.description=Restart the Flutter app
-app.reload.action.text=Reload
-app.reload.action.description=Reload changes to the running Flutter app
+app.reload.action.text=Hot Reload
+app.reload.action.description=Hot reload changes into the running Flutter app
 
 config.progargs.caption=Program Arguments
 

--- a/src/io/flutter/actions/ReloadFlutterApp.java
+++ b/src/io/flutter/actions/ReloadFlutterApp.java
@@ -6,6 +6,7 @@
 package io.flutter.actions;
 
 import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.jetbrains.lang.dart.ide.runner.ObservatoryConnector;
 import icons.FlutterIcons;
 import io.flutter.FlutterBundle;
@@ -19,6 +20,9 @@ public class ReloadFlutterApp extends FlutterAppAction {
 
   @Override
   public void actionPerformed(AnActionEvent e) {
-    ifReadyThen(() -> getApp().performReload());
+    ifReadyThen(() -> {
+      FileDocumentManager.getInstance().saveAllDocuments();
+      getApp().performReload();
+    });
   }
 }

--- a/src/io/flutter/actions/RestartFlutterApp.java
+++ b/src/io/flutter/actions/RestartFlutterApp.java
@@ -6,6 +6,7 @@
 package io.flutter.actions;
 
 import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.jetbrains.lang.dart.ide.runner.ObservatoryConnector;
 import icons.FlutterIcons;
 import io.flutter.FlutterBundle;
@@ -19,6 +20,9 @@ public class RestartFlutterApp extends FlutterAppAction {
 
   @Override
   public void actionPerformed(AnActionEvent e) {
-    ifReadyThen(() -> getApp().performRestart());
+    ifReadyThen(() -> {
+      FileDocumentManager.getInstance().saveAllDocuments();
+      getApp().performRestart();
+    });
   }
 }

--- a/src/io/flutter/run/daemon/FlutterApp.java
+++ b/src/io/flutter/run/daemon/FlutterApp.java
@@ -208,7 +208,7 @@ class RunningFlutterApp implements FlutterApp {
 
   @Override
   public void performRestart() {
-    myManager.restartApp(this, true);
+    myManager.restartApp(this);
   }
 
   @Override

--- a/src/io/flutter/run/daemon/FlutterAppManager.java
+++ b/src/io/flutter/run/daemon/FlutterAppManager.java
@@ -193,6 +193,10 @@ public class FlutterAppManager {
     app.getController().removeDeviceId(app.deviceId());
   }
 
+  void restartApp(@NotNull RunningFlutterApp app) {
+    restartApp(app, false);
+  }
+
   void restartApp(@NotNull RunningFlutterApp app, boolean isFullRestart) {
     AppRestart appStart = new AppRestart(app.appId(), isFullRestart);
     Method cmd = makeMethod(CMD_APP_RESTART, appStart);


### PR DESCRIPTION
- change the tooltips for reload and restart in order to help differentiate them for users
- have them both save all documents before running
- update `RestartFlutterApp` to pass in false for the isFullRestart flag

@stevemessick 