### PR TITLE
have the flutter upgrade action better locate pubspec files

### DIFF
--- a/src/io/flutter/FlutterBundle.properties
+++ b/src/io/flutter/FlutterBundle.properties
@@ -19,9 +19,8 @@ error.path.to.sdk.not.specified=Error: path to the Flutter SDK is not specified.
 error.flutter.sdk.without.dart.sdk=Error: Flutter SDK installation is incomplete, see <a href='https://flutter.io/setup/#get-the-flutter-sdk'>setup instructions</a>.
 error.sdk.not.found.in.specified.location=Error: Flutter SDK is not found in the specified location.
 
-flutter.command.exception.title=Error Running Flutter Command
+flutter.command.exception.title=Flutter Command Error
 flutter.command.exception.message=Exception: {0}
-flutter.command.upgrade.missing.pubspec.message=No pubspec could be found for: {0}
 flutter.incompatible.dart.plugin.warning=Flutter requires a Dart plugin with a minimum version of {0} (currently installed: {1}).
 flutter.module.name=Flutter
 flutter.old.sdk.warning=The current configured Flutter SDK is not known to be fully supported. Please update your SDK and restart IntelliJ.

--- a/src/io/flutter/FlutterConstants.java
+++ b/src/io/flutter/FlutterConstants.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2016 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+package io.flutter;
+
+public class FlutterConstants {
+  public static final String FLUTTER_YAML = "flutter.yaml";
+  public static final String PUBSPEC_YAML = "pubspec.yaml";
+
+  private FlutterConstants() {
+
+  }
+}

--- a/src/io/flutter/inspections/FlutterYamlNotificationProvider.java
+++ b/src/io/flutter/inspections/FlutterYamlNotificationProvider.java
@@ -16,6 +16,7 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.ui.EditorNotificationPanel;
 import com.intellij.ui.EditorNotifications;
 import icons.FlutterIcons;
+import io.flutter.FlutterConstants;
 import io.flutter.sdk.FlutterSdk;
 import io.flutter.sdk.FlutterSdkUtil;
 import org.jetbrains.annotations.NotNull;
@@ -26,7 +27,6 @@ import java.awt.*;
 
 public class FlutterYamlNotificationProvider extends EditorNotifications.Provider<EditorNotificationPanel> implements DumbAware {
   private static final Key<EditorNotificationPanel> KEY = Key.create("flutter.yaml");
-  public static final String FLUTTER_YAML_NAME = "flutter.yaml";
 
   @NotNull
   @Override
@@ -41,7 +41,7 @@ public class FlutterYamlNotificationProvider extends EditorNotifications.Provide
       return null;
     }
 
-    if (!FLUTTER_YAML_NAME.equalsIgnoreCase(file.getName())) {
+    if (!FlutterConstants.FLUTTER_YAML.equalsIgnoreCase(file.getName())) {
       return null;
     }
 

--- a/src/io/flutter/inspections/WrongModuleTypeNotificationProvider.java
+++ b/src/io/flutter/inspections/WrongModuleTypeNotificationProvider.java
@@ -26,9 +26,9 @@ import com.intellij.util.containers.ContainerUtil;
 import com.jetbrains.lang.dart.DartFileType;
 import com.jetbrains.lang.dart.sdk.DartSdk;
 import com.jetbrains.lang.dart.sdk.DartSdkGlobalLibUtil;
-import com.jetbrains.lang.dart.util.PubspecYamlUtil;
 import icons.FlutterIcons;
 import io.flutter.FlutterBundle;
+import io.flutter.FlutterConstants;
 import io.flutter.module.FlutterModuleType;
 import io.flutter.sdk.FlutterSdkUtil;
 import org.jetbrains.annotations.NotNull;
@@ -41,9 +41,6 @@ import java.util.regex.Pattern;
 public class WrongModuleTypeNotificationProvider extends EditorNotifications.Provider<EditorNotificationPanel> implements DumbAware {
   private static final Key<EditorNotificationPanel> KEY = Key.create("Wrong module type");
   private static final String DONT_ASK_TO_CHANGE_MODULE_TYPE_KEY = "do.not.ask.to.change.module.type"; //NON-NLS
-  private static final String FLUTTER_YAML_FILE = "flutter.yaml"; //NON-NLS
-  private static final String PUBSPEC_YAML_FILE = "pubspec.yaml"; //NON-NLS
-
   private static final Pattern FLUTTER_SDK_DEP = Pattern.compile(".*sdk:\\s*flutter"); //NON-NLS
 
   private final Project myProject;
@@ -55,11 +52,11 @@ public class WrongModuleTypeNotificationProvider extends EditorNotifications.Pro
   private static boolean usesFlutter(@NotNull Module module) {
     final VirtualFile[] roots = ModuleRootManager.getInstance(module).getContentRoots();
     for (VirtualFile baseDir : roots) {
-      final VirtualFile flutterYaml = baseDir.findChild(FLUTTER_YAML_FILE);
+      final VirtualFile flutterYaml = baseDir.findChild(FlutterConstants.FLUTTER_YAML);
       if (flutterYaml != null && flutterYaml.exists()) {
         return true;
       }
-      final VirtualFile pubspec = baseDir.findChild(PUBSPEC_YAML_FILE);
+      final VirtualFile pubspec = baseDir.findChild(FlutterConstants.PUBSPEC_YAML);
       if (declaresFlutterDependency(pubspec)) {
         return true;
       }
@@ -123,8 +120,8 @@ public class WrongModuleTypeNotificationProvider extends EditorNotifications.Pro
   private static boolean isFlutteryFile(@NotNull VirtualFile file) {
     final String fileName = file.getName();
     return file.getFileType() == DartFileType.INSTANCE ||
-           fileName.equals(FLUTTER_YAML_FILE) ||
-           fileName.equals(PubspecYamlUtil.PUBSPEC_YAML);
+           fileName.equals(FlutterConstants.FLUTTER_YAML) ||
+           fileName.equals(FlutterConstants.PUBSPEC_YAML);
   }
 
   @NotNull


### PR DESCRIPTION
- have the flutter upgrade action better locate pubspec files; previously, it would only work when invoked on `flutter.yaml` directly. Now it looks in the Module for the most likely pubspec to act on.
- some refactoring of our use of dart+flutter constants

@pq 