### PR TITLE
Add Flutter Module type on project open (#316).

### DIFF
--- a/src/io/flutter/actions/DeviceSelectorAction.java
+++ b/src/io/flutter/actions/DeviceSelectorAction.java
@@ -18,7 +18,7 @@ import io.flutter.run.daemon.FlutterDaemonService;
 import io.flutter.run.daemon.FlutterDevice;
 import io.flutter.sdk.FlutterSdk;
 import io.flutter.sdk.FlutterSdkManager;
-import io.flutter.sdk.FlutterSdkUtil;
+import io.flutter.utils.FlutterModuleUtils;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
@@ -53,7 +53,7 @@ public class DeviceSelectorAction extends ComboBoxAction implements DumbAware {
 
     // And only present in the context of a flutter project.
     final Project project = e.getProject();
-    if (project == null || !FlutterSdkUtil.hasFlutterModule(project)) {
+    if (project == null || !FlutterModuleUtils.hasFlutterModule(project)) {
       e.getPresentation().setVisible(false);
       return;
     }

--- a/src/io/flutter/actions/FlutterRetargetAction.java
+++ b/src/io/flutter/actions/FlutterRetargetAction.java
@@ -11,7 +11,7 @@ import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.Presentation;
 import com.intellij.openapi.project.DumbAwareAction;
 import com.intellij.openapi.project.Project;
-import io.flutter.sdk.FlutterSdkUtil;
+import io.flutter.utils.FlutterModuleUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -54,7 +54,7 @@ public abstract class FlutterRetargetAction extends DumbAwareAction {
     final Presentation presentation = e.getPresentation();
 
     final Project project = e.getProject();
-    if (project == null || !FlutterSdkUtil.hasFlutterModule(project) || !myPlaces.contains(e.getPlace())) {
+    if (project == null || !FlutterModuleUtils.hasFlutterModule(project) || !myPlaces.contains(e.getPlace())) {
       presentation.setVisible(false);
       return;
     }

--- a/src/io/flutter/actions/FlutterSdkAction.java
+++ b/src/io/flutter/actions/FlutterSdkAction.java
@@ -21,7 +21,7 @@ import io.flutter.FlutterBundle;
 import io.flutter.FlutterErrors;
 import io.flutter.FlutterInitializer;
 import io.flutter.sdk.FlutterSdk;
-import io.flutter.sdk.FlutterSdkUtil;
+import io.flutter.utils.FlutterModuleUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -43,9 +43,9 @@ public abstract class FlutterSdkAction extends DumbAwareAction {
     Module module = e == null ? null : LangDataKeys.MODULE.getData(e.getDataContext());
     final PsiFile psiFile = e == null ? null : CommonDataKeys.PSI_FILE.getData(e.getDataContext());
 
-    VirtualFile pubspec = FlutterSdkUtil.findPubspecFrom(project, psiFile);
+    VirtualFile pubspec = FlutterModuleUtils.findPubspecFrom(project, psiFile);
     if (pubspec == null) {
-      pubspec = FlutterSdkUtil.findPubspecFrom(module);
+      pubspec = FlutterModuleUtils.findPubspecFrom(module);
     }
 
     if (module == null && pubspec != null) {
@@ -82,7 +82,10 @@ public abstract class FlutterSdkAction extends DumbAwareAction {
     }
   }
 
-  public final void perform(@NotNull FlutterSdk sdk, @NotNull Project project, @Nullable AnActionEvent event, boolean logAction)
+  public final void perform(@NotNull FlutterSdk sdk,
+                            @NotNull Project project,
+                            @Nullable AnActionEvent event,
+                            @SuppressWarnings("SameParameterValue") boolean logAction)
     throws ExecutionException {
     if (logAction) {
       sendActionEvent();

--- a/src/io/flutter/editor/FlutterEditorAnnotator.java
+++ b/src/io/flutter/editor/FlutterEditorAnnotator.java
@@ -16,7 +16,7 @@ import com.intellij.util.ui.ColorIcon;
 import com.jetbrains.lang.dart.psi.DartArrayAccessExpression;
 import com.jetbrains.lang.dart.psi.DartNewExpression;
 import com.jetbrains.lang.dart.psi.DartReferenceExpression;
-import io.flutter.sdk.FlutterSdkUtil;
+import io.flutter.utils.FlutterModuleUtils;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
@@ -118,7 +118,7 @@ public class FlutterEditorAnnotator implements Annotator {
   }
 
   private static boolean isInFlutterModule(@NotNull PsiElement element) {
-    return FlutterSdkUtil.isFlutterModule(ModuleUtil.findModuleForPsiElement(element));
+    return FlutterModuleUtils.isFlutterModule(ModuleUtil.findModuleForPsiElement(element));
   }
 
   private Icon getIcon(String id) {

--- a/src/io/flutter/inspections/FlutterYamlNotificationProvider.java
+++ b/src/io/flutter/inspections/FlutterYamlNotificationProvider.java
@@ -18,7 +18,7 @@ import com.intellij.ui.EditorNotifications;
 import icons.FlutterIcons;
 import io.flutter.FlutterConstants;
 import io.flutter.sdk.FlutterSdk;
-import io.flutter.sdk.FlutterSdkUtil;
+import io.flutter.utils.FlutterModuleUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -51,7 +51,7 @@ public class FlutterYamlNotificationProvider extends EditorNotifications.Provide
       return null;
     }
 
-    if (!FlutterSdkUtil.hasFlutterModule(project)) {
+    if (!FlutterModuleUtils.hasFlutterModule(project)) {
       return null;
     }
 

--- a/src/io/flutter/inspections/IncompatibleDartPluginNotificationProvider.java
+++ b/src/io/flutter/inspections/IncompatibleDartPluginNotificationProvider.java
@@ -23,7 +23,7 @@ import com.jetbrains.lang.dart.DartLanguage;
 import io.flutter.FlutterBundle;
 import io.flutter.FlutterUtils;
 import io.flutter.dart.DartPlugin;
-import io.flutter.sdk.FlutterSdkUtil;
+import io.flutter.utils.FlutterModuleUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -74,7 +74,7 @@ public class IncompatibleDartPluginNotificationProvider extends EditorNotificati
     final Module module = ModuleUtilCore.findModuleForPsiElement(psiFile);
     if (module == null) return null;
 
-    if (!FlutterSdkUtil.isFlutterModule(module)) return null;
+    if (!FlutterModuleUtils.isFlutterModule(module)) return null;
 
     final Version minimumVersion = DartPlugin.getInstance().getMinimumVersion();
     final Version dartVersion = DartPlugin.getInstance().getVersion();

--- a/src/io/flutter/inspections/SdkConfigurationNotificationProvider.java
+++ b/src/io/flutter/inspections/SdkConfigurationNotificationProvider.java
@@ -21,9 +21,9 @@ import com.jetbrains.lang.dart.DartFileType;
 import com.jetbrains.lang.dart.DartLanguage;
 import io.flutter.FlutterBundle;
 import io.flutter.sdk.FlutterSdk;
-import io.flutter.sdk.FlutterSdkUtil;
 import io.flutter.sdk.FlutterSdkVersion;
 import io.flutter.settings.FlutterUIConfig;
+import io.flutter.utils.FlutterModuleUtils;
 import org.jetbrains.annotations.NotNull;
 
 public class SdkConfigurationNotificationProvider extends EditorNotifications.Provider<EditorNotificationPanel>
@@ -72,7 +72,7 @@ public class SdkConfigurationNotificationProvider extends EditorNotifications.Pr
     final Module module = ModuleUtilCore.findModuleForPsiElement(psiFile);
     if (module == null) return null;
 
-    if (!FlutterSdkUtil.isFlutterModule(module)) return null;
+    if (!FlutterModuleUtils.isFlutterModule(module)) return null;
 
     final FlutterSdk flutterSdk = FlutterSdk.getFlutterSdk(project);
     if (flutterSdk == null) {

--- a/src/io/flutter/inspections/WrongModuleTypeNotificationProvider.java
+++ b/src/io/flutter/inspections/WrongModuleTypeNotificationProvider.java
@@ -8,13 +8,11 @@ package io.flutter.inspections;
 
 import com.intellij.CommonBundle;
 import com.intellij.ide.util.PropertiesComponent;
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.fileEditor.FileEditor;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleUtilCore;
 import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.project.ProjectManager;
 import com.intellij.openapi.ui.Messages;
 import com.intellij.openapi.util.Key;
 import com.intellij.openapi.util.text.StringUtil;
@@ -22,13 +20,10 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.ui.EditorNotificationPanel;
 import com.intellij.ui.EditorNotifications;
 import com.intellij.util.containers.ContainerUtil;
-import com.jetbrains.lang.dart.sdk.DartSdk;
-import com.jetbrains.lang.dart.sdk.DartSdkGlobalLibUtil;
 import icons.FlutterIcons;
 import io.flutter.FlutterBundle;
 import io.flutter.FlutterUtils;
-import io.flutter.module.FlutterModuleType;
-import io.flutter.sdk.FlutterSdkUtil;
+import io.flutter.utils.FlutterModuleUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Set;
@@ -54,16 +49,7 @@ public class WrongModuleTypeNotificationProvider extends EditorNotifications.Pro
                                     FlutterBundle.message("update.module.type"),
                                     FlutterBundle.message("reload.project"), CommonBundle.getCancelButtonText(), null);
       if (message == Messages.YES) {
-        module.setOption(Module.ELEMENT_TYPE, FlutterModuleType.getInstance().getId());
-
-        if (DartSdk.getDartSdk(project) != null && !DartSdkGlobalLibUtil.isDartSdkEnabled(module)) {
-          ApplicationManager.getApplication().runWriteAction(() -> DartSdkGlobalLibUtil.enableDartSdk(module));
-        }
-
-        project.save();
-
-        EditorNotifications.getInstance(project).updateAllNotifications();
-        ProjectManager.getInstance().reloadProject(project);
+        FlutterModuleUtils.setFlutterModuleAndReload(module, project);
       }
     });
     panel.createActionLabel(FlutterBundle.message("don.t.show.again.for.this.module"), () -> {
@@ -91,7 +77,7 @@ public class WrongModuleTypeNotificationProvider extends EditorNotifications.Pro
   public EditorNotificationPanel createNotificationPanel(@NotNull VirtualFile file, @NotNull FileEditor fileEditor) {
     if (!FlutterUtils.isFlutteryFile(file)) return null;
     final Module module = ModuleUtilCore.findModuleForFile(file, myProject);
-    if (module == null || FlutterSdkUtil.isFlutterModule(module) || getIgnoredModules(myProject).contains(module.getName())) return null;
-    return FlutterSdkUtil.usesFlutter(module) ? createPanel(myProject, module) : null;
+    if (module == null || FlutterModuleUtils.isFlutterModule(module) || getIgnoredModules(myProject).contains(module.getName())) return null;
+    return FlutterModuleUtils.usesFlutter(module) ? createPanel(myProject, module) : null;
   }
 }

--- a/src/io/flutter/run/FlutterRunConfigurationType.java
+++ b/src/io/flutter/run/FlutterRunConfigurationType.java
@@ -15,7 +15,7 @@ import com.intellij.psi.search.GlobalSearchScope;
 import com.jetbrains.lang.dart.DartFileType;
 import icons.FlutterIcons;
 import io.flutter.FlutterBundle;
-import io.flutter.sdk.FlutterSdkUtil;
+import io.flutter.utils.FlutterModuleUtils;
 import org.jetbrains.annotations.NotNull;
 
 public class FlutterRunConfigurationType extends ConfigurationTypeBase {
@@ -51,7 +51,7 @@ public class FlutterRunConfigurationType extends ConfigurationTypeBase {
     @Override
     public boolean isApplicable(@NotNull Project project) {
       return FileTypeIndex.containsFileOfType(DartFileType.INSTANCE, GlobalSearchScope.projectScope(project)) &&
-             FlutterSdkUtil.hasFlutterModule(project);
+             FlutterModuleUtils.hasFlutterModule(project);
     }
   }
 }

--- a/src/io/flutter/utils/FlutterModuleUtils.java
+++ b/src/io/flutter/utils/FlutterModuleUtils.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright  2017 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.utils;
+
+import com.intellij.execution.ExecutionException;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleManager;
+import com.intellij.openapi.module.ModuleType;
+import com.intellij.openapi.module.ModuleUtil;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectManager;
+import com.intellij.openapi.roots.ModuleRootManager;
+import com.intellij.openapi.roots.ProjectRootManager;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiFile;
+import com.intellij.ui.EditorNotifications;
+import com.intellij.util.PlatformUtils;
+import com.jetbrains.lang.dart.sdk.DartSdk;
+import com.jetbrains.lang.dart.sdk.DartSdkGlobalLibUtil;
+import io.flutter.FlutterBundle;
+import io.flutter.FlutterConstants;
+import io.flutter.FlutterUtils;
+import io.flutter.module.FlutterModuleType;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class FlutterModuleUtils {
+
+  private static final Pattern FLUTTER_SDK_DEP = Pattern.compile(".*sdk:\\s*flutter"); //NON-NLS
+
+  private FlutterModuleUtils() {
+  }
+
+  public static boolean hasFlutterYaml(@NotNull Module module) {
+    return FlutterUtils.exists(findFilesInContentRoots(module, dir -> dir.findChild(FlutterConstants.FLUTTER_YAML)));
+  }
+
+  public static boolean isFlutterModule(@Nullable Module module) {
+    return module != null && ModuleType.is(module, FlutterModuleType.getInstance());
+  }
+
+  public static boolean hasFlutterModule(@NotNull Project project) {
+    if (ModuleUtil.hasModulesOfType(project, FlutterModuleType.getInstance())) {
+      return true;
+    }
+
+    // If not IntelliJ, assume a small IDE (no multi-module project support).
+    // Look for a module with a flutter-like file structure.
+    if (!PlatformUtils.isIntelliJ()) {
+      for (Module module : ModuleManager.getInstance(project).getModules()) {
+        if (usesFlutter(module)) {
+          return true;
+        }
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * Check if any module in this project {@link #usesFlutter(Module)}.
+   */
+  public static boolean usesFlutter(@NotNull Project project) {
+    return Arrays.stream(ModuleManager.getInstance(project).getModules()).anyMatch(FlutterModuleUtils::usesFlutter);
+  }
+
+  /**
+   * Introspect into the module's content roots, looking for flutter.yaml or a pubspec.yaml that
+   * references flutter.
+   */
+  public static boolean usesFlutter(@NotNull Module module) {
+    final VirtualFile[] roots = ModuleRootManager.getInstance(module).getContentRoots();
+    for (VirtualFile baseDir : roots) {
+      final VirtualFile flutterYaml = baseDir.findChild(FlutterConstants.FLUTTER_YAML);
+      if (flutterYaml != null && flutterYaml.exists()) {
+        return true;
+      }
+      final VirtualFile pubspec = baseDir.findChild(FlutterConstants.PUBSPEC_YAML);
+      if (declaresFlutterDependency(pubspec)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  public static boolean declaresFlutterDependency(@Nullable VirtualFile pubspec) {
+    if (!FlutterUtils.exists(pubspec)) {
+      return false;
+    }
+
+    try {
+      final String contents = new String(pubspec.contentsToByteArray(true /* cache contents */));
+      if (FLUTTER_SDK_DEP.matcher(contents).find()) {
+        return true;
+      }
+    }
+    catch (IOException e) {
+      // Ignore IO exceptions.
+    }
+    return false;
+  }
+
+  @Nullable
+  public static VirtualFile findPackagesFileFrom(@NotNull Project project,
+                                                 @SuppressWarnings("SameParameterValue") @Nullable PsiFile psiFile)
+    throws ExecutionException {
+    if (psiFile == null) {
+      final List<VirtualFile> packagesFiles = findPackagesFiles(ModuleManager.getInstance(project).getModules());
+      if (packagesFiles.isEmpty()) {
+        return null;
+      }
+      else if (packagesFiles.size() == 1) {
+        return packagesFiles.get(0);
+      }
+      else {
+        throw new ExecutionException(FlutterBundle.message("multiple.packages.files.error"));
+      }
+    }
+    final VirtualFile file = psiFile.getVirtualFile();
+    final VirtualFile contentRoot = ProjectRootManager.getInstance(project).getFileIndex().getContentRootForFile(file);
+    return contentRoot == null ? null : contentRoot.findChild(FlutterConstants.PACKAGES_FILE);
+  }
+
+  @Nullable
+  public static VirtualFile findPubspecFrom(@NotNull Project project, @Nullable PsiFile psiFile) throws ExecutionException {
+    if (psiFile == null) {
+      final List<VirtualFile> pubspecs = findPubspecs(ModuleManager.getInstance(project).getModules());
+      if (pubspecs.isEmpty()) {
+        return null;
+      }
+      else if (pubspecs.size() == 1) {
+        return pubspecs.get(0);
+      }
+      else {
+        throw new ExecutionException(FlutterBundle.message("multiple.pubspecs.error"));
+      }
+    }
+    final VirtualFile file = psiFile.getVirtualFile();
+    final VirtualFile contentRoot = ProjectRootManager.getInstance(project).getFileIndex().getContentRootForFile(file);
+    return contentRoot == null ? null : contentRoot.findChild(FlutterConstants.PUBSPEC_YAML);
+  }
+
+  @NotNull
+  private static List<VirtualFile> findModuleFiles(@NotNull Module[] modules, Function<Module, VirtualFile> finder) {
+    return Arrays.stream(modules).flatMap(m -> {
+      final VirtualFile file = finder.apply(m);
+      return file != null ? Stream.of(file) : Stream.empty();
+    }).collect(Collectors.toList());
+  }
+
+  @NotNull
+  public static List<VirtualFile> findPubspecs(@NotNull Module[] modules) {
+    return findModuleFiles(modules, FlutterModuleUtils::findPubspecFrom);
+  }
+
+  @NotNull
+  public static List<VirtualFile> findPackagesFiles(@NotNull Module[] modules) {
+    return findModuleFiles(modules, FlutterModuleUtils::findPackagesFileFrom);
+  }
+
+  @Nullable
+  public static VirtualFile findPubspecFrom(@Nullable Module module) {
+    return findFilesInContentRoots(module, dir -> dir.findChild(FlutterConstants.PUBSPEC_YAML));
+  }
+
+  @Nullable
+  public static VirtualFile findPackagesFileFrom(@Nullable Module module) {
+    return findFilesInContentRoots(module, dir -> dir.findChild(FlutterConstants.PACKAGES_FILE));
+  }
+
+  @Nullable
+  public static VirtualFile findFilesInContentRoots(@Nullable Module module, @NotNull Function<VirtualFile, VirtualFile> finder) {
+    if (module == null) {
+      return null;
+    }
+    final ModuleRootManager moduleRootManager = ModuleRootManager.getInstance(module);
+    for (VirtualFile dir : moduleRootManager.getContentRoots()) {
+      final VirtualFile file = finder.apply(dir);
+      if (file != null) {
+        return file;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Find flutter modules.
+   *
+   * Flutter modules are defined as:
+   *   1. being tagged with the #FlutterModuleType, or
+   *   2. containing a pubspec that #declaresFlutterDependency
+   */
+  @NotNull
+  public static List<Module> findModulesWithFlutterContents(@NotNull Project project) {
+    return Arrays.stream(ModuleManager.getInstance(project).getModules()).filter(
+      m -> isFlutterModule(m) || usesFlutter(m)).collect(Collectors.toList());
+  }
+
+  public static void setFlutterModuleType(@NotNull Module module) {
+    module.setOption(Module.ELEMENT_TYPE, FlutterModuleType.getInstance().getId());
+  }
+
+  public static void setFlutterModuleAndReload(@NotNull Module module, @NotNull Project project) {
+    setFlutterModuleType(module);
+
+    if (DartSdk.getDartSdk(project) != null && !DartSdkGlobalLibUtil.isDartSdkEnabled(module)) {
+      ApplicationManager.getApplication().runWriteAction(() -> DartSdkGlobalLibUtil.enableDartSdk(module));
+    }
+
+    project.save();
+
+    EditorNotifications.getInstance(project).updateAllNotifications();
+    ProjectManager.getInstance().reloadProject(project);
+  }
+}

--- a/src/io/flutter/view/FlutterViewCondition.java
+++ b/src/io/flutter/view/FlutterViewCondition.java
@@ -7,11 +7,11 @@ package io.flutter.view;
 
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Condition;
-import io.flutter.sdk.FlutterSdkUtil;
+import io.flutter.utils.FlutterModuleUtils;
 
 public class FlutterViewCondition implements Condition<Project> {
   @Override
   public boolean value(Project project) {
-    return FlutterSdkUtil.hasFlutterModule(project);
+    return FlutterModuleUtils.hasFlutterModule(project);
   }
 }


### PR DESCRIPTION
* adds flutter module type (if missing)
* reloads project
* runs `flutter packages get`
* code cleanup (new `FlutterModuleUtils` class)

Fixes: #316.