### PR TITLE
change the icon for the hot reload toast

### DIFF
--- a/src/io/flutter/FlutterBundle.properties
+++ b/src/io/flutter/FlutterBundle.properties
@@ -84,7 +84,7 @@ flutter.analytics.notification.decline=No thanks
 flutter.analytics.privacyUrl=http://www.google.com/policies/privacy/
 
 flutter.reload.firstRun.title=Flutter supports hot reload!
-flutter.reload.firstRun.content=Apply changes to a running app using <a href="url">hot reload</a>.
+flutter.reload.firstRun.content=Apply changes to your app without restarting.
 flutter.reload.firstRun.url=https://flutter.io/getting-started/#quickly-viewing-source-code-changes-with-hot-reload
 
 flutter.view.debugPaint.text=Toggle Debug Paint

--- a/src/io/flutter/FlutterBundle.properties
+++ b/src/io/flutter/FlutterBundle.properties
@@ -84,7 +84,7 @@ flutter.analytics.notification.decline=No thanks
 flutter.analytics.privacyUrl=http://www.google.com/policies/privacy/
 
 flutter.reload.firstRun.title=Flutter supports hot reload!
-flutter.reload.firstRun.content=Apply changes to your app without restarting.
+flutter.reload.firstRun.content=Apply changes to your app in place, instantly.
 flutter.reload.firstRun.url=https://flutter.io/getting-started/#quickly-viewing-source-code-changes-with-hot-reload
 
 flutter.view.debugPaint.text=Toggle Debug Paint

--- a/src/io/flutter/run/FlutterRunNotifications.java
+++ b/src/io/flutter/run/FlutterRunNotifications.java
@@ -8,14 +8,14 @@ package io.flutter.run;
 import com.intellij.ide.BrowserUtil;
 import com.intellij.ide.util.PropertiesComponent;
 import com.intellij.notification.*;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
 import icons.FlutterIcons;
 import io.flutter.FlutterBundle;
 import io.flutter.view.FlutterViewMessages;
 import org.jetbrains.annotations.NotNull;
-
-import javax.swing.event.HyperlinkEvent;
 
 public class FlutterRunNotifications {
   public static final String GROUP_DISPLAY_ID = "Flutter App Run";
@@ -56,15 +56,14 @@ public class FlutterRunNotifications {
         GROUP_DISPLAY_ID,
         FlutterBundle.message("flutter.reload.firstRun.title"),
         FlutterBundle.message("flutter.reload.firstRun.content"),
-        NotificationType.INFORMATION,
-        (notification1, event) -> {
-          if (event.getEventType() == HyperlinkEvent.EventType.ACTIVATED) {
-            if ("url".equals(event.getDescription())) {
-              BrowserUtil.browse(FlutterBundle.message("flutter.reload.firstRun.url"));
-            }
-          }
-        });
-      notification.setIcon(FlutterIcons.Flutter);
+        NotificationType.INFORMATION);
+      notification.setIcon(FlutterIcons.HotReload);
+      notification.addAction(new AnAction("Learn more") {
+        @Override
+        public void actionPerformed(AnActionEvent event) {
+          BrowserUtil.browse(FlutterBundle.message("flutter.reload.firstRun.url"));
+        }
+      });
       Notifications.Bus.notify(notification);
     }
   }


### PR DESCRIPTION
Some changes to the hot reload first-run toast:
- use the hot reload icon (to help the user identify where in the ui to access reload)
- use an action instead of a hyperlink
- make the text terse to ensure it doesn't wrap and end up below the fold

<img width="378" alt="screen shot 2017-04-09 at 4 36 46 pm" src="https://cloud.githubusercontent.com/assets/1269969/24841880/6f59b100-1d43-11e7-8ba7-ca4b38a71a5c.png">

@pq @skybrian 