### PR TITLE
add a butter-bar for flutter.yaml files

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -23,6 +23,11 @@
       <option name="processLiterals" value="true" />
       <option name="processComments" value="true" />
     </inspection_tool>
+    <inspection_tool class="WeakerAccess" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="SUGGEST_PACKAGE_LOCAL_FOR_MEMBERS" value="true" />
+      <option name="SUGGEST_PACKAGE_LOCAL_FOR_TOP_CLASSES" value="true" />
+      <option name="SUGGEST_PRIVATE_FOR_INNERS" value="false" />
+    </inspection_tool>
     <inspection_tool class="unused" enabled="false" level="WARNING" enabled_by_default="false">
       <option name="LOCAL_VARIABLE" value="true" />
       <option name="FIELD" value="true" />

--- a/resources/META-INF/idea-contribs.xml
+++ b/resources/META-INF/idea-contribs.xml
@@ -6,5 +6,6 @@
     <editorNotificationProvider implementation="io.flutter.inspections.IncompatibleDartPluginNotificationProvider"/>
     <editorNotificationProvider implementation="io.flutter.inspections.SdkConfigurationNotificationProvider"/>
     <editorNotificationProvider implementation="io.flutter.inspections.WrongModuleTypeNotificationProvider"/>
+    <editorNotificationProvider implementation="io.flutter.inspections.FlutterYamlNotificationProvider"/>
   </extensions>
 </idea-plugin>

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -13,7 +13,7 @@
   <!-- supported in CE and UE -->
   <!-- see: http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html -->
   <depends>com.intellij.modules.java</depends>
-  
+
   <change-notes>
 <![CDATA[
 0.1.5:
@@ -88,6 +88,10 @@
       <add-to-group anchor="before" group-id="RunContextGroup" relative-to-action="RunConfiguration"/>
       <add-to-group anchor="before" group-id="ToolbarRunGroup" relative-to-action="RunConfiguration"/>
     </group>
+    <action id="flutter.upgrade" class="io.flutter.actions.FlutterUpgradeAction" text="Flutter: Upgrade"
+            description="Run 'flutter upgrade'"/>
+    <action id="flutter.doctor" class="io.flutter.actions.FlutterDoctorAction" text="Flutter: Doctor"
+            description="Run 'flutter doctor'"/>
   </actions>
 
   <extensions defaultExtensionNs="com.intellij">

--- a/src/io/flutter/FlutterBundle.properties
+++ b/src/io/flutter/FlutterBundle.properties
@@ -21,7 +21,8 @@ error.path.to.sdk.not.specified=Error: path to the Flutter SDK is not specified.
 error.flutter.sdk.without.dart.sdk=Error: Flutter SDK installation is incomplete, see <a href='https://flutter.io/setup/#get-the-flutter-sdk'>setup instructions</a>.
 error.sdk.not.found.in.specified.location=Error: Flutter SDK is not found in the specified location.
 
-flutter.command.exception=Flutter Command Exception: {0}
+flutter.command.exception.title=Error Running Flutter Command
+flutter.command.exception.message=Exception: {0}
 flutter.incompatible.dart.plugin.warning=Flutter requires a Dart plugin with a minimum version of {0} (currently installed: {1}).
 flutter.module.name=Flutter
 flutter.old.sdk.warning=The current configured Flutter SDK is not known to be fully supported.  Please update your SDK and restart IntelliJ.
@@ -31,6 +32,8 @@ flutter.sdk.is.not.configured=The Flutter SDK is not configured
 flutter.sdk.path.label=Flutter &SDK path:
 flutter.title=Flutter
 flutter.wrong.dart.sdk.warning=The Dart SDK for this module is not the same as Flutter's.  Setting Dart to use the Flutter vended SDK is strongly recommended.
+flutter.sdk.notAvailable.title=No Flutter SDK Configured
+flutter.sdk.notAvailable.message=This action requires a Flutter SDK to be available.
 
 no.flutter.app.title=No Flutter app
 no.flutter.app.description=No Flutter application currently running.

--- a/src/io/flutter/actions/DeviceSelectorAction.java
+++ b/src/io/flutter/actions/DeviceSelectorAction.java
@@ -85,7 +85,8 @@ public class DeviceSelectorAction extends ComboBoxAction implements DumbAware {
     final Project project = e.getProject();
     if (project != null && FlutterSdkUtil.hasFlutterModule(project)) {
       e.getPresentation().setVisible(true);
-    } else {
+    }
+    else {
       e.getPresentation().setVisible(false);
       return;
     }
@@ -178,7 +179,7 @@ public class DeviceSelectorAction extends ComboBoxAction implements DumbAware {
         Notifications.Bus.notify(
           new Notification(FlutterSdk.GROUP_DISPLAY_ID,
                            "Error Opening Simulator",
-                           FlutterBundle.message("flutter.command.exception", e.getMessage()),
+                           FlutterBundle.message("flutter.command.exception.message", e.getMessage()),
                            NotificationType.ERROR));
       }
     }

--- a/src/io/flutter/actions/FlutterDoctorAction.java
+++ b/src/io/flutter/actions/FlutterDoctorAction.java
@@ -6,10 +6,14 @@
 package io.flutter.actions;
 
 import com.intellij.execution.ExecutionException;
+import com.intellij.notification.Notification;
+import com.intellij.notification.NotificationType;
+import com.intellij.notification.Notifications;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.DumbAwareAction;
 import com.intellij.openapi.project.Project;
+import io.flutter.FlutterBundle;
 import io.flutter.sdk.FlutterSdk;
 
 public class FlutterDoctorAction extends DumbAwareAction {
@@ -22,16 +26,23 @@ public class FlutterDoctorAction extends DumbAwareAction {
 
     if (sdk != null) {
       try {
-        sdk.runProject(project, "Flutter: Doctor", null, "doctor");
+        sdk.runProject(project, "Flutter doctor", null, "doctor");
       }
       catch (ExecutionException e) {
-        // TODO: display to the user
-
+        Notifications.Bus.notify(
+          new Notification(FlutterSdk.GROUP_DISPLAY_ID,
+                           FlutterBundle.message("flutter.command.exception.title"),
+                           FlutterBundle.message("flutter.command.exception.message", e.getMessage()),
+                           NotificationType.ERROR));
         LOG.warn(e);
       }
-    } else {
-      // TODO: Notification? Popup?
-      //JBPopupFactory.getInstance().
+    }
+    else {
+      Notifications.Bus.notify(
+        new Notification(FlutterSdk.GROUP_DISPLAY_ID,
+                         FlutterBundle.message("flutter.sdk.notAvailable.title"),
+                         FlutterBundle.message("flutter.sdk.notAvailable.message"),
+                         NotificationType.ERROR));
     }
   }
 }

--- a/src/io/flutter/actions/FlutterDoctorAction.java
+++ b/src/io/flutter/actions/FlutterDoctorAction.java
@@ -17,7 +17,7 @@ public class FlutterDoctorAction extends DumbAwareAction {
 
   @Override
   public void actionPerformed(AnActionEvent event) {
-    Project project = DumbAwareAction.getEventProject(event);
+    final Project project = DumbAwareAction.getEventProject(event);
     final FlutterSdk sdk = FlutterSdk.getFlutterSdk(project);
 
     if (sdk != null) {

--- a/src/io/flutter/actions/FlutterDoctorAction.java
+++ b/src/io/flutter/actions/FlutterDoctorAction.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2016 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.actions;
+
+import com.intellij.execution.ExecutionException;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.project.DumbAwareAction;
+import com.intellij.openapi.project.Project;
+import io.flutter.sdk.FlutterSdk;
+
+public class FlutterDoctorAction extends DumbAwareAction {
+  private static final Logger LOG = Logger.getInstance(FlutterDoctorAction.class);
+
+  @Override
+  public void actionPerformed(AnActionEvent event) {
+    Project project = DumbAwareAction.getEventProject(event);
+    final FlutterSdk sdk = FlutterSdk.getFlutterSdk(project);
+
+    if (sdk != null) {
+      try {
+        sdk.runProject(project, "Flutter: Doctor", null, "doctor");
+      }
+      catch (ExecutionException e) {
+        // TODO: display to the user
+
+        LOG.warn(e);
+      }
+    } else {
+      // TODO: Notification? Popup?
+      //JBPopupFactory.getInstance().
+    }
+  }
+}

--- a/src/io/flutter/actions/FlutterUpgradeAction.java
+++ b/src/io/flutter/actions/FlutterUpgradeAction.java
@@ -25,9 +25,9 @@ public class FlutterUpgradeAction extends DumbAwareAction {
 
   @Override
   public void actionPerformed(AnActionEvent event) {
-    Project project = DumbAwareAction.getEventProject(event);
+    final Project project = DumbAwareAction.getEventProject(event);
     final FlutterSdk sdk = FlutterSdk.getFlutterSdk(project);
-    Pair<Module, VirtualFile> pair = this.getModuleAndPubspecYamlFile(event);
+    final Pair<Module, VirtualFile> pair = this.getModuleAndPubspecYamlFile(event);
 
     if (sdk != null) {
       try {

--- a/src/io/flutter/actions/FlutterUpgradeAction.java
+++ b/src/io/flutter/actions/FlutterUpgradeAction.java
@@ -6,6 +6,9 @@
 package io.flutter.actions;
 
 import com.intellij.execution.ExecutionException;
+import com.intellij.notification.Notification;
+import com.intellij.notification.NotificationType;
+import com.intellij.notification.Notifications;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
 import com.intellij.openapi.actionSystem.LangDataKeys;
@@ -16,6 +19,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Pair;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
+import io.flutter.FlutterBundle;
 import io.flutter.inspections.FlutterYamlNotificationProvider;
 import io.flutter.sdk.FlutterSdk;
 import org.jetbrains.annotations.Nullable;
@@ -34,13 +38,20 @@ public class FlutterUpgradeAction extends DumbAwareAction {
         sdk.run(FlutterSdk.Command.UPGRADE, pair.first, pair.second.getParent(), null);
       }
       catch (ExecutionException e) {
-        // TODO: display to the user
-
+        Notifications.Bus.notify(
+          new Notification(FlutterSdk.GROUP_DISPLAY_ID,
+                           FlutterBundle.message("flutter.command.exception.title"),
+                           FlutterBundle.message("flutter.command.exception.message", e.getMessage()),
+                           NotificationType.ERROR));
         LOG.warn(e);
       }
-    } else {
-      // TODO: Notification? Popup?
-      //JBPopupFactory.getInstance().
+    }
+    else {
+      Notifications.Bus.notify(
+        new Notification(FlutterSdk.GROUP_DISPLAY_ID,
+                         FlutterBundle.message("flutter.sdk.notAvailable.title"),
+                         FlutterBundle.message("flutter.sdk.notAvailable.message"),
+                         NotificationType.ERROR));
     }
   }
 

--- a/src/io/flutter/actions/FlutterUpgradeAction.java
+++ b/src/io/flutter/actions/FlutterUpgradeAction.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2016 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.actions;
+
+import com.intellij.execution.ExecutionException;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.CommonDataKeys;
+import com.intellij.openapi.actionSystem.LangDataKeys;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.project.DumbAwareAction;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Pair;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiFile;
+import io.flutter.inspections.FlutterYamlNotificationProvider;
+import io.flutter.sdk.FlutterSdk;
+import org.jetbrains.annotations.Nullable;
+
+public class FlutterUpgradeAction extends DumbAwareAction {
+  private static final Logger LOG = Logger.getInstance(FlutterUpgradeAction.class);
+
+  @Override
+  public void actionPerformed(AnActionEvent event) {
+    Project project = DumbAwareAction.getEventProject(event);
+    final FlutterSdk sdk = FlutterSdk.getFlutterSdk(project);
+    Pair<Module, VirtualFile> pair = this.getModuleAndPubspecYamlFile(event);
+
+    if (sdk != null) {
+      try {
+        sdk.run(FlutterSdk.Command.UPGRADE, pair.first, pair.second.getParent(), null);
+      }
+      catch (ExecutionException e) {
+        // TODO: display to the user
+
+        LOG.warn(e);
+      }
+    } else {
+      // TODO: Notification? Popup?
+      //JBPopupFactory.getInstance().
+    }
+  }
+
+  @Nullable
+  private static Pair<Module, VirtualFile> getModuleAndPubspecYamlFile(final AnActionEvent e) {
+    final Module module = LangDataKeys.MODULE.getData(e.getDataContext());
+    final PsiFile psiFile = CommonDataKeys.PSI_FILE.getData(e.getDataContext());
+
+    if (module != null && psiFile != null && psiFile.getName().equalsIgnoreCase(FlutterYamlNotificationProvider.FLUTTER_YAML_NAME)) {
+      final VirtualFile file = psiFile.getOriginalFile().getVirtualFile();
+      return file != null ? Pair.create(module, file) : null;
+    }
+
+    return null;
+  }
+}

--- a/src/io/flutter/console/FlutterConsole.java
+++ b/src/io/flutter/console/FlutterConsole.java
@@ -22,6 +22,8 @@ import com.intellij.ui.content.ContentManager;
 import com.intellij.ui.content.MessageView;
 import org.jetbrains.annotations.NotNull;
 
+// TODO(devoncarew): These pile up - how to close or recycle an existing one?
+
 public class FlutterConsole {
 
   /**
@@ -30,17 +32,24 @@ public class FlutterConsole {
   public static void attach(@NotNull Module module, @NotNull OSProcessHandler processHandler, @NotNull String processTitle) {
     final ConsoleView console = getConsole(module);
     console.attachToProcess(processHandler);
-    show(module, console, processTitle);
+    show(module.getProject(), console, processTitle);
   }
 
-  private static void show(@NotNull Module module, @NotNull ConsoleView console, String processTitle) {
+  /**
+   * Attach the flutter console to the process managed by the given processHandler.
+   */
+  public static void attach(@NotNull Project project, @NotNull OSProcessHandler processHandler, @NotNull String processTitle) {
+    final ConsoleView console = getConsole(project);
+    console.attachToProcess(processHandler);
+    show(project, console, processTitle);
+  }
+
+  private static void show(@NotNull Project project, @NotNull ConsoleView console, String processTitle) {
     final SimpleToolWindowPanel toolWindowPanel = new SimpleToolWindowPanel(false, true);
     toolWindowPanel.setContent(console.getComponent());
 
     final Content content = ContentFactory.SERVICE.getInstance().createContent(toolWindowPanel.getComponent(), processTitle, true);
     Disposer.register(content, console);
-
-    final Project project = module.getProject();
 
     final MessageView messageView = MessageView.SERVICE.getInstance(project);
     messageView.runWhenInitialized(() -> {
@@ -58,6 +67,13 @@ public class FlutterConsole {
       TextConsoleBuilderFactory.getInstance().createBuilder(module.getProject());
     consoleBuilder.setViewer(true);
     consoleBuilder.addFilter(new FlutterConsoleFilter(module));
+    return consoleBuilder.getConsole();
+  }
+
+  private static ConsoleView getConsole(@NotNull Project project) {
+    final TextConsoleBuilder consoleBuilder =
+      TextConsoleBuilderFactory.getInstance().createBuilder(project);
+    consoleBuilder.setViewer(true);
     return consoleBuilder.getConsole();
   }
 }

--- a/src/io/flutter/console/FlutterConsoleFilter.java
+++ b/src/io/flutter/console/FlutterConsoleFilter.java
@@ -16,15 +16,16 @@ import com.intellij.openapi.roots.ModuleRootManager;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
 import io.flutter.sdk.FlutterSdk;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class FlutterConsoleFilter implements Filter {
 
   private static final Logger LOG = Logger.getInstance(FlutterConsoleFilter.class);
 
-  private final Module module;
+  private final @NotNull Module module;
 
-  public FlutterConsoleFilter(Module module) {
+  public FlutterConsoleFilter(@NotNull Module module) {
     this.module = module;
   }
 
@@ -79,6 +80,8 @@ public class FlutterConsoleFilter implements Filter {
           sdk.run(FlutterSdk.Command.DOCTOR, module, workingDir, null);
         }
         catch (ExecutionException e) {
+          // TODO: display to the user
+
           LOG.warn(e);
         }
       }

--- a/src/io/flutter/console/FlutterConsoleFilter.java
+++ b/src/io/flutter/console/FlutterConsoleFilter.java
@@ -9,12 +9,16 @@ import com.intellij.execution.ExecutionException;
 import com.intellij.execution.filters.Filter;
 import com.intellij.execution.filters.HyperlinkInfo;
 import com.intellij.execution.filters.OpenFileHyperlinkInfo;
+import com.intellij.notification.Notification;
+import com.intellij.notification.NotificationType;
+import com.intellij.notification.Notifications;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ModuleRootManager;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
+import io.flutter.FlutterBundle;
 import io.flutter.sdk.FlutterSdk;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -73,15 +77,14 @@ public class FlutterConsoleFilter implements Filter {
       final FlutterSdk sdk = FlutterSdk.getFlutterSdk(project);
       if (sdk != null) {
         try {
-
-          final VirtualFile[] roots = ModuleRootManager.getInstance(module).getContentRoots();
-          // Prefer the content root if there is exactly one, otherwise fall-back to Flutter home for the working dir.
-          final VirtualFile workingDir = roots.length == 1 ? roots[0] : LocalFileSystem.getInstance().findFileByPath(sdk.getHomePath());
-          sdk.run(FlutterSdk.Command.DOCTOR, module, workingDir, null);
+          sdk.runProject(project, "Flutter doctor", null, "doctor");
         }
         catch (ExecutionException e) {
-          // TODO: display to the user
-
+          Notifications.Bus.notify(
+            new Notification(FlutterSdk.GROUP_DISPLAY_ID,
+                             FlutterBundle.message("flutter.command.exception.title"),
+                             FlutterBundle.message("flutter.command.exception.message", e.getMessage()),
+                             NotificationType.ERROR));
           LOG.warn(e);
         }
       }

--- a/src/io/flutter/console/FlutterConsoleHelper.java
+++ b/src/io/flutter/console/FlutterConsoleHelper.java
@@ -25,7 +25,7 @@ import org.jetbrains.annotations.NotNull;
 // TODO(devoncarew): These pile up - how to close or recycle an existing one?
 // See: https://github.com/JetBrains/intellij-plugins/blob/8573cd83bb6826e339d60be7b9cdb97add1af2a2/Dart/src/com/jetbrains/lang/dart/ide/actions/DartPubActionBase.java#L203
 
-public class FlutterConsole {
+public class FlutterConsoleHelper {
 
   /**
    * Attach the flutter console to the process managed by the given processHandler.

--- a/src/io/flutter/console/FlutterConsoleHelper.java
+++ b/src/io/flutter/console/FlutterConsoleHelper.java
@@ -23,6 +23,7 @@ import com.intellij.ui.content.MessageView;
 import org.jetbrains.annotations.NotNull;
 
 // TODO(devoncarew): These pile up - how to close or recycle an existing one?
+// See: https://github.com/JetBrains/intellij-plugins/blob/8573cd83bb6826e339d60be7b9cdb97add1af2a2/Dart/src/com/jetbrains/lang/dart/ide/actions/DartPubActionBase.java#L203
 
 public class FlutterConsole {
 

--- a/src/io/flutter/inspections/FlutterYamlNotificationProvider.java
+++ b/src/io/flutter/inspections/FlutterYamlNotificationProvider.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2016 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.inspections;
+
+import com.intellij.openapi.editor.colors.EditorColors;
+import com.intellij.openapi.editor.colors.EditorColorsManager;
+import com.intellij.openapi.fileEditor.FileEditor;
+import com.intellij.openapi.project.DumbAware;
+import com.intellij.openapi.util.Key;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.ui.EditorNotificationPanel;
+import com.intellij.ui.EditorNotifications;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+import java.awt.*;
+
+public class FlutterYamlNotificationProvider extends EditorNotifications.Provider<EditorNotificationPanel> implements DumbAware {
+  private static final Key<EditorNotificationPanel> KEY = Key.create("flutter.yaml");
+  public static final String FLUTTER_YAML_NAME = "flutter.yaml";
+
+  @NotNull
+  @Override
+  public Key<EditorNotificationPanel> getKey() {
+    return KEY;
+  }
+
+  @Nullable
+  @Override
+  public EditorNotificationPanel createNotificationPanel(@NotNull VirtualFile file, @NotNull FileEditor editor) {
+    if (!file.isInLocalFileSystem()) {
+      return null;
+    }
+
+    // TODO: check for flutter sdk and such
+
+    if (FLUTTER_YAML_NAME.equalsIgnoreCase(file.getName())) {
+      return new FlutterYamlActionsPanel(file);
+    }
+
+    return null;
+  }
+}
+
+class FlutterYamlActionsPanel extends EditorNotificationPanel {
+  @NotNull VirtualFile myFile;
+
+  FlutterYamlActionsPanel(@NotNull VirtualFile file) {
+    myFile = file;
+
+    myLinksPanel.add(new JLabel("Flutter actions:"));
+    createActionLabel("Flutter upgrade...", "flutter.upgrade");
+    createActionLabel("Flutter doctor", "flutter.doctor");
+
+    // TODO: Add for 2017.1.
+    //background(EditorColors.GUTTER_BACKGROUND);
+  }
+
+  // TODO: Remove for 2017.1.
+  @Override
+  public Color getBackground() {
+    final Color color = EditorColorsManager.getInstance().getGlobalScheme().getColor(EditorColors.GUTTER_BACKGROUND);
+    return color != null ? color : super.getBackground();
+  }
+}

--- a/src/io/flutter/inspections/FlutterYamlNotificationProvider.java
+++ b/src/io/flutter/inspections/FlutterYamlNotificationProvider.java
@@ -16,6 +16,7 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.ui.EditorNotificationPanel;
 import com.intellij.ui.EditorNotifications;
 import io.flutter.sdk.FlutterSdk;
+import io.flutter.sdk.FlutterSdkUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -39,21 +40,26 @@ public class FlutterYamlNotificationProvider extends EditorNotifications.Provide
       return null;
     }
 
+    if (!FLUTTER_YAML_NAME.equalsIgnoreCase(file.getName())) {
+      return null;
+    }
+
     // Check for a flutter sdk.
-    Project project = ProjectLocator.getInstance().guessProjectForFile(file);
-
-    if (project != null) {
-      final FlutterSdk sdk = FlutterSdk.getFlutterSdk(project);
-      if (sdk == null) {
-        return null;
-      }
+    final Project project = ProjectLocator.getInstance().guessProjectForFile(file);
+    if (project == null) {
+      return null;
     }
 
-    if (FLUTTER_YAML_NAME.equalsIgnoreCase(file.getName())) {
-      return new FlutterYamlActionsPanel(file);
+    if (!FlutterSdkUtil.hasFlutterModule(project)) {
+      return null;
     }
 
-    return null;
+    final FlutterSdk sdk = FlutterSdk.getFlutterSdk(project);
+    if (sdk == null) {
+      return null;
+    }
+
+    return new FlutterYamlActionsPanel(file);
   }
 }
 

--- a/src/io/flutter/inspections/FlutterYamlNotificationProvider.java
+++ b/src/io/flutter/inspections/FlutterYamlNotificationProvider.java
@@ -9,10 +9,13 @@ import com.intellij.openapi.editor.colors.EditorColors;
 import com.intellij.openapi.editor.colors.EditorColorsManager;
 import com.intellij.openapi.fileEditor.FileEditor;
 import com.intellij.openapi.project.DumbAware;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectLocator;
 import com.intellij.openapi.util.Key;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.ui.EditorNotificationPanel;
 import com.intellij.ui.EditorNotifications;
+import io.flutter.sdk.FlutterSdk;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -36,7 +39,15 @@ public class FlutterYamlNotificationProvider extends EditorNotifications.Provide
       return null;
     }
 
-    // TODO: check for flutter sdk and such
+    // Check for a flutter sdk.
+    Project project = ProjectLocator.getInstance().guessProjectForFile(file);
+
+    if (project != null) {
+      final FlutterSdk sdk = FlutterSdk.getFlutterSdk(project);
+      if (sdk == null) {
+        return null;
+      }
+    }
 
     if (FLUTTER_YAML_NAME.equalsIgnoreCase(file.getName())) {
       return new FlutterYamlActionsPanel(file);

--- a/src/io/flutter/sdk/FlutterSdk.java
+++ b/src/io/flutter/sdk/FlutterSdk.java
@@ -30,7 +30,7 @@ import com.intellij.util.ArrayUtil;
 import com.jetbrains.lang.dart.sdk.DartSdk;
 import com.jetbrains.lang.dart.sdk.DartSdkGlobalLibUtil;
 import io.flutter.FlutterBundle;
-import io.flutter.console.FlutterConsole;
+import io.flutter.console.FlutterConsoleHelper;
 import io.flutter.run.FlutterRunConfiguration;
 import io.flutter.run.FlutterRunConfigurationType;
 import io.flutter.run.FlutterRunnerParameters;
@@ -43,9 +43,8 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class FlutterSdk {
-
   public static final String FLUTTER_SDK_GLOBAL_LIB_NAME = "Flutter SDK";
-  public static final String GROUP_DISPLAY_ID = "Flutter Command Invocation";
+  public static final String GROUP_DISPLAY_ID = "Flutter Commands";
   private static final Logger LOG = Logger.getInstance(FlutterSdk.class);
   private static final AtomicBoolean inProgress = new AtomicBoolean(false);
   private final @NotNull String myHomePath;
@@ -101,7 +100,6 @@ public class FlutterSdk {
     toolArgs = ArrayUtil.prepend("--no-color", toolArgs);
     command.addParameters(toolArgs);
 
-    // TODO: We don't always need to call this.
     FileDocumentManager.getInstance().saveAllDocuments();
 
     try {
@@ -120,18 +118,17 @@ public class FlutterSdk {
 
         if (cmd.attachToConsole() && module != null) {
           final String commandPrefix = "[" + module.getName() + "] ";
-          FlutterConsole.attach(module, handler, commandPrefix + cmd.title);
+          FlutterConsoleHelper.attach(module, handler, commandPrefix + cmd.title);
         }
 
         cmd.onStart(module, workingDir, args);
-
         handler.startNotify();
       }
     }
     catch (ExecutionException e) {
       inProgress.set(false);
       Notifications.Bus.notify(
-        new Notification(GROUP_DISPLAY_ID, cmd.title, FlutterBundle.message("flutter.command.exception", e.getMessage()),
+        new Notification(GROUP_DISPLAY_ID, cmd.title, FlutterBundle.message("flutter.command.exception.message", e.getMessage()),
                          NotificationType.ERROR));
     }
   }
@@ -161,15 +158,14 @@ public class FlutterSdk {
           }
         });
 
-        FlutterConsole.attach(project, handler, title);
-
+        FlutterConsoleHelper.attach(project, handler, title);
         handler.startNotify();
       }
     }
     catch (ExecutionException e) {
       inProgress.set(false);
       Notifications.Bus.notify(
-        new Notification(GROUP_DISPLAY_ID, title, FlutterBundle.message("flutter.command.exception", e.getMessage()),
+        new Notification(GROUP_DISPLAY_ID, title, FlutterBundle.message("flutter.command.exception.message", e.getMessage()),
                          NotificationType.ERROR));
     }
   }
@@ -195,7 +191,7 @@ public class FlutterSdk {
 
   public enum Command {
 
-    CREATE("create", "Flutter: Create") {
+    CREATE("create", "Flutter create") {
       @Override
       void onStart(@Nullable Module module, @Nullable VirtualFile workingDir, @NotNull String... args) {
         // Enable Dart.
@@ -266,9 +262,9 @@ public class FlutterSdk {
         });
       }
     },
-    DOCTOR("doctor", "Flutter: Doctor"),
-    UPGRADE("upgrade", "Flutter: Upgrade"),
-    VERSION("--version", "Flutter: Version") {
+    DOCTOR("doctor", "Flutter doctor"),
+    UPGRADE("upgrade", "Flutter upgrade"),
+    VERSION("--version", "Flutter version") {
       @Override
       boolean attachToConsole() {
         return false;


### PR DESCRIPTION
- create a better-bar for flutter.yaml files (fix https://github.com/flutter/flutter-intellij/issues/169)
- include actions for flutter upgrade and flutter doctor

<img width="774" alt="screen shot 2016-11-30 at 1 36 58 pm" src="https://cloud.githubusercontent.com/assets/1269969/20772395/19fee34e-b702-11e6-964f-29f287717243.png">

@pq, I have a few questions here:

- what's the best way to display an error to the user ("No Flutter SDK present")?
- how can we prevent the consoles from piling up (see associated TODO:)?

Thanks! Will do some cleanup of this PR once I know the above.
