### PR TITLE
store the last used flutter sdk path first

### DIFF
--- a/src/io/flutter/project/FlutterProjectOpenProcessor.java
+++ b/src/io/flutter/project/FlutterProjectOpenProcessor.java
@@ -21,7 +21,6 @@ import icons.FlutterIcons;
 import io.flutter.FlutterBundle;
 import io.flutter.FlutterMessages;
 import io.flutter.ProjectOpenActivity;
-import io.flutter.actions.FlutterPackagesGetAction;
 import io.flutter.pub.PubRoot;
 import io.flutter.sdk.FlutterSdk;
 import io.flutter.utils.FlutterModuleUtils;

--- a/src/io/flutter/sdk/FlutterSdkUtil.java
+++ b/src/io/flutter/sdk/FlutterSdkUtil.java
@@ -21,11 +21,8 @@ import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.util.ArrayUtil;
 import com.jetbrains.lang.dart.sdk.DartSdkUpdateOption;
-import gnu.trove.THashSet;
 import io.flutter.FlutterBundle;
-import io.flutter.FlutterConstants;
 import io.flutter.dart.DartPlugin;
-import io.flutter.pub.PubRoot;
 import io.flutter.utils.FlutterModuleUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -34,7 +31,6 @@ import javax.swing.*;
 import java.io.File;
 import java.io.IOException;
 import java.util.*;
-
 
 public class FlutterSdkUtil {
   /** The environment variable to use to tell the flutter tool which app is driving it. */
@@ -62,20 +58,23 @@ public class FlutterSdkUtil {
 
   private static void updateKnownPaths(@SuppressWarnings("SameParameterValue") @NotNull final String propertyKey,
                                        @NotNull final String newPath) {
-    final Set<String> known = new THashSet<>();
+    final Set<String> allPaths = new LinkedHashSet<>();
 
-    final String[] oldKnownPaths = PropertiesComponent.getInstance().getValues(propertyKey);
-    if (oldKnownPaths != null) {
-      known.addAll(Arrays.asList(oldKnownPaths));
+    // Add the new value first; this ensures that it's the 'default' flutter sdk.
+    allPaths.add(newPath);
+
+    // Add the existing known paths.
+    final String[] oldPaths = PropertiesComponent.getInstance().getValues(propertyKey);
+    if (oldPaths != null) {
+      allPaths.addAll(Arrays.asList(oldPaths));
     }
 
-    known.add(newPath);
-
-    if (known.isEmpty()) {
+    // Store the values back.
+    if (allPaths.isEmpty()) {
       PropertiesComponent.getInstance().unsetValue(propertyKey);
     }
     else {
-      PropertiesComponent.getInstance().setValues(propertyKey, ArrayUtil.toStringArray(known));
+      PropertiesComponent.getInstance().setValues(propertyKey, ArrayUtil.toStringArray(allPaths));
     }
   }
 

--- a/testSrc/unit/io/flutter/testing/Testing.java
+++ b/testSrc/unit/io/flutter/testing/Testing.java
@@ -58,7 +58,7 @@ public class Testing {
   @SuppressWarnings("RedundantTypeArguments")
   public static <T> T computeInWriteAction(ThrowableComputable<T, Exception> callback) throws Exception {
     return computeOnDispatchThread(() -> {
-      Application app = ApplicationManager.getApplication();
+      final Application app = ApplicationManager.getApplication();
       return app.<T, Exception>runWriteAction(callback);
     });
   }


### PR DESCRIPTION
- store the last used flutter sdk path first; this ensures that the last one selected by the user is the 'default' flutter sdk path to use when opening a project w/o a previously set flutter sdk
- fix https://github.com/flutter/flutter-intellij/issues/951

@pq, @skybrian 