### PR TITLE
Prefer packages `get` over `upgrade` in project open (#648).

### DIFF
--- a/src/io/flutter/project/FlutterProjectOpenProcessor.java
+++ b/src/io/flutter/project/FlutterProjectOpenProcessor.java
@@ -127,9 +127,10 @@ public class FlutterProjectOpenProcessor extends ProjectOpenProcessor {
     private final Project myProject;
 
     public PackagesOutOfDateNotification(@NotNull Project project) {
-      super("Flutter Packages", FlutterIcons.Flutter, "Package updates.",
-            null, "This project's packages are ready to" +
-                  " <a href=\"\">update</a>.",
+      super("Flutter Packages", FlutterIcons.Flutter, "Flutter packages get.",
+            null, "The pubspec.yaml file has been modified since " +
+                  "the last time the 'flutter packages get' was run;" +
+                  " <a href=\"\">run that now</a>?",
             NotificationType.INFORMATION, new NotificationListener() {
           @Override
           public void hyperlinkUpdate(@NotNull Notification notification, @NotNull HyperlinkEvent event) {

--- a/src/io/flutter/project/FlutterProjectOpenProcessor.java
+++ b/src/io/flutter/project/FlutterProjectOpenProcessor.java
@@ -137,7 +137,7 @@ public class FlutterProjectOpenProcessor extends ProjectOpenProcessor {
             final FlutterSdk sdk = FlutterSdk.getFlutterSdk(project);
             if (sdk != null) {
               try {
-                new FlutterPackagesUpgradeAction().perform(sdk, project, null);
+                new FlutterPackagesGetAction().perform(sdk, project, null);
                 notification.expire();
               }
               catch (ExecutionException e) {


### PR DESCRIPTION
* perform packages `get` rather than `upgrade` on project import

Follow-up on: https://github.com/flutter/flutter-intellij/pull/648#discussion_r97264115.

@devoncarew @danrubel

