### PR TITLE
Fix reload/restart action keybinding tooltips.

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -99,14 +99,6 @@
   <!-- See: http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html -->
 
   <actions>
-    <action id="Flutter.HotReloadFlutterAppKey" class="io.flutter.actions.HotReloadFlutterAppRetarget" text="Flutter Hot Reload">
-      <keyboard-shortcut keymap="$default" first-keystroke="ctrl alt SEMICOLON"/>
-      <keyboard-shortcut keymap="$default" first-keystroke="ctrl BACK_SLASH"/>
-    </action>
-    <action id="Flutter.RestartFlutterAppKey" class="io.flutter.actions.RestartFlutterAppRetarget" text="Flutter Restart Application">
-      <keyboard-shortcut keymap="$default" first-keystroke="shift ctrl alt SEMICOLON"/>
-      <keyboard-shortcut keymap="$default" first-keystroke="shift ctrl BACK_SLASH"/>
-    </action>
     <group id="Flutter.MainToolbarActions">
       <separator/>
       <action id="Flutter.DeviceSelector" class="io.flutter.actions.DeviceSelectorAction"
@@ -163,10 +155,16 @@
       <separator/>
       <action id="Flutter.Toolbar.ReloadAction" class="io.flutter.actions.HotReloadFlutterAppRetarget"
               description="Reload"
-              icon="FlutterIcons.ReloadBoth"/>
+              icon="FlutterIcons.ReloadBoth">
+        <keyboard-shortcut keymap="$default" first-keystroke="ctrl alt SEMICOLON"/>
+        <keyboard-shortcut keymap="$default" first-keystroke="ctrl BACK_SLASH"/>
+    </action>
       <action id="Flutter.Toolbar.RestartAction" class="io.flutter.actions.RestartFlutterAppRetarget"
               description="Restart"
-              icon="FlutterIcons.Restart"/>
+              icon="FlutterIcons.Restart">
+        <keyboard-shortcut keymap="$default" first-keystroke="shift ctrl alt SEMICOLON"/>
+        <keyboard-shortcut keymap="$default" first-keystroke="shift ctrl BACK_SLASH"/>
+      </action>
       <separator/>
       <add-to-group anchor="last" group-id="RunContextGroup" />
       <add-to-group anchor="last" group-id="ToolbarRunGroup" />

--- a/src/io/flutter/actions/HotReloadFlutterApp.java
+++ b/src/io/flutter/actions/HotReloadFlutterApp.java
@@ -5,6 +5,7 @@
  */
 package io.flutter.actions;
 
+import com.intellij.openapi.actionSystem.ActionManager;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.util.Computable;
@@ -23,6 +24,8 @@ public class HotReloadFlutterApp extends FlutterAppAction {
 
   public HotReloadFlutterApp(ObservatoryConnector connector, Computable<Boolean> isApplicable) {
     super(connector, TEXT, DESCRIPTION, FlutterIcons.ReloadBoth, isApplicable, ID);
+    // Shortcut is associated with toolbar action.
+    copyShortcutFrom(ActionManager.getInstance().getAction("Flutter.Toolbar.ReloadAction"));
   }
 
   @Override

--- a/src/io/flutter/actions/RestartFlutterApp.java
+++ b/src/io/flutter/actions/RestartFlutterApp.java
@@ -5,6 +5,7 @@
  */
 package io.flutter.actions;
 
+import com.intellij.openapi.actionSystem.ActionManager;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.util.Computable;
@@ -21,6 +22,8 @@ public class RestartFlutterApp extends FlutterAppAction {
 
   public RestartFlutterApp(ObservatoryConnector connector, Computable<Boolean> isApplicable) {
     super(connector, TEXT, DESCRIPTION, FlutterIcons.Restart, isApplicable, ID);
+    // Shortcut is associated with toolbar action.
+    copyShortcutFrom(ActionManager.getInstance().getAction("Flutter.Toolbar.RestartAction"));
   }
 
   @Override


### PR DESCRIPTION
**TL;DR; we had no shortcuts displayed in reload/restart action tooltips... now we do!** 👍 

* removes now unneeded `FlutterAppKey` actions in favor of attaching shortcuts to the toolbar actions
* connects shortcuts to associated debugger view actions

![screen shot 2017-01-04 at 11 41 40 am](https://cloud.githubusercontent.com/assets/67586/21656586/9bc301ee-d273-11e6-8ca2-e69fe35d0b5a.png)

Confirmed custom keybindings are tracked:

![screen shot 2017-01-04 at 11 40 34 am](https://cloud.githubusercontent.com/assets/67586/21656585/99f2a0cc-d273-11e6-9c9f-7093dcb89584.png)


@devoncarew 

