### PR TITLE
Clean up internal structures when processes exit.

### DIFF
--- a/src/io/flutter/run/daemon/DaemonListener.java
+++ b/src/io/flutter/run/daemon/DaemonListener.java
@@ -5,6 +5,8 @@
  */
 package io.flutter.run.daemon;
 
+import com.intellij.execution.process.ProcessHandler;
+
 public interface DaemonListener {
 
   /**
@@ -21,4 +23,8 @@ public interface DaemonListener {
    * @param controller The FlutterDaemonController that controls the daemon
    */
   void enableDevicePolling(FlutterDaemonController controller);
+
+  void aboutToTerminate(ProcessHandler handler, FlutterDaemonController controller);
+
+  void processTerminated(ProcessHandler handler, FlutterDaemonController controller);
 }

--- a/src/io/flutter/run/daemon/FlutterDaemonController.java
+++ b/src/io/flutter/run/daemon/FlutterDaemonController.java
@@ -141,6 +141,20 @@ public class FlutterDaemonController extends ProcessAdapter {
   }
 
   @Override
+  public void processTerminated(ProcessEvent event) {
+    for (DaemonListener listener : myListeners) {
+      listener.processTerminated(event.getProcessHandler(), this);
+    }
+  }
+
+  @Override
+  public void processWillTerminate(ProcessEvent event, boolean willBeDestroyed) {
+    for (DaemonListener listener : myListeners) {
+      listener.aboutToTerminate(event.getProcessHandler(), this);
+    }
+  }
+
+  @Override
   public void onTextAvailable(@NotNull ProcessEvent event, @NotNull Key outputType) {
     if (outputType.toString().equals(STDOUT_KEY)) {
       String text = event.getText().trim();

--- a/src/io/flutter/run/daemon/FlutterDaemonService.java
+++ b/src/io/flutter/run/daemon/FlutterDaemonService.java
@@ -6,6 +6,7 @@
 package io.flutter.run.daemon;
 
 import com.intellij.execution.ExecutionException;
+import com.intellij.execution.process.ProcessHandler;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.diagnostic.Logger;
@@ -51,6 +52,20 @@ public class FlutterDaemonService {
       synchronized (myLock) {
         myManager.enableDevicePolling(controller);
       }
+    }
+
+    @Override
+    public void aboutToTerminate(ProcessHandler handler, FlutterDaemonController controller) {
+      assert handler == controller.getProcessHandler();
+      synchronized (myLock) {
+        myManager.aboutToTerminateAll(controller);
+      }
+    }
+
+    @Override
+    public void processTerminated(ProcessHandler handler, FlutterDaemonController controller) {
+      assert handler == controller.getProcessHandler() || controller.getProcessHandler() == null;
+      discard(controller);
     }
   };
 


### PR DESCRIPTION
@pq @devoncarew This allows launching apps repeatedly without having to restart IntelliJ.

There's still something wrong because the app running on the device isn't always terminated when the Stop button is clicked. I'll continue to look into that.