### PR TITLE
Bump to `0.1.6`.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ javaVersion = 1.6
 # To test against a different IDEA product.
 #intellij.alternativeIdePath =
 
-version = 0.1.5
+version = 0.1.6
 
 buildNumber = SNAPSHOT
 

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -21,7 +21,6 @@
   <li>reload and restart keybinding mapping fixes</li>
   <li>new buttter bar with actions for flutter.yaml files</li>
   <li>"run" behavior re-designed to support reload</li>
-  <li>fix to restore breakpoints across a reload</li>
   <li>improved console output for reloading and restarting</li>
   <li>miscellaneous fixes and stability improvements</li>
 </ul>

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -6,7 +6,7 @@
 
   <category>Custom Languages</category>
 
-  <version>0.1.5</version>
+  <version>0.1.6</version>
 
   <idea-version since-build="162.1" until-build="163.*"/>
 
@@ -16,6 +16,16 @@
 
   <change-notes>
 <![CDATA[
+0.1.6:
+<ul>
+  <li>reload and restart keybinding mapping fixes</li>
+  <li>new buttter bar with actions for flutter.yaml files</li>
+  <li>"run" behavior re-designed to support reload</li>
+  <li>fix to restore breakpoints across a reload</li>
+  <li>improved console output for reloading and restarting</li>
+  <li>miscellaneous fixes and stability improvements</li>
+</ul>
+
 0.1.5:
 <ul>
   <li>console filtering for flutter run output</li>


### PR DESCRIPTION
  * reload and restart keybinding mapping fixes
  * new buttter bar with actions for flutter.yaml files
  * ”run" behavior re-designed to support reload
  * improved console output for reloading and restarting
  * miscellaneous fixes and stability improvements

/cc @devoncarew 

/FYI @mit-mit 