### PR TITLE
Notification to detect Flutter projects w/o Flutter Module Types (#341).

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,6 +1,18 @@
 <component name="InspectionProjectProfileManager">
   <profile version="1.0">
     <option name="myName" value="Project Default" />
+    <inspection_tool class="HardCodedStringLiteral" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="ignoreForAssertStatements" value="true" />
+      <option name="ignoreForExceptionConstructors" value="true" />
+      <option name="ignoreForSpecifiedExceptionConstructors" value="" />
+      <option name="ignoreForJUnitAsserts" value="true" />
+      <option name="ignoreForClassReferences" value="true" />
+      <option name="ignoreForPropertyKeyReferences" value="true" />
+      <option name="ignoreForNonAlpha" value="true" />
+      <option name="ignoreAssignedToConstants" value="false" />
+      <option name="ignoreToString" value="false" />
+      <option name="nonNlsCommentPattern" value="NON-NLS" />
+    </inspection_tool>
     <inspection_tool class="LoggerInitializedWithForeignClass" enabled="false" level="WARNING" enabled_by_default="false">
       <option name="loggerClassName" value="org.apache.log4j.Logger,org.slf4j.LoggerFactory,org.apache.commons.logging.LogFactory,java.util.logging.Logger" />
       <option name="loggerFactoryMethodName" value="getLogger,getLogger,getLog,getLogger" />

--- a/resources/META-INF/idea-contribs.xml
+++ b/resources/META-INF/idea-contribs.xml
@@ -3,7 +3,8 @@
   <extensions defaultExtensionNs="com.intellij">
     <projectService serviceInterface="io.flutter.sdk.FlutterSdkService" serviceImplementation="io.flutter.sdk.FlutterIdeaSdkService"
                     overrides="true"/>
-    <editorNotificationProvider implementation="io.flutter.inspections.SdkConfigurationNotificationProvider"/>
     <editorNotificationProvider implementation="io.flutter.inspections.IncompatibleDartPluginNotificationProvider"/>
+    <editorNotificationProvider implementation="io.flutter.inspections.SdkConfigurationNotificationProvider"/>
+    <editorNotificationProvider implementation="io.flutter.inspections.WrongModuleTypeNotificationProvider"/>
   </extensions>
 </idea-plugin>

--- a/src/io/flutter/FlutterBundle.properties
+++ b/src/io/flutter/FlutterBundle.properties
@@ -7,10 +7,13 @@ app.restart.action.description=Restart the Flutter app
 app.reload.action.text=Hot Reload
 app.reload.action.description=Hot reload changes into the running Flutter app
 
+change.module.type.to.flutter.and.reload.project=Change module type to Flutter and reload project
 config.progargs.caption=Program Arguments
 
+dart.plugin.update.action.label=Update Dart
 dart.sdk.configuration.action.label=Configure Dart SDK
 dart.sdk.is.not.configured=Dart SDK is not configured
+don.t.show.again.for.this.module=Don't show again for this module
 
 debugger.trying.to.connect.vm.at.0=Connecting to Dart VM at {0}
 
@@ -19,6 +22,7 @@ error.path.to.sdk.not.specified=Error: path to the Flutter SDK is not specified.
 error.sdk.not.found.in.specified.location=Error: Flutter SDK is not found in the specified location.
 
 flutter.command.exception=Flutter Command Exception: {0}
+flutter.incompatible.dart.plugin.warning=Flutter requires a Dart plugin with a minimum version of {0} (currently installed: {1}).
 flutter.module.name=Flutter
 flutter.old.sdk.warning=The current configured Flutter SDK is not known to be fully supported.  Please update your SDK and restart IntelliJ.
 flutter.project.description=Flutter modules are used to build high-performance, high-fidelity, mobile apps for iOS and Android using the Flutter framework.
@@ -30,15 +34,18 @@ flutter.wrong.dart.sdk.warning=The Dart SDK for this module is not the same as F
 
 no.flutter.app.title=No Flutter app
 no.flutter.app.description=No Flutter application currently running.
-
 no.project.dir=Project directory not given
 no.socket.for.debugging=The debugger cannot find an available socket for the Observatory connection
+not.flutter.bundle="{0}" is not a Flutter module, device debugging is not fully supported.
 
 open.observatory.action.text=Open Observatory
 open.observatory.action.description=Open Observatory: a Profiler for Dart apps
 
+reload.project=Reload project
 runner.flutter.configuration.description=Flutter run configuration
 runner.flutter.configuration.name=Flutter
-flutter.incompatible.dart.plugin.warning=Flutter requires a Dart plugin with a minimum version of {0} (currently installed: {1}).
-dart.plugin.update.action.label=Update Dart
+
+update.module.type=Update Module Type
+updating.module.type.requires.project.reload.proceed=Updating module type requires project reload. Proceed?
+
 waiting.for.flutter=Waiting for debug connection...

--- a/src/io/flutter/inspections/WrongModuleTypeNotificationProvider.java
+++ b/src/io/flutter/inspections/WrongModuleTypeNotificationProvider.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2016 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.inspections;
+
+
+import com.intellij.ide.util.PropertiesComponent;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.fileEditor.FileEditor;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleUtilCore;
+import com.intellij.openapi.project.DumbAware;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectManager;
+import com.intellij.openapi.ui.Messages;
+import com.intellij.openapi.util.Key;
+import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.ui.EditorNotificationPanel;
+import com.intellij.ui.EditorNotifications;
+import com.intellij.util.containers.ContainerUtil;
+import com.jetbrains.lang.dart.DartFileType;
+import com.jetbrains.lang.dart.util.PubspecYamlUtil;
+import io.flutter.module.FlutterModuleType;
+import io.flutter.sdk.FlutterSdkGlobalLibUtil;
+import io.flutter.sdk.FlutterSdkUtil;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Set;
+
+
+public class WrongModuleTypeNotificationProvider extends EditorNotifications.Provider<EditorNotificationPanel> implements DumbAware {
+  private static final Key<EditorNotificationPanel> KEY = Key.create("Wrong module type");
+  private static final String DONT_ASK_TO_CHANGE_MODULE_TYPE_KEY = "do.not.ask.to.change.module.type";
+  private static final String FLUTTER_YAML_FILE = "flutter.yaml";
+
+  private final Project myProject;
+
+  public WrongModuleTypeNotificationProvider(@NotNull Project project) {
+    myProject = project;
+  }
+
+  private static boolean hasFlutterYaml(Module module) {
+    VirtualFile baseDir = module.getProject().getBaseDir();
+    if (baseDir != null) {
+      VirtualFile flutterYaml = baseDir.findFileByRelativePath(FLUTTER_YAML_FILE);
+      return flutterYaml != null && flutterYaml.exists();
+    }
+    return false;
+  }
+
+  @NotNull
+  private static EditorNotificationPanel createPanel(@NotNull Project project, @NotNull Module module) {
+    EditorNotificationPanel panel = new EditorNotificationPanel();
+    panel.setText("'" + module.getName() + "' is not Flutter Module, device debugging is not fully supported.");
+    panel.createActionLabel("Change module type to Flutter and reload project", () -> {
+      int message = Messages.showOkCancelDialog(project, "Updating module type requires project reload. Proceed?", "Update Module Type",
+                                                "Reload project", "Cancel", null);
+      if (message == Messages.YES) {
+        module.setOption(Module.ELEMENT_TYPE, FlutterModuleType.getInstance().getId());
+        ApplicationManager.getApplication().runWriteAction(() -> {
+          FlutterSdkUtil.enableDartSupport(module);
+          FlutterSdkGlobalLibUtil.enableFlutterSdk(module);
+          project.save();
+
+          EditorNotifications.getInstance(project).updateAllNotifications();
+          ProjectManager.getInstance().reloadProject(project);
+        });
+      }
+    });
+    panel.createActionLabel("Don't show again for this module", () -> {
+      Set<String> ignoredModules = getIgnoredModules(project);
+      ignoredModules.add(module.getName());
+      PropertiesComponent.getInstance(project).setValue(DONT_ASK_TO_CHANGE_MODULE_TYPE_KEY, StringUtil.join(ignoredModules, ","));
+      EditorNotifications.getInstance(project).updateAllNotifications();
+    });
+    return panel;
+  }
+
+  @NotNull
+  private static Set<String> getIgnoredModules(@NotNull Project project) {
+    String value = PropertiesComponent.getInstance(project).getValue(DONT_ASK_TO_CHANGE_MODULE_TYPE_KEY, "");
+    return ContainerUtil.newLinkedHashSet(StringUtil.split(value, ","));
+  }
+
+  private static boolean isFlutteryFile(@NotNull VirtualFile file) {
+    String fileName = file.getName();
+    return file.getFileType() == DartFileType.INSTANCE ||
+           fileName.equals(FLUTTER_YAML_FILE) ||
+           fileName.equals(PubspecYamlUtil.PUBSPEC_YAML);
+  }
+
+  @NotNull
+  @Override
+  public Key<EditorNotificationPanel> getKey() {
+    return KEY;
+  }
+
+  @Override
+  public EditorNotificationPanel createNotificationPanel(@NotNull VirtualFile file, @NotNull FileEditor fileEditor) {
+    if (!isFlutteryFile(file)) return null;
+    Module module = ModuleUtilCore.findModuleForFile(file, myProject);
+    if (module == null || FlutterSdkUtil.isFlutterModule(module) || getIgnoredModules(myProject).contains(module.getName())) return null;
+    return hasFlutterYaml(module) ? createPanel(myProject, module) : null;
+  }
+}

--- a/src/io/flutter/inspections/WrongModuleTypeNotificationProvider.java
+++ b/src/io/flutter/inspections/WrongModuleTypeNotificationProvider.java
@@ -6,6 +6,7 @@
 package io.flutter.inspections;
 
 
+import com.intellij.CommonBundle;
 import com.intellij.ide.util.PropertiesComponent;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.fileEditor.FileEditor;
@@ -23,6 +24,7 @@ import com.intellij.ui.EditorNotifications;
 import com.intellij.util.containers.ContainerUtil;
 import com.jetbrains.lang.dart.DartFileType;
 import com.jetbrains.lang.dart.util.PubspecYamlUtil;
+import io.flutter.FlutterBundle;
 import io.flutter.module.FlutterModuleType;
 import io.flutter.sdk.FlutterSdkGlobalLibUtil;
 import io.flutter.sdk.FlutterSdkUtil;
@@ -33,8 +35,8 @@ import java.util.Set;
 
 public class WrongModuleTypeNotificationProvider extends EditorNotifications.Provider<EditorNotificationPanel> implements DumbAware {
   private static final Key<EditorNotificationPanel> KEY = Key.create("Wrong module type");
-  private static final String DONT_ASK_TO_CHANGE_MODULE_TYPE_KEY = "do.not.ask.to.change.module.type";
-  private static final String FLUTTER_YAML_FILE = "flutter.yaml";
+  private static final String DONT_ASK_TO_CHANGE_MODULE_TYPE_KEY = "do.not.ask.to.change.module.type"; //NON-NLS
+  private static final String FLUTTER_YAML_FILE = "flutter.yaml"; //NON-NLS
 
   private final Project myProject;
 
@@ -54,10 +56,11 @@ public class WrongModuleTypeNotificationProvider extends EditorNotifications.Pro
   @NotNull
   private static EditorNotificationPanel createPanel(@NotNull Project project, @NotNull Module module) {
     EditorNotificationPanel panel = new EditorNotificationPanel();
-    panel.setText("'" + module.getName() + "' is not a Flutter Module, device debugging is not fully supported.");
-    panel.createActionLabel("Change module type to Flutter and reload project", () -> {
-      int message = Messages.showOkCancelDialog(project, "Updating module type requires project reload. Proceed?", "Update Module Type",
-                                                "Reload project", "Cancel", null);
+    panel.setText(FlutterBundle.message("not.flutter.bundle", module.getName()));
+    panel.createActionLabel(FlutterBundle.message("change.module.type.to.flutter.and.reload.project"), () -> {
+      int message = Messages.showOkCancelDialog(project, FlutterBundle.message("updating.module.type.requires.project.reload.proceed"),
+                                                FlutterBundle.message("update.module.type"),
+                                                FlutterBundle.message("reload.project"), CommonBundle.getCancelButtonText(), null);
       if (message == Messages.YES) {
         module.setOption(Module.ELEMENT_TYPE, FlutterModuleType.getInstance().getId());
         ApplicationManager.getApplication().runWriteAction(() -> {
@@ -70,7 +73,7 @@ public class WrongModuleTypeNotificationProvider extends EditorNotifications.Pro
         });
       }
     });
-    panel.createActionLabel("Don't show again for this module", () -> {
+    panel.createActionLabel(FlutterBundle.message("don.t.show.again.for.this.module"), () -> {
       Set<String> ignoredModules = getIgnoredModules(project);
       ignoredModules.add(module.getName());
       PropertiesComponent.getInstance(project).setValue(DONT_ASK_TO_CHANGE_MODULE_TYPE_KEY, StringUtil.join(ignoredModules, ","));

--- a/src/io/flutter/inspections/WrongModuleTypeNotificationProvider.java
+++ b/src/io/flutter/inspections/WrongModuleTypeNotificationProvider.java
@@ -54,7 +54,7 @@ public class WrongModuleTypeNotificationProvider extends EditorNotifications.Pro
   @NotNull
   private static EditorNotificationPanel createPanel(@NotNull Project project, @NotNull Module module) {
     EditorNotificationPanel panel = new EditorNotificationPanel();
-    panel.setText("'" + module.getName() + "' is not Flutter Module, device debugging is not fully supported.");
+    panel.setText("'" + module.getName() + "' is not a Flutter Module, device debugging is not fully supported.");
     panel.createActionLabel("Change module type to Flutter and reload project", () -> {
       int message = Messages.showOkCancelDialog(project, "Updating module type requires project reload. Proceed?", "Update Module Type",
                                                 "Reload project", "Cancel", null);


### PR DESCRIPTION
Fixes: #341 

Taking inspiration from the Go plugin, this check tests for the presence of a `flutter.yaml` file and the absence of the Flutter module type and gives users the opportunity to enable Flutter support.

![screen shot 2016-10-20 at 12 44 07 pm](https://cloud.githubusercontent.com/assets/67586/19575642/8bf06bb6-96c4-11e6-85b6-67c79e8db3de.png)

/cc @alexander-doroshko @devoncarew @stevemessick 

