### PR TITLE
faster stops

### DIFF
--- a/src/io/flutter/run/daemon/FlutterAppManager.java
+++ b/src/io/flutter/run/daemon/FlutterAppManager.java
@@ -200,7 +200,8 @@ public class FlutterAppManager {
     AppStop appStop = new AppStop(app.appId());
     Method cmd = makeMethod(CMD_APP_STOP, appStop);
     sendCommand(app.getController(), cmd);
-    FlutterJsonObject obj = waitForResponse(cmd);
+    // We don't wait for a response here; we'll get an app.stop event later as a notification.
+    //waitForResponse(cmd);
     synchronized (myLock) {
       myApps.remove(app);
     }


### PR DESCRIPTION
Speed up the stop implementation; we don't wait for a response from the daemon.

@stevemessick, I wasn't able to find a way to notify that the debug session was completed, when we receive an `app.stop` event. The session already completes when the app stops - the service protocol connection closes, and the debug session ends because of that. Still, it would be nice to also be able to close it on receipt of `app.stop`.