### PR TITLE
Flutter SDK installation WIP (#764).

### DIFF
--- a/src/io/flutter/actions/InstallSdkAction.java
+++ b/src/io/flutter/actions/InstallSdkAction.java
@@ -99,7 +99,6 @@ public class InstallSdkAction extends DumbAwareAction {
           final GeneralCommandLine cmd = new GeneralCommandLine().withParentEnvironmentType(
             GeneralCommandLine.ParentEnvironmentType.CONSOLE).withWorkDirectory(sdkDir).withExePath("bin/flutter")
             .withParameters("doctor");
-
           runCommand(cmd, new CommandListener("Running Flutter doctor…") {
             @Override
             void onTextAvailable(ProcessEvent event, Key outputType) {

--- a/src/io/flutter/actions/InstallSdkAction.java
+++ b/src/io/flutter/actions/InstallSdkAction.java
@@ -62,6 +62,7 @@ public class InstallSdkAction extends DumbAwareAction {
 
     @Override
     void perform() {
+      //TODO(pq): consider prompting w a sensible default location (~/flutter)?
       @SuppressWarnings("DialogTitleCapitalization") final FileChooserDescriptor descriptor =
         new FileChooserDescriptor(FileChooserDescriptorFactory.createSingleFolderDescriptor()) {
           @Override
@@ -98,8 +99,8 @@ public class InstallSdkAction extends DumbAwareAction {
 
           final GeneralCommandLine cmd = new GeneralCommandLine().withParentEnvironmentType(
             GeneralCommandLine.ParentEnvironmentType.CONSOLE).withWorkDirectory(sdkDir).withExePath("bin/flutter")
-            .withParameters("doctor");
-          runCommand(cmd, new CommandListener("Running Flutter doctor…") {
+            .withParameters("precache");
+          runCommand(cmd, new CommandListener("Running 'flutter precache'…") {
             @Override
             void onTextAvailable(ProcessEvent event, Key outputType) {
               //TODO(pq): filter less useful / truncated messages.
@@ -211,7 +212,7 @@ public class InstallSdkAction extends DumbAwareAction {
 
   @SuppressWarnings("SameReturnValue")
   private static boolean hasGit() {
-    // Flow bypassed by default; return true for testing.
+    //TODO(pq): Flow bypassed by default; return true for testing.
     return false;  //SystemInfo.isMac;
   }
 

--- a/src/io/flutter/actions/InstallSdkAction.java
+++ b/src/io/flutter/actions/InstallSdkAction.java
@@ -6,9 +6,26 @@
 package io.flutter.actions;
 
 
+import com.intellij.execution.ExecutionException;
+import com.intellij.execution.configurations.GeneralCommandLine;
+import com.intellij.execution.process.OSProcessHandler;
+import com.intellij.execution.process.ProcessAdapter;
+import com.intellij.execution.process.ProcessEvent;
 import com.intellij.ide.BrowserUtil;
 import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.fileChooser.FileChooser;
+import com.intellij.openapi.fileChooser.FileChooserDescriptor;
+import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory;
 import com.intellij.openapi.project.DumbAwareAction;
+import com.intellij.openapi.util.Key;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.ui.JBProgressBar;
+import io.flutter.module.FlutterGeneratorPeer;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+import java.io.File;
 
 @SuppressWarnings("ComponentNotRegistered")
 public class InstallSdkAction extends DumbAwareAction {
@@ -17,6 +34,11 @@ public class InstallSdkAction extends DumbAwareAction {
     abstract void perform();
 
     abstract String getLinkText();
+
+    void showError(@NotNull String title, @NotNull String message) {
+      //TODO(pq): implement
+      System.out.println("Error: " + title + ", Message: " + message);
+    }
   }
 
   private static class ViewDocsAction extends InstallAction {
@@ -31,15 +53,167 @@ public class InstallSdkAction extends DumbAwareAction {
     }
   }
 
-  private final InstallAction myInstallAction;
+  private static class GitCloneAction extends InstallAction {
+    private final FlutterGeneratorPeer myPeer;
 
-  public InstallSdkAction() {
-    myInstallAction = createInstallAction();
+    public GitCloneAction(FlutterGeneratorPeer peer) {
+      myPeer = peer;
+    }
+
+    @Override
+    void perform() {
+      @SuppressWarnings("DialogTitleCapitalization") final FileChooserDescriptor descriptor =
+        new FileChooserDescriptor(FileChooserDescriptorFactory.createSingleFolderDescriptor()) {
+          @Override
+          public void validateSelectedFiles(VirtualFile[] files) throws Exception {
+            for (VirtualFile file : files) {
+              if (file.findChild("flutter") != null) {
+                throw new IllegalArgumentException("A file callled 'flutter' already exists in this location.");
+              }
+            }
+          }
+        }.withTitle("Flutter SDK Directory").withDescription("Choose a directory to install the Flutter SDK");
+
+      final VirtualFile installTarget = FileChooser.chooseFile(descriptor, null, null);
+      if (installTarget != null) {
+        installTo(installTarget);
+      }
+    }
+
+    private void installTo(final @NotNull VirtualFile directory)  {
+      final String installPath = directory.getPath();
+
+      final GeneralCommandLine cmd = new GeneralCommandLine().withParentEnvironmentType(
+        GeneralCommandLine.ParentEnvironmentType.CONSOLE).withWorkDirectory(installPath).withExePath("git")
+        .withParameters("clone", "https://github.com/flutter/flutter.git");
+      runCommand(cmd, new CommandListener("Cloning Flutter repository…") {
+        @Override
+        void onError(@NotNull ExecutionException exception) {
+          showError("Error Cloning Flutter Repository", exception.getMessage());
+        }
+
+        @Override
+        protected void onSuccess(@NotNull ProcessEvent event) {
+          final String sdkDir = new File(directory.getPath(), "flutter").getPath();
+
+          final GeneralCommandLine cmd = new GeneralCommandLine().withParentEnvironmentType(
+            GeneralCommandLine.ParentEnvironmentType.CONSOLE).withWorkDirectory(sdkDir).withExePath("bin/flutter")
+            .withParameters("doctor");
+
+          runCommand(cmd, new CommandListener("Running Flutter doctor…") {
+            @Override
+            void onTextAvailable(ProcessEvent event, Key outputType) {
+              //TODO(pq): filter less useful / truncated messages.
+              getProgressText().setText(event.getText());
+            }
+
+            @Override
+            void onSuccess(@NotNull ProcessEvent event) {
+              myPeer.setSdkPath(sdkDir);
+            }
+          });
+        }
+      });
+    }
+
+    private JBProgressBar getProgress() {
+      return myPeer.getProgressBar();
+    }
+
+    private JTextPane getProgressText() {
+      return myPeer.getProgressText();
+    }
+
+    @Override
+    String getLinkText() {
+      return "Install SDK…";
+    }
+
+    private void runCommand(@NotNull GeneralCommandLine cmd, @NotNull CommandListener listener) {
+      final OSProcessHandler handler;
+      try {
+        handler = new OSProcessHandler(cmd);
+      }
+      catch (ExecutionException e) {
+        listener.onError(e);
+        return;
+      }
+      listener.registerTo(handler);
+
+      handler.startNotify();
+    }
+
+    private abstract class CommandListener {
+
+      CommandListener(@Nullable String title) {
+        getProgressText().setText(title);
+      }
+
+      final void registerTo(OSProcessHandler handler) {
+        handler.addProcessListener(new ProcessAdapter() {
+
+          @Override
+          public void startNotified(ProcessEvent event) {
+            setInProgress(true);
+          }
+
+          @Override
+          public void processTerminated(ProcessEvent event) {
+            // Order matters here as onSuccess may produce more progress info.
+            setInProgress(false);
+
+            if (event.getExitCode() == 0) {
+              onSuccess(event);
+            }
+            else {
+              onError(new ExecutionException(event.getText()));
+            }
+          }
+
+          @Override
+          public void onTextAvailable(ProcessEvent event, Key outputType) {
+            CommandListener.this.onTextAvailable(event, outputType);
+          }
+        });
+      }
+
+
+      void onSuccess(@NotNull ProcessEvent event) {
+      }
+
+      void onError(@NotNull ExecutionException event) {
+      }
+
+      void onTextAvailable(ProcessEvent event, Key outputType) {
+      }
+    }
+
+    private void setInProgress(boolean visible) {
+      if (visible) {
+        getProgress().setIndeterminate(true);
+        myPeer.hideErrorDetails();
+        //TODO(pq): Disable Next button.
+      }
+
+      getProgress().setVisible(visible);
+      getProgressText().setVisible(visible);
+    }
   }
 
-  private static InstallAction createInstallAction() {
-    //TODO(pq): update to start a git workflow where possible.
-    return new ViewDocsAction();
+  private final InstallAction myInstallAction;
+
+  public InstallSdkAction(FlutterGeneratorPeer peer) {
+    myInstallAction = createInstallAction(peer);
+  }
+
+  private static InstallAction createInstallAction(FlutterGeneratorPeer peer) {
+    return hasGit() ? new GitCloneAction(peer) : new ViewDocsAction();
+  }
+
+  @SuppressWarnings("SameReturnValue")
+  private static boolean hasGit() {
+    // Flow bypassed by default; return true for testing.
+    return false;  //SystemInfo.isMac;
   }
 
   @Override

--- a/src/io/flutter/module/FlutterGeneratorPeer.form
+++ b/src/io/flutter/module/FlutterGeneratorPeer.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="io.flutter.module.FlutterGeneratorPeer">
-  <grid id="27dc6" binding="myMainPanel" layout-manager="GridLayoutManager" row-count="4" column-count="5" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="myMainPanel" layout-manager="GridLayoutManager" row-count="5" column-count="10" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="565" height="335"/>
@@ -19,7 +19,7 @@
       </component>
       <component id="b09db" class="com.intellij.ui.ComboboxWithBrowseButton" binding="mySdkPathComboWithBrowse" custom-create="true">
         <constraints>
-          <grid row="0" column="1" row-span="1" col-span="4" vsize-policy="0" hsize-policy="7" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="0" column="1" row-span="1" col-span="9" vsize-policy="0" hsize-policy="7" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
       </component>
@@ -33,13 +33,13 @@
       </component>
       <vspacer id="e8033">
         <constraints>
-          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
       <grid id="91fa8" layout-manager="GridLayoutManager" row-count="1" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="0" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="3" column="0" row-span="1" col-span="5" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="4" column="0" row-span="1" col-span="10" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>
@@ -74,17 +74,17 @@
           </scrollpane>
         </children>
       </grid>
-      <grid id="bdced" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="bdced" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="32"/>
         <constraints>
-          <grid row="1" column="2" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="4" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="1" column="2" row-span="1" col-span="7" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>
         <children>
           <component id="5f26c" class="com.intellij.ui.components.labels.LinkLabel" binding="myInstallActionLink">
             <constraints>
-              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <horizontalAlignment value="0"/>
@@ -94,6 +94,29 @@
               <toolTipText value="Install the Flutter SDK"/>
             </properties>
           </component>
+          <component id="916e" class="com.intellij.ui.JBProgressBar" binding="myProgressBar">
+            <constraints>
+              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties/>
+          </component>
+          <scrollpane id="1540a" binding="myProgressScrollPane">
+            <constraints>
+              <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="7" hsize-policy="7" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties/>
+            <border type="empty"/>
+            <children>
+              <component id="e35c4" class="javax.swing.JTextPane" binding="myProgressText">
+                <constraints/>
+                <properties>
+                  <editable value="false"/>
+                  <font style="2"/>
+                  <text value="Install progress placeholder&#10;"/>
+                </properties>
+              </component>
+            </children>
+          </scrollpane>
         </children>
       </grid>
     </children>

--- a/src/io/flutter/module/FlutterGeneratorPeer.java
+++ b/src/io/flutter/module/FlutterGeneratorPeer.java
@@ -14,6 +14,7 @@ import com.intellij.openapi.ui.ValidationInfo;
 import com.intellij.openapi.util.io.FileUtilRt;
 import com.intellij.ui.ComboboxWithBrowseButton;
 import com.intellij.ui.DocumentAdapter;
+import com.intellij.ui.JBProgressBar;
 import com.intellij.ui.components.JBLabel;
 import com.intellij.ui.components.labels.LinkLabel;
 import com.intellij.xml.util.XmlStringUtil;
@@ -36,16 +37,23 @@ public class FlutterGeneratorPeer {
   private JTextPane errorText;
   private JScrollPane errorPane;
   private LinkLabel myInstallActionLink;
+  private JBProgressBar myProgressBar;
+  private JTextPane myProgressText;
+  private JScrollPane myProgressScrollPane;
 
-  private static final InstallSdkAction ourInstallAction = new InstallSdkAction();
+  private final InstallSdkAction myInstallSdkAction;
 
   public FlutterGeneratorPeer() {
+    myInstallSdkAction = new InstallSdkAction(this);
+
     errorIcon.setText("");
     errorIcon.setIcon(AllIcons.Actions.Lightning);
     Messages.installHyperlinkSupport(errorText);
 
     // Hide pending real content.
     myVersionContent.setVisible(false);
+    myProgressBar.setVisible(false);
+    myProgressText.setVisible(false);
 
     init();
     validate();
@@ -59,7 +67,7 @@ public class FlutterGeneratorPeer {
                                                      FileChooserDescriptorFactory.createSingleFolderDescriptor(),
                                                      TextComponentAccessor.STRING_COMBOBOX_WHOLE_TEXT);
 
-    final JTextComponent editorComponent = (JTextComponent)mySdkPathComboWithBrowse.getComboBox().getEditor().getEditorComponent();
+    final JTextComponent editorComponent = (JTextComponent)getSdkEditor().getEditorComponent();
     editorComponent.getDocument().addDocumentListener(new DocumentAdapter() {
       @Override
       protected void textChanged(DocumentEvent e) {
@@ -68,11 +76,9 @@ public class FlutterGeneratorPeer {
     });
 
     myInstallActionLink.setIcon(null);
-    myInstallActionLink.setText(ourInstallAction.getLinkText());
-    myInstallActionLink.setListener((label, linkUrl) -> {
-        ourInstallAction.actionPerformed(null);
-    }, null);
-
+    myInstallActionLink.setText(myInstallSdkAction.getLinkText());
+    //noinspection unchecked
+    myInstallActionLink.setListener((label, linkUrl) -> myInstallSdkAction.actionPerformed(null), null);
   }
 
   @SuppressWarnings("EmptyMethod")
@@ -113,6 +119,28 @@ public class FlutterGeneratorPeer {
 
   @NotNull
   public String getSdkComboPath() {
-    return FileUtilRt.toSystemIndependentName(mySdkPathComboWithBrowse.getComboBox().getEditor().getItem().toString().trim());
+    return FileUtilRt.toSystemIndependentName(getSdkEditor().getItem().toString().trim());
+  }
+
+  @NotNull
+  public ComboBoxEditor getSdkEditor() {
+    return mySdkPathComboWithBrowse.getComboBox().getEditor();
+  }
+
+  public void setSdkPath(@NotNull String sdkPath) {
+    getSdkEditor().setItem(sdkPath);
+  }
+
+  public JBProgressBar getProgressBar() {
+    return myProgressBar;
+  }
+
+  public JTextPane getProgressText() {
+    return myProgressText;
+  }
+
+  public void hideErrorDetails() {
+    errorIcon.setVisible(false);
+    errorPane.setVisible(false);
   }
 }


### PR DESCRIPTION
Still very much a work in progress and disabled by default but gives us an initial steel thread that:

0. prompts for install location
1. clones repo
2. runs flutter doctor (to complete installation) and reports progress
3. sets SDK location

![image](https://user-images.githubusercontent.com/67586/27407722-640b13e6-568e-11e7-8e58-b0710c1bc17a.png)

![image](https://user-images.githubusercontent.com/67586/27407820-cd8d56f8-568e-11e7-8340-5e4c5d0e2e2e.png)


![image](https://user-images.githubusercontent.com/67586/27407674-397311a6-568e-11e7-8753-7d8889e7441d.png)

![image](https://user-images.githubusercontent.com/67586/27407682-400f8a62-568e-11e7-8e45-ba5d0f8ab368.png)


Lots of hardening, UI refinement and error-handling to follow.  Some things notably:

* support for progress cancellation
* `flutter doctor` message cleanup
* `NEXT` button disablement
* proper error reporting
* error handling in general

For more context see: #764

@devoncarew 