### PR TITLE
Error Text scrollpane fix.

### DIFF
--- a/src/io/flutter/module/FlutterGeneratorPeer.form
+++ b/src/io/flutter/module/FlutterGeneratorPeer.form
@@ -52,14 +52,6 @@
         <properties/>
         <border type="none"/>
         <children>
-          <component id="a87fb" class="javax.swing.JTextPane" binding="errorText">
-            <constraints>
-              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <text value="Error text placeholder"/>
-            </properties>
-          </component>
           <component id="a1cd0" class="javax.swing.JLabel" binding="errorIcon">
             <constraints>
               <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
@@ -73,9 +65,23 @@
               <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
           </hspacer>
+          <scrollpane id="63dd2" binding="errorPane">
+            <constraints>
+              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="7" hsize-policy="7" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties/>
+            <border type="empty"/>
+            <children>
+              <component id="a87fb" class="javax.swing.JTextPane" binding="errorText">
+                <constraints/>
+                <properties>
+                  <text value="Error text placeholder"/>
+                </properties>
+              </component>
+            </children>
+          </scrollpane>
         </children>
       </grid>
     </children>
   </grid>
 </form>
-

--- a/src/io/flutter/module/FlutterGeneratorPeer.java
+++ b/src/io/flutter/module/FlutterGeneratorPeer.java
@@ -36,6 +36,7 @@ public class FlutterGeneratorPeer {
   private JBLabel myVersionContent;
   private JLabel errorIcon;
   private JTextPane errorText;
+  private JScrollPane errorPane;
 
   public FlutterGeneratorPeer() {
     errorIcon.setText("");
@@ -94,7 +95,7 @@ public class FlutterGeneratorPeer {
       errorText.setText(XmlStringUtil.wrapInHtml(info.message));
     }
     errorIcon.setVisible(info != null);
-    errorText.setVisible(info != null);
+    errorPane.setVisible(info != null);
 
     return info == null;
   }


### PR DESCRIPTION
Follow-up from: https://github.com/flutter/flutter-intellij/pull/598.

* scrollpane as per @alexander-doroshko's recommendation
* no border to keep presentation clean (and the same)

<img width="470" alt="screen shot 2017-01-09 at 5 48 04 am" src="https://cloud.githubusercontent.com/assets/67586/21768714/f542e0c6-d62f-11e6-8dd6-d82bc26ff5ca.png">

@alexander-doroshko @devoncarew 
