### PR TITLE
add an experimental reload on save option

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -331,6 +331,10 @@
                      implementationClass="io.flutter.inspections.FlutterDependencyInspection"/>
 
     <editorNotificationProvider implementation="io.flutter.editor.FlutterPubspecNotificationProvider"/>
+
+    <projectService serviceInterface="io.flutter.run.FlutterReloadManager"
+                    serviceImplementation="io.flutter.run.FlutterReloadManager"
+                    overrides="false"/>
   </extensions>
 
 </idea-plugin>

--- a/src/io/flutter/FlutterInitializer.java
+++ b/src/io/flutter/FlutterInitializer.java
@@ -18,6 +18,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.startup.StartupActivity;
 import io.flutter.analytics.Analytics;
 import io.flutter.run.FlutterRunNotifications;
+import io.flutter.run.FlutterReloadManager;
 import io.flutter.run.daemon.DeviceService;
 import io.flutter.view.FlutterViewFactory;
 import org.jetbrains.annotations.NotNull;
@@ -96,6 +97,9 @@ public class FlutterInitializer implements StartupActivity {
     FlutterViewFactory.init(project);
 
     FlutterRunNotifications.init(project);
+
+    // Watch save actions.
+    FlutterReloadManager.getInstance(project);
 
     // Initialize the analytics notification group.
     NotificationsConfiguration.getNotificationsConfiguration().register(

--- a/src/io/flutter/actions/FlutterAppAction.java
+++ b/src/io/flutter/actions/FlutterAppAction.java
@@ -70,7 +70,8 @@ abstract public class FlutterAppAction extends DumbAwareAction {
     }
   }
 
-  @NotNull FlutterApp getApp() {
+  @NotNull
+  public FlutterApp getApp() {
     return myApp;
   }
 }

--- a/src/io/flutter/actions/ReloadFlutterApp.java
+++ b/src/io/flutter/actions/ReloadFlutterApp.java
@@ -7,12 +7,12 @@ package io.flutter.actions;
 
 import com.intellij.openapi.actionSystem.ActionManager;
 import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.fileEditor.FileDocumentManager;
+import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Computable;
-import com.jetbrains.lang.dart.DartPluginCapabilities;
 import icons.FlutterIcons;
 import io.flutter.FlutterBundle;
 import io.flutter.FlutterInitializer;
+import io.flutter.run.FlutterReloadManager;
 import io.flutter.run.daemon.FlutterApp;
 
 import java.awt.event.InputEvent;
@@ -31,23 +31,23 @@ public class ReloadFlutterApp extends FlutterAppAction {
 
   @Override
   public void actionPerformed(AnActionEvent e) {
+    final Project project = getEventProject(e);
+    if (project == null) {
+      return;
+    }
+
     FlutterInitializer.sendAnalyticsAction(this);
 
-    if (getApp().isStarted()) {
-      FileDocumentManager.getInstance().saveAllDocuments();
+    // If the shift key is held down, perform a restart. We check to see if we're being invoked from the
+    // 'GoToAction' dialog. If so, the modifiers are for the command that opened the go to action dialog.
+    final boolean shouldRestart = (e.getModifiers() & InputEvent.SHIFT_MASK) != 0 && !"GoToAction".equals(e.getPlace());
 
-      // If the shift key is held down, perform a restart. We check to see if we're being invoked from the
-      // 'GoToAction' dialog. If so, the modifiers are for the command that opened the go to action dialog.
-      final boolean shouldRestart = (e.getModifiers() & InputEvent.SHIFT_MASK) != 0 && !"GoToAction".equals(e.getPlace());
-
-      if (shouldRestart) {
-        getApp().performRestartApp();
-      }
-      else {
-        // Else perform a hot reload.
-        final boolean pauseAfterRestart = DartPluginCapabilities.isSupported("supports.pausePostRequest");
-        getApp().performHotReload(pauseAfterRestart);
-      }
+    if (shouldRestart) {
+      FlutterReloadManager.getInstance(project).saveAllAndRestart(getApp());
+    }
+    else {
+      // Else perform a hot reload.
+      FlutterReloadManager.getInstance(project).saveAllAndReload(getApp());
     }
   }
 }

--- a/src/io/flutter/actions/RestartFlutterApp.java
+++ b/src/io/flutter/actions/RestartFlutterApp.java
@@ -8,10 +8,11 @@ package io.flutter.actions;
 import com.intellij.icons.AllIcons;
 import com.intellij.openapi.actionSystem.ActionManager;
 import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.fileEditor.FileDocumentManager;
+import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Computable;
 import io.flutter.FlutterBundle;
 import io.flutter.FlutterInitializer;
+import io.flutter.run.FlutterReloadManager;
 import io.flutter.run.daemon.FlutterApp;
 
 @SuppressWarnings("ComponentNotRegistered")
@@ -28,11 +29,13 @@ public class RestartFlutterApp extends FlutterAppAction {
 
   @Override
   public void actionPerformed(AnActionEvent e) {
+    final Project project = getEventProject(e);
+    if (project == null) {
+      return;
+    }
+
     FlutterInitializer.sendAnalyticsAction(this);
 
-    if (getApp().isStarted()) {
-      FileDocumentManager.getInstance().saveAllDocuments();
-      getApp().performRestartApp();
-    }
+    FlutterReloadManager.getInstance(project).saveAllAndRestart(getApp());
   }
 }

--- a/src/io/flutter/run/FlutterReloadManager.java
+++ b/src/io/flutter/run/FlutterReloadManager.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2017 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.run;
+
+import com.intellij.AppTopics;
+import com.intellij.openapi.actionSystem.ActionManager;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.fileEditor.FileDocumentManager;
+import com.intellij.openapi.fileEditor.FileDocumentManagerAdapter;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleUtilCore;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiDocumentManager;
+import com.intellij.psi.PsiErrorElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.util.PsiTreeUtil;
+import com.jetbrains.lang.dart.DartPluginCapabilities;
+import io.flutter.FlutterUtils;
+import io.flutter.actions.FlutterAppAction;
+import io.flutter.actions.ReloadFlutterApp;
+import io.flutter.run.daemon.FlutterApp;
+import io.flutter.settings.FlutterSettings;
+import io.flutter.utils.FlutterModuleUtils;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+
+// TODO: Also experiment with live reloading:
+//   - if the analysis server completes an analysis w/o issues, then issue a reload
+
+// TODO: Show a live typing / live reloading butter bar in the editor?
+
+/**
+ * Handle the mechanics of performing a hot reload on file save.
+ */
+public class FlutterReloadManager extends FileDocumentManagerAdapter {
+  private final @NotNull Project myProject;
+  private final FlutterSettings mySettings;
+
+  private int ignoreCount = 0;
+
+  private Timer timer;
+  private int fileChangedCount = 0;
+
+  public static FlutterReloadManager getInstance(@NotNull Project project) {
+    return ServiceManager.getService(project, FlutterReloadManager.class);
+  }
+
+  private FlutterReloadManager(@NotNull Project project) {
+    this.myProject = project;
+    this.mySettings = FlutterSettings.getInstance(myProject);
+
+    // Subscribe to file saved notifications.
+    project.getMessageBus().connect().subscribe(AppTopics.FILE_DOCUMENT_SYNC, this);
+  }
+
+  public void saveAllAndReload() {
+    final FlutterApp app = getApp();
+    if (app != null) {
+      saveAllAndReload(app);
+    }
+  }
+
+  public void saveAllAndReload(@NotNull FlutterApp app) {
+    if (app.isStarted()) {
+      cancelTimer();
+
+      try {
+        ignoreCount++;
+        FileDocumentManager.getInstance().saveAllDocuments();
+      }
+      finally {
+        ignoreCount--;
+      }
+
+      app.performHotReload(supportsPauseAfterReload());
+    }
+  }
+
+  public void saveAllAndRestart() {
+    final FlutterApp app = getApp();
+    if (app != null) {
+      saveAllAndRestart(app);
+    }
+  }
+
+  public void saveAllAndRestart(@NotNull FlutterApp app) {
+    if (app.isStarted()) {
+      cancelTimer();
+
+      try {
+        ignoreCount++;
+        FileDocumentManager.getInstance().saveAllDocuments();
+      }
+      finally {
+        ignoreCount--;
+      }
+
+      app.performRestartApp();
+    }
+  }
+
+  private FlutterApp getApp() {
+    final AnAction action = ActionManager.getInstance().getAction(ReloadFlutterApp.ID);
+    return action instanceof FlutterAppAction ? ((FlutterAppAction)action).getApp() : null;
+  }
+
+  private boolean supportsPauseAfterReload() {
+    return DartPluginCapabilities.isSupported("supports.pausePostRequest");
+  }
+
+  @Override
+  public void beforeAllDocumentsSaving() {
+    if (ignoreCount > 0) {
+      return;
+    }
+
+    if (!mySettings.isReloadOnSave()) {
+      cancelTimer();
+    }
+    else {
+      fileChangedCount = 0;
+
+      if (timer != null) {
+        timer.stop();
+      }
+      startTimer();
+    }
+  }
+
+  @Override
+  public void beforeDocumentSaving(@NotNull Document document) {
+    if (ignoreCount > 0) {
+      return;
+    }
+
+    if (timer == null) {
+      return;
+    }
+
+    final VirtualFile file = FileDocumentManager.getInstance().getFile(document);
+    if (file == null || !FlutterUtils.isDartFile(file)) {
+      return;
+    }
+
+    final Module module = ModuleUtilCore.findModuleForFile(file, myProject);
+    if (module != null && FlutterModuleUtils.usesFlutter(module)) {
+      if (documentHasErrors(myProject, document)) {
+        cancelTimer();
+      }
+      else {
+        fileChangedCount++;
+      }
+    }
+  }
+
+  private boolean documentHasErrors(@NotNull Project project, @NotNull Document document) {
+    final PsiFile psiFile = PsiDocumentManager.getInstance(myProject).getPsiFile(document);
+    final PsiErrorElement firstError = PsiTreeUtil.findChildOfType(psiFile, PsiErrorElement.class, false);
+    return firstError != null;
+  }
+
+  private void startTimer() {
+    timer = new Timer(10, e -> {
+      timer = null;
+
+      if (fileChangedCount > 0) {
+        final AnAction action = ActionManager.getInstance().getAction(ReloadFlutterApp.ID);
+        if (action instanceof FlutterAppAction) {
+          final FlutterApp app = ((FlutterAppAction)action).getApp();
+          if (app.isStarted()) {
+            app.performHotReload(supportsPauseAfterReload());
+          }
+        }
+      }
+    });
+    timer.setRepeats(false);
+    timer.start();
+  }
+
+  private void cancelTimer() {
+    if (timer != null) {
+      timer.stop();
+      timer = null;
+    }
+  }
+}

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.form
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.form
@@ -63,7 +63,7 @@
         <border type="none"/>
         <children/>
       </grid>
-      <grid id="e885c" layout-manager="GridLayoutManager" row-count="3" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="e885c" layout-manager="GridLayoutManager" row-count="4" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -76,7 +76,7 @@
         <children>
           <component id="6304a" class="javax.swing.JCheckBox" binding="myReportUsageInformationCheckBox">
             <constraints>
-              <grid row="0" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="1" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text value="&amp;Report usage information to Google Analytics"/>
@@ -85,18 +85,27 @@
           </component>
           <vspacer id="4a2f0">
             <constraints>
-              <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+              <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
             </constraints>
           </vspacer>
           <component id="abbab" class="com.intellij.ui.components.labels.LinkLabel" binding="myPrivacyPolicy">
             <constraints>
-              <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="3" use-parent-layout="false"/>
+              <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="3" use-parent-layout="false"/>
             </constraints>
             <properties>
               <horizontalAlignment value="2"/>
               <horizontalTextPosition value="2"/>
               <text value="www.google.com/policies/privacy"/>
               <toolTipText value="http://www.google.com/policies/privacy/"/>
+            </properties>
+          </component>
+          <component id="18e73" class="javax.swing.JCheckBox" binding="myHotReloadOnSaveCheckBox">
+            <constraints>
+              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Perform hot reload on save (experimental)"/>
+              <toolTipText value="On save, hot reload changes into running Flutter apps."/>
             </properties>
           </component>
         </children>

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.java
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.java
@@ -29,6 +29,7 @@ import com.intellij.ui.components.labels.LinkLabel;
 import io.flutter.FlutterBundle;
 import io.flutter.FlutterConstants;
 import io.flutter.FlutterInitializer;
+import io.flutter.settings.FlutterSettings;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -50,6 +51,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
   private JBLabel myVersionLabel;
   private JCheckBox myReportUsageInformationCheckBox;
   private LinkLabel<String> myPrivacyPolicy;
+  private JCheckBox myHotReloadOnSaveCheckBox;
   private final @NotNull Project myProject;
 
   FlutterSettingsConfigurable(@NotNull Project project) {
@@ -110,6 +112,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
   @Override
   public boolean isModified() {
     final FlutterSdk sdk = FlutterSdk.getFlutterSdk(myProject);
+    final FlutterSettings settings = FlutterSettings.getInstance(myProject);
     final String sdkPathInModel = sdk == null ? "" : sdk.getHomePath();
     final String sdkPathInUI = FileUtilRt.toSystemIndependentName(getSdkPathText());
 
@@ -117,8 +120,12 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
       return true;
     }
 
-    //noinspection RedundantIfStatement
     if (FlutterInitializer.getCanReportAnalytics() != myReportUsageInformationCheckBox.isSelected()) {
+      return true;
+    }
+
+    //noinspection RedundantIfStatement
+    if (settings.isReloadOnSave() != myHotReloadOnSaveCheckBox.isSelected()) {
       return true;
     }
 
@@ -142,6 +149,9 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
 
     FlutterInitializer.setCanReportAnalaytics(myReportUsageInformationCheckBox.isSelected());
 
+    final FlutterSettings settings = FlutterSettings.getInstance(myProject);
+    settings.setReloadOnSave(myHotReloadOnSaveCheckBox.isSelected());
+
     reset(); // because we rely on remembering initial state
   }
 
@@ -156,7 +166,11 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     mySdkCombo.getComboBox().getEditor().setItem(FileUtil.toSystemDependentName(path));
 
     updateVersionText();
+
     myReportUsageInformationCheckBox.setSelected(FlutterInitializer.getCanReportAnalytics());
+    final FlutterSettings settings = FlutterSettings.getInstance(myProject);
+
+    myHotReloadOnSaveCheckBox.setSelected(settings.isReloadOnSave());
   }
 
   private void updateVersionText() {

--- a/src/io/flutter/settings/FlutterSettings.java
+++ b/src/io/flutter/settings/FlutterSettings.java
@@ -38,6 +38,18 @@ public class FlutterSettings implements PersistentStateComponent<FlutterSettings
     listeners.remove(listener);
   }
 
+  private boolean reloadOnSave = false;
+
+  public boolean isReloadOnSave() {
+    return reloadOnSave;
+  }
+
+  public void setReloadOnSave(boolean value) {
+    this.reloadOnSave = value;
+  }
+
+  // PersistentStateComponent interface
+
   public FlutterSettings getState() {
     return this;
   }

--- a/src/io/flutter/settings/FlutterUIConfig.java
+++ b/src/io/flutter/settings/FlutterUIConfig.java
@@ -11,21 +11,13 @@ package io.flutter.settings;
 public class FlutterUIConfig {
   private static final FlutterUIConfig INSTANCE = new FlutterUIConfig();
 
-  private boolean ignoreMismatchedDartSdks;
   private boolean ignoreOutOfDateFlutterSdks;
 
-  private FlutterUIConfig() {}
+  private FlutterUIConfig() {
+  }
 
   public static FlutterUIConfig getInstance() {
     return INSTANCE;
-  }
-
-  public boolean shouldIgnoreMismatchedDartSdks() {
-    return ignoreMismatchedDartSdks;
-  }
-
-  public void setIgnoreMismatchedDartSdks() {
-    this.ignoreMismatchedDartSdks = true;
   }
 
   public boolean shouldIgnoreOutOfDateFlutterSdks() {


### PR DESCRIPTION
This PR adds an experimental reload-on-save option. When resources are written to disk, we:

- check if any dart files in a flutter module were affected
- check that the files are structurally sound (that they pass IntelliJ's parser)
- and if there's an active flutter launch, we issue a reload command

There are a bunch of corner cases to work through, and decisions about how best to validate that a auto-reload should happen (should we take signals from the analysis server?).

Not clear that this PR will land; not yet for review :)
