### PR TITLE
Fix miscellaneous minor bugs related to debugging

### DIFF
--- a/.idea/runConfigurations/Flutter_Plugin.xml
+++ b/.idea/runConfigurations/Flutter_Plugin.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Flutter Plugin" type="#org.jetbrains.idea.devkit.run.PluginConfigurationType" factoryName="Plugin">
     <module name="flutter-intellij" />
-    <option name="VM_PARAMETERS" value="-Xmx512m -Xms256m -XX:MaxPermSize=250m -ea" />
+    <option name="VM_PARAMETERS" value="-Xmx512m -Xms256m -XX:MaxPermSize=250m -ea -Didea.fatal.error.notification=enabled" />
     <option name="PROGRAM_PARAMETERS" value="" />
     <predefined_log_file id="idea.log" enabled="true" />
     <method />

--- a/src/io/flutter/run/FlutterDebugProcess.java
+++ b/src/io/flutter/run/FlutterDebugProcess.java
@@ -46,7 +46,7 @@ public class FlutterDebugProcess extends DartVmServiceDebugProcessZ {
 
   public FlutterDebugProcess(@NotNull FlutterApp app,
                              @NotNull XDebugSession session,
-                             @Nullable ExecutionResult executionResult,
+                             @NotNull ExecutionResult executionResult,
                              @NotNull DartUrlResolver dartUrlResolver,
                              @Nullable String dasExecutionContextId,
                              @Nullable VirtualFile currentWorkingDirectory) {


### PR DESCRIPTION
FlutterApp:
- fix a hang when stopping the Flutter process. (It could hang for 10 seconds waiting for
the process to terminate when it has already terminated.)

Launcher:
- extract code to get analysis server execution id. Log a warning if it's not available.
- don't try to get an execution id when not debugging.

DartVmServiceDebugProcessZ:
- suppress assert error logged in DartVmServiceDebugProcess constructor if analysis server
  execution id isn't available. (Always pass in an execution id to fake it out.)
- remove overrides that are called in the superclass's constructor when subclass variables
aren't initialized yet.
- add comments