### PR TITLE
misc fixes around launching flutter apps

### DIFF
--- a/src/io/flutter/console/FlutterConsoleFilter.java
+++ b/src/io/flutter/console/FlutterConsoleFilter.java
@@ -39,8 +39,8 @@ public class FlutterConsoleFilter implements Filter {
 
     String pathPart = line.trim();
 
-    // Check for, e.g., "Running lib/main.dart"
-    if (line.startsWith("Running")) {
+    // Check for, e.g., "Launching lib/main.dart"
+    if (line.startsWith("Launching ")) {
       final String[] parts = line.split(" ");
       if (parts.length > 1) {
         pathPart = parts[1];

--- a/src/io/flutter/run/FlutterDebugProcess.java
+++ b/src/io/flutter/run/FlutterDebugProcess.java
@@ -59,6 +59,11 @@ public class FlutterDebugProcess extends DartVmServiceDebugProcessZ {
     return (state instanceof FlutterAppState) && ((FlutterAppState)state).getMode() == RunMode.DEBUG;
   }
 
+  @Override
+  public boolean shouldEnableHotReload() {
+    return ((FlutterAppState)myState).getMode().isReloadEnabled();
+  }
+
   private boolean isDebuggingSession() {
     return isDebuggingSession(myState);
   }

--- a/src/io/flutter/run/daemon/FlutterAppManager.java
+++ b/src/io/flutter/run/daemon/FlutterAppManager.java
@@ -19,10 +19,7 @@ import java.io.File;
 import java.lang.reflect.Type;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -95,6 +92,7 @@ public class FlutterAppManager {
     final long timeout = 10000L;
     final FlutterJsonObject[] resp = {null};
     try {
+      // TODO(devonarew): We get ThreadDeath exceptions from here.
       TimeoutUtil.executeWithTimeout(timeout, () -> {
         while (resp[0] == null) {
           synchronized (myLock) {
@@ -229,6 +227,18 @@ public class FlutterAppManager {
       apps = new ArrayList<>(myApps);
     }
     apps.stream().filter(app -> app.getController() == controller).forEach(this::stopApp);
+  }
+
+  void terminateAllFor(FlutterDaemonController controller) {
+    synchronized (myLock) {
+      final ListIterator<FlutterApp> itor = myApps.listIterator();
+      while (itor.hasNext()) {
+        FlutterApp app = itor.next();
+        if (app.getController() == controller) {
+          itor.remove();
+        }
+      }
+    }
   }
 
   @NotNull
@@ -667,6 +677,7 @@ public class FlutterAppManager {
     // "event":"app.eventDebugPort"
     @SuppressWarnings("unused") private String appId;
     @SuppressWarnings("unused") private int port;
+    @SuppressWarnings("unused") private String wsUri;
     @SuppressWarnings("unused") private String baseUri;
 
     void process(FlutterAppManager manager, FlutterDaemonController controller) {

--- a/src/io/flutter/run/daemon/FlutterAppManager.java
+++ b/src/io/flutter/run/daemon/FlutterAppManager.java
@@ -92,7 +92,7 @@ public class FlutterAppManager {
     final long timeout = 10000L;
     final FlutterJsonObject[] resp = {null};
     try {
-      // TODO(devonarew): We get ThreadDeath exceptions from here.
+      // TODO(devoncarew): We get ThreadDeath exceptions from here.
       TimeoutUtil.executeWithTimeout(timeout, () -> {
         while (resp[0] == null) {
           synchronized (myLock) {

--- a/src/io/flutter/run/daemon/FlutterDaemonService.java
+++ b/src/io/flutter/run/daemon/FlutterDaemonService.java
@@ -53,6 +53,7 @@ public class FlutterDaemonService {
 
     @Override
     public void processTerminated(ProcessHandler handler, FlutterDaemonController controller) {
+      myManager.terminateAllFor(controller);
       if (handler == controller.getProcessHandler()) {
         discard(controller);
       }


### PR DESCRIPTION
Varied fixes around launching flutter apps:

- update the text we're looking for to link to source files in the console
- add a new `wsUri` field to the app.debugPort event
- remove apps when the daemon controller exists. This fixes an issue with action enablement on subsequent runs
- stop looking for an observatory connection message if the process exists

@pq