### PR TITLE
toggle the default for whole file format

### DIFF
--- a/src/io/flutter/FlutterInitializer.java
+++ b/src/io/flutter/FlutterInitializer.java
@@ -21,6 +21,7 @@ import com.intellij.openapi.startup.StartupActivity;
 import io.flutter.analytics.Analytics;
 import io.flutter.analytics.ToolWindowTracker;
 import io.flutter.android.AndroidSdk;
+import io.flutter.dart.DartfmtSettings;
 import io.flutter.pub.PubRoot;
 import io.flutter.run.FlutterRunNotifications;
 import io.flutter.run.daemon.DeviceService;
@@ -130,6 +131,13 @@ public class FlutterInitializer implements StartupActivity {
     }
 
     FlutterRunNotifications.init(project);
+
+    // Do a one-time set for the default value of the whole file dartfmt setting.
+    if (DartfmtSettings.dartPluginHasSetting()) {
+      if (!DartfmtSettings.hasBeenOneTimeSet()) {
+        DartfmtSettings.setDartfmtValue();
+      }
+    }
 
     // Initialize the analytics notification group.
     NotificationsConfiguration.getNotificationsConfiguration().register(

--- a/src/io/flutter/dart/DartfmtSettings.java
+++ b/src/io/flutter/dart/DartfmtSettings.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.dart;
+
+import com.intellij.ide.util.PropertiesComponent;
+import com.intellij.psi.codeStyle.CodeStyleSettingsManager;
+import com.intellij.psi.codeStyle.CustomCodeStyleSettings;
+
+import java.lang.reflect.Field;
+
+/**
+ * A class to set the default value for "use dartfmt when formatting the whole file" setting once.
+ */
+public class DartfmtSettings {
+  private static final String codeStyleSettingsClass = "com.jetbrains.lang.dart.ide.application.options.DartCodeStyleSettings";
+
+  private static final String oneTimeSetKey = "io.flutter.dartfmt.oneTimeSet";
+
+  public static boolean hasBeenOneTimeSet() {
+    final PropertiesComponent properties = PropertiesComponent.getInstance();
+    return properties.getBoolean(oneTimeSetKey, false);
+  }
+
+  public static void setDartfmtValue() {
+    if (!dartPluginHasSetting()) {
+      return;
+    }
+
+    try {
+      // CodeStyleSettingsManager.getSettings(project).getCustomSettings(DartCodeStyleSettings.class).DELEGATE_TO_DARTFMT
+      final Class settingsClass = Class.forName(codeStyleSettingsClass);
+      //noinspection unchecked
+      final CustomCodeStyleSettings settings = CodeStyleSettingsManager.getInstance().getCurrentSettings().getCustomSettings(settingsClass);
+      final Field delegateDartfmtField = settingsClass.getField("DELEGATE_TO_DARTFMT");
+      delegateDartfmtField.setBoolean(settings, true);
+    }
+    catch (NoSuchFieldException | IllegalAccessException | ClassNotFoundException e) {
+      return;
+    }
+
+    // Set the setting to remember that we toggled this value.
+    final PropertiesComponent properties = PropertiesComponent.getInstance();
+    properties.setValue(oneTimeSetKey, true);
+  }
+
+  public static boolean dartPluginHasSetting() {
+    try {
+      Class.forName(codeStyleSettingsClass);
+      return true;
+    }
+    catch (Throwable t) {
+      return false;
+    }
+  }
+}

--- a/src/io/flutter/sdk/FlutterSdkUtil.java
+++ b/src/io/flutter/sdk/FlutterSdkUtil.java
@@ -28,7 +28,9 @@ import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 import java.io.File;
-import java.util.*;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 public class FlutterSdkUtil {
   /**
@@ -61,7 +63,6 @@ public class FlutterSdkUtil {
 
     // Add the new value first; this ensures that it's the 'default' flutter sdk.
     allPaths.add(newPath);
-
 
     final PropertiesComponent props = PropertiesComponent.getInstance();
 


### PR DESCRIPTION
Toggle the default for whole file format (fix https://github.com/flutter/flutter-intellij/issues/1108):

- if the `DartCodeStyleSettings` class exists
- we use reflection to set the default value of the 'use dartfmt for whole file formats'
- and set a setting so we remember we changed the default, and only do it once (the user can then override)

@pq @skybrian 