### PR TITLE
remove the IntelliJ reload success message

### DIFF
--- a/src/io/flutter/run/daemon/FlutterAppListener.java
+++ b/src/io/flutter/run/daemon/FlutterAppListener.java
@@ -128,12 +128,8 @@ class FlutterAppListener implements DaemonEvent.Listener {
   }
 
   private void reportElapsed(@NotNull Stopwatch watch, String verb, String analyticsName) {
-    final long elapsed = watch.elapsed(TimeUnit.MILLISECONDS);
-    FlutterInitializer.getAnalytics().sendTiming("run", analyticsName, elapsed);
-
-    final ConsoleView console = app.getConsole();
-    if (console == null) return;
-    console.print("\n" + verb + " in " + elapsed + " ms.\n", ConsoleViewContentType.NORMAL_OUTPUT);
+    final long elapsedMs = watch.elapsed(TimeUnit.MILLISECONDS);
+    FlutterInitializer.getAnalytics().sendTiming("run", analyticsName, elapsedMs);
   }
 
   @Override


### PR DESCRIPTION
- remove the IntelliJ reload success message

As of https://github.com/flutter/flutter/pull/9328, we can now just use the reload success message from flutter_tools.

@pq @skybrian 

<img width="294" alt="screen shot 2017-04-11 at 8 04 08 am" src="https://cloud.githubusercontent.com/assets/1269969/24916000/ae10befc-1e8d-11e7-8895-b23fe3154228.png">
