### PR TITLE
Use project's Java SDK to set ANDROID_HOME for flutter commands

### DIFF
--- a/src/io/flutter/android/AndroidSdk.java
+++ b/src/io/flutter/android/AndroidSdk.java
@@ -53,6 +53,15 @@ public class AndroidSdk {
   }
 
   /**
+   * Returns the Java SDK in the project's configuration, or null if not an Android SDK.
+   */
+  @Nullable
+  public static AndroidSdk fromProject(@NotNull Project project) {
+    final Sdk candidate = ProjectRootManager.getInstance(project).getProjectSdk();
+    return fromSdk(candidate);
+  }
+
+  /**
    * Returns the Android SDK that matches the ANDROID_HOME environment variable, provided it exists.
    */
   @Nullable
@@ -68,6 +77,14 @@ public class AndroidSdk {
       return null;
     }
 
+    return fromHome(file);
+  }
+
+  /**
+   * Returns the Android SDK for the given home directory, or null if no SDK matches.
+   */
+  @Nullable
+  public static AndroidSdk fromHome(VirtualFile file) {
     for (AndroidSdk candidate : findAll()) {
       if (file.equals(candidate.getHome())) {
         return candidate;
@@ -75,6 +92,16 @@ public class AndroidSdk {
     }
 
     return null; // not found
+  }
+
+  /**
+   * Returns the best value of ANDROID_HOME to use.
+   * <p>
+   * If the given project has an Android SDK set, prefer that. Otherwise get it from the environment.
+   */
+  public static String chooseAndroidHome(@Nullable Project project) {
+    final AndroidSdk sdk = project == null ? null : fromProject(project);
+    return sdk == null ? EnvironmentUtil.getValue("ANDROID_HOME") : sdk.getHome().getPath();
   }
 
   /**

--- a/src/io/flutter/pub/PubRoot.java
+++ b/src/io/flutter/pub/PubRoot.java
@@ -207,6 +207,11 @@ public class PubRoot {
   }
 
   @NotNull
+  public String getPath() {
+    return root.getPath();
+  }
+
+  @NotNull
   public VirtualFile getPubspec() {
     return pubspec;
   }
@@ -285,6 +290,20 @@ public class PubRoot {
   public Module getModule(@NotNull Project project) {
     if (project.isDisposed()) return null;
     return ProjectRootManager.getInstance(project).getFileIndex().getModuleForFile(pubspec);
+  }
+
+  /**
+   * Returns true if the PubRoot is an ancestor of the given file.
+   */
+  public boolean contains(@NotNull VirtualFile file) {
+    VirtualFile dir = file.getParent();
+    while (dir != null) {
+      if (dir.equals(root)) {
+        return true;
+      }
+      dir = dir.getParent();
+    }
+    return false;
   }
 
   @Override

--- a/src/io/flutter/run/daemon/DeviceService.java
+++ b/src/io/flutter/run/daemon/DeviceService.java
@@ -11,6 +11,7 @@ import com.intellij.execution.ExecutionException;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.ex.ProjectRootManagerEx;
 import com.intellij.openapi.util.Disposer;
 import io.flutter.bazel.WorkspaceCache;
 import io.flutter.sdk.FlutterSdkManager;
@@ -69,6 +70,9 @@ public class DeviceService {
 
     // Watch for Bazel workspace changes.
     WorkspaceCache.getInstance(project).subscribe(this::refreshDeviceDaemon);
+
+    // Watch for Java SDK changes. (Used to get the value of ANDROID_HOME.)
+    ProjectRootManagerEx.getInstanceEx(project).addProjectJdkListener(this::refreshDeviceDaemon);
   }
 
   /**


### PR DESCRIPTION
This allows the user to override the setting of ANDROID_HOME from IntelliJ's
environment, and ensures that it's consistent with the one used to resolve
imports in Java code.

If the project's Java SDK isn't set to an Android SDK, we still fall back
to using ANDROID_HOME.

Fixes #981