### PR TITLE
remap reload and restart keybindings

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -73,10 +73,12 @@
 
   <actions>
     <action id="Flutter.HotReloadFlutterAppKey" class="io.flutter.actions.HotReloadFlutterAppKeyAction" text="Flutter Hot Reload">
-      <keyboard-shortcut first-keystroke="control BACK_SLASH" keymap="$default"/>
+      <keyboard-shortcut keymap="$default" first-keystroke="ctrl alt SEMICOLON"/>
+      <keyboard-shortcut keymap="$default" first-keystroke="ctrl BACK_SLASH"/>
     </action>
     <action id="Flutter.RestartFlutterAppKey" class="io.flutter.actions.RestartFlutterAppKeyAction" text="Flutter Restart Application">
-      <keyboard-shortcut first-keystroke="control shift BACK_SLASH" keymap="$default"/>
+      <keyboard-shortcut keymap="$default" first-keystroke="shift ctrl alt SEMICOLON"/>
+      <keyboard-shortcut keymap="$default" first-keystroke="shift ctrl BACK_SLASH"/>
     </action>
     <group id="Flutter.MainToolbarActions">
       <separator/>

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -13,7 +13,7 @@
   <!-- supported in CE and UE -->
   <!-- see: http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html -->
   <depends>com.intellij.modules.java</depends>
-  
+
   <change-notes>
 <![CDATA[
 0.1.5:
@@ -73,10 +73,10 @@
 
   <actions>
     <action id="Flutter.HotReloadFlutterAppKey" class="io.flutter.actions.HotReloadFlutterAppKeyAction" text="Flutter Hot Reload">
-      <keyboard-shortcut first-keystroke="ctrl F5" keymap="$default"/>
+      <keyboard-shortcut first-keystroke="control BACK_SLASH" keymap="$default"/>
     </action>
     <action id="Flutter.RestartFlutterAppKey" class="io.flutter.actions.RestartFlutterAppKeyAction" text="Flutter Restart Application">
-      <keyboard-shortcut first-keystroke="ctrl shift F5" keymap="$default"/>
+      <keyboard-shortcut first-keystroke="control shift BACK_SLASH" keymap="$default"/>
     </action>
     <group id="Flutter.MainToolbarActions">
       <separator/>

--- a/testing.md
+++ b/testing.md
@@ -10,12 +10,12 @@ Validate basic project creation.
 * Confirm that:
   * Project contents are created.
     * Verify that a run configuration (sharing the project name) is enabled in the run/debug selector.
-  * Navigation works. 
+  * Navigation works.
     * Open `lib/main.dart` and navigate to `ThemeData`.
   * There are no analysis errors or warnings.
   * Pub operations work.
     * Open `pubspec.yaml` and click the "Get" and "Update" actions.
-    
+
 ## Device Detection.
 
 Validate device selection.
@@ -64,7 +64,7 @@ Assuming the app state from above:
 * validate that the text and state resets
 
 Keybindings:
-* verify that the hot reload keybinding works (on a mac: `cmd-F5`)
+* verify that the hot reload keybinding works (on a mac: `cmd-\`)
 
 ## Debugging Sessions
 
@@ -83,5 +83,5 @@ Verify installation and configuration in a fresh IDEA installation.
 * Open "Languages & Frameworks>Flutter" in Preferences and verify that there is no Flutter SDK set.
 * Set the Flutter SDK path to a valid SDK location.
   * Verify that invalid locations are rejected (and cannot be applied).
-* Verify project creation, run/debug.  
+* Verify project creation, run/debug.
 

--- a/testing.md
+++ b/testing.md
@@ -64,7 +64,7 @@ Assuming the app state from above:
 * validate that the text and state resets
 
 Keybindings:
-* verify that the hot reload keybinding works (on a mac: `cmd-\`)
+* verify that the hot reload keybinding works (on a mac: `cmd-option-;` or `cmd-\`)
 
 ## Debugging Sessions
 


### PR DESCRIPTION
- remap reload and restart keybindings; use `ctrl-\` and `shift-ctrl-\`
- fix https://github.com/flutter/flutter-intellij/issues/335 (IntelliJ mapped `ctrl-,` to `cmd-,` on the mac, which conflicts with the binding to open preferences)

@pq @mit-mit 
