### PR TITLE
rev the versions we build against

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,14 +24,17 @@ env:
 
   # IntelliJ CE internal version
   # TODO(devoncarew): Re-enable unit testing on the bots (UNIT_TEST=true).
-  - IDEA_PRODUCT=ideaIC             IDEA_VERSION=2017.1.1    DART_PLUGIN_VERSION=171.4424.10
+  - IDEA_PRODUCT=ideaIC             IDEA_VERSION=2017.1.1    DART_PLUGIN_VERSION=171.4424.63
 
-  # IntelliJ CE supported range
+  # IntelliJ CE stable
   # TODO(devoncarew): Re-enable unit testing on the bots (UNIT_TEST=true).
-  - IDEA_PRODUCT=ideaIC             IDEA_VERSION=2017.1.2      DART_PLUGIN_VERSION=171.4424.10
+  - IDEA_PRODUCT=ideaIC             IDEA_VERSION=2017.1.3      DART_PLUGIN_VERSION=171.4424.63
+
+  # IntelliJ CE EAP
+  - IDEA_PRODUCT=ideaIC             IDEA_VERSION=171.3780.15   DART_PLUGIN_VERSION=172.2273.2
 
   # WebStorm supported range
-  - IDEA_PRODUCT=WebStorm           IDEA_VERSION=2017.1.2
+  - IDEA_PRODUCT=WebStorm           IDEA_VERSION=2017.1.3
 
 # execution
 script: ./tool/travis.sh

--- a/build.xml
+++ b/build.xml
@@ -11,7 +11,7 @@
   <!-- one of ideaIC, WebStorm, or android-studio-ide -->
   <property name="idea.product" value="ideaIC"/>
   <!-- the platform version, and substring to use when downloading from google storage -->
-  <property name="idea.version" value="2017.1.2"/>
+  <property name="idea.version" value="2017.1.3"/>
 
   <property name="google.storage.base" value="https://storage.googleapis.com/flutter_infra/flutter/intellij"/>
 

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -10,7 +10,7 @@
 
   <version>13.1</version>
 
-  <idea-version since-build="171.1" until-build="171.*"/>
+  <idea-version since-build="171.1" until-build="172.*"/>
 
   <!-- plugin compatibility -->
   <!-- see: http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html -->


### PR DESCRIPTION
- update to the latest version of IntelliJ and the Dart plugin that we support
- increase our IntelliJ version range to support 2017.2 (https://github.com/flutter/flutter-intellij/issues/1040)

@pq @skybrian 