### PR TITLE
Move device list tracking to a separate service

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -236,6 +236,8 @@
   <extensions defaultExtensionNs="com.intellij">
     <consoleInputFilterProvider implementation="io.flutter.run.daemon.DaemonJsonInputFilterProvider"/>?
     <postStartupActivity implementation="io.flutter.FlutterInitializer"/>
+    <projectService serviceInterface="io.flutter.run.daemon.DeviceService"
+                    serviceImplementation="io.flutter.run.daemon.DeviceService"/>
     <projectService serviceInterface="io.flutter.run.daemon.FlutterDaemonService"
                     serviceImplementation="io.flutter.run.daemon.FlutterDaemonService"/>
     <projectService serviceInterface="io.flutter.bazel.WorkspaceCache"

--- a/src/io/flutter/FlutterInitializer.java
+++ b/src/io/flutter/FlutterInitializer.java
@@ -17,6 +17,7 @@ import com.intellij.openapi.extensions.PluginId;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.startup.StartupActivity;
 import io.flutter.analytics.Analytics;
+import io.flutter.run.daemon.DeviceService;
 import io.flutter.run.daemon.FlutterDaemonService;
 import io.flutter.view.FlutterViewFactory;
 import org.jetbrains.annotations.NotNull;
@@ -88,7 +89,10 @@ public class FlutterInitializer implements StartupActivity {
 
   @Override
   public void runActivity(@NotNull Project project) {
-    // Initialize the daemon service (this starts a device watcher).
+    // Start watching for devices.
+    DeviceService.getInstance(project);
+
+    // Initialize the daemon service (for launching apps).
     FlutterDaemonService.getInstance(project);
 
     // Start watching for Flutter debug active events.

--- a/src/io/flutter/run/FlutterAppState.java
+++ b/src/io/flutter/run/FlutterAppState.java
@@ -26,10 +26,7 @@ import io.flutter.FlutterConstants;
 import io.flutter.actions.OpenObservatoryAction;
 import io.flutter.actions.OpenSimulatorAction;
 import io.flutter.console.FlutterConsoleFilter;
-import io.flutter.run.daemon.FlutterApp;
-import io.flutter.run.daemon.FlutterDaemonService;
-import io.flutter.run.daemon.FlutterDevice;
-import io.flutter.run.daemon.RunMode;
+import io.flutter.run.daemon.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -77,22 +74,14 @@ public class FlutterAppState extends FlutterAppStateBase {
    */
   @NotNull
   protected ProcessHandler startProcess() throws ExecutionException {
-    final FlutterDaemonService service = FlutterDaemonService.getInstance(getEnvironment().getProject());
 
     final Project project = getEnvironment().getProject();
     final String workingDir = project.getBasePath();
     assert workingDir != null;
 
-    FlutterDevice device = null;
-
-    // Only pass the current device in if we are showing the device selector.
-    if (service.isActive()) {
-      final Collection<FlutterDevice> devices = service.getConnectedDevices();
-      if (devices.isEmpty()) {
-        throw new ExecutionException("No connected device");
-      }
-      device = service.getSelectedDevice();
-    }
+    // The device will be null if we aren't showing the device selector.
+    final DeviceService devService = DeviceService.getInstance(getEnvironment().getProject());
+    final FlutterDevice device = devService.getSelectedDevice();
 
     final FlutterRunnerParameters parameters =
       ((FlutterRunConfigurationBase)getEnvironment().getRunProfile()).getRunnerParameters().clone();
@@ -117,6 +106,7 @@ public class FlutterAppState extends FlutterAppStateBase {
       }
     }
 
+    final FlutterDaemonService service = FlutterDaemonService.getInstance(getEnvironment().getProject());
     myApp = service.startApp(project, cwd, device == null ? null : device.deviceId(), myMode, relativePath);
     return myApp.getController().getProcessHandler();
   }

--- a/src/io/flutter/run/FlutterRunner.java
+++ b/src/io/flutter/run/FlutterRunner.java
@@ -32,8 +32,8 @@ import com.jetbrains.lang.dart.ide.runner.ObservatoryConnector;
 import com.jetbrains.lang.dart.sdk.DartSdk;
 import com.jetbrains.lang.dart.util.DartUrlResolver;
 import io.flutter.dart.DartPlugin;
+import io.flutter.run.daemon.DeviceService;
 import io.flutter.run.daemon.FlutterApp;
-import io.flutter.run.daemon.FlutterDaemonService;
 import io.flutter.sdk.FlutterSdk;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -67,9 +67,7 @@ public class FlutterRunner extends FlutterRunnerBase {
       return false;
     }
 
-    final FlutterDaemonService service = FlutterDaemonService.getInstance(project);
-    //noinspection SimplifiableIfStatement
-    if (!service.isActive() || !service.hasSelectedDevice()) {
+    if (DeviceService.getInstance(project).getSelectedDevice() == null) {
       return false;
     }
 

--- a/src/io/flutter/run/bazel/FlutterBazelAppState.java
+++ b/src/io/flutter/run/bazel/FlutterBazelAppState.java
@@ -13,6 +13,7 @@ import com.intellij.openapi.project.Project;
 import io.flutter.run.FlutterAppState;
 import io.flutter.run.FlutterRunConfigurationBase;
 import io.flutter.run.FlutterRunnerParameters;
+import io.flutter.run.daemon.DeviceService;
 import io.flutter.run.daemon.FlutterDaemonService;
 import io.flutter.run.daemon.FlutterDevice;
 import org.jetbrains.annotations.NotNull;
@@ -31,20 +32,12 @@ public class FlutterBazelAppState extends FlutterAppState {
 
   @NotNull
   protected ProcessHandler startProcess() throws ExecutionException {
-    final FlutterDaemonService service = FlutterDaemonService.getInstance(getEnvironment().getProject());
-
     final Project project = getEnvironment().getProject();
+
     final String workingDir = project.getBasePath();
     assert workingDir != null;
 
-    // Only pass the current device in if we are showing the device selector.
-    FlutterDevice device = null;
-    if (service.isActive()) {
-      final Collection<FlutterDevice> devices = service.getConnectedDevices();
-      if (!devices.isEmpty()) {
-        device = service.getSelectedDevice();
-      }
-    }
+    final FlutterDevice device = DeviceService.getInstance(project).getSelectedDevice();
 
     final FlutterRunnerParameters parameters =
       ((FlutterRunConfigurationBase)getEnvironment().getRunProfile()).getRunnerParameters().clone();
@@ -55,6 +48,7 @@ public class FlutterBazelAppState extends FlutterAppState {
     final String bazelTarget = parameters.getBazelTarget();
     assert bazelTarget != null;
 
+    final FlutterDaemonService service = FlutterDaemonService.getInstance(getEnvironment().getProject());
     myApp = service.startBazelApp(
       project,
       cwd,

--- a/src/io/flutter/run/daemon/DeviceSelection.java
+++ b/src/io/flutter/run/daemon/DeviceSelection.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright  2017 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.run.daemon;
+
+import com.google.common.collect.ImmutableList;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.*;
+
+/**
+ * An immutable snapshot of the list of connected devices and current selection.
+ */
+class DeviceSelection {
+  static final DeviceSelection EMPTY = new DeviceSelection(ImmutableList.of(), null);
+
+  private final ImmutableList<FlutterDevice> devices;
+  private final @Nullable FlutterDevice selection;
+
+  private DeviceSelection(ImmutableList<FlutterDevice> devices, @Nullable FlutterDevice selected) {
+    this.devices = devices;
+    this.selection = selected;
+  }
+
+  @NotNull ImmutableList<FlutterDevice> getDevices() {
+    return devices;
+  }
+
+  @Nullable FlutterDevice getSelection() {
+    return selection;
+  }
+
+  /**
+   * Returns a new snapshot with the devices changed and the selection updated appropriately.
+   */
+  @NotNull DeviceSelection withDevices(@NotNull List<FlutterDevice> newDevices) {
+    final String selectedId = selection == null ? null : selection.deviceId();
+    final Optional<FlutterDevice> selectedDevice = findById(newDevices, selectedId);
+    // If there is only one device, default to it.
+    final FlutterDevice selectionOrDefault = selectedDevice.orElse(newDevices.size() == 1 ? newDevices.get(0) : null);
+    return new DeviceSelection(ImmutableList.copyOf(newDevices), selectionOrDefault);
+  }
+
+  /**
+   * Returns a new snapshot with the given device id selected, if possible.
+   */
+  @NotNull DeviceSelection withSelection(@Nullable String id) {
+    return new DeviceSelection(devices, findById(devices, id).orElse(selection));
+  }
+
+  private static Optional<FlutterDevice> findById(@NotNull List<FlutterDevice> candidates, @Nullable String id) {
+    if (id == null) return Optional.empty();
+    return candidates.stream().filter((d) -> d.deviceId().equals(id)).findFirst();
+  }
+}

--- a/src/io/flutter/run/daemon/DeviceSelection.java
+++ b/src/io/flutter/run/daemon/DeviceSelection.java
@@ -17,10 +17,10 @@ import java.util.*;
 class DeviceSelection {
   static final DeviceSelection EMPTY = new DeviceSelection(ImmutableList.of(), null);
 
-  private final ImmutableList<FlutterDevice> devices;
+  private final @NotNull ImmutableList<FlutterDevice> devices;
   private final @Nullable FlutterDevice selection;
 
-  private DeviceSelection(ImmutableList<FlutterDevice> devices, @Nullable FlutterDevice selected) {
+  private DeviceSelection(@NotNull ImmutableList<FlutterDevice> devices, @Nullable FlutterDevice selected) {
     this.devices = devices;
     this.selection = selected;
   }

--- a/src/io/flutter/run/daemon/DeviceService.java
+++ b/src/io/flutter/run/daemon/DeviceService.java
@@ -142,6 +142,7 @@ public class DeviceService {
    * <p>This might mean starting it, stopping it, or restarting it.
    */
   private void refreshDeviceDaemon() {
+    if (project.isDisposed()) return;
     deviceDaemon.refresh(this::chooseNextDaemon);
   }
 

--- a/src/io/flutter/run/daemon/DeviceService.java
+++ b/src/io/flutter/run/daemon/DeviceService.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright  2017 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.run.daemon;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.intellij.execution.ExecutionException;
+import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Disposer;
+import io.flutter.bazel.WorkspaceCache;
+import io.flutter.sdk.FlutterSdkManager;
+import io.flutter.utils.Refreshable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Provides the list of available devices (mobile phones or emulators) that appears in the dropdown menu.
+ */
+public class DeviceService {
+  private final Project project;
+
+  /**
+   * The process used to watch for device list changes (for the device menu). May be null if not running.
+   */
+  private final Refreshable<DeviceDaemon> deviceDaemon = new Refreshable<>(DeviceDaemon::shutdown);
+
+  private final AtomicReference<DeviceSelection> deviceSelection = new AtomicReference<>(DeviceSelection.EMPTY);
+
+  private final AtomicReference<ImmutableSet<Runnable>> listeners = new AtomicReference<>(ImmutableSet.of());
+
+  public static @NotNull DeviceService getInstance(@NotNull Project project) {
+    return ServiceManager.getService(project, DeviceService.class);
+  }
+
+  private DeviceService(Project project) {
+    this.project = project;
+
+    deviceDaemon.setDisposeParent(project);
+    deviceDaemon.subscribe(this::refreshDeviceSelection);
+    refreshDeviceDaemon();
+
+    // Watch for Flutter SDK changes.
+    final FlutterSdkManager.Listener sdkListener = new FlutterSdkManager.Listener() {
+      @Override
+      public void flutterSdkAdded() {
+        refreshDeviceDaemon();
+      }
+
+      @Override
+      public void flutterSdkRemoved() {
+        refreshDeviceDaemon();
+      }
+    };
+    FlutterSdkManager.getInstance().addListener(sdkListener);
+    Disposer.register(project, () -> FlutterSdkManager.getInstance().removeListener(sdkListener));
+
+    // Watch for Bazel workspace changes.
+    WorkspaceCache.getInstance(project).subscribe(this::refreshDeviceDaemon);
+  }
+
+  /**
+   * Adds a callback for any changes to the status, device list, or selection.
+   */
+  public void addListener(@NotNull Runnable callback) {
+    listeners.updateAndGet((old) -> {
+      final List<Runnable> changed = new ArrayList<>();
+      changed.addAll(old);
+      changed.add(callback);
+      return ImmutableSet.copyOf(changed);
+    });
+  }
+
+  /**
+   * Returns whether the device list is inactive, loading, or ready.
+   */
+  public State getStatus() {
+    final DeviceDaemon daemon = deviceDaemon.getNow();
+    if (daemon != null && daemon.isRunning()) {
+      return State.READY;
+    } else if (deviceDaemon.getState() == Refreshable.State.BUSY) {
+      return State.LOADING;
+    } else {
+      return State.INACTIVE;
+    }
+  }
+
+  /**
+   * Returns the currently connected devices, sorted by device name.
+   */
+  public Collection<FlutterDevice> getConnectedDevices() {
+    return deviceSelection.get().getDevices();
+  }
+
+  /**
+   * Returns the currently selected device.
+   *
+   * <p>When there is no device list (perhaps because the daemon isn't running), this will be null.
+   */
+  public @Nullable FlutterDevice getSelectedDevice() {
+    return deviceSelection.get().getSelection();
+  }
+
+  public void setSelectedDevice(@Nullable FlutterDevice device) {
+    deviceSelection.updateAndGet((old) -> old.withSelection(device == null ? null : device.deviceId()));
+    fireChangeEvent();
+  }
+
+  private synchronized void refreshDeviceSelection() {
+    deviceSelection.updateAndGet((old) -> {
+      final DeviceDaemon daemon = deviceDaemon.getNow();
+      final List<FlutterDevice> newDevices = daemon == null ? ImmutableList.of() : daemon.getDevices();
+      return old.withDevices(newDevices);
+    });
+    fireChangeEvent();
+  }
+
+  private void fireChangeEvent() {
+    SwingUtilities.invokeLater(() -> {
+      if (project.isDisposed()) return;
+      for (Runnable listener : listeners.get()) {
+        try {
+          listener.run();
+        } catch (Exception e) {
+          LOG.error("DeviceDaemon listerner threw an exception", e);
+        }
+      }
+    });
+  }
+
+  /**
+   * Updates the device daemon to what it should be based on current configuation.
+   *
+   * <p>This might mean starting it, stopping it, or restarting it.
+   */
+  private void refreshDeviceDaemon() {
+    deviceDaemon.refresh(this::chooseNextDaemon);
+  }
+
+  /**
+   * Returns the device daemon that should be running.
+   *
+   * <p>Starts it if needed. If null is returned then the previous daemon will be shut down.
+   */
+  private DeviceDaemon chooseNextDaemon(Refreshable.Request<DeviceDaemon> request) {
+    final DeviceDaemon.Command nextCommand = DeviceDaemon.chooseCommand(project);
+    if (nextCommand == null) {
+      return null; // Unconfigured; shut down if running.
+    }
+
+    final DeviceDaemon previous = request.getPrevious();
+    if (previous != null && !previous.needRestart(nextCommand)) {
+      return previous; // Don't do anything; current daemon is what we want.
+    }
+
+    // Wait a bit to see if we get cancelled.
+    // This is to try to avoid starting a process only to immediately kill it.
+    try {
+      Thread.sleep(50);
+    } catch (InterruptedException e) {
+      return previous;
+    }
+    if (request.isCancelled()) {
+      return previous;
+    }
+
+    try {
+      return nextCommand.start(request::isCancelled, this::refreshDeviceSelection);
+    }
+    catch (ExecutionException e) {
+      LOG.error("Unable to start process to watch Flutter devices", e);
+      return previous; // Couldn't start a new one so don't shut it down.
+    }
+  }
+
+  public enum State { INACTIVE, LOADING, READY }
+
+  private static final Logger LOG = Logger.getInstance(DeviceService.class.getName());
+}

--- a/src/io/flutter/run/daemon/FlutterDaemonController.java
+++ b/src/io/flutter/run/daemon/FlutterDaemonController.java
@@ -46,8 +46,6 @@ public class FlutterDaemonController extends ProcessAdapter {
   private final FlutterDaemonControllerHelper myControllerHelper;
   private final List<DaemonListener> myListeners = Collections.synchronizedList(new ArrayList<>());
   private ProcessHandler myProcessHandler;
-  private boolean myIsPollingController = false;
-  private boolean myIsPollingStarted = false;
 
   public FlutterDaemonController(@NotNull FlutterDaemonService service) {
     myService = service;
@@ -97,11 +95,6 @@ public class FlutterDaemonController extends ProcessAdapter {
       myProcessHandler.destroyProcess();
     }
     myProcessHandler = null;
-  }
-
-  void startDevicePoller(GeneralCommandLine command) throws ExecutionException {
-    myIsPollingController = true;
-    startProcess(command);
   }
 
   public FlutterApp startRunnerProcess(@NotNull Project project,
@@ -195,14 +188,6 @@ public class FlutterDaemonController extends ProcessAdapter {
         text = text.substring(1, text.length() - 1);
         for (DaemonListener listener : myListeners) {
           listener.daemonInput(text, this);
-        }
-      }
-
-      if (myIsPollingController && !myIsPollingStarted) {
-        myIsPollingStarted = true;
-
-        for (DaemonListener listener : myListeners) {
-          myControllerHelper.enableDevicePolling();
         }
       }
     }

--- a/src/io/flutter/run/daemon/FlutterDaemonControllerHelper.java
+++ b/src/io/flutter/run/daemon/FlutterDaemonControllerHelper.java
@@ -229,11 +229,6 @@ class FlutterDaemonControllerHelper {
     }
   }
 
-  void enableDevicePolling() {
-    final Method method = makeMethod(CMD_DEVICE_ENABLE, null);
-    sendCommand(method);
-  }
-
   void aboutToTerminateAll(FlutterDaemonController controller) {
     final List<FlutterApp> apps;
     synchronized (myLock) {
@@ -299,10 +294,6 @@ class FlutterDaemonControllerHelper {
   @Nullable
   private Event eventHandler(@NotNull String eventName, @Nullable String json) {
     switch (eventName) {
-      case "device.added":
-        return new DeviceAddedEvent();
-      case "device.removed":
-        return new DeviceRemovedEvent();
       case "app.start":
         return new AppStartEvent();
       case "app.started":
@@ -369,22 +360,6 @@ class FlutterDaemonControllerHelper {
 
       if (message.progressId != null && message.progressId.startsWith("hot.")) {
         myProgressStopWatch = Stopwatch.createStarted();
-      }
-    }
-  }
-
-  private void eventDeviceAdded(@NotNull DeviceAddedEvent added, @NotNull FlutterDaemonController controller) {
-    synchronized (myLock) {
-      myController.getService().addConnectedDevice(new FlutterDevice(added.name, added.id, added.platform, added.emulator));
-    }
-  }
-
-  private void eventDeviceRemoved(@NotNull DeviceRemovedEvent removed, @NotNull FlutterDaemonController controller) {
-    synchronized (myLock) {
-      for (FlutterDevice candidate : myController.getService().getConnectedDevices()) {
-        if (candidate.deviceId().equals(removed.id)) {
-          myController.getService().removeConnectedDevice(candidate);
-        }
       }
     }
   }
@@ -640,32 +615,6 @@ class FlutterDaemonControllerHelper {
 
     void process(FlutterDaemonControllerHelper manager, FlutterDaemonController controller) {
       manager.eventProgressMessage(this);
-    }
-  }
-
-  @SuppressWarnings("CanBeFinal")
-  private static class DeviceAddedEvent extends Event {
-    // "event":"device.added"
-    @SuppressWarnings("unused") private String id;
-    @SuppressWarnings("unused") private String name;
-    @SuppressWarnings("unused") private String platform;
-    @SuppressWarnings("unused") private boolean emulator;
-
-    void process(FlutterDaemonControllerHelper manager, FlutterDaemonController controller) {
-      manager.eventDeviceAdded(this, controller);
-    }
-  }
-
-  @SuppressWarnings("CanBeFinal")
-  private static class DeviceRemovedEvent extends Event {
-    // "event":"device.removed"
-    @SuppressWarnings("unused") private String id;
-    @SuppressWarnings("unused") private String name;
-    @SuppressWarnings("unused") private String platform;
-    @SuppressWarnings("unused") private boolean emulator;
-
-    void process(FlutterDaemonControllerHelper manager, FlutterDaemonController controller) {
-      manager.eventDeviceRemoved(this, controller);
     }
   }
 

--- a/src/io/flutter/sdk/FlutterSdkManager.java
+++ b/src/io/flutter/sdk/FlutterSdkManager.java
@@ -100,12 +100,12 @@ public class FlutterSdkManager {
     /**
      * Fired when the Flutter global library is set.
      */
-    void flutterSdkAdded();
+    default void flutterSdkAdded() {}
 
     /**
      * Fired when the Flutter global library is removed.
      */
-    void flutterSdkRemoved();
+    default void flutterSdkRemoved() {}
   }
 
   // Listens for changes in Flutter Library configuration state in the Library table.


### PR DESCRIPTION
Keeps track of the device list in the DeviceDaemon class. This
avoids a possible bug due to lost events when the process
restarts.

Simpified event handling when updating the device list UI. The
same code gets executed regardless of what changed.