### PR TITLE
respond to an app stopped event

### DIFF
--- a/src/io/flutter/run/FlutterRunConfiguration.java
+++ b/src/io/flutter/run/FlutterRunConfiguration.java
@@ -11,13 +11,14 @@ import com.intellij.execution.configurations.ConfigurationFactory;
 import com.intellij.execution.configurations.RunConfiguration;
 import com.intellij.execution.configurations.RunProfileState;
 import com.intellij.execution.runners.ExecutionEnvironment;
+import com.intellij.execution.runners.RunConfigurationWithSuppressedDefaultRunAction;
 import com.intellij.openapi.options.SettingsEditor;
 import com.intellij.openapi.project.Project;
 import com.intellij.util.PathUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public class FlutterRunConfiguration extends FlutterRunConfigurationBase {
+public class FlutterRunConfiguration extends FlutterRunConfigurationBase implements RunConfigurationWithSuppressedDefaultRunAction {
   private @NotNull FlutterRunnerParameters myRunnerParameters = new FlutterRunnerParameters();
 
   public FlutterRunConfiguration(final Project project, final ConfigurationFactory factory, final String name) {

--- a/src/io/flutter/run/daemon/FlutterApp.java
+++ b/src/io/flutter/run/daemon/FlutterApp.java
@@ -14,8 +14,6 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 
-import static io.flutter.run.daemon.FlutterAppManager.AppStartEvent;
-
 /**
  * Handle for a running Flutter app.
  */
@@ -40,21 +38,6 @@ public interface FlutterApp {
    * @return The appId for the running app.
    */
   String appId();
-
-  /**
-   * @return The Flutter project directory.
-   */
-  String projectDirectory();
-
-  /**
-   * @return The deviceId the app is running on.
-   */
-  String deviceId();
-
-  /**
-   * @return <code>true</code> if the app can be restarted.
-   */
-  boolean isRestartable();
 
   /**
    * @return <code>true</code> if the app is in hot-restart mode.
@@ -150,7 +133,7 @@ class RunningFlutterApp implements FlutterApp {
   private final FlutterDaemonService myService;
   private final FlutterDaemonController myController;
   private final FlutterAppManager myManager;
-  private AppStartEvent myApp;
+  private String myAppId;
   private final RunMode myMode;
   private final Project myProject;
   private final boolean isHot;
@@ -181,7 +164,6 @@ class RunningFlutterApp implements FlutterApp {
     myTarget = target;
   }
 
-
   @Override
   public void changeState(State newState) {
     myState = newState;
@@ -199,8 +181,8 @@ class RunningFlutterApp implements FlutterApp {
     myListeners.remove(null);
   }
 
-  void setApp(AppStartEvent app) {
-    myApp = app;
+  void setAppId(String id) {
+    myAppId = id;
   }
 
   @Override
@@ -215,27 +197,12 @@ class RunningFlutterApp implements FlutterApp {
 
   @Override
   public boolean hasAppId() {
-    return myApp != null && myApp.appId != null;
+    return myAppId != null;
   }
 
   @Override
   public String appId() {
-    return myApp.appId;
-  }
-
-  @Override
-  public String projectDirectory() {
-    return myApp.directory;
-  }
-
-  @Override
-  public String deviceId() {
-    return myApp.deviceId;
-  }
-
-  @Override
-  public boolean isRestartable() {
-    return myApp.supportsRestart;
+    return myAppId;
   }
 
   @Override

--- a/src/io/flutter/run/daemon/FlutterDaemonService.java
+++ b/src/io/flutter/run/daemon/FlutterDaemonService.java
@@ -192,7 +192,13 @@ public class FlutterDaemonService {
       mgr = myManager;
     }
     // TODO(devoncarew): Remove this call - inline what it does.
-    return mgr.startApp(controller, deviceId, mode, project, startPaused, isHot, relativePath);
+    FlutterApp app = mgr.startApp(controller, deviceId, mode, project, startPaused, isHot, relativePath);
+    app.addStateListener(newState -> {
+      if (newState == FlutterApp.State.TERMINATED) {
+        controller.forceExit();
+      }
+    });
+    return app;
   }
 
   /**


### PR DESCRIPTION
- respond to an app stopped event (terminate the debug process). Previously we only knew about an app stopping if we'd requested it ourselves; this handles the case were the phone goes away or the app stops for some other reason
- only show the run button as active if we can run something (it behaves similarly to the debug button now)
- some refactoring to remove unused code and to simplify things a bit

@pq