### PR TITLE
Add new run configuration type for 'flutter test'

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -326,6 +326,9 @@
     <configurationType implementation="io.flutter.run.bazel.FlutterBazelRunConfigurationType"/>
     <programRunner implementation="io.flutter.run.bazel.BazelRunner"/>
 
+    <configurationType implementation="io.flutter.run.test.TestConfigType"/>
+    <runConfigurationProducer implementation="io.flutter.run.test.TestConfigProducer"/>
+
     <defaultLiveTemplatesProvider implementation="io.flutter.template.FlutterLiveTemplatesProvider"/>
     <liveTemplateContext implementation="io.flutter.template.DartToplevelTemplateContextType"/>
 

--- a/src/io/flutter/dart/DartPlugin.java
+++ b/src/io/flutter/dart/DartPlugin.java
@@ -78,6 +78,10 @@ public class DartPlugin {
     return type.getId().equals("DartCommandLineRunConfigurationType");
   }
 
+  public static boolean isDartTestConfiguration(ConfigurationType type) {
+    return type.getId().equals("DartTestRunConfigurationType");
+  }
+
   /**
    * @return the minimum required version of the Dart Plugin
    */

--- a/src/io/flutter/pub/PubRoot.java
+++ b/src/io/flutter/pub/PubRoot.java
@@ -42,6 +42,7 @@ public class PubRoot {
   private final VirtualFile lib;
 
   private PubRoot(@NotNull VirtualFile root, @NotNull VirtualFile pubspec, @Nullable VirtualFile packages, @Nullable VirtualFile lib) {
+    assert(!root.getPath().endsWith("/"));
     this.root = root;
     this.pubspec = pubspec;
     this.packages = packages;
@@ -189,6 +190,21 @@ public class PubRoot {
     final VirtualFile lib = root.getLib();
     if (lib != null) lib.refresh(false, false);
     return root;
+  }
+
+  /**
+   * Returns the relative path to a file within this PubRoot.
+   * <p>
+   * Returns null if not within the pubroot.
+   */
+  @Nullable
+  public String getRelativePath(@NotNull VirtualFile file) {
+    final String root = this.root.getPath();
+    final String path = file.getPath();
+    if (!path.startsWith(root) || path.length() < root.length() + 2) {
+      return null;
+    }
+    return path.substring(root.length() + 1);
   }
 
   /**

--- a/src/io/flutter/run/LaunchState.java
+++ b/src/io/flutter/run/LaunchState.java
@@ -197,7 +197,9 @@ public class LaunchState extends CommandLineState {
   @Override
   protected @NotNull
   ProcessHandler startProcess() throws ExecutionException {
-    throw new ExecutionException("not implemented"); // Not used; callback does this.
+    // This can happen if there isn't a custom runner defined in plugin.xml.
+    // The runner should extend LaunchState.Runner (below).
+    throw new ExecutionException("need to implement LaunchState.Runner for " + runConfig.getClass());
   }
 
   /**

--- a/src/io/flutter/run/test/TestConfigProducer.java
+++ b/src/io/flutter/run/test/TestConfigProducer.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.run.test;
+
+import com.intellij.execution.actions.ConfigurationContext;
+import com.intellij.execution.actions.ConfigurationFromContext;
+import com.intellij.execution.actions.RunConfigurationProducer;
+import com.intellij.openapi.util.Ref;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiElement;
+import io.flutter.dart.DartPlugin;
+import io.flutter.run.FlutterRunConfigurationProducer;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Determines when we can run a test using "flutter test".
+ */
+public class TestConfigProducer extends RunConfigurationProducer<TestConfig> {
+
+  protected TestConfigProducer() {
+    super(TestConfigType.getInstance());
+  }
+
+  /**
+   * If the current file looks like a Flutter test, initializes the run config to run it.
+   */
+  @Override
+  protected boolean setupConfigurationFromContext(TestConfig config, ConfigurationContext context, Ref<PsiElement> sourceElement) {
+    final VirtualFile candidate = FlutterRunConfigurationProducer.getFlutterEntryFile(context, false);
+    if (candidate == null || !candidate.getName().endsWith("_test.dart")) {
+      return false;
+    }
+
+    config.setFields(new TestFields(candidate.getPath()));
+    config.setGeneratedName();
+
+    return true;
+  }
+
+  /**
+   * Returns true if a run config was already created for this file. If so we will reuse it.
+   */
+  @Override
+  public boolean isConfigurationFromContext(TestConfig config, ConfigurationContext context) {
+    final String testFile = config.getFields().getTestFile();
+    return FlutterRunConfigurationProducer.hasDartFile(context, testFile);
+  }
+
+  @Override
+  public boolean shouldReplace(@NotNull ConfigurationFromContext self, @NotNull ConfigurationFromContext other) {
+    return DartPlugin.isDartTestConfiguration(other.getConfigurationType());
+  }
+}

--- a/src/io/flutter/run/test/TestConfigType.java
+++ b/src/io/flutter/run/test/TestConfigType.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.run.test;
+
+import com.intellij.execution.configurations.ConfigurationFactory;
+import com.intellij.execution.configurations.ConfigurationTypeBase;
+import com.intellij.execution.configurations.RunConfiguration;
+import com.intellij.openapi.extensions.Extensions;
+import com.intellij.openapi.project.Project;
+import icons.FlutterIcons;
+import io.flutter.utils.FlutterModuleUtils;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * The type of configs that run tests using "flutter test".
+ */
+public class TestConfigType extends ConfigurationTypeBase {
+  protected TestConfigType() {
+    super("FlutterTestConfigType", "Flutter Test",
+          "description", FlutterIcons.Flutter);
+    addFactory(new Factory(this));
+  }
+
+  public static TestConfigType getInstance() {
+    return Extensions.findExtension(CONFIGURATION_TYPE_EP, TestConfigType.class);
+  }
+
+  private static class Factory extends ConfigurationFactory {
+    public Factory(TestConfigType type) {
+      super(type);
+    }
+
+    @NotNull
+    @Override
+    public RunConfiguration createTemplateConfiguration(@NotNull Project project) {
+      return new TestConfig(project, this, "Flutter Test");
+    }
+
+    @Override
+    public boolean isApplicable(@NotNull Project project) {
+      return FlutterModuleUtils.hasFlutterModule(project);
+    }
+  }
+}

--- a/src/io/flutter/run/test/TestFields.java
+++ b/src/io/flutter/run/test/TestFields.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2017 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.run.test;
+
+import com.intellij.execution.ExecutionException;
+import com.intellij.execution.configurations.RuntimeConfigurationError;
+import com.intellij.execution.process.ProcessHandler;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.InvalidDataException;
+import io.flutter.pub.PubRoot;
+import io.flutter.run.MainFile;
+import io.flutter.run.daemon.FlutterDevice;
+import io.flutter.run.daemon.RunMode;
+import io.flutter.sdk.FlutterSdk;
+import org.jdom.Element;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Settings for running a Flutter test.
+ */
+public class TestFields {
+  @NotNull
+  private final String testFile;
+
+  TestFields(@NotNull String testFile) {
+    this.testFile = testFile;
+  }
+
+  /**
+   * The Dart file containing the tests to run.
+   */
+  @NotNull
+  public String getTestFile() {
+    return testFile;
+  }
+
+  void writeTo(Element elt) {
+    addOption(elt, "testFile", testFile);
+  }
+
+  /**
+   * Reads the fields from an XML Element, if available.
+   */
+  @NotNull
+  static TestFields readFrom(Element elt) throws InvalidDataException {
+    final Map<String, String> options = readOptions(elt);
+
+    final String testFile = options.get("testFile");
+    if (testFile == null) {
+      throw new InvalidDataException("can't read testFile option in run configuration");
+    }
+
+    return new TestFields(testFile);
+  }
+
+  /**
+   * Reports any errors that the user should correct.
+   * <p>
+   * This will be called while the user is typing; see RunConfiguration.checkConfiguration.
+   */
+  void checkRunnable(@NotNull Project project) throws RuntimeConfigurationError {
+    checkSdk(project);
+
+    final MainFile.Result main = MainFile.verify(testFile, project);
+    if (!main.canLaunch()) {
+      throw new RuntimeConfigurationError(main.getError());
+    }
+
+    final PubRoot root = PubRoot.forDirectory(main.get().getAppDir());
+    if (root == null) {
+      throw new RuntimeConfigurationError("Test file isn't within a Flutter pub root");
+    }
+  }
+
+  /**
+   * Starts running the tests.
+   */
+  ProcessHandler run(Project project, FlutterDevice device, RunMode mode) throws ExecutionException {
+    final FlutterSdk sdk = FlutterSdk.getFlutterSdk(project);
+    if (sdk == null) {
+      throw new ExecutionException("The Flutter SDK is not configured");
+    }
+
+    final MainFile main = MainFile.verify(testFile, project).get();
+    final PubRoot root = PubRoot.forDirectory(main.getAppDir());
+    if (root == null) {
+      throw new ExecutionException("Test file isn't within a Flutter pub root");
+    }
+
+    return sdk.flutterTest(root, main.getFile(), device).startProcess(project);
+  }
+
+  private void checkSdk(@NotNull Project project) throws RuntimeConfigurationError {
+    if (FlutterSdk.getFlutterSdk(project) == null) {
+      throw new RuntimeConfigurationError("Flutter SDK isn't set");
+    }
+  }
+
+  private void addOption(Element elt, String name, String value) {
+    final Element child = new Element("option");
+    child.setAttribute("name", name);
+    child.setAttribute("value", value);
+    elt.addContent(child);
+  }
+
+  private static Map<String, String> readOptions(Element elt) {
+    final Map<String, String> result = new HashMap<>();
+    for (Element child : elt.getChildren()) {
+      if ("option".equals(child.getName())) {
+        final String name = child.getAttributeValue("name");
+        final String value = child.getAttributeValue("value");
+        if (name != null && value != null) {
+          result.put(name, value);
+        }
+      }
+    }
+    return result;
+  }
+}

--- a/src/io/flutter/run/test/TestForm.form
+++ b/src/io/flutter/run/test/TestForm.form
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="io.flutter.run.test.TestForm">
+  <grid id="27dc6" binding="form" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+    <margin top="0" left="0" bottom="0" right="0"/>
+    <constraints>
+      <xy x="20" y="20" width="500" height="400"/>
+    </constraints>
+    <properties/>
+    <border type="none"/>
+    <children>
+      <component id="e1221" class="javax.swing.JLabel">
+        <constraints>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="File containing Flutter tests"/>
+        </properties>
+      </component>
+      <vspacer id="fff30">
+        <constraints>
+          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+        </constraints>
+      </vspacer>
+      <component id="3abe7" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="testFile">
+        <constraints>
+          <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+      </component>
+    </children>
+  </grid>
+</form>

--- a/src/io/flutter/run/test/TestForm.java
+++ b/src/io/flutter/run/test/TestForm.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.run.test;
+
+import com.intellij.openapi.options.ConfigurationException;
+import com.intellij.openapi.options.SettingsEditor;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.TextFieldWithBrowseButton;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+
+import static com.jetbrains.lang.dart.ide.runner.server.ui.DartCommandLineConfigurationEditorForm.initDartFileTextWithBrowse;
+
+/**
+ * Settings editor for running Flutter tests.
+ */
+public class TestForm extends SettingsEditor<TestConfig> {
+  private JPanel form;
+  private TextFieldWithBrowseButton testFile;
+
+  TestForm(@NotNull Project project) {
+    initDartFileTextWithBrowse(project, testFile);
+  }
+
+  @NotNull
+  @Override
+  protected JComponent createEditor() {
+    return form;
+  }
+
+  @Override
+  protected void resetEditorFrom(@NotNull TestConfig config) {
+    final TestFields fields = config.getFields();
+    testFile.setText(fields.getTestFile());
+  }
+
+  @Override
+  protected void applyEditorTo(@NotNull TestConfig config) throws ConfigurationException {
+    final TestFields fields = new TestFields(testFile.getText());
+    config.setFields(fields);
+  }
+}

--- a/src/io/flutter/sdk/FlutterCommand.java
+++ b/src/io/flutter/sdk/FlutterCommand.java
@@ -159,7 +159,7 @@ public class FlutterCommand {
    * Returns the handler if successfully started.
    */
   @Nullable
-  private OSProcessHandler startProcess(@Nullable Project project) {
+  public OSProcessHandler startProcess(@Nullable Project project) {
     if (!inProgress.compareAndSet(null, this)) {
       return null;
     }
@@ -222,7 +222,8 @@ public class FlutterCommand {
     PACKAGES_UPGRADE("Flutter packages upgrade", "packages", "upgrade"),
     UPGRADE("Flutter upgrade", "upgrade"),
     VERSION("Flutter version", "--version"),
-    RUN("Flutter run", "run");
+    RUN("Flutter run", "run"),
+    TEST("Flutter test", "test");
 
     final public String title;
     final ImmutableList<String> subCommand;

--- a/src/io/flutter/sdk/FlutterSdk.java
+++ b/src/io/flutter/sdk/FlutterSdk.java
@@ -120,10 +120,6 @@ public class FlutterSdk {
 
   public FlutterCommand flutterRun(@NotNull PubRoot root, @NotNull VirtualFile main,
                                    @Nullable FlutterDevice device, @NotNull RunMode mode, String... additionalArgs) {
-    if (!root.contains(main)) {
-      throw new IllegalArgumentException("main isn't within the pub root: " + main.getPath());
-    }
-
     final List<String> args = new ArrayList<>();
     args.add("--machine");
     if (FlutterInitializer.isVerboseLogging()) {
@@ -141,12 +137,34 @@ public class FlutterSdk {
     args.addAll(asList(additionalArgs));
 
     // Make the path to main relative (to make the command line prettier).
-    assert main.getPath().startsWith(root.getPath());
-    assert !root.getPath().endsWith("/");
-    final String mainPath = main.getPath().substring(root.getPath().length() + 1);
+    final String mainPath = root.getRelativePath(main);
+    if (mainPath == null) {
+      throw new IllegalArgumentException("main isn't within the pub root: " + main.getPath());
+    }
     args.add(FileUtil.toSystemDependentName(mainPath));
 
     return new FlutterCommand(this, root.getRoot(), FlutterCommand.Type.RUN, args.toArray(new String[]{}));
+  }
+
+  public FlutterCommand flutterTest(@NotNull PubRoot root, @NotNull VirtualFile main, @Nullable FlutterDevice device) {
+
+    // We don't have machine mode yet, so just run it normally and show the output in the console.
+    final List<String> args = new ArrayList<>();
+    if (FlutterInitializer.isVerboseLogging()) {
+      args.add("--verbose");
+    }
+    if (device != null) {
+      args.add("--device-id=" + device.deviceId());
+    }
+
+    // Make the path to main relative (to make the command line prettier).
+    final String mainPath = root.getRelativePath(main);
+    if (mainPath == null) {
+      throw new IllegalArgumentException("main isn't within the pub root: " + main.getPath());
+    }
+    args.add(FileUtil.toSystemDependentName(mainPath));
+
+    return new FlutterCommand(this, root.getRoot(), FlutterCommand.Type.TEST, args.toArray(new String[]{}));
   }
 
   /**


### PR DESCRIPTION
For now this just executes 'flutter test' and sends the output
to the console. Still to do: show test output in IDEA's UI
and support debugging. (That will require modifying the
"flutter test" command to support --machine mode.)

Previously, running a test from within IDEA would fail because
the Dart plugin does it and it doesn't use "flutter test",
which is needed for all tests using a flutter pubspec.