### PR TITLE
fix new project creation for WebStorm

### DIFF
--- a/src/io/flutter/module/FlutterModuleBuilder.java
+++ b/src/io/flutter/module/FlutterModuleBuilder.java
@@ -26,7 +26,6 @@ import icons.FlutterIcons;
 import io.flutter.FlutterBundle;
 import io.flutter.FlutterConstants;
 import io.flutter.FlutterUtils;
-import io.flutter.dart.DartPlugin;
 import io.flutter.pub.PubRoot;
 import io.flutter.sdk.FlutterSdk;
 import io.flutter.sdk.FlutterSdkUtil;

--- a/src/io/flutter/module/FlutterModuleBuilder.java
+++ b/src/io/flutter/module/FlutterModuleBuilder.java
@@ -228,30 +228,6 @@ public class FlutterModuleBuilder extends ModuleBuilder {
     return result.get();
   }
 
-  /**
-   * Set up a "small IDE" project. (For example, WebStorm.)
-   */
-  public static void setupSmallProject(@NotNull Project project, ModifiableRootModel model, VirtualFile baseDir, String flutterSdkPath)
-    throws ConfigurationException {
-    final FlutterSdk sdk = FlutterSdk.forPath(flutterSdkPath);
-    if (sdk == null) {
-      throw new ConfigurationException(flutterSdkPath + " is not a valid Flutter SDK");
-    }
-    model.addContentEntry(baseDir);
-
-    final PubRoot root = sdk.createFiles(baseDir, model.getModule());
-    if (root != null) {
-      FlutterModuleUtils.autoShowMain(project, root);
-    }
-    final String dartSdkPath = sdk.getDartSdkPath();
-    if (dartSdkPath == null) {
-      throw new ConfigurationException("unable to get Dart SDK"); // shouldn't happen; we just created it.
-    }
-
-    DartPlugin.ensureDartSdkConfigured(model.getProject(), sdk.getDartSdkPath());
-    FlutterSdkUtil.updateKnownSdkPaths(sdk.getHomePath());
-  }
-
   private static class FlutterModuleWizardStep extends ModuleWizardStep implements Disposable {
     private final FlutterGeneratorPeer peer;
     private FlutterSdk myFlutterSdk;

--- a/src/io/flutter/sdk/FlutterSdkUtil.java
+++ b/src/io/flutter/sdk/FlutterSdkUtil.java
@@ -62,40 +62,46 @@ public class FlutterSdkUtil {
     // Add the new value first; this ensures that it's the 'default' flutter sdk.
     allPaths.add(newPath);
 
+
+    final PropertiesComponent props = PropertiesComponent.getInstance();
+
     // Add the existing known paths.
-    final String[] oldPaths = PropertiesComponent.getInstance().getValues(propertyKey);
+    final String[] oldPaths = props.getValues(propertyKey);
     if (oldPaths != null) {
       allPaths.addAll(Arrays.asList(oldPaths));
     }
 
     // Store the values back.
     if (allPaths.isEmpty()) {
-      PropertiesComponent.getInstance().unsetValue(propertyKey);
+      props.unsetValue(propertyKey);
     }
     else {
-      PropertiesComponent.getInstance().setValues(propertyKey, ArrayUtil.toStringArray(allPaths));
+      props.setValues(propertyKey, ArrayUtil.toStringArray(allPaths));
     }
   }
 
+  /**
+   * Adds the current path and other known paths to the combo, most recently used first.
+   */
   public static void addKnownSDKPathsToCombo(@NotNull JComboBox combo) {
-    final Set<String> validPathsForUI = new HashSet<>();
-    final String currentPath = combo.getEditor().getItem().toString().trim();
+    final Set<String> pathsToShow = new LinkedHashSet<>();
 
+    final String currentPath = combo.getEditor().getItem().toString().trim();
     if (!currentPath.isEmpty()) {
-      validPathsForUI.add(currentPath);
+      pathsToShow.add(currentPath);
     }
 
     final String[] knownPaths = getKnownFlutterSdkPaths();
-    if (knownPaths != null && knownPaths.length > 0) {
+    if (knownPaths != null) {
       for (String path : knownPaths) {
         if (FlutterSdk.forPath(path) != null) {
-          validPathsForUI.add(FileUtil.toSystemDependentName(path));
+          pathsToShow.add(FileUtil.toSystemDependentName(path));
         }
       }
     }
 
     //noinspection unchecked
-    combo.setModel(new DefaultComboBoxModel(ArrayUtil.toStringArray(validPathsForUI)));
+    combo.setModel(new DefaultComboBoxModel(ArrayUtil.toStringArray(pathsToShow)));
 
     if (combo.getSelectedIndex() == -1 && combo.getItemCount() > 0) {
       combo.setSelectedIndex(0);


### PR DESCRIPTION
- It wasn't enabling Dart for the module.
- Default to the most recently used Flutter SDK.
- Sort Flutter SDK's in most-recently-used order.
(Previously was random order.)

Also simplify the code a bit.