### PR TITLE
Track and check minimum supported Flutter SDK (#194).

### DIFF
--- a/resources/META-INF/idea-contribs.xml
+++ b/resources/META-INF/idea-contribs.xml
@@ -3,7 +3,7 @@
   <extensions defaultExtensionNs="com.intellij">
     <projectService serviceInterface="io.flutter.sdk.FlutterSdkService" serviceImplementation="io.flutter.sdk.FlutterIdeaSdkService"
                     overrides="true"/>
-    <editorNotificationProvider implementation="io.flutter.inspections.WrongDartSdkConfigurationNotificationProvider"/>
+    <editorNotificationProvider implementation="io.flutter.inspections.SdkConfigurationNotificationProvider"/>
     <editorNotificationProvider implementation="io.flutter.inspections.IncompatibleDartPluginNotificationProvider"/>
   </extensions>
 </idea-plugin>

--- a/src/io/flutter/FlutterBundle.properties
+++ b/src/io/flutter/FlutterBundle.properties
@@ -20,6 +20,7 @@ error.sdk.not.found.in.specified.location=Error: Flutter SDK is not found in the
 
 flutter.command.exception=Flutter Command Exception: {0}
 flutter.module.name=Flutter
+flutter.old.sdk.warning=The current configured Flutter SDK is not known to be fully supported.  Please update your SDK and restart IntelliJ.
 flutter.project.description=Flutter modules are used to build high-performance, high-fidelity, mobile apps for iOS and Android using the Flutter framework.
 flutter.sdk.browse.path.label=Select Flutter SDK Path
 flutter.sdk.is.not.configured=The Flutter SDK is not configured

--- a/src/io/flutter/inspections/SdkConfigurationNotificationProvider.java
+++ b/src/io/flutter/inspections/SdkConfigurationNotificationProvider.java
@@ -27,19 +27,24 @@ import io.flutter.FlutterBundle;
 import io.flutter.module.FlutterModuleType;
 import io.flutter.sdk.FlutterSdk;
 import io.flutter.sdk.FlutterSdkService;
+import io.flutter.sdk.FlutterSdkVersion;
 import io.flutter.settings.FlutterSettings;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public class WrongDartSdkConfigurationNotificationProvider extends EditorNotifications.Provider<EditorNotificationPanel>
+public class SdkConfigurationNotificationProvider extends EditorNotifications.Provider<EditorNotificationPanel>
   implements DumbAware {
+
+  // Minimum SDK known to support hot reload.
+  private static final FlutterSdkVersion MIN_SUPPORTED_SDK = FlutterSdkVersion.forVersionString("0.0.2");
+
   private static final Key<EditorNotificationPanel> KEY = Key.create("FlutterWrongDartSdkNotification");
 
-  private static final Logger LOG = Logger.getInstance(WrongDartSdkConfigurationNotificationProvider.class);
+  private static final Logger LOG = Logger.getInstance(SdkConfigurationNotificationProvider.class);
 
   private final Project project;
 
-  public WrongDartSdkConfigurationNotificationProvider(@NotNull Project project) {
+  public SdkConfigurationNotificationProvider(@NotNull Project project) {
     this.project = project;
   }
 
@@ -88,6 +93,10 @@ public class WrongDartSdkConfigurationNotificationProvider extends EditorNotific
         return createNoFlutterSdkPanel();
       }
 
+      if (flutterSdk.getVersion().isLessThan(MIN_SUPPORTED_SDK)) {
+        return createOutOfDateFlutterSdkPanel();
+      }
+
       DartSdk dartSdk = DartSdk.getDartSdk(project);
       if (dartSdk == null) {
         // TODO(devoncarew): Recommend to set up with Flutter's dart sdk.
@@ -106,6 +115,21 @@ public class WrongDartSdkConfigurationNotificationProvider extends EditorNotific
     }
 
     return null;
+  }
+
+  private EditorNotificationPanel createOutOfDateFlutterSdkPanel() {
+
+    final FlutterSettings settings = FlutterSettings.getInstance(project);
+    if (settings == null || settings.ignoreOutOfDateSdks()) return null;
+
+    EditorNotificationPanel panel = new EditorNotificationPanel();
+    panel.setText(FlutterBundle.message("flutter.old.sdk.warning"));
+    panel.createActionLabel("Dismiss", () -> {
+      settings.setIgnoreOutOfDateSdks(true);
+      panel.setVisible(false);
+    });
+
+    return panel;
   }
 
   private static EditorNotificationPanel createNoFlutterSdkPanel() {

--- a/src/io/flutter/inspections/SdkConfigurationNotificationProvider.java
+++ b/src/io/flutter/inspections/SdkConfigurationNotificationProvider.java
@@ -53,7 +53,7 @@ public class SdkConfigurationNotificationProvider extends EditorNotifications.Pr
     if (module == null) return null;
 
     final FlutterSettings settings = FlutterSettings.getInstance(project);
-    if (settings == null || settings.ignoreMismatchedDartSdks()) return null;
+    if (settings == null || settings.shouldIgnoreMismatchedDartSdks()) return null;
 
     EditorNotificationPanel panel = new EditorNotificationPanel();
     panel.setText(FlutterBundle.message("flutter.wrong.dart.sdk.warning"));
@@ -120,7 +120,7 @@ public class SdkConfigurationNotificationProvider extends EditorNotifications.Pr
   private EditorNotificationPanel createOutOfDateFlutterSdkPanel() {
 
     final FlutterSettings settings = FlutterSettings.getInstance(project);
-    if (settings == null || settings.ignoreOutOfDateSdks()) return null;
+    if (settings == null || settings.shouldIgnoreOutOfDateSdks()) return null;
 
     EditorNotificationPanel panel = new EditorNotificationPanel();
     panel.setText(FlutterBundle.message("flutter.old.sdk.warning"));

--- a/src/io/flutter/sdk/FlutterSdk.java
+++ b/src/io/flutter/sdk/FlutterSdk.java
@@ -28,7 +28,6 @@ import com.intellij.openapi.roots.OrderRootType;
 import com.intellij.openapi.roots.impl.libraries.ApplicationLibraryTable;
 import com.intellij.openapi.roots.libraries.Library;
 import com.intellij.openapi.util.Key;
-import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.util.CachedValue;
@@ -57,17 +56,16 @@ public class FlutterSdk {
   public static final String GROUP_DISPLAY_ID = "Flutter Command Invocation";
   private static final Logger LOG = Logger.getInstance(FlutterSdk.class);
   private static final AtomicBoolean inProgress = new AtomicBoolean(false);
-  private static final String UNKNOWN_VERSION = "unknown";
   private static final Key<CachedValue<FlutterSdk>> CACHED_FLUTTER_SDK_KEY = Key.create("CACHED_FLUTTER_SDK_KEY");
   private final @NotNull String myHomePath;
-  private final @NotNull String myVersion;
+  private final @NotNull FlutterSdkVersion myVersion;
 
   private FlutterSdk(@NotNull final String homePath, @Nullable final String version) {
     myHomePath = homePath;
-    myVersion = version != null ? version : UNKNOWN_VERSION;
+    myVersion = FlutterSdkVersion.forVersionString(version);
   }
 
-  private FlutterSdk(String homePath) {
+  private FlutterSdk(@NotNull final String homePath) {
     this(homePath, FlutterSdkUtil.getSdkVersion(homePath));
   }
 
@@ -123,7 +121,7 @@ public class FlutterSdk {
       final VirtualFile flutterSdkRoot = findFlutterSdkRoot(roots[0]);
       if (flutterSdkRoot != null) {
         final String homePath = flutterSdkRoot.getPath();
-        final String version = StringUtil.notNullize(FlutterSdkUtil.getSdkVersion(homePath), UNKNOWN_VERSION);
+        final String version = FlutterSdkUtil.getSdkVersion(homePath);
         return new FlutterSdk(homePath, version);
       }
     }
@@ -204,7 +202,7 @@ public class FlutterSdk {
    * rather only for sanity-checking the presence of baseline features (e.g, hot-reload).
    */
   @NotNull
-  public String getVersion() {
+  public FlutterSdkVersion getVersion() {
     return myVersion;
   }
 

--- a/src/io/flutter/sdk/FlutterSdkVersion.java
+++ b/src/io/flutter/sdk/FlutterSdkVersion.java
@@ -6,25 +6,36 @@
 package io.flutter.sdk;
 
 
+import com.intellij.openapi.util.Version;
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public class FlutterSdkVersion {
+public class FlutterSdkVersion implements Comparable<FlutterSdkVersion> {
 
-  @NonNls public static final FlutterSdkVersion UNKNOWN = new FlutterSdkVersion("<unknown>");
-  private final String versionString;
+  @NonNls private static final FlutterSdkVersion UNKNOWN = new FlutterSdkVersion("0.0.0");
 
-  FlutterSdkVersion(String versionString) {
-    this.versionString = versionString;
+  private final Version myVersion;
+
+  private FlutterSdkVersion(@NotNull String versionString) {
+    myVersion = Version.parseVersion(versionString);
   }
 
   public static FlutterSdkVersion forVersionString(@Nullable String versionString) {
     return versionString == null ? UNKNOWN : new FlutterSdkVersion(versionString);
   }
 
-  @NotNull
-  public String getPresentableName() {
-    return versionString;
+  public boolean isLessThan(FlutterSdkVersion other) {
+    return compareTo(other) < 0;
+  }
+
+  @Override
+  public String toString() {
+    return myVersion.toCompactString();
+  }
+
+  @Override
+  public int compareTo(@NotNull FlutterSdkVersion other) {
+    return myVersion.compareTo(other.myVersion);
   }
 }

--- a/src/io/flutter/settings/FlutterSettings.java
+++ b/src/io/flutter/settings/FlutterSettings.java
@@ -25,6 +25,7 @@ import org.jetbrains.annotations.Nullable;
 public class FlutterSettings implements PersistentStateComponent<FlutterSettings> {
 
   private boolean ignoreMismatchedDartSdks;
+  private boolean ignoreOutOfDateSdks;
 
   @Nullable
   public static FlutterSettings getInstance(Project project) {
@@ -48,5 +49,13 @@ public class FlutterSettings implements PersistentStateComponent<FlutterSettings
 
   public void setIgnoreMismatchedDartSdks(boolean ignoreMismatchedDartSdks) {
     this.ignoreMismatchedDartSdks = ignoreMismatchedDartSdks;
+  }
+
+  public void setIgnoreOutOfDateSdks(boolean ignoreOutOfDateSdks) {
+    this.ignoreOutOfDateSdks = ignoreOutOfDateSdks;
+  }
+
+  public boolean ignoreOutOfDateSdks() {
+    return ignoreOutOfDateSdks;
   }
 }

--- a/src/io/flutter/settings/FlutterSettings.java
+++ b/src/io/flutter/settings/FlutterSettings.java
@@ -43,7 +43,7 @@ public class FlutterSettings implements PersistentStateComponent<FlutterSettings
     XmlSerializerUtil.copyBean(settings, this);
   }
 
-  public boolean ignoreMismatchedDartSdks() {
+  public boolean shouldIgnoreMismatchedDartSdks() {
     return ignoreMismatchedDartSdks;
   }
 
@@ -55,7 +55,7 @@ public class FlutterSettings implements PersistentStateComponent<FlutterSettings
     this.ignoreOutOfDateSdks = ignoreOutOfDateSdks;
   }
 
-  public boolean ignoreOutOfDateSdks() {
+  public boolean shouldIgnoreOutOfDateSdks() {
     return ignoreOutOfDateSdks;
   }
 }


### PR DESCRIPTION
Adds an editor notification that pops up when Flutter is less than `0.0.2`, the earliest tagged reload-friendly SDK. (See: #293.)

Fixes #194 

/cc @stevemessick @devoncarew 