### PR TITLE
Add support for loading a plugin config file from a Bazel Workspace

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -210,6 +210,13 @@
 
   </actions>
 
+  <project-components>
+    <component>
+      <interface-class>io.flutter.bazel.WorkspaceCache</interface-class>
+      <implementation-class>io.flutter.bazel.WorkspaceCache$Impl</implementation-class>
+    </component>
+  </project-components>
+
   <extensions defaultExtensionNs="com.intellij">
     <consoleInputFilterProvider implementation="io.flutter.run.daemon.DaemonJsonInputFilterProvider"/>?
     <postStartupActivity implementation="io.flutter.FlutterInitializer"/>

--- a/src/io/flutter/bazel/PluginConfig.java
+++ b/src/io/flutter/bazel/PluginConfig.java
@@ -47,15 +47,14 @@ public class PluginConfig {
   /**
    * Reads plugin configuration from a file, if possible.
    */
-  public static @Nullable
-  PluginConfig load(@NotNull VirtualFile file) {
+  public static @Nullable PluginConfig load(@NotNull VirtualFile file) {
     final Computable<PluginConfig> readAction = () -> {
       try {
         final InputStreamReader input = new InputStreamReader(file.getInputStream(), "UTF-8");
         final Fields fields = GSON.fromJson(input, Fields.class);
         return new PluginConfig(fields);
       } catch (IOException e) {
-        LOG.debug("failed to load flutter plugin config", e);
+        LOG.warn("failed to load flutter plugin config", e);
         return null;
       }
     };

--- a/src/io/flutter/bazel/PluginConfig.java
+++ b/src/io/flutter/bazel/PluginConfig.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright  2017 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.bazel;
+
+import com.google.common.base.Objects;
+import com.google.gson.Gson;
+import com.google.gson.annotations.SerializedName;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.util.Computable;
+import com.intellij.openapi.vfs.VirtualFile;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+/**
+ * An in-memory snapshot of the flutter.json file from a Bazel workspace.
+ */
+public class PluginConfig {
+  private final @NotNull Fields fields;
+
+  private PluginConfig(@NotNull Fields fields) {
+    this.fields = fields;
+  }
+
+  public @Nullable String getFlutterDaemonScript() {
+    return fields.flutterDaemonScript;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof PluginConfig)) return false;
+    final PluginConfig other = (PluginConfig)obj;
+    return Objects.equal(fields, other.fields);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(fields);
+  }
+
+  /**
+   * Reads plugin configuration from a file, if possible.
+   */
+  public static @Nullable
+  PluginConfig load(@NotNull VirtualFile file) {
+    final Computable<PluginConfig> readAction = () -> {
+      try {
+        final InputStreamReader input = new InputStreamReader(file.getInputStream(), "UTF-8");
+        final Fields fields = GSON.fromJson(input, Fields.class);
+        return new PluginConfig(fields);
+      } catch (IOException e) {
+        LOG.debug("failed to load flutter plugin config", e);
+        return null;
+      }
+    };
+    return ApplicationManager.getApplication().runReadAction(readAction);
+  }
+
+  /**
+   * The JSON fields in a PluginConfig, as loaded from disk.
+   */
+  private static class Fields {
+    @SerializedName("start_flutter_daemon")
+    @SuppressWarnings("unused")
+    private String flutterDaemonScript;
+
+    Fields() {}
+
+    @Override
+    public boolean equals(Object obj) {
+      if (!(obj instanceof Fields)) return false;
+      final Fields other = (Fields)obj;
+      return Objects.equal(flutterDaemonScript, other.flutterDaemonScript);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(flutterDaemonScript);
+    }
+  }
+
+  private static final Gson GSON = new Gson();
+  private static final Logger LOG = Logger.getInstance(PluginConfig.class);
+}

--- a/src/io/flutter/bazel/Workspace.java
+++ b/src/io/flutter/bazel/Workspace.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright  2017 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.bazel;
+
+import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableSet;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.ProjectRootManager;
+import com.intellij.openapi.util.Computable;
+import com.intellij.openapi.vfs.VirtualFile;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * The directory tree for a Bazel workspace.
+ *
+ * <p>Bazel workspaces are identified by looking for a WORKSPACE file.
+ *
+ * <p>Also includes the flutter.json config file, which is loaded at the same time.
+ */
+public class Workspace {
+  private static final String PLUGIN_CONFIG_PATH = "dart/config/intellij-plugins/flutter.json";
+
+  private @NotNull final VirtualFile root;
+  private @Nullable final PluginConfig config;
+
+  private Workspace(@NotNull VirtualFile root, @Nullable PluginConfig config) {
+    this.root = root;
+    this.config = config;
+  }
+
+  /**
+   * Returns the directory containing the WORKSPACE file.
+   */
+  public @NotNull VirtualFile getRoot() {
+    return root;
+  }
+
+  /**
+   * Returns the flutter plugin configuration or null if not available.
+   */
+  public @Nullable PluginConfig getPluginConfig() {
+    return config;
+  }
+
+  /**
+   * Returns relative paths to the files within the workspace that it depends on.
+   *
+   * <p>When they change, the Workspace should be reloaded.
+   */
+  public @NotNull Set<String> getDependencies() {
+    return ImmutableSet.of("WORKSPACE", PLUGIN_CONFIG_PATH);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof Workspace)) return false;
+    final Workspace other = (Workspace) obj;
+    return Objects.equal(root, other.root) && Objects.equal(config, other.config);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(root, config);
+  }
+
+  /**
+   * Loads the Bazel workspace from the filesystem.
+   *
+   * <p>Also loads flutter.plugin if present.
+   *
+   * <p>(Note that we might not load all the way from disk due to the VirtualFileSystem's caching.)
+   *
+   * @return the Workspace, or null if there is none.
+   */
+  public static @Nullable Workspace load(@NotNull Project project) {
+    final VirtualFile workspaceFile = findWorkspaceFile(project);
+    if (workspaceFile == null) return null;
+
+    final VirtualFile root = workspaceFile.getParent();
+    final VirtualFile configFile = root.findFileByRelativePath(PLUGIN_CONFIG_PATH);
+    final PluginConfig config = configFile == null ? null : PluginConfig.load(configFile);
+    return new Workspace(root, config);
+  }
+
+  /**
+   * Returns the Bazel WORKSPACE file for a Project, or null if not using Bazel.
+   *
+   * At least one content root must be within the workspace, and the project cannot have
+   * content roots in more than one workspace.
+   */
+  private static @Nullable VirtualFile findWorkspaceFile(@NotNull Project p) {
+    final Computable<VirtualFile> readAction = () -> {
+      final Map<String, VirtualFile> candidates = new HashMap<>();
+      for (VirtualFile contentRoot : ProjectRootManager.getInstance(p).getContentRoots()) {
+        final VirtualFile wf = findContainingWorkspaceFile(contentRoot);
+        if (wf != null) {
+          candidates.put(wf.getPath(), wf);
+        }
+      }
+
+      if (candidates.size() == 1) {
+        return candidates.values().iterator().next();
+      }
+
+      // not found
+      return null;
+    };
+    return ApplicationManager.getApplication().runReadAction(readAction);
+  }
+
+  /**
+   * Returns the closest WORKSPACE file within or above the given directory, or null if not found.
+   */
+  private static @Nullable VirtualFile findContainingWorkspaceFile(@NotNull VirtualFile dir) {
+    while (dir != null) {
+      final VirtualFile child = dir.findChild("WORKSPACE");
+      if (child != null && child.exists() && !child.isDirectory()) {
+        return child;
+      }
+      dir = dir.getParent();
+    }
+
+    // not found
+    return null;
+  }
+
+  private static final Logger LOG = Logger.getInstance(Workspace.class);
+}

--- a/src/io/flutter/bazel/WorkspaceCache.java
+++ b/src/io/flutter/bazel/WorkspaceCache.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright  2017 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.bazel;
+
+import com.google.common.base.Objects;
+import com.google.common.base.Stopwatch;
+import com.google.common.collect.ImmutableSet;
+import com.intellij.openapi.components.ProjectComponent;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.project.Project;
+import com.intellij.util.concurrency.AppExecutorUtil;
+import io.flutter.project.ProjectWatch;
+import io.flutter.utils.FileWatch;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.concurrent.Future;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Holds the current Bazel workspace for a Project.
+ *
+ * <p>Automatically reloads the workspace when out of date.
+ */
+public abstract class WorkspaceCache {
+
+  public static WorkspaceCache getInstance(Project project) {
+    return project.getComponent(WorkspaceCache.class);
+  }
+
+  /**
+   * Returns the Workspace in the cache.
+   *
+   * <p>Returning a null means there is no current workspace for this project.
+   *
+   * <p>If the cache hasn't loaded yet, blocks until it's ready.
+   * Otherwise doesn't block.
+   *
+   * <p>To find out about Workspace changes, use a WorkspaceWatch.
+   */
+  public abstract @Nullable Workspace getValue();
+
+  /**
+   * Blocks until the refresh task finishes.
+   * (For testing.)
+   */
+  public abstract void waitForIdle();
+
+  abstract void subscribe(WorkspaceWatch ww);
+
+  abstract void unsubscribe(WorkspaceWatch ww);
+
+  @SuppressWarnings("ComponentNotRegistered") // Inspection doesn't work for inner class.
+  private static class Impl extends WorkspaceCache implements ProjectComponent {
+    private static final long MIN_MILLIS_BETWEEN_REFRESHES = 50;
+
+    private final Project project;
+    private final AtomicReference<Workspace> cache = new AtomicReference<>();
+    private final FutureTask cacheReady = new FutureTask<>(() -> null);
+
+    private final AtomicBoolean needRefresh = new AtomicBoolean();
+    private final AtomicReference<FutureTask<Workspace>> refreshTask = new AtomicReference<>();
+    private final Stopwatch timeSinceRefreshStart = Stopwatch.createUnstarted();
+
+    private final AtomicBoolean closed = new AtomicBoolean();
+
+    private final AtomicReference<FileWatch> fileWatch = new AtomicReference<>();
+
+    /**
+     * Subscriber list. (Access should be synchronized.)
+     */
+    private final Set<WorkspaceWatch> subscribers = new LinkedHashSet<>();
+
+    private Impl(Project project) {
+      this.project = project;
+    }
+
+    @Override
+    public Workspace getValue() {
+      try {
+        cacheReady.get();
+      }
+      catch (Exception e) {
+        LOG.debug("Unexpected exception waiting for cache to be ready", e);
+        return null;
+      }
+      return cache.get();
+    }
+
+    public void waitForIdle() {
+      final Future task = refreshTask.get();
+      if (task == null) return;
+
+      try {
+        task.get();
+      } catch (Exception e) {
+        LOG.debug("Unexpected exception waiting for refresh task to be idle", e);
+      }
+    }
+
+    @Override
+    synchronized void subscribe(WorkspaceWatch ww) {
+      subscribers.add(ww);
+    }
+
+    @Override
+    synchronized void unsubscribe(WorkspaceWatch ww) {
+      subscribers.remove(ww);
+    }
+
+    @Override
+    public void initComponent() {
+
+    }
+
+    @Override
+    public void projectOpened() {
+      refreshAsync(); // Load initial value.
+      ProjectWatch.subscribe(project, this::refreshAsync); // Detect module root changes.
+    }
+
+    @Override
+    public void projectClosed() {
+      closed.set(true);
+      refreshAsync(); // Deliver end-of-stream and unsubscribe all.
+    }
+
+    @Override
+    public void disposeComponent() {
+
+    }
+
+    @NotNull
+    @Override
+    public String getComponentName() {
+      return "WorkspaceCache";
+    }
+
+    /**
+     * Triggers a cache refresh.
+     *
+     * If a refresh is already in progress, schedules another one.
+     */
+    private void refreshAsync() {
+      needRefresh.set(true);
+
+      // Start up the background task if idle.
+      final FutureTask<Workspace> newTask = new FutureTask<>(this::runRefresh, null);
+      if (refreshTask.compareAndSet(null, newTask)) {
+        AppExecutorUtil.getAppExecutorService().submit(newTask);
+      }
+    }
+
+    private void runRefresh() {
+      try {
+        // Keep going until nobody asked for a refresh.
+        while (needRefresh.get()) {
+
+          // Throttle refreshes in case refreshAsync gets called multiple times quickly.
+          if (timeSinceRefreshStart.isRunning()) {
+            final long remaining = MIN_MILLIS_BETWEEN_REFRESHES - timeSinceRefreshStart.elapsed(TimeUnit.MILLISECONDS);
+            if (remaining > 0) {
+              try {
+                Thread.sleep(remaining);
+              }
+              catch (InterruptedException e) {
+                return;
+              }
+            }
+          }
+
+          needRefresh.set(false);
+          timeSinceRefreshStart.reset().start();
+          // Any refreshAsync() calls after this point will schedule another refresh.
+
+          Workspace next = null;
+          if (!closed.get()) {
+            next = Workspace.load(this.project);
+          }
+          final boolean endOfStream = closed.get(); // Read again in case it changed during refresh.
+          updateAndDeliver(endOfStream ? null : next, endOfStream);
+        }
+      } finally {
+        refreshTask.set(null); // Allow restart on exit.
+      }
+    }
+
+    private void updateAndDeliver(Workspace next, boolean endOfStream) {
+      final Workspace prev = cache.getAndSet(next);
+      cacheReady.run();
+      if (Objects.equal(prev, next) && !endOfStream) return; // Debounce.
+
+      // Update watched files.
+      final FileWatch nextWatch = next == null ? null : FileWatch.subscribe(next.getRoot(), next.getDependencies(), this::refreshAsync);
+      final FileWatch prevWatch = fileWatch.getAndSet(nextWatch);
+      if (prevWatch != null) prevWatch.close();
+
+      // We are on a background thread. Deliver events on the Swing thread.
+      for (final WorkspaceWatch ww : getSubscribers()) {
+        SwingUtilities.invokeLater(() -> ww.fireEvent(next, endOfStream));
+      }
+    }
+
+    private synchronized Set<WorkspaceWatch> getSubscribers() {
+      return ImmutableSet.copyOf(subscribers);
+    }
+  }
+
+  private static final Logger LOG = Logger.getInstance(WorkspaceCache.class);
+}

--- a/src/io/flutter/bazel/WorkspaceCache.java
+++ b/src/io/flutter/bazel/WorkspaceCache.java
@@ -90,7 +90,7 @@ public abstract class WorkspaceCache {
         cacheReady.get();
       }
       catch (Exception e) {
-        LOG.debug("Unexpected exception waiting for cache to be ready", e);
+        LOG.warn("Unexpected exception waiting for cache to be ready", e);
         return null;
       }
       return cache.get();
@@ -103,7 +103,7 @@ public abstract class WorkspaceCache {
       try {
         task.get();
       } catch (Exception e) {
-        LOG.debug("Unexpected exception waiting for refresh task to be idle", e);
+        LOG.warn("Unexpected exception waiting for refresh task to be idle", e);
       }
     }
 

--- a/src/io/flutter/bazel/WorkspaceWatch.java
+++ b/src/io/flutter/bazel/WorkspaceWatch.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright  2017 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.bazel;
+
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.project.Project;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.Closeable;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+/**
+ * Watches a project for Bazel workspace changes.
+ *
+ * <p>Each WorkspaceWatch instance represents one subscription.
+ */
+public class WorkspaceWatch implements Closeable {
+  private final @NotNull Project project;
+  private final @NotNull Consumer<Workspace> callback;
+  /**
+   * The cache that delivers events to us. Non-null while subscribed.
+   */
+  private final AtomicReference<WorkspaceCache> cache = new AtomicReference<>();
+
+  private WorkspaceWatch(@NotNull Project project, @NotNull Consumer<Workspace> callback, WorkspaceCache cache) {
+    this.project = project;
+    this.callback = callback;
+    this.cache.set(cache);
+  }
+
+  /**
+   * Subscribes to updates to a workspace in the given project.
+   **
+   * <p>The Consumer will be called each time the workspace changes (added, moved
+   * or deleted). If there is no current workspace, the argument will be null.
+   *
+   * <p>To unsubscribe, call close(). The watch will automatically be unsubscribed when the
+   * Project is closed or the callback throws an exception.
+   *
+   * <p>Events will be delivered asynchronously on the Swing event thread.</p>
+   */
+  public static @NotNull WorkspaceWatch subscribe(Project project, Consumer<Workspace> callback) {
+    final WorkspaceCache cache = project.getComponent(WorkspaceCache.class);
+    final WorkspaceWatch ww = new WorkspaceWatch(project, callback, cache);
+    cache.subscribe(ww);
+    return ww;
+  }
+
+  /**
+   * Returns the currently cached value of the Bazel Workspace.
+   *
+   * <p>A null means that there is no current workspace (or we have unsubscribed).
+   */
+  public @Nullable Workspace get() {
+    final WorkspaceCache cache = this.cache.get();
+    return cache == null ? null : cache.getValue();
+  }
+
+  /**
+   * Unsubscribe from events.
+   */
+  @Override
+  public void close() {
+    final WorkspaceCache cache = this.cache.getAndSet(null);
+    if (cache != null) cache.unsubscribe(this);
+  }
+
+  void fireEvent(Workspace w, boolean endOfStream) {
+    try {
+      callback.accept(w);
+    } catch (Exception e) {
+      LOG.warn("WorkspaceWatch callback threw exception", e);
+      endOfStream = true; // Unsubscribe to avoid more exceptions.
+    }
+    if (endOfStream) close();
+  }
+
+  private static final Logger LOG = Logger.getInstance(WorkspaceWatch.class);
+}

--- a/src/io/flutter/project/ProjectWatch.java
+++ b/src/io/flutter/project/ProjectWatch.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright  2017 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.project;
+
+import com.intellij.ProjectTopics;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectManager;
+import com.intellij.openapi.project.ProjectManagerListener;
+import com.intellij.openapi.roots.ModuleRootEvent;
+import com.intellij.openapi.roots.ModuleRootListener;
+import com.intellij.util.messages.MessageBusConnection;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.Closeable;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Watches a project for module root changes.
+ *
+ * <p>Each ProjectWatch instance represents one subscription.
+ */
+public class ProjectWatch implements Closeable {
+  private final @NotNull Runnable callback;
+
+  // Value is null when unsubscribed.
+  private final AtomicReference<Runnable> unsubscribe = new AtomicReference<>();
+
+  private ProjectWatch(@NotNull Project project, @NotNull Runnable callback) {
+    this.callback = callback;
+
+    final ProjectManagerListener listener = new ProjectManagerListener() {
+      @Override
+      public void projectClosed(Project project) {
+        fireEvent();
+      }
+    };
+
+    final ProjectManager manager = ProjectManager.getInstance();
+    manager.addProjectManagerListener(project, listener);
+
+    final MessageBusConnection bus = project.getMessageBus().connect();
+    bus.subscribe(ProjectTopics.PROJECT_ROOTS, new ModuleRootListener() {
+      @Override
+      public void rootsChanged(ModuleRootEvent event) {
+        fireEvent();
+      }
+    });
+
+    unsubscribe.set(() -> {
+      bus.disconnect();
+      manager.removeProjectManagerListener(project, listener);
+    });
+  }
+
+  /**
+   * Subscribes to project changes. This includes module root changes and closing the project.
+   */
+  public static @NotNull ProjectWatch subscribe(@NotNull Project project, @NotNull Runnable callback) {
+    return new ProjectWatch(project, callback);
+  }
+
+  /**
+   * Unsubscribes this ProjectWatch from events.
+   */
+  @Override
+  public void close() {
+    final Runnable unsubscribe = this.unsubscribe.getAndSet(null);
+    if (unsubscribe != null) {
+      unsubscribe.run();
+    }
+  }
+
+  private void fireEvent() {
+    if (unsubscribe.get() == null) return;
+
+    try {
+      callback.run();
+    } catch (Exception e) {
+      LOG.error("Uncaught exception in ProjectWatch callback", e);
+      close(); // avoid further errors
+    }
+  }
+
+  private static final Logger LOG = Logger.getInstance(ProjectWatch.class);
+}

--- a/src/io/flutter/project/ProjectWatch.java
+++ b/src/io/flutter/project/ProjectWatch.java
@@ -9,6 +9,7 @@ import com.intellij.ProjectTopics;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
+import com.intellij.openapi.project.ProjectManagerAdapter;
 import com.intellij.openapi.project.ProjectManagerListener;
 import com.intellij.openapi.roots.ModuleRootEvent;
 import com.intellij.openapi.roots.ModuleRootListener;
@@ -32,7 +33,7 @@ public class ProjectWatch implements Closeable {
   private ProjectWatch(@NotNull Project project, @NotNull Runnable callback) {
     this.callback = callback;
 
-    final ProjectManagerListener listener = new ProjectManagerListener() {
+    final ProjectManagerListener listener = new ProjectManagerAdapter() {
       @Override
       public void projectClosed(Project project) {
         fireEvent();

--- a/src/io/flutter/utils/FileWatch.java
+++ b/src/io/flutter/utils/FileWatch.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright  2017 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.utils;
+
+import com.google.common.base.Splitter;
+import com.google.common.collect.*;
+import com.intellij.openapi.application.Application;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.openapi.vfs.VirtualFileManager;
+import com.intellij.openapi.vfs.newvfs.BulkFileListener;
+import com.intellij.openapi.vfs.newvfs.events.VFileCreateEvent;
+import com.intellij.openapi.vfs.newvfs.events.VFileEvent;
+import com.intellij.util.messages.MessageBusConnection;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.Closeable;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Watches a set of VirtualFiles for changes.
+ *
+ * <p>Each FileWatch instance represents one subscription.
+ *
+ * <p>The callback will be called when the IntelliJ Platform notices the change,
+ * which may be different from when it's changed on disk, due to caching.
+ */
+public class FileWatch implements Closeable {
+  private final @NotNull ImmutableSet<Location> watched;
+  private final @NotNull Runnable callback;
+
+  /**
+   * When true, no more events should be delivered.
+   */
+  private final AtomicBoolean closed = new AtomicBoolean();
+
+  private FileWatch(@NotNull ImmutableSet<Location> watched, @NotNull Runnable callback) {
+    this.watched = watched;
+    this.callback = callback;
+  }
+
+  /**
+   * Starts watching a single file or directory.
+   */
+  public static @NotNull FileWatch subscribe(@NotNull VirtualFile file, @NotNull Runnable callback) {
+    final FileWatch watcher =  new FileWatch(ImmutableSet.of(new Location(file, null)), callback);
+    subscriptions.subscribe(watcher);
+    return watcher;
+  }
+
+  /**
+   * Starts watching some paths beneath a VirtualFile.
+   *
+   * <p>Each path is relative to the VirtualFile and need not exist.
+   *
+   * @param callback will be run asynchronously sometime after the file changed.
+   */
+  public static @NotNull FileWatch subscribe(@NotNull VirtualFile base, @NotNull Iterable<String> paths, @NotNull Runnable callback) {
+    final ImmutableSet.Builder<Location> builder = ImmutableSet.builder();
+    for (String path : paths) {
+      builder.add(new Location(base, path));
+    }
+    final FileWatch watcher =  new FileWatch(builder.build(), callback);
+    subscriptions.subscribe(watcher);
+    return watcher;
+  }
+
+  /**
+   * Returns true if the given file matches this watch.
+   */
+  public boolean matches(VirtualFile file) {
+    for (Location loc : watched) {
+      if (loc.matches(file)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Unsubscribes this FileWatch from events.
+   */
+  @Override
+  public void close() {
+    if (!closed.compareAndSet(false, true)) {
+      return; // already closed
+    }
+    subscriptions.unsubscribe(this);
+  }
+
+  private void fireEvent() {
+    if (closed.get()) return;
+
+    try {
+      callback.run();
+    } catch (Exception e) {
+      LOG.error("Uncaught exception in FileWatch callback", e);
+      close(); // avoid further errors
+    }
+  }
+
+  /**
+   * The location of a file or directory being watched.
+   *
+   * Since it might not exist yet, this consists of a base VirtualFile and a path to where it might appear.
+   */
+  private static class Location {
+    private final @NotNull VirtualFile base;
+    private final @Nullable String path;
+
+    /**
+     * The segments in the watched path, in reverse order (from leaf to base).
+     */
+    private final @NotNull List<String> reversedNames;
+
+    Location(@NotNull VirtualFile base, @Nullable String path) {
+      if (path != null && path.isEmpty()) {
+        throw new IllegalArgumentException("can't watch an empty path");
+      }
+      this.base = base;
+      this.path = path;
+      this.reversedNames = path == null ? ImmutableList.of() : ImmutableList.copyOf(splitter.splitToList(path)).reverse();
+    }
+
+    /**
+     * Returns the name at the end of the path being watched.
+     */
+    String getName() {
+      if (reversedNames.isEmpty()) {
+        return base.getName();
+      } else {
+        return reversedNames.get(0);
+      }
+    }
+
+    /**
+     * Returns true if the given VirtualFile is at this location.
+     */
+    boolean matches(VirtualFile file) {
+      for (String name : reversedNames) {
+        if (file == null || !file.getName().equals(name)) {
+          return false;
+        }
+        file = file.getParent();
+      }
+      return base.equals(file);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      return super.equals(obj);
+    }
+
+    private static final Splitter splitter = Splitter.on('/');
+  }
+
+  private static final Subscriptions subscriptions = new Subscriptions();
+
+  private static class Subscriptions {
+
+    /**
+     * For each VirtualFile name, the FileWatches that are subscribed (across all Projects).
+     *
+     * <p>For thread safety, all access should be synchronized.
+     */
+    private final Multimap<String, FileWatch> byFile = LinkedListMultimap.create();
+
+    private final Delivery delivery = new Delivery();
+
+    synchronized void subscribe(FileWatch w) {
+      for (Location loc : w.watched) {
+        byFile.put(loc.getName(), w);
+      }
+      delivery.enable(!byFile.isEmpty());
+    }
+
+    synchronized void unsubscribe(FileWatch w) {
+      for (Location loc : w.watched) {
+        byFile.remove(loc.getName(), w);
+      }
+      delivery.enable(!byFile.isEmpty());
+    }
+
+    synchronized void addWatchesForFile(Set<FileWatch> out, VirtualFile f) {
+      for (FileWatch w : byFile.get(f.getName())) {
+        if (w.matches(f)) {
+          out.add(w);
+        }
+      }
+    }
+  }
+
+  private static class Delivery implements BulkFileListener {
+
+    /**
+     * The shared connection to IDEA's event system.
+     *
+     * <p>This will be non-null when there are one or more subscriptions.
+     *
+     * <p>For thread safety, all access should be synchronized.
+     */
+    private @Nullable MessageBusConnection bus;
+
+    void enable(boolean enabled) {
+      if (enabled) {
+        if (bus == null) {
+          final Application app = ApplicationManager.getApplication();
+          bus = app.getMessageBus().connect();
+          bus.subscribe(VirtualFileManager.VFS_CHANGES, this);
+        }
+      } else {
+        if (bus != null) {
+          bus.disconnect();
+          bus = null;
+        }
+      }
+    }
+
+    @Override
+    public void before(@NotNull List<? extends VFileEvent> events) {}
+
+    @Override
+    public void after(@NotNull List<? extends VFileEvent> events) {
+      final Set<FileWatch> todo = new LinkedHashSet<>();
+      synchronized (subscriptions) {
+        for (VFileEvent event : events) {
+          subscriptions.addWatchesForFile(todo, event.getFile());
+        }
+      }
+
+      // Deliver changes synchronously, but after releasing the lock in case
+      // the callback subscribes/unsubscribes.
+      for (FileWatch w : todo) {
+        w.fireEvent();
+      }
+    }
+  }
+
+  private static final Logger LOG = Logger.getInstance(FileWatch.class);
+}

--- a/testSrc/unit/io/flutter/bazel/WorkspaceCacheTest.java
+++ b/testSrc/unit/io/flutter/bazel/WorkspaceCacheTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright  2017 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.bazel;
+
+import com.intellij.openapi.roots.ModifiableRootModel;
+import com.intellij.openapi.roots.ModuleRootModel;
+import com.intellij.openapi.roots.ModuleRootModificationUtil;
+import com.intellij.openapi.vfs.VirtualFile;
+import io.flutter.testing.ProjectFixture;
+import io.flutter.testing.TestDir;
+import io.flutter.testing.Testing;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static junit.framework.TestCase.assertNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class WorkspaceCacheTest {
+
+  @Rule
+  public final ProjectFixture fixture = Testing.makeEmptyModule();
+
+  @Rule
+  public final TestDir tmp = new TestDir();
+
+  private WorkspaceCache cache;
+
+  @Before
+  public void setUp() throws Exception {
+    cache = fixture.getProject().getComponent(WorkspaceCache.class);
+
+    tmp.ensureDir("abc");
+    tmp.writeFile("abc/WORKSPACE", "");
+    tmp.ensureDir("abc/dart/config/intellij-plugins");
+    final VirtualFile contentRoot = tmp.ensureDir("abc/dart/something");
+
+    Testing.runOnDispatchThread(
+      () -> ModuleRootModificationUtil.addContentRoot(fixture.getModule(), contentRoot.getPath()));
+  }
+
+  @Test
+  public void shouldDetectConfigFileChanges() throws Exception {
+    // This test causes stack traces to be logged at shutdown in local history: "Recursive records found".
+    // (Unknown cause.)
+    cache.waitForIdle();
+    checkNoConfig();
+
+    final String configPath = "abc/dart/config/intellij-plugins/flutter.json";
+
+    tmp.writeFile(configPath, "{\"start_flutter_daemon\": \"first\"}");
+    cache.waitForIdle();
+    checkConfigSetting("first");
+
+    tmp.writeFile(configPath, "{}");
+    cache.waitForIdle();
+    checkConfigSetting(null);
+
+    tmp.writeFile(configPath, "{\"start_flutter_daemon\": \"second\"}");
+    cache.waitForIdle();
+    checkConfigSetting("second");
+
+    tmp.deleteFile(configPath);
+    cache.waitForIdle();
+    checkNoConfig();
+  }
+  
+  @Test
+  public void shouldDetectModuleRootChange() throws Exception {
+    cache.waitForIdle();
+    checkWorkspaceExists();
+
+    removeContentRoot();
+    cache.waitForIdle();
+    checkNoWorkspaceExists();
+  }
+
+  private void removeContentRoot() throws Exception {
+    Testing.runOnDispatchThread(
+      () -> ModuleRootModificationUtil.updateModel(
+        fixture.getModule(),
+        (ModifiableRootModel model) -> model.removeContentEntry(model.getContentEntries()[0])));
+  }
+
+  private void checkNoWorkspaceExists() {
+    assertNull("expected no workspace to exist", cache.getValue());
+  }
+
+
+  private void checkWorkspaceExists() {
+    assertNotNull("expected a workspace but it doesn't exist", cache.getValue());
+  }
+
+  private void checkNoConfig() {
+    final Workspace w = cache.getValue();
+    assertNotNull("expected a workspace but it doesn't exist", w);
+    assertNull("workspace has unexpected plugin config", w.getPluginConfig());
+  }
+
+  private void checkConfigSetting(String expected) {
+    final Workspace w = cache.getValue();
+    assertNotNull("expected a workspace but it doesn't exist", w);
+
+    final PluginConfig c = w.getPluginConfig();
+    assertNotNull("config file is missing", c);
+    assertEquals(expected, c.getFlutterDaemonScript());
+  }
+}

--- a/testSrc/unit/io/flutter/bazel/WorkspaceTest.java
+++ b/testSrc/unit/io/flutter/bazel/WorkspaceTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright  2017 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.bazel;
+
+import com.intellij.openapi.roots.ModuleRootModificationUtil;
+import com.intellij.openapi.vfs.VirtualFile;
+import io.flutter.testing.ProjectFixture;
+import io.flutter.testing.TestDir;
+import io.flutter.testing.Testing;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class WorkspaceTest {
+
+  @Rule
+  public final ProjectFixture fixture = Testing.makeEmptyModule();
+
+  @Rule
+  public final TestDir tmp = new TestDir();
+
+  @Test
+  public void canLoadWorkspaceWithoutConfigFile() throws Exception {
+    Testing.runOnDispatchThread(() -> {
+      final VirtualFile expectedRoot = tmp.ensureDir("abc");
+      tmp.writeFile("abc/WORKSPACE", "");
+
+      tmp.ensureDir("abc/dart");
+      final VirtualFile contentRoot = tmp.ensureDir("abc/dart/something");
+      ModuleRootModificationUtil.addContentRoot(fixture.getModule(), contentRoot.getPath());
+
+      final Workspace w = Workspace.load(fixture.getProject());
+
+      assertNotNull("expected a workspace", w);
+      assertEquals(expectedRoot, w.getRoot());
+      assertNull("config shouldn't be there", w.getPluginConfig());
+    });
+  }
+
+  @Test
+  public void canLoadWorkspaceWithConfigFile() throws Exception {
+    Testing.runOnDispatchThread(() -> {
+      final VirtualFile expectedRoot = tmp.ensureDir("abc");
+      tmp.writeFile("abc/WORKSPACE", "");
+
+      tmp.ensureDir("abc/dart");
+      final VirtualFile contentRoot = tmp.ensureDir("abc/dart/something");
+      ModuleRootModificationUtil.addContentRoot(fixture.getModule(), contentRoot.getPath());
+
+      tmp.ensureDir("abc/dart/config/intellij-plugins");
+      tmp.writeFile("abc/dart/config/intellij-plugins/flutter.json", "{\"start_flutter_daemon\": \"something\"}");
+
+      final Workspace w = Workspace.load(fixture.getProject());
+
+      assertNotNull("expected a workspace", w);
+      assertEquals(expectedRoot, w.getRoot());
+      final PluginConfig c = w.getPluginConfig();
+      assertNotNull("expected a plugin config", c);
+      assertEquals("something", c.getFlutterDaemonScript());
+    });
+  }
+}

--- a/testSrc/unit/io/flutter/project/ProjectWatchTest.java
+++ b/testSrc/unit/io/flutter/project/ProjectWatchTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright  2017 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.project;
+
+import com.intellij.openapi.project.ProjectManager;
+import com.intellij.openapi.roots.ModuleRootModificationUtil;
+import io.flutter.testing.ProjectFixture;
+import io.flutter.testing.Testing;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+
+public class ProjectWatchTest {
+
+  @Rule
+  public final ProjectFixture fixture = Testing.makeEmptyModule();
+
+  @Test
+  public void shouldSendEventWhenProjectCloses() throws Exception {
+    Testing.runOnDispatchThread(() -> {
+      final AtomicInteger callCount = new AtomicInteger();
+      final ProjectWatch listen = ProjectWatch.subscribe(fixture.getProject(), callCount::incrementAndGet);
+
+      ProjectManager.getInstance().closeProject(fixture.getProject());
+      assertEquals(1, callCount.get());
+    });
+  }
+
+  @Test
+  public void shouldSendEventWhenModuleRootsChange() throws Exception {
+    Testing.runOnDispatchThread(() -> {
+      final AtomicInteger callCount = new AtomicInteger();
+      final ProjectWatch listen = ProjectWatch.subscribe(fixture.getProject(), callCount::incrementAndGet);
+
+      ModuleRootModificationUtil.addContentRoot(fixture.getModule(), "testDir");
+      assertEquals(1, callCount.get());
+    });
+  }
+
+}

--- a/testSrc/unit/io/flutter/testing/AdaptedFixture.java
+++ b/testSrc/unit/io/flutter/testing/AdaptedFixture.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright  2017 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.testing;
+
+import com.intellij.testFramework.fixtures.IdeaTestFixture;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+/**
+ * Wraps an IDEA fixture so it works as a Junit 4 Rule.
+ *
+ * <p>(That is, it can be used with the @Rule annotation.)
+ */
+public class AdaptedFixture<T extends IdeaTestFixture> implements TestRule {
+  public final Factory<T> factory;
+  private T inner;
+
+  AdaptedFixture(Factory<T> factory) {
+    this.factory = factory;
+  }
+
+  public T getInner() {
+    return inner;
+  }
+
+  @Override
+  public Statement apply(Statement base, Description description) {
+    return new Statement() {
+      public void evaluate() throws Throwable {
+        inner = factory.create(description.getClassName());
+        Testing.runOnDispatchThread(inner::setUp);
+        try {
+          base.evaluate();
+        } finally {
+          Testing.runOnDispatchThread(inner::tearDown);
+          inner = null;
+        }
+      }
+    };
+  }
+
+  public interface Factory<T extends IdeaTestFixture> {
+    T create(String testClassName);
+  }
+}

--- a/testSrc/unit/io/flutter/testing/ProjectFixture.java
+++ b/testSrc/unit/io/flutter/testing/ProjectFixture.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright  2017 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.testing;
+
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.project.Project;
+import com.intellij.testFramework.fixtures.IdeaProjectTestFixture;
+
+public class ProjectFixture extends AdaptedFixture<IdeaProjectTestFixture> {
+  ProjectFixture(Factory<IdeaProjectTestFixture> factory) {
+    super(factory);
+  }
+
+  public Project getProject() {
+    return getInner().getProject();
+  }
+
+  public Module getModule() {
+    return getInner().getModule();
+  }
+}

--- a/testSrc/unit/io/flutter/testing/TestDir.java
+++ b/testSrc/unit/io/flutter/testing/TestDir.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright  2017 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.testing;
+
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.testFramework.fixtures.impl.TempDirTestFixtureImpl;
+import org.junit.rules.ExternalResource;
+
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Represents a temporary directory to be used in a JUnit 4 test.
+ *
+ * <p>To set up, use JUnit 4's @Rule or @ClassRule attribute.
+ */
+public class TestDir extends ExternalResource {
+  private TempDirTestFixtureImpl fixture;
+
+  @Override
+  protected void before() throws Exception {
+    fixture = new TempDirTestFixtureImpl();
+    fixture.setUp();
+  }
+
+  @Override
+  protected void after() {
+    try {
+      if (ApplicationManager.getApplication() != null) {
+        fixture.tearDown();
+      }
+    }
+    catch (Exception e) {
+      e.printStackTrace();
+    }
+  }
+
+  /**
+   * Creates a subdirectory of the temp directory if it doesn't already exist.
+   *
+   * @param path relative to the temp directory.
+   * @return The corresponding VirtualFile.
+   */
+  public VirtualFile ensureDir(String path) throws Exception {
+    return fixture.findOrCreateDir(path);
+  }
+
+  /**
+   * Sets the contents of a file in the temp directory.
+   *
+   * <p>Creates it if it doesn't exist.
+   *
+   * @return The curresponding VirtualFile.
+   */
+  public VirtualFile writeFile(String path, String text) throws Exception {
+    return Testing.computeInWriteAction(() -> fixture.createFile(path, text));
+  }
+
+  /**
+   * Deletes a file in the temp directory.
+   *
+   * @param path relative to the temp directory.
+   */
+  public void deleteFile(String path) throws Exception {
+    Testing.runInWriteAction(() -> {
+      final VirtualFile target = fixture.getFile(path);
+      assertNotNull("attempted to delete nonexistentent file: " + path, target);
+      target.delete(this);
+    });
+  }
+}

--- a/testSrc/unit/io/flutter/testing/Testing.java
+++ b/testSrc/unit/io/flutter/testing/Testing.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright  2017 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.testing;
+
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.util.ThrowableComputable;
+import com.intellij.testFramework.builders.EmptyModuleFixtureBuilder;
+import com.intellij.testFramework.fixtures.IdeaProjectTestFixture;
+import com.intellij.testFramework.fixtures.IdeaTestFixture;
+import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory;
+import com.intellij.testFramework.fixtures.TestFixtureBuilder;
+
+import javax.swing.*;
+import java.lang.reflect.InvocationTargetException;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Test utilities.
+ */
+public class Testing {
+
+  private Testing() {}
+
+  /**
+   * Returns a "light" test fixture containing an empty project.
+   *
+   * <p>(No modules are allowed.)
+   */
+  public static ProjectFixture makeEmptyProject() {
+    return new ProjectFixture(
+      (x) -> IdeaTestFixtureFactory.getFixtureFactory().createLightFixtureBuilder().getFixture());
+  }
+
+  /**
+   * Creates a "heavy" test fixture containing a Project with an empty Module.
+   */
+  public static ProjectFixture makeEmptyModule() {
+    return new ProjectFixture((String testClassName) -> {
+      final TestFixtureBuilder<IdeaProjectTestFixture> builder =
+        IdeaTestFixtureFactory.getFixtureFactory().createFixtureBuilder(testClassName);
+      builder.addModule(EmptyModuleFixtureBuilder.class);
+      return builder.getFixture();
+    });
+  }
+
+  public static <T> T computeInWriteAction(ThrowableComputable<T, Exception> callback) throws Exception {
+    return computeOnDispatchThread(() -> ApplicationManager.getApplication().<T, Exception>runWriteAction(callback));
+  }
+
+  public static void runInWriteAction(RunnableThatThrows callback) throws Exception {
+    final ThrowableComputable<Object, Exception> action = () -> {
+      callback.run();
+      return null;
+    };
+    runOnDispatchThread(() -> ApplicationManager.getApplication().<Object, Exception>runWriteAction(action));
+  }
+
+  public static <T> T computeOnDispatchThread(ThrowableComputable<T,Exception> callback) throws Exception {
+    final AtomicReference<T> result = new AtomicReference<>();
+    runOnDispatchThread(() -> result.set(callback.compute()));
+    return result.get();
+  }
+
+  public static void runOnDispatchThread(RunnableThatThrows callback) throws Exception {
+    try {
+      final AtomicReference<Exception> ex = new AtomicReference<>();
+      SwingUtilities.invokeAndWait(() -> {
+        try {
+          callback.run();
+        }
+        catch (Exception e) {
+          ex.set(e);
+        }
+      });
+      if (ex.get() != null) {
+        throw ex.get();
+      }
+    } catch (InvocationTargetException e) {
+      if (e.getCause() instanceof AssertionError) {
+        throw (AssertionError) e.getCause();
+      }
+    }
+  }
+
+  public interface RunnableThatThrows {
+    void run() throws Exception;
+  }
+}

--- a/testSrc/unit/io/flutter/utils/FileWatchTest.java
+++ b/testSrc/unit/io/flutter/utils/FileWatchTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright  2017 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.utils;
+
+import com.google.common.collect.ImmutableSet;
+import com.intellij.mock.MockVirtualFile;
+import com.intellij.openapi.vfs.VirtualFile;
+import io.flutter.testing.ProjectFixture;
+import io.flutter.testing.TestDir;
+import io.flutter.testing.Testing;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Verifies that we can watch files and directories.
+ */
+public class FileWatchTest {
+  @Rule
+  public final ProjectFixture fixture = Testing.makeEmptyProject();
+
+  @Rule
+  public final TestDir tmp = new TestDir();
+
+  @Test
+  public void shouldFireEvents() throws Exception {
+    final VirtualFile dir = tmp.ensureDir("abc");
+
+    final AtomicInteger eventCount = new AtomicInteger();
+    final FileWatch fileWatch = FileWatch.subscribe(dir, ImmutableSet.of("child"), eventCount::incrementAndGet);
+    assertEquals(0, eventCount.get());
+
+    // create
+    tmp.writeFile("abc/child", "");
+    assertEquals(1, eventCount.get());
+
+    // modify
+    tmp.writeFile("abc/child", "hello");
+    assertEquals(2, eventCount.get());
+
+    // delete
+    tmp.deleteFile("abc/child");
+    assertEquals(3, eventCount.get());
+  }
+}


### PR DESCRIPTION
Finds the workspace based on the content roots. The ancestor directories of
each content root are searched for a WORKSPACE file. There should be a unique
workspace for each project.

Also, automatically detect changes to the configuration. This can be due
to a changed WORKSPACE file, config file, or a changed module configuration.

Also, implemented some test infrastructure to test it all, based on JUnit 4.

Not hooked up to anything yet.