### PR TITLE
refactor the launch config code to split out from Dart base

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -23,5 +23,17 @@
       <option name="processLiterals" value="true" />
       <option name="processComments" value="true" />
     </inspection_tool>
+    <inspection_tool class="unused" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="LOCAL_VARIABLE" value="true" />
+      <option name="FIELD" value="true" />
+      <option name="METHOD" value="true" />
+      <option name="CLASS" value="true" />
+      <option name="PARAMETER" value="true" />
+      <option name="REPORT_PARAMETER_FOR_PUBLIC_METHODS" value="true" />
+      <option name="ADD_MAINS_TO_ENTRIES" value="true" />
+      <option name="ADD_APPLET_TO_ENTRIES" value="true" />
+      <option name="ADD_SERVLET_TO_ENTRIES" value="true" />
+      <option name="ADD_NONJAVA_TO_ENTRIES" value="true" />
+    </inspection_tool>
   </profile>
 </component>

--- a/src/io/flutter/FlutterBundle.properties
+++ b/src/io/flutter/FlutterBundle.properties
@@ -48,3 +48,8 @@ update.module.type=Update Module Type
 updating.module.type.requires.project.reload.proceed=Updating module type requires project reload. Proceed?
 
 waiting.for.flutter=Waiting for debug connection...
+
+path.to.dart.file.not.set=path to Dart source not specified
+dart.file.not.found=Dart file not found: {0}
+not.a.dart.file.or.directory=Specified file is not a Dart file or directory: {0}
+work.dir.does.not.exist=Working directory doesn''t exist: {0}

--- a/src/io/flutter/run/FlutterAppState.java
+++ b/src/io/flutter/run/FlutterAppState.java
@@ -17,7 +17,6 @@ import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.Separator;
 import com.intellij.openapi.project.Project;
 import com.intellij.util.net.NetUtils;
-import com.jetbrains.lang.dart.ide.runner.server.DartCommandLineRunningState;
 import com.jetbrains.lang.dart.ide.runner.server.OpenDartObservatoryUrlAction;
 import io.flutter.run.daemon.ConnectedDevice;
 import io.flutter.run.daemon.FlutterApp;
@@ -29,8 +28,7 @@ import java.io.File;
 import java.util.Collection;
 import java.util.List;
 
-public class FlutterAppState extends DartCommandLineRunningState {
-
+public class FlutterAppState extends FlutterAppStateBase {
   private static final String RUN = DefaultRunExecutor.EXECUTOR_ID;
   private FlutterApp myApp;
   private RunMode myMode;

--- a/src/io/flutter/run/FlutterAppStateBase.java
+++ b/src/io/flutter/run/FlutterAppStateBase.java
@@ -29,7 +29,6 @@ import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.vfs.CharsetToolkit;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.util.net.NetUtils;
-import com.jetbrains.lang.dart.coverage.DartCoverageProgramRunner;
 import com.jetbrains.lang.dart.ide.runner.DartConsoleFilter;
 import com.jetbrains.lang.dart.ide.runner.DartRelativePathsConsoleFilter;
 import com.jetbrains.lang.dart.ide.runner.client.DartiumUtil;
@@ -177,10 +176,6 @@ public abstract class FlutterAppStateBase extends CommandLineState {
       }
 
       commandLine.addParameter("--enable-vm-service:" + myObservatoryPort);
-
-      if (getEnvironment().getRunner() instanceof DartCoverageProgramRunner) {
-        commandLine.addParameter("--pause-isolates-on-exit");
-      }
     }
 
     commandLine.addParameter(FileUtil.toSystemDependentName(overriddenMainFilePath == null ? dartFile.getPath() : overriddenMainFilePath));

--- a/src/io/flutter/run/FlutterAppStateBase.java
+++ b/src/io/flutter/run/FlutterAppStateBase.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2016 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.run;
+
+import com.intellij.execution.ExecutionException;
+import com.intellij.execution.Executor;
+import com.intellij.execution.configurations.CommandLineState;
+import com.intellij.execution.configurations.CommandLineTokenizer;
+import com.intellij.execution.configurations.GeneralCommandLine;
+import com.intellij.execution.configurations.GeneralCommandLine.ParentEnvironmentType;
+import com.intellij.execution.configurations.RuntimeConfigurationError;
+import com.intellij.execution.executors.DefaultDebugExecutor;
+import com.intellij.execution.filters.TextConsoleBuilder;
+import com.intellij.execution.filters.TextConsoleBuilderImpl;
+import com.intellij.execution.filters.UrlFilter;
+import com.intellij.execution.process.ColoredProcessHandler;
+import com.intellij.execution.process.OSProcessHandler;
+import com.intellij.execution.process.ProcessHandler;
+import com.intellij.execution.process.ProcessTerminatedListener;
+import com.intellij.execution.runners.ExecutionEnvironment;
+import com.intellij.execution.ui.ConsoleView;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.Separator;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.io.FileUtil;
+import com.intellij.openapi.vfs.CharsetToolkit;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.util.net.NetUtils;
+import com.jetbrains.lang.dart.coverage.DartCoverageProgramRunner;
+import com.jetbrains.lang.dart.ide.runner.DartConsoleFilter;
+import com.jetbrains.lang.dart.ide.runner.DartRelativePathsConsoleFilter;
+import com.jetbrains.lang.dart.ide.runner.client.DartiumUtil;
+import com.jetbrains.lang.dart.ide.runner.server.OpenDartObservatoryUrlAction;
+import com.jetbrains.lang.dart.sdk.DartSdk;
+import com.jetbrains.lang.dart.sdk.DartSdkUtil;
+import io.flutter.FlutterBundle;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.StringTokenizer;
+
+public abstract class FlutterAppStateBase extends CommandLineState {
+  protected final @NotNull FlutterRunnerParameters myRunnerParameters;
+  private int myObservatoryPort = -1;
+
+  public FlutterAppStateBase(final @NotNull ExecutionEnvironment env) throws ExecutionException {
+    super(env);
+    myRunnerParameters = ((FlutterRunConfiguration)env.getRunProfile()).getRunnerParameters().clone();
+
+    final Project project = env.getProject();
+    try {
+      myRunnerParameters.check(project);
+    }
+    catch (RuntimeConfigurationError e) {
+      throw new ExecutionException(e);
+    }
+
+    final TextConsoleBuilder builder = getConsoleBuilder();
+    if (builder instanceof TextConsoleBuilderImpl) {
+      ((TextConsoleBuilderImpl)builder).setUsePredefinedMessageFilter(false);
+    }
+
+    try {
+      builder.addFilter(new DartConsoleFilter(project, myRunnerParameters.getDartFileOrDirectory()));
+      builder.addFilter(new DartRelativePathsConsoleFilter(project, myRunnerParameters.computeProcessWorkingDirectory(project)));
+      builder.addFilter(new UrlFilter());
+    }
+    catch (RuntimeConfigurationError e) { /* can't happen because already checked */}
+  }
+
+  @Override
+  protected AnAction[] createActions(final ConsoleView console, final ProcessHandler processHandler, final Executor executor) {
+    // These actions are effectively added only to the Run tool window. For Debug see DartCommandLineDebugProcess.registerAdditionalActions()
+    final List<AnAction> actions = new ArrayList(Arrays.asList(super.createActions(console, processHandler, executor)));
+    addObservatoryActions(actions, processHandler);
+    return actions.toArray(new AnAction[actions.size()]);
+  }
+
+  protected void addObservatoryActions(List<AnAction> actions, final ProcessHandler processHandler) {
+    actions.add(new Separator());
+    actions.add(new OpenDartObservatoryUrlAction(
+      "http://" + NetUtils.getLocalHostString() + ":" + myObservatoryPort,
+      () -> !processHandler.isProcessTerminated()));
+  }
+
+  @NotNull
+  @Override
+  protected ProcessHandler startProcess() throws ExecutionException {
+    return doStartProcess(null);
+  }
+
+  protected ProcessHandler doStartProcess(final @Nullable String overriddenMainFilePath) throws ExecutionException {
+    final GeneralCommandLine commandLine = createCommandLine(overriddenMainFilePath);
+    final OSProcessHandler processHandler = new ColoredProcessHandler(commandLine);
+
+    ProcessTerminatedListener.attach(processHandler, getEnvironment().getProject());
+    return processHandler;
+  }
+
+  private GeneralCommandLine createCommandLine(@Nullable final String overriddenMainFilePath) throws ExecutionException {
+    final DartSdk sdk = DartSdk.getDartSdk(getEnvironment().getProject());
+    if (sdk == null) {
+      throw new ExecutionException(FlutterBundle.message("dart.sdk.is.not.configured"));
+    }
+
+    final GeneralCommandLine commandLine = new GeneralCommandLine()
+      .withWorkDirectory(myRunnerParameters.computeProcessWorkingDirectory(getEnvironment().getProject()));
+    commandLine.setCharset(CharsetToolkit.UTF8_CHARSET);
+    commandLine.setExePath(FileUtil.toSystemDependentName(DartSdkUtil.getDartExePath(sdk)));
+    commandLine.getEnvironment().putAll(myRunnerParameters.getEnvs());
+    commandLine
+      .withParentEnvironmentType(myRunnerParameters.isIncludeParentEnvs() ? ParentEnvironmentType.CONSOLE : ParentEnvironmentType.NONE);
+    setupParameters(sdk, commandLine, overriddenMainFilePath);
+
+    return commandLine;
+  }
+
+  private void setupParameters(@NotNull final DartSdk sdk,
+                               @NotNull final GeneralCommandLine commandLine,
+                               @Nullable final String overriddenMainFilePath) throws ExecutionException {
+    int customObservatoryPort = -1;
+
+    final String vmOptions = myRunnerParameters.getVMOptions();
+    if (vmOptions != null) {
+      final StringTokenizer vmOptionsTokenizer = new CommandLineTokenizer(vmOptions);
+      while (vmOptionsTokenizer.hasMoreTokens()) {
+        final String vmOption = vmOptionsTokenizer.nextToken();
+        commandLine.addParameter(vmOption);
+
+        try {
+          if (vmOption.equals("--enable-vm-service") || vmOption.equals("--observe")) {
+            customObservatoryPort = 8181; // default port, see https://www.dartlang.org/tools/dart-vm/
+          }
+          else if (vmOption.startsWith("--enable-vm-service:")) {
+            customObservatoryPort = parseIntBeforeSlash(vmOption.substring("--enable-vm-service:".length()));
+          }
+          else if (vmOption.startsWith("--observe:")) {
+            customObservatoryPort = parseIntBeforeSlash(vmOption.substring("--observe:".length()));
+          }
+        }
+        catch (NumberFormatException ignore) {/**/}
+      }
+    }
+
+    if (myRunnerParameters.isCheckedMode()) {
+      commandLine.addParameter(DartiumUtil.CHECKED_MODE_OPTION);
+    }
+
+    final VirtualFile dartFile;
+    try {
+      dartFile = myRunnerParameters.getDartFileOrDirectory();
+    }
+    catch (RuntimeConfigurationError e) {
+      throw new ExecutionException(e);
+    }
+
+    if (DefaultDebugExecutor.EXECUTOR_ID.equals(getEnvironment().getExecutor().getId())) {
+      commandLine.addParameter("--pause_isolates_on_start");
+    }
+
+    if (customObservatoryPort > 0) {
+      myObservatoryPort = customObservatoryPort;
+    }
+    else {
+      try {
+        myObservatoryPort = NetUtils.findAvailableSocketPort();
+      }
+      catch (IOException e) {
+        throw new ExecutionException(e);
+      }
+
+      commandLine.addParameter("--enable-vm-service:" + myObservatoryPort);
+
+      if (getEnvironment().getRunner() instanceof DartCoverageProgramRunner) {
+        commandLine.addParameter("--pause-isolates-on-exit");
+      }
+    }
+
+    commandLine.addParameter(FileUtil.toSystemDependentName(overriddenMainFilePath == null ? dartFile.getPath() : overriddenMainFilePath));
+
+    final String arguments = myRunnerParameters.getArguments();
+    if (arguments != null) {
+      StringTokenizer argumentsTokenizer = new CommandLineTokenizer(arguments);
+      while (argumentsTokenizer.hasMoreTokens()) {
+        commandLine.addParameter(argumentsTokenizer.nextToken());
+      }
+    }
+  }
+
+  private static int parseIntBeforeSlash(@NotNull final String s) throws NumberFormatException {
+    // "5858" or "5858/0.0.0.0"
+    final int index = s.indexOf('/');
+    return Integer.parseInt(index > 0 ? s.substring(0, index) : s);
+  }
+
+  public int getObservatoryPort() {
+    return myObservatoryPort;
+  }
+}

--- a/src/io/flutter/run/FlutterRunConfiguration.java
+++ b/src/io/flutter/run/FlutterRunConfiguration.java
@@ -14,11 +14,10 @@ import com.intellij.execution.runners.ExecutionEnvironment;
 import com.intellij.openapi.options.SettingsEditor;
 import com.intellij.openapi.project.Project;
 import com.intellij.util.PathUtil;
-import com.jetbrains.lang.dart.ide.runner.base.DartRunConfigurationBase;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public class FlutterRunConfiguration extends DartRunConfigurationBase {
+public class FlutterRunConfiguration extends FlutterRunConfigurationBase {
   private @NotNull FlutterRunnerParameters myRunnerParameters = new FlutterRunnerParameters();
 
   public FlutterRunConfiguration(final Project project, final ConfigurationFactory factory, final String name) {

--- a/src/io/flutter/run/FlutterRunConfigurationBase.java
+++ b/src/io/flutter/run/FlutterRunConfigurationBase.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2016 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.run;
+
+import com.intellij.execution.configurations.*;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.InvalidDataException;
+import com.intellij.openapi.util.WriteExternalException;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiDirectory;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiFileSystemItem;
+import com.intellij.refactoring.listeners.RefactoringElementListener;
+import com.intellij.refactoring.listeners.UndoRefactoringElementAdapter;
+import com.intellij.util.PathUtil;
+import com.intellij.util.xmlb.SkipDefaultValuesSerializationFilters;
+import com.intellij.util.xmlb.XmlSerializer;
+import org.jdom.Element;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public abstract class FlutterRunConfigurationBase extends LocatableConfigurationBase
+  implements RefactoringListenerProvider, RunConfiguration {
+
+  protected FlutterRunConfigurationBase(final Project project, final ConfigurationFactory factory, final String name) {
+    super(project, factory, name);
+  }
+
+  @NotNull
+  public abstract FlutterRunnerParameters getRunnerParameters();
+
+  public void checkConfiguration() throws RuntimeConfigurationException {
+    getRunnerParameters().check(getProject());
+  }
+
+  @Override
+  public void writeExternal(final Element element) throws WriteExternalException {
+    super.writeExternal(element);
+    XmlSerializer.serializeInto(getRunnerParameters(), element, new SkipDefaultValuesSerializationFilters());
+  }
+
+  @Override
+  public void readExternal(final Element element) throws InvalidDataException {
+    super.readExternal(element);
+    XmlSerializer.deserializeInto(getRunnerParameters(), element);
+  }
+
+  @Nullable
+  @Override
+  public RefactoringElementListener getRefactoringElementListener(final PsiElement element) {
+    if (!(element instanceof PsiFileSystemItem)) return null;
+
+    final String filePath = getRunnerParameters().getFilePath();
+    final VirtualFile file = filePath == null ? null : ((PsiFileSystemItem)element).getVirtualFile();
+    if (file == null) return null;
+
+    final String affectedPath = file.getPath();
+    if (element instanceof PsiFile) {
+      if (filePath.equals(affectedPath)) {
+        return new RenameRefactoringListener(affectedPath);
+      }
+    }
+    if (element instanceof PsiDirectory) {
+      if (filePath.startsWith(affectedPath + "/")) {
+        return new RenameRefactoringListener(affectedPath);
+      }
+    }
+
+    return null;
+  }
+
+  private class RenameRefactoringListener extends UndoRefactoringElementAdapter {
+    private @NotNull String myAffectedPath;
+
+    private RenameRefactoringListener(final @NotNull String affectedPath) {
+      myAffectedPath = affectedPath;
+    }
+
+    private String getNewPathAndUpdateAffectedPath(final @NotNull PsiElement newElement) {
+      final String oldPath = getRunnerParameters().getFilePath();
+
+      final VirtualFile newFile = newElement instanceof PsiFileSystemItem ? ((PsiFileSystemItem)newElement).getVirtualFile() : null;
+      if (newFile != null && oldPath != null && oldPath.startsWith(myAffectedPath)) {
+        final String newPath = newFile.getPath() + oldPath.substring(myAffectedPath.length());
+        myAffectedPath = newFile.getPath(); // needed if refactoring will be undone
+        return newPath;
+      }
+
+      return oldPath;
+    }
+
+    @Override
+    protected void refactored(@NotNull final PsiElement element, @Nullable final String oldQualifiedName) {
+      final boolean generatedName = getName().equals(suggestedName());
+      final String filePath = getRunnerParameters().getFilePath();
+      final boolean updateWorkingDir = filePath != null &&
+                                       PathUtil.getParentPath(filePath).equals(getRunnerParameters().getWorkingDirectory());
+
+      final String newPath = getNewPathAndUpdateAffectedPath(element);
+      getRunnerParameters().setFilePath(newPath);
+
+      if (updateWorkingDir) {
+        getRunnerParameters().setWorkingDirectory(PathUtil.getParentPath(newPath));
+      }
+
+      if (generatedName) {
+        setGeneratedName();
+      }
+    }
+  }
+}
+

--- a/src/io/flutter/run/FlutterRunner.java
+++ b/src/io/flutter/run/FlutterRunner.java
@@ -13,18 +13,13 @@ import com.intellij.execution.executors.DefaultRunExecutor;
 import com.intellij.execution.runners.ExecutionEnvironment;
 import com.intellij.execution.ui.RunContentDescriptor;
 import com.intellij.xdebugger.XDebugSession;
-import com.jetbrains.lang.dart.ide.runner.DartRunner;
 import com.jetbrains.lang.dart.ide.runner.ObservatoryConnector;
 import io.flutter.run.daemon.FlutterApp;
 import io.flutter.run.daemon.FlutterDaemonService;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-/**
- * This class could be independent of DartRunner; just copy down the code that is not implemented here.
- * Note that we have redefined DartRunner in third_party, which is a slightly modified version of the original.
- */
-public class FlutterRunner extends DartRunner {
+public class FlutterRunner extends FlutterRunnerBase {
 
   @Nullable
   private ObservatoryConnector myConnector;

--- a/src/io/flutter/run/FlutterRunnerParameters.java
+++ b/src/io/flutter/run/FlutterRunnerParameters.java
@@ -5,12 +5,170 @@
  */
 package io.flutter.run;
 
+import com.intellij.execution.configurations.RuntimeConfigurationError;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.io.FileUtil;
+import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.util.xmlb.annotations.MapAnnotation;
+import com.jetbrains.lang.dart.DartFileType;
 import com.jetbrains.lang.dart.ide.runner.server.DartCommandLineRunnerParameters;
+import com.jetbrains.lang.dart.sdk.DartConfigurable;
+import com.jetbrains.lang.dart.sdk.DartSdk;
+import io.flutter.FlutterBundle;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-public class FlutterRunnerParameters extends DartCommandLineRunnerParameters implements Cloneable {
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class FlutterRunnerParameters implements Cloneable {
+  private @Nullable String myFilePath = null;
+  private @Nullable String myVMOptions = null;
+  private boolean myCheckedMode = true;
+  private @Nullable String myArguments = null;
+  private @Nullable String myWorkingDirectory = null;
+  private @NotNull Map<String, String> myEnvs = new LinkedHashMap<>();
+  private boolean myIncludeParentEnvs = true;
+
+  @NotNull
+  public String computeProcessWorkingDirectory(@NotNull final Project project) {
+    if (!StringUtil.isEmptyOrSpaces(myWorkingDirectory)) return myWorkingDirectory;
+
+    try {
+      return DartCommandLineRunnerParameters.suggestDartWorkingDir(project, getDartFileOrDirectory());
+    }
+    catch (RuntimeConfigurationError error) {
+      return "";
+    }
+  }
+
+  @Nullable
+  public String getFilePath() {
+    return myFilePath;
+  }
+
+  public void setFilePath(final @Nullable String filePath) {
+    myFilePath = filePath;
+  }
+
+  @Nullable
+  public String getVMOptions() {
+    return myVMOptions;
+  }
+
+  public void setVMOptions(final @Nullable String vmOptions) {
+    myVMOptions = vmOptions;
+  }
+
+  public boolean isCheckedMode() {
+    return myCheckedMode;
+  }
+
+  public void setCheckedMode(final boolean checkedMode) {
+    myCheckedMode = checkedMode;
+  }
+
+  @Nullable
+  public String getArguments() {
+    return myArguments;
+  }
+
+  public void setArguments(final @Nullable String arguments) {
+    myArguments = arguments;
+  }
+
+  @Nullable
+  public String getWorkingDirectory() {
+    return myWorkingDirectory;
+  }
+
+  public void setWorkingDirectory(final @Nullable String workingDirectory) {
+    myWorkingDirectory = workingDirectory;
+  }
+
+  @NotNull
+  @MapAnnotation(surroundWithTag = false, surroundKeyWithTag = false, surroundValueWithTag = false)
+  public Map<String, String> getEnvs() {
+    return myEnvs;
+  }
+
+  public void setEnvs(@SuppressWarnings("NullableProblems") final Map<String, String> envs) {
+    if (envs != null) { // null comes from old projects or if storage corrupted
+      myEnvs = envs;
+    }
+  }
+
+  public boolean isIncludeParentEnvs() {
+    return myIncludeParentEnvs;
+  }
+
+  public void setIncludeParentEnvs(final boolean includeParentEnvs) {
+    myIncludeParentEnvs = includeParentEnvs;
+  }
+
+  @NotNull
+  public VirtualFile getDartFile() throws RuntimeConfigurationError {
+    final VirtualFile dartFile = getDartFileOrDirectory();
+    if (dartFile.isDirectory()) {
+      assert myFilePath != null;
+      throw new RuntimeConfigurationError(FlutterBundle.message("dart.file.not.found", FileUtil.toSystemDependentName(myFilePath)));
+    }
+    return dartFile;
+  }
+
+  @NotNull
+  public VirtualFile getDartFileOrDirectory() throws RuntimeConfigurationError {
+    if (StringUtil.isEmptyOrSpaces(myFilePath)) {
+      throw new RuntimeConfigurationError(FlutterBundle.message("path.to.dart.file.not.set"));
+    }
+
+    final VirtualFile dartFile = LocalFileSystem.getInstance().findFileByPath(myFilePath);
+    if (dartFile == null) {
+      throw new RuntimeConfigurationError(FlutterBundle.message("dart.file.not.found", FileUtil.toSystemDependentName(myFilePath)));
+    }
+
+    if (dartFile.getFileType() != DartFileType.INSTANCE && !dartFile.isDirectory()) {
+      throw new RuntimeConfigurationError(
+        FlutterBundle.message("not.a.dart.file.or.directory", FileUtil.toSystemDependentName(myFilePath)));
+    }
+
+    return dartFile;
+  }
+
+  // TODO(devoncarew): Open flutter settings.
+  public void check(final @NotNull Project project) throws RuntimeConfigurationError {
+    // check sdk
+    final DartSdk sdk = DartSdk.getDartSdk(project);
+    if (sdk == null) {
+      throw new RuntimeConfigurationError(FlutterBundle.message("dart.sdk.is.not.configured"),
+                                          () -> DartConfigurable.openDartSettings(project));
+    }
+
+    // check main dart file
+    getDartFileOrDirectory();
+
+    // check working directory
+    if (!StringUtil.isEmptyOrSpaces(myWorkingDirectory)) {
+      final VirtualFile workDir = LocalFileSystem.getInstance().findFileByPath(myWorkingDirectory);
+      if (workDir == null || !workDir.isDirectory()) {
+        throw new RuntimeConfigurationError(
+          FlutterBundle.message("work.dir.does.not.exist", FileUtil.toSystemDependentName(myWorkingDirectory)));
+      }
+    }
+  }
+
   @Override
   protected FlutterRunnerParameters clone() {
-    final FlutterRunnerParameters clone = (FlutterRunnerParameters)super.clone();
-    return clone;
+    try {
+      final FlutterRunnerParameters clone = (FlutterRunnerParameters)super.clone();
+      clone.myEnvs = new LinkedHashMap<>();
+      clone.myEnvs.putAll(myEnvs);
+      return clone;
+    }
+    catch (CloneNotSupportedException e) {
+      throw new RuntimeException(e);
+    }
   }
 }


### PR DESCRIPTION
- refactor the launch config code to split out from Dart base

A larger PR, but this sets the stage for future work, including creating a second Flutter launch config to support the Bazel/internal use case. This fully separates out the Flutter and Dart launch config code.

@pq