### PR TITLE
Add console output on Flutter command completion (#527).

### DIFF
--- a/src/io/flutter/FlutterBundle.properties
+++ b/src/io/flutter/FlutterBundle.properties
@@ -19,6 +19,8 @@ error.path.to.sdk.not.specified=Error: path to the Flutter SDK is not specified.
 error.flutter.sdk.without.dart.sdk=Error: Flutter SDK installation is incomplete, see <a href='https://flutter.io/setup/#get-the-flutter-sdk'>setup instructions</a>.
 error.sdk.not.found.in.specified.location=Error: Flutter SDK is not found in the specified location.
 
+finished.with.exit.code.text.message=Process finished with exit code {0}
+
 flutter.command.exception.title=Flutter Command Error
 flutter.command.exception.message=Exception: {0}
 flutter.command.missing.pubspec=Missing pubspec
@@ -35,9 +37,6 @@ flutter.title=Flutter
 flutter.wrong.dart.sdk.warning=The Dart SDK for this module is not the same as Flutter's. Setting Dart to use the Flutter vended SDK is strongly recommended.
 flutter.sdk.notAvailable.title=No Flutter SDK Configured
 flutter.sdk.notAvailable.message=This action requires a Flutter SDK to be available.
-
-no.project.dir=Project directory not given
-no.socket.for.debugging=The debugger cannot find an available socket for the Observatory connection
 
 open.observatory.action.text=Open Observatory
 open.observatory.action.description=Open Observatory: a Profiler for Dart apps

--- a/src/io/flutter/FlutterBundle.properties
+++ b/src/io/flutter/FlutterBundle.properties
@@ -38,6 +38,8 @@ flutter.wrong.dart.sdk.warning=The Dart SDK for this module is not the same as F
 flutter.sdk.notAvailable.title=No Flutter SDK Configured
 flutter.sdk.notAvailable.message=This action requires a Flutter SDK to be available.
 
+multiple.pubspecs.error=Unable to find project root dir (multiple pubspecs found)
+
 open.observatory.action.text=Open Observatory
 open.observatory.action.description=Open Observatory: a Profiler for Dart apps
 

--- a/src/io/flutter/console/FlutterConsoleHelper.java
+++ b/src/io/flutter/console/FlutterConsoleHelper.java
@@ -105,6 +105,20 @@ public class FlutterConsoleHelper {
     }
     return null;
   }
+
+  @Nullable
+  public static ConsoleView findConsoleView(@Nullable Project project, @Nullable Module module) {
+    if (project == null && module != null) {
+      project = module.getProject();
+    }
+    if (project != null) {
+      final FlutterConsoleInfo info = findExistingInfoForCommand(project, module);
+      if (info != null) {
+        return info.console;
+      }
+    }
+    return null;
+  }
 }
 
 class FlutterConsoleInfo {


### PR DESCRIPTION
Fixes: #527.

* adds process termination console output
* fixes pubspec finding (when `CommonDataKeys.PSI_FILE` or `LangDataKeys.MODULE` cache-miss)

![screen shot 2016-12-12 at 12 25 57 pm](https://cloud.githubusercontent.com/assets/67586/21115523/8a9a6bd8-c066-11e6-8892-346c0c8ca113.png)

/cc @devoncarew 