### PR TITLE
Bump minimume Dart to `162.2485`.

### DIFF
--- a/src/io/flutter/dart/DartPlugin.java
+++ b/src/io/flutter/dart/DartPlugin.java
@@ -18,7 +18,7 @@ public class DartPlugin {
   /**
    * Tracks the minimum required Dart Plugin version.
    */
-  private static final String MINIMUM_REQUIRED_PLUGIN_VERSION = "162.2233";
+  private static final String MINIMUM_REQUIRED_PLUGIN_VERSION = "162.2485";
   private static final Version MINIMUM_VERSION = Version.parseVersion(MINIMUM_REQUIRED_PLUGIN_VERSION);
 
   private static final DartPlugin INSTANCE = new DartPlugin();


### PR DESCRIPTION
Ensures that we have a Dart plugin where `pub` works as expected.

See: https://github.com/flutter/flutter-intellij/issues/271

/cc @alexander-doroshko @devoncarew @stevemessick 