### PR TITLE
Bazel: load plugin config and daemon script from READONLY directory

### DIFF
--- a/src/io/flutter/bazel/PluginConfig.java
+++ b/src/io/flutter/bazel/PluginConfig.java
@@ -27,7 +27,7 @@ import java.util.regex.PatternSyntaxException;
 /**
  * An in-memory snapshot of the flutter.json file from a Bazel workspace.
  */
-public class PluginConfig {
+class PluginConfig {
   private final @NotNull Fields fields;
   private final @Nullable List<Pattern> directoryPatterns;
 
@@ -41,7 +41,7 @@ public class PluginConfig {
    *
    * <p>The path should be relative to the workspace root.
    */
-  public boolean withinFlutterDirectory(@NotNull String path) {
+  boolean withinFlutterDirectory(@NotNull String path) {
     if (directoryPatterns == null) {
       // Default if unconfigured.
       return path.contains("flutter");
@@ -53,11 +53,11 @@ public class PluginConfig {
     return false;
   }
 
-  public @Nullable String getDaemonScript() {
+  @Nullable String getDaemonScript() {
     return fields.daemonScript;
   }
 
-  public @Nullable String getLaunchScript() {
+  @Nullable String getLaunchScript() {
     return fields.launchScript;
   }
 

--- a/testSrc/unit/io/flutter/bazel/WorkspaceCacheTest.java
+++ b/testSrc/unit/io/flutter/bazel/WorkspaceCacheTest.java
@@ -17,6 +17,7 @@ import org.junit.Test;
 
 import static junit.framework.TestCase.assertNull;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 
 public class WorkspaceCacheTest {
@@ -51,14 +52,16 @@ public class WorkspaceCacheTest {
 
     final String configPath = "abc/dart/config/intellij-plugins/flutter.json";
 
-    tmp.writeFile(configPath, "{\"daemonScript\": \"first\"}");
-    checkConfigSetting("first");
+    tmp.writeFile(configPath, "{\"daemonScript\": \"first.sh\"}");
+    tmp.writeFile("abc/first.sh", "");
+    checkConfigSetting("first.sh");
 
     tmp.writeFile(configPath, "{}");
     checkConfigSetting(null);
 
-    tmp.writeFile(configPath, "{\"daemonScript\": \"second\"}");
-    checkConfigSetting("second");
+    tmp.writeFile(configPath, "{\"daemonScript\": \"second.sh\"}");
+    tmp.writeFile("abc/second.sh", "");
+    checkConfigSetting("second.sh");
 
     tmp.deleteFile(configPath);
     checkNoConfig();
@@ -90,15 +93,12 @@ public class WorkspaceCacheTest {
   private void checkNoConfig() {
     final Workspace w = cache.getWhenReady();
     assertNotNull("expected a workspace but it doesn't exist", w);
-    assertNull("workspace has unexpected plugin config", w.getPluginConfig());
+    assertFalse("workspace has unexpected plugin config", w.hasPluginConfig());
   }
 
   private void checkConfigSetting(String expected) {
     final Workspace w = cache.getWhenReady();
     assertNotNull("expected a workspace but it doesn't exist", w);
-
-    final PluginConfig c = w.getPluginConfig();
-    assertNotNull("config file is missing", c);
-    assertEquals(expected, c.getDaemonScript());
+    assertEquals(expected, w.getDaemonScript());
   }
 }


### PR DESCRIPTION
This handles the case where dart/config/intellij-plugins is not checked out, or the directory containing the daemon script isn't checked out.

Fixes #791