### PR TITLE
SuppressWarnings for getBigIcon override

### DIFF
--- a/src/io/flutter/module/FlutterModuleBuilder.java
+++ b/src/io/flutter/module/FlutterModuleBuilder.java
@@ -54,6 +54,8 @@ public class FlutterModuleBuilder extends ModuleBuilder {
     return FlutterBundle.message("flutter.module.name");
   }
 
+  // This method does not exist in 2017.2.
+  @SuppressWarnings("override")
   public Icon getBigIcon() {
     return FlutterIcons.Flutter_2x;
   }

--- a/src/io/flutter/module/FlutterModuleType.java
+++ b/src/io/flutter/module/FlutterModuleType.java
@@ -42,6 +42,8 @@ public class FlutterModuleType extends ModuleType<FlutterModuleBuilder> {
     return FlutterBundle.message("flutter.project.description");
   }
 
+  // This method does not exist in 2017.2.
+  @SuppressWarnings("override")
   public Icon getBigIcon() {
     return FlutterIcons.Flutter_2x;
   }


### PR DESCRIPTION
Note why we don't use the override annotation, so we don't accidentally re-add it.

@alexander-doroshko 