### PR TITLE
Fix race condition when there is a breakpoint in main

### DIFF
--- a/src/io/flutter/run/daemon/FlutterApp.java
+++ b/src/io/flutter/run/daemon/FlutterApp.java
@@ -53,6 +53,8 @@ public class FlutterApp {
     myConnector = new ObservatoryConnector() {
       @Override
       public @Nullable String getWebSocketUrl() {
+        // Don't try to use observatory until the flutter command is done starting up.
+        if (getState() != State.STARTED) return null;
         return myWsUrl;
       }
 
@@ -111,7 +113,6 @@ public class FlutterApp {
   void setAppId(@NotNull String id) {
     myAppId = id;
   }
-
 
   void setWsUrl(@NotNull String url) {
     myWsUrl = url;


### PR DESCRIPTION
We should not set any breakpoints until receiving the app.started
event from the flutter command, because until then, the flutter
command is still using Observatory.

To be safe, don't tell the debugger the Observatory URL until then.

Possibly related to #784 (found while attempting to reproduce it)
but the symptoms are different.
