### PR TITLE
group dart and flutter wizards

### DIFF
--- a/src/io/flutter/module/FlutterModuleBuilder.java
+++ b/src/io/flutter/module/FlutterModuleBuilder.java
@@ -30,6 +30,8 @@ public class FlutterModuleBuilder extends ModuleBuilder {
 
   private static final Logger LOG = Logger.getInstance(FlutterModuleBuilder.class);
 
+  private static final String DART_GROUP_NAME = "Static Web";
+
   @Override
   public String getName() {
     return getPresentableName();
@@ -72,11 +74,9 @@ public class FlutterModuleBuilder extends ModuleBuilder {
     return step;
   }
 
-  @SuppressWarnings("EmptyMethod")
   @Override
   public String getParentGroup() {
-    //TODO(pq): find an appropriate parent group
-    return super.getParentGroup();
+    return DART_GROUP_NAME;
   }
 
   @Override


### PR DESCRIPTION
- group the dart and flutter wizards in the new project dialog

<img width="159" alt="screen shot 2016-10-08 at 6 07 10 am" src="https://cloud.githubusercontent.com/assets/1269969/19213308/a8162368-8d1d-11e6-888c-9b0feb259114.png">

I'm of two minds about this; I like the Dart and Flutter wizards being grouped, but in a more web based intelliJ product, this would but the Flutter wizard in with the web focused wizards. @pq @stevemessick 