### PR TITLE
update plugin metadata

### DIFF
--- a/flutter-intellij.iml
+++ b/flutter-intellij.iml
@@ -11,6 +11,8 @@
       <sourceFolder url="file://$MODULE_DIR$/third_party/intellij-plugins-dart/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/third_party/intellij-plugins-dart/testSrc" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
+      <excludeFolder url="file://$MODULE_DIR$/packages" />
+      <excludeFolder url="file://$MODULE_DIR$/tool/packages" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ javaVersion = 1.6
 # To test against a different IDEA product.
 #intellij.alternativeIdePath =
 
-version = 0.0.7
+version = 0.1.0
 
 buildNumber = SNAPSHOT
 

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -1,22 +1,21 @@
 <idea-plugin version="2">
   <id>io.flutter</id>
   <name>Flutter</name>
-  <description>Support for developing Flutter (flutter.io) applications.</description>
+  <description>Support for developing Flutter applications. Flutter gives developers an easy and productive way to build and deploy cross-platform, high-performance mobile apps on both Android and iOS.</description>
+  <vendor url="https://github.com/flutter/flutter-intellij">flutter.io</vendor>
 
-  <version>0.0.7</version>
-  <vendor>flutter.io</vendor>
-  <vendor url="https://github.com/flutter/flutter-intellij"/>
   <category>Custom Languages</category>
 
-<!-- change-notes>
+  <version>0.1.0</version>
+
+<change-notes>
 <![CDATA[
-
+0.1.0:
 <ul>
-  <li>Improvements and bug fixes</li>
+  <li>initial alpha release</li>
 </ul>
-
  ]]>
- </change-notes -->
+ </change-notes>
 
   <depends>Dart</depends>
 


### PR DESCRIPTION
- fix an issue w/ the `<vendor>` field in the plugin.xml meta-data (we had two entries for vendor)
- make the description more verbose
- uncomment the change-log entry; add some initial notes
- rev to `0.1.0`; @pq, @stevemessick, thoughts?

The entry now looks something like this (modulo the exact change log notes):

<img width="442" alt="screen shot 2016-10-11 at 6 00 07 pm" src="https://cloud.githubusercontent.com/assets/1269969/19294698/cfc26f8e-8fe3-11e6-9314-a81f980ae2f3.png">
