### PR TITLE
Flutter dependency inspection.

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -235,6 +235,10 @@
                     serviceImplementation="io.flutter.view.FlutterView"
                     overrides="false"/>
     <projectOpenProcessor implementation="io.flutter.project.FlutterProjectOpenProcessor" order="first"/>
+
+    <localInspection bundle="io.flutter.FlutterBundle" key="outdated.dependencies.inspection.name"
+                     groupName="Flutter" enabledByDefault="true" level="WARNING" language="Dart"
+                     implementationClass="io.flutter.inspections.FlutterDependencyInspection"/>
   </extensions>
 
 </idea-plugin>

--- a/resources/inspectionDescriptions/FlutterDependency.html
+++ b/resources/inspectionDescriptions/FlutterDependency.html
@@ -1,0 +1,14 @@
+<!--
+  ~ Copyright  2017 The Chromium Authors. All rights reserved.
+  ~ Use of this source code is governed by a BSD-style license that can be
+  ~ found in the LICENSE file.
+  -->
+
+<html>
+<body>
+Flutter package dependency check.
+<!-- tooltip end -->
+Checks whether a Flutter <code><a href="https://www.dartlang.org/tools/pub/pubspec.html">pubspec.yaml</a></code> has been edited
+since the last <a href="https://flutter.io/upgrading/l">package update</a>.
+</body>
+</html>

--- a/resources/inspectionDescriptions/FlutterDependency.html
+++ b/resources/inspectionDescriptions/FlutterDependency.html
@@ -9,6 +9,6 @@
 Flutter package dependency check.
 <!-- tooltip end -->
 Checks whether a Flutter <code><a href="https://www.dartlang.org/tools/pub/pubspec.html">pubspec.yaml</a></code> has been edited
-since the last <a href="https://flutter.io/upgrading/l">package update</a>.
+since the last <a href="https://flutter.io/upgrading/">package update</a>.
 </body>
 </html>

--- a/src/io/flutter/FlutterBundle.properties
+++ b/src/io/flutter/FlutterBundle.properties
@@ -43,6 +43,15 @@ multiple.pubspecs.error=Unable to find project root dir (multiple pubspecs found
 open.observatory.action.text=Open Observatory
 open.observatory.action.description=Open Observatory: a Profiler for Dart apps
 
+
+outdated.dependencies.inspection.name=Outdated package dependencies
+packages.get.never.done='Packages get' has not been run
+pubspec.edited=Pubspec has been edited
+get.dependencies=Get dependencies
+upgrade.dependencies=Upgrade dependencies
+open.pubspec=Open pubspec
+ignore.warning=Ignore
+
 reload.project=Reload project
 runner.flutter.configuration.description=Flutter run configuration
 runner.flutter.configuration.name=Flutter

--- a/src/io/flutter/FlutterConstants.java
+++ b/src/io/flutter/FlutterConstants.java
@@ -10,6 +10,9 @@ public class FlutterConstants {
   public static final String PACKAGES_FILE = ".packages";
   public static final String PUBSPEC_YAML = "pubspec.yaml";
 
+  public static final String PACKAGES_GET_ACTION_ID = "flutter.packages.get";
+  public static final String PACKAGES_UPGRADE_ACTION_ID = "flutter.packages.upgrade";
+
   private FlutterConstants() {
 
   }

--- a/src/io/flutter/FlutterUtils.java
+++ b/src/io/flutter/FlutterUtils.java
@@ -9,6 +9,7 @@ import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.progress.ProcessCanceledException;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiFile;
 import com.jetbrains.lang.dart.DartFileType;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -46,4 +47,10 @@ public class FlutterUtils {
   public static boolean exists(@Nullable VirtualFile file) {
     return file != null && file.exists();
   }
+
+  @Nullable
+  public static VirtualFile getRealVirtualFile(@Nullable PsiFile psiFile) {
+    return psiFile != null ? psiFile.getOriginalFile().getVirtualFile() : null;
+  }
+
 }

--- a/src/io/flutter/inspections/FlutterDependencyInspection.java
+++ b/src/io/flutter/inspections/FlutterDependencyInspection.java
@@ -12,7 +12,6 @@ import com.intellij.openapi.actionSystem.ActionManager;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
-import com.intellij.openapi.fileEditor.OpenFileDescriptor;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleUtilCore;
 import com.intellij.openapi.project.Project;
@@ -94,7 +93,6 @@ public class FlutterDependencyInspection extends LocalInspectionTool {
     final LocalQuickFix[] fixes = new LocalQuickFix[]{
       new PackageUpdateFix(FlutterBundle.message("get.dependencies"), FlutterConstants.PACKAGES_GET_ACTION_ID),
       new PackageUpdateFix(FlutterBundle.message("upgrade.dependencies"), FlutterConstants.PACKAGES_UPGRADE_ACTION_ID),
-      new OpenPubspecFix(),
       new IgnoreWarningFix(myIgnoredPubspecPaths, pubspecFile.getPath())};
 
     return new ProblemDescriptor[]{
@@ -151,36 +149,6 @@ public class FlutterDependencyInspection extends LocalInspectionTool {
           FlutterErrors.showError("Error performing action", e.getMessage());
         }
       }
-    }
-  }
-
-  private static class OpenPubspecFix extends IntentionAndQuickFixAction {
-    @Override
-    @NotNull
-    public String getName() {
-      return FlutterBundle.message("open.pubspec");
-    }
-
-    @Override
-    @NotNull
-    public String getFamilyName() {
-      return getName();
-    }
-
-    @Override
-    public boolean startInWriteAction() {
-      return false;
-    }
-
-    @Override
-    public void applyFix(@NotNull final Project project, @NotNull final PsiFile psiFile, @Nullable final Editor editor) {
-      final VirtualFile file = FlutterUtils.getRealVirtualFile(psiFile);
-      if (file == null || !file.isInLocalFileSystem()) return;
-
-      final VirtualFile pubspecFile = findPubspecOrNull(project, psiFile);
-      if (pubspecFile == null) return;
-
-      new OpenFileDescriptor(project, pubspecFile).navigate(true);
     }
   }
 

--- a/src/io/flutter/inspections/FlutterDependencyInspection.java
+++ b/src/io/flutter/inspections/FlutterDependencyInspection.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright  2017 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.inspections;
+
+import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer;
+import com.intellij.codeInspection.*;
+import com.intellij.execution.ExecutionException;
+import com.intellij.openapi.actionSystem.ActionManager;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.fileEditor.FileDocumentManager;
+import com.intellij.openapi.fileEditor.OpenFileDescriptor;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleUtilCore;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.ProjectRootManager;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiFile;
+import com.jetbrains.lang.dart.ide.actions.DartPubActionBase;
+import com.jetbrains.lang.dart.psi.DartFile;
+import gnu.trove.THashSet;
+import io.flutter.FlutterBundle;
+import io.flutter.FlutterConstants;
+import io.flutter.FlutterErrors;
+import io.flutter.FlutterUtils;
+import io.flutter.actions.FlutterSdkAction;
+import io.flutter.sdk.FlutterSdk;
+import io.flutter.utils.FlutterModuleUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Set;
+
+public class FlutterDependencyInspection extends LocalInspectionTool {
+  private final Set<String> myIgnoredPubspecPaths = new THashSet<>(); // remember for the current session only, do not serialize
+
+  @Nullable
+  @Override
+  public ProblemDescriptor[] checkFile(@NotNull final PsiFile psiFile, @NotNull final InspectionManager manager, final boolean isOnTheFly) {
+    if (!isOnTheFly) return null;
+
+    if (!(psiFile instanceof DartFile)) return null;
+
+
+    if (DartPubActionBase.isInProgress()) return null;
+
+    final VirtualFile file = FlutterUtils.getRealVirtualFile(psiFile);
+    if (file == null || !file.isInLocalFileSystem()) return null;
+
+    final Project project = psiFile.getProject();
+    if (!ProjectRootManager.getInstance(project).getFileIndex().isInContent(file)) return null;
+
+    final FlutterSdk sdk = FlutterSdk.getFlutterSdk(project);
+    final Module module = ModuleUtilCore.findModuleForFile(file, project);
+    if (!FlutterModuleUtils.isFlutterModule(module)) return null;
+
+    final VirtualFile pubspec = findPubspecOrNull(project, psiFile);
+
+    if (pubspec == null || myIgnoredPubspecPaths.contains(pubspec.getPath())) return null;
+
+    //TODO(pq): consider validating package name here (`get` will fail if it's invalid).
+
+    final VirtualFile packages = pubspec.getParent().findChild(FlutterConstants.PACKAGES_FILE);
+    if (packages == null) {
+      return createProblemDescriptors(manager, psiFile, pubspec, FlutterBundle.message("packages.get.never.done"));
+    }
+
+    if (FileDocumentManager.getInstance().isFileModified(pubspec) || pubspec.getTimeStamp() > packages.getTimeStamp()) {
+      return createProblemDescriptors(manager, psiFile, pubspec, FlutterBundle.message("pubspec.edited"));
+    }
+
+    return null;
+  }
+
+
+  @Nullable
+  private static VirtualFile findPubspecOrNull(@NotNull Project project, @Nullable PsiFile psiFile) {
+    try {
+      return FlutterModuleUtils.findPubspecFrom(project, psiFile);
+    }
+    catch (ExecutionException e) {
+      return null;
+    }
+  }
+
+  @NotNull
+  private ProblemDescriptor[] createProblemDescriptors(@NotNull final InspectionManager manager,
+                                                       @NotNull final PsiFile psiFile,
+                                                       @NotNull final VirtualFile pubspecFile,
+                                                       @NotNull final String errorMessage) {
+    final LocalQuickFix[] fixes = new LocalQuickFix[]{
+      new PackageUpdateFix(FlutterBundle.message("get.dependencies"), FlutterConstants.PACKAGES_GET_ACTION_ID),
+      new PackageUpdateFix(FlutterBundle.message("upgrade.dependencies"), FlutterConstants.PACKAGES_UPGRADE_ACTION_ID),
+      new OpenPubspecFix(),
+      new IgnoreWarningFix(myIgnoredPubspecPaths, pubspecFile.getPath())};
+
+    return new ProblemDescriptor[]{
+      manager.createProblemDescriptor(psiFile, errorMessage, true, fixes, ProblemHighlightType.GENERIC_ERROR_OR_WARNING)};
+  }
+
+  private static class PackageUpdateFix extends IntentionAndQuickFixAction {
+    private final String myFixName;
+    private final String myActionId;
+
+    private PackageUpdateFix(@NotNull final String fixName, @NotNull final String actionId) {
+      myFixName = fixName;
+      myActionId = actionId;
+    }
+
+    @Override
+    @NotNull
+    public String getName() {
+      return myFixName;
+    }
+
+    @Override
+    @NotNull
+    public String getFamilyName() {
+      return getName();
+    }
+
+    @Override
+    public boolean startInWriteAction() {
+      return false;
+    }
+
+    @Override
+    public void applyFix(@NotNull final Project project, @NotNull final PsiFile psiFile, @Nullable final Editor editor) {
+      final VirtualFile file = FlutterUtils.getRealVirtualFile(psiFile);
+      if (file == null || !file.isInLocalFileSystem()) return;
+
+      final VirtualFile pubspecFile = findPubspecOrNull(project, psiFile);
+      if (pubspecFile == null) return;
+
+      final Module module = ModuleUtilCore.findModuleForFile(file, project);
+      if (module == null) return;
+
+      final FlutterSdk sdk = FlutterSdk.getFlutterSdk(project);
+      if (sdk == null) return;
+
+
+      final AnAction packageAction = ActionManager.getInstance().getAction(myActionId);
+      if (packageAction instanceof FlutterSdkAction) {
+        try {
+          ((FlutterSdkAction)packageAction).perform(sdk, project, null);
+        }
+        catch (ExecutionException e) {
+          FlutterErrors.showError("Error performing action", e.getMessage());
+        }
+      }
+    }
+  }
+
+  private static class OpenPubspecFix extends IntentionAndQuickFixAction {
+    @Override
+    @NotNull
+    public String getName() {
+      return FlutterBundle.message("open.pubspec");
+    }
+
+    @Override
+    @NotNull
+    public String getFamilyName() {
+      return getName();
+    }
+
+    @Override
+    public boolean startInWriteAction() {
+      return false;
+    }
+
+    @Override
+    public void applyFix(@NotNull final Project project, @NotNull final PsiFile psiFile, @Nullable final Editor editor) {
+      final VirtualFile file = FlutterUtils.getRealVirtualFile(psiFile);
+      if (file == null || !file.isInLocalFileSystem()) return;
+
+      final VirtualFile pubspecFile = findPubspecOrNull(project, psiFile);
+      if (pubspecFile == null) return;
+
+      new OpenFileDescriptor(project, pubspecFile).navigate(true);
+    }
+  }
+
+  private static class IgnoreWarningFix extends IntentionAndQuickFixAction {
+    @NotNull private final Set<String> myIgnoredPubspecPaths;
+    @NotNull private final String myPubspecPath;
+
+    public IgnoreWarningFix(@NotNull final Set<String> ignoredPubspecPaths, @NotNull final String pubspecPath) {
+      myIgnoredPubspecPaths = ignoredPubspecPaths;
+      myPubspecPath = pubspecPath;
+    }
+
+    @Override
+    @NotNull
+    public String getName() {
+      return FlutterBundle.message("ignore.warning");
+    }
+
+    @Override
+    @NotNull
+    public String getFamilyName() {
+      return getName();
+    }
+
+    @Override
+    public boolean startInWriteAction() {
+      return false;
+    }
+
+    @Override
+    public void applyFix(@NotNull final Project project, @NotNull final PsiFile psiFile, @Nullable final Editor editor) {
+      myIgnoredPubspecPaths.add(myPubspecPath);
+      DaemonCodeAnalyzer.getInstance(project).restart();
+    }
+  }
+}


### PR DESCRIPTION
* Flutter’s version of the check performed by the Dart Plugin  (soon suppressed) on `pubspec.yaml` edits
* Offers to run `flutter packages get` or `flutter packages update`

![screen shot 2017-01-26 at 10 05 15 am](https://cloud.githubusercontent.com/assets/67586/22344112/a0213682-e3af-11e6-9c43-72c25716bf95.png)

(Notice the pile-up of notifications --- https://github.com/JetBrains/intellij-plugins/pull/472 will suppress the Dart one.)

Still TODO:

* word-smithing (input welcome)
* consider auto-close of inspection banner on fix execution (not done by the Dart one either)

@devoncarew 
