### PR TITLE
Debug refactor

### DIFF
--- a/src/io/flutter/run/FlutterRunnerBase.java
+++ b/src/io/flutter/run/FlutterRunnerBase.java
@@ -117,6 +117,8 @@ public class FlutterRunnerBase extends DefaultProgramRunner {
         ((FlutterRunConfigurationBase)runConfiguration).getRunnerParameters().computeProcessWorkingDirectory(env.getProject());
       currentWorkingDirectory = LocalFileSystem.getInstance().findFileByPath((cwd));
 
+      // TODO: insert one-shot mode here
+
       executionResult = state.execute(env.getExecutor(), this);
       if (executionResult == null) {
         return null;

--- a/src/io/flutter/run/daemon/FlutterAppManager.java
+++ b/src/io/flutter/run/daemon/FlutterAppManager.java
@@ -30,10 +30,10 @@ import java.util.stream.Stream;
 
 /**
  * Keeper of running Flutter apps.
+ *
  * TODO(messick) Clean up myResponses as things change
  */
 public class FlutterAppManager {
-
   private static final String CMD_APP_START = "app.start";
   private static final String CMD_APP_STOP = "app.stop";
   private static final String CMD_APP_RESTART = "app.restart";
@@ -67,6 +67,7 @@ public class FlutterAppManager {
       throw new ProcessCanceledException();
     }
     myProgressHandler = new ProgressHandler(project);
+    // TODO(devoncarew): We don't need this call.
     if (!waitForDevice(deviceId)) {
       return null;
     }
@@ -156,13 +157,11 @@ public class FlutterAppManager {
   }
 
   void startDevicePoller(@NotNull FlutterDaemonController pollster) {
-    final Project project = null;
     try {
-      pollster.forkProcess(project);
+      pollster.startDevicePoller();
     }
     catch (ExecutionException e) {
-      // User notification comes in the way of editor toasts.
-      // See: IncompatibleDartPluginNotification.
+      // User notification comes in the way of editor toasts (see IncompatibleDartPluginNotification).
       myLogger.warn(e);
     }
   }
@@ -315,11 +314,7 @@ public class FlutterAppManager {
   }
 
   private void addPendingCmd(int id, @NotNull Command command) {
-    List<Command> list = myPendingCommands.get(id);
-    if (list == null) {
-      list = new ArrayList<>();
-      myPendingCommands.put(id, list);
-    }
+    List<Command> list = myPendingCommands.computeIfAbsent(id, k -> new ArrayList<>());
     list.add(command);
   }
 

--- a/src/io/flutter/run/daemon/FlutterDaemonService.java
+++ b/src/io/flutter/run/daemon/FlutterDaemonService.java
@@ -183,17 +183,16 @@ public class FlutterDaemonService {
                              @NotNull RunMode mode,
                              @Nullable String relativePath)
     throws ExecutionException {
-    boolean isPaused = mode.isDebug();
+    boolean startPaused = mode.isDebug();
     boolean isHot = mode.isDebug() ? HOT_MODE_DEFAULT : HOT_MODE_RELEASE;
-    FlutterDaemonController controller = controllerFor(projectDir, deviceId);
-    if (controller.getProcessHandler() == null || controller.getProcessHandler().isProcessTerminated()) {
-      controller.forkProcess(project);
-    }
+    FlutterDaemonController controller = createDaemonController(projectDir);
+    controller.startRunnerDaemon(project, deviceId, mode, startPaused, isHot, relativePath);
     FlutterAppManager mgr;
     synchronized (myLock) {
       mgr = myManager;
     }
-    return mgr.startApp(controller, deviceId, mode, project, isPaused, isHot, relativePath);
+    // TODO(devoncarew): Remove this call - inline what it does.
+    return mgr.startApp(controller, deviceId, mode, project, startPaused, isHot, relativePath);
   }
 
   /**
@@ -203,19 +202,11 @@ public class FlutterDaemonService {
    * NB: Currently controllers are not shared due to limitations of the debugger.
    *
    * @param projectDir The path to the project root directory
-   * @param deviceId   The device id reported by the daemon
    * @return A FlutterDaemonController that can be used to start the app in the project directory
    */
   @NotNull
-  private FlutterDaemonController controllerFor(String projectDir, String deviceId) {
+  private FlutterDaemonController createDaemonController(String projectDir) {
     synchronized (myLock) {
-      //for (FlutterDaemonController controller : myControllers) {
-      //  if (controller.isForProject(projectDir)) {
-      //    controller.setProjectAndDevice(projectDir, deviceId);
-      //    controller.addListener(myListener);
-      //    return controller;
-      //  }
-      //}
       FlutterDaemonController newController = new FlutterDaemonController(projectDir);
       myControllers.add(newController);
       newController.addListener(myListener);
@@ -224,15 +215,17 @@ public class FlutterDaemonService {
   }
 
   void schedulePolling() {
-    if (!FlutterSdkUtil.isFluttering()) return;
+    if (!FlutterSdkUtil.hasFlutterModules()) return;
+
     synchronized (myLock) {
       if (myPollster != null && myPollster.getProcessHandler() != null && !myPollster.getProcessHandler().isProcessTerminating()) {
         return;
       }
     }
+
     ApplicationManager.getApplication().executeOnPooledThread(() -> {
       synchronized (myLock) {
-        myPollster = new FlutterDaemonController(null);
+        myPollster = new FlutterDaemonController();
         myPollster.addListener(myListener);
         myControllers.add(myPollster);
         myManager.startDevicePoller(myPollster);
@@ -242,14 +235,9 @@ public class FlutterDaemonService {
 
   private void discard(FlutterDaemonController controller) {
     synchronized (myLock) {
-      if (controller == myPollster) {
-        controller.setProjectAndDevice(null, null);
-      }
-      else {
-        myControllers.remove(controller);
-        controller.removeListener(myListener);
-        controller.forceExit();
-      }
+      myControllers.remove(controller);
+      controller.removeListener(myListener);
+      controller.forceExit();
     }
   }
 

--- a/src/io/flutter/sdk/FlutterSdkManager.java
+++ b/src/io/flutter/sdk/FlutterSdkManager.java
@@ -76,7 +76,7 @@ public class FlutterSdkManager {
   }
 
   private static boolean isGlobalFlutterSdkSetAndNeeded() {
-    return FlutterSdk.getGlobalFlutterSdk() != null && FlutterSdkUtil.isFluttering();
+    return FlutterSdk.getGlobalFlutterSdk() != null && FlutterSdkUtil.hasFlutterModules();
   }
 
   /**

--- a/src/io/flutter/sdk/FlutterSdkUtil.java
+++ b/src/io/flutter/sdk/FlutterSdkUtil.java
@@ -116,7 +116,7 @@ public class FlutterSdkUtil {
    *
    * @return true if an open Flutter project is found
    */
-  public static boolean isFluttering() {
+  public static boolean hasFlutterModules() {
     return Arrays.stream(ProjectManager.getInstance().getOpenProjects()).anyMatch((Project p) -> FlutterSdkUtil.hasFlutterModule(p));
   }
 


### PR DESCRIPTION
- some debugging code refactorings to help code clarity and to set us up for more significant refactorings later (in particular, switching over to `flutter run --machine`
- move to separating out the daemon instance used for device polling and the daemon instance(s) used for running apps

Part of writing this PR was just to get me more familiar with the architecture of the flutter debugger code.

@pq 
