### PR TITLE
Flutter package actions (#515).

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -115,6 +115,13 @@
               text="Flutter Doctor"
               description="Run 'flutter doctor'"/>
       <separator/>
+      <action id="flutter.packages.get" class="io.flutter.actions.FlutterPackagesGetAction"
+              text="Flutter Packages Get"
+              description="Run 'flutter packages get'"/>
+      <action id="flutter.packages.upgrade" class="io.flutter.actions.FlutterPackagesUpgradeAction"
+              text="Flutter Packages Upgrade"
+              description="Run 'flutter packages upgrade'"/>
+      <separator/>
       <action id="flutter.submitFeedback" class="io.flutter.actions.FlutterSubmitFeedback"
               text="Submit Feedback…"
               description="Provie feedback for the Flutter plugin"/>

--- a/src/io/flutter/FlutterBundle.properties
+++ b/src/io/flutter/FlutterBundle.properties
@@ -21,6 +21,8 @@ error.sdk.not.found.in.specified.location=Error: Flutter SDK is not found in the
 
 flutter.command.exception.title=Flutter Command Error
 flutter.command.exception.message=Exception: {0}
+flutter.command.missing.pubspec=Missing pubspec
+flutter.command.missing.pubspec.message=`{0}` can only be run on a project with a pubspec.yaml.
 flutter.incompatible.dart.plugin.warning=Flutter requires a Dart plugin with a minimum version of {0} (currently installed: {1}).
 flutter.module.name=Flutter
 flutter.old.sdk.warning=The current configured Flutter SDK is not known to be fully supported. Please update your SDK and restart IntelliJ.

--- a/src/io/flutter/actions/FlutterDoctorAction.java
+++ b/src/io/flutter/actions/FlutterDoctorAction.java
@@ -7,36 +7,13 @@ package io.flutter.actions;
 
 import com.intellij.execution.ExecutionException;
 import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.diagnostic.Logger;
-import com.intellij.openapi.project.DumbAwareAction;
 import com.intellij.openapi.project.Project;
-import io.flutter.FlutterBundle;
-import io.flutter.FlutterErrors;
 import io.flutter.sdk.FlutterSdk;
+import org.jetbrains.annotations.NotNull;
 
-public class FlutterDoctorAction extends DumbAwareAction {
-  private static final Logger LOG = Logger.getInstance(FlutterDoctorAction.class);
-
+public class FlutterDoctorAction extends FlutterSdkAction {
   @Override
-  public void actionPerformed(AnActionEvent event) {
-    final Project project = DumbAwareAction.getEventProject(event);
-    final FlutterSdk sdk = project != null ? FlutterSdk.getFlutterSdk(project) : null;
-
-    if (sdk != null) {
-      try {
-        sdk.runProject(project, "Flutter doctor", "doctor");
-      }
-      catch (ExecutionException e) {
-        FlutterErrors.showError(
-          FlutterBundle.message("flutter.command.exception.title"),
-          FlutterBundle.message("flutter.command.exception.message", e.getMessage()));
-        LOG.warn(e);
-      }
-    }
-    else {
-      FlutterErrors.showError(
-        FlutterBundle.message("flutter.sdk.notAvailable.title"),
-        FlutterBundle.message("flutter.sdk.notAvailable.message"));
-    }
+  public void perform(@NotNull FlutterSdk sdk, @NotNull Project project, AnActionEvent event) throws ExecutionException {
+    sdk.runProject(project, "Flutter doctor", "doctor");
   }
 }

--- a/src/io/flutter/actions/FlutterPackagesGetAction.java
+++ b/src/io/flutter/actions/FlutterPackagesGetAction.java
@@ -11,20 +11,26 @@ import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Pair;
 import com.intellij.openapi.vfs.VirtualFile;
+import io.flutter.FlutterBundle;
+import io.flutter.FlutterErrors;
 import io.flutter.sdk.FlutterSdk;
 import org.jetbrains.annotations.NotNull;
 
 
 public class FlutterPackagesGetAction extends FlutterSdkAction {
 
+  private static final FlutterSdk.Command COMMAND = FlutterSdk.Command.PACKAGES_GET;
+
   @Override
   public void perform(@NotNull FlutterSdk sdk, @NotNull Project project, AnActionEvent event) throws ExecutionException {
     final Pair<Module, VirtualFile> pair = getModuleAndPubspecYamlFile(project, event);
     if (pair != null) {
-      sdk.run(FlutterSdk.Command.PACKAGES_GET, pair.first, pair.second.getParent(), null);
+      sdk.run(COMMAND, pair.first, pair.second.getParent(), null);
     }
     else {
-      sdk.runProject(project, "Flutter packages get", "packages", "get");
+      FlutterErrors.showError(
+        FlutterBundle.message("flutter.command.missing.pubspec"),
+        FlutterBundle.message("flutter.command.missing.pubspec.message", COMMAND.name()));
     }
   }
 }

--- a/src/io/flutter/actions/FlutterPackagesGetAction.java
+++ b/src/io/flutter/actions/FlutterPackagesGetAction.java
@@ -30,7 +30,7 @@ public class FlutterPackagesGetAction extends FlutterSdkAction {
     else {
       FlutterErrors.showError(
         FlutterBundle.message("flutter.command.missing.pubspec"),
-        FlutterBundle.message("flutter.command.missing.pubspec.message", COMMAND.name()));
+        FlutterBundle.message("flutter.command.missing.pubspec.message", COMMAND.title));
     }
   }
 }

--- a/src/io/flutter/actions/FlutterPackagesGetAction.java
+++ b/src/io/flutter/actions/FlutterPackagesGetAction.java
@@ -14,15 +14,17 @@ import com.intellij.openapi.vfs.VirtualFile;
 import io.flutter.sdk.FlutterSdk;
 import org.jetbrains.annotations.NotNull;
 
-public class FlutterUpgradeAction extends FlutterSdkAction {
+
+public class FlutterPackagesGetAction extends FlutterSdkAction {
+
   @Override
   public void perform(@NotNull FlutterSdk sdk, @NotNull Project project, AnActionEvent event) throws ExecutionException {
     final Pair<Module, VirtualFile> pair = getModuleAndPubspecYamlFile(project, event);
     if (pair != null) {
-      sdk.run(FlutterSdk.Command.UPGRADE, pair.first, pair.second.getParent(), null);
+      sdk.run(FlutterSdk.Command.PACKAGES_GET, pair.first, pair.second.getParent(), null);
     }
     else {
-      sdk.runProject(project, "Flutter upgrade", "upgrade");
+      sdk.runProject(project, "Flutter packages get", "packages", "get");
     }
   }
 }

--- a/src/io/flutter/actions/FlutterPackagesGetAction.java
+++ b/src/io/flutter/actions/FlutterPackagesGetAction.java
@@ -16,7 +16,6 @@ import io.flutter.FlutterErrors;
 import io.flutter.sdk.FlutterSdk;
 import org.jetbrains.annotations.NotNull;
 
-
 public class FlutterPackagesGetAction extends FlutterSdkAction {
 
   private static final FlutterSdk.Command COMMAND = FlutterSdk.Command.PACKAGES_GET;

--- a/src/io/flutter/actions/FlutterPackagesUpgradeAction.java
+++ b/src/io/flutter/actions/FlutterPackagesUpgradeAction.java
@@ -12,18 +12,25 @@ import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Pair;
 import com.intellij.openapi.vfs.VirtualFile;
+import io.flutter.FlutterBundle;
+import io.flutter.FlutterErrors;
 import io.flutter.sdk.FlutterSdk;
 import org.jetbrains.annotations.NotNull;
 
 public class FlutterPackagesUpgradeAction extends FlutterSdkAction {
+
+  private static final FlutterSdk.Command COMMAND = FlutterSdk.Command.PACKAGES_UPGRADE;
+
   @Override
   public void perform(@NotNull FlutterSdk sdk, @NotNull Project project, AnActionEvent event) throws ExecutionException {
     final Pair<Module, VirtualFile> pair = getModuleAndPubspecYamlFile(project, event);
     if (pair != null) {
-      sdk.run(FlutterSdk.Command.PACKAGES_UPGRADE, pair.first, pair.second.getParent(), null);
+      sdk.run(COMMAND, pair.first, pair.second.getParent(), null);
     }
     else {
-      sdk.runProject(project, "Flutter packages upgrade", "packages", "upgrade");
+      FlutterErrors.showError(
+        FlutterBundle.message("flutter.command.missing.pubspec"),
+        FlutterBundle.message("flutter.command.missing.pubspec.message", COMMAND.name()));
     }
   }
 }

--- a/src/io/flutter/actions/FlutterPackagesUpgradeAction.java
+++ b/src/io/flutter/actions/FlutterPackagesUpgradeAction.java
@@ -5,6 +5,7 @@
  */
 package io.flutter.actions;
 
+
 import com.intellij.execution.ExecutionException;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.module.Module;
@@ -14,15 +15,15 @@ import com.intellij.openapi.vfs.VirtualFile;
 import io.flutter.sdk.FlutterSdk;
 import org.jetbrains.annotations.NotNull;
 
-public class FlutterUpgradeAction extends FlutterSdkAction {
+public class FlutterPackagesUpgradeAction extends FlutterSdkAction {
   @Override
   public void perform(@NotNull FlutterSdk sdk, @NotNull Project project, AnActionEvent event) throws ExecutionException {
     final Pair<Module, VirtualFile> pair = getModuleAndPubspecYamlFile(project, event);
     if (pair != null) {
-      sdk.run(FlutterSdk.Command.UPGRADE, pair.first, pair.second.getParent(), null);
+      sdk.run(FlutterSdk.Command.PACKAGES_UPGRADE, pair.first, pair.second.getParent(), null);
     }
     else {
-      sdk.runProject(project, "Flutter upgrade", "upgrade");
+      sdk.runProject(project, "Flutter packages upgrade", "packages", "upgrade");
     }
   }
 }

--- a/src/io/flutter/actions/FlutterPackagesUpgradeAction.java
+++ b/src/io/flutter/actions/FlutterPackagesUpgradeAction.java
@@ -30,7 +30,7 @@ public class FlutterPackagesUpgradeAction extends FlutterSdkAction {
     else {
       FlutterErrors.showError(
         FlutterBundle.message("flutter.command.missing.pubspec"),
-        FlutterBundle.message("flutter.command.missing.pubspec.message", COMMAND.name()));
+        FlutterBundle.message("flutter.command.missing.pubspec.message", COMMAND.title));
     }
   }
 }

--- a/src/io/flutter/actions/FlutterSdkAction.java
+++ b/src/io/flutter/actions/FlutterSdkAction.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2016 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.actions;
+
+import com.intellij.execution.ExecutionException;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.CommonDataKeys;
+import com.intellij.openapi.actionSystem.LangDataKeys;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.project.DumbAwareAction;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.ModuleRootManager;
+import com.intellij.openapi.roots.ProjectRootManager;
+import com.intellij.openapi.util.Pair;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiFile;
+import io.flutter.FlutterBundle;
+import io.flutter.FlutterConstants;
+import io.flutter.FlutterErrors;
+import io.flutter.sdk.FlutterSdk;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Base class for Flutter commands.
+ */
+public abstract class FlutterSdkAction extends DumbAwareAction {
+
+  private static final Logger LOG = Logger.getInstance(FlutterSdkAction.class);
+
+  @Override
+  public void actionPerformed(AnActionEvent event) {
+    final Project project = DumbAwareAction.getEventProject(event);
+    final FlutterSdk sdk = project != null ? FlutterSdk.getFlutterSdk(project) : null;
+
+    if (sdk != null) {
+      try {
+        perform(sdk, project, event);
+      }
+      catch (ExecutionException e) {
+        FlutterErrors.showError(
+          FlutterBundle.message("flutter.command.exception.title"),
+          FlutterBundle.message("flutter.command.exception.message", e.getMessage()));
+        LOG.warn(e);
+      }
+    }
+    else {
+      FlutterErrors.showError(
+        FlutterBundle.message("flutter.sdk.notAvailable.title"),
+        FlutterBundle.message("flutter.sdk.notAvailable.message"));
+    }
+  }
+
+  public abstract void perform(@NotNull FlutterSdk sdk, @NotNull Project project, AnActionEvent event) throws ExecutionException;
+
+
+  @Nullable
+  public static Pair<Module, VirtualFile> getModuleAndPubspecYamlFile(final Project project, final AnActionEvent e) {
+    Module module = LangDataKeys.MODULE.getData(e.getDataContext());
+    final PsiFile psiFile = CommonDataKeys.PSI_FILE.getData(e.getDataContext());
+
+    VirtualFile pubspec = findPubspecFrom(project, psiFile);
+    if (pubspec == null) {
+      pubspec = findPubspecFrom(module);
+    }
+
+    if (module == null && pubspec != null) {
+      module = ProjectRootManager.getInstance(project).getFileIndex().getModuleForFile(pubspec);
+    }
+
+    return pubspec == null ? null : Pair.create(module, pubspec);
+  }
+
+  protected static VirtualFile findPubspecFrom(Project project, PsiFile psiFile) {
+    if (psiFile == null) {
+      return null;
+    }
+    final VirtualFile file = psiFile.getVirtualFile();
+    final VirtualFile contentRoot = ProjectRootManager.getInstance(project).getFileIndex().getContentRootForFile(file);
+    return contentRoot == null ? null : contentRoot.findChild(FlutterConstants.PUBSPEC_YAML);
+  }
+
+  protected static VirtualFile findPubspecFrom(Module module) {
+    if (module == null) {
+      return null;
+    }
+    final ModuleRootManager moduleRootManager = ModuleRootManager.getInstance(module);
+    for (VirtualFile dir : moduleRootManager.getContentRoots()) {
+      final VirtualFile pubspec = dir.findChild(FlutterConstants.PUBSPEC_YAML);
+      if (pubspec != null) {
+        return pubspec;
+      }
+    }
+    return null;
+  }
+
+}

--- a/src/io/flutter/actions/FlutterSdkAction.java
+++ b/src/io/flutter/actions/FlutterSdkAction.java
@@ -32,32 +32,6 @@ public abstract class FlutterSdkAction extends DumbAwareAction {
 
   private static final Logger LOG = Logger.getInstance(FlutterSdkAction.class);
 
-  @Override
-  public void actionPerformed(AnActionEvent event) {
-    final Project project = DumbAwareAction.getEventProject(event);
-    final FlutterSdk sdk = project != null ? FlutterSdk.getFlutterSdk(project) : null;
-
-    if (sdk != null) {
-      try {
-        perform(sdk, project, event);
-      }
-      catch (ExecutionException e) {
-        FlutterErrors.showError(
-          FlutterBundle.message("flutter.command.exception.title"),
-          FlutterBundle.message("flutter.command.exception.message", e.getMessage()));
-        LOG.warn(e);
-      }
-    }
-    else {
-      FlutterErrors.showError(
-        FlutterBundle.message("flutter.sdk.notAvailable.title"),
-        FlutterBundle.message("flutter.sdk.notAvailable.message"));
-    }
-  }
-
-  public abstract void perform(@NotNull FlutterSdk sdk, @NotNull Project project, AnActionEvent event) throws ExecutionException;
-
-
   @Nullable
   public static Pair<Module, VirtualFile> getModuleAndPubspecYamlFile(final Project project, final AnActionEvent e) {
     Module module = LangDataKeys.MODULE.getData(e.getDataContext());
@@ -98,4 +72,28 @@ public abstract class FlutterSdkAction extends DumbAwareAction {
     return null;
   }
 
+  @Override
+  public void actionPerformed(AnActionEvent event) {
+    final Project project = DumbAwareAction.getEventProject(event);
+    final FlutterSdk sdk = project != null ? FlutterSdk.getFlutterSdk(project) : null;
+
+    if (sdk != null) {
+      try {
+        perform(sdk, project, event);
+      }
+      catch (ExecutionException e) {
+        FlutterErrors.showError(
+          FlutterBundle.message("flutter.command.exception.title"),
+          FlutterBundle.message("flutter.command.exception.message", e.getMessage()));
+        LOG.warn(e);
+      }
+    }
+    else {
+      FlutterErrors.showError(
+        FlutterBundle.message("flutter.sdk.notAvailable.title"),
+        FlutterBundle.message("flutter.sdk.notAvailable.message"));
+    }
+  }
+
+  public abstract void perform(@NotNull FlutterSdk sdk, @NotNull Project project, AnActionEvent event) throws ExecutionException;
 }

--- a/src/io/flutter/sdk/FlutterSdk.java
+++ b/src/io/flutter/sdk/FlutterSdk.java
@@ -254,7 +254,7 @@ public class FlutterSdk {
         });
       }
     },
-    DOCTOR( "Flutter doctor", "doctor"),
+    DOCTOR("Flutter doctor", "doctor"),
     PACKAGES_GET("Flutter packages get", "packages", "get"),
     PACKAGES_UPGRADE("Flutter packages upgrade", "packages", "upgrade"),
     UPGRADE("Flutter upgrade", "upgrade"),
@@ -266,9 +266,9 @@ public class FlutterSdk {
     };
 
     final String[] command;
-    final String title;
+    final public String title;
 
-    Command(String title, String ... command) {
+    Command(String title, String... command) {
       this.title = title;
       this.command = command;
     }

--- a/src/io/flutter/sdk/FlutterSdk.java
+++ b/src/io/flutter/sdk/FlutterSdk.java
@@ -93,7 +93,7 @@ public class FlutterSdk {
     final GeneralCommandLine command = new GeneralCommandLine().withWorkDirectory(dirPath);
     command.setExePath(flutterPath);
     // Example: [create, foo_bar]
-    String[] toolArgs = ArrayUtil.prepend(cmd.command, args);
+    String[] toolArgs = ArrayUtil.mergeArrays(cmd.command, args);
     toolArgs = ArrayUtil.prepend("--no-color", toolArgs);
     command.addParameters(toolArgs);
 
@@ -183,7 +183,7 @@ public class FlutterSdk {
 
   public enum Command {
 
-    CREATE("create", "Flutter create") {
+    CREATE("Flutter create", "create") {
       @Override
       void onStart(@Nullable Module module, @Nullable VirtualFile workingDir, @NotNull String... args) {
         // Enable Dart.
@@ -254,21 +254,23 @@ public class FlutterSdk {
         });
       }
     },
-    DOCTOR("doctor", "Flutter doctor"),
-    UPGRADE("upgrade", "Flutter upgrade"),
-    VERSION("--version", "Flutter version") {
+    DOCTOR( "Flutter doctor", "doctor"),
+    PACKAGES_GET("Flutter packages get", "packages", "get"),
+    PACKAGES_UPGRADE("Flutter packages upgrade", "packages", "upgrade"),
+    UPGRADE("Flutter upgrade", "upgrade"),
+    VERSION("Flutter version", "--version") {
       @Override
       boolean attachToConsole() {
         return false;
       }
     };
 
-    final String command;
+    final String[] command;
     final String title;
 
-    Command(String command, String title) {
-      this.command = command;
+    Command(String title, String ... command) {
       this.title = title;
+      this.command = command;
     }
 
     /**


### PR DESCRIPTION
* adds Tools menu actions for `flutter packages get` and `flutter packages upgrade`
* rejiggers actions a bit and adds a base class to do away with some duplication

Fixes: #515.

<img width="598" alt="screen shot 2016-12-12 at 8 44 37 am" src="https://cloud.githubusercontent.com/assets/67586/21108202/38ca4ef8-c049-11e6-9ebf-a6af4b3e7db0.png">

/cc @devoncarew 