### PR TITLE
Show Flutter SDK version details as a copyable multiline label

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -18,7 +18,6 @@
       <option name="loggerFactoryMethodName" value="getLogger,getLogger,getLog,getLogger" />
     </inspection_tool>
     <inspection_tool class="NoLabelFor" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="NoScrollPane" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="SpellCheckingInspection" enabled="false" level="TYPO" enabled_by_default="false">
       <option name="processCode" value="true" />
       <option name="processLiterals" value="true" />

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.form
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="io.flutter.sdk.FlutterSettingsConfigurable">
-  <grid id="27dc6" binding="mainPanel" layout-manager="GridLayoutManager" row-count="5" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="mainPanel" layout-manager="GridLayoutManager" row-count="4" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="500" height="400"/>
@@ -8,55 +8,17 @@
     <properties/>
     <border type="none"/>
     <children>
-      <grid id="6d822" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
-        <margin top="0" left="0" bottom="0" right="0"/>
-        <constraints>
-          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties/>
-        <border type="none"/>
-        <children>
-          <component id="926fd" class="com.intellij.ui.components.JBLabel">
-            <constraints>
-              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <labelFor value="83a87"/>
-              <text resource-bundle="io/flutter/FlutterBundle" key="flutter.sdk.path.label"/>
-            </properties>
-          </component>
-          <component id="83a87" class="com.intellij.ui.ComboboxWithBrowseButton" binding="sdkCombo" custom-create="true">
-            <constraints>
-              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties/>
-          </component>
-        </children>
-      </grid>
       <component id="f16d5" class="com.intellij.ui.components.JBLabel" binding="errorLabel">
         <constraints>
-          <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="3" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text resource-bundle="io/flutter/FlutterBundle" key="error.path.to.sdk.not.specified"/>
         </properties>
       </component>
-      <component id="5a409" class="javax.swing.JTextArea" binding="versionDetails">
-        <constraints>
-          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="3" indent="0" use-parent-layout="false">
-            <preferred-size width="150" height="150"/>
-          </grid>
-        </constraints>
-        <properties>
-          <alignmentX value="1.0"/>
-          <editable value="false"/>
-          <enabled value="false"/>
-          <margin top="8" left="8" bottom="8" right="8"/>
-        </properties>
-      </component>
       <component id="a59e7" class="javax.swing.JLabel">
         <constraints>
-          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="9" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Version details:"/>
@@ -64,9 +26,32 @@
       </component>
       <vspacer id="b5ec9">
         <constraints>
-          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="2" column="0" row-span="1" col-span="2" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
+      <component id="926fd" class="com.intellij.ui.components.JBLabel">
+        <constraints>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <labelFor value="83a87"/>
+          <text resource-bundle="io/flutter/FlutterBundle" key="flutter.sdk.path.label"/>
+        </properties>
+      </component>
+      <component id="83a87" class="com.intellij.ui.ComboboxWithBrowseButton" binding="sdkCombo" custom-create="true">
+        <constraints>
+          <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+      </component>
+      <component id="6278f" class="com.intellij.ui.components.JBLabel" binding="versionLabel">
+        <constraints>
+          <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="9" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="&lt;html&gt;placeholder for&lt;br/&gt;version details&lt;br/&gt;(this text is not visible at runtime)&lt;/html&gt;"/>
+        </properties>
+      </component>
     </children>
   </grid>
 </form>

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.java
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.java
@@ -19,12 +19,12 @@ import com.intellij.openapi.options.SearchableConfigurable;
 import com.intellij.openapi.ui.ComboBox;
 import com.intellij.openapi.ui.TextComponentAccessor;
 import com.intellij.openapi.util.io.FileUtilRt;
+import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.ui.ColorUtil;
 import com.intellij.ui.ComboboxWithBrowseButton;
 import com.intellij.ui.DocumentAdapter;
 import com.intellij.ui.JBColor;
 import com.intellij.ui.components.JBLabel;
-import com.intellij.util.ui.UIUtil;
 import com.intellij.xml.util.XmlStringUtil;
 import io.flutter.FlutterBundle;
 import org.jetbrains.annotations.Nls;
@@ -46,11 +46,15 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
 
   private JPanel mainPanel;
   private ComboboxWithBrowseButton sdkCombo;
+  private JBLabel versionLabel;
   private JBLabel errorLabel;
-  private JTextArea versionDetails;
 
   FlutterSettingsConfigurable() {
     init();
+
+    versionLabel.setText("");
+    versionLabel.setCopyable(true);
+
     errorLabel.setIcon(AllIcons.Actions.Lightning);
   }
 
@@ -67,8 +71,6 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     sdkCombo.addBrowseFolderListener("Select Flutter SDK Path", null, null,
                                      FileChooserDescriptorFactory.createSingleFolderDescriptor(),
                                      TextComponentAccessor.STRING_COMBOBOX_WHOLE_TEXT);
-
-    versionDetails.setBackground(UIUtil.getPanelBackground());
   }
 
   private void createUIComponents() {
@@ -130,7 +132,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
   private void updateVersionText() {
     final FlutterSdk sdk = FlutterSdk.forPath(getSdkPathText());
     if (sdk == null) {
-      versionDetails.setVisible(false);
+      versionLabel.setText("");
     }
     else {
       try {
@@ -141,8 +143,8 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
             final ProcessOutput output = getOutput();
             final String stdout = output.getStdout();
             ApplicationManager.getApplication().invokeLater(() -> {
-              versionDetails.setText(stdout);
-              versionDetails.setVisible(true);
+              final String htmlText = "<html>" + StringUtil.replace(StringUtil.escapeXml(stdout.trim()), "\n", "<br/>") + "</html>";
+              versionLabel.setText(htmlText);
             }, modalityState);
           }
         });


### PR DESCRIPTION
Now it look like this:
![image](https://cloud.githubusercontent.com/assets/4499789/19607433/8a3f0bb0-97d2-11e6-8846-9fe3e40b0efd.png)

As a bonus the text is copyable now:
![image](https://cloud.githubusercontent.com/assets/4499789/19607453/a5310bbc-97d2-11e6-86a4-44fd34fe7b04.png)

@pq @devoncarew 

P.S. useful inspection is enabled back, now there are no more violators