### PR TITLE
Restore Flutter pubspec editor banner.

### DIFF
--- a/resources/META-INF/idea-contribs.xml
+++ b/resources/META-INF/idea-contribs.xml
@@ -8,6 +8,7 @@
     <editorNotificationProvider implementation="io.flutter.inspections.IncompatibleDartPluginNotificationProvider"/>
     <editorNotificationProvider implementation="io.flutter.inspections.SdkConfigurationNotificationProvider"/>
     <editorNotificationProvider implementation="io.flutter.inspections.WrongModuleTypeNotificationProvider"/>
+    <editorNotificationProvider implementation="io.flutter.editor.FlutterPubspecNotificationProvider"/>
 
     <moduleConfigurationEditorProvider implementation="io.flutter.module.FlutterModuleConfigurationEditorProvider"/>
   </extensions>

--- a/src/io/flutter/editor/FlutterPubspecNotificationProvider.java
+++ b/src/io/flutter/editor/FlutterPubspecNotificationProvider.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2017 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.editor;
+
+import com.intellij.openapi.editor.colors.EditorColors;
+import com.intellij.openapi.editor.colors.EditorColorsManager;
+import com.intellij.openapi.fileEditor.FileEditor;
+import com.intellij.openapi.project.DumbAware;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectLocator;
+import com.intellij.openapi.util.Key;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.ui.EditorNotificationPanel;
+import com.intellij.ui.EditorNotifications;
+import icons.FlutterIcons;
+import io.flutter.FlutterConstants;
+import io.flutter.sdk.FlutterSdk;
+import io.flutter.utils.FlutterModuleUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+import java.awt.*;
+
+public class FlutterPubspecNotificationProvider extends EditorNotifications.Provider<EditorNotificationPanel> implements DumbAware {
+  private static final Key<EditorNotificationPanel> KEY = Key.create("flutter.pubspec");
+
+  @NotNull
+  @Override
+  public Key<EditorNotificationPanel> getKey() {
+    return KEY;
+  }
+
+  @Nullable
+  @Override
+  public EditorNotificationPanel createNotificationPanel(@NotNull VirtualFile file, @NotNull FileEditor editor) {
+    if (!file.isInLocalFileSystem()) {
+      return null;
+    }
+
+    if (!FlutterConstants.PUBSPEC_YAML.equalsIgnoreCase(file.getName())) {
+      return null;
+    }
+
+    // Check for a flutter sdk.
+    final Project project = ProjectLocator.getInstance().guessProjectForFile(file);
+    if (project == null) {
+      return null;
+    }
+
+    if (!FlutterModuleUtils.hasFlutterModule(project)) {
+      return null;
+    }
+
+    final FlutterSdk sdk = FlutterSdk.getFlutterSdk(project);
+    if (sdk == null) {
+      return null;
+    }
+
+    return new FlutterPubspecActionsPanel(file);
+  }
+
+  static class FlutterPubspecActionsPanel extends EditorNotificationPanel {
+    @NotNull final VirtualFile myFile;
+
+    FlutterPubspecActionsPanel(@NotNull VirtualFile file) {
+      myFile = file;
+
+      icon(FlutterIcons.Flutter);
+      text("Flutter commands");
+
+      createActionLabel("Packages get", "flutter.packages.get");
+      createActionLabel("Packages upgrade", "flutter.packages.upgrade");
+      myLinksPanel.add(new JSeparator(SwingConstants.VERTICAL));
+      createActionLabel("Flutter upgrade", "flutter.upgrade");
+      myLinksPanel.add(new JSeparator(SwingConstants.VERTICAL));
+      createActionLabel("Flutter doctor", "flutter.doctor");
+
+      // TODO: Add for 2017.1.
+      //background(EditorColors.GUTTER_BACKGROUND);
+    }
+
+    // TODO: Remove for 2017.1.
+    @Override
+    public Color getBackground() {
+      final Color color = EditorColorsManager.getInstance().getGlobalScheme().getColor(EditorColors.GUTTER_BACKGROUND);
+      return color != null ? color : super.getBackground();
+    }
+  }
+}


### PR DESCRIPTION
<img width="977" alt="screen shot 2017-01-27 at 6 00 07 am" src="https://cloud.githubusercontent.com/assets/67586/22373390/799d0afc-e456-11e6-8ca1-0c1ffa11ecde.png">

(Note that this is _in addition_ to the Dart Plugin provided pubspec notification until JetBrains/intellij-plugins#472 is pushed to stable suppressing that.)

@devoncarew 