### PR TITLE
Form cleanup.

### DIFF
--- a/src/io/flutter/module/FlutterGeneratorPeer.form
+++ b/src/io/flutter/module/FlutterGeneratorPeer.form
@@ -52,14 +52,6 @@
         <properties/>
         <border type="none"/>
         <children>
-          <component id="a87fb" class="javax.swing.JTextPane" binding="errorText">
-            <constraints>
-              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <text value="Error text placeholder"/>
-            </properties>
-          </component>
           <component id="a1cd0" class="javax.swing.JLabel" binding="errorIcon">
             <constraints>
               <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
@@ -73,6 +65,21 @@
               <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
           </hspacer>
+          <scrollpane id="2b6f">
+            <constraints>
+              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="7" hsize-policy="7" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties/>
+            <border type="none"/>
+            <children>
+              <component id="a87fb" class="javax.swing.JTextPane" binding="errorText">
+                <constraints/>
+                <properties>
+                  <text value="Error text placeholder"/>
+                </properties>
+              </component>
+            </children>
+          </scrollpane>
         </children>
       </grid>
     </children>

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.form
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.form
@@ -14,6 +14,9 @@
           <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
+        <clientProperties>
+          <BorderFactoryClass class="java.lang.String" value="com.intellij.ui.IdeBorderFactory$PlainSmallWithIndent"/>
+        </clientProperties>
         <border type="etched" title="SDK"/>
         <children>
           <component id="a59e7" class="javax.swing.JLabel">
@@ -66,6 +69,9 @@
           <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
+        <clientProperties>
+          <BorderFactoryClass class="java.lang.String" value="com.intellij.ui.IdeBorderFactory$PlainSmallWithIndent"/>
+        </clientProperties>
         <border type="etched" title="General"/>
         <children>
           <component id="6304a" class="javax.swing.JCheckBox" binding="myReportUsageInformationCheckBox">

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.form
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.form
@@ -14,9 +14,6 @@
           <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
-        <clientProperties>
-          <BorderFactoryClass class="java.lang.String" value="com.intellij.ui.IdeBorderFactory$PlainSmallWithIndent"/>
-        </clientProperties>
         <border type="etched" title="SDK"/>
         <children>
           <component id="a59e7" class="javax.swing.JLabel">
@@ -69,9 +66,6 @@
           <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
-        <clientProperties>
-          <BorderFactoryClass class="java.lang.String" value="com.intellij.ui.IdeBorderFactory$PlainSmallWithIndent"/>
-        </clientProperties>
         <border type="etched" title="General"/>
         <children>
           <component id="6304a" class="javax.swing.JCheckBox" binding="myReportUsageInformationCheckBox">
@@ -79,7 +73,7 @@
               <grid row="0" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
-              <text value="Report usage information to Google Analytics"/>
+              <text value="&amp;Report usage information to Google Analytics"/>
               <toolTipText value="Report anonymized usage information to Google Analytics."/>
             </properties>
           </component>


### PR DESCRIPTION
* adds missing mnemomic to Analytics checkbox

<img width="743" alt="screen shot 2017-01-05 at 6 54 37 am" src="https://cloud.githubusercontent.com/assets/67586/21684908/5f10db1c-d314-11e6-91e8-bb057f674e23.png">

* wraps settings error text in a scrollpane (as per recommended IDEA style)


@devoncarew 