### PR TITLE
`findConnector` cleanup.

### DIFF
--- a/src/io/flutter/actions/FlutterKeyAction.java
+++ b/src/io/flutter/actions/FlutterKeyAction.java
@@ -5,9 +5,9 @@
  */
 package io.flutter.actions;
 
+import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.project.DumbAwareAction;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.project.ProjectManager;
 import com.intellij.xdebugger.XDebugProcess;
 import com.intellij.xdebugger.XDebugSession;
 import com.intellij.xdebugger.XDebuggerManager;
@@ -16,7 +16,7 @@ import com.jetbrains.lang.dart.ide.runner.server.vmService.DartVmServiceDebugPro
 import org.jetbrains.annotations.Nullable;
 
 public abstract class FlutterKeyAction extends DumbAwareAction {
-  public static final String RELOAD_DISPLAY_ID = "Flutter Commands";
+  public static final String RELOAD_DISPLAY_ID = "Flutter Commands"; //NON-NLS
 
   /**
    * Find an active Dart VM debug process and get it's observatory connector.
@@ -25,19 +25,17 @@ public abstract class FlutterKeyAction extends DumbAwareAction {
    */
   static
   @Nullable
-  ObservatoryConnector findConnector() {
-    final Project[] projects = ProjectManager.getInstance().getOpenProjects();
-    for (Project project : projects) {
-      final XDebuggerManager manager = XDebuggerManager.getInstance(project);
-      final XDebugSession session = manager.getCurrentSession();
-      if (session != null) {
-        final XDebugProcess debugProcess = session.getDebugProcess();
-        if (debugProcess instanceof DartVmServiceDebugProcessZ) {
-          return ((DartVmServiceDebugProcessZ)debugProcess).getConnector();
-        }
+  ObservatoryConnector findConnector(AnActionEvent e) {
+    final Project project = getEventProject(e);
+    if (project == null) return null;
+    final XDebuggerManager manager = XDebuggerManager.getInstance(project);
+    final XDebugSession session = manager.getCurrentSession();
+    if (session != null) {
+      final XDebugProcess debugProcess = session.getDebugProcess();
+      if (debugProcess instanceof DartVmServiceDebugProcessZ) {
+        return ((DartVmServiceDebugProcessZ)debugProcess).getConnector();
       }
     }
     return null;
   }
-
 }

--- a/src/io/flutter/actions/HotReloadFlutterAppKeyAction.java
+++ b/src/io/flutter/actions/HotReloadFlutterAppKeyAction.java
@@ -18,7 +18,7 @@ import io.flutter.FlutterBundle;
 public class HotReloadFlutterAppKeyAction extends FlutterKeyAction {
   @Override
   public void actionPerformed(AnActionEvent e) {
-    final ObservatoryConnector connector = findConnector();
+    final ObservatoryConnector connector = findConnector(e);
     if (connector != null) {
       new HotReloadFlutterApp(connector, connector::isConnectionReady).actionPerformed(e);
     }

--- a/src/io/flutter/actions/RestartFlutterAppKeyAction.java
+++ b/src/io/flutter/actions/RestartFlutterAppKeyAction.java
@@ -19,7 +19,7 @@ public class RestartFlutterAppKeyAction extends FlutterKeyAction {
 
   @Override
   public void actionPerformed(AnActionEvent e) {
-    final ObservatoryConnector connector = findConnector();
+    final ObservatoryConnector connector = findConnector(e);
     if (connector != null) {
       new RestartFlutterApp(connector, connector::isConnectionReady).actionPerformed(e);
     }

--- a/src/io/flutter/run/FlutterAppState.java
+++ b/src/io/flutter/run/FlutterAppState.java
@@ -26,8 +26,6 @@ import io.flutter.run.daemon.RunMode;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
@@ -101,7 +99,7 @@ public class FlutterAppState extends DartCommandLineRunningState {
   protected void addObservatoryActions(List<AnAction> actions, final ProcessHandler processHandler) {
     actions.add(new Separator());
     actions.add(new OpenDartObservatoryUrlAction(
-      "http://" + NetUtils.getLocalHostString() + ":" + myApp.port(),
+      "http://" + NetUtils.getLocalHostString() + ":" + myApp.port(), //NON-NLS
       () -> !processHandler.isProcessTerminated()));
   }
 


### PR DESCRIPTION
Use project associated with action when invoking via key events.

Alex pointed this out in a side-band conversation and this is just follow-up.

/cc @stevemessick @alexander-doroshko 