### PR TITLE
remove the old update site

### DIFF
--- a/docs/alpha/updatePlugins.xml
+++ b/docs/alpha/updatePlugins.xml
@@ -1,6 +1,0 @@
-<plugins>
-  <plugin
-      id="io.flutter"
-      url="https://github.com/flutter/flutter-intellij/releases/download/0.1.3/flutter-intellij.jar"
-      version="0.1.3"/>
-</plugins>


### PR DESCRIPTION
Remove the old update site - this isn't used since we started hosting in the main plugin repo.

@pq @eseidelGoogle 