### PR TITLE
change the 'open flutter view' icon

### DIFF
--- a/src/io/flutter/view/OpenFlutterViewAction.java
+++ b/src/io/flutter/view/OpenFlutterViewAction.java
@@ -21,7 +21,7 @@ public class OpenFlutterViewAction extends DumbAwareAction {
   private final Computable<Boolean> myIsApplicable;
 
   public OpenFlutterViewAction(@NotNull final Computable<Boolean> isApplicable) {
-    super("Open Flutter View", "Open Flutter View", FlutterIcons.Flutter_inspect);
+    super("Open Flutter View", "Open Flutter View", FlutterIcons.Flutter);
 
     myIsApplicable = isApplicable;
   }


### PR DESCRIPTION
- tweak the 'open flutter view' icon to not include the small arrow badge (from seeing it for a while, it seems more distracting than helpful)

@pq, @skybrian 