### PR TITLE
Show error when Dart SDK is not set correctly (#636)

### DIFF
--- a/src/io/flutter/FlutterBundle.properties
+++ b/src/io/flutter/FlutterBundle.properties
@@ -27,6 +27,7 @@ flutter.command.missing.pubspec=Missing pubspec
 flutter.command.missing.pubspec.message=`{0}` can only be run on a project with a pubspec.yaml.
 flutter.incompatible.dart.plugin.warning=Flutter requires a Dart plugin with a minimum version of {0} (currently installed: {1}).
 flutter.module.name=Flutter
+flutter.no.sdk.warning=No Flutter SDK Configured.
 flutter.old.sdk.warning=The current configured Flutter SDK is not known to be fully supported. Please update your SDK and restart IntelliJ.
 flutter.project.description=Build high-performance, high-fidelity, mobile apps for iOS and Android using the Flutter framework.
 flutter.sdk.browse.path.label=Select Flutter SDK Path
@@ -34,7 +35,6 @@ flutter.sdk.is.not.configured=The Flutter SDK is not configured
 flutter.sdk.path.label=Flutter &SDK path:
 flutter.support.is.not.enabled.for.module.0=Flutter support is not enabled for module ''{0}''
 flutter.title=Flutter
-flutter.wrong.dart.sdk.warning=The Dart SDK for this module is not the same as Flutter's. Setting Dart to use the Flutter vended SDK is strongly recommended.
 flutter.sdk.notAvailable.title=No Flutter SDK Configured
 flutter.sdk.notAvailable.message=This action requires a Flutter SDK to be available.
 

--- a/src/io/flutter/inspections/SdkConfigurationNotificationProvider.java
+++ b/src/io/flutter/inspections/SdkConfigurationNotificationProvider.java
@@ -47,30 +47,18 @@ public class SdkConfigurationNotificationProvider extends EditorNotifications.Pr
     this.project = project;
   }
 
-  @Nullable
-  private static EditorNotificationPanel createWrongSdkPanel(@NotNull Project project, @Nullable Module module) {
-    if (module == null) return null;
-
-    final FlutterUIConfig settings = FlutterUIConfig.getInstance();
-    if (settings.shouldIgnoreMismatchedDartSdks()) return null;
-
+  @SuppressWarnings("SameReturnValue")
+  private static EditorNotificationPanel createNoFlutterSdkPanel() {
     final EditorNotificationPanel panel = new EditorNotificationPanel();
-    panel.setText(FlutterBundle.message("flutter.wrong.dart.sdk.warning"));
-    panel.createActionLabel(FlutterBundle.message("dart.sdk.configuration.action.label"),
-                            () -> FlutterSdkService.getInstance(project).configureDartSdk(module));
+    panel.setText(FlutterBundle.message("flutter.no.sdk.warning"));
     panel.createActionLabel("Dismiss", () -> {
-      settings.setIgnoreMismatchedDartSdks();
       panel.setVisible(false);
     });
 
+    // TODO(skybrian) we should add a link to go to the Dart SDK panel.
+    // However, not yet because this will change with 2017.1 to be project-specific.
+
     return panel;
-  }
-
-  @SuppressWarnings("SameReturnValue")
-  private static EditorNotificationPanel createNoFlutterSdkPanel() {
-    // TODO(pq): add panel for unconfigured Flutter SDK.
-
-    return null;
   }
 
   @NotNull
@@ -93,31 +81,13 @@ public class SdkConfigurationNotificationProvider extends EditorNotifications.Pr
 
     if (!FlutterSdkUtil.isFlutterModule(module)) return null;
 
-    try {
-      final FlutterSdk flutterSdk = FlutterSdk.getFlutterSdk(project);
-      if (flutterSdk == null) {
-        return createNoFlutterSdkPanel();
-      }
-
-      if (flutterSdk.getVersion().isLessThan(MIN_SUPPORTED_SDK)) {
-        return createOutOfDateFlutterSdkPanel(flutterSdk);
-      }
-
-      final DartSdk dartSdk = DartSdk.getDartSdk(project);
-      if (dartSdk == null) {
-        // TODO(devoncarew): Recommend to set up with Flutter's dart sdk.
-
-        return null;
-      }
-
-      final String flutterDartSdkPath = flutterSdk.getDartSdkPath();
-      final String dartSdkPath = dartSdk.getHomePath();
-      if (!StringUtil.equals(flutterDartSdkPath, dartSdkPath)) {
-        return createWrongSdkPanel(project, module);
-      }
+    final FlutterSdk flutterSdk = FlutterSdk.getFlutterSdk(project);
+    if (flutterSdk == null) {
+      return createNoFlutterSdkPanel();
     }
-    catch (ExecutionException e) {
-      LOG.warn(e);
+
+    if (flutterSdk.getVersion().isLessThan(MIN_SUPPORTED_SDK)) {
+      return createOutOfDateFlutterSdkPanel(flutterSdk);
     }
 
     return null;

--- a/src/io/flutter/sdk/FlutterSdkManager.java
+++ b/src/io/flutter/sdk/FlutterSdkManager.java
@@ -43,25 +43,22 @@ public class FlutterSdkManager {
     ProjectManager.getInstance().addProjectManagerListener(new ProjectManagerAdapter() {
       @Override
       public void projectOpened(@NotNull Project project) {
-        checkForFlutterSdkAddition();
+        checkForFlutterSdkChange();
       }
 
       @Override
       public void projectClosed(@NotNull Project project) {
-        checkForFlutterSdkRemoval();
+        checkForFlutterSdkChange();
       }
     });
   }
 
-  private void checkForFlutterSdkAddition() {
+  // Send events if Flutter SDK was configured or unconfigured.
+  public void checkForFlutterSdkChange() {
     if (!isFlutterConfigured && isGlobalFlutterSdkSetAndNeeded()) {
       isFlutterConfigured = true;
       myDispatcher.getMulticaster().flutterSdkAdded();
-    }
-  }
-
-  private void checkForFlutterSdkRemoval() {
-    if (isFlutterConfigured && !isGlobalFlutterSdkSetAndNeeded()) {
+    } else if (isFlutterConfigured && !isGlobalFlutterSdkSetAndNeeded()) {
       isFlutterConfigured = false;
       myDispatcher.getMulticaster().flutterSdkRemoved();
     }
@@ -100,13 +97,13 @@ public class FlutterSdkManager {
 
     @Override
     public void afterLibraryAdded(Library newLibrary) {
-      checkForFlutterSdkAddition();
+      checkForFlutterSdkChange();
     }
 
     @Override
     public void afterLibraryRenamed(Library library) {
       // Since we key off name, test to be safe.
-      checkForFlutterSdkRemoval();
+      checkForFlutterSdkChange();
     }
 
     @Override
@@ -116,7 +113,7 @@ public class FlutterSdkManager {
 
     @Override
     public void afterLibraryRemoved(Library library) {
-      checkForFlutterSdkRemoval();
+      checkForFlutterSdkChange();
     }
   }
 }

--- a/src/io/flutter/sdk/FlutterSdkUtil.java
+++ b/src/io/flutter/sdk/FlutterSdkUtil.java
@@ -359,5 +359,8 @@ public class FlutterSdkUtil {
 
     // Update the list of known sdk paths.
     FlutterSdkUtil.updateKnownSdkPaths(flutterSdkPath);
+
+    // Fire events for a Flutter SDK change, which updates the UI.
+    FlutterSdkManager.getInstance().checkForFlutterSdkChange();
   }
 }

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.java
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.java
@@ -143,8 +143,12 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
   public void reset() {
     final FlutterSdk sdk = FlutterSdk.getGlobalFlutterSdk();
     final String path = sdk != null ? sdk.getHomePath() : "";
-    mySdkCombo.getComboBox().getEditor().setItem(FileUtil.toSystemDependentName(path));
     FlutterSdkUtil.addKnownSDKPathsToCombo(mySdkCombo.getComboBox());
+
+    // Set this after populating the combo box to display correctly when the Flutter SDK is unset.
+    // (This can happen if the user changed the Dart SDK.)
+    mySdkCombo.getComboBox().getEditor().setItem(FileUtil.toSystemDependentName(path));
+
     updateVersionText();
     myReportUsageInformationCheckBox.setSelected(FlutterInitializer.getCanReportAnalytics());
   }


### PR DESCRIPTION
Since the Flutter SDK is derived the from Dart SDK, we actually handle
this by reporting: 'No Flutter SDK configured'. When the user fixes
the Flutter SDK, the Dart SDK will also be fixed.

Fixed combo box to display correctly when no Flutter SDK is configured.
Fire a Flutter SDK changed event when the user changes the Flutter SDK.
Removed dead code.

Not done: when the user changes the Dart SDK, we should fire a Flutter
SDK changed event.

(Sorry about the repost; I accidentally deleted the branch for the last pull request.)