### PR TITLE
some 2016.3 cleanup and remove obsolete todos

### DIFF
--- a/src/io/flutter/actions/ReloadFlutterApp.java
+++ b/src/io/flutter/actions/ReloadFlutterApp.java
@@ -9,13 +9,11 @@ import com.intellij.openapi.actionSystem.ActionManager;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.util.Computable;
-import com.jetbrains.lang.dart.ide.runner.ObservatoryConnector;
+import com.jetbrains.lang.dart.DartPluginCapabilities;
 import icons.FlutterIcons;
 import io.flutter.FlutterBundle;
 import io.flutter.FlutterInitializer;
 import io.flutter.run.daemon.FlutterApp;
-
-import java.lang.reflect.Method;
 
 @SuppressWarnings("ComponentNotRegistered")
 public class ReloadFlutterApp extends FlutterAppAction {
@@ -41,16 +39,6 @@ public class ReloadFlutterApp extends FlutterAppAction {
   }
 
   private static boolean hasCapability(@SuppressWarnings("SameParameterValue") String featureId) {
-    // return DartPluginCapabilities.isSupported(featureId);
-
-    try {
-      final Class clazz = Class.forName("com.jetbrains.lang.dart.DartPluginCapabilities");
-      @SuppressWarnings("unchecked") final Method method = clazz.getMethod("isSupported", String.class);
-      final Object result = method.invoke(null, featureId);
-      return result instanceof Boolean && (Boolean)result;
-    }
-    catch (Throwable t) {
-      return false;
-    }
+    return DartPluginCapabilities.isSupported(featureId);
   }
 }

--- a/src/io/flutter/dart/DartPlugin.java
+++ b/src/io/flutter/dart/DartPlugin.java
@@ -71,13 +71,7 @@ public class DartPlugin {
   }
 
   public static void setPubActionInProgress(boolean inProgress) {
-    // TODO: replace w/ DartPubActionBase.setIsInProgress() when DartPlugin lower-bound is upped to 163.10154.
-    try {
-      DartPubActionBase.class.getMethod("setIsInProgress", boolean.class).invoke(null, inProgress);
-    }
-    catch (Throwable th) {
-      // ignore and move on
-    }
+    DartPubActionBase.setIsInProgress(inProgress);
   }
 
   public static boolean isDartRunConfiguration(ConfigurationType type) {

--- a/src/io/flutter/module/FlutterGeneratorPeer.java
+++ b/src/io/flutter/module/FlutterGeneratorPeer.java
@@ -40,7 +40,7 @@ public class FlutterGeneratorPeer {
     errorIcon.setIcon(AllIcons.Actions.Lightning);
     Messages.installHyperlinkSupport(errorText);
 
-    // Hide pending real content -- TODO: #83.
+    // Hide pending real content.
     myVersionLabel.setVisible(false);
     myVersionContent.setVisible(false);
 

--- a/src/io/flutter/module/FlutterModuleBuilder.java
+++ b/src/io/flutter/module/FlutterModuleBuilder.java
@@ -109,7 +109,6 @@ public class FlutterModuleBuilder extends ModuleBuilder {
 
   public static void setupProject(@NotNull Project project, ModifiableRootModel model, VirtualFile baseDir, String flutterSdkPath)
     throws ConfigurationException {
-    // TODO(devoncarew): Store the flutterSdkPath info (in the project? module?).
     final FlutterSdk sdk = FlutterSdk.forPath(flutterSdkPath);
     if (sdk == null) {
       throw new ConfigurationException(flutterSdkPath + " is not a valid Flutter SDK");

--- a/src/io/flutter/run/FlutterDebugProcess.java
+++ b/src/io/flutter/run/FlutterDebugProcess.java
@@ -30,10 +30,9 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
-
 /**
  * A debug process that handles hot reloads for Flutter.
- *
+ * <p>
  * <p>It's used for both the 'Run' and 'Debug' modes. (We apparently need a debug process even
  * when not debugging in order to support hot reload.)
  */

--- a/src/io/flutter/run/FlutterDebugProcess.java
+++ b/src/io/flutter/run/FlutterDebugProcess.java
@@ -33,7 +33,7 @@ import java.util.Objects;
 /**
  * A debug process that handles hot reloads for Flutter.
  * <p>
- * <p>It's used for both the 'Run' and 'Debug' modes. (We apparently need a debug process even
+ * It's used for both the 'Run' and 'Debug' modes. (We apparently need a debug process even
  * when not debugging in order to support hot reload.)
  */
 public class FlutterDebugProcess extends DartVmServiceDebugProcessZ {

--- a/src/io/flutter/run/SdkRunConfig.java
+++ b/src/io/flutter/run/SdkRunConfig.java
@@ -71,7 +71,8 @@ public class SdkRunConfig extends LocatableConfigurationBase
   public Launcher getState(@NotNull Executor executor, @NotNull ExecutionEnvironment env) throws ExecutionException {
     try {
       fields.checkRunnable(env.getProject());
-    } catch (RuntimeConfigurationError e) {
+    }
+    catch (RuntimeConfigurationError e) {
       throw new ExecutionException(e);
     }
 
@@ -84,7 +85,8 @@ public class SdkRunConfig extends LocatableConfigurationBase
       launchFile = SdkFields.checkLaunchFile(fields.getFilePath());
       workDir = fields.chooseWorkDir(launchFile, env.getProject());
       additionalArgs = fields.getAdditionalArgs();
-    } catch (RuntimeConfigurationError e) {
+    }
+    catch (RuntimeConfigurationError e) {
       throw new ExecutionException(e); // Shouldn't happen here since we already checked.
     }
 
@@ -196,5 +198,4 @@ public class SdkRunConfig extends LocatableConfigurationBase
       }
     }
   }
-
 }

--- a/src/io/flutter/view/FlutterViewFactory.java
+++ b/src/io/flutter/view/FlutterViewFactory.java
@@ -25,7 +25,6 @@ public class FlutterViewFactory implements ToolWindowFactory {
 
   private static void initFlutterView(@NotNull Project project, FlutterViewMessages.FlutterDebugEvent event) {
     ApplicationManager.getApplication().invokeLater(() -> {
-      // TODO: re-enable auto-show after UI review (#691)
       final FlutterView flutterView = ServiceManager.getService(project, FlutterView.class);
       flutterView.debugActive(event);
     });

--- a/third_party/intellij-plugins-dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceBreakpointHandlerZ.java
+++ b/third_party/intellij-plugins-dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceBreakpointHandlerZ.java
@@ -1,9 +1,0 @@
-package com.jetbrains.lang.dart.ide.runner.server.vmService;
-
-import org.jetbrains.annotations.NotNull;
-
-public class DartVmServiceBreakpointHandlerZ extends DartVmServiceBreakpointHandler {
-  protected DartVmServiceBreakpointHandlerZ(@NotNull DartVmServiceDebugProcessZ debugProcess) {
-    super(debugProcess);
-  }
-}

--- a/third_party/intellij-plugins-dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcessZ.java
+++ b/third_party/intellij-plugins-dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcessZ.java
@@ -65,7 +65,7 @@ public class DartVmServiceDebugProcessZ extends DartVmServiceDebugProcess {
     myConnector = connector;
 
     myIsolatesInfo = new IsolatesInfo();
-    final DartVmServiceBreakpointHandler breakpointHandler = new DartVmServiceBreakpointHandlerZ(this);
+    final DartVmServiceBreakpointHandler breakpointHandler = new DartVmServiceBreakpointHandler(this);
     myBreakpointHandlers = new XBreakpointHandler[]{breakpointHandler};
 
     setLogger();
@@ -168,8 +168,8 @@ public class DartVmServiceDebugProcessZ extends DartVmServiceDebugProcess {
    * We override the parent with a no-op implementation; our preferred implementation
    * (scheduleConnectNew) is called elsewhere.
    */
-  @SuppressWarnings("EmptyMethod")
-  public void scheduleConnect() {
+  @Override
+  protected void scheduleConnect(@NotNull final String url) {
     // This page intentionally left blank.
 
   }


### PR DESCRIPTION
- some 2016.3 cleanup (remove some uses of reflection)
- update debugger code now that we're fully on 2017.1
- remove obsolete todos

@skybrian 