### PR TITLE
Add some Flutter templates to create widgets

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -255,6 +255,9 @@
     <configurationType implementation="io.flutter.run.bazel.FlutterBazelRunConfigurationType"/>
     <programRunner implementation="io.flutter.run.bazel.BazelRunner"/>
 
+    <defaultLiveTemplatesProvider implementation="io.flutter.template.FlutterLiveTemplatesProvider"/>
+    <liveTemplateContext implementation="io.flutter.template.DartToplevelTemplateContextType"/>
+
     <!-- IDEA only -->
     <moduleType id="FLUTTER_MODULE_TYPE" implementationClass="io.flutter.module.FlutterModuleType"/>
 

--- a/resources/liveTemplates/flutter_miscellaneous.xml
+++ b/resources/liveTemplates/flutter_miscellaneous.xml
@@ -1,0 +1,20 @@
+<templateSet group="Flutter">
+  <template name="stless" value="class $NAME$ extends StatelessWidget {&#10;  @override&#10;  Widget build(BuildContext context) {&#10;    return new Container($END$);&#10;  }&#10;}&#10;" description="New Stateless widget" toReformat="false" toShortenFQNames="true">
+    <variable name="NAME" expression="" defaultValue="" alwaysStopAt="true" />
+    <context>
+      <option name="DART_TOPLEVEL" value="true" />
+    </context>
+  </template>
+  <template name="stful" value="class $NAME$ extends StatefulWidget {&#10;  @override&#10;  _$NAME$State createState() =&gt; new _$NAME$State();&#10;}&#10;&#10;class _$NAME$State extends State&lt;$NAME$&gt; {&#10;  @override&#10;  Widget build(BuildContext context) {&#10;    return new Container($END$);&#10;  }&#10;}&#10;" description="New Stateful widget" toReformat="false" toShortenFQNames="true">
+    <variable name="NAME" expression="" defaultValue="" alwaysStopAt="true" />
+    <context>
+      <option name="DART_TOPLEVEL" value="true" />
+    </context>
+  </template>
+  <template name="stanim" value="class $NAME$ extends StatefulWidget {&#10;  @override&#10;  _$NAME$State createState() =&gt; new _$NAME$State();&#10;}&#10;&#10;class _$NAME$State extends State&lt;$NAME$&gt;&#10;    with SingleTickerProviderStateMixin {&#10;  AnimationController _controller;&#10;&#10;  @override&#10;  void initState() {&#10;    super.initState();&#10;    _controller = new AnimationController(vsync: this);&#10;  }&#10;&#10;  @override&#10;  void dispose() {&#10;    super.dispose();&#10;    _controller.dispose();&#10;  }&#10;&#10;  @override&#10;  Widget build(BuildContext context) {&#10;    return new Container($END$);&#10;  }&#10;}&#10;" description="New widget with AnimationController" toReformat="false" toShortenFQNames="true">
+    <variable name="NAME" expression="" defaultValue="" alwaysStopAt="true" />
+    <context>
+      <option name="DART_TOPLEVEL" value="true" />
+    </context>
+  </template>
+</templateSet>

--- a/src/io/flutter/template/DartToplevelTemplateContextType.java
+++ b/src/io/flutter/template/DartToplevelTemplateContextType.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.template;
+
+import com.intellij.psi.PsiComment;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.util.PsiTreeUtil;
+import com.jetbrains.lang.dart.ide.template.DartTemplateContextType;
+import com.jetbrains.lang.dart.psi.DartClassDefinition;
+import org.jetbrains.annotations.NotNull;
+
+public class DartToplevelTemplateContextType extends DartTemplateContextType {
+  public DartToplevelTemplateContextType() {
+    super("DART_TOPLEVEL", "Top-level", Generic.class);
+  }
+
+  @Override
+  protected boolean isInContext(@NotNull PsiElement element) {
+    //noinspection unchecked
+    return PsiTreeUtil.getNonStrictParentOfType(element, DartClassDefinition.class, PsiComment.class) == null;
+  }
+}

--- a/src/io/flutter/template/FlutterLiveTemplatesProvider.java
+++ b/src/io/flutter/template/FlutterLiveTemplatesProvider.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2017 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.template;
+
+import com.intellij.codeInsight.template.impl.DefaultLiveTemplatesProvider;
+import org.jetbrains.annotations.NonNls;
+
+public class FlutterLiveTemplatesProvider implements DefaultLiveTemplatesProvider {
+  private static final @NonNls String[] DEFAULT_TEMPLATES =
+    new String[]{"/liveTemplates/flutter_miscellaneous"};
+
+  public String[] getDefaultLiveTemplateFiles() {
+    return DEFAULT_TEMPLATES;
+  }
+
+  @Override
+  public String[] getHiddenLiveTemplateFiles() {
+    return null;
+  }
+}


### PR DESCRIPTION
@pq @devoncarew Define three live templates to generate boilerplate code for certain types of widgets as defined in #814.

I'm open to suggestions for different template names. I chose: stless, stful, stanim. Respectively, they generate new subclasses of StatelessWidget, StatefulWidget, and StatefulWidget with an animation controller.

To generate a new StatefulWidget, for example, you would type `stful` then `tab`, then type the name of the class once. That name will be inserted everywhere it needs to be, according to the boilerplate @HansMuller gave.

#814 should remain open because we still need to provide a mechanism to add (and remove?) various attributes of Flutter classes (like animation controllers).