### PR TITLE
Revert scrollpane wrapping.

### DIFF
--- a/src/io/flutter/module/FlutterGeneratorPeer.form
+++ b/src/io/flutter/module/FlutterGeneratorPeer.form
@@ -52,6 +52,14 @@
         <properties/>
         <border type="none"/>
         <children>
+          <component id="a87fb" class="javax.swing.JTextPane" binding="errorText">
+            <constraints>
+              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Error text placeholder"/>
+            </properties>
+          </component>
           <component id="a1cd0" class="javax.swing.JLabel" binding="errorIcon">
             <constraints>
               <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
@@ -65,23 +73,9 @@
               <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
           </hspacer>
-          <scrollpane id="2b6f">
-            <constraints>
-              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="7" hsize-policy="7" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties/>
-            <border type="none"/>
-            <children>
-              <component id="a87fb" class="javax.swing.JTextPane" binding="errorText">
-                <constraints/>
-                <properties>
-                  <text value="Error text placeholder"/>
-                </properties>
-              </component>
-            </children>
-          </scrollpane>
         </children>
       </grid>
     </children>
   </grid>
 </form>
+


### PR DESCRIPTION
Inspection be damned, wrapping this in a scrollpane produces an ugly UI artifact.

![screen shot 2017-01-06 at 10 14 11 am](https://cloud.githubusercontent.com/assets/67586/21729959/4ebbf87a-d402-11e6-9d7c-2d7909fbf1f5.png)

Reverting to remove.

@devoncarew 

FYI: @alexander-doroshko : advice on addressing the inspection appreciated.

![screen shot 2017-01-06 at 11 22 26 am](https://cloud.githubusercontent.com/assets/67586/21729974/6cfa26e0-d402-11e6-9fc7-e041968d2a22.png)
