### PR TITLE
improved feedback on reload

### DIFF
--- a/src/io/flutter/FlutterBundle.properties
+++ b/src/io/flutter/FlutterBundle.properties
@@ -88,7 +88,7 @@ flutter.view.debugPaint.description=Toggle Debug Paint
 flutter.view.togglePlatform.text=Toggle Platform
 flutter.view.togglePlatform.description=Toggle Platform
 # suppress inspection "TrailingSpacesInProperty"
-flutter.view.togglePlatform.output=Switched platform OS to {0}.\n
+flutter.view.togglePlatform.output=Switched platform rendering to {0}.\n
 
 devicelist.loading=Loading...
 devicelist.empty=No devices

--- a/src/io/flutter/run/daemon/FlutterApp.java
+++ b/src/io/flutter/run/daemon/FlutterApp.java
@@ -187,8 +187,10 @@ public class FlutterApp {
       LOG.warn("cannot restart Flutter app because app id is not set");
       return;
     }
+
+    changeState(State.RELOADING);
     myDaemonApi.restartApp(myAppId, true, false)
-      .thenRunAsync(() -> changeState(FlutterApp.State.STARTED));
+      .thenRunAsync(() -> changeState(State.STARTED));
   }
 
   /**
@@ -199,8 +201,10 @@ public class FlutterApp {
       LOG.warn("cannot reload Flutter app because app id is not set");
       return;
     }
+
+    changeState(State.RELOADING);
     myDaemonApi.restartApp(myAppId, false, pauseAfterRestart)
-      .thenRunAsync(() -> changeState(FlutterApp.State.STARTED));
+      .thenRunAsync(() -> changeState(State.STARTED));
   }
 
   public CompletableFuture<Boolean> togglePlatform() {
@@ -338,5 +342,5 @@ public class FlutterApp {
     void stateChanged(State newState);
   }
 
-  public enum State {STARTING, STARTED, TERMINATING, TERMINATED}
+  public enum State {STARTING, STARTED, RELOADING, TERMINATING, TERMINATED}
 }

--- a/src/io/flutter/run/daemon/FlutterAppListener.java
+++ b/src/io/flutter/run/daemon/FlutterAppListener.java
@@ -109,7 +109,9 @@ class FlutterAppListener implements DaemonEvent.Listener {
     if (event.getType().startsWith("hot.")) {
       // We clear the console view in order to help indicate that a reload is happening.
       if (app.getConsole() != null) {
-        app.getConsole().clear();
+        if (!FlutterInitializer.isVerboseLogging()) {
+          app.getConsole().clear();
+        }
       }
 
       stopwatch.set(Stopwatch.createStarted());

--- a/src/io/flutter/run/daemon/FlutterAppListener.java
+++ b/src/io/flutter/run/daemon/FlutterAppListener.java
@@ -105,8 +105,18 @@ class FlutterAppListener implements DaemonEvent.Listener {
   @Override
   public void onAppProgressStarting(@NotNull DaemonEvent.AppProgress event) {
     progress.start(event.message);
+
     if (event.getType().startsWith("hot.")) {
+      // We clear the console view in order to help indicate that a reload is happening.
+      if (app.getConsole() != null) {
+        app.getConsole().clear();
+      }
+
       stopwatch.set(Stopwatch.createStarted());
+    }
+
+    if (app.getConsole() != null) {
+      app.getConsole().print(event.message + "\n", ConsoleViewContentType.NORMAL_OUTPUT);
     }
   }
 

--- a/src/io/flutter/view/AbstractToggleableAction.java
+++ b/src/io/flutter/view/AbstractToggleableAction.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2017 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.view;
+
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.Presentation;
+import com.intellij.openapi.actionSystem.Toggleable;
+import com.intellij.openapi.application.ApplicationManager;
+import io.flutter.FlutterInitializer;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+
+abstract class AbstractToggleableAction extends AnAction implements Toggleable {
+  @NotNull final FlutterView view;
+  private boolean selected = false;
+
+  AbstractToggleableAction(@NotNull FlutterView view, @Nullable String text) {
+    super(text);
+
+    this.view = view;
+  }
+
+  AbstractToggleableAction(@NotNull FlutterView view, @Nullable String text, @Nullable String description, @Nullable Icon icon) {
+    super(text, description, icon);
+
+    this.view = view;
+  }
+
+  @Override
+  public final void update(AnActionEvent e) {
+    final boolean hasFlutterApp = view.getFlutterApp() != null;
+    if (!hasFlutterApp) {
+      selected = false;
+    }
+
+    // selected
+    final boolean selected = this.isSelected(e);
+    final Presentation presentation = e.getPresentation();
+    presentation.putClientProperty("selected", selected);
+
+    // enabled
+    e.getPresentation().setEnabled(hasFlutterApp);
+  }
+
+  @Override
+  public void actionPerformed(AnActionEvent event) {
+    if (view.getFlutterApp() == null) {
+      return;
+    }
+
+    this.setSelected(event, !isSelected(event));
+    final Presentation presentation = event.getPresentation();
+    presentation.putClientProperty("selected", isSelected(event));
+
+    FlutterInitializer.sendAnalyticsAction(this);
+    perform(event);
+  }
+
+  protected abstract void perform(AnActionEvent event);
+
+  public boolean isSelected(AnActionEvent var1) {
+    return selected;
+  }
+
+  public void setSelected(AnActionEvent event, boolean selected) {
+    this.selected = selected;
+
+    ApplicationManager.getApplication().invokeLater(() -> this.update(event));
+  }
+}

--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -9,7 +9,9 @@ import com.intellij.execution.runners.ExecutionUtil;
 import com.intellij.execution.ui.ConsoleViewContentType;
 import com.intellij.icons.AllIcons;
 import com.intellij.openapi.Disposable;
-import com.intellij.openapi.actionSystem.*;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.DefaultActionGroup;
+import com.intellij.openapi.actionSystem.Separator;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.PersistentStateComponent;
 import com.intellij.openapi.components.Storage;
@@ -162,65 +164,6 @@ public class FlutterView implements PersistentStateComponent<FlutterView.State>,
   }
 }
 
-abstract class AbstractToggleableAction extends AnAction implements Toggleable {
-  @NotNull final FlutterView view;
-  private boolean selected = false;
-
-  AbstractToggleableAction(@NotNull FlutterView view, @Nullable String text) {
-    super(text);
-
-    this.view = view;
-  }
-
-  AbstractToggleableAction(@NotNull FlutterView view, @Nullable String text, @Nullable String description, @Nullable Icon icon) {
-    super(text, description, icon);
-
-    this.view = view;
-  }
-
-  @Override
-  public final void update(AnActionEvent e) {
-    final boolean hasFlutterApp = view.getFlutterApp() != null;
-    if (!hasFlutterApp) {
-      selected = false;
-    }
-
-    // selected
-    final boolean selected = this.isSelected(e);
-    final Presentation presentation = e.getPresentation();
-    presentation.putClientProperty("selected", selected);
-
-    // enabled
-    e.getPresentation().setEnabled(hasFlutterApp);
-  }
-
-  @Override
-  public void actionPerformed(AnActionEvent event) {
-    if (view.getFlutterApp() == null) {
-      return;
-    }
-
-    this.setSelected(event, !isSelected(event));
-    final Presentation presentation = event.getPresentation();
-    presentation.putClientProperty("selected", isSelected(event));
-
-    FlutterInitializer.sendAnalyticsAction(this);
-    perform(event);
-  }
-
-  protected abstract void perform(AnActionEvent event);
-
-  public boolean isSelected(AnActionEvent var1) {
-    return selected;
-  }
-
-  public void setSelected(AnActionEvent event, boolean selected) {
-    this.selected = selected;
-
-    ApplicationManager.getApplication().invokeLater(() -> this.update(event));
-  }
-}
-
 class DebugDrawAction extends AbstractToggleableAction {
   DebugDrawAction(@NotNull FlutterView view) {
     super(view, FlutterBundle.message("flutter.view.debugPaint.text"), FlutterBundle.message("flutter.view.debugPaint.description"),
@@ -242,7 +185,7 @@ class PerformanceOverlayAction extends AbstractToggleableAction {
   }
 }
 
-class TogglePlatformAction extends AbstractFlutterAction {
+class TogglePlatformAction extends FlutterViewAction {
   TogglePlatformAction(@NotNull FlutterView view) {
     super(view, FlutterBundle.message("flutter.view.togglePlatform.text"), FlutterBundle.message("flutter.view.togglePlatform.description"),
           AllIcons.RunConfigurations.Application);
@@ -316,28 +259,7 @@ class ShowPaintBaselinesAction extends AbstractToggleableAction {
   }
 }
 
-abstract class AbstractFlutterAction extends AnAction {
-  @NotNull final FlutterView view;
-
-  AbstractFlutterAction(@NotNull FlutterView view, @Nullable String text) {
-    super(text);
-
-    this.view = view;
-  }
-
-  AbstractFlutterAction(@NotNull FlutterView view, @Nullable String text, @Nullable String description, @Nullable Icon icon) {
-    super(text, description, icon);
-
-    this.view = view;
-  }
-
-  @Override
-  public final void update(AnActionEvent e) {
-    e.getPresentation().setEnabled(view.getFlutterApp() != null);
-  }
-}
-
-class ObservatoryTimelineAction extends AbstractFlutterAction {
+class ObservatoryTimelineAction extends FlutterViewAction {
   ObservatoryTimelineAction(@NotNull FlutterView view) {
     super(view, "Open Observatory Timeline");
   }

--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -13,7 +13,6 @@ import com.intellij.openapi.actionSystem.*;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.PersistentStateComponent;
 import com.intellij.openapi.components.Storage;
-import com.intellij.openapi.project.DumbAwareAction;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.SimpleToolWindowPanel;
 import com.intellij.openapi.wm.ToolWindow;
@@ -163,7 +162,7 @@ public class FlutterView implements PersistentStateComponent<FlutterView.State>,
   }
 }
 
-abstract class AbstractToggleableAction extends DumbAwareAction implements Toggleable {
+abstract class AbstractToggleableAction extends AnAction implements Toggleable {
   @NotNull final FlutterView view;
   private boolean selected = false;
 
@@ -317,7 +316,7 @@ class ShowPaintBaselinesAction extends AbstractToggleableAction {
   }
 }
 
-abstract class AbstractFlutterAction extends DumbAwareAction {
+abstract class AbstractFlutterAction extends AnAction {
   @NotNull final FlutterView view;
 
   AbstractFlutterAction(@NotNull FlutterView view, @Nullable String text) {

--- a/src/io/flutter/view/FlutterViewAction.java
+++ b/src/io/flutter/view/FlutterViewAction.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.view;
+
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+
+abstract class FlutterViewAction extends AnAction {
+  @NotNull final FlutterView view;
+
+  FlutterViewAction(@NotNull FlutterView view, @Nullable String text) {
+    super(text);
+
+    this.view = view;
+  }
+
+  FlutterViewAction(@NotNull FlutterView view, @Nullable String text, @Nullable String description, @Nullable Icon icon) {
+    super(text, description, icon);
+
+    this.view = view;
+  }
+
+  @Override
+  public final void update(AnActionEvent e) {
+    e.getPresentation().setEnabled(view.getFlutterApp() != null);
+  }
+}

--- a/src/io/flutter/view/FlutterViewFactory.java
+++ b/src/io/flutter/view/FlutterViewFactory.java
@@ -7,7 +7,6 @@ package io.flutter.view;
 
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.ServiceManager;
-import com.intellij.openapi.project.DumbService;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowFactory;
@@ -32,9 +31,6 @@ public class FlutterViewFactory implements ToolWindowFactory {
 
   @Override
   public void createToolWindowContent(@NotNull Project project, @NotNull ToolWindow toolWindow) {
-    //noinspection CodeBlock2Expr
-    DumbService.getInstance(project).runWhenSmart(() -> {
-      (ServiceManager.getService(project, FlutterView.class)).initToolWindow(toolWindow);
-    });
+    (ServiceManager.getService(project, FlutterView.class)).initToolWindow(toolWindow);
   }
 }


### PR DESCRIPTION
improved feedback on reload:

- clear the console when a reload starts (fix #939)
- disable the reload button while a reload is occurring
- print progress messages to the console view (in addition to using IntelliJ's normal progress mechanism) (part of #1068)
- (and, some small tweaks to the FlutterView)

@skybrian @pq

