### PR TITLE
re-add DumbAwareAction

### DIFF
--- a/src/io/flutter/view/AbstractToggleableAction.java
+++ b/src/io/flutter/view/AbstractToggleableAction.java
@@ -5,18 +5,18 @@
  */
 package io.flutter.view;
 
-import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.Presentation;
 import com.intellij.openapi.actionSystem.Toggleable;
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.project.DumbAwareAction;
 import io.flutter.FlutterInitializer;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 
-abstract class AbstractToggleableAction extends AnAction implements Toggleable {
+abstract class AbstractToggleableAction extends DumbAwareAction implements Toggleable {
   @NotNull final FlutterView view;
   private boolean selected = false;
 

--- a/src/io/flutter/view/FlutterViewAction.java
+++ b/src/io/flutter/view/FlutterViewAction.java
@@ -5,14 +5,14 @@
  */
 package io.flutter.view;
 
-import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.project.DumbAwareAction;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 
-abstract class FlutterViewAction extends AnAction {
+abstract class FlutterViewAction extends DumbAwareAction {
   @NotNull final FlutterView view;
 
   FlutterViewAction(@NotNull FlutterView view, @Nullable String text) {

--- a/src/io/flutter/view/FlutterViewFactory.java
+++ b/src/io/flutter/view/FlutterViewFactory.java
@@ -7,12 +7,14 @@ package io.flutter.view;
 
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.project.DumbAware;
+import com.intellij.openapi.project.DumbService;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowFactory;
 import org.jetbrains.annotations.NotNull;
 
-public class FlutterViewFactory implements ToolWindowFactory {
+public class FlutterViewFactory implements ToolWindowFactory, DumbAware {
   public static void init(@NotNull Project project) {
     //noinspection CodeBlock2Expr
     project.getMessageBus().connect().subscribe(
@@ -31,6 +33,9 @@ public class FlutterViewFactory implements ToolWindowFactory {
 
   @Override
   public void createToolWindowContent(@NotNull Project project, @NotNull ToolWindow toolWindow) {
-    (ServiceManager.getService(project, FlutterView.class)).initToolWindow(toolWindow);
+    //noinspection CodeBlock2Expr
+    DumbService.getInstance(project).runWhenSmart(() -> {
+      (ServiceManager.getService(project, FlutterView.class)).initToolWindow(toolWindow);
+    });
   }
 }


### PR DESCRIPTION
Revert parts of https://github.com/flutter/flutter-intellij/pull/1077 - re-add `DumbAwareAction`.

From the docs: `A marker interface for the things that are allowed to run in dumb mode` - so it sounds since these actions do not need to access bits of the index, we want to keep them dumb aware.