### PR TITLE
Tweak WrongModuleTypeNotificationProvider (#466).

### DIFF
--- a/src/io/flutter/FlutterBundle.properties
+++ b/src/io/flutter/FlutterBundle.properties
@@ -14,10 +14,6 @@ dart.sdk.configuration.action.label=Configure Dart SDK
 dart.sdk.is.not.configured=Dart SDK is not configured
 don.t.show.again.for.this.module=Don't show again for this module
 
-debugger.trying.to.connect.vm.at.0=Connecting to Dart VM at {0}
-
-enable.flutter.support=Enable Flutter support
-
 error.folder.specified.as.sdk.not.exists=Error: the folder specified as the Flutter SDK home does not exist.
 error.path.to.sdk.not.specified=Error: path to the Flutter SDK is not specified.
 error.flutter.sdk.without.dart.sdk=Error: Flutter SDK installation is incomplete, see <a href='https://flutter.io/setup/#get-the-flutter-sdk'>setup instructions</a>.
@@ -39,11 +35,8 @@ flutter.wrong.dart.sdk.warning=The Dart SDK for this module is not the same as F
 flutter.sdk.notAvailable.title=No Flutter SDK Configured
 flutter.sdk.notAvailable.message=This action requires a Flutter SDK to be available.
 
-no.flutter.app.title=No Flutter app
-no.flutter.app.description=No Flutter application currently running.
 no.project.dir=Project directory not given
 no.socket.for.debugging=The debugger cannot find an available socket for the Observatory connection
-not.flutter.bundle="{0}" is not a Flutter module, device debugging is not fully supported.
 
 open.observatory.action.text=Open Observatory
 open.observatory.action.description=Open Observatory: a Profiler for Dart apps

--- a/src/io/flutter/FlutterBundle.properties
+++ b/src/io/flutter/FlutterBundle.properties
@@ -7,12 +7,12 @@ app.restart.action.description=Restart the Flutter app
 app.reload.action.text=Hot Reload
 app.reload.action.description=Hot reload changes into the running Flutter app
 
-change.module.type.to.flutter.and.reload.project=Change module type to Flutter and reload project
+change.module.type.to.flutter.and.reload.project=Change module type to Flutter
 
 dart.plugin.update.action.label=Update Dart
 dart.sdk.configuration.action.label=Configure Dart SDK
 dart.sdk.is.not.configured=Dart SDK is not configured
-don.t.show.again.for.this.module=Don't show again for this module
+don.t.show.again.for.this.module=Don't show again
 
 error.folder.specified.as.sdk.not.exists=Error: the folder specified as the Flutter SDK home does not exist.
 error.path.to.sdk.not.specified=Error: path to the Flutter SDK is not specified.
@@ -29,7 +29,7 @@ flutter.project.description=Flutter modules are used to build high-performance, 
 flutter.sdk.browse.path.label=Select Flutter SDK Path
 flutter.sdk.is.not.configured=The Flutter SDK is not configured
 flutter.sdk.path.label=Flutter &SDK path:
-flutter.support.is.not.enabled.for.module.0=Flutter support is not enabled for the module ''{0}''
+flutter.support.is.not.enabled.for.module.0=Flutter support is not enabled for module ''{0}''
 flutter.title=Flutter
 flutter.wrong.dart.sdk.warning=The Dart SDK for this module is not the same as Flutter's.  Setting Dart to use the Flutter vended SDK is strongly recommended.
 flutter.sdk.notAvailable.title=No Flutter SDK Configured

--- a/src/io/flutter/FlutterBundle.properties
+++ b/src/io/flutter/FlutterBundle.properties
@@ -16,6 +16,8 @@ don.t.show.again.for.this.module=Don't show again for this module
 
 debugger.trying.to.connect.vm.at.0=Connecting to Dart VM at {0}
 
+enable.flutter.support=Enable Flutter support
+
 error.folder.specified.as.sdk.not.exists=Error: the folder specified as the Flutter SDK home does not exist.
 error.path.to.sdk.not.specified=Error: path to the Flutter SDK is not specified.
 error.flutter.sdk.without.dart.sdk=Error: Flutter SDK installation is incomplete, see <a href='https://flutter.io/setup/#get-the-flutter-sdk'>setup instructions</a>.
@@ -31,6 +33,7 @@ flutter.project.description=Flutter modules are used to build high-performance, 
 flutter.sdk.browse.path.label=Select Flutter SDK Path
 flutter.sdk.is.not.configured=The Flutter SDK is not configured
 flutter.sdk.path.label=Flutter &SDK path:
+flutter.support.is.not.enabled.for.module.0=Flutter support is not enabled for the module ''{0}''
 flutter.title=Flutter
 flutter.wrong.dart.sdk.warning=The Dart SDK for this module is not the same as Flutter's.  Setting Dart to use the Flutter vended SDK is strongly recommended.
 flutter.sdk.notAvailable.title=No Flutter SDK Configured
@@ -58,3 +61,4 @@ path.to.dart.file.not.set=path to Dart source not specified
 dart.file.not.found=Dart file not found: {0}
 not.a.dart.file.or.directory=Specified file is not a Dart file or directory: {0}
 work.dir.does.not.exist=Working directory doesn''t exist: {0}
+

--- a/src/io/flutter/inspections/FlutterYamlNotificationProvider.java
+++ b/src/io/flutter/inspections/FlutterYamlNotificationProvider.java
@@ -5,12 +5,9 @@
  */
 package io.flutter.inspections;
 
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.editor.colors.EditorColors;
 import com.intellij.openapi.editor.colors.EditorColorsManager;
 import com.intellij.openapi.fileEditor.FileEditor;
-import com.intellij.openapi.module.Module;
-import com.intellij.openapi.module.ModuleUtil;
 import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectLocator;
@@ -18,11 +15,7 @@ import com.intellij.openapi.util.Key;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.ui.EditorNotificationPanel;
 import com.intellij.ui.EditorNotifications;
-import com.jetbrains.lang.dart.sdk.DartSdk;
-import com.jetbrains.lang.dart.sdk.DartSdkGlobalLibUtil;
 import icons.FlutterIcons;
-import io.flutter.FlutterBundle;
-import io.flutter.module.FlutterModuleType;
 import io.flutter.sdk.FlutterSdk;
 import io.flutter.sdk.FlutterSdkUtil;
 import org.jetbrains.annotations.NotNull;
@@ -59,14 +52,6 @@ public class FlutterYamlNotificationProvider extends EditorNotifications.Provide
     }
 
     if (!FlutterSdkUtil.hasFlutterModule(project)) {
-      final Module module = ModuleUtil.findModuleForFile(file, project);
-      if (module != null) {
-        final String message = FlutterBundle.message("flutter.support.is.not.enabled.for.module.0", module.getName());
-        final EditorNotificationPanel panel = new EditorNotificationPanel().icon(FlutterIcons.Flutter).text(message);
-        panel.createActionLabel(FlutterBundle.message("enable.flutter.support"), new EnableFlutterSupportAction(module, project));
-        return panel;
-      }
-
       return null;
     }
 
@@ -76,28 +61,6 @@ public class FlutterYamlNotificationProvider extends EditorNotifications.Provide
     }
 
     return new FlutterYamlActionsPanel(file);
-  }
-}
-
-class EnableFlutterSupportAction implements Runnable {
-  private final Module myModule;
-  private final Project myProject;
-
-  public EnableFlutterSupportAction(@NotNull final Module module, @NotNull Project project) {
-    myModule = module;
-    myProject = project;
-  }
-
-  @Override
-  public void run() {
-
-    myModule.setOption(Module.ELEMENT_TYPE, FlutterModuleType.getInstance().getId());
-
-    if (DartSdk.getDartSdk(myProject) != null && !DartSdkGlobalLibUtil.isDartSdkEnabled(myModule)) {
-      ApplicationManager.getApplication().runWriteAction(() -> DartSdkGlobalLibUtil.enableDartSdk(myModule));
-    }
-
-    myProject.save();
   }
 }
 

--- a/src/io/flutter/inspections/FlutterYamlNotificationProvider.java
+++ b/src/io/flutter/inspections/FlutterYamlNotificationProvider.java
@@ -5,9 +5,12 @@
  */
 package io.flutter.inspections;
 
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.editor.colors.EditorColors;
 import com.intellij.openapi.editor.colors.EditorColorsManager;
 import com.intellij.openapi.fileEditor.FileEditor;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleUtil;
 import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectLocator;
@@ -15,7 +18,11 @@ import com.intellij.openapi.util.Key;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.ui.EditorNotificationPanel;
 import com.intellij.ui.EditorNotifications;
+import com.jetbrains.lang.dart.sdk.DartSdk;
+import com.jetbrains.lang.dart.sdk.DartSdkGlobalLibUtil;
 import icons.FlutterIcons;
+import io.flutter.FlutterBundle;
+import io.flutter.module.FlutterModuleType;
 import io.flutter.sdk.FlutterSdk;
 import io.flutter.sdk.FlutterSdkUtil;
 import org.jetbrains.annotations.NotNull;
@@ -52,6 +59,14 @@ public class FlutterYamlNotificationProvider extends EditorNotifications.Provide
     }
 
     if (!FlutterSdkUtil.hasFlutterModule(project)) {
+      final Module module = ModuleUtil.findModuleForFile(file, project);
+      if (module != null) {
+        final String message = FlutterBundle.message("flutter.support.is.not.enabled.for.module.0", module.getName());
+        final EditorNotificationPanel panel = new EditorNotificationPanel().icon(FlutterIcons.Flutter).text(message);
+        panel.createActionLabel(FlutterBundle.message("enable.flutter.support"), new EnableFlutterSupportAction(module, project));
+        return panel;
+      }
+
       return null;
     }
 
@@ -61,6 +76,28 @@ public class FlutterYamlNotificationProvider extends EditorNotifications.Provide
     }
 
     return new FlutterYamlActionsPanel(file);
+  }
+}
+
+class EnableFlutterSupportAction implements Runnable {
+  private final Module myModule;
+  private final Project myProject;
+
+  public EnableFlutterSupportAction(@NotNull final Module module, @NotNull Project project) {
+    myModule = module;
+    myProject = project;
+  }
+
+  @Override
+  public void run() {
+
+    myModule.setOption(Module.ELEMENT_TYPE, FlutterModuleType.getInstance().getId());
+
+    if (DartSdk.getDartSdk(myProject) != null && !DartSdkGlobalLibUtil.isDartSdkEnabled(myModule)) {
+      ApplicationManager.getApplication().runWriteAction(() -> DartSdkGlobalLibUtil.enableDartSdk(myModule));
+    }
+
+    myProject.save();
   }
 }
 

--- a/src/io/flutter/inspections/WrongModuleTypeNotificationProvider.java
+++ b/src/io/flutter/inspections/WrongModuleTypeNotificationProvider.java
@@ -27,6 +27,7 @@ import com.jetbrains.lang.dart.DartFileType;
 import com.jetbrains.lang.dart.sdk.DartSdk;
 import com.jetbrains.lang.dart.sdk.DartSdkGlobalLibUtil;
 import com.jetbrains.lang.dart.util.PubspecYamlUtil;
+import icons.FlutterIcons;
 import io.flutter.FlutterBundle;
 import io.flutter.module.FlutterModuleType;
 import io.flutter.sdk.FlutterSdkUtil;
@@ -59,12 +60,13 @@ public class WrongModuleTypeNotificationProvider extends EditorNotifications.Pro
 
   @NotNull
   private static EditorNotificationPanel createPanel(@NotNull Project project, @NotNull Module module) {
-    final EditorNotificationPanel panel = new EditorNotificationPanel();
-    panel.setText(FlutterBundle.message("not.flutter.bundle", module.getName()));
+    final EditorNotificationPanel panel = new EditorNotificationPanel().icon(FlutterIcons.Flutter);
+    panel.setText(FlutterBundle.message("flutter.support.is.not.enabled.for.module.0", module.getName()));
     panel.createActionLabel(FlutterBundle.message("change.module.type.to.flutter.and.reload.project"), () -> {
-      final int message = Messages.showOkCancelDialog(project, FlutterBundle.message("updating.module.type.requires.project.reload.proceed"),
-                                                      FlutterBundle.message("update.module.type"),
-                                                      FlutterBundle.message("reload.project"), CommonBundle.getCancelButtonText(), null);
+      final int message =
+        Messages.showOkCancelDialog(project, FlutterBundle.message("updating.module.type.requires.project.reload.proceed"),
+                                    FlutterBundle.message("update.module.type"),
+                                    FlutterBundle.message("reload.project"), CommonBundle.getCancelButtonText(), null);
       if (message == Messages.YES) {
         module.setOption(Module.ELEMENT_TYPE, FlutterModuleType.getInstance().getId());
 


### PR DESCRIPTION
Adds a new action to `flutter.yaml` files that allows you to enable Flutter support.

![screen shot 2016-12-05 at 3 59 29 pm](https://cloud.githubusercontent.com/assets/67586/20907648/606b40f6-bb04-11e6-8aa1-c7150bf49ef0.png)

Partially address: #466.

/cc @devoncarew 
