### PR TITLE
restore breakpoints across a reload

### DIFF
--- a/src/io/flutter/actions/HotReloadFlutterApp.java
+++ b/src/io/flutter/actions/HotReloadFlutterApp.java
@@ -12,6 +12,8 @@ import com.jetbrains.lang.dart.ide.runner.ObservatoryConnector;
 import icons.FlutterIcons;
 import io.flutter.FlutterBundle;
 
+import java.lang.reflect.Method;
+
 public class HotReloadFlutterApp extends FlutterAppAction {
 
   public static final String ID = "Flutter.HotReloadFlutterApp"; //NON-NLS
@@ -25,8 +27,22 @@ public class HotReloadFlutterApp extends FlutterAppAction {
   public void actionPerformed(AnActionEvent e) {
     ifReadyThen(() -> {
       FileDocumentManager.getInstance().saveAllDocuments();
-      // TODO(devoncarew): Update to pass in true for pauseAfterRestart.
-      getApp().performHotReload(false);
+      boolean pauseAfterRestart = hasCapability("supports.pausePostRequest");
+      getApp().performHotReload(pauseAfterRestart);
     });
+  }
+
+  private static boolean hasCapability(String featureId) {
+    // return DartPluginCapabilities.isSupported(featureId);
+
+    try {
+      Class clazz = Class.forName("com.jetbrains.lang.dart.DartPluginCapabilities");
+      Method method = clazz.getMethod("isSupported", String.class);
+      Object result = method.invoke(null, featureId);
+      return result instanceof Boolean && ((Boolean)result).booleanValue();
+    }
+    catch (Throwable t) {
+      return false;
+    }
   }
 }

--- a/src/io/flutter/run/daemon/FlutterAppManager.java
+++ b/src/io/flutter/run/daemon/FlutterAppManager.java
@@ -13,7 +13,6 @@ import com.intellij.openapi.progress.ProcessCanceledException;
 import com.intellij.openapi.project.Project;
 import com.intellij.util.TimeoutUtil;
 import gnu.trove.THashMap;
-import org.apache.commons.lang.time.StopWatch;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -702,5 +701,26 @@ public class FlutterAppManager {
     void process(FlutterAppManager manager, FlutterDaemonController controller) {
       manager.eventDebugPort(this, controller);
     }
+  }
+}
+
+class StopWatch {
+  private long startTime;
+  private long stopTime;
+
+  StopWatch() {
+
+  }
+
+  public void start() {
+    startTime = System.currentTimeMillis();
+  }
+
+  public void stop() {
+    stopTime = System.currentTimeMillis();
+  }
+
+  public long getTime() {
+    return stopTime - startTime;
   }
 }


### PR DESCRIPTION
- some work to restore breakpoints across a hot reload; this tests for the capability in the dart plugin and if it's found, it requests that an isolate be paused after a reload
- also, inline a `StopWatch` to remove a dep on apache.commons

@pq