### PR TITLE
Bugfix: shut down device daemon process when project is closed

### DIFF
--- a/src/io/flutter/run/daemon/FlutterDaemonService.java
+++ b/src/io/flutter/run/daemon/FlutterDaemonService.java
@@ -66,6 +66,7 @@ public class FlutterDaemonService {
     this.project = project;
     Disposer.register(project, this::stopAppControllers);
 
+    myDeviceDaemon.setDisposeParent(project);
     refreshDeviceDaemon();
 
     // Watch for Flutter SDK changes.


### PR DESCRIPTION
- Register device daemon as a disposable
- Make sure that a Reflectable calls its unpublish callback when closing, which kills the process.
