### PR TITLE
adjust the text for invalid sdks

### DIFF
--- a/src/io/flutter/FlutterBundle.properties
+++ b/src/io/flutter/FlutterBundle.properties
@@ -14,9 +14,9 @@ dart.sdk.configuration.action.label=Configure Dart SDK
 dart.sdk.is.not.configured=Dart SDK is not configured
 don.t.show.again.for.this.module=Don't show again
 
-error.folder.specified.as.sdk.not.exists=Error: the folder specified as the Flutter SDK home does not exist.
-error.flutter.sdk.without.dart.sdk=Error: Flutter SDK installation is incomplete, see <a href='https://flutter.io/setup/#get-the-flutter-sdk'>setup instructions</a>.
-error.sdk.not.found.in.specified.location=Error: Flutter SDK is not found in the specified location.
+error.folder.specified.as.sdk.not.exists=The folder specified as the Flutter SDK home does not exist.
+error.flutter.sdk.without.dart.sdk=The Flutter SDK installation is incomplete; please see: https://flutter.io/setup.
+error.sdk.not.found.in.specified.location=Flutter SDK is not found in the specified location.
 
 # suppress inspection "TrailingSpacesInProperty"
 finished.with.exit.code.text.message=Process finished with exit code {0}\n


### PR DESCRIPTION
- adjust the text for invalid sdks (specify `https://flutter.io/setup` explicitly)
- fix https://github.com/flutter/flutter-intellij/issues/619

@pq 