### PR TITLE
add analytics events for run, debug, and process stop

### DIFF
--- a/src/io/flutter/FlutterInitializer.java
+++ b/src/io/flutter/FlutterInitializer.java
@@ -78,8 +78,12 @@ public class FlutterInitializer implements StartupActivity {
     return !properties.getBoolean(analyticsOptOutKey, false);
   }
 
-  public static void sendActionEvent(@NotNull AnAction action) {
-    getAnalytics().sendEvent("intellij", action.getClass().getSimpleName());
+  public static void sendAnalyticsAction(@NotNull AnAction action) {
+    sendAnalyticsAction(action.getClass().getSimpleName());
+  }
+
+  public static void sendAnalyticsAction(@NotNull String name) {
+    getAnalytics().sendEvent("intellij", name);
   }
 
   @Override

--- a/src/io/flutter/actions/FlutterGettingStarted.java
+++ b/src/io/flutter/actions/FlutterGettingStarted.java
@@ -14,7 +14,7 @@ import org.jetbrains.annotations.NotNull;
 public class FlutterGettingStarted extends DumbAwareAction {
   @Override
   public void actionPerformed(@NotNull final AnActionEvent e) {
-    FlutterInitializer.sendActionEvent(this);
+    FlutterInitializer.sendAnalyticsAction(this);
 
     final String url = "https://flutter.io/intellij-ide/";
     BrowserLauncher.getInstance().browse(url, null);

--- a/src/io/flutter/actions/FlutterSdkAction.java
+++ b/src/io/flutter/actions/FlutterSdkAction.java
@@ -57,7 +57,7 @@ public abstract class FlutterSdkAction extends DumbAwareAction {
   }
 
   protected void sendActionEvent() {
-    FlutterInitializer.sendActionEvent(this);
+    FlutterInitializer.sendAnalyticsAction(this);
   }
 
   @Override

--- a/src/io/flutter/actions/FlutterSubmitFeedback.java
+++ b/src/io/flutter/actions/FlutterSubmitFeedback.java
@@ -14,7 +14,7 @@ import org.jetbrains.annotations.NotNull;
 public class FlutterSubmitFeedback extends DumbAwareAction {
   @Override
   public void actionPerformed(@NotNull final AnActionEvent e) {
-    FlutterInitializer.sendActionEvent(this);
+    FlutterInitializer.sendAnalyticsAction(this);
 
     final String url = "https://github.com/flutter/flutter-intellij/issues/new";
     BrowserLauncher.getInstance().browse(url, null);

--- a/src/io/flutter/actions/OpenObservatoryAction.java
+++ b/src/io/flutter/actions/OpenObservatoryAction.java
@@ -53,7 +53,7 @@ public class OpenObservatoryAction extends DumbAwareAction {
 
   @Override
   public void actionPerformed(@NotNull final AnActionEvent e) {
-    FlutterInitializer.sendActionEvent(this);
+    FlutterInitializer.sendAnalyticsAction(this);
 
     openInAnyChromeFamilyBrowser(myUrl.compute());
   }

--- a/src/io/flutter/actions/ReloadFlutterApp.java
+++ b/src/io/flutter/actions/ReloadFlutterApp.java
@@ -36,7 +36,7 @@ public class ReloadFlutterApp extends FlutterAppAction implements FlutterRetarge
 
   @Override
   public void actionPerformed(FlutterApp app) {
-    FlutterInitializer.sendActionEvent(this);
+    FlutterInitializer.sendAnalyticsAction(this);
 
     ifReadyThen(() -> {
       FileDocumentManager.getInstance().saveAllDocuments();

--- a/src/io/flutter/actions/RestartFlutterApp.java
+++ b/src/io/flutter/actions/RestartFlutterApp.java
@@ -34,7 +34,7 @@ public class RestartFlutterApp extends FlutterAppAction implements FlutterRetarg
 
   @Override
   public void actionPerformed(FlutterApp app) {
-    FlutterInitializer.sendActionEvent(this);
+    FlutterInitializer.sendAnalyticsAction(this);
 
     ifReadyThen(() -> {
       FileDocumentManager.getInstance().saveAllDocuments();

--- a/src/io/flutter/run/daemon/FlutterDaemonController.java
+++ b/src/io/flutter/run/daemon/FlutterDaemonController.java
@@ -19,6 +19,7 @@ import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.CharsetToolkit;
 import io.flutter.FlutterBundle;
+import io.flutter.FlutterInitializer;
 import io.flutter.sdk.FlutterSdk;
 import io.flutter.sdk.FlutterSdkUtil;
 import org.jetbrains.annotations.NotNull;
@@ -98,6 +99,16 @@ public class FlutterDaemonController extends ProcessAdapter {
     myProcessHandler = new OSProcessHandler(commandLine);
     myProcessHandler.addProcessListener(this);
     myProcessHandler.startNotify();
+
+    // Send analytics for the start and stop events.
+    FlutterInitializer.sendAnalyticsAction(StringUtil.capitalize(mode.mode()) + "App");
+    myProcessHandler.addProcessListener(new ProcessAdapter() {
+      @Override
+      public void processTerminated(ProcessEvent event) {
+        FlutterInitializer.sendAnalyticsAction("StopApp");
+      }
+    });
+
     return myControllerHelper.appStarting(deviceId, mode, project, startPaused, isHot);
   }
 
@@ -115,6 +126,16 @@ public class FlutterDaemonController extends ProcessAdapter {
     myProcessHandler = new OSProcessHandler(commandLine);
     myProcessHandler.addProcessListener(this);
     myProcessHandler.startNotify();
+
+    // Send analytics for the start and stop events.
+    FlutterInitializer.sendAnalyticsAction(StringUtil.capitalize(mode.mode()) + "BazelApp");
+    myProcessHandler.addProcessListener(new ProcessAdapter() {
+      @Override
+      public void processTerminated(ProcessEvent event) {
+        FlutterInitializer.sendAnalyticsAction("StopBazelApp");
+      }
+    });
+
     return myControllerHelper.appStarting(device == null ? null : device.deviceId(), mode, project, startPaused, isHot);
   }
 

--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -153,7 +153,7 @@ abstract class AbstractToggleableAction extends DumbAwareAction implements Toggl
     final Presentation presentation = event.getPresentation();
     presentation.putClientProperty("selected", isSelected(event));
 
-    FlutterInitializer.sendActionEvent(this);
+    FlutterInitializer.sendAnalyticsAction(this);
     perform(event);
   }
 
@@ -246,7 +246,7 @@ class ObservatoryTimelineAction extends AbstractObservatoryAction {
 
   @Override
   public void actionPerformed(AnActionEvent event) {
-    FlutterInitializer.sendActionEvent(this);
+    FlutterInitializer.sendAnalyticsAction(this);
 
     final String httpUrl = OpenObservatoryAction.convertWsToHttp(view.getFlutterApp().wsUrl());
     if (httpUrl != null) {


### PR DESCRIPTION
- add analytics events for run, debug, and process stop
- fix https://github.com/flutter/flutter-intellij/issues/697

These will look like `RunApp`, `DebugApp`, `StopApp` and `RunBazelApp`, `DebugBazelApp`, `StopBazelApp`.

@pq, @mit-mit 