### PR TITLE
App management improvements

### DIFF
--- a/src/io/flutter/run/daemon/FlutterDaemonController.java
+++ b/src/io/flutter/run/daemon/FlutterDaemonController.java
@@ -101,7 +101,7 @@ public class FlutterDaemonController extends ProcessAdapter {
     }
   }
 
-  private boolean hasDeviceId(String id) {
+  boolean hasDeviceId(String id) {
     return myDeviceIds.contains(id);
   }
 

--- a/src/io/flutter/run/daemon/FlutterDaemonService.java
+++ b/src/io/flutter/run/daemon/FlutterDaemonService.java
@@ -200,6 +200,9 @@ public class FlutterDaemonService {
   }
 
   void schedulePolling() {
+    if (myPollster != null && myPollster.getProcessHandler() != null && !myPollster.getProcessHandler().isProcessTerminating()) {
+      return;
+    }
     ApplicationManager.getApplication().executeOnPooledThread(() -> {
       synchronized (myLock) {
         myPollster = new FlutterDaemonController(null);


### PR DESCRIPTION
A few improvements and bug fixes for Flutter app management.

* De-bounce the Debug button. This still needs work but now if it is clicked when an app is running it won't break the world. It just does nothing. #221 
* Stop trying to stop an app if it isn't running.
* After the process has terminated, re-launch the polling service if needed.

@devoncarew @pq