### PR TITLE
remove the use of the VERSION file

### DIFF
--- a/src/io/flutter/inspections/SdkConfigurationNotificationProvider.java
+++ b/src/io/flutter/inspections/SdkConfigurationNotificationProvider.java
@@ -21,16 +21,11 @@ import com.jetbrains.lang.dart.DartFileType;
 import com.jetbrains.lang.dart.DartLanguage;
 import io.flutter.FlutterBundle;
 import io.flutter.sdk.FlutterSdk;
-import io.flutter.sdk.FlutterSdkVersion;
-import io.flutter.settings.FlutterUIConfig;
 import io.flutter.utils.FlutterModuleUtils;
 import org.jetbrains.annotations.NotNull;
 
 public class SdkConfigurationNotificationProvider extends EditorNotifications.Provider<EditorNotificationPanel>
   implements DumbAware {
-
-  // Minimum SDK known to support hot reload.
-  private static final FlutterSdkVersion MIN_SUPPORTED_SDK = FlutterSdkVersion.forVersionString("0.0.3");
 
   private static final Key<EditorNotificationPanel> KEY = Key.create("FlutterWrongDartSdkNotification");
 
@@ -79,25 +74,6 @@ public class SdkConfigurationNotificationProvider extends EditorNotifications.Pr
       return createNoFlutterSdkPanel();
     }
 
-    if (flutterSdk.getVersion().isLessThan(MIN_SUPPORTED_SDK)) {
-      return createOutOfDateFlutterSdkPanel(flutterSdk);
-    }
-
     return null;
-  }
-
-  private EditorNotificationPanel createOutOfDateFlutterSdkPanel(@NotNull FlutterSdk sdk) {
-
-    final FlutterUIConfig settings = FlutterUIConfig.getInstance();
-    if (settings.shouldIgnoreOutOfDateFlutterSdks()) return null;
-
-    final EditorNotificationPanel panel = new EditorNotificationPanel();
-    panel.setText(FlutterBundle.message("flutter.old.sdk.warning"));
-    panel.createActionLabel("Dismiss", () -> {
-      settings.setIgnoreOutOfDateFlutterSdks();
-      panel.setVisible(false);
-    });
-
-    return panel;
   }
 }

--- a/src/io/flutter/sdk/FlutterSdk.java
+++ b/src/io/flutter/sdk/FlutterSdk.java
@@ -43,15 +43,9 @@ public class FlutterSdk {
   private static final Logger LOG = Logger.getInstance(FlutterSdk.class);
   private static final AtomicReference<GeneralCommandLine> inProgress = new AtomicReference<>(null);
   private final @NotNull String myHomePath;
-  private final @NotNull FlutterSdkVersion myVersion;
-
-  private FlutterSdk(@NotNull final String homePath, @Nullable final String version) {
-    myHomePath = homePath;
-    myVersion = FlutterSdkVersion.forVersionString(version);
-  }
 
   private FlutterSdk(@NotNull final String homePath) {
-    this(homePath, FlutterSdkUtil.getSdkVersion(homePath));
+    myHomePath = homePath;
   }
 
   /**
@@ -207,7 +201,8 @@ public class FlutterSdk {
 
     if (module != null) {
       FlutterConsoles.displayProcess(handler, module.getProject(), module);
-    } else {
+    }
+    else {
       handler.startNotify();
     }
 
@@ -249,7 +244,8 @@ public class FlutterSdk {
 
     if (project != null) {
       FlutterConsoles.displayProcess(handler, project, null);
-    } else {
+    }
+    else {
       handler.startNotify();
     }
 
@@ -295,15 +291,6 @@ public class FlutterSdk {
   @NotNull
   public String getHomePath() {
     return myHomePath;
-  }
-
-  /**
-   * Returns the Flutter Version as captured in the VERSION file.  This version is very coarse grained and not meant for presentation and
-   * rather only for sanity-checking the presence of baseline features (e.g, hot-reload).
-   */
-  @NotNull
-  public FlutterSdkVersion getVersion() {
-    return myVersion;
   }
 
   /**

--- a/src/io/flutter/sdk/FlutterSdkUtil.java
+++ b/src/io/flutter/sdk/FlutterSdkUtil.java
@@ -29,7 +29,6 @@ import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 import java.io.File;
-import java.io.IOException;
 import java.util.*;
 
 public class FlutterSdkUtil {
@@ -153,11 +152,6 @@ public class FlutterSdkUtil {
     return flutterVersionFile.isFile() && flutterToolFile.isFile() && !dartLibFolder.isDirectory();
   }
 
-  @NotNull
-  public static String versionPath(@NotNull String sdkHomePath) {
-    return sdkHomePath + "/VERSION";
-  }
-
   /**
    * Checks the workspace for any open Flutter projects.
    *
@@ -169,40 +163,6 @@ public class FlutterSdkUtil {
 
   public static boolean hasFlutterModules(@NotNull Project project) {
     return FlutterModuleUtils.hasFlutterModule(project);
-  }
-
-  @Nullable
-  public static String getSdkVersion(@NotNull String sdkHomePath) {
-    final File versionFile = new File(versionPath(sdkHomePath));
-    if (versionFile.isFile()) {
-      final String cachedVersion = ourVersions.get(Pair.create(versionFile, versionFile.lastModified()));
-      if (cachedVersion != null) return cachedVersion;
-    }
-
-    final String version = readVersionFile(sdkHomePath);
-    if (version != null) {
-      ourVersions.put(Pair.create(versionFile, versionFile.lastModified()), version);
-      return version;
-    }
-
-    LOG.warn("Unable to find Flutter SDK version at " + sdkHomePath);
-    return null;
-  }
-
-  private static String readVersionFile(String sdkHomePath) {
-    final File versionFile = new File(versionPath(sdkHomePath));
-    if (versionFile.isFile() && versionFile.length() < 1000) {
-      try {
-        final String content = FileUtil.loadFile(versionFile).trim();
-        final int index = content.lastIndexOf('\n');
-        if (index < 0) return content;
-        return content.substring(index + 1).trim();
-      }
-      catch (IOException e) {
-        /* ignore */
-      }
-    }
-    return null;
   }
 
   @Nullable


### PR DESCRIPTION
- remove the use of the VERSION file
- https://github.com/flutter/flutter-intellij/issues/993

If we need to do version checks in the future, we can restore parts of this PR, but referencing https://github.com/flutter/flutter/blob/master/packages/flutter/pubspec.yaml instead.

@pq