### PR TITLE
Start and stop the daemon based on project open and close

### DIFF
--- a/src/io/flutter/run/daemon/FlutterAppManager.java
+++ b/src/io/flutter/run/daemon/FlutterAppManager.java
@@ -145,7 +145,8 @@ public class FlutterAppManager {
           }
         }
       });
-    } catch (ThreadDeath ex) {
+    }
+    catch (ThreadDeath ex) {
       // Can happen if external process is killed, but we don't care.
     }
     return resp[0];
@@ -419,8 +420,9 @@ public class FlutterAppManager {
           // Convert the file: url to a path.
           try {
             uri = new URL(uri).getPath();
-            if (uri.endsWith(File.separator))
+            if (uri.endsWith(File.separator)) {
               uri = uri.substring(0, uri.length() - 1);
+            }
           }
           catch (MalformedURLException e) {
             // ignore
@@ -551,7 +553,8 @@ public class FlutterAppManager {
         if (prim.getAsBoolean()) {
           manager.appStopped(this, controller);
         }
-      } else {
+      }
+      else {
         prim = obj.getAsJsonPrimitive("error");
         if (prim != null) {
           // Apparently the daemon does not find apps started in release mode.

--- a/src/io/flutter/run/daemon/FlutterAppManager.java
+++ b/src/io/flutter/run/daemon/FlutterAppManager.java
@@ -422,7 +422,9 @@ public class FlutterAppManager {
             if (uri.endsWith(File.separator))
               uri = uri.substring(0, uri.length() - 1);
           }
-          catch (MalformedURLException e) { }
+          catch (MalformedURLException e) {
+            // ignore
+          }
         }
         app.setBaseUri(uri);
       }

--- a/src/io/flutter/run/daemon/FlutterDaemonService.java
+++ b/src/io/flutter/run/daemon/FlutterDaemonService.java
@@ -39,10 +39,6 @@ public class FlutterDaemonService {
   private FlutterAppManager myManager = new FlutterAppManager(this);
   private List<DeviceListener> myDeviceListeners = new ArrayList<>();
 
-  static {
-    getInstance();
-  }
-
   private DaemonListener myListener = new DaemonListener() {
     public void daemonInput(String string, FlutterDaemonController controller) {
       FlutterAppManager mgr;
@@ -229,8 +225,10 @@ public class FlutterDaemonService {
 
   void schedulePolling() {
     if (!FlutterSdkUtil.isFluttering()) return;
-    if (myPollster != null && myPollster.getProcessHandler() != null && !myPollster.getProcessHandler().isProcessTerminating()) {
-      return;
+    synchronized (myLock) {
+      if (myPollster != null && myPollster.getProcessHandler() != null && !myPollster.getProcessHandler().isProcessTerminating()) {
+        return;
+      }
     }
     ApplicationManager.getApplication().executeOnPooledThread(() -> {
       synchronized (myLock) {

--- a/src/io/flutter/run/daemon/FlutterDaemonService.java
+++ b/src/io/flutter/run/daemon/FlutterDaemonService.java
@@ -14,6 +14,7 @@ import com.intellij.openapi.util.Disposer;
 import com.intellij.util.containers.SortedList;
 import gnu.trove.THashSet;
 import io.flutter.sdk.FlutterSdkManager;
+import io.flutter.sdk.FlutterSdkUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -227,6 +228,7 @@ public class FlutterDaemonService {
   }
 
   void schedulePolling() {
+    if (!FlutterSdkUtil.isFluttering()) return;
     if (myPollster != null && myPollster.getProcessHandler() != null && !myPollster.getProcessHandler().isProcessTerminating()) {
       return;
     }

--- a/src/io/flutter/run/daemon/ProgressHandler.java
+++ b/src/io/flutter/run/daemon/ProgressHandler.java
@@ -54,14 +54,13 @@ class ProgressHandler {
                 }
                 myTask = null;
               }
-
             }
           }
         };
 
         // TODO(devoncarew): Debounce this.
         ApplicationManager.getApplication().invokeLater(() -> {
-          synchronized(myTasks) {
+          synchronized (myTasks) {
             ProgressManager.getInstance().run(myTask);
           }
         });

--- a/src/io/flutter/sdk/FlutterSdkManager.java
+++ b/src/io/flutter/sdk/FlutterSdkManager.java
@@ -45,12 +45,12 @@ public class FlutterSdkManager {
     ProjectManager.getInstance().addProjectManagerListener(new ProjectManagerAdapter() {
       @Override
       public void projectOpened(@NotNull Project project) {
-        if (FlutterSdkUtil.isFluttering()) return;
+        if (!FlutterSdkUtil.isFluttering()) return;
         checkForFlutterSdkAddition();
       }
       @Override
       public void projectClosed(@NotNull Project project) {
-        if (!FlutterSdkUtil.isFluttering()) return;
+        if (FlutterSdkUtil.isFluttering()) return;
         checkForFlutterSdkRemoval();
       }
     });


### PR DESCRIPTION
@pq @devoncarew 
Make the daemon lifecycle mirror its projects.

The daemon is running now if any Flutter project is open. It doesn't have to have focus, since it takes a few seconds to spin up the device list. The alternative is to start and stop the daemon based on the project that has focus.

Also reformatted everything in flutter.io.run and picked up a few little things.

Fixes #372 