### PR TITLE
Populate work dir and launch script in new Bazel run configs

### DIFF
--- a/src/io/flutter/bazel/PluginConfig.java
+++ b/src/io/flutter/bazel/PluginConfig.java
@@ -57,6 +57,10 @@ public class PluginConfig {
     return fields.daemonScript;
   }
 
+  public @Nullable String getLaunchScript() {
+    return fields.launchScript;
+  }
+
   @Override
   public boolean equals(Object obj) {
     if (!(obj instanceof PluginConfig)) return false;
@@ -109,21 +113,26 @@ public class PluginConfig {
   /**
    * The JSON fields in a PluginConfig, as loaded from disk.
    */
+  @SuppressWarnings("unused")
   private static class Fields {
     /**
      * A list of regular expressions that match workspace-relative paths that contain flutter apps.
      * (Used to decide whether to show the device menu.)
      */
     @SerializedName("directoryPatterns")
-    @SuppressWarnings("unused")
     private List<String> directoryPatterns;
 
     /**
      * The script to run to start 'flutter daemon'.
      */
     @SerializedName("daemonScript")
-    @SuppressWarnings("unused")
     private String daemonScript;
+
+    /**
+     *
+     */
+    @SerializedName("launchScript")
+    private String launchScript;
 
     Fields() {}
 
@@ -132,12 +141,13 @@ public class PluginConfig {
       if (!(obj instanceof Fields)) return false;
       final Fields other = (Fields)obj;
       return Objects.equal(directoryPatterns, other.directoryPatterns)
-             && Objects.equal(daemonScript, other.daemonScript);
+             && Objects.equal(daemonScript, other.daemonScript)
+             && Objects.equal(launchScript, other.launchScript);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hashCode(directoryPatterns, daemonScript);
+      return Objects.hashCode(directoryPatterns, daemonScript, launchScript);
     }
   }
 

--- a/src/io/flutter/bazel/Workspace.java
+++ b/src/io/flutter/bazel/Workspace.java
@@ -132,6 +132,13 @@ public class Workspace {
   }
 
   /**
+   * Returns the script that runs the bazel target for a Flutter app, or null if not configured.
+   */
+  public @Nullable String getLaunchScript() {
+    return (config == null) ? null : config.getLaunchScript();
+  }
+
+  /**
    * Returns the flutter plugin configuration or null if not available.
    */
   public @Nullable PluginConfig getPluginConfig() {

--- a/src/io/flutter/run/SdkRunConfig.java
+++ b/src/io/flutter/run/SdkRunConfig.java
@@ -42,7 +42,7 @@ public class SdkRunConfig extends LocatableConfigurationBase
   implements Launcher.RunConfig, RefactoringListenerProvider, RunConfigurationWithSuppressedDefaultRunAction {
   private @NotNull SdkFields fields = new SdkFields();
 
-  public SdkRunConfig(final @NotNull Project project, final @NotNull ConfigurationFactory factory, final @NotNull String name) {
+  SdkRunConfig(final @NotNull Project project, final @NotNull ConfigurationFactory factory, final @NotNull String name) {
     super(project, factory, name);
   }
 

--- a/src/io/flutter/run/bazel/BazelRunConfig.java
+++ b/src/io/flutter/run/bazel/BazelRunConfig.java
@@ -84,9 +84,9 @@ public class BazelRunConfig extends RunConfigurationBase
     return clone;
   }
 
-  RunConfiguration copyTemplateToNonTemplate() {
+  RunConfiguration copyTemplateToNonTemplate(String name) {
     final BazelRunConfig copy = (BazelRunConfig)super.clone();
-    copy.setName(getProject().getName());
+    copy.setName(name);
     copy.fields = fields.copyTemplateToNonTemplate(getProject());
     return copy;
   }

--- a/src/io/flutter/run/bazel/BazelRunConfig.java
+++ b/src/io/flutter/run/bazel/BazelRunConfig.java
@@ -27,7 +27,7 @@ public class BazelRunConfig extends RunConfigurationBase
   implements RunConfigurationWithSuppressedDefaultRunAction, Launcher.RunConfig {
   private @NotNull BazelFields fields = new BazelFields();
 
-  public BazelRunConfig(final @NotNull Project project, final @NotNull ConfigurationFactory factory, @NotNull final String name) {
+  BazelRunConfig(final @NotNull Project project, final @NotNull ConfigurationFactory factory, @NotNull final String name) {
     super(project, factory, name);
   }
 
@@ -82,6 +82,13 @@ public class BazelRunConfig extends RunConfigurationBase
     final BazelRunConfig clone = (BazelRunConfig)super.clone();
     clone.fields = fields.copy();
     return clone;
+  }
+
+  RunConfiguration copyTemplateToNonTemplate() {
+    final BazelRunConfig copy = (BazelRunConfig)super.clone();
+    copy.setName(getProject().getName());
+    copy.fields = fields.copyTemplateToNonTemplate(getProject());
+    return copy;
   }
 
   @Override

--- a/src/io/flutter/run/bazel/FlutterBazelRunConfigurationType.java
+++ b/src/io/flutter/run/bazel/FlutterBazelRunConfigurationType.java
@@ -5,6 +5,7 @@
  */
 package io.flutter.run.bazel;
 
+import com.intellij.execution.ExecutionBundle;
 import com.intellij.execution.configurations.ConfigurationFactory;
 import com.intellij.execution.configurations.ConfigurationTypeBase;
 import com.intellij.execution.configurations.RunConfiguration;
@@ -45,12 +46,22 @@ public class FlutterBazelRunConfigurationType extends ConfigurationTypeBase {
       //   - whenever the run configuration editor is open (for creating snapshots).
       // In the first case, we want to override the defaults from the template.
       // In the second case, don't change anything.
-      //   (But the name doesn't matter; it will immediately be overwritten.)
-      if ((name.equals("Unnamed") || name.startsWith("Unnamed (")) && template instanceof BazelRunConfig) {
-        return ((BazelRunConfig)template).copyTemplateToNonTemplate();
+      if (isNewlyGeneratedName(name) && template instanceof BazelRunConfig) {
+        // TODO(skybrian) is this really a good name for a new run config? Not sure why we override this.
+        // Note that if the user creates more than one run config, they will need to rename it manually.
+        name = template.getProject().getName();
+        return ((BazelRunConfig)template).copyTemplateToNonTemplate(name);
       } else {
         return super.createConfiguration(name, template);
       }
+    }
+
+    private boolean isNewlyGeneratedName(String name) {
+      // Try to determine if this we are creating a non-template configuration from a template.
+      // This is a hack based on what the code does in RunConfigurable.createUniqueName().
+      // If it fails to match, the new run config still works, just without any defaults set.
+      final String baseName = ExecutionBundle.message("run.configuration.unnamed.name.prefix");
+      return name.equals(baseName) || name.startsWith(baseName + " (");
     }
 
     @Override


### PR DESCRIPTION
* Uses the workspace root as the work dir by default.
* Gets the launch script from flutter.json
* Sets the fields only if the corresponding template field is blank.

Partial fix for #643 
(Doesn't try to calculate the target, which seems harder.)