### PR TITLE
Flutter run machine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ pubspec.lock
 .idea/workspace.xml
 .idea/shelf
 .idea/emacs.xml
+material-design-icons/

--- a/src/io/flutter/run/FlutterRunner.java
+++ b/src/io/flutter/run/FlutterRunner.java
@@ -16,7 +16,6 @@ import com.intellij.execution.runners.ExecutionEnvironment;
 import com.intellij.execution.ui.RunContentDescriptor;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
-import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.xdebugger.XDebugProcess;
@@ -53,6 +52,7 @@ public class FlutterRunner extends FlutterRunnerBase {
 
     final FlutterRunConfiguration runConfiguration = (FlutterRunConfiguration)profile;
     final FlutterDaemonService service = FlutterDaemonService.getInstance(runConfiguration.getProject());
+    //noinspection SimplifiableIfStatement
     if (service == null || service.getSelectedDevice() == null) {
       return false;
     }
@@ -148,10 +148,8 @@ public class FlutterRunner extends FlutterRunnerBase {
       ((FlutterRunConfigurationBase)runConfiguration).getRunnerParameters().computeProcessWorkingDirectory(env.getProject());
     currentWorkingDirectory = LocalFileSystem.getInstance().findFileByPath((cwd));
 
-    // TODO(devoncarew): Insert one-shot mode here.
     executionResult = appState.execute(env.getExecutor(), this);
 
-    debuggingHost = null; //TODO: should this be set?
     observatoryPort = appState.getObservatoryPort();
 
     FileDocumentManager.getInstance().saveAllDocuments();
@@ -163,7 +161,7 @@ public class FlutterRunner extends FlutterRunnerBase {
       public XDebugProcess start(@NotNull final XDebugSession session) {
         final DartUrlResolver dartUrlResolver = getDartUrlResolver(env.getProject(), contextFileOrDir);
         return new FlutterDebugProcess(session,
-                                       StringUtil.notNullize(debuggingHost, "localhost"),
+                                       "localhost",
                                        observatoryPort,
                                        state,
                                        executionResult,

--- a/src/io/flutter/run/daemon/DaemonJsonInputFilterProvider.java
+++ b/src/io/flutter/run/daemon/DaemonJsonInputFilterProvider.java
@@ -31,7 +31,12 @@ public class DaemonJsonInputFilterProvider implements ConsoleInputFilterProvider
     public List<Pair<String, ConsoleViewContentType>> applyFilter(String text, ConsoleViewContentType contentType) {
       if (!VERBOSE) {
         final String trimmed = text.trim();
+
         if (trimmed.startsWith("[{") && trimmed.endsWith("}]")) {
+          return Collections.singletonList(Pair.create(null, contentType));
+        }
+
+        if (trimmed.startsWith("Observatory listening on http") && !trimmed.contains("\n")) {
           return Collections.singletonList(Pair.create(null, contentType));
         }
       }

--- a/src/io/flutter/run/daemon/FlutterAppManager.java
+++ b/src/io/flutter/run/daemon/FlutterAppManager.java
@@ -375,6 +375,12 @@ public class FlutterAppManager {
     }
   }
 
+  private void eventAppStart(AppStartEvent event, FlutterDaemonController controller) {
+    // TODO:
+
+    System.out.println("eventAppStart: " + event);
+  }
+
   private void eventAppStarted(@NotNull AppStartEvent started, @NotNull FlutterDaemonController controller) {
     assert started.directory.equals(controller.getProjectDirectory());
     final Stream<Command> starts = findAllPendingCmds(controller).stream().filter(c -> {
@@ -637,7 +643,7 @@ public class FlutterAppManager {
     @SuppressWarnings("unused") boolean supportsRestart;
 
     void process(FlutterAppManager manager, FlutterDaemonController controller) {
-      // This event is ignored. The app.start command response is used instead.
+      manager.eventAppStart(this, controller);
     }
   }
 

--- a/src/io/flutter/run/daemon/FlutterDaemonController.java
+++ b/src/io/flutter/run/daemon/FlutterDaemonController.java
@@ -83,16 +83,14 @@ public class FlutterDaemonController extends ProcessAdapter {
     myProcessHandler.startNotify();
   }
 
-  public void startRunnerDaemon(
-    @NotNull Project project,
-    @NotNull String deviceId,
-    @NotNull RunMode mode,
-    boolean startPaused,
-    boolean isHot,
-    @Nullable String target) throws ExecutionException {
-
-    // TODO(devoncarew): Use the deviceId / mode / startPaused / isHot / target params.
-    final GeneralCommandLine commandLine = createCommandLineRunner(project);
+  public void startRunnerProcess(@NotNull Project project,
+                                 @NotNull String projectDir,
+                                 @NotNull String deviceId,
+                                 @NotNull RunMode mode,
+                                 boolean startPaused,
+                                 boolean isHot,
+                                 @Nullable String target) throws ExecutionException {
+    final GeneralCommandLine commandLine = createCommandLineRunner(project, projectDir, deviceId, mode, startPaused, isHot, target);
     myProcessHandler = new OSProcessHandler(commandLine);
     myProcessHandler.addProcessListener(this);
     myProcessHandler.startNotify();
@@ -175,9 +173,15 @@ public class FlutterDaemonController extends ProcessAdapter {
   }
 
   /**
-   * Create a command to start the Flutter daemon when used to launch apps.
+   * Create a command to run 'flutter run --machine'.
    */
-  private static GeneralCommandLine createCommandLineRunner(@NotNull Project project) throws ExecutionException {
+  private static GeneralCommandLine createCommandLineRunner(@NotNull Project project,
+                                                            @NotNull String projectDir,
+                                                            @NotNull String deviceId,
+                                                            @NotNull RunMode mode,
+                                                            boolean startPaused,
+                                                            boolean isHot,
+                                                            @Nullable String target) throws ExecutionException {
     final FlutterSdk flutterSdk = FlutterSdk.getFlutterSdk(project);
     if (flutterSdk == null) {
       throw new ExecutionException(FlutterBundle.message("flutter.sdk.is.not.configured"));
@@ -185,12 +189,27 @@ public class FlutterDaemonController extends ProcessAdapter {
     final String flutterSdkPath = flutterSdk.getHomePath();
     final String flutterExec = FlutterSdkUtil.pathToFlutterTool(flutterSdkPath);
 
-    // While not strictly required, we set the working directory to the flutter root for consistency.
-    final GeneralCommandLine commandLine = new GeneralCommandLine().withWorkDirectory(flutterSdkPath);
+    final GeneralCommandLine commandLine = new GeneralCommandLine().withWorkDirectory(projectDir);
     commandLine.setCharset(CharsetToolkit.UTF8_CHARSET);
     commandLine.setExePath(FileUtil.toSystemDependentName(flutterExec));
-    commandLine.addParameter("daemon");
-
+    commandLine.addParameters("daemon");
+    //commandLine.addParameters("run", "--machine");
+    //// TODO(devoncarew): Handle cases where device might be null.
+    //if (deviceId != null) {
+    //  commandLine.addParameter("--device-id=" + deviceId);
+    //}
+    //if (mode == RunMode.PROFILE) {
+    //  commandLine.addParameter("--profile");
+    //}
+    //if (startPaused) {
+    //  commandLine.addParameter("--start-paused");
+    //}
+    //if (!isHot) {
+    //  commandLine.addParameter("--no-hot");
+    //}
+    //if (target != null) {
+    //  commandLine.addParameter(target);
+    //}
     return commandLine;
   }
 

--- a/src/io/flutter/run/daemon/FlutterDaemonController.java
+++ b/src/io/flutter/run/daemon/FlutterDaemonController.java
@@ -192,24 +192,23 @@ public class FlutterDaemonController extends ProcessAdapter {
     final GeneralCommandLine commandLine = new GeneralCommandLine().withWorkDirectory(projectDir);
     commandLine.setCharset(CharsetToolkit.UTF8_CHARSET);
     commandLine.setExePath(FileUtil.toSystemDependentName(flutterExec));
-    commandLine.addParameters("daemon");
-    //commandLine.addParameters("run", "--machine");
-    //// TODO(devoncarew): Handle cases where device might be null.
-    //if (deviceId != null) {
-    //  commandLine.addParameter("--device-id=" + deviceId);
-    //}
-    //if (mode == RunMode.PROFILE) {
-    //  commandLine.addParameter("--profile");
-    //}
-    //if (startPaused) {
-    //  commandLine.addParameter("--start-paused");
-    //}
-    //if (!isHot) {
-    //  commandLine.addParameter("--no-hot");
-    //}
-    //if (target != null) {
-    //  commandLine.addParameter(target);
-    //}
+    commandLine.addParameters("run", "--machine");
+    // TODO(devoncarew): Handle cases where device might be null.
+    if (deviceId != null) {
+      commandLine.addParameter("--device-id=" + deviceId);
+    }
+    if (mode == RunMode.PROFILE) {
+      commandLine.addParameter("--profile");
+    }
+    if (startPaused) {
+      commandLine.addParameter("--start-paused");
+    }
+    if (!isHot) {
+      commandLine.addParameter("--no-hot");
+    }
+    if (target != null) {
+      commandLine.addParameter(target);
+    }
     return commandLine;
   }
 

--- a/src/io/flutter/run/daemon/FlutterDaemonService.java
+++ b/src/io/flutter/run/daemon/FlutterDaemonService.java
@@ -198,18 +198,23 @@ public class FlutterDaemonService {
     final boolean startPaused = mode == RunMode.DEBUG;
     final boolean isHot = mode.isReloadEnabled() ? HOT_MODE_DEFAULT : HOT_MODE_RELEASE;
     final FlutterDaemonController controller = createController(projectDir);
-    controller.startRunnerDaemon(project, deviceId, mode, startPaused, isHot, relativePath);
+    controller.startRunnerProcess(project, projectDir, deviceId, mode, startPaused, isHot, relativePath);
     final FlutterAppManager mgr;
     synchronized (myLock) {
       mgr = myManager;
     }
     // TODO(devoncarew): Remove this call - inline what it does.
-    FlutterApp app = mgr.startApp(controller, deviceId, mode, project, startPaused, isHot, relativePath);
-    app.addStateListener(newState -> {
-      if (newState == FlutterApp.State.TERMINATED) {
-        controller.forceExit();
-      }
-    });
+    final FlutterApp app = mgr.startApp(controller, deviceId, mode, project, startPaused, isHot, relativePath);
+    if (app == null) {
+      controller.forceExit();
+    }
+    else {
+      app.addStateListener(newState -> {
+        if (newState == FlutterApp.State.TERMINATED) {
+          controller.forceExit();
+        }
+      });
+    }
     return app;
   }
 

--- a/src/io/flutter/run/daemon/FlutterDaemonService.java
+++ b/src/io/flutter/run/daemon/FlutterDaemonService.java
@@ -27,9 +27,6 @@ import java.util.Set;
  * Long lived singleton that communicates with controllers attached to external Flutter processes.
  */
 public class FlutterDaemonService {
-  private static final boolean HOT_MODE_DEFAULT = true;
-  private static final boolean HOT_MODE_RELEASE = false;
-
   private final Object myLock = new Object();
   private final List<FlutterDaemonController> myControllers = new ArrayList<>();
   private FlutterDaemonController myPollster;
@@ -41,29 +38,17 @@ public class FlutterDaemonService {
 
   private final DaemonListener myListener = new DaemonListener() {
     public void daemonInput(String string, FlutterDaemonController controller) {
-      final FlutterAppManager mgr;
-      synchronized (myLock) {
-        mgr = myManager;
-      }
-      mgr.processInput(string, controller);
+      myManager.processInput(string, controller);
     }
 
     public void enableDevicePolling(FlutterDaemonController controller) {
-      final FlutterAppManager mgr;
-      synchronized (myLock) {
-        mgr = myManager;
-      }
-      mgr.enableDevicePolling(controller);
+      myManager.enableDevicePolling(controller);
     }
 
     @Override
     public void aboutToTerminate(ProcessHandler handler, FlutterDaemonController controller) {
       assert handler == controller.getProcessHandler();
-      final FlutterAppManager mgr;
-      synchronized (myLock) {
-        mgr = myManager;
-      }
-      mgr.aboutToTerminateAll(controller);
+      myManager.aboutToTerminateAll(controller);
     }
 
     @Override
@@ -196,25 +181,17 @@ public class FlutterDaemonService {
                              @Nullable String relativePath)
     throws ExecutionException {
     final boolean startPaused = mode == RunMode.DEBUG;
-    final boolean isHot = mode.isReloadEnabled() ? HOT_MODE_DEFAULT : HOT_MODE_RELEASE;
+    final boolean isHot = mode.isReloadEnabled();
+
     final FlutterDaemonController controller = createController(projectDir);
     controller.startRunnerProcess(project, projectDir, deviceId, mode, startPaused, isHot, relativePath);
-    final FlutterAppManager mgr;
-    synchronized (myLock) {
-      mgr = myManager;
-    }
-    // TODO(devoncarew): Remove this call - inline what it does.
-    final FlutterApp app = mgr.startApp(controller, deviceId, mode, project, startPaused, isHot, relativePath);
-    if (app == null) {
-      controller.forceExit();
-    }
-    else {
-      app.addStateListener(newState -> {
-        if (newState == FlutterApp.State.TERMINATED) {
-          controller.forceExit();
-        }
-      });
-    }
+
+    final FlutterApp app = myManager.appStarting(controller, deviceId, mode, project, startPaused, isHot, relativePath);
+    app.addStateListener(newState -> {
+      if (newState == FlutterApp.State.TERMINATED) {
+        controller.forceExit();
+      }
+    });
     return app;
   }
 


### PR DESCRIPTION
- update IntelliJ to use `flutter run --machine` (instead of flutter daemon `app.startApp`) when starting an app (fix https://github.com/flutter/flutter-intellij/issues/401). We still use the daemon protocol, but use it in the one-shot manner provided by flutter run --machine

@pq, @danrubel 