### PR TITLE
move two editor notification providers

### DIFF
--- a/resources/META-INF/idea-contribs.xml
+++ b/resources/META-INF/idea-contribs.xml
@@ -6,8 +6,6 @@
                     overrides="true"/>
 
     <editorNotificationProvider implementation="io.flutter.inspections.IncompatibleDartPluginNotificationProvider"/>
-    <editorNotificationProvider implementation="io.flutter.inspections.SdkConfigurationNotificationProvider"/>
-    <editorNotificationProvider implementation="io.flutter.inspections.WrongModuleTypeNotificationProvider"/>
 
     <moduleConfigurationEditorProvider implementation="io.flutter.module.FlutterModuleConfigurationEditorProvider"/>
   </extensions>

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -328,6 +328,8 @@
                      implementationClass="io.flutter.inspections.FlutterDependencyInspection"/>
 
     <editorNotificationProvider implementation="io.flutter.editor.FlutterPubspecNotificationProvider"/>
+    <editorNotificationProvider implementation="io.flutter.inspections.SdkConfigurationNotificationProvider"/>
+    <editorNotificationProvider implementation="io.flutter.inspections.WrongModuleTypeNotificationProvider"/>
 
     <iconProvider implementation="io.flutter.project.FlutterIconProvider" order="first"/>
   </extensions>


### PR DESCRIPTION
- move two editor notification providers (so that they're available in both IDEA and in small IDEs)

(follow up from https://github.com/flutter/flutter-intellij/pull/846)

@pq @skybrian 