### PR TITLE
Centralize pub directory-related code in PubRoot class

### DIFF
--- a/src/io/flutter/FlutterConstants.java
+++ b/src/io/flutter/FlutterConstants.java
@@ -7,8 +7,6 @@
 package io.flutter;
 
 public class FlutterConstants {
-  public static final String PACKAGES_FILE = ".packages";
-  public static final String PUBSPEC_YAML = "pubspec.yaml";
 
   public static final String PACKAGES_GET_ACTION_ID = "flutter.packages.get";
   public static final String PACKAGES_UPGRADE_ACTION_ID = "flutter.packages.upgrade";

--- a/src/io/flutter/FlutterUtils.java
+++ b/src/io/flutter/FlutterUtils.java
@@ -13,6 +13,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
 import com.jetbrains.lang.dart.DartFileType;
+import io.flutter.pub.PubRoot;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -35,11 +36,7 @@ public class FlutterUtils {
 
   @SuppressWarnings("BooleanMethodIsAlwaysInverted")
   public static boolean isFlutteryFile(@NotNull VirtualFile file) {
-    return isDartFile(file) || isPubspecFile(file);
-  }
-
-  public static boolean isPubspecFile(@NotNull VirtualFile file) {
-    return Objects.equals(file.getName(), FlutterConstants.PUBSPEC_YAML);
+    return isDartFile(file) || PubRoot.isPubspec(file);
   }
 
   public static boolean isDartFile(@NotNull VirtualFile file) {

--- a/src/io/flutter/actions/FlutterPackagesExplorerActionGroup.java
+++ b/src/io/flutter/actions/FlutterPackagesExplorerActionGroup.java
@@ -10,8 +10,7 @@ import com.intellij.openapi.actionSystem.CommonDataKeys;
 import com.intellij.openapi.actionSystem.DefaultActionGroup;
 import com.intellij.openapi.actionSystem.Presentation;
 import com.intellij.openapi.vfs.VirtualFile;
-import io.flutter.FlutterUtils;
-import io.flutter.utils.FlutterModuleUtils;
+import io.flutter.pub.PubRoot;
 import org.jetbrains.annotations.NotNull;
 
 
@@ -19,7 +18,8 @@ public class FlutterPackagesExplorerActionGroup extends DefaultActionGroup {
 
   private static boolean isFlutterPubspec(@NotNull AnActionEvent e) {
     final VirtualFile file = CommonDataKeys.VIRTUAL_FILE.getData(e.getDataContext());
-    return FlutterUtils.exists(file) && FlutterUtils.isPubspecFile(file) && FlutterModuleUtils.declaresFlutterDependency(file);
+    final PubRoot root = file == null ? null : PubRoot.forDirectory(file.getParent());
+    return root != null && root.getPubspec().equals(file) && root.declaresFlutter();
   }
 
   @Override

--- a/src/io/flutter/actions/FlutterPackagesGetAction.java
+++ b/src/io/flutter/actions/FlutterPackagesGetAction.java
@@ -12,11 +12,10 @@ import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Pair;
-import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
 import io.flutter.FlutterBundle;
-import io.flutter.FlutterConstants;
 import io.flutter.FlutterMessages;
+import io.flutter.pub.PubRoot;
 import io.flutter.sdk.FlutterSdk;
 import org.jetbrains.annotations.NotNull;
 
@@ -33,7 +32,7 @@ public class FlutterPackagesGetAction extends FlutterSdkAction {
         @Override
         public void processTerminated(ProcessEvent event) {
           // Refresh to ensure Dart Plugin sees .packages and doesn't mistakenly nag to run pub.
-          LocalFileSystem.getInstance().refreshAndFindFileByPath(workingDir.getPath() + "/" + FlutterConstants.PACKAGES_FILE);
+          PubRoot.forDirectoryWithRefresh(workingDir);
         }
       });
     }

--- a/src/io/flutter/actions/FlutterSdkAction.java
+++ b/src/io/flutter/actions/FlutterSdkAction.java
@@ -22,8 +22,8 @@ import io.flutter.FlutterBundle;
 import io.flutter.FlutterInitializer;
 import io.flutter.FlutterMessages;
 import io.flutter.FlutterUtils;
+import io.flutter.pub.PubRoot;
 import io.flutter.sdk.FlutterSdk;
-import io.flutter.utils.FlutterModuleUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -45,16 +45,15 @@ public abstract class FlutterSdkAction extends DumbAwareAction {
     Module module = e == null ? null : LangDataKeys.MODULE.getData(e.getDataContext());
     final PsiFile psiFile = e == null ? null : CommonDataKeys.PSI_FILE.getData(e.getDataContext());
 
-    VirtualFile pubspec = FlutterModuleUtils.findPubspecFrom(project, psiFile);
-    if (pubspec == null) {
-      pubspec = FlutterModuleUtils.findPubspecFrom(module);
+    PubRoot root = psiFile == null ? null : PubRoot.forPsiFile(psiFile);
+    if (root == null) root = PubRoot.forProjectWithRefresh(project);
+    if (root == null && module != null) root = PubRoot.forModuleWithRefresh(module);
+
+    if (module == null && root != null) {
+      module = ProjectRootManager.getInstance(project).getFileIndex().getModuleForFile(root.getPubspec());
     }
 
-    if (module == null && pubspec != null) {
-      module = ProjectRootManager.getInstance(project).getFileIndex().getModuleForFile(pubspec);
-    }
-
-    return pubspec == null ? null : Pair.create(module, pubspec);
+    return root == null ? null : Pair.create(module, root.getPubspec());
   }
 
   @Override

--- a/src/io/flutter/editor/FlutterPubspecNotificationProvider.java
+++ b/src/io/flutter/editor/FlutterPubspecNotificationProvider.java
@@ -18,7 +18,7 @@ import com.intellij.ui.EditorNotificationPanel;
 import com.intellij.ui.EditorNotifications;
 import com.intellij.ui.HyperlinkLabel;
 import icons.FlutterIcons;
-import io.flutter.FlutterConstants;
+import io.flutter.pub.PubRoot;
 import io.flutter.sdk.FlutterSdk;
 import io.flutter.utils.FlutterModuleUtils;
 import org.jetbrains.annotations.NotNull;
@@ -42,7 +42,7 @@ public class FlutterPubspecNotificationProvider extends EditorNotifications.Prov
       return null;
     }
 
-    if (!FlutterConstants.PUBSPEC_YAML.equalsIgnoreCase(file.getName())) {
+    if (!PubRoot.isPubspec(file)) {
       return null;
     }
 

--- a/src/io/flutter/project/FlutterIconProvider.java
+++ b/src/io/flutter/project/FlutterIconProvider.java
@@ -12,8 +12,8 @@ import com.intellij.openapi.util.Iconable;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiDirectory;
 import com.intellij.psi.PsiElement;
-import io.flutter.FlutterConstants;
 import io.flutter.module.FlutterModuleType;
+import io.flutter.pub.PubRoot;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -23,20 +23,16 @@ public class FlutterIconProvider extends IconProvider {
   @Nullable
   public Icon getIcon(@NotNull final PsiElement element, @Iconable.IconFlags final int flags) {
     if (element instanceof PsiDirectory && ModuleUtil.hasModulesOfType(element.getProject(), FlutterModuleType.getInstance())) {
-      final VirtualFile folder = ((PsiDirectory)element).getVirtualFile();
-      if (isFolderNearPubspecYaml(folder, "lib")) return AllIcons.Modules.SourceRoot;
-      if (isFolderNearPubspecYaml(folder, ".idea")) return AllIcons.Modules.GeneratedFolder;
+      final VirtualFile file = ((PsiDirectory)element).getVirtualFile();
+      if (!file.isInLocalFileSystem()) return null;
+
+      final PubRoot root = PubRoot.forDirectory(file.getParent());
+      if (root == null) return null;
+
+      if (file.equals(root.getLib())) return AllIcons.Modules.SourceRoot;
+      if (file.isDirectory() && file.getName().equals(".idea")) return AllIcons.Modules.GeneratedFolder;
     }
 
     return null;
-  }
-
-  private static boolean isFolderNearPubspecYaml(final @Nullable VirtualFile folder, final @NotNull String folderName) {
-    if (folder != null && folder.isDirectory() && folder.isInLocalFileSystem() && folderName.equals(folder.getName())) {
-      final VirtualFile parentFolder = folder.getParent();
-      final VirtualFile pubspecYamlFile = parentFolder != null ? parentFolder.findChild(FlutterConstants.PUBSPEC_YAML) : null;
-      return pubspecYamlFile != null;
-    }
-    return false;
   }
 }

--- a/src/io/flutter/pub/PubRoot.java
+++ b/src/io/flutter/pub/PubRoot.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2017 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.pub;
+
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.ProjectFileIndex;
+import com.intellij.openapi.roots.ProjectRootManager;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiFile;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * A snapshot of the root directory of a pub package.
+ * <p>
+ * That is, a directory containing (at a minimum) a pubspec.yaml file.
+ */
+public class PubRoot {
+  @NotNull
+  private final VirtualFile root;
+
+  @NotNull
+  private final VirtualFile pubspec;
+
+  @Nullable
+  private final VirtualFile packages;
+
+  @Nullable
+  private final VirtualFile lib;
+
+  private PubRoot(@NotNull VirtualFile root, @NotNull VirtualFile pubspec, @Nullable VirtualFile packages, @Nullable VirtualFile lib) {
+    this.root = root;
+    this.pubspec = pubspec;
+    this.packages = packages;
+    this.lib = lib;
+  }
+
+  /**
+   * Returns the unique pub root for a project.
+   * <p>
+   * If there is more than one, returns null.
+   * <p>
+   * Refreshes the returned pubroot's directory. (Not any others.)
+   */
+  @Nullable
+  public static PubRoot forProjectWithRefresh(@NotNull Project project) {
+    final List<PubRoot> roots = PubRoots.forProject(project);
+    if (roots.size() != 1) {
+      return null;
+    }
+    return roots.get(0).refresh();
+  }
+
+  /**
+   * Returns the unique pub root for a module.
+   * <p>
+   * If there is more than one, returns null.
+   * <p>
+   * Refreshes the returned pubroot's directory. (Not any others.)
+   */
+  @Nullable
+  public static PubRoot forModuleWithRefresh(@NotNull Module module) {
+    final List<PubRoot> roots = PubRoots.forModule(module);
+    if (roots.size() != 1) {
+      return null;
+    }
+    return roots.get(0).refresh();
+  }
+
+  /**
+   * Returns the most appropriate pub root for a PsiFile.
+   * <p>
+   * If the file is within a content root and it contains a pubspec.yaml file, use that one.
+   * Otherwise, use the pubspec.yaml file for the project (if unique).
+   * <p>
+   * Based on the filesystem cache; doesn't refresh anything.
+   */
+  @Nullable
+  public static PubRoot forPsiFile(@NotNull PsiFile file) {
+    final ProjectFileIndex index = ProjectRootManager.getInstance(file.getProject()).getFileIndex();
+    final VirtualFile root = index.getContentRootForFile(file.getVirtualFile());
+    if (root != null) {
+      return forDirectory(root);
+    }
+
+    // Fall back to using the unique pub root for this project (if any).
+    final List<PubRoot> roots = PubRoots.forProject(file.getProject());
+    if (roots.size() != 1) {
+      return null;
+    }
+
+    return roots.get(0);
+  }
+
+  /**
+   * Returns the PubRoot for a directory, provided it contains a pubspec.yaml file.
+   * <p>
+   * Otherwise returns null.
+   * <p>
+   * (The existence check is based on the filesystem cache; doesn't refresh anything.)
+   */
+  @Nullable
+  public static PubRoot forDirectory(@NotNull VirtualFile dir) {
+    if (!dir.isDirectory()) {
+      return null;
+    }
+
+    final VirtualFile pubspec = dir.findChild("pubspec.yaml");
+    if (pubspec == null || !pubspec.exists() || pubspec.isDirectory()) {
+      return null;
+    }
+
+    VirtualFile packages = dir.findChild(".packages");
+    if (packages == null || !packages.exists() || packages.isDirectory()) {
+      packages = null;
+    }
+
+    VirtualFile lib = dir.findChild("lib");
+    if (lib == null || !lib.exists() || !lib.isDirectory()) {
+      lib = null;
+    }
+
+    return new PubRoot(dir, pubspec, packages, lib);
+  }
+
+  /**
+   * Returns the PubRoot for a directory, provided it contains a pubspec.yaml file.
+   * <p>
+   * Refreshes the directory and the lib directory (if present). Returns null if not found.
+   */
+  @Nullable
+  public static PubRoot forDirectoryWithRefresh(@NotNull VirtualFile dir) {
+    // Ensure file existence and timestamps are up to date.
+    dir.refresh(false, false);
+
+    final PubRoot root = forDirectory(dir);
+    if (root == null) return null;
+
+    final VirtualFile lib = root.getLib();
+    if (lib != null) lib.refresh(false, false);
+    return root;
+  }
+
+  /**
+   * Refreshes the pubroot and lib directories and returns an up-to-date snapshot.
+   * <p>
+   * Returns null if the directory or pubspec file is no longer there.
+   */
+  @Nullable
+  public PubRoot refresh() {
+    return forDirectoryWithRefresh(root);
+  }
+
+  @NotNull
+  public VirtualFile getRoot() {
+    return root;
+  }
+
+  @NotNull
+  public VirtualFile getPubspec() {
+    return pubspec;
+  }
+
+  /**
+   * Returns true if the pubspec declares a flutter dependency.
+   */
+  public boolean declaresFlutter() {
+    try {
+      final String contents = new String(pubspec.contentsToByteArray(true /* cache contents */));
+      return FLUTTER_SDK_DEP.matcher(contents).find();
+    }
+    catch (IOException e) {
+      return false;
+    }
+  }
+
+  @Nullable
+  public VirtualFile getPackages() {
+    return packages;
+  }
+
+  /**
+   * Returns true if the packages file is up to date.
+   */
+  public boolean hasUpToDatePackages() {
+    return packages != null && pubspec.getTimeStamp() < packages.getTimeStamp();
+  }
+
+  @Nullable
+  public VirtualFile getLib() {
+    return lib;
+  }
+
+  /**
+   * Returns lib/main.dart if it exists.
+   */
+  @Nullable
+  public VirtualFile getLibMain() {
+    return lib == null ? null : lib.findChild("main.dart");
+  }
+
+  public static boolean isPubspec(@NotNull VirtualFile file) {
+    return !file.isDirectory() && file.getName().equals("pubspec.yaml");
+  }
+
+  private static final Pattern FLUTTER_SDK_DEP = Pattern.compile(".*sdk:\\s*flutter"); //NON-NLS
+}

--- a/src/io/flutter/pub/PubRoots.java
+++ b/src/io/flutter/pub/PubRoots.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.pub;
+
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleManager;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.ModuleRootManager;
+import com.intellij.openapi.vfs.VirtualFile;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Queries returning a list of {@link PubRoot} directories.
+ */
+public class PubRoots {
+  // Not instantiable.
+  private PubRoots() {}
+
+  /**
+   * Returns a PubRoot for each of the module's content roots that contains a pubspec.yaml file.
+   * <p>
+   * (Based on the filesystem cache; doesn't refresh anything.)
+   */
+  public static List<PubRoot> forModule(@NotNull Module module) {
+    final List<PubRoot> result = new ArrayList<>();
+    for (VirtualFile dir : ModuleRootManager.getInstance(module).getContentRoots()) {
+      final PubRoot root = PubRoot.forDirectory(dir);
+      if (root != null) {
+        result.add(root);
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Returns a PubRoot for each of the project's content roots that contains a pubspec.yaml file.
+   * <p>
+   * (Based on the filesystem cache; doesn't refresh anything.)
+   */
+  public static List<PubRoot> forProject(@NotNull Project project) {
+    final List<PubRoot> result = new ArrayList<>();
+    for (Module module : ModuleManager.getInstance(project).getModules()) {
+      result.addAll(forModule(module));
+    }
+    return result;
+  }
+}

--- a/src/io/flutter/sdk/FlutterSdkUtil.java
+++ b/src/io/flutter/sdk/FlutterSdkUtil.java
@@ -25,6 +25,7 @@ import gnu.trove.THashSet;
 import io.flutter.FlutterBundle;
 import io.flutter.FlutterConstants;
 import io.flutter.dart.DartPlugin;
+import io.flutter.pub.PubRoot;
 import io.flutter.utils.FlutterModuleUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -218,13 +219,6 @@ public class FlutterSdkUtil {
     if (!isFlutterSdkHome(sdkRootPath)) return FlutterBundle.message("error.sdk.not.found.in.specified.location");
 
     return null;
-  }
-
-  public static boolean isFlutterProjectDir(@Nullable VirtualFile dir) {
-    if (dir == null || !dir.isDirectory()) return false;
-
-    final VirtualFile pubspec = dir.findChild(FlutterConstants.PUBSPEC_YAML);
-    return FlutterModuleUtils.declaresFlutterDependency(pubspec);
   }
 
   public static void setFlutterSdkPath(@NotNull final Project project, @NotNull final String flutterSdkPath) {

--- a/src/io/flutter/utils/FlutterModuleUtils.java
+++ b/src/io/flutter/utils/FlutterModuleUtils.java
@@ -5,7 +5,6 @@
  */
 package io.flutter.utils;
 
-import com.intellij.execution.ExecutionException;
 import com.intellij.execution.RunManager;
 import com.intellij.execution.RunnerAndConfigurationSettings;
 import com.intellij.execution.configurations.ConfigurationFactory;
@@ -17,18 +16,13 @@ import com.intellij.openapi.module.ModuleType;
 import com.intellij.openapi.module.ModuleUtil;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
-import com.intellij.openapi.roots.ModuleRootManager;
-import com.intellij.openapi.roots.ProjectRootManager;
-import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
-import com.intellij.psi.PsiFile;
 import com.intellij.ui.EditorNotifications;
 import com.intellij.util.PlatformUtils;
-import io.flutter.FlutterBundle;
-import io.flutter.FlutterConstants;
-import io.flutter.FlutterUtils;
 import io.flutter.dart.DartPlugin;
 import io.flutter.module.FlutterModuleType;
+import io.flutter.pub.PubRoot;
+import io.flutter.pub.PubRoots;
 import io.flutter.run.FlutterRunConfigurationType;
 import io.flutter.run.SdkFields;
 import io.flutter.run.SdkRunConfig;
@@ -37,18 +31,11 @@ import io.flutter.sdk.FlutterSdkUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Function;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class FlutterModuleUtils {
-
-  private static final Pattern FLUTTER_SDK_DEP = Pattern.compile(".*sdk:\\s*flutter"); //NON-NLS
 
   private FlutterModuleUtils() {
   }
@@ -92,7 +79,6 @@ public class FlutterModuleUtils {
     return CollectionUtils.anyMatch(getModules(project), FlutterModuleUtils::usesFlutter);
   }
 
-
   /**
    * Create a Flutter run configuration.
    *
@@ -134,135 +120,16 @@ public class FlutterModuleUtils {
   }
 
   /**
-   * Returns file context describing the main file (`lib/main.dart`) and its content root for
-   * the given module.  Note that if there is more than one defined main in the given module,
-   * the first will be returned.  If none is found, returns `null`.
-   */
-  @Nullable
-  public static FileWithContext findFlutterMain(@NotNull Module module) {
-    final VirtualFile[] contentRoots = ModuleRootManager.getInstance(module).getContentRoots();
-    for (VirtualFile root : contentRoots) {
-      final VirtualFile main = LocalFileSystem.getInstance().refreshAndFindFileByPath(root.getPath() + "/lib/main.dart");
-      if (FlutterUtils.exists(main)) {
-        return new FileWithContext(main, root);
-      }
-    }
-    return null;
-  }
-
-  /**
    * Introspect into the module's content roots, looking for flutter.yaml or a pubspec.yaml that
    * references flutter.
    */
   public static boolean usesFlutter(@NotNull Module module) {
-    final VirtualFile[] roots = ModuleRootManager.getInstance(module).getContentRoots();
-    for (VirtualFile baseDir : roots) {
-      final VirtualFile pubspec = baseDir.findChild(FlutterConstants.PUBSPEC_YAML);
-      if (declaresFlutterDependency(pubspec)) {
+    for (PubRoot root : PubRoots.forModule(module)) {
+      if (root.declaresFlutter()) {
         return true;
       }
     }
     return false;
-  }
-
-  public static boolean declaresFlutterDependency(@Nullable VirtualFile pubspec) {
-    if (!FlutterUtils.exists(pubspec)) {
-      return false;
-    }
-
-    try {
-      final String contents = new String(pubspec.contentsToByteArray(true /* cache contents */));
-      if (FLUTTER_SDK_DEP.matcher(contents).find()) {
-        return true;
-      }
-    }
-    catch (IOException e) {
-      // Ignore IO exceptions.
-    }
-    return false;
-  }
-
-  @Nullable
-  public static VirtualFile findPackagesFileFrom(@NotNull Project project,
-                                                 @SuppressWarnings("SameParameterValue") @Nullable PsiFile psiFile)
-    throws ExecutionException {
-    if (psiFile == null) {
-      final List<VirtualFile> packagesFiles = findPackagesFiles(getModules(project));
-      if (packagesFiles.isEmpty()) {
-        return null;
-      }
-      else if (packagesFiles.size() == 1) {
-        return packagesFiles.get(0);
-      }
-      else {
-        throw new ExecutionException(FlutterBundle.message("multiple.packages.files.error"));
-      }
-    }
-    final VirtualFile file = psiFile.getVirtualFile();
-    final VirtualFile contentRoot = ProjectRootManager.getInstance(project).getFileIndex().getContentRootForFile(file);
-    return contentRoot == null ? null : contentRoot.findChild(FlutterConstants.PACKAGES_FILE);
-  }
-
-  @Nullable
-  public static VirtualFile findPubspecFrom(@NotNull Project project, @Nullable PsiFile psiFile) throws ExecutionException {
-    if (psiFile == null) {
-      final List<VirtualFile> pubspecs = findPubspecs(getModules(project));
-      if (pubspecs.isEmpty()) {
-        return null;
-      }
-      else if (pubspecs.size() == 1) {
-        return pubspecs.get(0);
-      }
-      else {
-        throw new ExecutionException(FlutterBundle.message("multiple.pubspecs.error"));
-      }
-    }
-    final VirtualFile file = psiFile.getVirtualFile();
-    final VirtualFile contentRoot = ProjectRootManager.getInstance(project).getFileIndex().getContentRootForFile(file);
-    return contentRoot == null ? null : contentRoot.findChild(FlutterConstants.PUBSPEC_YAML);
-  }
-
-  @NotNull
-  private static List<VirtualFile> findModuleFiles(@NotNull Module[] modules, Function<Module, VirtualFile> finder) {
-    return Arrays.stream(modules).flatMap(m -> {
-      final VirtualFile file = finder.apply(m);
-      return file != null ? Stream.of(file) : Stream.empty();
-    }).collect(Collectors.toList());
-  }
-
-  @NotNull
-  public static List<VirtualFile> findPubspecs(@NotNull Module[] modules) {
-    return findModuleFiles(modules, FlutterModuleUtils::findPubspecFrom);
-  }
-
-  @NotNull
-  public static List<VirtualFile> findPackagesFiles(@NotNull Module[] modules) {
-    return findModuleFiles(modules, FlutterModuleUtils::findPackagesFileFrom);
-  }
-
-  @Nullable
-  public static VirtualFile findPubspecFrom(@Nullable Module module) {
-    return findFilesInContentRoots(module, dir -> dir.findChild(FlutterConstants.PUBSPEC_YAML));
-  }
-
-  @Nullable
-  public static VirtualFile findPackagesFileFrom(@Nullable Module module) {
-    return findFilesInContentRoots(module, dir -> dir.findChild(FlutterConstants.PACKAGES_FILE));
-  }
-
-  @Nullable
-  public static VirtualFile findFilesInContentRoots(@Nullable Module module, @NotNull Function<VirtualFile, VirtualFile> finder) {
-    if (module == null) {
-      return null;
-    }
-    final ModuleRootManager moduleRootManager = ModuleRootManager.getInstance(module);
-    for (VirtualFile dir : moduleRootManager.getContentRoots()) {
-      final VirtualFile file = finder.apply(dir);
-      if (file != null) {
-        return file;
-      }
-    }
-    return null;
   }
 
   /**
@@ -310,20 +177,5 @@ public class FlutterModuleUtils {
       DartPlugin.ensureDartSdkConfigured(module.getProject(), dartSdkPath);
       DartPlugin.enableDartSdk(module);
     });
-  }
-
-  /**
-   * Describes a file and its associated content root.
-   */
-  public static class FileWithContext {
-    @NotNull
-    public final VirtualFile file;
-    @NotNull
-    public final VirtualFile contentRoot;
-
-    public FileWithContext(@NotNull VirtualFile file, @NotNull VirtualFile contentRoot) {
-      this.file = file;
-      this.contentRoot = contentRoot;
-    }
   }
 }


### PR DESCRIPTION
Most of this functionality was in FlutterModuleUtils before.
There shouldn't be any user-visible changes; this is for readability.
