### PR TITLE
sync Flutter SDK on open if Dart SDK doesn't exist

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -288,6 +288,7 @@
 
   <extensions defaultExtensionNs="com.intellij">
     <consoleInputFilterProvider implementation="io.flutter.run.daemon.DaemonJsonInputFilterProvider"/>?
+    <postStartupActivity implementation="io.flutter.ProjectOpenActivity"/>
     <postStartupActivity implementation="io.flutter.FlutterInitializer"/>
     <projectService serviceInterface="io.flutter.run.daemon.DeviceService"
                     serviceImplementation="io.flutter.run.daemon.DeviceService"/>

--- a/src/io/flutter/FlutterInitializer.java
+++ b/src/io/flutter/FlutterInitializer.java
@@ -25,6 +25,13 @@ import org.jetbrains.annotations.NotNull;
 import javax.swing.event.HyperlinkEvent;
 import java.util.UUID;
 
+/**
+ * Runs actions after the project has started up and the index is up to date.
+ *
+ * @see ProjectOpenActivity for actions that run earlier.
+ * @see io.flutter.project.FlutterProjectOpenProcessor for actions that only happen the
+ * first time a project was opened.
+ */
 public class FlutterInitializer implements StartupActivity {
   private static final String analyticsClientIdKey = "io.flutter.analytics.clientId";
   private static final String analyticsOptOutKey = "io.flutter.analytics.optOut";

--- a/src/io/flutter/FlutterInitializer.java
+++ b/src/io/flutter/FlutterInitializer.java
@@ -29,8 +29,8 @@ import java.util.UUID;
  * Runs actions after the project has started up and the index is up to date.
  *
  * @see ProjectOpenActivity for actions that run earlier.
- * @see io.flutter.project.FlutterProjectOpenProcessor for actions that only happen the
- * first time a project was opened.
+ * @see io.flutter.project.FlutterProjectOpenProcessor for additional actions that
+ * may run when a project is being imported.
  */
 public class FlutterInitializer implements StartupActivity {
   private static final String analyticsClientIdKey = "io.flutter.analytics.clientId";

--- a/src/io/flutter/ProjectOpenActivity.java
+++ b/src/io/flutter/ProjectOpenActivity.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter;
+
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.project.DumbAware;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.startup.StartupActivity;
+import io.flutter.sdk.FlutterSdk;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Runs startup actions just after a project is opened, before it's indexed.
+ *
+ * @see FlutterInitializer for actions that run later.
+ */
+public class ProjectOpenActivity implements StartupActivity, DumbAware {
+  @Override
+  public void runActivity(@NotNull Project project) {
+    final FlutterSdk sdk = FlutterSdk.getIncomplete(project);
+    if (sdk != null && sdk.getDartSdkPath() == null) {
+      final boolean ok = sdk.sync(project);
+      if (!ok) {
+        LOG.warn("failed to sync flutter SDK");
+      }
+    }
+  }
+
+  private static final Logger LOG = Logger.getInstance(ProjectOpenActivity.class.getName());
+}

--- a/src/io/flutter/module/FlutterModuleBuilder.java
+++ b/src/io/flutter/module/FlutterModuleBuilder.java
@@ -233,15 +233,13 @@ public class FlutterModuleBuilder extends ModuleBuilder {
     model.addContentEntry(baseDir);
 
     runFlutterCreate(sdk, baseDir, model.getModule());
+    final String dartSdkPath = sdk.getDartSdkPath();
+    if (dartSdkPath == null) {
+      throw new ConfigurationException("unable to get Dart SDK"); // shouldn't happen; we just created it.
+    }
 
-    try {
-      DartPlugin.ensureDartSdkConfigured(model.getProject(), sdk.getDartSdkPath());
-      FlutterSdkUtil.updateKnownSdkPaths(sdk.getHomePath());
-    }
-    catch (ExecutionException e) {
-      LOG.warn("Error configuring the Flutter SDK.", e);
-      throw new ConfigurationException("Error configuring Flutter SDK");
-    }
+    DartPlugin.ensureDartSdkConfigured(model.getProject(), sdk.getDartSdkPath());
+    FlutterSdkUtil.updateKnownSdkPaths(sdk.getHomePath());
   }
 
   private static class FlutterModuleWizardStep extends ModuleWizardStep implements Disposable {

--- a/src/io/flutter/project/FlutterProjectOpenProcessor.java
+++ b/src/io/flutter/project/FlutterProjectOpenProcessor.java
@@ -60,9 +60,11 @@ public class FlutterProjectOpenProcessor extends ProjectOpenProcessor {
   }
 
   /**
-   * Opens a Flutter project for the first time.
-   *
-   * For actions that run every time, see {@link ProjectOpenActivity} and {@link io.flutter.FlutterInitializer}.
+   * Runs when a project is opened by selecting the project directly, possibly for import.
+   * <p>
+   * Doesn't run when a project is opened via recent projects menu (and so on). Actions that
+   * should run every time a project is opened should be in
+   * {@link ProjectOpenActivity} or {@link io.flutter.FlutterInitializer}.
    */
   @Nullable
   @Override

--- a/src/io/flutter/project/FlutterProjectOpenProcessor.java
+++ b/src/io/flutter/project/FlutterProjectOpenProcessor.java
@@ -21,8 +21,8 @@ import icons.FlutterIcons;
 import io.flutter.FlutterBundle;
 import io.flutter.FlutterMessages;
 import io.flutter.FlutterUtils;
+import io.flutter.ProjectOpenActivity;
 import io.flutter.actions.FlutterPackagesGetAction;
-import io.flutter.actions.FlutterSdkAction;
 import io.flutter.sdk.FlutterSdk;
 import io.flutter.sdk.FlutterSdkUtil;
 import io.flutter.utils.FlutterModuleUtils;
@@ -39,16 +39,6 @@ import java.util.Objects;
 public class FlutterProjectOpenProcessor extends ProjectOpenProcessor {
 
   private static final Logger LOG = Logger.getInstance(FlutterProjectOpenProcessor.class.getName());
-
-  private static void doPerform(@NotNull FlutterSdkAction action, @NotNull Project project) throws ExecutionException {
-    final FlutterSdk sdk = FlutterSdk.getFlutterSdk(project);
-    if (sdk == null) {
-      // Lack of SDK will be flagged elsewhere by inspection.
-      return;
-    }
-
-    action.perform(sdk, project, null);
-  }
 
   private static void handleError(@NotNull Exception e) {
     FlutterMessages.showError("Error opening", e.getMessage());
@@ -69,6 +59,11 @@ public class FlutterProjectOpenProcessor extends ProjectOpenProcessor {
     return FlutterSdkUtil.isFlutterProjectDir(file);
   }
 
+  /**
+   * Opens a Flutter project for the first time.
+   *
+   * For actions that run every time, see {@link ProjectOpenActivity} and {@link io.flutter.FlutterInitializer}.
+   */
   @Nullable
   @Override
   public Project doOpenProject(@NotNull VirtualFile file, @Nullable Project projectToClose, boolean forceOpenInNewFrame) {
@@ -117,7 +112,10 @@ public class FlutterProjectOpenProcessor extends ProjectOpenProcessor {
     try {
       final VirtualFile packagesFile = FlutterModuleUtils.findPackagesFileFrom(project, null);
       if (!FlutterUtils.exists(packagesFile)) {
-        doPerform(new FlutterPackagesGetAction(), project);
+        final FlutterSdk sdk = FlutterSdk.getFlutterSdk(project);
+        if (sdk != null) {
+          new FlutterPackagesGetAction().perform(sdk, project, null);
+        }
       }
       else {
         final VirtualFile pubspecFile = FlutterModuleUtils.findPubspecFrom(project, null);


### PR DESCRIPTION
Also:
  - add cross-references between different code that runs at project open
  - FlutterSdk.getDartSdkPath() now returns null if the SDK doesn't exist
  - clean up callers