### PR TITLE
add some diagnostic logging

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -351,5 +351,4 @@
 
     <iconProvider implementation="io.flutter.project.FlutterIconProvider" order="first"/>
   </extensions>
-
 </idea-plugin>

--- a/src/io/flutter/FlutterInitializer.java
+++ b/src/io/flutter/FlutterInitializer.java
@@ -42,6 +42,7 @@ public class FlutterInitializer implements StartupActivity {
   private static final String analyticsClientIdKey = "io.flutter.analytics.clientId";
   private static final String analyticsOptOutKey = "io.flutter.analytics.optOut";
   private static final String analyticsToastShown = "io.flutter.analytics.toastShown";
+  private static final String verboseLoggingKey = "io.flutter.verboseLogging";
 
   private static Analytics analytics;
 
@@ -98,6 +99,16 @@ public class FlutterInitializer implements StartupActivity {
 
   public static void sendAnalyticsAction(@NotNull String name) {
     getAnalytics().sendEvent("intellij", name);
+  }
+
+  public static boolean isVerboseLogging() {
+    final PropertiesComponent properties = PropertiesComponent.getInstance();
+    return properties.getBoolean(verboseLoggingKey, false);
+  }
+
+  public static void setVerboseLogging(boolean value) {
+    final PropertiesComponent properties = PropertiesComponent.getInstance();
+    properties.setValue(verboseLoggingKey, value);
   }
 
   @Override

--- a/src/io/flutter/run/LaunchState.java
+++ b/src/io/flutter/run/LaunchState.java
@@ -296,9 +296,7 @@ public class LaunchState extends CommandLineState {
       // Else, launch the app.
       return launchState.launch(env);
     }
-
   }
-
 
   /**
    * Returns the currently running app for the given RunConfig, if any.

--- a/src/io/flutter/run/SdkRunConfig.java
+++ b/src/io/flutter/run/SdkRunConfig.java
@@ -11,6 +11,7 @@ import com.intellij.execution.configurations.*;
 import com.intellij.execution.filters.TextConsoleBuilder;
 import com.intellij.execution.runners.ExecutionEnvironment;
 import com.intellij.execution.runners.RunConfigurationWithSuppressedDefaultRunAction;
+import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleUtil;
 import com.intellij.openapi.options.SettingsEditor;
@@ -43,6 +44,8 @@ import org.jetbrains.annotations.Nullable;
  */
 public class SdkRunConfig extends LocatableConfigurationBase
   implements LaunchState.RunConfig, RefactoringListenerProvider, RunConfigurationWithSuppressedDefaultRunAction {
+  private static final Logger LOG = Logger.getInstance(SdkRunConfig.class);
+
   private @NotNull SdkFields fields = new SdkFields();
 
   SdkRunConfig(final @NotNull Project project, final @NotNull ConfigurationFactory factory, final @NotNull String name) {

--- a/src/io/flutter/run/SdkRunConfig.java
+++ b/src/io/flutter/run/SdkRunConfig.java
@@ -11,7 +11,6 @@ import com.intellij.execution.configurations.*;
 import com.intellij.execution.filters.TextConsoleBuilder;
 import com.intellij.execution.runners.ExecutionEnvironment;
 import com.intellij.execution.runners.RunConfigurationWithSuppressedDefaultRunAction;
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleUtil;
 import com.intellij.openapi.options.SettingsEditor;
@@ -44,8 +43,6 @@ import org.jetbrains.annotations.Nullable;
  */
 public class SdkRunConfig extends LocatableConfigurationBase
   implements LaunchState.RunConfig, RefactoringListenerProvider, RunConfigurationWithSuppressedDefaultRunAction {
-  private static final Logger LOG = Logger.getInstance(SdkRunConfig.class);
-
   private @NotNull SdkFields fields = new SdkFields();
 
   SdkRunConfig(final @NotNull Project project, final @NotNull ConfigurationFactory factory, final @NotNull String name) {

--- a/src/io/flutter/run/daemon/DaemonApi.java
+++ b/src/io/flutter/run/daemon/DaemonApi.java
@@ -13,6 +13,7 @@ import com.intellij.execution.process.ProcessHandler;
 import com.intellij.execution.process.ProcessOutputTypes;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.util.Key;
+import io.flutter.FlutterInitializer;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -39,7 +40,6 @@ import java.util.function.Function;
  * >The Flutter Daemon Mode</a>.
  */
 public class DaemonApi {
-  private static final boolean DEBUG_LOG = false;
   private static final int STDERR_LINES_TO_KEEP = 100;
 
   private final @NotNull Consumer<String> callback;
@@ -120,8 +120,8 @@ public class DaemonApi {
 
         final String text = event.getText().trim();
 
-        if (DEBUG_LOG) {
-          System.out.println("[<-- " + text + "]");
+        if (FlutterInitializer.isVerboseLogging()) {
+          LOG.info("[<-- " + text + "]");
         }
 
         if (!text.startsWith("[{") || !text.endsWith("}]")) {
@@ -242,8 +242,8 @@ public class DaemonApi {
     stdin.write(json);
     stdin.write("]\n");
 
-    if (DEBUG_LOG) {
-      System.out.println("[--> " + json + "]");
+    if (FlutterInitializer.isVerboseLogging()) {
+      LOG.info("[--> " + json + "]");
     }
 
     if (stdin.checkError()) {

--- a/src/io/flutter/run/daemon/DaemonConsoleView.java
+++ b/src/io/flutter/run/daemon/DaemonConsoleView.java
@@ -7,17 +7,17 @@ package io.flutter.run.daemon;
 
 import com.intellij.execution.impl.ConsoleViewImpl;
 import com.intellij.execution.ui.ConsoleViewContentType;
+import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.search.GlobalSearchScope;
+import io.flutter.FlutterInitializer;
 import org.jetbrains.annotations.NotNull;
 
 /**
  * A console view that filters out JSON messages sent in --machine mode.
  */
 public class DaemonConsoleView extends ConsoleViewImpl {
-  // TODO(skybrian) add UI to to set this to help people diagnose issues.
-  // https://github.com/flutter/flutter-intellij/issues/976
-  private static final boolean VERBOSE = false;
+  private static final Logger LOG = Logger.getInstance(DaemonConsoleView.class);
 
   public DaemonConsoleView(Project project, GlobalSearchScope searchScope) {
     super(project, searchScope, true, false);
@@ -25,7 +25,7 @@ public class DaemonConsoleView extends ConsoleViewImpl {
 
   @Override
   public void print(@NotNull String text, @NotNull ConsoleViewContentType contentType) {
-    if (VERBOSE) {
+    if (FlutterInitializer.isVerboseLogging()) {
       super.print(text, contentType);
       return;
     }
@@ -33,6 +33,7 @@ public class DaemonConsoleView extends ConsoleViewImpl {
     final String trimmed = text.trim();
 
     if (trimmed.startsWith("[{") && trimmed.endsWith("}]")) {
+      LOG.info(trimmed);
       return;
     }
 

--- a/src/io/flutter/run/daemon/FlutterApp.java
+++ b/src/io/flutter/run/daemon/FlutterApp.java
@@ -35,7 +35,7 @@ import java.util.concurrent.atomic.AtomicReference;
  * A running Flutter app.
  */
 public class FlutterApp {
-
+  private static final Logger LOG = Logger.getInstance(FlutterApp.class);
   private static final Key<FlutterApp> FLUTTER_APP_KEY = new Key<>("FLUTTER_APP_KEY");
 
   private final @NotNull RunMode myMode;
@@ -119,7 +119,7 @@ public class FlutterApp {
                                  @NotNull String analyticsStart,
                                  @NotNull String analyticsStop)
     throws ExecutionException {
-
+    LOG.info(command.toString());
     final ProcessHandler process = new OSProcessHandler(command);
     Disposer.register(project, process::destroyProcess);
 
@@ -128,6 +128,7 @@ public class FlutterApp {
     process.addProcessListener(new ProcessAdapter() {
       @Override
       public void processTerminated(ProcessEvent event) {
+        LOG.info("finished " + project.getName() + " " + mode.mode());
         FlutterInitializer.sendAnalyticsAction(analyticsStop);
       }
     });
@@ -326,6 +327,4 @@ public class FlutterApp {
   }
 
   public enum State {STARTING, STARTED, TERMINATING, TERMINATED}
-
-  private static final Logger LOG = Logger.getInstance(FlutterApp.class);
 }

--- a/src/io/flutter/run/daemon/FlutterApp.java
+++ b/src/io/flutter/run/daemon/FlutterApp.java
@@ -119,7 +119,9 @@ public class FlutterApp {
                                  @NotNull String analyticsStart,
                                  @NotNull String analyticsStop)
     throws ExecutionException {
+    LOG.info(analyticsStart + " " + project.getName() + " (" + mode.mode() + ")");
     LOG.info(command.toString());
+
     final ProcessHandler process = new OSProcessHandler(command);
     Disposer.register(project, process::destroyProcess);
 
@@ -128,7 +130,7 @@ public class FlutterApp {
     process.addProcessListener(new ProcessAdapter() {
       @Override
       public void processTerminated(ProcessEvent event) {
-        LOG.info("finished " + project.getName() + " " + mode.mode());
+        LOG.info(analyticsStop + " " + project.getName() + " (" + mode.mode() + ")");
         FlutterInitializer.sendAnalyticsAction(analyticsStop);
       }
     });

--- a/src/io/flutter/sdk/FlutterCommand.java
+++ b/src/io/flutter/sdk/FlutterCommand.java
@@ -21,7 +21,6 @@ import io.flutter.FlutterMessages;
 import io.flutter.android.AndroidSdk;
 import io.flutter.console.FlutterConsoles;
 import io.flutter.dart.DartPlugin;
-import io.flutter.run.daemon.FlutterApp;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -34,6 +33,8 @@ import java.util.function.Consumer;
  * A Flutter command to run, with its arguments.
  */
 public class FlutterCommand {
+  private static final Logger LOG = Logger.getInstance(FlutterCommand.class);
+
   @NotNull
   private final FlutterSdk sdk;
 
@@ -166,7 +167,9 @@ public class FlutterCommand {
 
     final OSProcessHandler handler;
     try {
-      handler = new OSProcessHandler(createGeneralCommandLine(project));
+      final GeneralCommandLine commandLine = createGeneralCommandLine(project);
+      LOG.info(commandLine.toString());
+      handler = new OSProcessHandler(commandLine);
       handler.addProcessListener(new ProcessAdapter() {
         @Override
         public void processTerminated(final ProcessEvent event) {
@@ -234,6 +237,4 @@ public class FlutterCommand {
       FlutterInitializer.getAnalytics().sendEvent("flutter", action);
     }
   }
-
-  private static final Logger LOG = Logger.getInstance(FlutterApp.class);
 }

--- a/src/io/flutter/sdk/FlutterSdk.java
+++ b/src/io/flutter/sdk/FlutterSdk.java
@@ -16,6 +16,7 @@ import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.vfs.VirtualFileManager;
 import com.jetbrains.lang.dart.sdk.DartSdk;
+import io.flutter.FlutterInitializer;
 import io.flutter.dart.DartPlugin;
 import io.flutter.pub.PubRoot;
 import io.flutter.run.daemon.FlutterDevice;
@@ -127,6 +128,9 @@ public class FlutterSdk {
 
     final List<String> args = new ArrayList<>();
     args.add("--machine");
+    if (FlutterInitializer.isVerboseLogging()) {
+      args.add("--verbose");
+    }
     if (device != null) {
       args.add("--device-id=" + device.deviceId());
     }

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.form
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.form
@@ -63,7 +63,7 @@
         <border type="none"/>
         <children/>
       </grid>
-      <grid id="e885c" layout-manager="GridLayoutManager" row-count="3" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="e885c" layout-manager="GridLayoutManager" row-count="4" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -76,7 +76,7 @@
         <children>
           <component id="6304a" class="javax.swing.JCheckBox" binding="myReportUsageInformationCheckBox">
             <constraints>
-              <grid row="0" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="1" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text value="&amp;Report usage information to Google Analytics"/>
@@ -85,18 +85,27 @@
           </component>
           <vspacer id="4a2f0">
             <constraints>
-              <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+              <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
             </constraints>
           </vspacer>
           <component id="abbab" class="com.intellij.ui.components.labels.LinkLabel" binding="myPrivacyPolicy">
             <constraints>
-              <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="3" use-parent-layout="false"/>
+              <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="3" use-parent-layout="false"/>
             </constraints>
             <properties>
               <horizontalAlignment value="2"/>
               <horizontalTextPosition value="2"/>
               <text value="www.google.com/policies/privacy"/>
               <toolTipText value="http://www.google.com/policies/privacy/"/>
+            </properties>
+          </component>
+          <component id="be19f" class="javax.swing.JCheckBox" binding="myEnableVerboseLoggingCheckBox" default-binding="true">
+            <constraints>
+              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Enable debug logging"/>
+              <toolTipText value="Enables debug logging (this can be useful for diagnostic purposes)."/>
             </properties>
           </component>
         </children>

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.java
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.java
@@ -47,6 +47,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
   private JBLabel myVersionLabel;
   private JCheckBox myReportUsageInformationCheckBox;
   private LinkLabel<String> myPrivacyPolicy;
+  private JCheckBox myEnableVerboseLoggingCheckBox;
   private final @NotNull Project myProject;
 
   FlutterSettingsConfigurable(@NotNull Project project) {
@@ -114,8 +115,12 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
       return true;
     }
 
-    //noinspection RedundantIfStatement
     if (FlutterInitializer.getCanReportAnalytics() != myReportUsageInformationCheckBox.isSelected()) {
+      return true;
+    }
+
+    //noinspection RedundantIfStatement
+    if (FlutterInitializer.isVerboseLogging() != myEnableVerboseLoggingCheckBox.isSelected()) {
       return true;
     }
 
@@ -138,6 +143,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     }
 
     FlutterInitializer.setCanReportAnalaytics(myReportUsageInformationCheckBox.isSelected());
+    FlutterInitializer.setVerboseLogging(myEnableVerboseLoggingCheckBox.isSelected());
 
     reset(); // because we rely on remembering initial state
   }
@@ -154,6 +160,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
 
     updateVersionText();
     myReportUsageInformationCheckBox.setSelected(FlutterInitializer.getCanReportAnalytics());
+    myEnableVerboseLoggingCheckBox.setSelected(FlutterInitializer.isVerboseLogging());
   }
 
   private void updateVersionText() {


### PR DESCRIPTION
add some diagnostic logging:

- log process start and stop to the IntelliJ log file
- add a user toggleable option to enable more verbose debug logging
- when that's set, start flutter run apps up with `--verbose`; this can help identify a lot of issues with the various toolchains (android, gradle, ios, ...) (the same as `flutter run -v` on the cli)

<img width="265" alt="screen shot 2017-05-19 at 4 05 07 pm" src="https://cloud.githubusercontent.com/assets/1269969/26270132/be297be2-3cad-11e7-9701-ce8b3a9561b9.png">

@skybrian @pq