### PR TITLE
device list visibility fixes for Bazel

### DIFF
--- a/src/io/flutter/bazel/Workspace.java
+++ b/src/io/flutter/bazel/Workspace.java
@@ -11,6 +11,7 @@ import com.google.common.collect.ImmutableSet;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ModuleRootManager;
 import com.intellij.openapi.roots.ProjectRootManager;
@@ -37,6 +38,16 @@ public class Workspace {
   private Workspace(@NotNull VirtualFile root, @Nullable PluginConfig config) {
     this.root = root;
     this.config = config;
+  }
+
+  /**
+   * Returns true for a project that uses Flutter code within this workspace.
+   */
+  public boolean usesFlutter(Project project) {
+    for (Module module : ModuleManager.getInstance(project).getModules()) {
+      if (usesFlutter(module)) return true;
+    }
+    return false;
   }
 
   /**


### PR DESCRIPTION
For Bazel, only show the device list when we are in a Flutter project (according to the Workspace).

If the Bazel repo has a script to start the device daemon, prefer that, but fall back to the Flutter SDK if configured.

Fixes a bug where the device menu would not show up because the user configured a Flutter SDK (for open source work) but forgot they did that. The device list should still appear.

Also, log when the device daemon starts and stops (at INFO level).
