### PR TITLE
Up flutter tools lower bound to `0.0.3`.

### DIFF
--- a/src/io/flutter/inspections/SdkConfigurationNotificationProvider.java
+++ b/src/io/flutter/inspections/SdkConfigurationNotificationProvider.java
@@ -35,7 +35,7 @@ public class SdkConfigurationNotificationProvider extends EditorNotifications.Pr
   implements DumbAware {
 
   // Minimum SDK known to support hot reload.
-  private static final FlutterSdkVersion MIN_SUPPORTED_SDK = FlutterSdkVersion.forVersionString("0.0.2");
+  private static final FlutterSdkVersion MIN_SUPPORTED_SDK = FlutterSdkVersion.forVersionString("0.0.3");
 
   private static final Key<EditorNotificationPanel> KEY = Key.create("FlutterWrongDartSdkNotification");
 


### PR DESCRIPTION
This mitigates app state message version skew.

See: https://github.com/flutter/flutter-intellij/pull/426

/cc @devoncarew 

(N.B. this hinges on https://github.com/flutter/flutter/pull/6771 for landing.)