### PR TITLE
show the flutter editor notification in small ides

### DIFF
--- a/resources/META-INF/idea-contribs.xml
+++ b/resources/META-INF/idea-contribs.xml
@@ -8,7 +8,6 @@
     <editorNotificationProvider implementation="io.flutter.inspections.IncompatibleDartPluginNotificationProvider"/>
     <editorNotificationProvider implementation="io.flutter.inspections.SdkConfigurationNotificationProvider"/>
     <editorNotificationProvider implementation="io.flutter.inspections.WrongModuleTypeNotificationProvider"/>
-    <editorNotificationProvider implementation="io.flutter.editor.FlutterPubspecNotificationProvider"/>
 
     <moduleConfigurationEditorProvider implementation="io.flutter.module.FlutterModuleConfigurationEditorProvider"/>
   </extensions>

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -303,6 +303,8 @@
     <localInspection bundle="io.flutter.FlutterBundle" key="outdated.dependencies.inspection.name"
                      groupName="Flutter" enabledByDefault="true" level="WARNING" language="Dart"
                      implementationClass="io.flutter.inspections.FlutterDependencyInspection"/>
+
+    <editorNotificationProvider implementation="io.flutter.editor.FlutterPubspecNotificationProvider"/>
   </extensions>
 
 </idea-plugin>

--- a/src/io/flutter/utils/FlutterModuleUtils.java
+++ b/src/io/flutter/utils/FlutterModuleUtils.java
@@ -52,7 +52,14 @@ public class FlutterModuleUtils {
   }
 
   public static boolean isFlutterModule(@Nullable Module module) {
-    return module != null && ModuleType.is(module, FlutterModuleType.getInstance());
+    // If not IntelliJ, assume a small IDE (no multi-module project support).
+    // Look for a module with a flutter-like file structure.
+    if (!PlatformUtils.isIntelliJ()) {
+      return module != null && FlutterModuleUtils.usesFlutter(module);
+    }
+    else {
+      return module != null && ModuleType.is(module, FlutterModuleType.getInstance());
+    }
   }
 
   public static boolean hasFlutterModule(@NotNull Project project) {


### PR DESCRIPTION
Fix an issue where the flutter pubspec.yaml editor notification would not show in small IDEs (note that this is not a recent regression).

@pq 

Phil, do you know why we only define `editorNotificationProvider`s in `idea-contribs.xml` and not the main `plugin.xml`?