### PR TITLE
Action registry fixes.

### DIFF
--- a/src/io/flutter/actions/FlutterAppAction.java
+++ b/src/io/flutter/actions/FlutterAppAction.java
@@ -44,6 +44,11 @@ abstract public class FlutterAppAction extends DumbAwareAction {
   private void registerAction(@NotNull String actionId) {
     final ActionManager actionManager = ActionManager.getInstance();
     final AnAction action = actionManager.getAction(actionId);
+    // New debug sessions create new actions, requiring us to overwrite existing ones in the registry.
+    // TODO(pq): consider moving actions to our own registry for lookup.
+    if (action != null) {
+      actionManager.unregisterAction(actionId);
+    }
     actionManager.registerAction(actionId, this);
   }
 


### PR DESCRIPTION
TL;DR; the action manager doesn't permit over-writing action mappings so we need to remove first.

/cc @devoncarew 