### PR TITLE
Use baseUri to prevent invalid uri errors

### DIFF
--- a/third_party/intellij-plugins-dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcessZ.java
+++ b/third_party/intellij-plugins-dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcessZ.java
@@ -538,9 +538,11 @@ public class DartVmServiceDebugProcessZ extends DartVmServiceDebugProcess {
       String uri = scriptRef.getUri();
 
       if (myDASExecutionContextId != null && !isDartPatchUri(uri)) {
-        final String path = DartAnalysisServerService.getInstance().execution_mapUri(myDASExecutionContextId, null, uri);
-        if (path != null) {
-          return LocalFileSystem.getInstance().findFileByPath(path);
+        if (myRemoteProjectRootUri == null || !uri.contains(myRemoteProjectRootUri)) {
+          String path = DartAnalysisServerService.getInstance().execution_mapUri(myDASExecutionContextId, null, uri);
+          if (path != null) {
+            return LocalFileSystem.getInstance().findFileByPath(path);
+          }
         }
       }
 


### PR DESCRIPTION
@pq @devoncarew I have not seen any docs saying this is the right thing to do, but it works for the cases that were causing problems. We should not try to use DAS to map URIs that are produced by a running Flutter app. This also keeps the Sync button (aka Scroll from Source) working.

The Flutter URIs look similar to:
`.../Library/Developer/CoreSimulator/Devices/E27B10B8-0E7D-4522-AD48-71DF05F0C237/data/Containers/Data/Application/543CCD6E-3543-45D1-9A4E-C8E83E9D2A79/tmp/myappxlOknB/lib/main.dart`

but the significant part is the `lib/main.dart`, which is relative to the project root.