### PR TITLE
updates to Refreshable

### DIFF
--- a/testSrc/unit/io/flutter/utils/RefreshableTest.java
+++ b/testSrc/unit/io/flutter/utils/RefreshableTest.java
@@ -17,22 +17,46 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
-import static junit.framework.TestCase.assertFalse;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.*;
 
 public class RefreshableTest {
 
-  private final List<String> logEntries = new ArrayList<>();
-  private final Semaphore unpublished = new Semaphore(0);
   private Refreshable<String> value;
+
+  private final List<String> logEntries = new ArrayList<>();
+
+  private final Semaphore canUnpublish = new Semaphore(0);
+  private final Semaphore unpublished = new Semaphore(0);
+
+  private final Semaphore canFireCloseEvent = new Semaphore(0);
+  private final Semaphore closeEventReceived = new Semaphore(0);
 
   @Before
   public void setUp() {
     value = new Refreshable<>((value) -> {
+      acquireOrLog(canUnpublish, "unpublish not expected here");
       log("unpublished: " + value);
       unpublished.release();
+    });
+
+    value.subscribe(() -> {
+      if (!SwingUtilities.isEventDispatchThread()) {
+        log("subscriber should be called on Swing thread");
+        return;
+      }
+
+      if (value.getState() == Refreshable.State.CLOSED) {
+        acquireOrLog(canFireCloseEvent, "close event not expected here");
+      }
+
+      log(value.getState() + ": " + value.getNow());
+
+      if (value.getState() == Refreshable.State.CLOSED) {
+        closeEventReceived.release();
+      }
     });
   }
 
@@ -46,67 +70,96 @@ public class RefreshableTest {
   public void refreshShouldPublishNewValue() throws Exception {
     value.refresh(() -> "hello");
     assertEquals("hello", value.getWhenReady());
-    checkLog();
+    checkLog("BUSY: null",
+             "BUSY: hello",
+             "IDLE: hello");
+
     value.close();
-    waitForUnpublish();
-    checkLog("unpublished: hello");
+    expectUnpublish();
+    expectCloseEvent();
+    checkLog(
+      "unpublished: hello",
+      "CLOSED: null");
   }
 
   @Test
-  public void refreshShouldUnpublishPreviousValue() throws Exception {
-    value.refresh(() -> "one");
-    assertEquals("one", value.getWhenReady());
-
-    value.refresh(() -> "two");
-    assertEquals("two", value.getWhenReady());
-    waitForUnpublish();
-    checkLog("unpublished: one");
-
-    value.close();
-    waitForUnpublish();
-    checkLog("unpublished: two");
-  }
-
-  @Test
-  public void refreshShouldNotifySubscriber() {
-    value.subscribe(() -> {
-      assertEquals("subscriber should see new value", "hello", value.getNow());
-      assertTrue("should be on Swing dispatch thread", SwingUtilities.isEventDispatchThread());
-      log("got event");
+  public void refreshShouldProvideAndUnpublishPreviousValue() throws Exception {
+    value.refresh((req) -> {
+      log("previous: " + req.getPrevious());
+      return "one";
     });
-    value.refresh(() -> "hello");
-    assertEquals("hello", value.getWhenReady());
-    checkLog("got event");
-  }
+    assertEquals("one", value.getWhenReady());
+    checkLog("BUSY: null",
+             "previous: null",
+             "BUSY: one",
+             "IDLE: one");
 
-  @Test
-  public void refreshShouldNotNotifySubscriberOfDuplicateValue() throws Exception {
-    value.subscribe(() -> log("got event"));
-    value.refresh(() -> "hello");
-    assertEquals("hello", value.getWhenReady());
-    checkLog("got event");
-
-    value.refresh(() -> "hello");
-    assertEquals("hello", value.getWhenReady());
-    checkLog();
+    value.refresh((req) -> {
+      log("previous: " + req.getPrevious());
+      return "two";
+    });
+    expectUnpublish();
+    assertEquals("two", value.getWhenReady());
+    checkLog(
+      "BUSY: one",
+      "previous: one",
+      "unpublished: one",
+      "BUSY: two",
+      "IDLE: two");
 
     value.close();
-    waitForUnpublish();
-    checkLog("unpublished: hello");
+    expectUnpublish();
+    expectCloseEvent();
+    checkLog("unpublished: two",
+             "CLOSED: null");
   }
 
   @Test
-  public void refreshShouldNotPublishWhenCallbackThrowsException() {
+  public void refreshShouldNotPublishOrUnpublishDuplicateValue() throws Exception {
+    value.refresh(() -> "hello");
+    assertEquals("hello", value.getWhenReady());
+    checkLog("BUSY: null",
+             "BUSY: hello",
+             "IDLE: hello");
+
+    value.refresh(() -> "hello");
+    assertEquals("hello", value.getWhenReady());
+    checkLog("BUSY: hello",
+             "IDLE: hello");
+
+    value.close();
+    expectUnpublish();
+    expectCloseEvent();
+    checkLog("unpublished: hello",
+             "CLOSED: null");
+  }
+
+  @Test
+  public void refreshShouldNotPublishWhenCallbackThrowsException() throws Exception {
     value.refresh(() -> "first");
     assertEquals("first", value.getWhenReady());
-
-    value.subscribe(() -> log("got event"));
+    checkLog("BUSY: null",
+             "BUSY: first",
+             "IDLE: first");
 
     value.refresh(() -> {
       throw new RuntimeException("expected failure in test");
     });
     assertEquals("first", value.getWhenReady());
-    checkLog();
+    checkLog("BUSY: first",
+             "IDLE: first");
+
+    value.refresh((req) -> {
+      log("previous: " + req.getPrevious());
+      return "second";
+    });
+    expectUnpublish();
+    assertEquals("second", value.getWhenReady());
+    checkLog("BUSY: first",
+             "previous: first",
+             "unpublished: first",
+             "BUSY: second",
+             "IDLE: second");
   }
 
   @Test
@@ -114,36 +167,15 @@ public class RefreshableTest {
     value.subscribe(() -> {
       throw new RuntimeException("expected failure in test");
     });
-    value.subscribe(() -> {
-      assertEquals("subscriber should see new value", "hello", value.getNow());
-      assertTrue("should be on Swing dispatch thread", SwingUtilities.isEventDispatchThread());
-      log("got event");
-    });
+    value.subscribe(() -> log(value.getState() + ": " + value.getNow() + " (last subscriber)"));
     value.refresh(() -> "hello");
     assertEquals("hello", value.getWhenReady());
-    checkLog("got event");
-  }
-
-  @Test
-  public void whenPublishedShouldFireOnce() throws Exception {
-    value.whenPublished(() -> log("got event"));
-
-    value.refresh(() -> "first");
-    assertEquals("first", value.getWhenReady());
-    checkLog("got event");
-
-    value.refresh(() -> "second");
-    assertEquals("second", value.getWhenReady());
-    waitForUnpublish();
-    checkLog("unpublished: first");
-  }
-
-  @Test
-  public void whenPublishedShouldFireWhenFirstValueIsNull() {
-    value.whenPublished(() -> log("got event"));
-    value.refresh(() -> null);
-    assertNull(value.getWhenReady());
-    checkLog("got event");
+    checkLog("BUSY: null",
+             "BUSY: null (last subscriber)",
+             "BUSY: hello",
+             "BUSY: hello (last subscriber)",
+             "IDLE: hello",
+             "IDLE: hello (last subscriber)");
   }
 
   @Test
@@ -151,7 +183,10 @@ public class RefreshableTest {
     // Create a task that will block until we say to finish.
     final FutureTask startedFirstTask = new FutureTask<>(() -> null);
     final FutureTask<String> dependency = new FutureTask<>(() -> "first task");
-    final Callable<String> firstTask = () -> {
+
+    final AtomicReference<Refreshable.Request> firstRequest = new AtomicReference<>();
+    final Refreshable.Callback<String> firstTask = (request) -> {
+      firstRequest.set(request);
       startedFirstTask.run();
       return dependency.get();
     };
@@ -162,16 +197,18 @@ public class RefreshableTest {
     startedFirstTask.get(); // wait for first task to start running.
 
     assertNull("should have blocked on the dependency", value.getNow());
-    checkLog();
+    checkLog("BUSY: null");
 
     value.refresh(secondTask);
-    assertTrue("should have cancelled first task", value.isCancelled(firstTask));
-    assertFalse("should not have cancelled second task", value.isCancelled(secondTask));
+    assertTrue("should have cancelled first task", firstRequest.get().isCancelled());
+    checkLog();
 
     dependency.run(); // Make first task exit, allowing second to run.
+    expectUnpublish();
     assertEquals("second task", value.getWhenReady());
-    waitForUnpublish();
-    checkLog("unpublished: first task");
+    checkLog("unpublished: first task",
+             "BUSY: second task",
+             "IDLE: second task");
   }
 
   @Test
@@ -179,32 +216,34 @@ public class RefreshableTest {
     // Queue up some events.
     SwingUtilities.invokeAndWait(() -> {
       value.refresh(() -> {
-        log("created first");
+        log("shouldn't create first");
         return "first";
       });
-      value.refresh(() -> {
-        log("created second");
+      value.refresh((req) -> {
+        log("shouldn't create second");
         return "second";
       });
-      SwingUtilities.invokeLater(() -> value.refresh(() -> {
-        log("created third");
+      SwingUtilities.invokeLater(() -> value.refresh((req) -> {
+        log("created third; previous: " + req.getPrevious());
         return "third";
       }));
     });
 
     assertEquals("third", value.getWhenReady());
-    checkLog("created third");
+    checkLog("BUSY: null",
+             "created third; previous: null",
+             "BUSY: third",
+             "IDLE: third");
   }
 
   @Test
   public void publishShouldYieldToQueuedEvents() throws Exception {
-    value.subscribe(() -> log("got event"));
     final Semaphore finish = startRefresh("first");
 
     SwingUtilities.invokeAndWait(() -> {
       finish.release();
 
-      // Make sure it's blocked until we exit.
+      // Make sure publishing values is blocked until we exit.
       try {
         Thread.sleep(100);
       }
@@ -216,48 +255,81 @@ public class RefreshableTest {
     });
 
     assertEquals("first", value.getWhenReady());
-    checkLog("entered refresh callback: first",
-             "exited refresh callback: first",
+    checkLog("BUSY: null",
+             "entered refresh",
+             "exited refresh: first",
              "event handler done",
-             "got event");
+             "BUSY: first",
+             "IDLE: first");
   }
 
   @Test
   public void shouldNotPublishWhenClosedDuringRefreshCallback() throws Exception {
-    value.subscribe(() -> log("got event"));
     final Semaphore finish = startRefresh("first");
     value.close();
+    expectCloseEvent();
     finish.release();
+    expectUnpublish();
     assertNull(value.getWhenReady());
-    waitForUnpublish();
-    checkLog("entered refresh callback: first",
-             "exited refresh callback: first",
-             "unpublished: first");
+    checkLog(
+      "BUSY: null",
+      "entered refresh",
+      "CLOSED: null",
+      "exited refresh: first",
+      "unpublished: first");
   }
 
   @Test
   public void shouldNotPublishWhenClosedBeforePublish() throws Exception {
-    value.subscribe(() -> log("got event"));
     final Semaphore finish = startRefresh("first");
 
     SwingUtilities.invokeAndWait(() -> {
       SwingUtilities.invokeLater(() -> {
+        // Need to lose race with background tasks's call to reschedule(),
+        // But win the race to publish().
+        // So, schedule Swing event now, but make it slower.
+        // (No suitable semaphore for this one.)
+        try {
+          Thread.sleep(50);
+        }
+        catch (InterruptedException e) {
+          log("interrupted");
+        }
         value.close();
-        log("closed");
+        log("called close()");
       });
       finish.release();
     });
+    expectUnpublish();
+    expectCloseEvent();
     assertNull(value.getWhenReady());
-    waitForUnpublish();
-    checkLog("entered refresh callback: first",
-             "exited refresh callback: first",
-             "closed",
-             "unpublished: first");
+
+    checkLog("BUSY: null",
+             "entered refresh",
+             "exited refresh: first",
+             "called close()",
+             "unpublished: first",
+             "CLOSED: null");
   }
 
-  private void waitForUnpublish() throws Exception {
-    assertTrue("timed out waiting for value to be unpublished",
-               unpublished.tryAcquire(1, TimeUnit.SECONDS));
+  private void expectUnpublish() throws Exception {
+    canUnpublish.release();
+    acquireOrLog(unpublished, "should have unpublished");
+  }
+
+  private void expectCloseEvent() throws Exception {
+    canFireCloseEvent.release();
+    acquireOrLog(closeEventReceived, "should have gotten close event");
+  }
+
+  private void acquireOrLog(Semaphore s, String error) {
+    try {
+      if (!s.tryAcquire(1, TimeUnit.SECONDS)) {
+        log(error);
+      }
+    } catch (InterruptedException e) {
+      log(error + " (interrupted)");
+    }
   }
 
   /**
@@ -270,10 +342,10 @@ public class RefreshableTest {
     final Semaphore start = new Semaphore(0);
     final Semaphore finish = new Semaphore(0);
     value.refresh(() -> {
-      log("entered refresh callback: " + newValue);
+      log("entered refresh");
       start.release();
       finish.acquire();
-      log("exited refresh callback: " + newValue);
+      log("exited refresh: " + newValue);
       return newValue;
     });
     start.acquire();


### PR DESCRIPTION
- change API to optionally pass a Request to the callback.
This provides access to the previous version and isCancelled() method.
- expose getState() with the current status: busy/idle/closed
- Fire events for state changes, not just value changes.

Avoid starting and immediately killing the daemon process due to another event arriving.
