### PR TITLE
Reduce upper bound of version range

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -8,7 +8,7 @@
 
   <version>0.1.4</version>
 
-  <idea-version since-build="162.1" until-build="171.*"/>
+  <idea-version since-build="162.1" until-build="163.*"/>
 
 <change-notes>
 <![CDATA[


### PR DESCRIPTION
@pq @devoncarew @alexander-doroshko 

Following up from Alex's comments about version ranges.

I looked for a way to revert the fix to #380 but realized typing the number and doing a normal commit would be faster.
