### PR TITLE
enable Dart support when setting the sdk location

### DIFF
--- a/src/io/flutter/sdk/FlutterSdkUtil.java
+++ b/src/io/flutter/sdk/FlutterSdkUtil.java
@@ -9,6 +9,8 @@ import com.intellij.execution.ExecutionException;
 import com.intellij.ide.util.PropertiesComponent;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
 import com.intellij.openapi.util.Pair;
@@ -217,5 +219,17 @@ public class FlutterSdkUtil {
 
     // Fire events for a Flutter SDK change, which updates the UI.
     FlutterSdkManager.getInstance(project).checkForFlutterSdkChange();
+  }
+
+  // TODO(devoncarew): The Dart plugin supports specifying individual modules in the settings page.
+
+  /**
+   * Do a best-effort basis to enable Dart support for the given project.
+   */
+  public static void enableDartSdk(@NotNull final Project project) {
+    final Module[] modules = ModuleManager.getInstance(project).getModules();
+    if (modules.length == 1) {
+      DartPlugin.enableDartSdk(modules[0]);
+    }
   }
 }

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.java
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.java
@@ -29,6 +29,7 @@ import com.intellij.ui.components.labels.LinkLabel;
 import io.flutter.FlutterBundle;
 import io.flutter.FlutterConstants;
 import io.flutter.FlutterInitializer;
+import io.flutter.dart.DartPlugin;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -134,7 +135,10 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
 
     final String sdkHomePath = getSdkPathText();
     if (FlutterSdkUtil.isFlutterSdkHome(sdkHomePath)) {
-      ApplicationManager.getApplication().runWriteAction(() -> FlutterSdkUtil.setFlutterSdkPath(myProject, sdkHomePath));
+      ApplicationManager.getApplication().runWriteAction(() -> {
+        FlutterSdkUtil.setFlutterSdkPath(myProject, sdkHomePath);
+        FlutterSdkUtil.enableDartSdk(myProject);
+      });
     }
 
     FlutterInitializer.setCanReportAnalaytics(myReportUsageInformationCheckBox.isSelected());


### PR DESCRIPTION
- enable Dart support when setting the sdk location

This will prevent the issue where users can see and set the sdk in the Flutter settings page, but the value doesn't persist (when they re-open the settings page, the sdk location isn't persisted and the project didn't have Dart enabled).

@skybrian (/cc @pq)
