### PR TITLE
Open processor first steps (#316)

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -227,6 +227,7 @@
                          id="flutter.settings" key="flutter.title" bundle="io.flutter.FlutterBundle"/>
     <annotator language="Dart" implementationClass="io.flutter.editor.FlutterEditorAnnotator"/>
     <errorHandler implementation="io.flutter.FlutterErrorReportSubmitter"/>
+    <projectOpenProcessor implementation="io.flutter.project.FlutterProjectOpenProcessor" order="first"/>
   </extensions>
 
 </idea-plugin>

--- a/src/io/flutter/FlutterBundle.properties
+++ b/src/io/flutter/FlutterBundle.properties
@@ -38,6 +38,7 @@ flutter.wrong.dart.sdk.warning=The Dart SDK for this module is not the same as F
 flutter.sdk.notAvailable.title=No Flutter SDK Configured
 flutter.sdk.notAvailable.message=This action requires a Flutter SDK to be available.
 
+multiple.packages.files.error=Unable to find project root dir (multiple .packages files found)
 multiple.pubspecs.error=Unable to find project root dir (multiple pubspecs found)
 
 open.observatory.action.text=Open Observatory

--- a/src/io/flutter/FlutterConstants.java
+++ b/src/io/flutter/FlutterConstants.java
@@ -8,6 +8,7 @@ package io.flutter;
 
 public class FlutterConstants {
   public static final String FLUTTER_YAML = "flutter.yaml";
+  public static final String PACKAGES_FILE = ".packages";
   public static final String PUBSPEC_YAML = "pubspec.yaml";
 
   private FlutterConstants() {

--- a/src/io/flutter/FlutterUtils.java
+++ b/src/io/flutter/FlutterUtils.java
@@ -11,6 +11,7 @@ import com.intellij.openapi.progress.ProcessCanceledException;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.jetbrains.lang.dart.DartFileType;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class FlutterUtils {
   private FlutterUtils() {
@@ -33,5 +34,9 @@ public class FlutterUtils {
     return file.getFileType() == DartFileType.INSTANCE ||
            fileName.equals(FlutterConstants.FLUTTER_YAML) ||
            fileName.equals(FlutterConstants.PUBSPEC_YAML);
+  }
+
+  public static boolean exists(@Nullable VirtualFile file) {
+    return file != null && file.exists();
   }
 }

--- a/src/io/flutter/actions/FlutterPackagesUpgradeAction.java
+++ b/src/io/flutter/actions/FlutterPackagesUpgradeAction.java
@@ -14,7 +14,6 @@ import com.intellij.openapi.util.Pair;
 import com.intellij.openapi.vfs.VirtualFile;
 import io.flutter.FlutterBundle;
 import io.flutter.FlutterErrors;
-import io.flutter.FlutterInitializer;
 import io.flutter.sdk.FlutterSdk;
 import org.jetbrains.annotations.NotNull;
 
@@ -24,8 +23,6 @@ public class FlutterPackagesUpgradeAction extends FlutterSdkAction {
 
   @Override
   public void perform(@NotNull FlutterSdk sdk, @NotNull Project project, AnActionEvent event) throws ExecutionException {
-    FlutterInitializer.sendActionEvent(this);
-
     final Pair<Module, VirtualFile> pair = getModuleAndPubspecYamlFile(project, event);
     if (pair != null) {
       sdk.run(COMMAND, pair.first, pair.second.getParent(), null);

--- a/src/io/flutter/actions/FlutterSdkAction.java
+++ b/src/io/flutter/actions/FlutterSdkAction.java
@@ -11,40 +11,41 @@ import com.intellij.openapi.actionSystem.CommonDataKeys;
 import com.intellij.openapi.actionSystem.LangDataKeys;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.module.Module;
-import com.intellij.openapi.module.ModuleManager;
 import com.intellij.openapi.project.DumbAwareAction;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.roots.ModuleRootManager;
 import com.intellij.openapi.roots.ProjectRootManager;
 import com.intellij.openapi.util.Pair;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
 import io.flutter.FlutterBundle;
-import io.flutter.FlutterConstants;
 import io.flutter.FlutterErrors;
+import io.flutter.FlutterInitializer;
 import io.flutter.sdk.FlutterSdk;
+import io.flutter.sdk.FlutterSdkUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.ArrayList;
-import java.util.List;
-
 /**
  * Base class for Flutter commands.
+ * <p>
+ * In general actions are executed via {@link #actionPerformed(AnActionEvent)}, and
+ * send analytics.  In case an action is performed and analytics should not be
+ * collected, prefer {@link #perform(FlutterSdk, Project, AnActionEvent, boolean)}.
  */
 public abstract class FlutterSdkAction extends DumbAwareAction {
 
   private static final Logger LOG = Logger.getInstance(FlutterSdkAction.class);
 
   @Nullable
-  public static Pair<Module, VirtualFile> getModuleAndPubspecYamlFile(@NotNull final Project project, final AnActionEvent e)
+  public static Pair<Module, VirtualFile> getModuleAndPubspecYamlFile(@NotNull final Project project, @Nullable final AnActionEvent e)
     throws ExecutionException {
-    Module module = LangDataKeys.MODULE.getData(e.getDataContext());
-    final PsiFile psiFile = CommonDataKeys.PSI_FILE.getData(e.getDataContext());
 
-    VirtualFile pubspec = findPubspecFrom(project, psiFile);
+    Module module = e == null ? null : LangDataKeys.MODULE.getData(e.getDataContext());
+    final PsiFile psiFile = e == null ? null : CommonDataKeys.PSI_FILE.getData(e.getDataContext());
+
+    VirtualFile pubspec = FlutterSdkUtil.findPubspecFrom(project, psiFile);
     if (pubspec == null) {
-      pubspec = findPubspecFrom(module);
+      pubspec = FlutterSdkUtil.findPubspecFrom(module);
     }
 
     if (module == null && pubspec != null) {
@@ -54,47 +55,8 @@ public abstract class FlutterSdkAction extends DumbAwareAction {
     return pubspec == null ? null : Pair.create(module, pubspec);
   }
 
-  protected static VirtualFile findPubspecFrom(@NotNull Project project, PsiFile psiFile) throws ExecutionException {
-    if (psiFile == null) {
-      final List<VirtualFile> pubspecs = findPubspecs(ModuleManager.getInstance(project).getModules());
-      if (pubspecs.size() == 0) {
-        return null;
-      }
-      else if (pubspecs.size() == 1) {
-        return pubspecs.get(0);
-      }
-      else {
-        throw new ExecutionException(FlutterBundle.message("multiple.pubspecs.error"));
-      }
-    }
-    final VirtualFile file = psiFile.getVirtualFile();
-    final VirtualFile contentRoot = ProjectRootManager.getInstance(project).getFileIndex().getContentRootForFile(file);
-    return contentRoot == null ? null : contentRoot.findChild(FlutterConstants.PUBSPEC_YAML);
-  }
-
-  private static List<VirtualFile> findPubspecs(@NotNull Module[] modules) {
-    final List<VirtualFile> pubspecs = new ArrayList<>();
-    for (Module module : modules) {
-      final VirtualFile file = findPubspecFrom(module);
-      if (file != null) {
-        pubspecs.add(file);
-      }
-    }
-    return pubspecs;
-  }
-
-  protected static VirtualFile findPubspecFrom(Module module) {
-    if (module == null) {
-      return null;
-    }
-    final ModuleRootManager moduleRootManager = ModuleRootManager.getInstance(module);
-    for (VirtualFile dir : moduleRootManager.getContentRoots()) {
-      final VirtualFile pubspec = dir.findChild(FlutterConstants.PUBSPEC_YAML);
-      if (pubspec != null) {
-        return pubspec;
-      }
-    }
-    return null;
+  protected void sendActionEvent() {
+    FlutterInitializer.sendActionEvent(this);
   }
 
   @Override
@@ -104,7 +66,7 @@ public abstract class FlutterSdkAction extends DumbAwareAction {
 
     if (sdk != null) {
       try {
-        perform(sdk, project, event);
+        perform(sdk, project, event, true);
       }
       catch (ExecutionException e) {
         FlutterErrors.showError(
@@ -120,5 +82,13 @@ public abstract class FlutterSdkAction extends DumbAwareAction {
     }
   }
 
-  public abstract void perform(@NotNull FlutterSdk sdk, @NotNull Project project, AnActionEvent event) throws ExecutionException;
+  public final void perform(@NotNull FlutterSdk sdk, @NotNull Project project, @Nullable AnActionEvent event, boolean logAction)
+    throws ExecutionException {
+    if (logAction) {
+      sendActionEvent();
+    }
+    perform(sdk, project, event);
+  }
+
+  abstract void perform(@NotNull FlutterSdk sdk, @NotNull Project project, AnActionEvent event) throws ExecutionException;
 }

--- a/src/io/flutter/actions/FlutterSdkAction.java
+++ b/src/io/flutter/actions/FlutterSdkAction.java
@@ -90,5 +90,5 @@ public abstract class FlutterSdkAction extends DumbAwareAction {
     perform(sdk, project, event);
   }
 
-  abstract void perform(@NotNull FlutterSdk sdk, @NotNull Project project, AnActionEvent event) throws ExecutionException;
+  public abstract void perform(@NotNull FlutterSdk sdk, @NotNull Project project, AnActionEvent event) throws ExecutionException;
 }

--- a/src/io/flutter/actions/FlutterUpgradeAction.java
+++ b/src/io/flutter/actions/FlutterUpgradeAction.java
@@ -11,15 +11,12 @@ import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Pair;
 import com.intellij.openapi.vfs.VirtualFile;
-import io.flutter.FlutterInitializer;
 import io.flutter.sdk.FlutterSdk;
 import org.jetbrains.annotations.NotNull;
 
 public class FlutterUpgradeAction extends FlutterSdkAction {
   @Override
   public void perform(@NotNull FlutterSdk sdk, @NotNull Project project, AnActionEvent event) throws ExecutionException {
-    FlutterInitializer.sendActionEvent(this);
-
     final Pair<Module, VirtualFile> pair = getModuleAndPubspecYamlFile(project, event);
     if (pair != null) {
       sdk.run(FlutterSdk.Command.UPGRADE, pair.first, pair.second.getParent(), null);

--- a/src/io/flutter/project/FlutterProjectOpenProcessor.java
+++ b/src/io/flutter/project/FlutterProjectOpenProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 The Chromium Authors. All rights reserved.
+ * Copyright 2017 The Chromium Authors. All rights reserved.
  * Use of this source code is governed by a BSD-style license that can be
  * found in the LICENSE file.
  */

--- a/src/io/flutter/project/FlutterProjectOpenProcessor.java
+++ b/src/io/flutter/project/FlutterProjectOpenProcessor.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2016 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.project;
+
+import com.intellij.execution.ExecutionException;
+import com.intellij.openapi.extensions.Extensions;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.projectImport.ProjectOpenProcessor;
+import icons.FlutterIcons;
+import io.flutter.FlutterBundle;
+import io.flutter.FlutterErrors;
+import io.flutter.FlutterUtils;
+import io.flutter.actions.FlutterPackagesGetAction;
+import io.flutter.actions.FlutterSdkAction;
+import io.flutter.sdk.FlutterSdk;
+import io.flutter.sdk.FlutterSdkUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+import java.util.Arrays;
+import java.util.Objects;
+
+
+public class FlutterProjectOpenProcessor extends ProjectOpenProcessor {
+
+  private static void doPerform(@NotNull FlutterSdkAction action, @NotNull Project project) throws ExecutionException {
+    final FlutterSdk sdk = FlutterSdk.getFlutterSdk(project);
+    if (sdk == null) {
+      // Lack of SDK will be flagged elsewhere by inspection.
+      return;
+    }
+
+    action.perform(sdk, project, null, false);
+  }
+
+  @Override
+  public String getName() {
+    return FlutterBundle.message("flutter.module.name");
+  }
+
+  @Override
+  public Icon getIcon() {
+    return FlutterIcons.Flutter;
+  }
+
+  @Override
+  public boolean canOpenProject(@Nullable VirtualFile file) {
+    return FlutterSdkUtil.isFlutterProjectDir(file);
+  }
+
+  @Nullable
+  @Override
+  public Project doOpenProject(@NotNull VirtualFile file, @Nullable Project projectToClose, boolean forceOpenInNewFrame) {
+
+    // Delegate opening to the platform open processor.
+    final ProjectOpenProcessor importProvider = getDelegateImportProvider(file);
+    if (importProvider == null) {
+      return null;
+    }
+
+    final Project project = importProvider.doOpenProject(file, projectToClose, forceOpenInNewFrame);
+    if (project == null) {
+      return null;
+    }
+
+    // Once open, perform post open processing.
+    doPostOpenProcessing(project);
+
+    return project;
+  }
+
+  private void doPostOpenProcessing(@NotNull Project project) {
+    try {
+      final VirtualFile packagesFile = FlutterSdkUtil.findPackagesFileFrom(project, null);
+      if (!FlutterUtils.exists(packagesFile)) {
+        doPerform(new FlutterPackagesGetAction(), project);
+      }
+      //TODO(pq): Check if .packages is out of date and offer to run `packages update`.
+      //else {
+      //
+      //}
+    }
+    catch (ExecutionException e) {
+      FlutterErrors.showError("Error opening",
+                              e.getMessage());
+    }
+  }
+
+  @Nullable
+  private ProjectOpenProcessor getDelegateImportProvider(@Nullable VirtualFile file) {
+    return Arrays.stream(Extensions.getExtensions(EXTENSION_POINT_NAME)).filter(
+      processor -> processor.canOpenProject(file) && !Objects.equals(processor.getName(), getName())
+    ).findFirst().orElse(null);
+  }
+
+  @Override
+  public boolean isStrongProjectInfoHolder() {
+    return true;
+  }
+}

--- a/src/io/flutter/project/FlutterProjectOpenProcessor.java
+++ b/src/io/flutter/project/FlutterProjectOpenProcessor.java
@@ -35,7 +35,7 @@ public class FlutterProjectOpenProcessor extends ProjectOpenProcessor {
       return;
     }
 
-    action.perform(sdk, project, null, false);
+    action.perform(sdk, project, null);
   }
 
   @Override

--- a/src/io/flutter/sdk/FlutterSdkUtil.java
+++ b/src/io/flutter/sdk/FlutterSdkUtil.java
@@ -16,10 +16,12 @@ import com.intellij.openapi.module.ModuleUtil;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
 import com.intellij.openapi.roots.ModuleRootManager;
+import com.intellij.openapi.roots.ProjectRootManager;
 import com.intellij.openapi.util.Pair;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiFile;
 import com.intellij.util.ArrayUtil;
 import com.intellij.util.PlatformUtils;
 import com.jetbrains.lang.dart.sdk.DartSdkGlobalLibUtil;
@@ -27,6 +29,7 @@ import com.jetbrains.lang.dart.sdk.DartSdkUpdateOption;
 import gnu.trove.THashSet;
 import io.flutter.FlutterBundle;
 import io.flutter.FlutterConstants;
+import io.flutter.FlutterUtils;
 import io.flutter.module.FlutterModuleType;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -35,7 +38,11 @@ import javax.swing.*;
 import java.io.File;
 import java.io.IOException;
 import java.util.*;
+import java.util.function.Function;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 
 public class FlutterSdkUtil {
   private static final Map<Pair<File, Long>, String> ourVersions = new HashMap<>();
@@ -50,7 +57,7 @@ public class FlutterSdkUtil {
     updateKnownPaths(FLUTTER_SDK_KNOWN_PATHS, newSdkPath);
   }
 
-  private static void updateKnownPaths(@NotNull final String propertyKey, @NotNull final String newPath) {
+  private static void updateKnownPaths(@SuppressWarnings("SameParameterValue") @NotNull final String propertyKey, @NotNull final String newPath) {
     final Set<String> known = new THashSet<>();
 
     final String[] oldKnownPaths = PropertiesComponent.getInstance().getValues(propertyKey);
@@ -159,6 +166,10 @@ public class FlutterSdkUtil {
     return null;
   }
 
+  public static boolean hasFlutterYaml(@NotNull Module module) {
+    return FlutterUtils.exists(findFilesInContentRoots(module, dir -> dir.findChild(FlutterConstants.FLUTTER_YAML)));
+  }
+
   private static String readVersionFile(String sdkHomePath) {
     final File versionFile = new File(versionPath(sdkHomePath));
     if (versionFile.isFile() && versionFile.length() < 1000) {
@@ -216,10 +227,11 @@ public class FlutterSdkUtil {
     return false;
   }
 
-  private static boolean declaresFlutterDependency(VirtualFile pubspec) {
-    if (pubspec == null || !pubspec.exists()) {
+  private static boolean declaresFlutterDependency(@Nullable VirtualFile pubspec) {
+    if (!FlutterUtils.exists(pubspec)) {
       return false;
     }
+
     try {
       final String contents = new String(pubspec.contentsToByteArray(true /* cache contents */));
       if (FLUTTER_SDK_DEP.matcher(contents).find()) {
@@ -230,6 +242,88 @@ public class FlutterSdkUtil {
       // Ignore IO exceptions.
     }
     return false;
+  }
+
+  @Nullable
+  public static VirtualFile findPackagesFileFrom(@NotNull Project project, @SuppressWarnings("SameParameterValue") @Nullable PsiFile psiFile) throws ExecutionException {
+    if (psiFile == null) {
+      final List<VirtualFile> packagesFiles = findPackagesFiles(ModuleManager.getInstance(project).getModules());
+      if (packagesFiles.isEmpty()) {
+        return null;
+      }
+      else if (packagesFiles.size() == 1) {
+        return packagesFiles.get(0);
+      }
+      else {
+        throw new ExecutionException(FlutterBundle.message("multiple.packages.files.error"));
+      }
+    }
+    final VirtualFile file = psiFile.getVirtualFile();
+    final VirtualFile contentRoot = ProjectRootManager.getInstance(project).getFileIndex().getContentRootForFile(file);
+    return contentRoot == null ? null : contentRoot.findChild(FlutterConstants.PACKAGES_FILE);
+  }
+
+
+  @Nullable
+  public static VirtualFile findPubspecFrom(@NotNull Project project, @Nullable PsiFile psiFile) throws ExecutionException {
+    if (psiFile == null) {
+      final List<VirtualFile> pubspecs = findPubspecs(ModuleManager.getInstance(project).getModules());
+      if (pubspecs.isEmpty()) {
+        return null;
+      }
+      else if (pubspecs.size() == 1) {
+        return pubspecs.get(0);
+      }
+      else {
+        throw new ExecutionException(FlutterBundle.message("multiple.pubspecs.error"));
+      }
+    }
+    final VirtualFile file = psiFile.getVirtualFile();
+    final VirtualFile contentRoot = ProjectRootManager.getInstance(project).getFileIndex().getContentRootForFile(file);
+    return contentRoot == null ? null : contentRoot.findChild(FlutterConstants.PUBSPEC_YAML);
+  }
+
+  @NotNull
+  private static List<VirtualFile> findModuleFiles(@NotNull Module[] modules, Function<Module, VirtualFile> finder) {
+    return Arrays.stream(modules).flatMap(m -> {
+      final VirtualFile file = finder.apply(m);
+      return file != null ? Stream.of(file) : Stream.empty();
+    }).collect(Collectors.toList());
+  }
+
+  @NotNull
+  public static List<VirtualFile> findPubspecs(@NotNull Module[] modules) {
+    return findModuleFiles(modules, FlutterSdkUtil::findPubspecFrom);
+  }
+
+  @NotNull
+  public static List<VirtualFile> findPackagesFiles(@NotNull Module[] modules) {
+    return findModuleFiles(modules, FlutterSdkUtil::findPackagesFileFrom);
+  }
+
+  @Nullable
+  public static VirtualFile findPubspecFrom(@Nullable Module module) {
+    return findFilesInContentRoots(module, dir -> dir.findChild(FlutterConstants.PUBSPEC_YAML));
+  }
+
+  @Nullable
+  public static VirtualFile findPackagesFileFrom(@Nullable Module module) {
+    return findFilesInContentRoots(module, dir -> dir.findChild(FlutterConstants.PACKAGES_FILE));
+  }
+
+  @Nullable
+  public static VirtualFile findFilesInContentRoots(@Nullable Module module, @NotNull Function<VirtualFile, VirtualFile> finder) {
+    if (module == null) {
+      return null;
+    }
+    final ModuleRootManager moduleRootManager = ModuleRootManager.getInstance(module);
+    for (VirtualFile dir : moduleRootManager.getContentRoots()) {
+      final VirtualFile file = finder.apply(dir);
+      if (file != null) {
+        return file;
+      }
+    }
+    return null;
   }
 
   @Nullable
@@ -245,6 +339,14 @@ public class FlutterSdkUtil {
     if (!isFlutterSdkHome(sdkRootPath)) return FlutterBundle.message("error.sdk.not.found.in.specified.location");
 
     return null;
+  }
+
+  public static boolean isFlutterProjectDir(@Nullable VirtualFile dir) {
+    if (dir == null || !dir.isDirectory()) return false;
+    if (dir.findChild(FlutterConstants.FLUTTER_YAML) != null) return true;
+
+    final VirtualFile pubspec = dir.findChild(FlutterConstants.PUBSPEC_YAML);
+    return declaresFlutterDependency(pubspec);
   }
 
   public static void setFlutterSdkPath(@NotNull final String flutterSdkPath) {


### PR DESCRIPTION
* adds an open processor that delegates to the platform for basic project import but adds it’s own post-processing hooks
* detects missing `.packages` and runs `flutter packages get` (#630)
* updates SDK actions to allow for running w/o analytics (for programmatic access)
* analytics reporing enabled for flutter doctor calls
* `FlutterSdkUtil` cleanup and refactoring

![screen shot 2017-01-18 at 1 54 19 pm](https://cloud.githubusercontent.com/assets/67586/22084661/d520f974-dd85-11e6-9db9-b099e0645669.png)

Still TODO: add detection and handling of stale `.packages` (a toast suggesting update) --- I'll pick that up in a follow-up PR with a bit more cleanup too.

@devoncarew 

