### PR TITLE
add tooltips to the pubspec editor inspector

### DIFF
--- a/src/io/flutter/editor/FlutterPubspecNotificationProvider.java
+++ b/src/io/flutter/editor/FlutterPubspecNotificationProvider.java
@@ -17,6 +17,7 @@ import com.intellij.openapi.util.Key;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.ui.EditorNotificationPanel;
 import com.intellij.ui.EditorNotifications;
+import com.intellij.ui.HyperlinkLabel;
 import icons.FlutterIcons;
 import io.flutter.FlutterConstants;
 import io.flutter.sdk.FlutterSdk;
@@ -75,12 +76,19 @@ public class FlutterPubspecNotificationProvider extends EditorNotifications.Prov
       icon(FlutterIcons.Flutter);
       text("Flutter commands");
 
-      createActionLabel("Packages get", "flutter.packages.get");
-      createActionLabel("Packages upgrade", "flutter.packages.upgrade");
+      HyperlinkLabel label = createActionLabel("Packages get", "flutter.packages.get");
+      label.setToolTipText("Install referenced packages");
+
+      label = createActionLabel("Packages upgrade", "flutter.packages.upgrade");
+      label.setToolTipText("Upgrade referenced packages to the latest versions");
+
       myLinksPanel.add(new JSeparator(SwingConstants.VERTICAL));
-      createActionLabel("Flutter upgrade", "flutter.upgrade");
+      label = createActionLabel("Flutter upgrade", "flutter.upgrade");
+      label.setToolTipText("Upgrade the Flutter framework to the latest version");
+
       myLinksPanel.add(new JSeparator(SwingConstants.VERTICAL));
-      createActionLabel("Flutter doctor", "flutter.doctor");
+      label = createActionLabel("Flutter doctor", "flutter.doctor");
+      label.setToolTipText("Validate installed tools and their versions");
 
       // TODO: Add for 2017.1.
       //background(EditorColors.GUTTER_BACKGROUND);


### PR DESCRIPTION
- add tooltips to the pubspec editor inspector
- fix https://github.com/flutter/flutter-intellij/issues/733

<img width="477" alt="screen shot 2017-02-14 at 9 17 11 pm" src="https://cloud.githubusercontent.com/assets/1269969/22961506/6424669e-f2fb-11e6-939a-84ef5c8572d7.png">

@pq, @skybrian 