### PR TITLE
Widen version constraints to play nice with EAP.

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -8,7 +8,7 @@
 
   <version>0.1.3</version>
 
-  <idea-version since-build="162.1" until-build="162.*"/>
+  <idea-version since-build="162.1" until-build="163.*"/>
   
 <change-notes>
 <![CDATA[


### PR DESCRIPTION
Technically we’re overreaching but this is necessary for the plugin to load in the latest 2016.3 EAP.

FYI @stevemessick I think this address your loading issue of earlier today.

/cc @devoncarew 
