### PR TITLE
Enable android module if present when creating Flutter project

### DIFF
--- a/src/io/flutter/actions/FlutterPackagesGetAction.java
+++ b/src/io/flutter/actions/FlutterPackagesGetAction.java
@@ -29,7 +29,7 @@ public class FlutterPackagesGetAction extends FlutterSdkAction {
     final Pair<Module, VirtualFile> pair = getModuleAndPubspecYamlFile(project, event);
     if (pair != null) {
       final VirtualFile workingDir = pair.second.getParent();
-      sdk.run(COMMAND, pair.first, workingDir, new ProcessAdapter() {
+      sdk.startProcess(COMMAND, pair.first, workingDir, new ProcessAdapter() {
         @Override
         public void processTerminated(ProcessEvent event) {
           // Refresh to ensure Dart Plugin sees .packages and doesn't mistakenly nag to run pub.

--- a/src/io/flutter/actions/FlutterPackagesUpgradeAction.java
+++ b/src/io/flutter/actions/FlutterPackagesUpgradeAction.java
@@ -25,7 +25,7 @@ public class FlutterPackagesUpgradeAction extends FlutterSdkAction {
   public void perform(@NotNull FlutterSdk sdk, @NotNull Project project, AnActionEvent event) throws ExecutionException {
     final Pair<Module, VirtualFile> pair = getModuleAndPubspecYamlFile(project, event);
     if (pair != null) {
-      sdk.run(COMMAND, pair.first, pair.second.getParent(), null);
+      sdk.startProcess(COMMAND, pair.first, pair.second.getParent(), null);
     }
     else {
       FlutterMessages.showError(

--- a/src/io/flutter/actions/FlutterUpgradeAction.java
+++ b/src/io/flutter/actions/FlutterUpgradeAction.java
@@ -19,7 +19,7 @@ public class FlutterUpgradeAction extends FlutterSdkAction {
   public void perform(@NotNull FlutterSdk sdk, @NotNull Project project, AnActionEvent event) throws ExecutionException {
     final Pair<Module, VirtualFile> pair = getModuleAndPubspecYamlFile(project, event);
     if (pair != null) {
-      sdk.run(FlutterSdk.Command.UPGRADE, pair.first, pair.second.getParent(), null);
+      sdk.startProcess(FlutterSdk.Command.UPGRADE, pair.first, pair.second.getParent(), null);
     }
     else {
       sdk.runProject(project, "Flutter upgrade", "upgrade");

--- a/src/io/flutter/module/FlutterModuleBuilder.java
+++ b/src/io/flutter/module/FlutterModuleBuilder.java
@@ -5,18 +5,22 @@
  */
 package io.flutter.module;
 
+import com.google.common.collect.ImmutableList;
 import com.intellij.execution.ExecutionException;
 import com.intellij.ide.util.projectWizard.ModuleBuilder;
 import com.intellij.ide.util.projectWizard.ModuleWizardStep;
 import com.intellij.ide.util.projectWizard.WizardContext;
 import com.intellij.openapi.Disposable;
+import com.intellij.openapi.application.WriteAction;
 import com.intellij.openapi.diagnostic.Logger;
-import com.intellij.openapi.module.ModuleType;
+import com.intellij.openapi.module.*;
 import com.intellij.openapi.options.ConfigurationException;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ContentEntry;
 import com.intellij.openapi.roots.ModifiableRootModel;
+import com.intellij.openapi.roots.ui.configuration.ModulesProvider;
 import com.intellij.openapi.util.Disposer;
+import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
 import icons.FlutterIcons;
 import io.flutter.FlutterBundle;
@@ -27,6 +31,9 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
 
 public class FlutterModuleBuilder extends ModuleBuilder {
   private static final Logger LOG = Logger.getInstance(FlutterModuleBuilder.class);
@@ -58,9 +65,69 @@ public class FlutterModuleBuilder extends ModuleBuilder {
   @Override
   public void setupRootModel(ModifiableRootModel model) throws ConfigurationException {
     final ContentEntry contentEntry = doAddContentEntry(model);
+
     final VirtualFile baseDir = contentEntry == null ? null : contentEntry.getFile();
-    if (baseDir != null) {
-      createProjectFiles(model, baseDir, myStep.getFlutterSdk());
+    if (baseDir == null) {
+      return;
+    }
+    createProjectFiles(model, baseDir, myStep.getFlutterSdk());
+  }
+
+  @Nullable
+  @Override
+  public List<Module> commit(@NotNull Project project, @Nullable ModifiableModuleModel model, ModulesProvider modulesProvider) {
+    final List<Module> result = super.commit(project, model, modulesProvider);
+    if (result == null || result.size() != 1) {
+      return result;
+    }
+
+    final String baseDirPath = new File(result.get(0).getModuleFilePath()).getParent();
+    final Module android = addAndroidModule(project, model, baseDirPath);
+    if (android != null) {
+      return ImmutableList.of(result.get(0), android);
+    } else {
+      return result;
+    }
+  }
+
+  @Nullable
+  private Module addAndroidModule(@NotNull Project project,
+                                  @Nullable ModifiableModuleModel model,
+                                  @NotNull String baseDirPath) {
+    final VirtualFile baseDir = LocalFileSystem.getInstance().refreshAndFindFileByPath(baseDirPath);
+    if (baseDir == null) {
+      return null;
+    }
+
+    final String androidPath = baseDirPath + "/android.iml";
+    final VirtualFile androidFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(androidPath);
+    if (androidFile == null) {
+      return null;
+    }
+
+    try {
+      final ModifiableModuleModel toCommit;
+      if (model == null) {
+        toCommit = ModuleManager.getInstance(project).getModifiableModel();
+        model = toCommit;
+      } else {
+        toCommit = null;
+      }
+
+      final Module androidModule = model.loadModule(androidFile.getPath());
+
+      if (toCommit != null) {
+        WriteAction.run(toCommit::commit);
+      }
+
+      return androidModule;
+    }
+    catch (ModuleWithNameAlreadyExists exists) {
+      return null;
+    }
+    catch (IOException e) {
+      LOG.warn(e);
+      return null;
     }
   }
 
@@ -89,22 +156,40 @@ public class FlutterModuleBuilder extends ModuleBuilder {
 
   private static void createProjectFiles(@NotNull final ModifiableRootModel model,
                                          @NotNull final VirtualFile baseDir,
-                                         @NotNull final FlutterSdk sdk) {
+                                         @NotNull final FlutterSdk sdk) throws ConfigurationException {
+
+    runFlutterCreate(sdk, model.getModule(), baseDir);
+
     try {
       DartPlugin.ensureDartSdkConfigured(model.getProject(), sdk.getDartSdkPath());
       FlutterSdkUtil.updateKnownSdkPaths(sdk.getHomePath());
     }
     catch (ExecutionException e) {
       LOG.warn("Error configuring the Flutter SDK.", e);
+      throw new ConfigurationException("Error configuring Flutter SDK");
     }
+  }
 
+  private static void runFlutterCreate(@NotNull FlutterSdk sdk, Module module, @NotNull VirtualFile baseDir)
+    throws ConfigurationException {
     // Create files.
     try {
-      sdk.run(FlutterSdk.Command.CREATE, model.getModule(), baseDir, null, baseDir.getPath());
+      final Process process =
+        sdk.startProcess(FlutterSdk.Command.CREATE, module, baseDir, null, baseDir.getPath());
+      if (process != null) {
+        // Wait for process to finish. (We overwrite some files, so make sure we lose the race.)
+        // TODO(skybrian) the user sees a short pause. Show progress somehow?
+        final int exitCode = process.waitFor();
+        if (exitCode == 0) {
+          baseDir.refresh(false, true);
+          return; // success
+        }
+      }
     }
-    catch (ExecutionException e) {
+    catch (ExecutionException | InterruptedException e) {
       LOG.warn(e);
     }
+    throw new ConfigurationException("flutter create command was unsuccessful");
   }
 
   public static void setupProject(@NotNull Project project, ModifiableRootModel model, VirtualFile baseDir, String flutterSdkPath)

--- a/src/io/flutter/module/FlutterModuleBuilder.java
+++ b/src/io/flutter/module/FlutterModuleBuilder.java
@@ -192,7 +192,10 @@ public class FlutterModuleBuilder extends ModuleBuilder {
     throw new ConfigurationException("flutter create command was unsuccessful");
   }
 
-  public static void setupProject(@NotNull Project project, ModifiableRootModel model, VirtualFile baseDir, String flutterSdkPath)
+  /**
+   * Set up a "small IDE" project. (For example, WebStorm.)
+   */
+  public static void setupSmallProject(@NotNull Project project, ModifiableRootModel model, VirtualFile baseDir, String flutterSdkPath)
     throws ConfigurationException {
     final FlutterSdk sdk = FlutterSdk.forPath(flutterSdkPath);
     if (sdk == null) {

--- a/src/io/flutter/module/FlutterSmallIDEProjectGenerator.java
+++ b/src/io/flutter/module/FlutterSmallIDEProjectGenerator.java
@@ -46,7 +46,7 @@ public class FlutterSmallIDEProjectGenerator extends WebProjectTemplate<String> 
     ApplicationManager.getApplication().runWriteAction(() -> {
       try {
         final ModifiableRootModel modifiableModel = ModifiableModelsProvider.SERVICE.getInstance().getModuleModifiableModel(module);
-        FlutterModuleBuilder.setupProject(project, modifiableModel, baseDir, flutterSdkPath);
+        FlutterModuleBuilder.setupSmallProject(project, modifiableModel, baseDir, flutterSdkPath);
         ModifiableModelsProvider.SERVICE.getInstance().commitModuleModifiableModel(modifiableModel);
       }
       catch (ConfigurationException e) {

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.java
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.java
@@ -167,7 +167,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     }
     try {
       final ModalityState modalityState = ModalityState.current();
-      sdk.run(FlutterSdk.Command.VERSION, null, null, new CapturingProcessAdapter() {
+      sdk.startProcess(FlutterSdk.Command.VERSION, null, null, new CapturingProcessAdapter() {
         @Override
         public void processTerminated(@NotNull ProcessEvent event) {
           final ProcessOutput output = getOutput();


### PR DESCRIPTION
If "flutter create" writes an android.iml file, make sure it's added to the project.

Also, make sure all files generated by the "flutter create" command are visible in IDEA. (There was a race condition where we didn't wait for "flutter create" to finish before continuing.)

Progress towards fixing #782
The android.iml file will be added in https://github.com/flutter/flutter/pull/9335