### PR TITLE
Stop the flutter app even when paused

### DIFF
--- a/src/io/flutter/run/FlutterRunner.java
+++ b/src/io/flutter/run/FlutterRunner.java
@@ -12,28 +12,19 @@ import com.intellij.execution.executors.DefaultDebugExecutor;
 import com.intellij.execution.executors.DefaultRunExecutor;
 import com.intellij.execution.runners.ExecutionEnvironment;
 import com.intellij.execution.ui.RunContentDescriptor;
-import com.intellij.openapi.diagnostic.Logger;
-import com.intellij.openapi.project.Project;
-import com.intellij.openapi.util.SystemInfo;
-import com.intellij.openapi.vfs.LocalFileSystem;
-import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.xdebugger.XDebugSession;
 import com.jetbrains.lang.dart.ide.runner.DartRunner;
 import com.jetbrains.lang.dart.ide.runner.ObservatoryConnector;
-import com.jetbrains.lang.dart.util.DartUrlResolverImpl;
 import io.flutter.run.daemon.FlutterApp;
 import io.flutter.run.daemon.FlutterDaemonService;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
-import java.net.URI;
 
 /**
  * This class could be independent of DartRunner; just copy down the code that is not implemented here.
  * Note that we have redefined DartRunner in third_party, which is a slightly modified version of the original.
  */
 public class FlutterRunner extends DartRunner {
-
-  private static final Logger LOG = Logger.getInstance(FlutterRunner.class);
 
   @Nullable
   private ObservatoryConnector myConnector;
@@ -71,16 +62,20 @@ public class FlutterRunner extends DartRunner {
         public FlutterApp getApp() {
           return appState.getApp();
         }
+
+        @Override
+        public void sessionPaused(XDebugSession sessionHook) {
+          appState.getApp().sessionPaused(sessionHook);
+        }
+
+        @Override
+        public void sessionResumed() {
+          appState.getApp().sessionResumed();
+        }
       };
     }
     return super.doExecute(state, env);
   }
-
-  // TODO(devoncarew): This may not be necessary with the latest debugger code from the Dart plugin.
-  //@Override
-  //protected DartUrlResolver getDartUrlResolver(@NotNull final Project project, @NotNull final VirtualFile contextFileOrDir) {
-  //  return new FlutterUrlResolver(project, contextFileOrDir);
-  //}
 
   @Override
   protected int getTimeout() {
@@ -90,41 +85,5 @@ public class FlutterRunner extends DartRunner {
   @Nullable
   protected ObservatoryConnector getConnector() {
     return myConnector;
-  }
-
-  private static class FlutterUrlResolver extends DartUrlResolverImpl {
-    private static final String PACKAGE_PREFIX = "package:";
-    //private static final String PACKAGES_PREFIX = "packages/";
-
-    FlutterUrlResolver(final @NotNull Project project, final @NotNull VirtualFile contextFile) {
-      super(project, contextFile);
-    }
-
-    public boolean mayNeedDynamicUpdate() {
-      return false;
-    }
-
-    @NotNull
-    public String getDartUrlForFile(final @NotNull VirtualFile file) {
-      String str = super.getDartUrlForFile(file);
-      if (str.startsWith(PACKAGE_PREFIX)) {
-        // Convert package: prefix to packages/ one.
-        //return PACKAGES_PREFIX + str.substring(PACKAGE_PREFIX.length());
-        return file.getPath(); // TODO This works on Mac running flutter locally. Not sure about other configs.
-      }
-      else if (str.startsWith("file:")) {
-        return URI.create(str).toString();
-      }
-      return str;
-    }
-
-    @Nullable
-    public VirtualFile findFileByDartUrl(final @NotNull String url) {
-      VirtualFile file = super.findFileByDartUrl(url);
-      if (file == null) {
-        file = LocalFileSystem.getInstance().findFileByPath(SystemInfo.isWindows ? url : ("/" + url));
-      }
-      return file;
-    }
   }
 }

--- a/src/io/flutter/run/daemon/ConnectedDevice.java
+++ b/src/io/flutter/run/daemon/ConnectedDevice.java
@@ -72,7 +72,8 @@ class FlutterDevice implements ConnectedDevice {
       return Objects.equal(myDeviceName, ((FlutterDevice)other).deviceName()) &&
              Objects.equal(myDeviceId, ((FlutterDevice)other).deviceId()) &&
              Objects.equal(myPlatform, ((FlutterDevice)other).platform());
-    } else {
+    }
+    else {
       return false;
     }
   }

--- a/src/io/flutter/run/daemon/FlutterApp.java
+++ b/src/io/flutter/run/daemon/FlutterApp.java
@@ -7,6 +7,7 @@ package io.flutter.run.daemon;
 
 import com.intellij.execution.ui.ConsoleView;
 import com.intellij.openapi.project.Project;
+import com.intellij.xdebugger.XDebugSession;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -119,6 +120,14 @@ public interface FlutterApp {
   void setConsole(ConsoleView console);
 
   ConsoleView getConsole();
+
+  boolean isSessionPaused();
+
+  void sessionPaused(XDebugSession sessionHook);
+
+  void sessionResumed();
+
+  void forceResume();
 }
 
 class RunningFlutterApp implements FlutterApp {
@@ -135,6 +144,7 @@ class RunningFlutterApp implements FlutterApp {
   private int myPort;
   private String myBaseUri;
   private ConsoleView myConsole;
+  private XDebugSession mySesionHook;
 
   public RunningFlutterApp(@NotNull FlutterDaemonService service,
                            @NotNull FlutterDaemonController controller,
@@ -269,5 +279,27 @@ class RunningFlutterApp implements FlutterApp {
   @Override
   public ConsoleView getConsole() {
     return myConsole;
+  }
+
+  @Override
+  public boolean isSessionPaused() {
+    return mySesionHook != null;
+  }
+
+  @Override
+  public void sessionPaused(XDebugSession sessionHook) {
+    mySesionHook = sessionHook;
+  }
+
+  @Override
+  public void sessionResumed() {
+    mySesionHook = null;
+  }
+
+  @Override
+  public void forceResume() {
+    if (mySesionHook != null && mySesionHook.isPaused()) {
+      mySesionHook.resume();
+    }
   }
 }

--- a/src/io/flutter/run/daemon/ProgressHandler.java
+++ b/src/io/flutter/run/daemon/ProgressHandler.java
@@ -65,7 +65,6 @@ class ProgressHandler {
         });
       }
     }
-
   }
 
   /**

--- a/third_party/intellij-plugins-dart/src/com/jetbrains/lang/dart/ide/runner/ObservatoryConnector.java
+++ b/third_party/intellij-plugins-dart/src/com/jetbrains/lang/dart/ide/runner/ObservatoryConnector.java
@@ -1,5 +1,6 @@
 package com.jetbrains.lang.dart.ide.runner;
 
+import com.intellij.xdebugger.XDebugSession;
 import io.flutter.run.daemon.FlutterApp;
 
 public interface ObservatoryConnector {
@@ -18,4 +19,14 @@ public interface ObservatoryConnector {
    * Return the FlutterApp used to control the running app.
    */
   FlutterApp getApp();
+
+  /**
+   * The debug session has been paused.
+   */
+  void sessionPaused(XDebugSession sessionHook);
+
+  /**
+   * The debug session has been resumed.
+   */
+  void sessionResumed();
 }

--- a/third_party/intellij-plugins-dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcessZ.java
+++ b/third_party/intellij-plugins-dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcessZ.java
@@ -115,6 +115,16 @@ public class DartVmServiceDebugProcessZ extends DartVmServiceDebugProcess {
       @Override
       public void sessionPaused() {
         stackFrameChanged();
+        if (connector != null) {
+          connector.sessionPaused(session);
+        }
+      }
+
+      @Override
+      public void sessionResumed() {
+        if (connector != null) {
+          connector.sessionResumed();
+        }
       }
 
       @Override
@@ -137,6 +147,7 @@ public class DartVmServiceDebugProcessZ extends DartVmServiceDebugProcess {
     }
   }
 
+  @Nullable
   public ObservatoryConnector getConnector() {
     return myConnector;
   }
@@ -469,7 +480,7 @@ public class DartVmServiceDebugProcessZ extends DartVmServiceDebugProcess {
 
   @NotNull
   public Collection<String> getUrisForFile(@NotNull final VirtualFile file) {
-    final Set<String> result = new com.intellij.util.containers.HashSet<>();
+    final Set<String> result = new HashSet<>();
     String uriByIde = myDartUrlResolver.getDartUrlForFile(file);
 
     // If dart:, short circut the results.


### PR DESCRIPTION
If an app is paused at a breakpoint when the Stop button is clicked then make sure it is allowed to continue before the process terminates. Otherwise, the app will stay in the paused state on the device even after Flutter exits.

Fixes #242 

It is still possible to leave the app wedged. Clicking the Stop button while the flutter daemon is syncing files to the device, for instance, will not stop the app. Not sure if we can detect that case, but for now, patience is suggested: let the app get started before stopping it.

@pq @devoncarew 