### PR TITLE
show any error from app run termination

### DIFF
--- a/src/io/flutter/run/daemon/DaemonEvent.java
+++ b/src/io/flutter/run/daemon/DaemonEvent.java
@@ -251,6 +251,7 @@ abstract class DaemonEvent {
   static class AppStopped extends DaemonEvent {
     // "event":"app.stop"
     String appId;
+    String error;
 
     void accept(Listener listener) {
       listener.onAppStopped(this);

--- a/src/io/flutter/run/daemon/FlutterAppListener.java
+++ b/src/io/flutter/run/daemon/FlutterAppListener.java
@@ -99,7 +99,7 @@ class FlutterAppListener implements DaemonEvent.Listener {
   public void onAppLog(@NotNull DaemonEvent.AppLog message) {
     final ConsoleView console = app.getConsole();
     if (console == null) return;
-    console.print(message.log + "\n", ConsoleViewContentType.NORMAL_OUTPUT);
+    console.print(message.log + "\n", message.error ? ConsoleViewContentType.ERROR_OUTPUT : ConsoleViewContentType.NORMAL_OUTPUT);
   }
 
   @Override
@@ -134,6 +134,9 @@ class FlutterAppListener implements DaemonEvent.Listener {
 
   @Override
   public void onAppStopped(@NotNull DaemonEvent.AppStopped stopped) {
+    if (stopped.error != null && app.getConsole() != null) {
+      app.getConsole().print("Finished with error: " + stopped.error + "\n", ConsoleViewContentType.ERROR_OUTPUT);
+    }
     progress.cancel();
     app.getProcessHandler().destroyProcess();
   }

--- a/testSrc/unit/io/flutter/run/daemon/DaemonEventTest.java
+++ b/testSrc/unit/io/flutter/run/daemon/DaemonEventTest.java
@@ -158,14 +158,14 @@ public class DaemonEventTest {
   }
 
   @Test
-  public void canRecieveAppStopped() {
+  public void canReceiveAppStopped() {
     send("app.stop", curly("appId:42"));
     checkLog("AppStopped: 42");
   }
 
   @Test
-  public void canRecieveAppStoppedWithError() {
-    send("app.stop", curly("appId:42", "error:foobar"));
+  public void canReceiveAppStoppedWithError() {
+    send("app.stop", curly("appId:42", "error:\"foobar\""));
     checkLog("AppStopped: 42, foobar");
   }
 

--- a/testSrc/unit/io/flutter/run/daemon/DaemonEventTest.java
+++ b/testSrc/unit/io/flutter/run/daemon/DaemonEventTest.java
@@ -76,7 +76,12 @@ public class DaemonEventTest {
 
       @Override
       public void onAppStopped(DaemonEvent.AppStopped event) {
-        logEvent(event, event.appId);
+        if (event.error != null) {
+          logEvent(event, event.appId, event.error);
+        }
+        else {
+          logEvent(event, event.appId);
+        }
       }
 
       // device domain
@@ -156,6 +161,12 @@ public class DaemonEventTest {
   public void canRecieveAppStopped() {
     send("app.stop", curly("appId:42"));
     checkLog("AppStopped: 42");
+  }
+
+  @Test
+  public void canRecieveAppStoppedWithError() {
+    send("app.stop", curly("appId:42", "error:foobar"));
+    checkLog("AppStopped: 42, foobar");
   }
 
   // device domain


### PR DESCRIPTION
If we receive an error from the app.stop event, display that to the console as stderr output.

@pq @skybrian, /cc @tvolkert 
