### PR TITLE
Checkpoint multi-debugging

### DIFF
--- a/src/io/flutter/run/daemon/DaemonProcessWrapper.java
+++ b/src/io/flutter/run/daemon/DaemonProcessWrapper.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2016 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.run.daemon;
+
+import com.intellij.execution.process.ProcessHandler;
+import com.intellij.execution.process.ProcessListener;
+import com.intellij.openapi.util.Key;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.OutputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+public class DaemonProcessWrapper extends ProcessHandler {
+  private ProcessHandler myHandler;
+
+  DaemonProcessWrapper(ProcessHandler handler) {
+    super();
+    myHandler = handler;
+  }
+
+  public void startNotify() {
+    myHandler.startNotify();
+  }
+
+  @Override
+  public void destroyProcessImpl() {
+    reflectivelyInvoke("destroyProcessImpl");
+  }
+
+  @Override
+  public void detachProcessImpl() {
+    reflectivelyInvoke("detachProcessImpl");
+  }
+
+  @Override
+  public boolean detachIsDefault() {
+    return myHandler.detachIsDefault();
+  }
+
+  public boolean waitFor() {
+    return myHandler.waitFor();
+  }
+
+  public boolean waitFor(long timeoutInMilliseconds) {
+    return myHandler.waitFor(timeoutInMilliseconds);
+  }
+
+  public void destroyProcess() {
+    myHandler.destroyProcess();
+  }
+
+  public void detachProcess() {
+    myHandler.detachProcess();
+  }
+
+  public boolean isProcessTerminated() {
+    return myHandler.isProcessTerminated();
+  }
+
+  public boolean isProcessTerminating() {
+    return myHandler.isProcessTerminating();
+  }
+
+  public Integer getExitCode() {
+    return myHandler.getExitCode();
+  }
+
+  public void addProcessListener(final ProcessListener listener) {
+    myHandler.addProcessListener(listener);
+  }
+
+  public void removeProcessListener(final ProcessListener listener) {
+    myHandler.removeProcessListener(listener);
+  }
+
+  public void notifyProcessDetached() {
+    reflectivelyInvoke("notifyProcessDetached");
+  }
+
+  public void notifyProcessTerminated(final int exitCode) {
+    reflectivelyInvoke("notifyProcessTerminated");
+  }
+
+  public void notifyTextAvailable(final String text, final Key outputType) {
+    myHandler.notifyTextAvailable(text, outputType);
+  }
+
+  @Nullable
+  @Override
+  public OutputStream getProcessInput() {
+    return myHandler.getProcessInput();
+  }
+
+  public boolean isStartNotified() {
+    return myHandler.isStartNotified();
+  }
+
+  public boolean isSilentlyDestroyOnClose() {
+    return myHandler.isSilentlyDestroyOnClose();
+  }
+
+  private void reflectivelyInvoke(String methodName) {
+    try {
+      Method method = myHandler.getClass().getDeclaredMethod(methodName);
+      method.setAccessible(true);
+      method.invoke(myHandler);
+    }
+    catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException ex) {
+      // ignore
+    }
+  }
+}

--- a/src/io/flutter/run/daemon/FlutterDaemonController.java
+++ b/src/io/flutter/run/daemon/FlutterDaemonController.java
@@ -7,10 +7,7 @@ package io.flutter.run.daemon;
 
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configurations.GeneralCommandLine;
-import com.intellij.execution.process.OSProcessHandler;
-import com.intellij.execution.process.ProcessAdapter;
-import com.intellij.execution.process.ProcessEvent;
-import com.intellij.execution.process.ProcessHandler;
+import com.intellij.execution.process.*;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Key;
@@ -21,6 +18,7 @@ import io.flutter.FlutterBundle;
 import io.flutter.sdk.FlutterSdk;
 import io.flutter.sdk.FlutterSdkUtil;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.OutputStream;
 import java.io.PrintStream;
@@ -116,7 +114,7 @@ public class FlutterDaemonController extends ProcessAdapter {
   public void forkProcess(Project project) throws ExecutionException {
     try {
       GeneralCommandLine commandLine = createCommandLine(project);
-      myHandler = new OSProcessHandler(commandLine);
+      myHandler = new DaemonProcessWrapper(new OSProcessHandler(commandLine));
       myHandler.addProcessListener(this);
       myHandler.startNotify();
     }

--- a/src/io/flutter/run/daemon/FlutterDaemonService.java
+++ b/src/io/flutter/run/daemon/FlutterDaemonService.java
@@ -219,6 +219,7 @@ public class FlutterDaemonService {
         }
       }
       FlutterDaemonController newController = new FlutterDaemonController(projectDir);
+      newController.setProjectAndDevice(projectDir, deviceId);
       myControllers.add(newController);
       newController.addListener(myListener);
       return newController;
@@ -226,8 +227,10 @@ public class FlutterDaemonService {
   }
 
   void schedulePolling() {
-    if (myPollster != null && myPollster.getProcessHandler() != null && !myPollster.getProcessHandler().isProcessTerminating()) {
-      return;
+    synchronized (myLock) {
+      if (myPollster != null && myPollster.getProcessHandler() != null && !myPollster.getProcessHandler().isProcessTerminating()) {
+        return;
+      }
     }
     ApplicationManager.getApplication().executeOnPooledThread(() -> {
       synchronized (myLock) {


### PR DESCRIPTION
@pq @devoncarew Checkpoint. I'm probably not going to commit this as-is. But if you get a chance to take a look I'd like to know if you think the approach makes sense.

The new class, `DaemonProcessWrapper`, is a bit of trickery. It is a wrapper around the OSProcessHandler that controls the daemon process. All it does is change object identity so that the debugger connects to the correct process. The reflective bits are due to `ProcessHandler` code that cannot be simply redirected. I'll add a class comment to that effect before the final commit.