### PR TITLE
Handle project open more consistently

### DIFF
--- a/src/io/flutter/FlutterInitializer.java
+++ b/src/io/flutter/FlutterInitializer.java
@@ -18,8 +18,10 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.startup.StartupActivity;
 import io.flutter.analytics.Analytics;
 import io.flutter.analytics.ToolWindowTracker;
+import io.flutter.pub.PubRoot;
 import io.flutter.run.FlutterRunNotifications;
 import io.flutter.run.daemon.DeviceService;
+import io.flutter.utils.FlutterModuleUtils;
 import io.flutter.view.FlutterViewFactory;
 import org.jetbrains.annotations.NotNull;
 
@@ -102,6 +104,12 @@ public class FlutterInitializer implements StartupActivity {
 
     // Start watching for Flutter debug active events.
     FlutterViewFactory.init(project);
+
+    final PubRoot root = PubRoot.forProjectWithRefresh(project);
+    if (root != null) {
+      FlutterModuleUtils.autoCreateRunConfig(project, root);
+      FlutterModuleUtils.autoShowMain(project, root);
+    }
 
     FlutterRunNotifications.init(project);
 

--- a/src/io/flutter/ProjectOpenActivity.java
+++ b/src/io/flutter/ProjectOpenActivity.java
@@ -47,9 +47,6 @@ public class ProjectOpenActivity implements StartupActivity, DumbAware {
     if (!root.hasUpToDatePackages()) {
       Notifications.Bus.notify(new PackagesOutOfDateNotification(project));
     }
-
-    FlutterModuleUtils.autoCreateRunConfig(project, root);
-    FlutterModuleUtils.autoShowMain(project, root);
   }
 
   /**

--- a/src/io/flutter/ProjectOpenActivity.java
+++ b/src/io/flutter/ProjectOpenActivity.java
@@ -5,11 +5,20 @@
  */
 package io.flutter;
 
+import com.intellij.execution.ExecutionException;
+import com.intellij.notification.Notification;
+import com.intellij.notification.NotificationType;
+import com.intellij.notification.Notifications;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.startup.StartupActivity;
+import icons.FlutterIcons;
+import io.flutter.pub.PubRoot;
 import io.flutter.sdk.FlutterSdk;
+import io.flutter.utils.FlutterModuleUtils;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -20,12 +29,108 @@ import org.jetbrains.annotations.NotNull;
 public class ProjectOpenActivity implements StartupActivity, DumbAware {
   @Override
   public void runActivity(@NotNull Project project) {
+    if (!FlutterModuleUtils.hasFlutterModule(project)) {
+      // This method is called in twice when importing a project, because the project is reloaded.
+      // Don't do anything until the second time.
+      return;
+    }
+
+    final PubRoot root = PubRoot.forProjectWithRefresh(project);
+    if (root == null) {
+      return;
+    }
+
+    if (!downloadDependencies(project, root)) {
+      return;
+    }
+
+    if (!root.hasUpToDatePackages()) {
+      Notifications.Bus.notify(new PackagesOutOfDateNotification(project));
+    }
+
+    FlutterModuleUtils.autoCreateRunConfig(project, root);
+    FlutterModuleUtils.autoShowMain(project, root);
+  }
+
+  /**
+   * Ensures that we can start the analysis server and it won't see bad imports.
+   * <p>
+   * We might need to download the Dart SDK or some packages.
+   * <p>
+   * Waits until download is complete. (On a slow network, this can take many seconds.)
+   * <p>
+   * Returns true if successful.
+   */
+  private boolean downloadDependencies(@NotNull Project project, @NotNull PubRoot root) {
     final FlutterSdk sdk = FlutterSdk.getIncomplete(project);
-    if (sdk != null && sdk.getDartSdkPath() == null) {
+    if (sdk == null) {
+      // Can't do anything without a Flutter SDK.
+      return false;
+    }
+
+    if (root.getPackages() == null) {
+      // Get packages; as a side effect this will also download the Dart SDK if needed.
+      try {
+        final Process process = sdk.startPackagesGet(root, project);
+        if (process != null) {
+          process.waitFor();
+          return process.exitValue() == 0;
+        }
+      }
+      catch (ExecutionException | InterruptedException e) {
+        FlutterMessages.showError("Error opening", e.getMessage());
+      }
+      return false;
+    } else if (sdk.getDartSdkPath() == null) {
+      // This can happen when opening an example project after "git clone flutter".
+      // We have a .packages file, but need to run a flutter command to download the Dart SDK.
       final boolean ok = sdk.sync(project);
       if (!ok) {
         LOG.warn("failed to sync flutter SDK");
       }
+      return ok;
+    } else {
+      return true; // Nothing to do.
+    }
+  }
+
+  private static class PackagesOutOfDateNotification extends Notification {
+
+    @NotNull
+    private final Project myProject;
+
+    public PackagesOutOfDateNotification(@NotNull Project project) {
+      super("Flutter Packages", FlutterIcons.Flutter, "Flutter packages get.",
+            null, "The pubspec.yaml file has been modified since " +
+                  "the last time 'flutter packages get' was run.",
+            NotificationType.INFORMATION, null);
+
+      myProject = project;
+
+      addAction(new AnAction("Run 'flutter packages get'") {
+        @Override
+        public void actionPerformed(AnActionEvent event) {
+          expire();
+
+          final FlutterSdk sdk = FlutterSdk.getFlutterSdk(project);
+          if (sdk == null) {
+            return;
+          }
+
+          final PubRoot root = PubRoot.forProjectWithRefresh(project);
+          if (root == null) {
+            return;
+          }
+
+          try {
+            // TODO(skybrian) analytics?
+            sdk.startPackagesGet(root, project);
+          }
+          catch (ExecutionException e) {
+            FlutterMessages.showError("Error opening", e.getMessage());
+          }
+        }
+      });
     }
   }
 

--- a/src/io/flutter/ProjectOpenActivity.java
+++ b/src/io/flutter/ProjectOpenActivity.java
@@ -35,7 +35,7 @@ public class ProjectOpenActivity implements StartupActivity, DumbAware {
       return;
     }
 
-    final PubRoot root = PubRoot.forProjectWithRefresh(project);
+    PubRoot root = PubRoot.forProjectWithRefresh(project);
     if (root == null) {
       return;
     }
@@ -44,7 +44,8 @@ public class ProjectOpenActivity implements StartupActivity, DumbAware {
       return;
     }
 
-    if (!root.hasUpToDatePackages()) {
+    root = root.refresh();
+    if (root != null && !root.hasUpToDatePackages()) {
       Notifications.Bus.notify(new PackagesOutOfDateNotification(project));
     }
   }

--- a/src/io/flutter/module/FlutterModuleBuilder.java
+++ b/src/io/flutter/module/FlutterModuleBuilder.java
@@ -13,11 +13,9 @@ import com.intellij.ide.util.projectWizard.WizardContext;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.application.WriteAction;
 import com.intellij.openapi.diagnostic.Logger;
-import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.module.*;
 import com.intellij.openapi.options.ConfigurationException;
 import com.intellij.openapi.progress.ProgressManager;
-import com.intellij.openapi.project.DumbService;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ModifiableRootModel;
 import com.intellij.openapi.roots.ui.configuration.ModulesProvider;
@@ -104,7 +102,9 @@ public class FlutterModuleBuilder extends ModuleBuilder {
       return result;
     }
     final Module flutter = result.get(0);
-    setUpMain(root, flutter);
+
+    FlutterModuleUtils.autoCreateRunConfig(project, root);
+    FlutterModuleUtils.autoShowMain(project, root);
 
     final Module android = addAndroidModule(project, model, basePath);
     if (android != null) {
@@ -259,20 +259,6 @@ public class FlutterModuleBuilder extends ModuleBuilder {
   }
 
   /**
-   * Creates the run configuration and shows lib/main.dart.
-   */
-  private static void setUpMain(@NotNull PubRoot root, @NotNull Module module) {
-    final VirtualFile main = root.getLibMain();
-    if (main != null) {
-      FlutterModuleUtils.createRunConfig(module.getProject(), main);
-      DumbService.getInstance(module.getProject()).runWhenSmart(() -> {
-        final FileEditorManager manager = FileEditorManager.getInstance(module.getProject());
-        manager.openFile(main, true);
-      });
-    }
-  }
-
-  /**
    * Set up a "small IDE" project. (For example, WebStorm.)
    */
   public static void setupSmallProject(@NotNull Project project, ModifiableRootModel model, VirtualFile baseDir, String flutterSdkPath)
@@ -285,7 +271,8 @@ public class FlutterModuleBuilder extends ModuleBuilder {
 
     final PubRoot root = runFlutterCreate(sdk, baseDir, model.getModule());
     if (root != null) {
-      setUpMain(root, model.getModule());
+      FlutterModuleUtils.autoCreateRunConfig(project, root);
+      FlutterModuleUtils.autoShowMain(project, root);
     }
     final String dartSdkPath = sdk.getDartSdkPath();
     if (dartSdkPath == null) {

--- a/src/io/flutter/module/FlutterModuleBuilder.java
+++ b/src/io/flutter/module/FlutterModuleBuilder.java
@@ -103,7 +103,6 @@ public class FlutterModuleBuilder extends ModuleBuilder {
     }
     final Module flutter = result.get(0);
 
-    FlutterModuleUtils.autoCreateRunConfig(project, root);
     FlutterModuleUtils.autoShowMain(project, root);
 
     final Module android = addAndroidModule(project, model, basePath);
@@ -271,7 +270,6 @@ public class FlutterModuleBuilder extends ModuleBuilder {
 
     final PubRoot root = runFlutterCreate(sdk, baseDir, model.getModule());
     if (root != null) {
-      FlutterModuleUtils.autoCreateRunConfig(project, root);
       FlutterModuleUtils.autoShowMain(project, root);
     }
     final String dartSdkPath = sdk.getDartSdkPath();

--- a/src/io/flutter/project/FlutterProjectOpenProcessor.java
+++ b/src/io/flutter/project/FlutterProjectOpenProcessor.java
@@ -5,12 +5,6 @@
  */
 package io.flutter.project;
 
-import com.intellij.execution.ExecutionException;
-import com.intellij.notification.Notification;
-import com.intellij.notification.NotificationType;
-import com.intellij.notification.Notifications;
-import com.intellij.openapi.actionSystem.AnAction;
-import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.extensions.Extensions;
 import com.intellij.openapi.module.Module;
@@ -22,15 +16,12 @@ import io.flutter.FlutterBundle;
 import io.flutter.FlutterMessages;
 import io.flutter.ProjectOpenActivity;
 import io.flutter.pub.PubRoot;
-import io.flutter.sdk.FlutterSdk;
 import io.flutter.utils.FlutterModuleUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
-import java.text.MessageFormat;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Objects;
 
 
@@ -55,7 +46,7 @@ public class FlutterProjectOpenProcessor extends ProjectOpenProcessor {
   @Override
   public boolean canOpenProject(@Nullable VirtualFile file) {
     if (file == null) return false;
-    final PubRoot root = PubRoot.forDirectoryWithRefresh(file);
+    final PubRoot root = PubRoot.forDirectory(file);
     return root != null && root.declaresFlutter();
   }
 
@@ -77,58 +68,14 @@ public class FlutterProjectOpenProcessor extends ProjectOpenProcessor {
     }
 
     final Project project = importProvider.doOpenProject(file, projectToClose, forceOpenInNewFrame);
-
-    // Once open, process.
-    doPostOpenProcessing(project);
-
-    return project;
-  }
-
-  private void doPostOpenProcessing(@Nullable Project project) {
     if (project == null) {
-      return;
+      return null;
     }
 
     if (!FlutterModuleUtils.hasFlutterModule(project)) {
-      if (FlutterModuleUtils.usesFlutter(project)) {
-        final List<Module> modules = FlutterModuleUtils.findModulesWithFlutterContents(project);
-        if (modules.isEmpty()) {
-          LOG.warn(MessageFormat.format("No module found for {0}", project.getName()));
-          return;
-        }
-        else if (modules.size() > 1) {
-          LOG.warn(MessageFormat.format("{0} contains {1} modules.", project.getName(), modules.size()));
-        }
-
-        final Module module = modules.get(0);
-        final PubRoot root = PubRoot.forModuleWithRefresh(module);
-        final VirtualFile main = root == null ? null : root.getLibMain();
-        if (main != null) {
-          FlutterModuleUtils.createRunConfig(project, main);
-        }
-
-        FlutterModuleUtils.setFlutterModuleAndReload(module, project);
-        return;
-      }
+      convertToFlutterProject(project);
     }
-
-    try {
-      final PubRoot root = PubRoot.forProjectWithRefresh(project);
-      if (root != null && root.getPackages() == null) {
-        final FlutterSdk sdk = FlutterSdk.getFlutterSdk(project);
-        if (sdk != null) {
-          sdk.startPackagesGet(root, project);
-        }
-      }
-      else {
-        if (root != null && !root.hasUpToDatePackages()) {
-          Notifications.Bus.notify(new PackagesOutOfDateNotification(project));
-        }
-      }
-    }
-    catch (ExecutionException e) {
-      handleError(e);
-    }
+    return project;
   }
 
   @Nullable
@@ -138,48 +85,27 @@ public class FlutterProjectOpenProcessor extends ProjectOpenProcessor {
     ).findFirst().orElse(null);
   }
 
+  /**
+   * Sets up a project that doesn't have any Flutter modules.
+   * <p>
+   * (It probably wasn't created with "flutter create" and probably didn't have any IntelliJ configuration before.)
+   */
+  private void convertToFlutterProject(@NotNull Project project) {
+    final PubRoot root = PubRoot.forProjectWithRefresh(project);
+    if (root == null) {
+      return; // Either no pub roots, or more than one.
+    }
+
+    final Module module = root.getModule(project);
+    if (module == null) {
+      return; // Shouldn't happen or root would have been null.
+    }
+
+    FlutterModuleUtils.setFlutterModuleAndReload(module, project);
+  }
+
   @Override
   public boolean isStrongProjectInfoHolder() {
     return true;
-  }
-
-  private static class PackagesOutOfDateNotification extends Notification {
-
-    @NotNull
-    private final Project myProject;
-
-    public PackagesOutOfDateNotification(@NotNull Project project) {
-      super("Flutter Packages", FlutterIcons.Flutter, "Flutter packages get.",
-            null, "The pubspec.yaml file has been modified since " +
-                  "the last time 'flutter packages get' was run.",
-            NotificationType.INFORMATION, null);
-
-      myProject = project;
-
-      addAction(new AnAction("Run 'flutter packages get'") {
-        @Override
-        public void actionPerformed(AnActionEvent event) {
-          expire();
-
-          final FlutterSdk sdk = FlutterSdk.getFlutterSdk(project);
-          if (sdk == null) {
-            return;
-          }
-
-          final PubRoot root = PubRoot.forProjectWithRefresh(project);
-          if (root == null) {
-            return;
-          }
-
-          try {
-            // TODO(skybrian) analytics?
-            sdk.startPackagesGet(root, project);
-          }
-          catch (ExecutionException e) {
-            handleError(e);
-          }
-        }
-      });
-    }
   }
 }

--- a/src/io/flutter/run/FlutterRunConfigurationType.java
+++ b/src/io/flutter/run/FlutterRunConfigurationType.java
@@ -20,18 +20,25 @@ import org.jetbrains.annotations.NotNull;
 
 public class FlutterRunConfigurationType extends ConfigurationTypeBase {
 
+  private final Factory factory;
+
   public FlutterRunConfigurationType() {
     super("FlutterRunConfigurationType", FlutterBundle.message("runner.flutter.configuration.name"),
           FlutterBundle.message("runner.flutter.configuration.description"), FlutterIcons.Flutter);
-    addFactory(new FlutterConfigurationFactory(this));
+    factory = new Factory(this);
+    addFactory(factory);
+  }
+
+  public Factory getFactory() {
+    return factory;
   }
 
   public static FlutterRunConfigurationType getInstance() {
     return Extensions.findExtension(CONFIGURATION_TYPE_EP, FlutterRunConfigurationType.class);
   }
 
-  public static class FlutterConfigurationFactory extends ConfigurationFactory {
-    public FlutterConfigurationFactory(FlutterRunConfigurationType type) {
+  public static class Factory extends ConfigurationFactory {
+    public Factory(FlutterRunConfigurationType type) {
       super(type);
     }
 

--- a/src/io/flutter/utils/FlutterModuleUtils.java
+++ b/src/io/flutter/utils/FlutterModuleUtils.java
@@ -7,13 +7,13 @@ package io.flutter.utils;
 
 import com.intellij.execution.RunManager;
 import com.intellij.execution.RunnerAndConfigurationSettings;
-import com.intellij.execution.configurations.ConfigurationFactory;
-import com.intellij.execution.configurations.RunConfiguration;
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleManager;
 import com.intellij.openapi.module.ModuleType;
 import com.intellij.openapi.module.ModuleUtil;
+import com.intellij.openapi.project.DumbService;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -31,9 +31,7 @@ import io.flutter.sdk.FlutterSdkUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 
 public class FlutterModuleUtils {
 
@@ -80,43 +78,52 @@ public class FlutterModuleUtils {
   }
 
   /**
-   * Create a Flutter run configuration.
-   *
-   * @param project the project
-   * @param main    the target main
+   * Creates a Flutter run configuration if none exist.
    */
-  public static void createRunConfig(@NotNull Project project, @Nullable VirtualFile main) {
-    final ConfigurationFactory[] factories = FlutterRunConfigurationType.getInstance().getConfigurationFactories();
-    final Optional<ConfigurationFactory> factory =
-      Arrays.stream(factories).filter((f) -> f instanceof FlutterRunConfigurationType.FlutterConfigurationFactory).findFirst();
-    assert (factory.isPresent());
-    final ConfigurationFactory configurationFactory = factory.get();
+  public static void autoCreateRunConfig(@NotNull Project project, @NotNull PubRoot root) {
+    final VirtualFile main = root.getLibMain();
+    if (main == null || !main.exists()) return;
+
+    final FlutterRunConfigurationType configType = FlutterRunConfigurationType.getInstance();
 
     final RunManager runManager = RunManager.getInstance(project);
-    final List<RunConfiguration> configurations = runManager.getConfigurationsList(FlutterRunConfigurationType.getInstance());
-
-    // If the target project has no flutter run configurations, create one.
-    if (configurations.isEmpty()) {
-      final RunnerAndConfigurationSettings settings =
-        runManager.createRunConfiguration(project.getName(), configurationFactory);
-      final SdkRunConfig config = (SdkRunConfig)settings.getConfiguration();
-
-      // Set config name.
-      final String name = config.suggestedName();
-      if (name == null) {
-        config.setName(project.getName());
-      }
-
-      // Set fields.
-      final SdkFields fields = new SdkFields();
-      if (main != null && main.exists()) {
-        fields.setFilePath(main.getPath());
-      }
-      config.setFields(fields);
-
-      runManager.addConfiguration(settings, false);
-      runManager.setSelectedConfiguration(settings);
+    if (!runManager.getConfigurationsList(configType).isEmpty()) {
+      return;
     }
+
+    final RunnerAndConfigurationSettings settings =
+      runManager.createRunConfiguration(project.getName(), configType.getFactory());
+
+    final SdkRunConfig config = (SdkRunConfig)settings.getConfiguration();
+
+    // Set config name.
+    final String name = config.suggestedName();
+    if (name == null) {
+      config.setName(project.getName());
+    }
+
+    // Set fields.
+    final SdkFields fields = new SdkFields();
+    fields.setFilePath(main.getPath());
+    config.setFields(fields);
+
+    runManager.addConfiguration(settings, false);
+    runManager.setSelectedConfiguration(settings);
+  }
+
+  /**
+   * If no files are open, show lib/main.dart for the given PubRoot.
+   */
+  public static void autoShowMain(@NotNull Project project, @NotNull PubRoot root) {
+    final VirtualFile main = root.getLibMain();
+    if (main == null) return;
+
+    DumbService.getInstance(project).runWhenSmart(() -> {
+      final FileEditorManager manager = FileEditorManager.getInstance(project);
+      if (manager.getAllEditors().length == 0) {
+        manager.openFile(main, true);
+      }
+    });
   }
 
   /**

--- a/src/io/flutter/utils/FlutterModuleUtils.java
+++ b/src/io/flutter/utils/FlutterModuleUtils.java
@@ -81,6 +81,8 @@ public class FlutterModuleUtils {
    * Creates a Flutter run configuration if none exist.
    */
   public static void autoCreateRunConfig(@NotNull Project project, @NotNull PubRoot root) {
+    assert ApplicationManager.getApplication().isReadAccessAllowed();
+
     final VirtualFile main = root.getLibMain();
     if (main == null || !main.exists()) return;
 
@@ -97,10 +99,7 @@ public class FlutterModuleUtils {
     final SdkRunConfig config = (SdkRunConfig)settings.getConfiguration();
 
     // Set config name.
-    final String name = config.suggestedName();
-    if (name == null) {
-      config.setName(project.getName());
-    }
+    config.setName("main.dart");
 
     // Set fields.
     final SdkFields fields = new SdkFields();


### PR DESCRIPTION
- If .packages file is missing, we don't need to run two flutter commands.
- On project open, check if we should create a run configuration
- On project open, check if we should open lib/main.dart

(Depends on #965; look at the second commit.)

