### PR TITLE
Rev dart plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,9 +36,9 @@ allprojects {
     pluginName = 'Flutter'
 
     // IntelliJ IDEA 2016.2.3 / IC-162.1812.17
-    // Dart 162.2017
+    // Dart 162.2233
     version = '2016.2.3'
-    plugins = ['Dart:162.2017']
+    plugins = ['Dart:162.2233']
 
     // IntelliJ IDEA 2016.1.4 (~Android Studio 2.2) / IC-145.2070.6
     // Dart 145.971.7

--- a/flutter-intellij.iml
+++ b/flutter-intellij.iml
@@ -21,7 +21,7 @@
     <orderEntry type="module-library" scope="PROVIDED">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/lib/dart-plugin/162.2017/Dart.jar!/" />
+          <root url="jar://$MODULE_DIR$/lib/dart-plugin/162.2233/Dart.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES />

--- a/src/io/flutter/run/FlutterRunner.java
+++ b/src/io/flutter/run/FlutterRunner.java
@@ -77,10 +77,11 @@ public class FlutterRunner extends DartRunner {
     return super.doExecute(state, env);
   }
 
-  @Override
-  protected DartUrlResolver getDartUrlResolver(@NotNull final Project project, @NotNull final VirtualFile contextFileOrDir) {
-    return new FlutterUrlResolver(project, contextFileOrDir);
-  }
+  // TODO(devoncarew): This may not be necessary with the latest debugger code from the Dart plugin.
+  //@Override
+  //protected DartUrlResolver getDartUrlResolver(@NotNull final Project project, @NotNull final VirtualFile contextFileOrDir) {
+  //  return new FlutterUrlResolver(project, contextFileOrDir);
+  //}
 
   @Override
   protected int getTimeout() {
@@ -91,7 +92,7 @@ public class FlutterRunner extends DartRunner {
   protected ObservatoryConnector getConnector() {
     return myConnector;
   }
-  // TODO: Remove this?
+
   private static class FlutterUrlResolver extends DartUrlResolverImpl {
     private static final String PACKAGE_PREFIX = "package:";
     //private static final String PACKAGES_PREFIX = "packages/";

--- a/src/io/flutter/run/FlutterRunner.java
+++ b/src/io/flutter/run/FlutterRunner.java
@@ -84,14 +84,14 @@ public class FlutterRunner extends DartRunner {
 
   @Override
   protected int getTimeout() {
-    return 30000; // Allow 30 seconds to connect to the observatory.
+    return 60000; // Allow 60 seconds to connect to the observatory.
   }
 
   @Nullable
   protected ObservatoryConnector getConnector() {
     return myConnector;
   }
-
+  // TODO: Remove this?
   private static class FlutterUrlResolver extends DartUrlResolverImpl {
     private static final String PACKAGE_PREFIX = "package:";
     //private static final String PACKAGES_PREFIX = "packages/";

--- a/src/io/flutter/run/daemon/FlutterApp.java
+++ b/src/io/flutter/run/daemon/FlutterApp.java
@@ -5,9 +5,9 @@
  */
 package io.flutter.run.daemon;
 
+import com.intellij.openapi.util.text.StringUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 import static io.flutter.run.daemon.FlutterAppManager.AppStarted;
 
@@ -90,6 +90,7 @@ public interface FlutterApp {
    * Refresh the app.
    */
   void performReload();
+
   /**
    * Fetch the widget hierarchy.
    *
@@ -218,11 +219,28 @@ class RunningFlutterApp implements FlutterApp {
 
   @Override
   public Object fetchWidgetHierarchy() {
-    throw new NotImplementedException();
+    throw new NoSuchMethodError("fetchWidgetHierarchy");
   }
 
   @Override
   public Object fetchRenderTree() {
-    throw new NotImplementedException();
+    throw new NoSuchMethodError("fetchRenderTree");
+  }
+
+  @Override
+  public int hashCode() {
+    return appId().hashCode();
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (!(other instanceof FlutterApp)) {
+      return false;
+    }
+
+    FlutterApp flutterApp = (FlutterApp)other;
+    return
+      flutterApp.getController() == getController() &&
+      StringUtil.equals(appId(), ((FlutterApp)other).appId());
   }
 }

--- a/src/io/flutter/run/daemon/FlutterApp.java
+++ b/src/io/flutter/run/daemon/FlutterApp.java
@@ -5,7 +5,6 @@
  */
 package io.flutter.run.daemon;
 
-import com.intellij.openapi.util.text.StringUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -225,22 +224,5 @@ class RunningFlutterApp implements FlutterApp {
   @Override
   public Object fetchRenderTree() {
     throw new NoSuchMethodError("fetchRenderTree");
-  }
-
-  @Override
-  public int hashCode() {
-    return appId().hashCode();
-  }
-
-  @Override
-  public boolean equals(Object other) {
-    if (!(other instanceof FlutterApp)) {
-      return false;
-    }
-
-    FlutterApp flutterApp = (FlutterApp)other;
-    return
-      flutterApp.getController() == getController() &&
-      StringUtil.equals(appId(), ((FlutterApp)other).appId());
   }
 }

--- a/third_party/intellij-plugins-dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcessZ.java
+++ b/third_party/intellij-plugins-dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcessZ.java
@@ -284,6 +284,9 @@ public class DartVmServiceDebugProcessZ extends DartVmServiceDebugProcess {
   public boolean isRemoteDebug() {
     // TODO(devoncarew): This is a hack for now - we want to instead look for prefix matches
     // if remote debugging, or running a Flutter app.
+    // We're depending on the remote debugging's functionality of scanning for prefixes
+    // in use by the VM in order to generate correct paths for the debugger. We could
+    // instead try using the prefix returned over the daemon protocol.
     return true; //myRemoteDebug;
   }
 

--- a/third_party/intellij-plugins-dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcessZ.java
+++ b/third_party/intellij-plugins-dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcessZ.java
@@ -81,7 +81,6 @@ public class DartVmServiceDebugProcessZ extends DartVmServiceDebugProcess {
   @Nullable private ObservatoryConnector myConnector;
 
   @Nullable String myRemoteProjectRootUri;
-  private boolean scheduled = false;
 
   public DartVmServiceDebugProcessZ(@NotNull final XDebugSession session,
                                     @NotNull final String debuggingHost,
@@ -93,8 +92,8 @@ public class DartVmServiceDebugProcessZ extends DartVmServiceDebugProcess {
                                     final int timeout,
                                     @Nullable final VirtualFile currentWorkingDirectory,
                                     @Nullable final ObservatoryConnector connector) {
-    // TODO Delete <code>true</code>, add <code>currentWorkingDirectory</code> to work with EAP version
-    super(session, debuggingHost, observatoryPort, executionResult, dartUrlResolver, dasExecutionContextId, remoteDebug, true, timeout);
+    super(session, debuggingHost, observatoryPort, executionResult, dartUrlResolver, dasExecutionContextId, remoteDebug, timeout, currentWorkingDirectory);
+
     myDebuggingHost = debuggingHost;
     myObservatoryPort = observatoryPort;
     myExecutionResult = executionResult;
@@ -246,8 +245,9 @@ public class DartVmServiceDebugProcessZ extends DartVmServiceDebugProcess {
 
     vmService.addVmServiceListener(vmServiceListener);
 
-    myVmServiceWrapper =
-      new VmServiceWrapper(this, vmService, myIsolatesInfo, (DartVmServiceBreakpointHandler)myBreakpointHandlers[0]);
+    final DartVmServiceBreakpointHandler breakpointHandler = (DartVmServiceBreakpointHandler)myBreakpointHandlers[0];
+
+    myVmServiceWrapper = new VmServiceWrapper(this, vmService, vmServiceListener, myIsolatesInfo, breakpointHandler);
     myVmServiceWrapper.handleDebuggerConnected();
 
     myVmConnected = true;

--- a/third_party/intellij-plugins-dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcessZ.java
+++ b/third_party/intellij-plugins-dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcessZ.java
@@ -282,7 +282,9 @@ public class DartVmServiceDebugProcessZ extends DartVmServiceDebugProcess {
   }
 
   public boolean isRemoteDebug() {
-    return myRemoteDebug;
+    // TODO(devoncarew): This is a hack for now - we want to instead look for prefix matches
+    // if remote debugging, or running a Flutter app.
+    return true; //myRemoteDebug;
   }
 
   public void guessRemoteProjectRoot(@NotNull final ElementList<LibraryRef> libraries) {
@@ -460,7 +462,7 @@ public class DartVmServiceDebugProcessZ extends DartVmServiceDebugProcess {
     }
 
     // remote prefix (if applicable)
-    if (myRemoteDebug && myRemoteProjectRootUri != null) {
+    if (myRemoteProjectRootUri != null) {
       final VirtualFile pubspec = myDartUrlResolver.getPubspecYamlFile();
       if (pubspec != null) {
         final String projectPath = pubspec.getParent().getPath();
@@ -495,7 +497,7 @@ public class DartVmServiceDebugProcessZ extends DartVmServiceDebugProcess {
       }
 
       final VirtualFile pubspec = myDartUrlResolver.getPubspecYamlFile();
-      if (myRemoteDebug && myRemoteProjectRootUri != null && uri.startsWith(myRemoteProjectRootUri) && pubspec != null) {
+      if (myRemoteProjectRootUri != null && uri.startsWith(myRemoteProjectRootUri) && pubspec != null) {
         final String localRootUri = StringUtil.trimEnd(myDartUrlResolver.getDartUrlForFile(pubspec.getParent()), '/');
         LOG.assertTrue(localRootUri.startsWith(DartUrlResolver.FILE_PREFIX), localRootUri);
 


### PR DESCRIPTION
- rev to 162.2233 of the dart plugin
- fix debugging for the latest Dart plugin

@stevemessick, this upgrades us to compiling against the latest published version of the Dart plugin, and fixes debugging against that latest version. We'll need to update this later - as part of debugging apps running under hot reload, we need to guess the uri prefix for the app. The Dart plugin currently only does this when remote debugging, so we spoof that here.
