### PR TITLE
fix an NPE in the icon provider

### DIFF
--- a/src/io/flutter/pub/PubRoot.java
+++ b/src/io/flutter/pub/PubRoot.java
@@ -137,8 +137,8 @@ public class PubRoot {
    * (The existence check is based on the filesystem cache; doesn't refresh anything.)
    */
   @Nullable
-  public static PubRoot forDirectory(@NotNull VirtualFile dir) {
-    if (!dir.isDirectory()) {
+  public static PubRoot forDirectory(@Nullable VirtualFile dir) {
+    if (dir == null || !dir.isDirectory()) {
       return null;
     }
 


### PR DESCRIPTION
@pq, @skybrian, fix an NPE in the icon provider:

```
Argument for @NotNull parameter 'dir' of io/flutter/pub/PubRoot.forDirectory must not be null
java.lang.IllegalArgumentException: Argument for @NotNull parameter 'dir' of io/flutter/pub/PubRoot.forDirectory must not be null
	at io.flutter.pub.PubRoot.$$$reportNull$$$0(PubRoot.java)
	at io.flutter.pub.PubRoot.forDirectory(PubRoot.java)
	at io.flutter.project.FlutterIconProvider.getIcon(FlutterIconProvider.java:29)
	at com.intellij.util.PsiIconUtil.getProvidersIcon(PsiIconUtil.java:42)
	at com.intellij.psi.impl.ElementBase.computeIconNow(ElementBase.java:118)
	at com.intellij.psi.impl.ElementBase.lambda$static$0(ElementBase.java:59)
	at com.intellij.ui.DeferredIconImpl.evaluate(DeferredIconImpl.java:275)
	at com.intellij.ui.DeferredIconImpl.lambda$null$0(DeferredIconImpl.java:161)
	at com.intellij.ui.IconDeferrerImpl.evaluateDeferred(IconDeferrerImpl.java:111)
	at com.intellij.ui.DeferredIconImpl.lambda$null$1(DeferredIconImpl.java:161)
	at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:1153)
	at com.intellij.openapi.progress.util.ProgressIndicatorUtils.lambda$runInReadActionWithWriteActionPriority$0(ProgressIndicatorUtils.java:91)
	at com.intellij.openapi.progress.util.ProgressIndicatorUtils.lambda$runWithWriteActionPriority$2(ProgressIndicatorUtils.java:147)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$runProcess$1(CoreProgressManager.java:176)
	at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:556)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:501)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:66)
	at com.intellij.openapi.progress.impl.CoreProgressManager.runProcess(CoreProgressManager.java:163)
	at com.intellij.openapi.progress.util.ProgressIndicatorUtils.runWithWriteActionPriority(ProgressIndicatorUtils.java:145)
	at com.intellij.openapi.progress.util.ProgressIndicatorUtils.runInReadActionWithWriteActionPriority(ProgressIndicatorUtils.java:91)
	at com.intellij.openapi.progress.util.ProgressIndicatorUtils.runInReadActionWithWriteActionPriority(ProgressIndicatorUtils.java:112)
	at com.intellij.ui.DeferredIconImpl.lambda$paintIcon$4(DeferredIconImpl.java:160)
	at com.intellij.util.concurrency.BoundedTaskExecutor$2.run(BoundedTaskExecutor.java:212)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
```