### PR TITLE
Watch for SDK config changes and trigger daemon starts/stops (#178).

### DIFF
--- a/src/io/flutter/run/daemon/FlutterAppManager.java
+++ b/src/io/flutter/run/daemon/FlutterAppManager.java
@@ -154,7 +154,9 @@ public class FlutterAppManager {
       pollster.forkProcess(project);
     }
     catch (ExecutionException e) {
-      myLogger.error(e);
+      // User notification comes in the way of editor toasts.
+      // See: IncompatibleDartPluginNotification.
+      myLogger.warn(e);
     }
   }
 

--- a/src/io/flutter/run/daemon/FlutterDaemonController.java
+++ b/src/io/flutter/run/daemon/FlutterDaemonController.java
@@ -121,7 +121,9 @@ public class FlutterDaemonController extends ProcessAdapter {
       myHandler.startNotify();
     }
     catch (ExecutionException ex) {
-      LOG.error(ex);
+      // User notification comes in the way of editor toasts.
+      // See: IncompatibleDartPluginNotification.
+      LOG.warn(ex);
     }
   }
 

--- a/src/io/flutter/sdk/FlutterSdk.java
+++ b/src/io/flutter/sdk/FlutterSdk.java
@@ -102,7 +102,6 @@ public class FlutterSdk {
 
   @Nullable
   public static FlutterSdk getGlobalFlutterSdk() {
-    //TODO(pq): update to use proper SDK and migrate from app lib.
     return findFlutterSdkAmongGlobalLibs(ApplicationLibraryTable.getApplicationTable().getLibraries());
   }
 
@@ -146,7 +145,7 @@ public class FlutterSdk {
   static FlutterSdk forPath(String path) {
     return FlutterSdkUtil.isFlutterSdkHome(path) ? new FlutterSdk(path) : null;
   }
-
+  
   public void run(@NotNull Command cmd,
                   @Nullable Module module,
                   @Nullable VirtualFile workingDir,

--- a/src/io/flutter/sdk/FlutterSdkManager.java
+++ b/src/io/flutter/sdk/FlutterSdkManager.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2016 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.sdk;
+
+
+import com.intellij.openapi.roots.impl.libraries.ApplicationLibraryTable;
+import com.intellij.openapi.roots.libraries.Library;
+import com.intellij.openapi.roots.libraries.LibraryTable;
+import com.intellij.util.EventDispatcher;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.EventListener;
+
+/**
+ * Monitors the application library table to notify clients when Flutter SDK configuration changes.
+ */
+public class FlutterSdkManager {
+
+  private static FlutterSdkManager INSTANCE;
+  private final EventDispatcher<Listener> myDispatcher = EventDispatcher.create(Listener.class);
+  private final LibraryTableListener myLibraryTableListener = new LibraryTableListener();
+  private boolean isFlutterConfigured;
+
+  private FlutterSdkManager() {
+    listenForSdkChanges();
+    // Cache initial state.
+    isFlutterConfigured = isGlobalFlutterSdkSet();
+  }
+
+  public static FlutterSdkManager getInstance() {
+    if (INSTANCE == null) {
+      INSTANCE = new FlutterSdkManager();
+    }
+    return INSTANCE;
+  }
+
+  private void listenForSdkChanges() {
+    ApplicationLibraryTable.getApplicationTable().addListener(myLibraryTableListener);
+  }
+
+  public void addListener(@NotNull Listener listener) {
+    myDispatcher.addListener(listener);
+  }
+
+  public void removeListener(@NotNull Listener listener) {
+    myDispatcher.removeListener(listener);
+  }
+
+  private static boolean isGlobalFlutterSdkSet() {
+    return FlutterSdk.getGlobalFlutterSdk() != null;
+  }
+
+  /**
+   * Listen for SDK configuration changes.
+   */
+  public interface Listener extends EventListener {
+
+    /**
+     * Fired when the Flutter global library is set.
+     */
+    void flutterSdkAdded();
+
+    /**
+     * Fired when the Flutter global library is removed.
+     */
+    void flutterSdkRemoved();
+  }
+
+  // Listens for changes in Flutter Library configuration state in the Library table.
+  private final class LibraryTableListener implements LibraryTable.Listener {
+
+    @Override
+    public void afterLibraryAdded(Library newLibrary) {
+      if (!isFlutterConfigured && isGlobalFlutterSdkSet()) {
+          isFlutterConfigured = true;
+          myDispatcher.getMulticaster().flutterSdkAdded();
+      }
+    }
+
+    @Override
+    public void afterLibraryRenamed(Library library) {
+      // Since we key off name, test to be safe.
+      checkForFlutterSdkRemoval();
+    }
+
+    private void checkForFlutterSdkRemoval() {
+      if (isFlutterConfigured && !isGlobalFlutterSdkSet()) {
+          isFlutterConfigured = false;
+          myDispatcher.getMulticaster().flutterSdkRemoved();
+      }
+    }
+
+    @Override
+    public void beforeLibraryRemoved(Library library) {
+      // Test after.
+    }
+
+    @Override
+    public void afterLibraryRemoved(Library library) {
+      checkForFlutterSdkRemoval();
+    }
+
+  }
+}


### PR DESCRIPTION
Makes the device daemon more “self-healing”.

With this, the “Clean Install” user story becomes:

1. Install Flutter plugin
2. Restart IDE
3. Create Flutter project (setting SDK in the process)
4. Profit

:)

No more extra restart and fatal exceptions.

Fixes: https://github.com/flutter/flutter-intellij/issues/178