### PR TITLE
Check for minum required Dart Plugin version (#168).

### DIFF
--- a/resources/META-INF/idea-contribs.xml
+++ b/resources/META-INF/idea-contribs.xml
@@ -4,5 +4,6 @@
     <projectService serviceInterface="io.flutter.sdk.FlutterSdkService" serviceImplementation="io.flutter.sdk.FlutterIdeaSdkService"
                     overrides="true"/>
     <editorNotificationProvider implementation="io.flutter.inspections.WrongDartSdkConfigurationNotificationProvider"/>
+    <editorNotificationProvider implementation="io.flutter.inspections.IncompatibleDartPluginNotificationProvider"/>
   </extensions>
 </idea-plugin>

--- a/src/io/flutter/FlutterBundle.properties
+++ b/src/io/flutter/FlutterBundle.properties
@@ -38,3 +38,5 @@ open.observatory.action.description=Open Observatory: a Profiler for Dart apps
 
 runner.flutter.configuration.description=Flutter run configuration
 runner.flutter.configuration.name=Flutter
+flutter.incompatible.dart.plugin.warning=Flutter requires a Dart plugin with a minimum version of {0} (currently installed: {1}).
+dart.plugin.update.action.label=Update Dart

--- a/src/io/flutter/dart/DartPlugin.java
+++ b/src/io/flutter/dart/DartPlugin.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2016 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.dart;
+
+import com.intellij.ide.plugins.IdeaPluginDescriptor;
+import com.intellij.ide.plugins.PluginManager;
+import com.intellij.openapi.util.Version;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * Provides access to the Dart Plugin.
+ */
+public class DartPlugin {
+
+  /**
+   * Tracks the minimum required Dart Plugin version.
+   */
+  private static final String MINIMUM_REQUIRED_PLUGIN_VERSION = "162.2233";
+  private static final Version MINIMUM_VERSION = Version.parseVersion(MINIMUM_REQUIRED_PLUGIN_VERSION);
+
+  private static final DartPlugin INSTANCE = new DartPlugin();
+
+  private Version myVersion;
+
+  public static DartPlugin getInstance() {
+    return INSTANCE;
+  }
+
+  private IdeaPluginDescriptor getIdeaPluginDescriptor() {
+    final IdeaPluginDescriptor[] plugins = PluginManager.getPlugins();
+    return Arrays.asList(plugins).stream().filter(p -> Objects.equals(p.getName(), "Dart")).findFirst().get();
+  }
+
+  /**
+   * @return the minimum required version of the Dart Plugin
+   */
+  public Version getMinimumVersion() {
+    return MINIMUM_VERSION;
+  }
+
+  /**
+   * @return the version of the currently installed Dart Plugin
+   */
+  public Version getVersion() {
+    if (myVersion == null) {
+      IdeaPluginDescriptor descriptor = getIdeaPluginDescriptor();
+      myVersion = Version.parseVersion(descriptor.getVersion());
+    }
+    return myVersion;
+  }
+}

--- a/src/io/flutter/inspections/IncompatibleDartPluginNotificationProvider.java
+++ b/src/io/flutter/inspections/IncompatibleDartPluginNotificationProvider.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2016 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.inspections;
+
+import com.intellij.ide.actions.ShowSettingsUtilImpl;
+import com.intellij.openapi.fileEditor.FileEditor;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleType;
+import com.intellij.openapi.module.ModuleUtilCore;
+import com.intellij.openapi.project.DumbAware;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Key;
+import com.intellij.openapi.util.Version;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiManager;
+import com.intellij.ui.EditorNotificationPanel;
+import com.intellij.ui.EditorNotifications;
+import com.jetbrains.lang.dart.DartFileType;
+import com.jetbrains.lang.dart.DartLanguage;
+import io.flutter.FlutterBundle;
+import io.flutter.dart.DartPlugin;
+import io.flutter.module.FlutterModuleType;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class IncompatibleDartPluginNotificationProvider extends EditorNotifications.Provider<EditorNotificationPanel> implements DumbAware {
+
+  private static final Key<EditorNotificationPanel> KEY = Key.create("IncompatibleDartPluginNotificationProvider");
+
+  private final Project myProject;
+
+  public IncompatibleDartPluginNotificationProvider(@NotNull Project project) {
+    this.myProject = project;
+  }
+
+  @Nullable
+  private static EditorNotificationPanel createUpdateDartPanel(@NotNull Project project,
+                                                               @Nullable Module module,
+                                                               @NotNull String currentVersion) {
+    if (module == null) return null;
+
+    EditorNotificationPanel panel = new EditorNotificationPanel();
+    panel.setText(FlutterBundle.message("flutter.incompatible.dart.plugin.warning", getPrintableRequiredDartVersion(), currentVersion));
+    panel.createActionLabel(FlutterBundle.message("dart.plugin.update.action.label"),
+                            () -> ShowSettingsUtilImpl.showSettingsDialog(project, "preferences.plugins", ""));
+
+    return panel;
+  }
+
+  private static String getPrintableRequiredDartVersion() {
+    return DartPlugin.getInstance().getMinimumVersion().toCompactString();
+  }
+
+  @NotNull
+  @Override
+  public Key<EditorNotificationPanel> getKey() {
+    return KEY;
+  }
+
+  @Override
+  public EditorNotificationPanel createNotificationPanel(@NotNull VirtualFile file, @NotNull FileEditor fileEditor) {
+    if (file.getFileType() != DartFileType.INSTANCE) return null;
+
+    PsiFile psiFile = PsiManager.getInstance(myProject).findFile(file);
+    if (psiFile == null) return null;
+
+    if (psiFile.getLanguage() != DartLanguage.INSTANCE) return null;
+
+    Module module = ModuleUtilCore.findModuleForPsiElement(psiFile);
+    if (module == null) return null;
+
+    if (!ModuleType.is(module, FlutterModuleType.getInstance())) return null;
+
+    Version minimumVersion = DartPlugin.getInstance().getMinimumVersion();
+    Version dartVersion = DartPlugin.getInstance().getVersion();
+    return dartVersion.compareTo(minimumVersion) < 0 ? createUpdateDartPanel(myProject, module, getPrintableRequiredDartVersion()) : null;
+  }
+}


### PR DESCRIPTION
Adds an inspection to check for a minimum Dart Plugin version.

Also adds a new class `DartPlugin` to centralize our access to the Dart Plugin.

If this approach looks good, I'd like to move many if not all of our Dart Plugin API access to this class.  A step in the direction of better managing our dependency...

fixes #168

/cc @devoncarew @stevemessick 