### PR TITLE
add a module config editor page

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -173,6 +173,7 @@
     <programRunner implementation="io.flutter.run.bazel.FlutterBazelRunner"/ -->
 
     <moduleType id="FLUTTER_MODULE_TYPE" implementationClass="io.flutter.module.FlutterModuleType"/>
+    <moduleConfigurationEditorProvider implementation="io.flutter.module.FlutterModuleConfigurationEditorProvider"/>
 
     <!-- Plugin service with SmallIDE default, optionally overridden by product-specific implementations -->
     <projectService serviceInterface="io.flutter.sdk.FlutterSdkService"

--- a/src/io/flutter/module/FlutterModuleConfigurationEditorProvider.java
+++ b/src/io/flutter/module/FlutterModuleConfigurationEditorProvider.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2016 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.module;
+
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleConfigurationEditor;
+import com.intellij.openapi.module.ModuleType;
+import com.intellij.openapi.roots.ui.configuration.CommonContentEntriesEditor;
+import com.intellij.openapi.roots.ui.configuration.ModuleConfigurationEditorProvider;
+import com.intellij.openapi.roots.ui.configuration.ModuleConfigurationState;
+
+public class FlutterModuleConfigurationEditorProvider implements ModuleConfigurationEditorProvider {
+  @Override
+  public ModuleConfigurationEditor[] createEditors(ModuleConfigurationState state) {
+    final Module module = state.getRootModel().getModule();
+
+    if (ModuleType.get(module) != FlutterModuleType.getInstance()) {
+      return ModuleConfigurationEditor.EMPTY;
+    }
+    else {
+      return new ModuleConfigurationEditor[]{new CommonContentEntriesEditor(module.getName(), state)};
+    }
+  }
+}


### PR DESCRIPTION
- add a module config editor page (fix #317)

Instead of being blank, the module page in the structure dialog now shows:

<img width="760" alt="screen shot 2016-12-16 at 3 17 14 pm" src="https://cloud.githubusercontent.com/assets/1269969/21281578/d82b605c-c3a2-11e6-8ddb-7fcd1e162e67.png">

@pq, @alexander-doroshko 