### PR TITLE
some cleanup to our use of the message bus

### DIFF
--- a/src/io/flutter/view/FlutterViewFactory.java
+++ b/src/io/flutter/view/FlutterViewFactory.java
@@ -19,12 +19,13 @@ public class FlutterViewFactory implements ToolWindowFactory {
     project.getMessageBus().connect().subscribe(
       FlutterViewMessages.FLUTTER_DEBUG_TOPIC, (event) -> {
         initFlutterView(project, event);
-      });
+      }
+    );
   }
 
   private static void initFlutterView(@NotNull Project project, FlutterViewMessages.FlutterDebugEvent event) {
     ApplicationManager.getApplication().invokeLater(() -> {
-      //TODO: re-enable auto-show after UI review (#691)
+      // TODO: re-enable auto-show after UI review (#691)
       final FlutterView flutterView = ServiceManager.getService(project, FlutterView.class);
       flutterView.debugActive(event);
     });

--- a/src/io/flutter/view/FlutterViewMessages.java
+++ b/src/io/flutter/view/FlutterViewMessages.java
@@ -6,6 +6,8 @@
 package io.flutter.view;
 
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectManager;
 import com.intellij.util.messages.MessageBus;
 import com.intellij.util.messages.Topic;
 import com.jetbrains.lang.dart.ide.runner.ObservatoryConnector;
@@ -37,10 +39,11 @@ public class FlutterViewMessages {
     }
   }
 
-  public static void sendDebugActive(@NotNull ObservatoryConnector observatoryConnector,
+  public static void sendDebugActive(@NotNull Project project,
+                                     @NotNull ObservatoryConnector observatoryConnector,
                                      @NotNull VmServiceWrapper vmServiceWrapper,
                                      @NotNull VmService vmService) {
-    final MessageBus bus = ApplicationManager.getApplication().getMessageBus();
+    final MessageBus bus = project.getMessageBus();
     final FlutterDebugNotifier publisher = bus.syncPublisher(FLUTTER_DEBUG_TOPIC);
     publisher.debugActive(new FlutterDebugEvent(observatoryConnector, vmServiceWrapper, vmService));
   }

--- a/third_party/intellij-plugins-dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcessZ.java
+++ b/third_party/intellij-plugins-dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcessZ.java
@@ -291,7 +291,7 @@ public class DartVmServiceDebugProcessZ extends DartVmServiceDebugProcess {
     myVmConnected = true;
     getSession().rebuildViews();
 
-    FlutterViewMessages.sendDebugActive(getConnector(), myVmServiceWrapper, vmService);
+    FlutterViewMessages.sendDebugActive(getSession().getProject(), getConnector(), myVmServiceWrapper, vmService);
   }
 
   @Override


### PR DESCRIPTION
- some cleanup to our use of the message bus

This converts to sending launch events on the project bus, not the application one. I think this is more correct, in that you don't want to have flutter views listening to launches in other windows.

@skybrian 