### PR TITLE
move the reload action into the main run group

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -248,18 +248,15 @@
     </group>
 
     <!-- main toolbar run actions -->
-    <group id="Flutter.MainToolbarActions.Run">
-      <separator/>
-      <action id="Flutter.Toolbar.ReloadAction" class="io.flutter.actions.ReloadFlutterAppRetarget"
-              description="Reload"
-              icon="FlutterIcons.HotReload">
-        <keyboard-shortcut keymap="$default" first-keystroke="ctrl alt SEMICOLON"/>
-        <keyboard-shortcut keymap="$default" first-keystroke="ctrl BACK_SLASH"/>
-      </action>
-      <separator/>
-      <add-to-group group-id="RunContextGroup" anchor="last"/>
-      <add-to-group group-id="ToolbarRunGroup" anchor="last"/>
-    </group>
+    <action id="Flutter.Toolbar.ReloadAction" class="io.flutter.actions.ReloadFlutterAppRetarget"
+            description="Reload"
+            icon="FlutterIcons.HotReload">
+      <add-to-group group-id="ToolbarRunGroup" anchor="after" relative-to-action="RunnerActions"/>
+      <keyboard-shortcut keymap="$default" first-keystroke="ctrl alt SEMICOLON"/>
+      <keyboard-shortcut keymap="$default" first-keystroke="ctrl BACK_SLASH"/>
+    </action>
+
+    <!-- run menu actions -->
     <group id="Flutter.MenuActions.Run">
       <separator/>
       <reference ref="Flutter.Toolbar.ReloadAction"/>
@@ -285,7 +282,6 @@
     <action class="io.flutter.actions.FlutterGettingStarted" id="Flutter.FlutterHelp" text="Flutter Plugin Help">
       <add-to-group group-id="HelpMenu" anchor="after" relative-to-action="HelpTopics"/>
     </action>
-
   </actions>
 
   <extensions defaultExtensionNs="com.intellij">


### PR DESCRIPTION
- move the reload action into the main run group

<img width="354" alt="screen shot 2017-04-20 at 10 25 25 am" src="https://cloud.githubusercontent.com/assets/1269969/25244045/0d18f3ec-25b4-11e7-8c73-16a5799b7543.png">

@pq, @skybrian 

(given we have screenshots for the current release, we can wait to land this until after M13)
