### PR TITLE
fix the restart action enablement

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -255,6 +255,8 @@
       <action id="Flutter.Toolbar.RestartAction" class="io.flutter.actions.RestartFlutterAppRetarget"
               description="Restart"
               icon="AllIcons.Actions.Restart">
+        <keyboard-shortcut keymap="$default" first-keystroke="ctrl shift alt SEMICOLON"/>
+        <keyboard-shortcut keymap="$default" first-keystroke="ctrl shift BACK_SLASH"/>
       </action>
       <action id="Flutter.Menu.RunProfileAction" class="io.flutter.actions.RunProfileFlutterApp"
               description="Profile"

--- a/src/io/flutter/run/FlutterDebugProcess.java
+++ b/src/io/flutter/run/FlutterDebugProcess.java
@@ -18,6 +18,7 @@ import com.jetbrains.lang.dart.ide.runner.server.vmService.DartVmServiceDebugPro
 import com.jetbrains.lang.dart.util.DartUrlResolver;
 import io.flutter.actions.OpenObservatoryAction;
 import io.flutter.actions.ReloadFlutterApp;
+import io.flutter.actions.RestartFlutterApp;
 import io.flutter.run.daemon.FlutterApp;
 import io.flutter.run.daemon.RunMode;
 import io.flutter.view.FlutterViewMessages;
@@ -94,6 +95,8 @@ public class FlutterDebugProcess extends DartVmServiceDebugProcessZ {
 
     topToolbar.addSeparator();
     topToolbar.addAction(new ReloadFlutterApp(app, canReload));
+    topToolbar.addAction(new RestartFlutterApp(app, canReload));
+    topToolbar.addSeparator();
     topToolbar.addAction(new OpenObservatoryAction(app.getConnector(), isSessionActive));
 
     // Don't call super since we have our own observatory action.


### PR DESCRIPTION
- fix the restart action enablement
- fix https://github.com/flutter/flutter-intellij/issues/901

In order for the action to be enabled, we need to have an instance of `RestartFlutterApp` created w/ the right FlutterApp. Also, re-add the keybindings for full restart; we still have a bit of work left to do wrt rationalizing the keybindings.

@pq 