### PR TITLE
Remove SDK settings from the template project (#1018).

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -329,7 +329,7 @@
     <console.folding implementation="io.flutter.console.FlutterConsoleFolding"/>
 
     <projectConfigurable groupId="language" instance="io.flutter.sdk.FlutterSettingsConfigurable"
-                         id="flutter.settings" key="flutter.title" bundle="io.flutter.FlutterBundle"/>
+                         id="flutter.settings" key="flutter.title" bundle="io.flutter.FlutterBundle" nonDefaultProject="true"/>
     <annotator language="Dart" implementationClass="io.flutter.editor.FlutterEditorAnnotator"/>
     <errorHandler implementation="io.flutter.FlutterErrorReportSubmitter"/>
 


### PR DESCRIPTION
Since SDKs are set on a per-project level this doesn’t make sense.

![screen shot 2017-05-15 at 1 15 30 pm](https://cloud.githubusercontent.com/assets/67586/26077492/129a99f8-3971-11e7-86d4-3ebf556f44e8.png)

Fixes: #1018.

@devoncarew @alexander-doroshko 