### PR TITLE
Fix invalid thread access (#554).

### DIFF
--- a/src/io/flutter/actions/DeviceSelectorAction.java
+++ b/src/io/flutter/actions/DeviceSelectorAction.java
@@ -12,6 +12,8 @@ import com.intellij.execution.process.ProcessAdapter;
 import com.intellij.execution.process.ProcessEvent;
 import com.intellij.openapi.actionSystem.*;
 import com.intellij.openapi.actionSystem.ex.ComboBoxAction;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.SystemInfo;
@@ -142,25 +144,33 @@ public class DeviceSelectorAction extends ComboBoxAction implements DumbAware {
       actions.add(new Separator());
       actions.add(new OpenSimulatorAction(!simulatorOpen));
 
+      final boolean updatedPresentation[] = {false};
+
       if (service != null) {
         final ConnectedDevice selectedDevice = service.getSelectedDevice();
+        
+        ApplicationManager.getApplication().invokeAndWait(() -> {
+          for (AnAction action : actions) {
+            if (action instanceof SelectDeviceAction) {
+              final SelectDeviceAction deviceAction = (SelectDeviceAction)action;
 
-        for (AnAction action : actions) {
-          if (action instanceof SelectDeviceAction) {
-            final SelectDeviceAction deviceAction = (SelectDeviceAction)action;
-
-            if (Objects.equals(deviceAction.device, selectedDevice)) {
-              final Presentation template = action.getTemplatePresentation();
-              presentation.setIcon(template.getIcon());
-              presentation.setText(template.getText());
-              presentation.setEnabled(true);
-              return;
+              if (Objects.equals(deviceAction.device, selectedDevice)) {
+                final Presentation template = action.getTemplatePresentation();
+                presentation.setIcon(template.getIcon());
+                presentation.setText(template.getText());
+                presentation.setEnabled(true);
+                updatedPresentation[0] = true;
+                return;
+              }
             }
           }
-        }
+        }, ModalityState.NON_MODAL);
       }
 
-      presentation.setText(null);
+      if (!updatedPresentation[0]) {
+        ApplicationManager.getApplication().invokeAndWait(() ->
+                                                            presentation.setText(null), ModalityState.NON_MODAL);
+      }
     }
   }
 

--- a/src/io/flutter/actions/DeviceSelectorAction.java
+++ b/src/io/flutter/actions/DeviceSelectorAction.java
@@ -144,12 +144,10 @@ public class DeviceSelectorAction extends ComboBoxAction implements DumbAware {
       actions.add(new Separator());
       actions.add(new OpenSimulatorAction(!simulatorOpen));
 
-      final boolean updatedPresentation[] = {false};
+      ApplicationManager.getApplication().invokeAndWait(() -> {
+        if (service != null) {
+          final ConnectedDevice selectedDevice = service.getSelectedDevice();
 
-      if (service != null) {
-        final ConnectedDevice selectedDevice = service.getSelectedDevice();
-        
-        ApplicationManager.getApplication().invokeAndWait(() -> {
           for (AnAction action : actions) {
             if (action instanceof SelectDeviceAction) {
               final SelectDeviceAction deviceAction = (SelectDeviceAction)action;
@@ -159,18 +157,14 @@ public class DeviceSelectorAction extends ComboBoxAction implements DumbAware {
                 presentation.setIcon(template.getIcon());
                 presentation.setText(template.getText());
                 presentation.setEnabled(true);
-                updatedPresentation[0] = true;
                 return;
               }
             }
           }
-        }, ModalityState.NON_MODAL);
-      }
+        }
 
-      if (!updatedPresentation[0]) {
-        ApplicationManager.getApplication().invokeAndWait(() ->
-                                                            presentation.setText(null), ModalityState.NON_MODAL);
-      }
+        presentation.setText(null);
+      });
     }
   }
 


### PR DESCRIPTION
* ensure presentation update occurs on the AWT dispatch thread

Reliably seeing this stack trace on `2016.2.5` without this fix.

```
[  15413]   WARN - tellij.ide.HackyRepaintManager - Access to realized (ever shown) UI components should be done only from the AWT event dispatch thread, revalidate(), invalidate() & repaint() is ok from any thread 
java.lang.Exception
	at com.intellij.ide.IdeRepaintManager.checkThreadViolations(IdeRepaintManager.java:107)
	at com.intellij.ide.IdeRepaintManager.addDirtyRegion(IdeRepaintManager.java:97)
	at javax.swing.JComponent.repaint(JComponent.java:4793)
	at java.awt.Component.repaint(Component.java:3356)
	at java.awt.Component.repaintParentIfNeeded(Component.java:2332)
	at java.awt.Component.reshape(Component.java:2320)
	at javax.swing.JComponent.reshape(JComponent.java:4207)
	at java.awt.Component.setBounds(Component.java:2263)
	at java.awt.Component.resize(Component.java:2186)
	at java.awt.Component.setSize(Component.java:2175)
	at java.awt.Component.resize(Component.java:2215)
	at java.awt.Component.setSize(Component.java:2206)
	at com.intellij.openapi.actionSystem.ex.ComboBoxAction$ComboBoxButton.updateButtonSize(ComboBoxAction.java:490)
	at com.intellij.openapi.actionSystem.ex.ComboBoxAction$ComboBoxButton$MyButtonSynchronizer.propertyChange(ComboBoxAction.java:342)
	at java.beans.PropertyChangeSupport.fire(PropertyChangeSupport.java:335)
	at java.beans.PropertyChangeSupport.firePropertyChange(PropertyChangeSupport.java:327)
	at java.beans.PropertyChangeSupport.firePropertyChange(PropertyChangeSupport.java:263)
	at com.intellij.openapi.actionSystem.Presentation.setText(Presentation.java:162)
	at com.intellij.openapi.actionSystem.Presentation.setText(Presentation.java:172)
	at io.flutter.actions.DeviceSelectorAction.updateActions(DeviceSelectorAction.java:155)
	at io.flutter.actions.DeviceSelectorAction.access$000(DeviceSelectorAction.java:35)
	at io.flutter.actions.DeviceSelectorAction$1.selectedDeviceChanged(DeviceSelectorAction.java:93)
	at io.flutter.run.daemon.FlutterDaemonService.setSelectedDevice(FlutterDaemonService.java:141)
	at io.flutter.run.daemon.FlutterDaemonService.addConnectedDevice(FlutterDaemonService.java:149)
	at io.flutter.run.daemon.FlutterAppManager.eventDeviceAdded(FlutterAppManager.java:367)
	at io.flutter.run.daemon.FlutterAppManager.access$3500(FlutterAppManager.java:32)
	at io.flutter.run.daemon.FlutterAppManager$DeviceAddedEvent.process(FlutterAppManager.java:629)
	at io.flutter.run.daemon.FlutterAppManager.handleEvent(FlutterAppManager.java:169)
	at io.flutter.run.daemon.FlutterAppManager.processInput(FlutterAppManager.java:134)
	at io.flutter.run.daemon.FlutterDaemonService$1.daemonInput(FlutterDaemonService.java:41)
	at io.flutter.run.daemon.FlutterDaemonController.onTextAvailable(FlutterDaemonController.java:136)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at com.intellij.execution.process.ProcessHandler$4.invoke(ProcessHandler.java:226)
	at com.sun.proxy.$Proxy14.onTextAvailable(Unknown Source)
	at com.intellij.execution.process.ProcessHandler.notifyTextAvailable(ProcessHandler.java:200)
	at com.intellij.execution.process.BaseOSProcessHandler$SimpleOutputReader.onTextAvailable(BaseOSProcessHandler.java:291)
	at com.intellij.util.io.BaseOutputReader.sendText(BaseOutputReader.java:200)
	at com.intellij.util.io.BaseOutputReader.processInput(BaseOutputReader.java:184)
	at com.intellij.util.io.BaseOutputReader.readAvailableNonBlocking(BaseOutputReader.java:104)
	at com.intellij.util.io.BaseDataReader.readAvailable(BaseDataReader.java:82)
	at com.intellij.util.io.BaseDataReader.doRun(BaseDataReader.java:160)
	at com.intellij.util.io.BaseDataReader$1.run(BaseDataReader.java:61)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
```

See: #554.

@devoncarew 