### PR TITLE
show a hot reload info toast on first run

### DIFF
--- a/src/io/flutter/FlutterBundle.properties
+++ b/src/io/flutter/FlutterBundle.properties
@@ -80,6 +80,10 @@ flutter.analytics.notification.accept=Sounds good!
 flutter.analytics.notification.decline=No thanks
 flutter.analytics.privacyUrl=http://www.google.com/policies/privacy/
 
+flutter.reload.firstRun.title=Flutter supports hot reload!
+flutter.reload.firstRun.content=Apply changes to a running app using <a href="url">hot reload</a>.
+flutter.reload.firstRun.url=https://flutter.io/getting-started/#quickly-viewing-source-code-changes-with-hot-reload
+
 flutter.view.debugPaint.text=Toggle Debug Paint
 flutter.view.debugPaint.description=Toggle Debug Paint
 flutter.view.performanceOverlay.text=Toggle Performance Overlay

--- a/src/io/flutter/FlutterInitializer.java
+++ b/src/io/flutter/FlutterInitializer.java
@@ -17,6 +17,7 @@ import com.intellij.openapi.extensions.PluginId;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.startup.StartupActivity;
 import io.flutter.analytics.Analytics;
+import io.flutter.run.FlutterRunNotifications;
 import io.flutter.run.daemon.DeviceService;
 import io.flutter.view.FlutterViewFactory;
 import org.jetbrains.annotations.NotNull;
@@ -93,6 +94,8 @@ public class FlutterInitializer implements StartupActivity {
 
     // Start watching for Flutter debug active events.
     FlutterViewFactory.init(project);
+
+    FlutterRunNotifications.init(project);
 
     // Initialize the analytics notification group.
     NotificationsConfiguration.getNotificationsConfiguration().register(

--- a/src/io/flutter/run/FlutterRunNotifications.java
+++ b/src/io/flutter/run/FlutterRunNotifications.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2017 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.run;
+
+import com.intellij.ide.BrowserUtil;
+import com.intellij.ide.util.PropertiesComponent;
+import com.intellij.notification.*;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.project.Project;
+import icons.FlutterIcons;
+import io.flutter.FlutterBundle;
+import io.flutter.view.FlutterViewMessages;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.event.HyperlinkEvent;
+
+public class FlutterRunNotifications {
+  public static final String GROUP_DISPLAY_ID = "Flutter App Run";
+
+  private static final String RELOAD_ALREADY_RUN = "io.flutter.reload.alreadyRun";
+
+  public static void init(@NotNull Project project) {
+    // Initialize the flutter run notification group.
+    NotificationsConfiguration.getNotificationsConfiguration().register(
+      FlutterRunNotifications.GROUP_DISPLAY_ID,
+      NotificationDisplayType.BALLOON,
+      false);
+
+    final FlutterRunNotifications notifications = new FlutterRunNotifications(project);
+
+    //noinspection CodeBlock2Expr
+    project.getMessageBus().connect().subscribe(
+      FlutterViewMessages.FLUTTER_DEBUG_TOPIC, (event) -> {
+        ApplicationManager.getApplication().invokeLater(notifications::checkForDisplayFirstReload);
+      }
+    );
+  }
+
+  @NotNull Project myProject;
+
+  FlutterRunNotifications(@NotNull Project project) {
+    this.myProject = project;
+  }
+
+  private void checkForDisplayFirstReload() {
+    final PropertiesComponent properties = PropertiesComponent.getInstance(myProject);
+
+    final boolean alreadyRun = properties.getBoolean(RELOAD_ALREADY_RUN);
+    if (!alreadyRun) {
+      properties.setValue(RELOAD_ALREADY_RUN, true);
+
+      final Notification notification = new Notification(
+        GROUP_DISPLAY_ID,
+        FlutterBundle.message("flutter.reload.firstRun.title"),
+        FlutterBundle.message("flutter.reload.firstRun.content"),
+        NotificationType.INFORMATION,
+        (notification1, event) -> {
+          if (event.getEventType() == HyperlinkEvent.EventType.ACTIVATED) {
+            if ("url".equals(event.getDescription())) {
+              BrowserUtil.browse(FlutterBundle.message("flutter.reload.firstRun.url"));
+            }
+          }
+        });
+      notification.setIcon(FlutterIcons.Flutter);
+      Notifications.Bus.notify(notification);
+    }
+  }
+}


### PR DESCRIPTION
The first time we run a Flutter app for a project, show a notification as a prompt to use hot reload:

<img width="383" alt="screen shot 2017-04-05 at 4 33 44 pm" src="https://cloud.githubusercontent.com/assets/1269969/24731250/b1f2077a-1a1d-11e7-8138-c22b7323c650.png">

@pq @skybrian @mit-mit 