### PR TITLE
Don't require a test's filename to end with _test.dart

### DIFF
--- a/src/io/flutter/run/FlutterRunConfigurationProducer.java
+++ b/src/io/flutter/run/FlutterRunConfigurationProducer.java
@@ -121,7 +121,7 @@ public class FlutterRunConfigurationProducer extends RunConfigurationProducer<Sd
   /**
    * Returns the Dart file at the current location, or null if not a match.
    */
-  private static @Nullable DartFile getDartFile(final @NotNull ConfigurationContext context) {
+  public static @Nullable DartFile getDartFile(final @NotNull ConfigurationContext context) {
     final PsiElement elt = context.getPsiLocation();
     if (elt == null) return null;
 

--- a/src/io/flutter/run/test/TestConfigProducer.java
+++ b/src/io/flutter/run/test/TestConfigProducer.java
@@ -11,7 +11,9 @@ import com.intellij.execution.actions.RunConfigurationProducer;
 import com.intellij.openapi.util.Ref;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiElement;
+import com.jetbrains.lang.dart.psi.DartFile;
 import io.flutter.dart.DartPlugin;
+import io.flutter.pub.PubRoot;
 import io.flutter.run.FlutterRunConfigurationProducer;
 import org.jetbrains.annotations.NotNull;
 
@@ -29,10 +31,17 @@ public class TestConfigProducer extends RunConfigurationProducer<TestConfig> {
    */
   @Override
   protected boolean setupConfigurationFromContext(TestConfig config, ConfigurationContext context, Ref<PsiElement> sourceElement) {
+    final DartFile file = FlutterRunConfigurationProducer.getDartFile(context);
+    if (file == null) return false;
+
+    final PubRoot root = PubRoot.forPsiFile(file);
+    if (root == null) return false;
+
     final VirtualFile candidate = FlutterRunConfigurationProducer.getFlutterEntryFile(context, false);
-    if (candidate == null || !candidate.getName().endsWith("_test.dart")) {
-      return false;
-    }
+    if (candidate == null) return false;
+
+    final String relativePath = root.getRelativePath(candidate);
+    if (relativePath == null || !relativePath.startsWith("test/")) return false;
 
     config.setFields(new TestFields(candidate.getPath()));
     config.setGeneratedName();


### PR DESCRIPTION
Instead, require it to be in the test directory of a pubroot.
(This is closer to what the Dart plugin does.)