### PR TITLE
Debugger code refactor

### DIFF
--- a/src/io/flutter/actions/DeviceSelectorAction.java
+++ b/src/io/flutter/actions/DeviceSelectorAction.java
@@ -21,8 +21,8 @@ import com.intellij.openapi.util.text.StringUtil;
 import icons.FlutterIcons;
 import io.flutter.FlutterBundle;
 import io.flutter.FlutterErrors;
-import io.flutter.run.daemon.ConnectedDevice;
 import io.flutter.run.daemon.FlutterDaemonService;
+import io.flutter.run.daemon.FlutterDevice;
 import io.flutter.sdk.FlutterSdk;
 import io.flutter.sdk.FlutterSdkManager;
 import io.flutter.sdk.FlutterSdkUtil;
@@ -91,17 +91,17 @@ public class DeviceSelectorAction extends ComboBoxAction implements DumbAware {
 
       service.addDeviceListener(new FlutterDaemonService.DeviceListener() {
         @Override
-        public void deviceAdded(ConnectedDevice device) {
+        public void deviceAdded(FlutterDevice device) {
           updateActions(e.getPresentation(), project);
         }
 
         @Override
-        public void selectedDeviceChanged(ConnectedDevice device) {
+        public void selectedDeviceChanged(FlutterDevice device) {
           updateActions(e.getPresentation(), project);
         }
 
         @Override
-        public void deviceRemoved(ConnectedDevice device) {
+        public void deviceRemoved(FlutterDevice device) {
           updateActions(e.getPresentation(), project);
         }
       });
@@ -127,7 +127,7 @@ public class DeviceSelectorAction extends ComboBoxAction implements DumbAware {
     actions.clear();
 
     final FlutterDaemonService service = FlutterDaemonService.getInstance(project);
-    final Collection<ConnectedDevice> devices = service.getConnectedDevices();
+    final Collection<FlutterDevice> devices = service.getConnectedDevices();
     actions.addAll(devices.stream().map(SelectDeviceAction::new).collect(Collectors.toList()));
 
     if (actions.isEmpty()) {
@@ -139,7 +139,7 @@ public class DeviceSelectorAction extends ComboBoxAction implements DumbAware {
       for (AnAction action : actions) {
         if (action instanceof SelectDeviceAction) {
           final SelectDeviceAction deviceAction = (SelectDeviceAction)action;
-          final ConnectedDevice device = deviceAction.device;
+          final FlutterDevice device = deviceAction.device;
           if (StringUtil.equals(device.platform(), "ios") && device.emulator()) {
             simulatorOpen = true;
           }
@@ -150,7 +150,7 @@ public class DeviceSelectorAction extends ComboBoxAction implements DumbAware {
       actions.add(new OpenSimulatorAction(!simulatorOpen));
 
       ApplicationManager.getApplication().invokeAndWait(() -> {
-        final ConnectedDevice selectedDevice = service.getSelectedDevice();
+        final FlutterDevice selectedDevice = service.getSelectedDevice();
 
         for (AnAction action : actions) {
           if (action instanceof SelectDeviceAction) {
@@ -224,9 +224,9 @@ public class DeviceSelectorAction extends ComboBoxAction implements DumbAware {
 
   private static class SelectDeviceAction extends AnAction {
     @NotNull
-    private final ConnectedDevice device;
+    private final FlutterDevice device;
 
-    SelectDeviceAction(@NotNull ConnectedDevice device) {
+    SelectDeviceAction(@NotNull FlutterDevice device) {
       super(device.deviceName(), null, FlutterIcons.Phone);
       this.device = device;
     }

--- a/src/io/flutter/console/FlutterConsoleHelper.java
+++ b/src/io/flutter/console/FlutterConsoleHelper.java
@@ -119,15 +119,16 @@ public class FlutterConsoleHelper {
     }
     return null;
   }
-}
 
-class FlutterConsoleInfo {
-  @NotNull final ConsoleView console;
-  @Nullable final Module module;
-  Content content;
 
-  FlutterConsoleInfo(@NotNull ConsoleView console, @Nullable Module module) {
-    this.console = console;
-    this.module = module;
+  static class FlutterConsoleInfo {
+    @NotNull final ConsoleView console;
+    @Nullable final Module module;
+    Content content;
+
+    FlutterConsoleInfo(@NotNull ConsoleView console, @Nullable Module module) {
+      this.console = console;
+      this.module = module;
+    }
   }
 }

--- a/src/io/flutter/inspections/FlutterYamlNotificationProvider.java
+++ b/src/io/flutter/inspections/FlutterYamlNotificationProvider.java
@@ -62,32 +62,32 @@ public class FlutterYamlNotificationProvider extends EditorNotifications.Provide
 
     return new FlutterYamlActionsPanel(file);
   }
-}
 
-class FlutterYamlActionsPanel extends EditorNotificationPanel {
-  @NotNull final VirtualFile myFile;
+  static class FlutterYamlActionsPanel extends EditorNotificationPanel {
+    @NotNull final VirtualFile myFile;
 
-  FlutterYamlActionsPanel(@NotNull VirtualFile file) {
-    myFile = file;
+    FlutterYamlActionsPanel(@NotNull VirtualFile file) {
+      myFile = file;
 
-    icon(FlutterIcons.Flutter);
-    text("Flutter commands");
+      icon(FlutterIcons.Flutter);
+      text("Flutter commands");
 
-    createActionLabel("Packages get", "flutter.packages.get");
-    createActionLabel("Packages upgrade", "flutter.packages.upgrade");
-    myLinksPanel.add(new JSeparator(SwingConstants.VERTICAL));
-    createActionLabel("Flutter upgrade", "flutter.upgrade");
-    myLinksPanel.add(new JSeparator(SwingConstants.VERTICAL));
-    createActionLabel("Flutter doctor", "flutter.doctor");
+      createActionLabel("Packages get", "flutter.packages.get");
+      createActionLabel("Packages upgrade", "flutter.packages.upgrade");
+      myLinksPanel.add(new JSeparator(SwingConstants.VERTICAL));
+      createActionLabel("Flutter upgrade", "flutter.upgrade");
+      myLinksPanel.add(new JSeparator(SwingConstants.VERTICAL));
+      createActionLabel("Flutter doctor", "flutter.doctor");
 
-    // TODO: Add for 2017.1.
-    //background(EditorColors.GUTTER_BACKGROUND);
-  }
+      // TODO: Add for 2017.1.
+      //background(EditorColors.GUTTER_BACKGROUND);
+    }
 
-  // TODO: Remove for 2017.1.
-  @Override
-  public Color getBackground() {
-    final Color color = EditorColorsManager.getInstance().getGlobalScheme().getColor(EditorColors.GUTTER_BACKGROUND);
-    return color != null ? color : super.getBackground();
+    // TODO: Remove for 2017.1.
+    @Override
+    public Color getBackground() {
+      final Color color = EditorColorsManager.getInstance().getGlobalScheme().getColor(EditorColors.GUTTER_BACKGROUND);
+      return color != null ? color : super.getBackground();
+    }
   }
 }

--- a/src/io/flutter/run/FlutterAppState.java
+++ b/src/io/flutter/run/FlutterAppState.java
@@ -24,9 +24,9 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.util.net.NetUtils;
 import io.flutter.actions.OpenObservatoryAction;
 import io.flutter.console.FlutterConsoleFilter;
-import io.flutter.run.daemon.ConnectedDevice;
 import io.flutter.run.daemon.FlutterApp;
 import io.flutter.run.daemon.FlutterDaemonService;
+import io.flutter.run.daemon.FlutterDevice;
 import io.flutter.run.daemon.RunMode;
 import org.jetbrains.annotations.NotNull;
 
@@ -80,11 +80,11 @@ public class FlutterAppState extends FlutterAppStateBase {
     final String workingDir = project.getBasePath();
     assert workingDir != null;
 
-    ConnectedDevice device = null;
+    FlutterDevice device = null;
 
     // Only pass the current device in if we are showing the device selector.
     if (service.isActive()) {
-      final Collection<ConnectedDevice> devices = service.getConnectedDevices();
+      final Collection<FlutterDevice> devices = service.getConnectedDevices();
       if (devices.isEmpty()) {
         throw new ExecutionException("No connected device");
       }

--- a/src/io/flutter/run/README.md
+++ b/src/io/flutter/run/README.md
@@ -1,13 +1,10 @@
 # Debugger Architecture Overiew
 
-## Packages:
-
-### `io.flutter.run`
+## `io.flutter.run`
 
 * `FlutterAppState` - a `RunProfileState` that puts together and starts Flutter command-line processes.
 * `FlutterAppStateBase` - abstract base class for `FlutterAppState` (appears to be copied from
   `DartCommandLineRunningState`)
-   * TODO: consider consolidating into `FlutterAppState`
 * `FlutterRunConfiguration` - creates:
   * `FlutterRunnerParameters`
   * `FlutterConfigurationEditorForm`
@@ -16,7 +13,6 @@
   to the current launch configuration (run vs. debug).
 * `FlutterRunConfigurationBase` - abstract base class for `FlutterRunConfiguration` (appears to be
   copied from `DartRunConfigurationBase`).
-  * TODO: consider consolidating into `FlutterRunConfiguration`
 * `FlutterRunConfigurationProducer` - creates `FlutterRunConfiguration` based on context (e.g.,
   active file).
 * `FlutterRunConfigurationType` - singleton that determines if Flutter run configurations are
@@ -32,20 +28,27 @@
 * `FlutterRunnerParameters` - encapsulates configuration options for Flutter runs.
 * `FlutterConfigurationEditorForm` - form for editing run configuration settings.
 
-### `io.flutter.run.daemon`
+## `io.flutter.run.daemon`
 
-* `ConnectedDevice` - interface representing a connected Flutter device.
+* `FlutterDevice` - interface representing a connected Flutter device.
 * `DaemonJsonInputFilterProvider` - trims daemon console output.
-* `FlutterDevice` - implements `ConnectedDevice`.
 * `DaemonListener` - callback for daemon lifecycle events.
-* `FlutterApp` - interface representing a running Flutter app.
-* `FlutterAppManager` - manages running Flutter apps.
-  * starts apps
-  * processes daemon JSON input and dispatches handling to appropriate pending Flutter commands.
+* `FlutterApp` - represents a running Flutter app.
+* `FlutterDaemonService` - a project level singleton. It manages the device poller and
+    helps launch apps
 * `FlutterDaemonController`
   * starts a Flutter daemon process, as an external OS-level process.
   * reads from the process standard output and writes to the process standard input, using JSON
     format to control the daemon.
   * defines classes (instances of a base `FlutterJsonObject` that process JSON).
-* `RunningFlutterApp` - concrete implementation of `FlutterApp`.
+* `FlutterDaemonControllerHelper` - manages running Flutter apps.
+  * starts apps
+  * processes daemon JSON input and dispatches handling to appropriate pending Flutter commands.
 
+## `io.flutter.run.bazel`
+
+* `FlutterBazelAppState` - a subclass of `FlutterAppStateBase` specialized for launching Flutter Bazel targets
+* `FlutterBazelRunConfiguration` - a run configuration for Bazel targets; creates FlutterBazelAppState and FlutterBazelConfigurationEditorForm
+* `FlutterBazelRunConfigurationType` - creates Bazel run configurations
+* `FlutterBazelRunner` - a subclass of `FlutterRunner` that customizes the enablement logic
+* `FlutterBazelConfigurationEditorForm` - the UI for Bazel run configurations

--- a/src/io/flutter/run/bazel/FlutterBazelAppState.java
+++ b/src/io/flutter/run/bazel/FlutterBazelAppState.java
@@ -13,8 +13,8 @@ import com.intellij.openapi.project.Project;
 import io.flutter.run.FlutterAppState;
 import io.flutter.run.FlutterRunConfigurationBase;
 import io.flutter.run.FlutterRunnerParameters;
-import io.flutter.run.daemon.ConnectedDevice;
 import io.flutter.run.daemon.FlutterDaemonService;
+import io.flutter.run.daemon.FlutterDevice;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
@@ -38,9 +38,9 @@ public class FlutterBazelAppState extends FlutterAppState {
     assert workingDir != null;
 
     // Only pass the current device in if we are showing the device selector.
-    ConnectedDevice device = null;
+    FlutterDevice device = null;
     if (service.isActive()) {
-      final Collection<ConnectedDevice> devices = service.getConnectedDevices();
+      final Collection<FlutterDevice> devices = service.getConnectedDevices();
       if (!devices.isEmpty()) {
         device = service.getSelectedDevice();
       }

--- a/src/io/flutter/run/daemon/DaemonListener.java
+++ b/src/io/flutter/run/daemon/DaemonListener.java
@@ -17,13 +17,6 @@ public interface DaemonListener {
    */
   void daemonInput(String json, FlutterDaemonController controller);
 
-  /**
-   * Instruct the listener that it should enable device polling for the <code>controller.</code>
-   *
-   * @param controller The FlutterDaemonController that controls the daemon
-   */
-  void enableDevicePolling(FlutterDaemonController controller);
-
   void aboutToTerminate(ProcessHandler handler, FlutterDaemonController controller);
 
   void processTerminated(ProcessHandler handler, FlutterDaemonController controller);

--- a/src/io/flutter/run/daemon/FlutterApp.java
+++ b/src/io/flutter/run/daemon/FlutterApp.java
@@ -17,9 +17,8 @@ import java.util.List;
  * A running Flutter app.
  */
 public class FlutterApp {
-  private final FlutterDaemonService myService;
   private final FlutterDaemonController myController;
-  private final FlutterAppManager myManager;
+  private final FlutterDaemonControllerHelper myManager;
   private String myAppId;
   private final RunMode myMode;
   private final Project myProject;
@@ -31,25 +30,16 @@ public class FlutterApp {
   private State myState;
   private final List<StateListener> myListeners = new ArrayList<>();
 
-  public FlutterApp(@NotNull FlutterDaemonService service,
-                    @NotNull FlutterDaemonController controller,
-                    @NotNull FlutterAppManager manager,
+  public FlutterApp(@NotNull FlutterDaemonController controller,
+                    @NotNull FlutterDaemonControllerHelper manager,
                     @NotNull RunMode mode,
                     @NotNull Project project,
                     boolean hot) {
-    myService = service;
     myController = controller;
     myManager = manager;
     myMode = mode;
     myProject = project;
     isHot = hot;
-  }
-
-  /**
-   * @return The FlutterDaemonService used to communicate with the Flutter app.
-   */
-  public FlutterDaemonService getService() {
-    return myService;
   }
 
   /**
@@ -118,13 +108,6 @@ public class FlutterApp {
 
   public void setBaseUri(String uri) {
     myBaseUri = uri;
-  }
-
-  /**
-   * Stop the app.
-   */
-  public void performStop() {
-    myManager.stopApp(this);
   }
 
   /**

--- a/src/io/flutter/run/daemon/FlutterApp.java
+++ b/src/io/flutter/run/daemon/FlutterApp.java
@@ -14,111 +14,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Handle for a running Flutter app.
+ * A running Flutter app.
  */
-public interface FlutterApp {
-
-  /**
-   * @return The FlutterDaemonService used to communicate with the Flutter app.
-   */
-  FlutterDaemonService getService();
-
-  /**
-   * @return The FlutterDaemonController that controls the process running the daemon.
-   */
-  FlutterDaemonController getController();
-
-  /**
-   * @return <code>true</code> if the appId has been set. This is set asynchronously after the app is launched.
-   */
-  boolean hasAppId();
-
-  /**
-   * @return The appId for the running app.
-   */
-  String appId();
-
-  /**
-   * @return <code>true</code> if the app is in hot-restart mode.
-   */
-  boolean isHot();
-
-  /**
-   * @return The mode the app is running in.
-   */
-  RunMode mode();
-
-  /**
-   * @return The project associated with this app.
-   */
-  Project project();
-
-  /**
-   * @return The debug port used to talk to the observatory.
-   */
-  int port();
-
-  /**
-   * @return The (optional) baseUri to use for debugger paths.
-   */
-  String baseUri();
-
-  /**
-   * Stop the app.
-   */
-  void performStop();
-
-  /**
-   * Perform a full restart of the the app.
-   */
-  void performRestartApp();
-
-  /**
-   * Perform a hot reload of the app.
-   */
-  void performHotReload(boolean pauseAfterRestart);
-
-  /**
-   * Fetch the widget hierarchy.
-   *
-   * @return Unknown
-   */
-  Object fetchWidgetHierarchy();
-
-  /**
-   * Fetch the render tree
-   *
-   * @return Unknown
-   */
-  Object fetchRenderTree();
-
-  void setConsole(ConsoleView console);
-
-  ConsoleView getConsole();
-
-  boolean isSessionPaused();
-
-  void sessionPaused(XDebugSession sessionHook);
-
-  void sessionResumed();
-
-  void forceResume();
-
-  void changeState(State newState);
-
-  void addStateListener(StateListener listener);
-
-  void removeStateListener(StateListener listener);
-
-  interface StateListener {
-    void stateChanged(State newState);
-  }
-
-  enum State {STARTING, STARTED, TERMINATING, TERMINATED}
-}
-
-class RunningFlutterApp implements FlutterApp {
-
+public class FlutterApp {
   private final FlutterDaemonService myService;
   private final FlutterDaemonController myController;
   private final FlutterAppManager myManager;
@@ -133,12 +31,12 @@ class RunningFlutterApp implements FlutterApp {
   private State myState;
   private final List<StateListener> myListeners = new ArrayList<>();
 
-  public RunningFlutterApp(@NotNull FlutterDaemonService service,
-                           @NotNull FlutterDaemonController controller,
-                           @NotNull FlutterAppManager manager,
-                           @NotNull RunMode mode,
-                           @NotNull Project project,
-                           boolean hot) {
+  public FlutterApp(@NotNull FlutterDaemonService service,
+                    @NotNull FlutterDaemonController controller,
+                    @NotNull FlutterAppManager manager,
+                    @NotNull RunMode mode,
+                    @NotNull Project project,
+                    boolean hot) {
     myService = service;
     myController = controller;
     myManager = manager;
@@ -147,134 +45,164 @@ class RunningFlutterApp implements FlutterApp {
     isHot = hot;
   }
 
-  @Override
-  public void changeState(State newState) {
-    myState = newState;
-    myListeners.iterator().forEachRemaining(x -> x.stateChanged(myState));
-  }
-
-  @Override
-  public void addStateListener(StateListener listener) {
-    myListeners.add(listener);
-    listener.stateChanged(myState);
-  }
-
-  @Override
-  public void removeStateListener(StateListener listener) {
-    myListeners.remove(null);
-  }
-
-  void setAppId(String id) {
-    myAppId = id;
-  }
-
-  @Override
+  /**
+   * @return The FlutterDaemonService used to communicate with the Flutter app.
+   */
   public FlutterDaemonService getService() {
     return myService;
   }
 
-  @Override
+  /**
+   * @return The FlutterDaemonController that controls the process running the daemon.
+   */
   public FlutterDaemonController getController() {
     return myController;
   }
 
-  @Override
+  /**
+   * @return <code>true</code> if the appId has been set. This is set asynchronously after the app is launched.
+   */
   public boolean hasAppId() {
     return myAppId != null;
   }
 
-  @Override
+  /**
+   * @return The appId for the running app.
+   */
   public String appId() {
     return myAppId;
   }
 
-  @Override
+  public void setAppId(String id) {
+    myAppId = id;
+  }
+
+  /**
+   * @return <code>true</code> if the app is in hot-restart mode.
+   */
   public boolean isHot() {
     return isHot;
   }
 
-  @Override
+  /**
+   * @return The mode the app is running in.
+   */
   public RunMode mode() {
     return myMode;
   }
 
-  @Override
+  /**
+   * @return The project associated with this app.
+   */
   public Project project() {
     return myProject;
   }
 
-  @Override
+  /**
+   * @return The debug port used to talk to the observatory.
+   */
   public int port() {
     return myPort;
   }
 
-  void setPort(int port) {
+  public void setPort(int port) {
     myPort = port;
   }
 
-  @Override
+  /**
+   * @return The (optional) baseUri to use for debugger paths.
+   */
   public String baseUri() {
     return myBaseUri;
   }
 
-  public void setBaseUri(String baseUri) {
-    myBaseUri = baseUri;
+  public void setBaseUri(String uri) {
+    myBaseUri = uri;
   }
 
-  @Override
+  /**
+   * Stop the app.
+   */
   public void performStop() {
     myManager.stopApp(this);
   }
 
-  @Override
+  /**
+   * Perform a full restart of the the app.
+   */
   public void performRestartApp() {
     myManager.restartApp(this, true, false);
   }
 
-  @Override
+  /**
+   * Perform a hot reload of the app.
+   */
   public void performHotReload(boolean pauseAfterRestart) {
     myManager.restartApp(this, false, pauseAfterRestart);
   }
 
-  @Override
+  /**
+   * Fetch the widget hierarchy.
+   *
+   * @return Unknown
+   */
   public Object fetchWidgetHierarchy() {
     throw new NoSuchMethodError("fetchWidgetHierarchy");
   }
 
-  @Override
+  /**
+   * Fetch the render tree
+   *
+   * @return Unknown
+   */
   public Object fetchRenderTree() {
     throw new NoSuchMethodError("fetchRenderTree");
   }
 
-  @Override
   public void setConsole(ConsoleView console) {
     myConsole = console;
   }
 
-  @Override
   public ConsoleView getConsole() {
     return myConsole;
   }
 
-  @Override
   public boolean isSessionPaused() {
     return mySesionHook != null;
   }
 
-  @Override
   public void sessionPaused(XDebugSession sessionHook) {
     mySesionHook = sessionHook;
   }
 
-  @Override
   public void sessionResumed() {
     mySesionHook = null;
   }
 
-  @Override
   public void forceResume() {
     if (mySesionHook != null && mySesionHook.isPaused()) {
       mySesionHook.resume();
     }
   }
+
+  public void changeState(State newState) {
+    myState = newState;
+    myListeners.iterator().forEachRemaining(x -> x.stateChanged(myState));
+  }
+
+  public void addStateListener(StateListener listener) {
+    myListeners.add(listener);
+    listener.stateChanged(myState);
+  }
+
+  public void removeStateListener(StateListener listener) {
+    myListeners.remove(null);
+  }
+
+
+  public interface StateListener {
+    void stateChanged(State newState);
+  }
+
+  public enum State {STARTING, STARTED, TERMINATING, TERMINATED}
 }

--- a/src/io/flutter/run/daemon/FlutterDaemonControllerHelper.java
+++ b/src/io/flutter/run/daemon/FlutterDaemonControllerHelper.java
@@ -6,7 +6,7 @@
 package io.flutter.run.daemon;
 
 import com.google.gson.*;
-import com.intellij.execution.ExecutionException;
+import com.intellij.execution.process.ProcessHandler;
 import com.intellij.execution.ui.ConsoleViewContentType;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
@@ -30,7 +30,9 @@ import java.util.stream.Stream;
  * <p>
  * TODO(messick) Clean up myResponses as things change
  */
-public class FlutterAppManager {
+class FlutterDaemonControllerHelper {
+  private static final Logger LOG = Logger.getInstance(FlutterDaemonControllerHelper.class.getName());
+
   private static final String CMD_APP_START = "app.start";
   private static final String CMD_APP_STOP = "app.stop";
   private static final String CMD_APP_RESTART = "app.restart";
@@ -38,33 +40,44 @@ public class FlutterAppManager {
 
   private static final Gson GSON = new Gson();
 
-  private static final Logger LOG = Logger.getInstance(FlutterAppManager.class.getName());
-  private final FlutterDaemonService myService;
+  private final FlutterDaemonController myController;
   private final List<FlutterApp> myApps = new ArrayList<>();
   private final Map<Integer, List<Command>> myPendingCommands = new THashMap<>();
   private int myCommandId = 0;
   private final Object myLock = new Object();
   private final Map<Method, FlutterJsonObject> myResponses = new THashMap<>();
-  private ProgressHandler myProgressHandler;
+  private ProgressHelper myProgressHandler;
   private StopWatch myProgressStopWatch;
 
-  FlutterAppManager(@NotNull FlutterDaemonService service) {
-    this.myService = service;
+  FlutterDaemonControllerHelper(@NotNull FlutterDaemonController controller) {
+    myController = controller;
+
+    myController.addDaemonListener(new DaemonListener() {
+      public void daemonInput(String string, FlutterDaemonController controller) {
+        processInput(string, controller);
+      }
+
+      @Override
+      public void aboutToTerminate(ProcessHandler handler, FlutterDaemonController controller) {
+        aboutToTerminateAll(controller);
+      }
+
+      @Override
+      public void processTerminated(ProcessHandler handler, FlutterDaemonController controller) {
+        // TODO:
+        terminateAllFor(controller);
+      }
+    });
   }
 
   @NotNull
-  public FlutterApp appStarting(@NotNull FlutterDaemonController controller,
-                                @Nullable String deviceId,
+  public FlutterApp appStarting(@Nullable String deviceId,
                                 @NotNull RunMode mode,
                                 @NotNull Project project,
                                 boolean startPaused,
                                 boolean isHot) {
-    myProgressHandler = new ProgressHandler(project);
-    final FlutterDaemonService service;
-    synchronized (myLock) {
-      service = myService;
-    }
-    final FlutterApp app = new FlutterApp(service, controller, this, mode, project, isHot);
+    myProgressHandler = new ProgressHelper(project);
+    final FlutterApp app = new FlutterApp(myController, this, mode, project, isHot);
     synchronized (myLock) {
       myApps.add(app);
     }
@@ -78,7 +91,7 @@ public class FlutterAppManager {
     final FlutterApp[] resp = {null};
     TimeoutUtil.executeWithTimeout(timeout, () -> {
       while (resp[0] == null) {
-        final FlutterApp app = findApp(controller, appId);
+        final FlutterApp app = findApp(appId);
         if (app != null) {
           resp[0] = app;
         }
@@ -112,16 +125,6 @@ public class FlutterAppManager {
       // Can happen if external process is killed, but we don't care.
     }
     return resp[0];
-  }
-
-  void startDevicePoller(@NotNull FlutterDaemonController pollster) {
-    try {
-      pollster.startDevicePoller();
-    }
-    catch (ExecutionException e) {
-      // User notification comes in the way of editor toasts (see IncompatibleDartPluginNotification).
-      LOG.warn(e);
-    }
   }
 
   void processInput(@NotNull String string, @NotNull FlutterDaemonController controller) {
@@ -181,7 +184,7 @@ public class FlutterAppManager {
       // This needs to run synchronously. The next thing that happens is the process
       // streams are closed which immediately terminates the process.
       CompletableFuture
-        .completedFuture(sendCommand(app.getController(), cmd))
+        .completedFuture(sendCommand(cmd))
         .thenApply((Method method) -> waitForResponse(method, 300))
         .thenAccept((stopped) -> {
           synchronized (myLock) {
@@ -195,7 +198,7 @@ public class FlutterAppManager {
     final AppRestart appStart = new AppRestart(app.appId(), isFullRestart, pauseAfterRestart);
     app.changeState(FlutterApp.State.STARTING);
     final Method cmd = makeMethod(CMD_APP_RESTART, appStart);
-    sendCommand(app.getController(), cmd);
+    sendCommand(cmd);
   }
 
   private void appStopped(AppStop stopped, FlutterDaemonController controller) {
@@ -209,20 +212,19 @@ public class FlutterAppManager {
     });
     final Optional<Command> opt = starts.findFirst();
     assert (opt.isPresent());
-    final FlutterApp app = findApp(controller, stopped.appId);
+    final FlutterApp app = findApp(stopped.appId);
     if (app != null) {
       app.changeState(FlutterApp.State.TERMINATED);
     }
     final Command cmd = opt.get();
     synchronized (myLock) {
       myResponses.put(cmd.method, stopped);
-      myService.schedulePolling();
     }
   }
 
-  void enableDevicePolling(@NotNull FlutterDaemonController controller) {
+  void enableDevicePolling() {
     final Method method = makeMethod(CMD_DEVICE_ENABLE, null);
-    sendCommand(controller, method);
+    sendCommand(method);
   }
 
   void aboutToTerminateAll(FlutterDaemonController controller) {
@@ -250,9 +252,9 @@ public class FlutterAppManager {
     return new Method(methodName, params, myCommandId++);
   }
 
-  private Method sendCommand(@NotNull FlutterDaemonController controller, @NotNull Method method) {
-    controller.sendCommand(GSON.toJson(method), this);
-    addPendingCmd(method.id, new Command(method, controller));
+  private Method sendCommand(@NotNull Method method) {
+    myController.sendCommand(GSON.toJson(method), this);
+    addPendingCmd(method.id, new Command(method, myController));
     return method;
   }
 
@@ -313,12 +315,12 @@ public class FlutterAppManager {
     }
   }
 
-  private void eventLogMessage(@NotNull LogMessageEvent message, @NotNull FlutterDaemonController controller) {
+  private void eventLogMessage(@NotNull LogMessageEvent message) {
     LOG.info(message.message);
   }
 
-  private void eventLogMessage(@NotNull AppLogEvent message, @NotNull FlutterDaemonController controller) {
-    final FlutterApp app = findApp(controller, message.appId);
+  private void eventLogMessage(@NotNull AppLogEvent message) {
+    final FlutterApp app = findApp(message.appId);
 
     if (app == null) {
       return;
@@ -327,8 +329,8 @@ public class FlutterAppManager {
     app.getConsole().print(message.log + "\n", ConsoleViewContentType.NORMAL_OUTPUT);
   }
 
-  private void eventProgressMessage(@NotNull AppProgressEvent message, @NotNull FlutterDaemonController controller) {
-    final FlutterApp app = findApp(controller, message.appId);
+  private void eventProgressMessage(@NotNull AppProgressEvent message) {
+    final FlutterApp app = findApp(message.appId);
 
     if (app == null) {
       return;
@@ -364,16 +366,17 @@ public class FlutterAppManager {
 
   private void eventDeviceAdded(@NotNull DeviceAddedEvent added, @NotNull FlutterDaemonController controller) {
     synchronized (myLock) {
-      myService.addConnectedDevice(new FlutterDevice(added.name, added.id, added.platform, added.emulator));
+      myController.getService().addConnectedDevice(new FlutterDevice(added.name, added.id, added.platform, added.emulator));
     }
   }
 
   private void eventDeviceRemoved(@NotNull DeviceRemovedEvent removed, @NotNull FlutterDaemonController controller) {
     synchronized (myLock) {
-      myService.getConnectedDevices().stream().filter(device -> device.deviceName().equals(removed.name) &&
-                                                                device.deviceId().equals(removed.id) &&
-                                                                device.platform().equals(removed.platform))
-        .forEach(myService::removeConnectedDevice);
+      myController.getService().getConnectedDevices().stream().filter(
+        device -> device.deviceName().equals(removed.name) &&
+                  device.deviceId().equals(removed.id) &&
+                  device.platform().equals(removed.platform))
+        .forEach(myController.getService()::removeConnectedDevice);
     }
   }
 
@@ -387,7 +390,6 @@ public class FlutterAppManager {
   }
 
   private void eventAppStarted(@NotNull AppStartEvent started, @NotNull FlutterDaemonController controller) {
-    assert started.directory.equals(controller.getProjectDirectory());
     final Stream<Command> starts = findAllPendingCmds(controller).stream().filter(c -> {
       final Params p = c.method.params;
       if (p instanceof AppStart) {
@@ -404,10 +406,10 @@ public class FlutterAppManager {
     }
   }
 
-  private void eventAppStopped(@NotNull AppStoppedEvent stopped, @NotNull FlutterDaemonController controller) {
+  private void eventAppStopped(@NotNull AppStoppedEvent stopped) {
     myProgressHandler.cancel();
 
-    final FlutterApp app = findApp(controller, stopped.appId);
+    final FlutterApp app = findApp(stopped.appId);
     if (app != null) {
       app.changeState(FlutterApp.State.TERMINATED);
     }
@@ -441,7 +443,7 @@ public class FlutterAppManager {
     LOG.warn(json.toString());
   }
 
-  private FlutterApp findApp(FlutterDaemonController controller, String appId) {
+  private FlutterApp findApp(String appId) {
     synchronized (myLock) {
       for (FlutterApp app : myApps) {
         if (app.hasAppId() && app.appId().equals(appId)) {
@@ -479,14 +481,14 @@ public class FlutterAppManager {
     @SuppressWarnings("unused") private final Params params;
     @SuppressWarnings("unused") private final int id;
 
-    void process(JsonObject obj, FlutterAppManager manager, FlutterDaemonController controller) {
+    void process(JsonObject obj, FlutterDaemonControllerHelper manager, FlutterDaemonController controller) {
       if (params != null) params.process(obj, manager, controller);
     }
   }
 
   private abstract static class Params extends FlutterJsonObject {
 
-    abstract void process(JsonObject obj, FlutterAppManager manager, FlutterDaemonController controller);
+    abstract void process(JsonObject obj, FlutterDaemonControllerHelper manager, FlutterDaemonController controller);
   }
 
   private static class AppStart extends Params {
@@ -509,7 +511,7 @@ public class FlutterAppManager {
     @SuppressWarnings("unused") private final String target;
     @SuppressWarnings("unused") private final boolean hot;
 
-    void process(JsonObject obj, FlutterAppManager manager, FlutterDaemonController controller) {
+    void process(JsonObject obj, FlutterDaemonControllerHelper manager, FlutterDaemonController controller) {
       final JsonObject result = obj.getAsJsonObject("result");
       if (result == null) {
         manager.error(obj);
@@ -536,8 +538,8 @@ public class FlutterAppManager {
     @SuppressWarnings("unused") private final boolean fullRestart;
     @SuppressWarnings("unused") private final boolean pause;
 
-    void process(JsonObject obj, FlutterAppManager manager, FlutterDaemonController controller) {
-      final FlutterApp app = manager.findApp(controller, appId);
+    void process(JsonObject obj, FlutterDaemonControllerHelper manager, FlutterDaemonController controller) {
+      final FlutterApp app = manager.findApp(appId);
       assert app != null;
       app.changeState(FlutterApp.State.STARTED);
     }
@@ -551,7 +553,7 @@ public class FlutterAppManager {
 
     @SuppressWarnings("unused") private final String appId;
 
-    void process(JsonObject obj, FlutterAppManager manager, FlutterDaemonController controller) {
+    void process(JsonObject obj, FlutterDaemonControllerHelper manager, FlutterDaemonController controller) {
       JsonPrimitive prim = obj.getAsJsonPrimitive("result");
       if (prim != null) {
         if (prim.getAsBoolean()) {
@@ -569,12 +571,11 @@ public class FlutterAppManager {
   }
 
   private abstract static class Event extends FlutterJsonObject {
-
     Event from(JsonElement element) {
       return GSON.fromJson(element, (Type)this.getClass());
     }
 
-    abstract void process(FlutterAppManager manager, FlutterDaemonController controller);
+    abstract void process(FlutterDaemonControllerHelper manager, FlutterDaemonController controller);
   }
 
   @SuppressWarnings("CanBeFinal")
@@ -584,8 +585,8 @@ public class FlutterAppManager {
     @SuppressWarnings("unused") private String message;
     @SuppressWarnings("unused") private String stackTrace;
 
-    void process(FlutterAppManager manager, FlutterDaemonController controller) {
-      manager.eventLogMessage(this, controller);
+    void process(FlutterDaemonControllerHelper manager, FlutterDaemonController controller) {
+      manager.eventLogMessage(this);
     }
   }
 
@@ -595,8 +596,8 @@ public class FlutterAppManager {
     @SuppressWarnings("unused") private String appId;
     @SuppressWarnings("unused") private String log;
 
-    void process(FlutterAppManager manager, FlutterDaemonController controller) {
-      manager.eventLogMessage(this, controller);
+    void process(FlutterDaemonControllerHelper manager, FlutterDaemonController controller) {
+      manager.eventLogMessage(this);
     }
   }
 
@@ -609,8 +610,8 @@ public class FlutterAppManager {
     @SuppressWarnings("unused") private String message;
     @SuppressWarnings("unused") private boolean finished;
 
-    void process(FlutterAppManager manager, FlutterDaemonController controller) {
-      manager.eventProgressMessage(this, controller);
+    void process(FlutterDaemonControllerHelper manager, FlutterDaemonController controller) {
+      manager.eventProgressMessage(this);
     }
   }
 
@@ -622,7 +623,7 @@ public class FlutterAppManager {
     @SuppressWarnings("unused") private String platform;
     @SuppressWarnings("unused") private boolean emulator;
 
-    void process(FlutterAppManager manager, FlutterDaemonController controller) {
+    void process(FlutterDaemonControllerHelper manager, FlutterDaemonController controller) {
       manager.eventDeviceAdded(this, controller);
     }
   }
@@ -635,7 +636,7 @@ public class FlutterAppManager {
     @SuppressWarnings("unused") private String platform;
     @SuppressWarnings("unused") private boolean emulator;
 
-    void process(FlutterAppManager manager, FlutterDaemonController controller) {
+    void process(FlutterDaemonControllerHelper manager, FlutterDaemonController controller) {
       manager.eventDeviceRemoved(this, controller);
     }
   }
@@ -647,7 +648,7 @@ public class FlutterAppManager {
     @SuppressWarnings("unused") String directory;
     @SuppressWarnings("unused") boolean supportsRestart;
 
-    void process(FlutterAppManager manager, FlutterDaemonController controller) {
+    void process(FlutterDaemonControllerHelper manager, FlutterDaemonController controller) {
       manager.eventAppStart(this, controller);
     }
   }
@@ -657,8 +658,8 @@ public class FlutterAppManager {
     // "event":"app.started"
     @SuppressWarnings("unused") String appId;
 
-    void process(FlutterAppManager manager, FlutterDaemonController controller) {
-      final FlutterApp app = manager.findApp(controller, appId);
+    void process(FlutterDaemonControllerHelper manager, FlutterDaemonController controller) {
+      final FlutterApp app = manager.findApp(appId);
       assert app != null;
       app.changeState(FlutterApp.State.STARTED);
     }
@@ -668,8 +669,8 @@ public class FlutterAppManager {
     // "event":"app.stop"
     @SuppressWarnings("unused") private String appId;
 
-    void process(FlutterAppManager manager, FlutterDaemonController controller) {
-      manager.eventAppStopped(this, controller);
+    void process(FlutterDaemonControllerHelper manager, FlutterDaemonController controller) {
+      manager.eventAppStopped(this);
     }
   }
 
@@ -681,9 +682,8 @@ public class FlutterAppManager {
     @SuppressWarnings("unused") private String wsUri;
     @SuppressWarnings("unused") private String baseUri;
 
-    void process(FlutterAppManager manager, FlutterDaemonController controller) {
+    void process(FlutterDaemonControllerHelper manager, FlutterDaemonController controller) {
       manager.eventDebugPort(this, controller);
     }
   }
 }
-

--- a/src/io/flutter/run/daemon/FlutterDaemonService.java
+++ b/src/io/flutter/run/daemon/FlutterDaemonService.java
@@ -31,9 +31,9 @@ public class FlutterDaemonService {
   private final Object myLock = new Object();
   private final List<FlutterDaemonController> myControllers = new ArrayList<>();
   private FlutterDaemonController myPollster;
-  private final Set<ConnectedDevice> myConnectedDevices = new THashSet<>();
+  private final Set<FlutterDevice> myConnectedDevices = new THashSet<>();
   private final SdkListener mySdkListener = new SdkListener();
-  private ConnectedDevice mySelectedDevice;
+  private FlutterDevice mySelectedDevice;
   private final FlutterAppManager myManager = new FlutterAppManager(this);
   private final List<DeviceListener> myDeviceListeners = new ArrayList<>();
 
@@ -62,11 +62,11 @@ public class FlutterDaemonService {
   };
 
   public interface DeviceListener {
-    void deviceAdded(ConnectedDevice device);
+    void deviceAdded(FlutterDevice device);
 
-    void selectedDeviceChanged(ConnectedDevice device);
+    void selectedDeviceChanged(FlutterDevice device);
 
-    void deviceRemoved(ConnectedDevice device);
+    void deviceRemoved(FlutterDevice device);
   }
 
   @NotNull
@@ -123,8 +123,8 @@ public class FlutterDaemonService {
    *
    * @return List of ConnectedDevice
    */
-  public List<ConnectedDevice> getConnectedDevices() {
-    final SortedList<ConnectedDevice> list = new SortedList<>(Comparator.comparing(ConnectedDevice::deviceName));
+  public List<FlutterDevice> getConnectedDevices() {
+    final SortedList<FlutterDevice> list = new SortedList<>(Comparator.comparing(FlutterDevice::deviceName));
     list.addAll(myConnectedDevices);
     return list;
   }
@@ -133,7 +133,7 @@ public class FlutterDaemonService {
    * @return the currently selected device
    */
   @Nullable
-  public ConnectedDevice getSelectedDevice() {
+  public FlutterDevice getSelectedDevice() {
     return mySelectedDevice;
   }
 
@@ -144,7 +144,7 @@ public class FlutterDaemonService {
   /**
    * Set the current selected device.
    */
-  public void setSelectedDevice(@Nullable ConnectedDevice device) {
+  public void setSelectedDevice(@Nullable FlutterDevice device) {
     mySelectedDevice = device;
 
     for (DeviceListener listener : myDeviceListeners) {
@@ -152,7 +152,7 @@ public class FlutterDaemonService {
     }
   }
 
-  void addConnectedDevice(@NotNull ConnectedDevice device) {
+  void addConnectedDevice(@NotNull FlutterDevice device) {
     myConnectedDevices.add(device);
 
     if (mySelectedDevice == null) {
@@ -164,7 +164,7 @@ public class FlutterDaemonService {
     }
   }
 
-  void removeConnectedDevice(@NotNull ConnectedDevice device) {
+  void removeConnectedDevice(@NotNull FlutterDevice device) {
     myConnectedDevices.remove(device);
 
     if (mySelectedDevice == device) {

--- a/src/io/flutter/run/daemon/FlutterDaemonService.java
+++ b/src/io/flutter/run/daemon/FlutterDaemonService.java
@@ -13,6 +13,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Disposer;
 import com.intellij.util.containers.SortedList;
 import gnu.trove.THashSet;
+import io.flutter.FlutterErrors;
 import io.flutter.sdk.FlutterSdk;
 import io.flutter.sdk.FlutterSdkManager;
 import io.flutter.sdk.FlutterSdkUtil;
@@ -26,38 +27,32 @@ import java.util.Set;
 
 /**
  * Long lived singleton that communicates with controllers attached to external Flutter processes.
+ * <p>
+ * There is one Daemon service per IntelliJ project.
  */
 public class FlutterDaemonService {
   private final Object myLock = new Object();
+
   private final List<FlutterDaemonController> myControllers = new ArrayList<>();
-  private FlutterDaemonController myPollster;
+  private FlutterDaemonController myPollingController;
+
   private final Set<FlutterDevice> myConnectedDevices = new THashSet<>();
-  private final SdkListener mySdkListener = new SdkListener();
   private FlutterDevice mySelectedDevice;
-  private final FlutterAppManager myManager = new FlutterAppManager(this);
+
+  private final FlutterSdkManager.Listener mySdkListener = new SdkListener();
   private final List<DeviceListener> myDeviceListeners = new ArrayList<>();
-
-  private final DaemonListener myListener = new DaemonListener() {
-    public void daemonInput(String string, FlutterDaemonController controller) {
-      myManager.processInput(string, controller);
-    }
-
-    public void enableDevicePolling(FlutterDaemonController controller) {
-      myManager.enableDevicePolling(controller);
+  private final DaemonListener myDiscardListener = new DaemonListener() {
+    @Override
+    public void daemonInput(String json, FlutterDaemonController controller) {
     }
 
     @Override
     public void aboutToTerminate(ProcessHandler handler, FlutterDaemonController controller) {
-      assert handler == controller.getProcessHandler();
-      myManager.aboutToTerminateAll(controller);
     }
 
     @Override
     public void processTerminated(ProcessHandler handler, FlutterDaemonController controller) {
-      myManager.terminateAllFor(controller);
-      if (handler == controller.getProcessHandler()) {
-        discard(controller);
-      }
+      discard(controller);
     }
   };
 
@@ -115,7 +110,7 @@ public class FlutterDaemonService {
    * Return whether the daemon service is up and running.
    */
   public boolean isActive() {
-    return myPollster != null;
+    return myPollingController != null;
   }
 
   /**
@@ -198,15 +193,15 @@ public class FlutterDaemonService {
     final boolean startPaused = mode == RunMode.DEBUG;
     final boolean isHot = mode.isReloadEnabled();
 
-    final FlutterDaemonController controller = createController(projectDir);
-    controller.startRunnerProcess(project, projectDir, deviceId, mode, startPaused, isHot, relativePath);
+    final FlutterDaemonController controller = createController();
+    final FlutterApp app = controller.startRunnerProcess(project, projectDir, deviceId, mode, startPaused, isHot, relativePath);
 
-    final FlutterApp app = myManager.appStarting(controller, deviceId, mode, project, startPaused, isHot);
     app.addStateListener(newState -> {
       if (newState == FlutterApp.State.TERMINATED) {
         controller.forceExit();
       }
     });
+
     return app;
   }
 
@@ -221,11 +216,10 @@ public class FlutterDaemonService {
     final boolean startPaused = mode == RunMode.DEBUG;
     final boolean isHot = mode.isReloadEnabled();
 
-    final FlutterDaemonController controller = createController(projectDir);
-    controller
-      .startBazelProcess(project, projectDir, deviceId, mode, startPaused, isHot, launchingScript, bazelTarget, additionalArguments);
+    final FlutterDaemonController controller = createController();
+    final FlutterApp app = controller.startBazelProcess(
+      project, projectDir, deviceId, mode, startPaused, isHot, launchingScript, bazelTarget, additionalArguments);
 
-    final FlutterApp app = myManager.appStarting(controller, deviceId, mode, project, startPaused, isHot);
     app.addStateListener(newState -> {
       if (newState == FlutterApp.State.TERMINATED) {
         controller.forceExit();
@@ -237,16 +231,15 @@ public class FlutterDaemonService {
   /**
    * Create a new FlutterDaemonController.
    *
-   * @param projectDir The path to the project root directory
    * @return A FlutterDaemonController that can be used to start the app in the project directory
    */
   @NotNull
-  private FlutterDaemonController createController(String projectDir) {
+  private FlutterDaemonController createController() {
     synchronized (myLock) {
-      final FlutterDaemonController newController = new FlutterDaemonController(projectDir);
-      myControllers.add(newController);
-      newController.addListener(myListener);
-      return newController;
+      final FlutterDaemonController controller = new FlutterDaemonController(this);
+      myControllers.add(controller);
+      controller.addDaemonListener(myDiscardListener);
+      return controller;
     }
   }
 
@@ -254,17 +247,25 @@ public class FlutterDaemonService {
     if (!FlutterSdkUtil.hasFlutterModules()) return;
 
     synchronized (myLock) {
-      if (myPollster != null && myPollster.getProcessHandler() != null && !myPollster.getProcessHandler().isProcessTerminating()) {
+      if (myPollingController != null &&
+          myPollingController.getProcessHandler() != null &&
+          !myPollingController.getProcessHandler().isProcessTerminating()) {
         return;
       }
     }
 
     ApplicationManager.getApplication().executeOnPooledThread(() -> {
       synchronized (myLock) {
-        myPollster = new FlutterDaemonController();
-        myPollster.addListener(myListener);
-        myControllers.add(myPollster);
-        myManager.startDevicePoller(myPollster);
+        myPollingController = new FlutterDaemonController(this);
+        myControllers.add(myPollingController);
+        myPollingController.addDaemonListener(myDiscardListener);
+      }
+
+      try {
+        myPollingController.startDevicePoller();
+      }
+      catch (ExecutionException error) {
+        FlutterErrors.showError("Unable to poll for Flutter devices", error.toString());
       }
     });
   }
@@ -272,7 +273,6 @@ public class FlutterDaemonService {
   private void discard(FlutterDaemonController controller) {
     synchronized (myLock) {
       myControllers.remove(controller);
-      controller.removeListener(myListener);
       controller.forceExit();
     }
   }
@@ -280,11 +280,10 @@ public class FlutterDaemonService {
   private void stopControllers() {
     synchronized (myLock) {
       for (FlutterDaemonController controller : myControllers) {
-        controller.removeListener(myListener);
         controller.forceExit();
       }
       myControllers.clear();
-      myPollster = null;
+      myPollingController = null;
     }
   }
 }

--- a/src/io/flutter/run/daemon/FlutterDevice.java
+++ b/src/io/flutter/run/daemon/FlutterDevice.java
@@ -7,33 +7,7 @@ package io.flutter.run.daemon;
 
 import java.util.Objects;
 
-public interface ConnectedDevice {
-
-  /**
-   * The name of the device, which can be shown to the user.
-   *
-   * @return The device name returned by the device
-   */
-  String deviceName();
-
-  /**
-   * @return The deviceId for a device or simulator
-   */
-  String deviceId();
-
-  /**
-   * @return The name of the platform of the device
-   */
-  String platform();
-
-  /**
-   * @return Whether the device is an emulator
-   */
-  boolean emulator();
-}
-
-class FlutterDevice implements ConnectedDevice {
-
+public class FlutterDevice {
   private final String myDeviceName;
   private final String myDeviceId;
   private final String myPlatform;
@@ -46,22 +20,18 @@ class FlutterDevice implements ConnectedDevice {
     myEmulator = emulator;
   }
 
-  @Override
   public String deviceName() {
     return myDeviceName;
   }
 
-  @Override
   public String deviceId() {
     return myDeviceId;
   }
 
-  @Override
   public String platform() {
     return myPlatform;
   }
 
-  @Override
   public boolean emulator() {
     return myEmulator;
   }

--- a/src/io/flutter/run/daemon/ProgressHelper.java
+++ b/src/io/flutter/run/daemon/ProgressHelper.java
@@ -15,13 +15,13 @@ import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 import java.util.List;
 
-class ProgressHandler {
+class ProgressHelper {
   final Project myProject;
   final List<String> myTasks = new ArrayList<>();
 
   private Task.Backgroundable myTask;
 
-  ProgressHandler(@NotNull Project project) {
+  ProgressHelper(@NotNull Project project) {
     this.myProject = project;
   }
 

--- a/src/io/flutter/utils/StopWatch.java
+++ b/src/io/flutter/utils/StopWatch.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2016 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.utils;
+
+public class StopWatch {
+  private long startTime;
+  private long stopTime;
+
+  public StopWatch() {
+
+  }
+
+  public void start() {
+    startTime = System.currentTimeMillis();
+  }
+
+  public void stop() {
+    stopTime = System.currentTimeMillis();
+  }
+
+  public long getTime() {
+    return stopTime - startTime;
+  }
+}

--- a/src/io/flutter/utils/StopWatch.java
+++ b/src/io/flutter/utils/StopWatch.java
@@ -5,6 +5,10 @@
  */
 package io.flutter.utils;
 
+/**
+ * Note: this class is a simplified version of one available in the Apache library. We use this one
+ * instead in order to avoid a dependency.
+ */
 public class StopWatch {
   private long startTime;
   private long stopTime;

--- a/src/io/flutter/utils/TimeoutUtil.java
+++ b/src/io/flutter/utils/TimeoutUtil.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2016 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.utils;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class TimeoutUtil {
+  private TimeoutUtil() {
+  }
+
+  public static void executeWithTimeout(long timeout, @NotNull final Runnable run) {
+    final long sleep = 50;
+    final long start = System.currentTimeMillis();
+    final AtomicBoolean done = new AtomicBoolean(false);
+    final Thread thread = new Thread("Fast Function Thread@" + run.hashCode()) {
+      public void run() {
+        try {
+          run.run();
+        }
+        catch (ThreadDeath ignored) {
+
+        }
+        finally {
+          done.set(true);
+        }
+      }
+    };
+    thread.start();
+
+    while (!done.get() && System.currentTimeMillis() - start < timeout) {
+      try {
+        Thread.sleep(sleep);
+      }
+      catch (InterruptedException var10) {
+        break;
+      }
+    }
+
+    if (!thread.isInterrupted()) {
+      //noinspection deprecation
+      thread.stop();
+    }
+  }
+
+  public static void sleep(long millis) {
+    try {
+      Thread.sleep(millis);
+    }
+    catch (InterruptedException ignored) {
+
+    }
+  }
+
+  public static long getDurationMillis(long startNanoTime) {
+    return (System.nanoTime() - startNanoTime) / 1000000L;
+  }
+}


### PR DESCRIPTION
- code motion and refactoring to simplify the debugger codebase
- rename FlutterAppManager to FlutterDaemonControllerHelper

This is a largely semantic free refactoring of the debugger codebase to improve maintainability. There's now:

- one daemon service per IntelliJ window
- one controller active for device detection
- one controller per launch, with a lifetime of that launch
- the FlutterDaemonControllerHelper, which is wholly owned by and assists the daemon controller

@pq