### PR TITLE
Simplify getting started instructions

### DIFF
--- a/getting_started.md
+++ b/getting_started.md
@@ -1,8 +1,10 @@
 ## Getting Started
 
-### Set up the Flutter SDK
+### Set up the Flutter SDK and IntelliJ
 
 See [flutter.io/setup](https://flutter.io/setup/) for instructions about installing the Flutter SDK, configuring your machine for Flutter development, and installing and configuring the IntelliJ plugins.
+
+If you already have the SDK, skip ahead to the [IntelliJ setup instructions](https://flutter.io/setup/#flutter-intellij-ide-plugins).
 
 ### Supported IDEs
 

--- a/getting_started.md
+++ b/getting_started.md
@@ -2,8 +2,7 @@
 
 ### Set up the Flutter SDK
 
-See [flutter.io/setup](https://flutter.io/setup/) for instructions about installing the Flutter SDK
-and configuring your machine for Flutter development.
+See [flutter.io/setup](https://flutter.io/setup/) for instructions about installing the Flutter SDK, configuring your machine for Flutter development, and installing and configuring the IntelliJ plugins.
 
 ### Supported IDEs
 
@@ -11,35 +10,12 @@ The Flutter plugin can be installed on following IntelliJ-based products:
 
 * IntelliJ 2016.2+ ([Ultimate or Community](https://www.jetbrains.com/idea/download/))
 
-### Install the Dart and Flutter plugins
-
-The Flutter plugin uses functionality from the Dart plugin. To install the Dart plugin:
-
-1. Open plugin preferences (**Preferences>Plugins** on macOS, **File>Settings>Plugins** on Linux)
-1. Select **"Browse repositories…"**
-1. search for `'Dart'`; select the option to install the plugin
-1. search for `'Flutter'`; install (and restart IntelliJ)
-
-### Flutter plugin configuration
-
-1. Open  preferences (**Preferences** on macOS, **File>Settings** on Linux)
-1. Select **Languages & Frameworks>Flutter**
-1. Set the path to the root of your flutter repo
-1. Click OK
-
-### Creating a project
+## Running your first app from IntelliJ
 
 1. Choose **File>New>Project** (or **Create new project** in the welcome dialog)
 2. In the **New Project Wizard**, select Flutter as your project type (in the left column) and click **Next**
 3. Give your project a name (change location if desired) and click **Finish**
-4. Expand the project view, and double-click `main.dart` inside `lib` to see the main program entrypoint
+4. In the main toolbar, make sure a target device is selected (you need a connected physical device, or a running simulator)
+5. click the **Debug** icon to launch the app
 
-### Running an app
-
-Ensure a development device is available and running (a development enabled Android device, or the
-iOS Simulator). In the IntelliJ toolbar, select the launch configuration for the created Flutter 
-project and hit the debug button.
-
-### Additional details
-
-For tips on opening existing projects, debugging, etc. see the [user journeys page](/docs/user_journeys.md).
+![Main IntelliJ toolbar with Flutter actions](http://flutter.io/images/intellij/main-toolbar.png)


### PR DESCRIPTION
Too much duplicated content, we already link to flutter.io/setup, and that now covers the IntelliJ setup piece