### PR TITLE
Cleanup run config UI (#258).

### DIFF
--- a/src/io/flutter/FlutterBundle.properties
+++ b/src/io/flutter/FlutterBundle.properties
@@ -8,7 +8,6 @@ app.reload.action.text=Hot Reload
 app.reload.action.description=Hot reload changes into the running Flutter app
 
 change.module.type.to.flutter.and.reload.project=Change module type to Flutter and reload project
-config.progargs.caption=Program Arguments
 
 dart.plugin.update.action.label=Update Dart
 dart.sdk.configuration.action.label=Configure Dart SDK

--- a/src/io/flutter/run/FlutterConfigurationEditorForm.form
+++ b/src/io/flutter/run/FlutterConfigurationEditorForm.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="io.flutter.run.FlutterConfigurationEditorForm">
-  <grid id="27dc6" binding="myMainPanel" default-binding="true" layout-manager="GridLayoutManager" row-count="4" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="myMainPanel" default-binding="true" layout-manager="GridLayoutManager" row-count="3" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="500" height="320"/>
@@ -10,7 +10,7 @@
     <children>
       <vspacer id="3f5de">
         <constraints>
-          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
       <component id="17e7a" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="myFileField">
@@ -28,28 +28,12 @@
         <properties>
           <inheritsPopupMenu value="true"/>
           <labelFor value="17e7a"/>
-          <text value="Dart &amp;file:"/>
+          <text value="Dart &amp;entry point:"/>
         </properties>
-      </component>
-      <component id="bd276" class="javax.swing.JLabel">
-        <constraints>
-          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <inheritsPopupMenu value="true"/>
-          <labelFor value="103fd"/>
-          <text value="Program a&amp;rguments:"/>
-        </properties>
-      </component>
-      <component id="103fd" class="com.intellij.ui.RawCommandLineEditor" binding="myArguments">
-        <constraints>
-          <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="7" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties/>
       </component>
       <component id="7b562" class="javax.swing.JLabel">
         <constraints>
-          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <labelFor value="849ec"/>
@@ -58,7 +42,7 @@
       </component>
       <component id="849ec" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="myWorkingDirectory">
         <constraints>
-          <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
       </component>

--- a/src/io/flutter/run/FlutterConfigurationEditorForm.java
+++ b/src/io/flutter/run/FlutterConfigurationEditorForm.java
@@ -13,8 +13,6 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.TextFieldWithBrowseButton;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.util.text.StringUtil;
-import com.intellij.ui.RawCommandLineEditor;
-import io.flutter.FlutterBundle;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
@@ -25,7 +23,6 @@ public class FlutterConfigurationEditorForm extends SettingsEditor<FlutterRunCon
   private JPanel myMainPanel;
   private JLabel myDartFileLabel;
   private TextFieldWithBrowseButton myFileField;
-  private RawCommandLineEditor myArguments;
   private TextFieldWithBrowseButton myWorkingDirectory;
 
   public FlutterConfigurationEditorForm(final Project project) {
@@ -33,14 +30,12 @@ public class FlutterConfigurationEditorForm extends SettingsEditor<FlutterRunCon
     //noinspection DialogTitleCapitalization
     myWorkingDirectory.addBrowseFolderListener(ExecutionBundle.message("select.working.directory.message"), null, project,
                                                FileChooserDescriptorFactory.createSingleFolderDescriptor());
-    myArguments.setDialogCaption(FlutterBundle.message("config.progargs.caption"));
   }
 
   @Override
   protected void resetEditorFrom(@NotNull final FlutterRunConfiguration configuration) {
     final FlutterRunnerParameters parameters = configuration.getRunnerParameters();
     myFileField.setText(FileUtil.toSystemDependentName(StringUtil.notNullize(parameters.getFilePath())));
-    myArguments.setText(StringUtil.notNullize(parameters.getArguments()));
     myWorkingDirectory.setText(FileUtil.toSystemDependentName(StringUtil.notNullize(parameters.getWorkingDirectory())));
   }
 
@@ -48,7 +43,6 @@ public class FlutterConfigurationEditorForm extends SettingsEditor<FlutterRunCon
   protected void applyEditorTo(@NotNull final FlutterRunConfiguration configuration) throws ConfigurationException {
     final FlutterRunnerParameters parameters = configuration.getRunnerParameters();
     parameters.setFilePath(StringUtil.nullize(FileUtil.toSystemIndependentName(myFileField.getText().trim()), true));
-    parameters.setArguments(StringUtil.nullize(myArguments.getText(), true));
     parameters.setWorkingDirectory(StringUtil.nullize(FileUtil.toSystemIndependentName(myWorkingDirectory.getText().trim()), true));
   }
 

--- a/src/io/flutter/run/FlutterRunConfigurationType.java
+++ b/src/io/flutter/run/FlutterRunConfigurationType.java
@@ -41,6 +41,13 @@ public class FlutterRunConfigurationType extends ConfigurationTypeBase {
     }
 
     @Override
+    @NotNull
+    public RunConfiguration createConfiguration(String name, RunConfiguration template) {
+      // Override the default name which is always "Unnamed".
+      return super.createConfiguration(template.getProject().getName(), template);
+    }
+
+    @Override
     public boolean isApplicable(@NotNull Project project) {
       return FileTypeIndex.containsFileOfType(DartFileType.INSTANCE, GlobalSearchScope.projectScope(project));
     }


### PR DESCRIPTION
* removes unused “program arguments” field
* sets default proposed name to project name (rather than “Unnamed”)
* renames “Dart file” label to “Dart entry point”

Fixes: #258 

/cc @alexander-doroshko @devoncarew 