### PR TITLE
Various device menu fixes

### DIFF
--- a/src/io/flutter/bazel/PluginConfig.java
+++ b/src/io/flutter/bazel/PluginConfig.java
@@ -41,7 +41,7 @@ public class PluginConfig {
    *
    * <p>The path should be relative to the workspace root.
    */
-  public boolean withinFlutterDirectory(String path) {
+  public boolean withinFlutterDirectory(@NotNull String path) {
     if (directoryPatterns == null) {
       // Default if unconfigured.
       return path.contains("flutter");

--- a/src/io/flutter/bazel/PluginConfig.java
+++ b/src/io/flutter/bazel/PluginConfig.java
@@ -6,7 +6,9 @@
 package io.flutter.bazel;
 
 import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableList;
 import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
 import com.google.gson.annotations.SerializedName;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
@@ -15,21 +17,44 @@ import com.intellij.openapi.vfs.VirtualFile;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 /**
  * An in-memory snapshot of the flutter.json file from a Bazel workspace.
  */
 public class PluginConfig {
   private final @NotNull Fields fields;
+  private final @Nullable List<Pattern> directoryPatterns;
 
-  private PluginConfig(@NotNull Fields fields) {
+  private PluginConfig(@NotNull Fields fields, @Nullable List<Pattern> patterns) {
     this.fields = fields;
+    this.directoryPatterns = patterns;
   }
 
-  public @Nullable String getFlutterDaemonScript() {
-    return fields.flutterDaemonScript;
+  /**
+   * Returns true if the given path is within a flutter project in this workspace.
+   *
+   * <p>The path should be relative to the workspace root.
+   */
+  public boolean withinFlutterDirectory(String path) {
+    if (directoryPatterns == null) {
+      // Default if unconfigured.
+      return path.contains("flutter");
+    }
+
+    for (Pattern p : directoryPatterns) {
+      if (p.matcher(path).find()) return true;
+    }
+    return false;
+  }
+
+  public @Nullable String getDaemonScript() {
+    return fields.daemonScript;
   }
 
   @Override
@@ -52,22 +77,53 @@ public class PluginConfig {
       try {
         final InputStreamReader input = new InputStreamReader(file.getInputStream(), "UTF-8");
         final Fields fields = GSON.fromJson(input, Fields.class);
-        return new PluginConfig(fields);
+        return new PluginConfig(fields, compilePatterns(fields.directoryPatterns));
+      } catch (FileNotFoundException e) {
+        LOG.info("Flutter plugin didn't find flutter.json at " + file.getPath());
+        return null;
       } catch (IOException e) {
-        LOG.warn("failed to load flutter plugin config", e);
+        LOG.warn("Flutter plugin failed to load config file at " + file.getPath(), e);
+        return null;
+      } catch (JsonSyntaxException e) {
+        LOG.warn("Flutter plugin failed to parse JSON in config file at " + file.getPath());
+        return null;
+      } catch (PatternSyntaxException e) {
+        LOG.warn("Flutter plugin failed to parse directory pattern (" + e.getPattern() +  ") in config file at " + file.getPath());
         return null;
       }
     };
+
     return ApplicationManager.getApplication().runReadAction(readAction);
+  }
+
+  private static @Nullable List<Pattern> compilePatterns(@Nullable Iterable<String> patterns) {
+    if (patterns == null) return null;
+
+    final ImmutableList.Builder<Pattern> result = ImmutableList.builder();
+    for (String regexp : patterns) {
+      result.add(Pattern.compile(regexp));
+    }
+    return result.build();
   }
 
   /**
    * The JSON fields in a PluginConfig, as loaded from disk.
    */
   private static class Fields {
-    @SerializedName("start_flutter_daemon")
+    /**
+     * A list of regular expressions that match workspace-relative paths that contain flutter apps.
+     * (Used to decide whether to show the device menu.)
+     */
+    @SerializedName("directoryPatterns")
     @SuppressWarnings("unused")
-    private String flutterDaemonScript;
+    private List<String> directoryPatterns;
+
+    /**
+     * The script to run to start 'flutter daemon'.
+     */
+    @SerializedName("daemonScript")
+    @SuppressWarnings("unused")
+    private String daemonScript;
 
     Fields() {}
 
@@ -75,12 +131,13 @@ public class PluginConfig {
     public boolean equals(Object obj) {
       if (!(obj instanceof Fields)) return false;
       final Fields other = (Fields)obj;
-      return Objects.equal(flutterDaemonScript, other.flutterDaemonScript);
+      return Objects.equal(directoryPatterns, other.directoryPatterns)
+             && Objects.equal(daemonScript, other.daemonScript);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hashCode(flutterDaemonScript);
+      return Objects.hashCode(directoryPatterns, daemonScript);
     }
   }
 

--- a/src/io/flutter/bazel/Workspace.java
+++ b/src/io/flutter/bazel/Workspace.java
@@ -5,20 +5,21 @@
  */
 package io.flutter.bazel;
 
+import com.google.common.base.Joiner;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableSet;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.ModuleRootManager;
 import com.intellij.openapi.roots.ProjectRootManager;
 import com.intellij.openapi.util.Computable;
 import com.intellij.openapi.vfs.VirtualFile;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 /**
  * The directory tree for a Bazel workspace.
@@ -39,10 +40,84 @@ public class Workspace {
   }
 
   /**
+   * Returns true for a module that uses flutter code within this workspace.
+   *
+   * <p>This is determined by looking for content roots that match a pattern.
+   * By default, any path containing 'flutter' will match, but this can be configured
+   * using the 'directoryPatterns' variable in flutter.json.
+   */
+  public boolean usesFlutter(Module module) {
+    for (String path : getContentPaths(module)) {
+      if (withinFlutterDirectory(path)) return true;
+    }
+    return false;
+  }
+
+  /**
+   * Returns the path to each content root within the module that is below the workspace root.
+   *
+   * <p>Each path will be relative to the workspace root directory.
+   */
+  public ImmutableSet<String> getContentPaths(Module module) {
+    // Find all the content roots within this workspace.
+    final VirtualFile[] contentRoots = ModuleRootManager.getInstance(module).getContentRoots();
+    final ImmutableSet.Builder<String> result = ImmutableSet.builder();
+    for (VirtualFile root : contentRoots) {
+      final String path = getRelativePath(root);
+      if (path != null) {
+        result.add(path);
+      }
+    }
+    return result.build();
+  }
+
+  /**
+   * Returns a VirtualFile's path relative to the workspace's root directory.
+   *
+   * <p>Returns null for the workspace root or anything outside the workspace.
+   */
+  public @Nullable String getRelativePath(VirtualFile file) {
+    final List<String> path = new ArrayList<>();
+    while (file != null) {
+      if (file.equals(root)) {
+        if (path.isEmpty()) {
+          return null; // This is the root.
+        }
+        Collections.reverse(path);
+        return Joiner.on('/').join(path);
+      }
+      path.add(file.getName());
+      file = file.getParent();
+    }
+    return null;
+  }
+
+  /**
+   * Returns true if the given path is within a flutter project.
+   *
+   * <p>The path should be relative to the workspace root.
+   */
+  public boolean withinFlutterDirectory(String path) {
+    final PluginConfig c = getPluginConfig();
+    if (c != null) {
+      return c.withinFlutterDirectory(path);
+    }
+    // Default if unconfigured.
+    return path.contains("flutter");
+  }
+
+  /**
    * Returns the directory containing the WORKSPACE file.
    */
   public @NotNull VirtualFile getRoot() {
     return root;
+  }
+
+  /**
+   * Returns the script that starts 'flutter daemon', or null if not configured.
+   */
+  public @Nullable String getDaemonScript() {
+    return (config == null) ? null : config.getDaemonScript();
   }
 
   /**

--- a/src/io/flutter/bazel/Workspace.java
+++ b/src/io/flutter/bazel/Workspace.java
@@ -76,7 +76,7 @@ public class Workspace {
    *
    * <p>Returns null for the workspace root or anything outside the workspace.
    */
-  public @Nullable String getRelativePath(VirtualFile file) {
+  public @Nullable String getRelativePath(@Nullable VirtualFile file) {
     final List<String> path = new ArrayList<>();
     while (file != null) {
       if (file.equals(root)) {
@@ -97,7 +97,7 @@ public class Workspace {
    *
    * <p>The path should be relative to the workspace root.
    */
-  public boolean withinFlutterDirectory(String path) {
+  public boolean withinFlutterDirectory(@NotNull String path) {
     final PluginConfig c = getPluginConfig();
     if (c != null) {
       return c.withinFlutterDirectory(path);

--- a/src/io/flutter/run/daemon/DeviceDaemon.java
+++ b/src/io/flutter/run/daemon/DeviceDaemon.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright  2017 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.run.daemon;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableList;
+import com.intellij.execution.ExecutionException;
+import com.intellij.execution.configurations.GeneralCommandLine;
+import com.intellij.execution.process.ProcessHandler;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.io.FileUtil;
+import com.intellij.openapi.vfs.CharsetToolkit;
+import io.flutter.bazel.Workspace;
+import io.flutter.bazel.WorkspaceCache;
+import io.flutter.sdk.FlutterSdk;
+import io.flutter.sdk.FlutterSdkUtil;
+import io.flutter.utils.FlutterModuleUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * A process running 'flutter daemon' to watch for devices.
+ */
+class DeviceDaemon {
+  /**
+   * The command used to start this daemon.
+   */
+  private final @NotNull Command command;
+
+  private final @NotNull FlutterDaemonController controller;
+
+  private DeviceDaemon(@NotNull Command command, @NotNull FlutterDaemonController controller) {
+    this.command = command;
+    this.controller = controller;
+  }
+
+  /**
+   * Returns true if the process is still running.
+   */
+  public boolean isRunning() {
+    final ProcessHandler handler = controller.getProcessHandler();
+    return handler != null && !handler.isProcessTerminating();
+  }
+
+  /**
+   * Returns true if the daemon should be restarted.
+   *
+   * @param next the command that should be running now.
+   */
+  public boolean needRestart(@NotNull Command next) {
+    return !isRunning() || !command.equals(next);
+  }
+
+  /**
+   * Kills the process.
+   */
+  public void shutdown() {
+    controller.forceExit();
+  }
+
+  /**
+   * Returns the appropriate command to start the device daemon, if any.
+   *
+   * A null means the device daemon should be shut down.
+   */
+  static @Nullable Command chooseCommand(Project project) {
+    // If an SDK is configured, prefer using it to the Bazel script.
+    final FlutterSdk sdk = FlutterSdk.getFlutterSdk(project);
+    if (sdk != null) {
+      // Only enable this for projects containing flutter modules.
+      if (!FlutterModuleUtils.hasFlutterModule(project)) return null;
+
+      try {
+        final String path = FlutterSdkUtil.pathToFlutterTool(sdk.getHomePath());
+        return new Command(sdk.getHomePath(), path, ImmutableList.of("daemon"));
+      }
+      catch (ExecutionException e) {
+        LOG.warn("Unable to calculate command to watch Flutter devices", e);
+        return null;
+      }
+    }
+
+    // See if the Bazel project provides a script.
+    final Workspace w = WorkspaceCache.getInstance(project).getNow();
+    if (w == null) return null;
+
+    final String script = w.getDaemonScript();
+    if (script == null) return null;
+
+    return new Command(w.getRoot().getPath(), script, ImmutableList.of());
+  }
+
+  /**
+   * The command used to start the daemon.
+   *
+   * <p>Comparing two Commands lets us detect configuration changes that require a restart.
+   */
+  static class Command {
+    /**
+     * Path to working directory for running the script. Should be an absolute path.
+     */
+    private final @NotNull String workDir;
+    private final @NotNull String command;
+    private final @NotNull ImmutableList<String> parameters;
+
+    private Command(@NotNull String workDir, @NotNull String command, @NotNull ImmutableList<String> parameters) {
+      this.workDir = workDir;
+      this.command = command;
+      this.parameters = parameters;
+    }
+
+    /**
+     * Launches the daemon.
+     */
+    DeviceDaemon start(FlutterDaemonService service) throws ExecutionException {
+      final FlutterDaemonController controller = new FlutterDaemonController(service);
+      controller.startDevicePoller(toCommandLine());
+      return new DeviceDaemon(this, controller);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (!(obj instanceof Command)) {
+        return false;
+      }
+      final Command other = (Command)obj;
+      return Objects.equal(workDir, other.workDir)
+             && Objects.equal(command, other.command)
+             && Objects.equal(parameters, other.parameters);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(workDir, command, parameters);
+    }
+
+    private GeneralCommandLine toCommandLine() {
+      final GeneralCommandLine result = new GeneralCommandLine().withWorkDirectory(workDir);
+      result.setCharset(CharsetToolkit.UTF8_CHARSET);
+      result.setExePath(FileUtil.toSystemDependentName(command));
+      for (String param : parameters) {
+        result.addParameter(param);
+      }
+      return result;
+    }
+
+    @Override
+    public String toString() {
+      final StringBuilder out = new StringBuilder();
+      out.append(command);
+      if (!parameters.isEmpty()) {
+        out.append(' ');
+        out.append(Joiner.on(' ').join(parameters));
+      }
+      return out.toString();
+    }
+  }
+
+  private static final Logger LOG = Logger.getInstance(DeviceDaemon.class);
+}

--- a/src/io/flutter/run/daemon/FlutterDaemonControllerHelper.java
+++ b/src/io/flutter/run/daemon/FlutterDaemonControllerHelper.java
@@ -448,7 +448,7 @@ class FlutterDaemonControllerHelper {
   }
 
   private static void error(JsonObject json) {
-    LOG.warn(json.toString());
+    LOG.warn("Flutter process responded with an error: " + json.toString());
   }
 
   private FlutterApp findApp(String appId) {
@@ -572,6 +572,7 @@ class FlutterDaemonControllerHelper {
         prim = obj.getAsJsonPrimitive("error");
         if (prim != null) {
           // Apparently the daemon does not find apps started in release mode.
+          error(obj);
           manager.appStopped(this, controller);
         }
       }

--- a/src/io/flutter/utils/Refreshable.java
+++ b/src/io/flutter/utils/Refreshable.java
@@ -9,36 +9,32 @@ import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableSet;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.util.Disposer;
 import com.intellij.util.concurrency.AppExecutorUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
+import java.io.Closeable;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.concurrent.*;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 
 /**
  * A thread-safe variable that can be updated by submitting a callback to run in the background.
  *
- * <p>When the task is finished (and there is no newer task that makes it obsolete),
+ * <p>When the create callback is finished (and there is no newer task that makes it obsolete),
  * its value will be published and subscribers will be notified.
+ *
+ * <p>It's guaranteed that a Refreshable's visible state won't change while an event handler
+ * is running on the Swing dispatch thread.
  */
-public class Refreshable<T> implements Disposable {
+public class Refreshable<T> implements Closeable {
 
   private final Schedule schedule = new Schedule();
-
-  /**
-   * Holds the most recently published value.
-   */
-  private final AtomicReference<T> published = new AtomicReference<>();
-
-  /**
-   * Completes when the first value is published.
-   */
-  private final FutureTask initialized = new FutureTask<>(() -> null);
+  private final Publisher publisher;
 
   /**
    * Holds a future that completes when the background task exits.
@@ -54,53 +50,63 @@ public class Refreshable<T> implements Disposable {
    */
   private final Set<Runnable> subscribers = new LinkedHashSet<>();
 
-  private final AtomicBoolean disposed = new AtomicBoolean();
-
   /**
-   * Returns the most recently published value without waiting for any updates.
+   * The representation of this Refreshable in IntelliJ's dispose tree.
    *
-   * <p>Returns null if the cache is uninitialized.
+   * <p>(Private so that nobody can add children.)
    */
-  public T getNow() {
-    return published.get();
+  private final Disposable disposeNode;
+
+  public Refreshable() {
+    this(null);
   }
 
   /**
-   * Waits for the first value to be published, then returns the current value.
+   * Creates a refreshable variable that reports when it stops using a value that it created.
    *
-   * <p>If {@link #refresh} is never called then this will block forever.
+   * @param unpublish  will be called when the value is no longer in use. Can be called even though
+   *                   the value was never published. It will run on the Swing dispatch thread.
    */
-  public T getWhenInitialized() {
-    try {
-      initialized.get();
-    } catch (Exception e) {
-      LOG.warn("Unexpected exception waiting for Refreshable to initialize", e);
-    }
-    return getNow();
+  public Refreshable(Consumer<T> unpublish) {
+    this.publisher = new Publisher(unpublish);
+    this.disposeNode = this::close;
+  }
+
+  /**
+   * Returns the most recently published value, without waiting for any updates.
+   *
+   * <p>Returns null if the cache is uninitialized.
+   *
+   * <p>Calling getNow() twice during the same Swing event handler will return the same result.
+   */
+  public T getNow() {
+    return publisher.get();
   }
 
   /**
    * Waits for the background task to finish, then returns the current value.
    *
-   * <p>The background task may be kept busy for a long time due to long-running tasks
-   * or frequent calls to {@link #refresh}. Therefore it shouldn't be called from the
-   * Swing dispatch thread.
+   * <p>If {@link #refresh} is never called then this will block forever waiting
+   * for the variable to be initialized.
+   *
+   * @throws IllegalStateException if called on the Swing dispatch thread.
    */
   public T getWhenReady() {
     if (SwingUtilities.isEventDispatchThread()) {
       throw new IllegalStateException("getWhenReady shouldn't be called from Swing dispatch thread");
     }
-    getWhenInitialized();
+
+    publisher.waitForFirstValue();
 
     final Future refreshDone = busy.get();
     if (refreshDone == null) {
-      return getNow(); // Already idle.
+      return getNow(); // No background task; currently idle.
     }
 
     try {
       refreshDone.get();
     } catch (Exception e) {
-      LOG.warn("Unexpected exception waiting for refresh task to be idle", e);
+      LOG.warn("Unexpected exception waiting for refresh task to finish", e);
     }
     return getNow();
   }
@@ -130,15 +136,15 @@ public class Refreshable<T> implements Disposable {
    */
   public void subscribe(@NotNull Runnable callback) {
     synchronized (subscribers) {
-      if (disposed.get()) {
-        throw new IllegalStateException("Can't subscribe to disposed Refreshable");
+      if (publisher.isClosing()) {
+        throw new IllegalStateException("Can't subscribe to closed Refreshable");
       }
       subscribers.add(callback);
     }
   }
 
   /**
-   * Stops notifications for a callback that was passed to {@link ::subscribe}.
+   * Stops notifications to a callback that was passed to {@link ::subscribe}.
    */
   public void unsubscribe(@NotNull Runnable callback) {
     synchronized (subscribers) {
@@ -147,11 +153,11 @@ public class Refreshable<T> implements Disposable {
   }
 
   /**
-   * Runs a callback in the background.
+   * Creates and publishes a new value in the background.
    *
-   * <p>If the callback finishes normally, no newer refresh request is submitted in
-   * the meantime, and its value is different from the previous one, the new value
-   * will be published and subscribers will be notified.
+   * <p>The new value will be published if the callback finishes normally,
+   * no newer refresh request is submitted in the meantime, and the value is different
+   * (according to {#link Object#equals}) from the previous one.
    *
    * <p>The Callable interface doesn't provide any way to find out if the task was
    * cancelled. Instead, the callback can use {@link #isCancelled} to poll for this.
@@ -160,16 +166,18 @@ public class Refreshable<T> implements Disposable {
    * new value. (Any other exception will have the same effect, but a warning will
    * be logged.)
    */
-  public void refresh(@NotNull Callable<T> callable) {
-    if (disposed.get()) {
-      throw new IllegalStateException("can't update disposed Refreshable");
+  public void refresh(@NotNull Callable<T> create) {
+    if (publisher.isClosing()) {
+      LOG.warn("attempted to update closed Refreshable");
+      return;
     }
-    schedule.reschedule(callable);
+    schedule.reschedule(create);
 
     // Start up the background task if it's not running.
     final FutureTask next = new FutureTask<>(this::runInBackground, null);
     if (busy.compareAndSet(null, next)) {
-      AppExecutorUtil.getAppExecutorService().submit(next);
+      // Wait until after event handler currently running, in case it calls refresh again.
+      SwingUtilities.invokeLater(() -> AppExecutorUtil.getAppExecutorService().submit(next));
     }
   }
 
@@ -184,16 +192,32 @@ public class Refreshable<T> implements Disposable {
   }
 
   /**
-   * Removes all subscribers and cancels any background tasks.
+   * Starts shutting down the Refreshable.
+   *
+   * Asynchronously removes all subscribers, cancels any background tasks,
+   * and unpublishes any values.
    */
-  @Override
-  public void dispose() {
-    if (disposed.compareAndSet(false, true)) {
-      synchronized (subscribers) {
-        subscribers.clear();
-      }
-      schedule.reschedule(null);
+  public void close() {
+    if (!publisher.close()) {
+      return; // already closed.
     }
+
+    // Cancel any running create task.
+    schedule.reschedule(null);
+
+    // Remove from dispose tree. Calls close() again, harmlessly.
+    Disposer.dispose(disposeNode);
+  }
+
+  /**
+   * Automatically unsubscribes and unpublishes when a parent object is disposed.
+   *
+   * <p>Only one parent can be registered at a time. Auto-unsubscribe
+   * will stop working for any object previously passed to this
+   * method.
+   */
+  public void setDisposeParent(Disposable parent) {
+    Disposer.register(parent, disposeNode);
   }
 
   /**
@@ -201,61 +225,45 @@ public class Refreshable<T> implements Disposable {
    */
   private void runInBackground() {
     try {
-      T response = null;
-      boolean canPublish = false;
+      // Yield to queued events.
+      // Avoids unnecessary work if they change the schedule.
+      try {
+        SwingUtilities.invokeAndWait(() -> {});
+      }
+      catch (Exception e) {
+        LOG.warn("Unexpected exception while updating a Refreshable", e);
+        return;
+      }
+
       for (Callable<T> request = schedule.next(); request != null; request = schedule.next()) {
         // Do the work.
         try {
-          response = request.call();
-          canPublish = true;
+          publisher.reschedule(request.call());
         } catch (CancellationException e) {
           // This is normal.
         } catch (Exception e) {
           if (!Objects.equal(e.getMessage(), "expected failure in test")) {
-            LOG.warn("Task threw an exception while updating a Refreshable", e);
+            LOG.warn("Callback threw an exception while updating a Refreshable", e);
           }
-          // Don't publish anything.
         } finally {
           schedule.done(request);
         }
-      }
-      if (canPublish) {
-        publish(response);
+
+        try {
+          // Wait for an opportunity to publish.
+          SwingUtilities.invokeAndWait(() -> {
+            // If the schedule changed in the meantime, skip publishing the value.
+            if (!schedule.hasNext()) {
+              publisher.publish();
+            }
+          });
+        }
+        catch (Exception e) {
+          LOG.warn("Unable to publish a value while updating a Refreshable", e);
+        }
       }
     } finally {
       busy.set(null); // Allow restart on exit.
-    }
-  }
-
-  private void publish(T next) {
-    final T prev = published.getAndSet(next);
-    if (initialized.isDone() && Objects.equal(prev, next)) {
-      return; // Debounce.
-    }
-    initialized.run();
-
-    final Set<Runnable> subscribers = getSubscribers();
-    if (subscribers.isEmpty()) {
-      return;
-    }
-
-    // We are on a background thread. Deliver events on the Swing thread.
-    // (We are still busy until subscribers are notified.)
-    try {
-      SwingUtilities.invokeAndWait(() -> {
-        for (Runnable sub : subscribers) {
-          try {
-            sub.run();
-          } catch (Exception e) {
-            if (!Objects.equal(e.getMessage(), "expected failure in test")) {
-              LOG.warn("A subscriber to a Refreshable threw an exception", e);
-            }
-          }
-        }
-      });
-    }
-    catch (Exception e) {
-      LOG.warn("Unable to notify subscribers when updating a Refreshable", e);
     }
   }
 
@@ -267,6 +275,9 @@ public class Refreshable<T> implements Disposable {
 
   private static final Logger LOG = Logger.getInstance(Refreshable.class);
 
+  /**
+   * Manages the schedule for creating new values on the background thread.
+   */
   private class Schedule {
     /**
      * The next request to run.
@@ -276,14 +287,14 @@ public class Refreshable<T> implements Disposable {
     private @Nullable Callable<T> scheduled;
 
     /**
-     * The currently running request.
+     * The currently running create callback.
      *
      * <p>Null when nothing is currently running.
      */
     private @Nullable Callable<T> running;
 
     /**
-     * If not null, the running task is cancelled.
+     * If not null, the create callback has been cancelled.
      */
     private @Nullable Callable<T> cancelled;
 
@@ -296,7 +307,14 @@ public class Refreshable<T> implements Disposable {
     }
 
     /**
-     * Returns the next thing to do, or null if nothing is scheduled.
+     * Checks if there is any work scheduled.
+     */
+    synchronized boolean hasNext() {
+      return scheduled != null;
+    }
+
+    /**
+     * Returns the next task to run, or null if nothing is scheduled.
      */
     synchronized @Nullable Callable<T> next() {
       assert(running == null);
@@ -306,7 +324,7 @@ public class Refreshable<T> implements Disposable {
     }
 
     /**
-     * Marks a task as done.
+     * Indicates that we finished creating a value.
      */
     synchronized void done(@NotNull Callable<T> request) {
       assert(running != null);
@@ -316,6 +334,131 @@ public class Refreshable<T> implements Disposable {
 
     synchronized boolean isCancelled(Callable<T> callback) {
       return callback == cancelled;
+    }
+  }
+
+  /**
+   * Manages the schedule for publishing and unpublishing values.
+   */
+  private class Publisher {
+    private final @NotNull Consumer<T> unpublish;
+
+    private @Nullable T scheduled;
+    private @Nullable T published;
+
+    /**
+     * Completes when the first value is published.
+     */
+    private final FutureTask initialized = new FutureTask<>(() -> null);
+
+    private boolean needToPublish;
+    private boolean closing;
+
+    Publisher(@Nullable Consumer<T> unpublish) {
+      if (unpublish == null) unpublish = (x) -> {};
+      this.unpublish = unpublish;
+    }
+
+    /**
+     * Schedules a value to be published later, provided that it's not a duplicate.
+     */
+    synchronized void reschedule(@Nullable T toPublish) {
+      if (closing) return;
+
+      if (scheduled != null && !Objects.equal(toPublish, scheduled)) {
+        final T old = scheduled;
+        SwingUtilities.invokeLater(() -> unpublish.accept(old));
+      }
+
+      if (initialized.isDone() && Objects.equal(toPublish, published)) {
+        // don't publish a duplicate
+        scheduled = null;
+        needToPublish = false;
+      } else {
+        scheduled = toPublish;
+        needToPublish = true;
+      }
+    }
+
+    synchronized boolean close() {
+      if (closing) return false;
+      reschedule(null);
+      closing = true;
+      publishAsync();
+      return true;
+    }
+
+    /**
+     * Publishes the next value synchronously.
+     *
+     * <p>Waits for any previously scheduled Swing event handlers to finish.
+     */
+    void waitAndPublish() {
+      synchronized(this) {
+        if (!needToPublish) return;
+      }
+      try {
+        SwingUtilities.invokeAndWait(this::publish);
+      }
+      catch (Exception e) {
+        LOG.warn("Unable to publish a value", e);
+      }
+    }
+
+    void publishAsync() {
+      synchronized(this) {
+        if (!needToPublish) return;
+      }
+      SwingUtilities.invokeLater(this::publish);
+    }
+
+    void publish() {
+      assert(SwingUtilities.isEventDispatchThread());
+
+      final T discarded;
+      synchronized (this) {
+        if (!needToPublish) return;
+        discarded = published;
+        published = scheduled;
+        needToPublish = false;
+        scheduled = null;
+        initialized.run();
+      }
+
+      if (discarded != null) {
+        try {
+          unpublish.accept(discarded);
+        } catch (Exception e) {
+          LOG.warn("An unpublish callback threw an exception while updating a Refreshable", e);
+        }
+      }
+
+      final Set<Runnable> subscribers = getSubscribers();
+      for (Runnable sub : subscribers) {
+        try {
+          sub.run();
+        } catch (Exception e) {
+          if (!Objects.equal(e.getMessage(), "expected failure in test")) {
+            LOG.warn("A subscriber to a Refreshable threw an exception", e);
+          }
+        }
+      }
+    }
+
+    void waitForFirstValue() {
+      try {
+        initialized.get();
+      } catch (Exception e) {
+        LOG.warn("Unexpected exception waiting for Refreshable to initialize", e);
+      }
+    }
+
+    synchronized T get() {
+      return published;
+    }
+
+    synchronized boolean isClosing() {
+      return closing;
     }
   }
 }

--- a/testSrc/unit/io/flutter/bazel/PluginConfigTest.java
+++ b/testSrc/unit/io/flutter/bazel/PluginConfigTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright  2017 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.bazel;
+
+import com.intellij.openapi.vfs.VirtualFile;
+import io.flutter.testing.ProjectFixture;
+import io.flutter.testing.TestDir;
+import io.flutter.testing.Testing;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNull;
+
+public class PluginConfigTest {
+
+  @Rule
+  public ProjectFixture fixture = Testing.makeEmptyProject();
+
+  @Rule
+  public TestDir dir = new TestDir();
+
+  @Test
+  public void shouldReturnNullForSyntaxError() throws Exception {
+    final VirtualFile config = dir.writeFile("config.json", "asdf");
+    final PluginConfig result = PluginConfig.load(config);
+    assertNull(result);
+  }
+
+  @Test
+  public void shouldReturnNullForBadRegexp() throws Exception {
+    final VirtualFile config = dir.writeFile("config.json", "{\"directoryPatterns\": [\"*hello\"]}");
+    final PluginConfig result = PluginConfig.load(config);
+    assertNull(result);
+  }
+}

--- a/testSrc/unit/io/flutter/bazel/WorkspaceCacheTest.java
+++ b/testSrc/unit/io/flutter/bazel/WorkspaceCacheTest.java
@@ -51,13 +51,13 @@ public class WorkspaceCacheTest {
 
     final String configPath = "abc/dart/config/intellij-plugins/flutter.json";
 
-    tmp.writeFile(configPath, "{\"start_flutter_daemon\": \"first\"}");
+    tmp.writeFile(configPath, "{\"daemonScript\": \"first\"}");
     checkConfigSetting("first");
 
     tmp.writeFile(configPath, "{}");
     checkConfigSetting(null);
 
-    tmp.writeFile(configPath, "{\"start_flutter_daemon\": \"second\"}");
+    tmp.writeFile(configPath, "{\"daemonScript\": \"second\"}");
     checkConfigSetting("second");
 
     tmp.deleteFile(configPath);
@@ -99,6 +99,6 @@ public class WorkspaceCacheTest {
 
     final PluginConfig c = w.getPluginConfig();
     assertNotNull("config file is missing", c);
-    assertEquals(expected, c.getFlutterDaemonScript());
+    assertEquals(expected, c.getDaemonScript());
   }
 }

--- a/testSrc/unit/io/flutter/utils/RefreshableTest.java
+++ b/testSrc/unit/io/flutter/utils/RefreshableTest.java
@@ -5,111 +5,125 @@
  */
 package io.flutter.utils;
 
+import com.google.common.collect.ImmutableList;
+import org.junit.Before;
 import org.junit.Test;
 
 import javax.swing.*;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.FutureTask;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static junit.framework.TestCase.assertFalse;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.*;
 
 public class RefreshableTest {
 
-  private final Refreshable<String> value = new Refreshable<>();
+  private final List<String> logEntries = new ArrayList<>();
+  private Refreshable<String> value;
+
+  @Before
+  public void setUp() {
+    value = new Refreshable<>((value) -> log("unpublished: " + value));
+  }
 
   @Test
   public void valueShouldBeNullAtStart() {
     assertNull(value.getNow());
+    checkLog();
   }
 
   @Test
   public void refreshShouldPublishNewValue() {
     value.refresh(() -> "hello");
     assertEquals("hello", value.getWhenReady());
+    checkLog();
+  }
+
+  @Test
+  public void refreshShouldUnpublishPreviousValue() {
+    value.refresh(() -> "one");
+    assertEquals("one", value.getWhenReady());
+
+    value.refresh(() -> "two");
+    assertEquals("two", value.getWhenReady());
+    checkLog("unpublished: one");
   }
 
   @Test
   public void refreshShouldNotifySubscriber() {
-    final AtomicInteger callCount = new AtomicInteger();
     value.subscribe(() -> {
       assertEquals("subscriber should see new value", "hello", value.getNow());
       assertTrue("should be on Swing dispatch thread", SwingUtilities.isEventDispatchThread());
-      callCount.incrementAndGet();
+      log("got event");
     });
     value.refresh(() -> "hello");
     assertEquals("hello", value.getWhenReady());
-    assertEquals(1, callCount.get());
+    checkLog("got event");
   }
 
   @Test
-  public void shouldNotNotifySubscriberOfDuplicateValue() {
-    final AtomicInteger callCount = new AtomicInteger();
-    value.subscribe(callCount::incrementAndGet);
+  public void refreshShouldNotNotifySubscriberOfDuplicateValue() {
+    value.subscribe(() -> log("got event"));
     value.refresh(() -> "hello");
     assertEquals("hello", value.getWhenReady());
-    assertEquals(1, callCount.get());
+    checkLog("got event");
 
     value.refresh(() -> "hello");
     assertEquals("hello", value.getWhenReady());
-    assertEquals(1, callCount.get());
+    checkLog();
   }
 
   @Test
-  public void shouldNotPublishWhenTaskThrowsException() {
+  public void refreshShouldNotPublishWhenCallbackThrowsException() {
     value.refresh(() -> "first");
     assertEquals("first", value.getWhenReady());
 
-    final AtomicInteger callCount = new AtomicInteger();
-    value.subscribe(callCount::incrementAndGet);
+    value.subscribe(() -> log("got event"));
 
     value.refresh(() -> {
       throw new RuntimeException("expected failure in test");
     });
     assertEquals("first", value.getWhenReady());
-    assertEquals("should not have notifiied subscribers", 0, callCount.get());
+    checkLog();
   }
 
   @Test
-  public void shouldRecoverIfSubscriberThrows() {
+  public void refreshShouldRecoverIfSubscriberThrows() {
     value.subscribe(() -> {
       throw new RuntimeException("expected failure in test");
     });
-    final AtomicInteger callCount = new AtomicInteger();
     value.subscribe(() -> {
       assertEquals("subscriber should see new value", "hello", value.getNow());
       assertTrue("should be on Swing dispatch thread", SwingUtilities.isEventDispatchThread());
-      callCount.incrementAndGet();
+      log("got event");
     });
     value.refresh(() -> "hello");
     assertEquals("hello", value.getWhenReady());
-    assertEquals(1, callCount.get());
+    checkLog("got event");
   }
 
   @Test
   public void whenPublishedShouldFireOnce() {
-    final AtomicInteger callCount = new AtomicInteger();
-    value.whenPublished(callCount::incrementAndGet);
+    value.whenPublished(() -> log("got event"));
 
     value.refresh(() -> "first");
     assertEquals("first", value.getWhenReady());
-    assertEquals(1, callCount.get());
+    checkLog("got event");
 
     value.refresh(() -> "second");
     assertEquals("second", value.getWhenReady());
-    assertEquals(1, callCount.get());
+    checkLog("unpublished: first");
   }
 
   @Test
   public void whenPublishedShouldFireWhenFirstValueIsNull() {
-    final AtomicInteger callCount = new AtomicInteger();
-    value.whenPublished(callCount::incrementAndGet);
+    value.whenPublished(() -> log("got event"));
     value.refresh(() -> null);
     assertNull(value.getWhenReady());
-    assertEquals(1, callCount.get());
+    checkLog("got event");
   }
 
   @Test
@@ -125,9 +139,10 @@ public class RefreshableTest {
     final Callable<String> secondTask = () -> "second task";
 
     value.refresh(firstTask);
-    startedFirstTask.get(); // wait for first task to run.
+    startedFirstTask.get(); // wait for first task to start running.
 
     assertNull("should have blocked on the dependency", value.getNow());
+    checkLog();
 
     value.refresh(secondTask);
     assertTrue("should have cancelled first task", value.isCancelled(firstTask));
@@ -135,10 +150,74 @@ public class RefreshableTest {
 
     dependency.run(); // Make first task exit, allowing second to run.
     assertEquals("second task", value.getWhenReady());
+    checkLog("unpublished: first task");
   }
 
   @Test
-  public void shouldNotPublishIfTaskThrowsCancellationException() throws Exception {
+  public void refreshShouldYieldToQueuedEvents() throws Exception {
+    // Queue up some events.
+    SwingUtilities.invokeAndWait(() -> {
+      value.refresh(() -> {
+        log("created first");
+        return "first";
+      });
+      value.refresh(() -> {
+        log("created second");
+        return "second";
+      });
+      SwingUtilities.invokeLater(() -> value.refresh(() -> {
+        log("created third");
+        return "third";
+      }));
+    });
 
+    assertEquals("third", value.getWhenReady());
+    checkLog("created third");
+  }
+
+  @Test
+  public void publishShouldYieldToQueuedEvents() throws Exception {
+    // Create a task that will block until we say to finish.
+    final FutureTask startedTask = new FutureTask<>(() -> null);
+    final FutureTask<String> dependency = new FutureTask<>(() -> "first");
+    final Callable<String> task = () -> {
+      startedTask.run();
+      return dependency.get();
+    };
+    value.subscribe(() -> log("got event"));
+
+    value.refresh(task);
+    startedTask.get(); // Wait for task to start running.
+
+    SwingUtilities.invokeAndWait(() -> {
+      dependency.run();
+
+      // Make sure it's blocked until we exit.
+      try {
+        Thread.sleep(100);
+      }
+      catch (InterruptedException e) {
+        log("unexpected exception: " + e);
+      }
+
+      log("event handler done");
+    });
+
+    assertEquals("first", value.getWhenReady());
+    checkLog("event handler done",
+             "got event");
+  }
+
+  private synchronized boolean log(String message) {
+    return logEntries.add(message);
+  }
+
+  private synchronized List<String> getLogEntries() {
+    return ImmutableList.copyOf(logEntries);
+  }
+
+  private void checkLog(String... expectedEntries) {
+    assertThat("logEntries entries are different", getLogEntries(), is(ImmutableList.copyOf(expectedEntries)));
+    logEntries.clear();
   }
 }


### PR DESCRIPTION
- Start showing the device menu for Bazel users. In this case they don't have
to configure a Flutter SDK. Instead, the device menu will be shown based on the
project's content roots.

By default, a content root containing 'flutter' will trigger the device menu.
This can be overridden by the 'directoryPatterns' setting in flutter.json.

- Show or hide device menu when the user changes the Dart or Flutter SDK,
or the Bazel workspace changes.

- Start/stop/restart the 'flutter daemon' process when the configuration changes.

- Fixed a bug where Flutter SDK changes would not be detected when the user changes
the Dart SDK.

- Made API clearer for attaching FileRoot or Refreshable to a Disposable.

- Refreshable class improvements:
  - add a callback when a value is unpublished
  - make sure the variable doesn't change while a Swing event handler is
    running.