### PR TITLE
add dart plugin version info to our error report

### DIFF
--- a/src/io/flutter/FlutterErrorReportSubmitter.java
+++ b/src/io/flutter/FlutterErrorReportSubmitter.java
@@ -13,7 +13,7 @@ import com.intellij.ide.scratch.ScratchRootType;
 import com.intellij.lang.Language;
 import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.actionSystem.PlatformDataKeys;
-import com.intellij.openapi.application.ApplicationNamesInfo;
+import com.intellij.openapi.application.ApplicationInfo;
 import com.intellij.openapi.diagnostic.ErrorReportSubmitter;
 import com.intellij.openapi.diagnostic.IdeaLoggingEvent;
 import com.intellij.openapi.diagnostic.Logger;
@@ -83,11 +83,22 @@ public class FlutterErrorReportSubmitter extends ErrorReportSubmitter {
 
     builder.append("## Version information\n");
     builder.append("\n");
-    final IdeaPluginDescriptor descriptor = PluginManager.getPlugin(PluginId.getId("io.flutter"));
+
+    // IntelliJ version
+    final ApplicationInfo info = ApplicationInfo.getInstance();
+    builder.append(info.getVersionName()).append(" `").append(info.getFullVersion()).append("`");
+
+    final IdeaPluginDescriptor flutterPlugin = PluginManager.getPlugin(PluginId.getId("io.flutter"));
     //noinspection ConstantConditions
-    builder.append("Flutter plugin `").append(descriptor.getVersion()).append("` • ");
-    builder.append(ApplicationNamesInfo.getInstance().getFullProductName()).append("\n");
-    builder.append("\n");
+    builder.append(" • Flutter plugin `").append(flutterPlugin.getVersion()).append("`");
+
+    final IdeaPluginDescriptor dartPlugin = PluginManager.getPlugin(PluginId.getId("Dart"));
+    if (dartPlugin != null) {
+      //noinspection ConstantConditions
+      builder.append(" • Dart plugin `").append(dartPlugin.getVersion()).append("`");
+    }
+    builder.append("\n\n");
+
     final FlutterSdk sdk = FlutterSdk.getFlutterSdk(project);
     if (sdk == null) {
       builder.append("No Flutter sdk configured.\n");


### PR DESCRIPTION
Add a bit more info to our error reports:

```
IntelliJ IDEA `2016.3.5` • Flutter plugin `0.1.11.1` • Dart plugin `163.13137`
```

(previous format seen here: https://github.com/flutter/flutter-intellij/issues/802)

@pq @skybrian 