### PR TITLE
dismiss the hot reload notification

### DIFF
--- a/src/io/flutter/run/FlutterRunNotifications.java
+++ b/src/io/flutter/run/FlutterRunNotifications.java
@@ -62,6 +62,7 @@ public class FlutterRunNotifications {
         @Override
         public void actionPerformed(AnActionEvent event) {
           BrowserUtil.browse(FlutterBundle.message("flutter.reload.firstRun.url"));
+          notification.expire();
         }
       });
       Notifications.Bus.notify(notification);


### PR DESCRIPTION
- dismiss the hot reload notification when the user clicks on the 'show more info' link

@pq @skybrian 