### PR TITLE
Hot reload/restart keybindings (#185).

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -31,6 +31,14 @@
       <action id="Flutter.DeviceSelector" class="io.flutter.actions.DeviceSelectorAction"
               description="Flutter Device Selection"
               icon="FlutterIcons.Phone"/>
+      <action id="Flutter.ReloadFlutterAppKey" class="io.flutter.actions.ReloadFlutterAppKeyAction" text="Reload Flutter app">
+        <!-- TODO: settle on a less conflicting binding -->
+        <keyboard-shortcut first-keystroke="ctrl shift r" keymap="$default"/>
+      </action>
+      <action id="Flutter.RestartFlutterAppKey" class="io.flutter.actions.RestartFlutterAppKeyAction" text="Restart Flutter app">
+        <!-- TODO: settle on a less conflicting binding -->
+        <keyboard-shortcut first-keystroke="alt shift r" keymap="$default"/>
+      </action>
     <separator/>
       <add-to-group anchor="before" group-id="RunContextGroup" relative-to-action="RunConfiguration"/>
       <add-to-group anchor="before" group-id="ToolbarRunGroup" relative-to-action="RunConfiguration"/>

--- a/src/io/flutter/actions/FlutterKeyAction.java
+++ b/src/io/flutter/actions/FlutterKeyAction.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2016 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.actions;
+
+import com.intellij.openapi.project.DumbAwareAction;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectManager;
+import com.intellij.xdebugger.XDebugProcess;
+import com.intellij.xdebugger.XDebugSession;
+import com.intellij.xdebugger.XDebuggerManager;
+import com.jetbrains.lang.dart.ide.runner.ObservatoryConnector;
+import com.jetbrains.lang.dart.ide.runner.server.vmService.DartVmServiceDebugProcessZ;
+import org.jetbrains.annotations.Nullable;
+
+public abstract class FlutterKeyAction extends DumbAwareAction {
+
+  /**
+   * Find an active Dart VM debug process and get it's observatory connector.
+   * <p>
+   * TODO: make this more robust in the face of multiple concurrent debug sessions.
+   */
+  static
+  @Nullable
+  ObservatoryConnector findConnector() {
+    final Project[] projects = ProjectManager.getInstance().getOpenProjects();
+    for (Project project : projects) {
+      final XDebuggerManager manager = XDebuggerManager.getInstance(project);
+      final XDebugSession session = manager.getCurrentSession();
+      if (session != null) {
+        final XDebugProcess debugProcess = session.getDebugProcess();
+        if (debugProcess instanceof DartVmServiceDebugProcessZ) {
+          return ((DartVmServiceDebugProcessZ)debugProcess).getConnector();
+        }
+      }
+    }
+    return null;
+  }
+
+}

--- a/src/io/flutter/actions/ReloadFlutterAppKeyAction.java
+++ b/src/io/flutter/actions/ReloadFlutterAppKeyAction.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2016 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.actions;
+
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.jetbrains.lang.dart.ide.runner.ObservatoryConnector;
+
+/**
+ * A keystroke invoked {@link ReloadFlutterApp} action.
+ */
+public class ReloadFlutterAppKeyAction extends FlutterKeyAction {
+
+  @Override
+  public void actionPerformed(AnActionEvent e) {
+    final ObservatoryConnector connector = findConnector();
+    if (connector != null) {
+      new ReloadFlutterApp(connector).actionPerformed(e);
+    }
+  }
+}

--- a/src/io/flutter/actions/RestartFlutterAppKeyAction.java
+++ b/src/io/flutter/actions/RestartFlutterAppKeyAction.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2016 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.actions;
+
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.jetbrains.lang.dart.ide.runner.ObservatoryConnector;
+
+/**
+ * A keystroke invoked {@link ReloadFlutterApp} action.
+ */
+public class RestartFlutterAppKeyAction extends FlutterKeyAction {
+
+  @Override
+  public void actionPerformed(AnActionEvent e) {
+    final ObservatoryConnector connector = findConnector();
+    if (connector != null) {
+      new RestartFlutterApp(connector).actionPerformed(e);
+    }
+  }
+}

--- a/third_party/intellij-plugins-dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcessZ.java
+++ b/third_party/intellij-plugins-dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcessZ.java
@@ -135,6 +135,8 @@ public class DartVmServiceDebugProcessZ extends DartVmServiceDebugProcess {
     }
   }
 
+  public ObservatoryConnector getConnector() { return myConnector; }
+
   public VmServiceWrapper getVmServiceWrapper() {
     return myVmServiceWrapper;
   }


### PR DESCRIPTION
* keybindings for reload and restart (provisional)
* (temporary) connection-finding logic

Non-conflicting key-bindings are hard so I just punted.  
![screen shot 2016-09-28 at 4 18 12 pm](https://cloud.githubusercontent.com/assets/67586/18935971/9f3c2044-8598-11e6-8058-cfd6906a8063.png)

They can easily be updated once we settle on better ones.  In the meantime, the actions can be invoked via the **Find Action** command (**⌘ + A**) and the keymappings updated locally for demo (**Preferences > Keymap**).

Console out from invocation:

![screen shot 2016-09-28 at 4 29 14 pm](https://cloud.githubusercontent.com/assets/67586/18935992/bbead0aa-8598-11e6-9ebb-c40d01b3cec6.png)


Fixes: https://github.com/flutter/flutter-intellij/issues/185

/cc @stevemessick @devoncarew 