### PR TITLE
proxy key bindings to the front-most debug process

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -168,7 +168,7 @@
     <!-- main toolbar run actions -->
     <group id="Flutter.MainToolbarActions.Run">
       <separator/>
-      <action id="Flutter.Toolbar.ReloadAction" class="io.flutter.actions.HotReloadFlutterAppRetarget"
+      <action id="Flutter.Toolbar.ReloadAction" class="io.flutter.actions.ReloadFlutterAppRetarget"
               description="Reload"
               icon="FlutterIcons.ReloadBoth">
         <keyboard-shortcut keymap="$default" first-keystroke="ctrl alt SEMICOLON"/>

--- a/src/io/flutter/actions/ReloadFlutterApp.java
+++ b/src/io/flutter/actions/ReloadFlutterApp.java
@@ -13,16 +13,17 @@ import com.jetbrains.lang.dart.ide.runner.ObservatoryConnector;
 import icons.FlutterIcons;
 import io.flutter.FlutterBundle;
 import io.flutter.FlutterInitializer;
+import io.flutter.run.daemon.FlutterApp;
 
 import java.lang.reflect.Method;
 
 @SuppressWarnings("ComponentNotRegistered")
-public class HotReloadFlutterApp extends FlutterAppAction {
-  public static final String ID = "Flutter.HotReloadFlutterApp"; //NON-NLS
+public class ReloadFlutterApp extends FlutterAppAction implements FlutterRetargetAppAction.AppAction {
+  public static final String ID = "Flutter.ReloadFlutterApp"; //NON-NLS
   public static final String TEXT = FlutterBundle.message("app.reload.action.text");
   public static final String DESCRIPTION = FlutterBundle.message("app.reload.action.description");
 
-  public HotReloadFlutterApp(ObservatoryConnector connector, Computable<Boolean> isApplicable) {
+  public ReloadFlutterApp(ObservatoryConnector connector, Computable<Boolean> isApplicable) {
     super(connector, TEXT, DESCRIPTION, FlutterIcons.ReloadBoth, isApplicable, ID);
     // Shortcut is associated with toolbar action.
     copyShortcutFrom(ActionManager.getInstance().getAction("Flutter.Toolbar.ReloadAction"));
@@ -30,12 +31,17 @@ public class HotReloadFlutterApp extends FlutterAppAction {
 
   @Override
   public void actionPerformed(AnActionEvent e) {
+    actionPerformed(getApp());
+  }
+
+  @Override
+  public void actionPerformed(FlutterApp app) {
     FlutterInitializer.sendActionEvent(this);
 
     ifReadyThen(() -> {
       FileDocumentManager.getInstance().saveAllDocuments();
       final boolean pauseAfterRestart = hasCapability("supports.pausePostRequest");
-      getApp().performHotReload(pauseAfterRestart);
+      app.performHotReload(pauseAfterRestart);
     });
   }
 

--- a/src/io/flutter/actions/ReloadFlutterAppRetarget.java
+++ b/src/io/flutter/actions/ReloadFlutterAppRetarget.java
@@ -8,13 +8,13 @@ package io.flutter.actions;
 import com.intellij.openapi.actionSystem.ActionPlaces;
 
 /**
- * A keystroke or tool-bar invoked {@link HotReloadFlutterApp} action.
+ * A keystroke or tool-bar invoked {@link ReloadFlutterApp} action.
  */
-public class HotReloadFlutterAppRetarget extends FlutterRetargetAction {
-  public HotReloadFlutterAppRetarget() {
-    super(HotReloadFlutterApp.ID,
-          HotReloadFlutterApp.TEXT,
-          HotReloadFlutterApp.DESCRIPTION,
+public class ReloadFlutterAppRetarget extends FlutterRetargetAppAction {
+  public ReloadFlutterAppRetarget() {
+    super(ReloadFlutterApp.ID,
+          ReloadFlutterApp.TEXT,
+          ReloadFlutterApp.DESCRIPTION,
           ActionPlaces.MAIN_TOOLBAR,
           ActionPlaces.NAVIGATION_BAR_TOOLBAR);
   }

--- a/src/io/flutter/actions/RestartFlutterApp.java
+++ b/src/io/flutter/actions/RestartFlutterApp.java
@@ -13,9 +13,10 @@ import com.jetbrains.lang.dart.ide.runner.ObservatoryConnector;
 import icons.FlutterIcons;
 import io.flutter.FlutterBundle;
 import io.flutter.FlutterInitializer;
+import io.flutter.run.daemon.FlutterApp;
 
 @SuppressWarnings("ComponentNotRegistered")
-public class RestartFlutterApp extends FlutterAppAction {
+public class RestartFlutterApp extends FlutterAppAction implements FlutterRetargetAppAction.AppAction {
   public static final String ID = "Flutter.RestartFlutterApp"; //NON-NLS
   public static final String TEXT = FlutterBundle.message("app.restart.action.text");
   public static final String DESCRIPTION = FlutterBundle.message("app.restart.action.description");
@@ -28,11 +29,16 @@ public class RestartFlutterApp extends FlutterAppAction {
 
   @Override
   public void actionPerformed(AnActionEvent e) {
+    actionPerformed(getApp());
+  }
+
+  @Override
+  public void actionPerformed(FlutterApp app) {
     FlutterInitializer.sendActionEvent(this);
 
     ifReadyThen(() -> {
       FileDocumentManager.getInstance().saveAllDocuments();
-      getApp().performRestartApp();
+      app.performRestartApp();
     });
   }
 }

--- a/src/io/flutter/actions/RestartFlutterAppRetarget.java
+++ b/src/io/flutter/actions/RestartFlutterAppRetarget.java
@@ -10,7 +10,7 @@ import com.intellij.openapi.actionSystem.ActionPlaces;
 /**
  * A keystroke or tool-bar invoked {@link RestartFlutterApp} action.
  */
-public class RestartFlutterAppRetarget extends FlutterRetargetAction {
+public class RestartFlutterAppRetarget extends FlutterRetargetAppAction {
   public RestartFlutterAppRetarget() {
     super(RestartFlutterApp.ID,
           RestartFlutterApp.TEXT,

--- a/src/io/flutter/sdk/FlutterSdkUtil.java
+++ b/src/io/flutter/sdk/FlutterSdkUtil.java
@@ -168,7 +168,6 @@ public class FlutterSdkUtil {
     return null;
   }
 
-
   @Nullable
   public static String getErrorMessageIfWrongSdkRootPath(final @NotNull String sdkRootPath) {
     if (sdkRootPath.isEmpty()) {

--- a/third_party/intellij-plugins-dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcessZ.java
+++ b/third_party/intellij-plugins-dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcessZ.java
@@ -37,8 +37,8 @@ import gnu.trove.THashMap;
 import gnu.trove.THashSet;
 import gnu.trove.TIntObjectHashMap;
 import io.flutter.FlutterBundle;
-import io.flutter.actions.HotReloadFlutterApp;
 import io.flutter.actions.OpenObservatoryAction;
+import io.flutter.actions.ReloadFlutterApp;
 import io.flutter.actions.RestartFlutterApp;
 import io.flutter.run.daemon.FlutterApp;
 import io.flutter.view.FlutterViewMessages;
@@ -468,7 +468,7 @@ public class DartVmServiceDebugProcessZ extends DartVmServiceDebugProcess {
     topToolbar.addSeparator();
     topToolbar.addAction(new OpenObservatoryAction(this::computeObservatoryBrowserUrl, this::isSessionActive));
     topToolbar.addSeparator();
-    topToolbar.addAction(new HotReloadFlutterApp(myConnector, () -> shouldEnableHotReload() && isSessionActive()));
+    topToolbar.addAction(new ReloadFlutterApp(myConnector, () -> shouldEnableHotReload() && isSessionActive()));
     topToolbar.addAction(new RestartFlutterApp(myConnector, () -> shouldEnableHotReload() && isSessionActive()));
   }
 


### PR DESCRIPTION
- for the hot reload and full restart key-bindings, send the reqests to the active (focused) debug process
- fix https://github.com/flutter/flutter-intellij/issues/644
- (some class renames so that similar actions are grouped together in the project view)

@pq 
