### PR TITLE
support nested packages

### DIFF
--- a/src/io/flutter/editor/FlutterPubspecNotificationProvider.java
+++ b/src/io/flutter/editor/FlutterPubspecNotificationProvider.java
@@ -77,33 +77,11 @@ public class FlutterPubspecNotificationProvider extends EditorNotifications.Prov
       text("Flutter commands");
 
       // "flutter.packages.get"
-      HyperlinkLabel label = createActionLabel("Packages get", () -> {
-        // We can assert below since we know we're on a pubspec.yaml file in a project, with a valid Flutter SDK.
-        final Project project = ProjectLocator.getInstance().guessProjectForFile(myFile);
-        assert (project != null);
-        final FlutterSdk sdk = FlutterSdk.getFlutterSdk(project);
-        assert (sdk != null);
-
-        final PubRoot root = PubRoot.forDirectory(myFile.getParent());
-        if (root != null) {
-          sdk.startPackagesGet(root, project);
-        }
-      });
+      HyperlinkLabel label = createActionLabel("Packages get", () -> runPackagesGet(false));
       label.setToolTipText("Install referenced packages");
 
       // "flutter.packages.upgrade"
-      label = createActionLabel("Packages upgrade", () -> {
-        // We can assert below since we know we're on a pubspec.yaml file in a project, with a valid Flutter SDK.
-        final Project project = ProjectLocator.getInstance().guessProjectForFile(myFile);
-        assert (project != null);
-        final FlutterSdk sdk = FlutterSdk.getFlutterSdk(project);
-        assert (sdk != null);
-
-        final PubRoot root = PubRoot.forDirectory(myFile.getParent());
-        if (root != null) {
-          sdk.startPackagesUpgrade(root, project);
-        }
-      });
+      label = createActionLabel("Packages upgrade", () -> runPackagesGet(true));
       label.setToolTipText("Upgrade referenced packages to the latest versions");
 
       myLinksPanel.add(new JSeparator(SwingConstants.VERTICAL));
@@ -113,6 +91,24 @@ public class FlutterPubspecNotificationProvider extends EditorNotifications.Prov
       myLinksPanel.add(new JSeparator(SwingConstants.VERTICAL));
       label = createActionLabel("Flutter doctor", "flutter.doctor");
       label.setToolTipText("Validate installed tools and their versions");
+    }
+
+    private void runPackagesGet(boolean upgrade) {
+      // We can assert below since we know we're on a pubspec.yaml file in a project, with a valid Flutter SDK.
+      final Project project = ProjectLocator.getInstance().guessProjectForFile(myFile);
+      assert (project != null);
+      final FlutterSdk sdk = FlutterSdk.getFlutterSdk(project);
+      assert (sdk != null);
+
+      final PubRoot root = PubRoot.forDirectory(myFile.getParent());
+      if (root != null) {
+        if (!upgrade) {
+          sdk.startPackagesGet(root, project);
+        }
+        else {
+          sdk.startPackagesUpgrade(root, project);
+        }
+      }
     }
   }
 }

--- a/src/io/flutter/editor/FlutterPubspecNotificationProvider.java
+++ b/src/io/flutter/editor/FlutterPubspecNotificationProvider.java
@@ -76,10 +76,34 @@ public class FlutterPubspecNotificationProvider extends EditorNotifications.Prov
       icon(FlutterIcons.Flutter);
       text("Flutter commands");
 
-      HyperlinkLabel label = createActionLabel("Packages get", "flutter.packages.get");
+      // "flutter.packages.get"
+      HyperlinkLabel label = createActionLabel("Packages get", () -> {
+        // We can assert below since we know we're on a pubspec.yaml file in a project, with a valid Flutter SDK.
+        final Project project = ProjectLocator.getInstance().guessProjectForFile(myFile);
+        assert (project != null);
+        final FlutterSdk sdk = FlutterSdk.getFlutterSdk(project);
+        assert (sdk != null);
+
+        final PubRoot root = PubRoot.forDirectory(myFile.getParent());
+        if (root != null) {
+          sdk.startPackagesGet(root, project);
+        }
+      });
       label.setToolTipText("Install referenced packages");
 
-      label = createActionLabel("Packages upgrade", "flutter.packages.upgrade");
+      // "flutter.packages.upgrade"
+      label = createActionLabel("Packages upgrade", () -> {
+        // We can assert below since we know we're on a pubspec.yaml file in a project, with a valid Flutter SDK.
+        final Project project = ProjectLocator.getInstance().guessProjectForFile(myFile);
+        assert (project != null);
+        final FlutterSdk sdk = FlutterSdk.getFlutterSdk(project);
+        assert (sdk != null);
+
+        final PubRoot root = PubRoot.forDirectory(myFile.getParent());
+        if (root != null) {
+          sdk.startPackagesUpgrade(root, project);
+        }
+      });
       label.setToolTipText("Upgrade referenced packages to the latest versions");
 
       myLinksPanel.add(new JSeparator(SwingConstants.VERTICAL));

--- a/src/io/flutter/pub/PubRoot.java
+++ b/src/io/flutter/pub/PubRoot.java
@@ -42,7 +42,7 @@ public class PubRoot {
   private final VirtualFile lib;
 
   private PubRoot(@NotNull VirtualFile root, @NotNull VirtualFile pubspec, @Nullable VirtualFile packages, @Nullable VirtualFile lib) {
-    assert(!root.getPath().endsWith("/"));
+    assert (!root.getPath().endsWith("/"));
     this.root = root;
     this.pubspec = pubspec;
     this.packages = packages;
@@ -126,8 +126,14 @@ public class PubRoot {
    * Based on the filesystem cache; doesn't refresh anything.
    */
   @Nullable
-  public static PubRoot forPsiFile(@NotNull PsiFile file) {
-    return forDescendant(file.getVirtualFile(), file.getProject());
+  public static PubRoot forPsiFile(@NotNull PsiFile psiFile) {
+    final VirtualFile file = psiFile.getVirtualFile();
+    if (isPubspec(file)) {
+      return forDirectory(file.getParent());
+    }
+    else {
+      return forDescendant(file, psiFile.getProject());
+    }
   }
 
   /**

--- a/src/io/flutter/pub/PubRoot.java
+++ b/src/io/flutter/pub/PubRoot.java
@@ -128,6 +128,9 @@ public class PubRoot {
   @Nullable
   public static PubRoot forPsiFile(@NotNull PsiFile psiFile) {
     final VirtualFile file = psiFile.getVirtualFile();
+    if (file == null) {
+      return null;
+    }
     if (isPubspec(file)) {
       return forDirectory(file.getParent());
     }


### PR DESCRIPTION
- support nested packages for `flutter packages get / upgrade`
- fix https://github.com/flutter/flutter-intellij/issues/1092

This specifically addresses the use case of the pubspec.yaml file editor banner, and a context click on a pubspec.yaml file in the project navigator.

@pq 

