### PR TITLE
Getting defensive: project disposal checking on open (#1013).

### DIFF
--- a/src/io/flutter/project/FlutterProjectOpenProcessor.java
+++ b/src/io/flutter/project/FlutterProjectOpenProcessor.java
@@ -68,11 +68,7 @@ public class FlutterProjectOpenProcessor extends ProjectOpenProcessor {
     }
 
     final Project project = importProvider.doOpenProject(file, projectToClose, forceOpenInNewFrame);
-    if (project == null) {
-      return null;
-    }
-
-    if (!FlutterModuleUtils.hasFlutterModule(project)) {
+    if (project != null && !project.isDisposed() && !FlutterModuleUtils.hasFlutterModule(project)) {
       convertToFlutterProject(project);
     }
     return project;


### PR DESCRIPTION
* extra check to ensure we don’t try and access modules in disposed projects

Fixes: #1013.

I was unable to repro the disposed project case captured in the stacktrace but this guard should ensure we don't fall over when trying to read modules.

@skybrian @devoncarew 