### PR TITLE
fix Flutter version handling again

### DIFF
--- a/src/io/flutter/inspections/SdkConfigurationNotificationProvider.java
+++ b/src/io/flutter/inspections/SdkConfigurationNotificationProvider.java
@@ -21,7 +21,6 @@ import com.jetbrains.lang.dart.DartFileType;
 import com.jetbrains.lang.dart.DartLanguage;
 import io.flutter.FlutterBundle;
 import io.flutter.sdk.FlutterSdk;
-import io.flutter.sdk.FlutterSdkVersion;
 import io.flutter.settings.FlutterUIConfig;
 import io.flutter.utils.FlutterModuleUtils;
 import org.jetbrains.annotations.NotNull;
@@ -75,7 +74,7 @@ public class SdkConfigurationNotificationProvider extends EditorNotifications.Pr
       return createNoFlutterSdkPanel();
     }
 
-    if (flutterSdk.getVersion().isLessThan(FlutterSdkVersion.MIN_SUPPORTED_SDK)) {
+    if (!flutterSdk.getVersion().isSupported()) {
       return createOutOfDateFlutterSdkPanel(flutterSdk);
     }
 

--- a/src/io/flutter/sdk/FlutterSdk.java
+++ b/src/io/flutter/sdk/FlutterSdk.java
@@ -30,9 +30,9 @@ public class FlutterSdk {
   private final @NotNull VirtualFile myHome;
   private final @NotNull FlutterSdkVersion myVersion;
 
-  private FlutterSdk(@NotNull final VirtualFile home, @Nullable final String version) {
+  private FlutterSdk(@NotNull final VirtualFile home, @NotNull final FlutterSdkVersion version) {
     myHome = home;
-    myVersion = FlutterSdkVersion.forVersionString(version);
+    myVersion = version;
   }
 
   /**
@@ -83,7 +83,7 @@ public class FlutterSdk {
     } else if (!FlutterSdkUtil.isFlutterSdkHome(path)) {
       return null;
     } else {
-      return new FlutterSdk(home, FlutterSdkUtil.getSdkVersion(path));
+      return new FlutterSdk(home, FlutterSdkVersion.readFromSdk(home));
     }
   }
 
@@ -249,7 +249,7 @@ public class FlutterSdk {
       if (url.endsWith(DART_CORE_SUFFIX)) {
         final String flutterUrl = url.substring(0, url.length() - DART_CORE_SUFFIX.length());
         final VirtualFile home = VirtualFileManager.getInstance().findFileByUrl(flutterUrl);
-        return home == null ? null : new FlutterSdk(home, FlutterSdkUtil.getSdkVersion(home.getPath()));
+        return home == null ? null : new FlutterSdk(home, FlutterSdkVersion.readFromSdk(home));
       }
     }
     return null;

--- a/src/io/flutter/sdk/FlutterSdkUtil.java
+++ b/src/io/flutter/sdk/FlutterSdkUtil.java
@@ -14,7 +14,6 @@ import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
-import com.intellij.openapi.util.Pair;
 import com.intellij.openapi.util.SystemInfo;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.vfs.LocalFileSystem;
@@ -29,7 +28,6 @@ import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 import java.io.File;
-import java.io.IOException;
 import java.util.*;
 
 public class FlutterSdkUtil {
@@ -38,7 +36,6 @@ public class FlutterSdkUtil {
    */
   public static final String FLUTTER_HOST_ENV = "FLUTTER_HOST_ENV";
 
-  private static final Map<Pair<File, Long>, String> ourVersions = new HashMap<>();
   private static final String FLUTTER_SDK_KNOWN_PATHS = "FLUTTER_SDK_KNOWN_PATHS";
   private static final Logger LOG = Logger.getInstance(FlutterSdkUtil.class);
 
@@ -155,11 +152,6 @@ public class FlutterSdkUtil {
     return flutterPubspecFile.isFile() && flutterToolFile.isFile() && !dartLibFolder.isDirectory();
   }
 
-  @NotNull
-  public static String versionPath(@NotNull String sdkHomePath) {
-    return sdkHomePath + "/VERSION";
-  }
-
   /**
    * Checks the workspace for any open Flutter projects.
    *
@@ -171,39 +163,6 @@ public class FlutterSdkUtil {
 
   public static boolean hasFlutterModules(@NotNull Project project) {
     return FlutterModuleUtils.hasFlutterModule(project);
-  }
-
-  @Nullable
-  public static String getSdkVersion(@NotNull String sdkHomePath) {
-    final File versionFile = new File(versionPath(sdkHomePath));
-    final Pair<File, Long> key = Pair.create(versionFile, versionFile.lastModified());
-    if (ourVersions.containsKey(key)) {
-      return ourVersions.get(key);
-    }
-
-    final String version = readVersionFile(sdkHomePath);
-    if (version == null) {
-      LOG.warn("Unable to find Flutter SDK version at " + sdkHomePath);
-    }
-
-    ourVersions.put(Pair.create(versionFile, versionFile.lastModified()), version);
-    return version;
-  }
-
-  private static String readVersionFile(String sdkHomePath) {
-    final File versionFile = new File(versionPath(sdkHomePath));
-    if (versionFile.isFile() && versionFile.length() < 1000) {
-      try {
-        final String content = FileUtil.loadFile(versionFile).trim();
-        final int index = content.lastIndexOf('\n');
-        if (index < 0) return content;
-        return content.substring(index + 1).trim();
-      }
-      catch (IOException e) {
-        /* ignore */
-      }
-    }
-    return null;
   }
 
   @Nullable

--- a/src/io/flutter/sdk/FlutterSdkVersion.java
+++ b/src/io/flutter/sdk/FlutterSdkVersion.java
@@ -6,39 +6,85 @@
 package io.flutter.sdk;
 
 
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.util.Pair;
 import com.intellij.openapi.util.Version;
-import org.jetbrains.annotations.NonNls;
+import com.intellij.openapi.util.io.FileUtil;
+import com.intellij.openapi.vfs.VirtualFile;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
-public class FlutterSdkVersion implements Comparable<FlutterSdkVersion> {
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
-  // Minimum SDK known to support hot reload.
-  public static final FlutterSdkVersion MIN_SUPPORTED_SDK = FlutterSdkVersion.forVersionString("0.0.3");
+public class FlutterSdkVersion {
 
-  @NonNls private static final FlutterSdkVersion UNKNOWN = new FlutterSdkVersion("0.0.0");
+  /**
+   * The minimum version known to support hot reload.
+   */
+  private static final FlutterSdkVersion MIN_SUPPORTED_SDK = new FlutterSdkVersion("0.0.3");
 
-  private final Version myVersion;
+  /**
+   * Cache from version file and its modification date to its contents.
+   */
+  private static final Map<Pair<File, Long>, FlutterSdkVersion> cache = new HashMap<>();
+
+  private final Version version;
 
   private FlutterSdkVersion(@NotNull String versionString) {
-    myVersion = Version.parseVersion(versionString);
+    version = Version.parseVersion(versionString);
   }
 
-  public static FlutterSdkVersion forVersionString(@Nullable String versionString) {
-    return versionString == null ? UNKNOWN : new FlutterSdkVersion(versionString);
+  @NotNull
+  public static FlutterSdkVersion readFromSdk(@NotNull VirtualFile sdkHome) {
+    final File versionFile = new File(sdkHome.getPath() + "/VERSION");
+
+    // Use the cache if the file's last modfication date didn't change.
+    // But we still stat the file every time this is called. Not sure the cache saves us much?
+    // TODO(skybrian) should we use the VirtualFile cache instead?
+    final Pair<File, Long> key = Pair.create(versionFile, versionFile.lastModified());
+    if (cache.containsKey(key)) {
+      return cache.get(key);
+    }
+
+    final String versionString = readVersionFromFile(versionFile);
+    if (versionString == null) {
+      LOG.warn("Unable to find Flutter SDK version at " + sdkHome.getPath());
+    }
+
+    // If we don't have a version file at all, assume it's a supported version and don't complain.
+    final FlutterSdkVersion version = versionString == null ? MIN_SUPPORTED_SDK : new FlutterSdkVersion(versionString);
+
+    cache.put(Pair.create(versionFile, versionFile.lastModified()), version);
+    return version;
   }
 
-  public boolean isLessThan(FlutterSdkVersion other) {
-    return compareTo(other) < 0;
+  public boolean isSupported() {
+    return version.compareTo(MIN_SUPPORTED_SDK.version) >= 0;
   }
 
   @Override
   public String toString() {
-    return myVersion.toCompactString();
+    return version.toCompactString();
   }
 
-  @Override
-  public int compareTo(@NotNull FlutterSdkVersion other) {
-    return myVersion.compareTo(other.myVersion);
+  private static String readVersionFromFile(File versionFile) {
+    if (!versionFile.isFile() || versionFile.length() >= 1000) {
+      return null;
+    }
+
+    try {
+      final String content = FileUtil.loadFile(versionFile).trim();
+      final int index = content.lastIndexOf('\n');
+      if (index < 0) return content;
+      return content.substring(index + 1).trim();
+    }
+    catch (IOException e) {
+      /* ignore */
+      return null;
+    }
   }
+
+  private static final Logger LOG = Logger.getInstance(FlutterSdkVersion.class);
 }


### PR DESCRIPTION
Redo fix from #1002, broken due to a bad merge.

While we're here, move this code to FlutterSdkVersion and simplify.