### PR TITLE
remove the dart nature for smaller build artifacts

### DIFF
--- a/flutter-intellij.iml
+++ b/flutter-intellij.iml
@@ -10,10 +10,7 @@
       <sourceFolder url="file://$MODULE_DIR$/gen" isTestSource="false" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/third_party/intellij-plugins-dart/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/third_party/intellij-plugins-dart/testSrc" isTestSource="true" />
-      <excludeFolder url="file://$MODULE_DIR$/.pub" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
-      <excludeFolder url="file://$MODULE_DIR$/packages" />
-      <excludeFolder url="file://$MODULE_DIR$/tool/packages" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
@@ -31,7 +28,5 @@
         <SOURCES />
       </library>
     </orderEntry>
-    <orderEntry type="library" name="Dart SDK" level="application" />
-    <orderEntry type="library" name="Dart Packages" level="project" />
   </component>
 </module>


### PR DESCRIPTION
- remove the dart nature for smaller build artifacts
- fix https://github.com/flutter/flutter-intellij/issues/254

We're back down to around 205k for the `flutter-intellij.jar` file; @pq.