### PR TITLE
Top-level Flutter Tool menu (#515).

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -103,9 +103,9 @@
     <group id="FlutterToolsActionGroup" class="io.flutter.actions.FlutterToolsActionGroup" popup="true"
            text="Flutter" description="Flutter Tools" icon="FlutterIcons.Flutter">
       <add-to-group group-id="ToolsMenu" anchor="last"/>
-      <action id="flutter.upgrade" class="io.flutter.actions.FlutterUpgradeAction" text="Flutter: Upgrade"
+      <action id="flutter.upgrade" class="io.flutter.actions.FlutterUpgradeAction" text="Flutter Upgrade"
               description="Run 'flutter upgrade'"/>
-      <action id="flutter.doctor" class="io.flutter.actions.FlutterDoctorAction" text="Flutter: Doctor"
+      <action id="flutter.doctor" class="io.flutter.actions.FlutterDoctorAction" text="Flutter Doctor"
               description="Run 'flutter doctor'"/>
     </group>
 

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -99,10 +99,16 @@
       <add-to-group anchor="before" group-id="RunContextGroup" relative-to-action="RunConfiguration"/>
       <add-to-group anchor="before" group-id="ToolbarRunGroup" relative-to-action="RunConfiguration"/>
     </group>
-    <action id="flutter.upgrade" class="io.flutter.actions.FlutterUpgradeAction" text="Flutter: Upgrade"
-            description="Run 'flutter upgrade'"/>
-    <action id="flutter.doctor" class="io.flutter.actions.FlutterDoctorAction" text="Flutter: Doctor"
-            description="Run 'flutter doctor'"/>
+
+    <group id="FlutterToolsActionGroup" class="io.flutter.actions.FlutterToolsActionGroup" popup="true"
+           text="Flutter" description="Flutter Tools" icon="FlutterIcons.Flutter">
+      <add-to-group group-id="ToolsMenu" anchor="last"/>
+      <action id="flutter.upgrade" class="io.flutter.actions.FlutterUpgradeAction" text="Flutter: Upgrade"
+              description="Run 'flutter upgrade'"/>
+      <action id="flutter.doctor" class="io.flutter.actions.FlutterDoctorAction" text="Flutter: Doctor"
+              description="Run 'flutter doctor'"/>
+    </group>
+
   </actions>
 
   <extensions defaultExtensionNs="com.intellij">

--- a/src/io/flutter/actions/FlutterToolsActionGroup.java
+++ b/src/io/flutter/actions/FlutterToolsActionGroup.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2016 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.actions;
+
+import com.intellij.openapi.actionSystem.DefaultActionGroup;
+
+public class FlutterToolsActionGroup extends DefaultActionGroup {
+
+}


### PR DESCRIPTION
Contents to be filled in.  To start, groups existing upgrade and doctor commands.

See: #515.

![screen shot 2016-12-09 at 2 23 51 pm](https://cloud.githubusercontent.com/assets/67586/21066579/220e83c6-be1b-11e6-8b11-efea20548420.png)

Not crazy about the text labels.  Maybe abbreviate to `Upgrade` and `Doctor`?

/cc @devoncarew 
