### PR TITLE
open flutter settings from the no flutter sdk notification

### DIFF
--- a/src/io/flutter/bazel/WorkspaceCache.java
+++ b/src/io/flutter/bazel/WorkspaceCache.java
@@ -54,7 +54,7 @@ public class WorkspaceCache {
     refreshAsync();
   }
 
-  @Nullable
+  @NotNull
   public static WorkspaceCache getInstance(@NotNull final Project project) {
     return ServiceManager.getService(project, WorkspaceCache.class);
   }

--- a/src/io/flutter/inspections/SdkConfigurationNotificationProvider.java
+++ b/src/io/flutter/inspections/SdkConfigurationNotificationProvider.java
@@ -19,7 +19,9 @@ import com.intellij.ui.EditorNotificationPanel;
 import com.intellij.ui.EditorNotifications;
 import com.jetbrains.lang.dart.DartFileType;
 import com.jetbrains.lang.dart.DartLanguage;
+import icons.FlutterIcons;
 import io.flutter.FlutterBundle;
+import io.flutter.FlutterUtils;
 import io.flutter.bazel.Workspace;
 import io.flutter.bazel.WorkspaceCache;
 import io.flutter.sdk.FlutterSdk;
@@ -40,14 +42,12 @@ public class SdkConfigurationNotificationProvider extends EditorNotifications.Pr
   }
 
   @SuppressWarnings("SameReturnValue")
-  private static EditorNotificationPanel createNoFlutterSdkPanel() {
+  private static EditorNotificationPanel createNoFlutterSdkPanel(Project project) {
     final EditorNotificationPanel panel = new EditorNotificationPanel();
+    panel.icon(FlutterIcons.Flutter);
     panel.setText(FlutterBundle.message("flutter.no.sdk.warning"));
     panel.createActionLabel("Dismiss", () -> panel.setVisible(false));
-
-    // TODO(skybrian) we should add a link to go to the Dart SDK panel.
-    // However, not yet because this will change with 2017.1 to be project-specific.
-
+    panel.createActionLabel("Open Flutter settings", () -> FlutterUtils.openFlutterSettings(project));
     return panel;
   }
 
@@ -76,7 +76,7 @@ public class SdkConfigurationNotificationProvider extends EditorNotifications.Pr
 
     final FlutterSdk flutterSdk = FlutterSdk.getFlutterSdk(project);
     if (flutterSdk == null) {
-      return createNoFlutterSdkPanel();
+      return createNoFlutterSdkPanel(module.getProject());
     }
     else if (!flutterSdk.getVersion().isSupported()) {
       return createOutOfDateFlutterSdkPanel(flutterSdk);
@@ -86,11 +86,11 @@ public class SdkConfigurationNotificationProvider extends EditorNotifications.Pr
   }
 
   private EditorNotificationPanel createOutOfDateFlutterSdkPanel(@NotNull FlutterSdk sdk) {
-
     final FlutterUIConfig settings = FlutterUIConfig.getInstance();
     if (settings.shouldIgnoreOutOfDateFlutterSdks()) return null;
 
     final EditorNotificationPanel panel = new EditorNotificationPanel();
+    panel.icon(FlutterIcons.Flutter);
     panel.setText(FlutterBundle.message("flutter.old.sdk.warning"));
     panel.createActionLabel("Dismiss", () -> {
       settings.setIgnoreOutOfDateFlutterSdks();

--- a/src/io/flutter/inspections/SdkConfigurationNotificationProvider.java
+++ b/src/io/flutter/inspections/SdkConfigurationNotificationProvider.java
@@ -76,7 +76,7 @@ public class SdkConfigurationNotificationProvider extends EditorNotifications.Pr
 
     final FlutterSdk flutterSdk = FlutterSdk.getFlutterSdk(project);
     if (flutterSdk == null) {
-      return createNoFlutterSdkPanel(module.getProject());
+      return createNoFlutterSdkPanel(project);
     }
     else if (!flutterSdk.getVersion().isSupported()) {
       return createOutOfDateFlutterSdkPanel(flutterSdk);

--- a/src/io/flutter/module/FlutterSmallIDEProjectGenerator.java
+++ b/src/io/flutter/module/FlutterSmallIDEProjectGenerator.java
@@ -56,7 +56,7 @@ public class FlutterSmallIDEProjectGenerator extends WebProjectTemplate<String> 
     }
 
     // Run "flutter create".
-    OutputListener listener = new OutputListener();
+    final OutputListener listener = new OutputListener();
     final PubRoot root = sdk.createFiles(baseDir, module, listener);
     if (root == null) {
       final String stderr = listener.getOutput().getStderr();

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.form
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.form
@@ -104,7 +104,7 @@
               <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
-              <text value="Enable verbose logging"/>
+              <text value="Enable &amp;verbose logging"/>
               <toolTipText value="Enables verbose logging (this can be useful for diagnostic purposes)."/>
             </properties>
           </component>


### PR DESCRIPTION
- in the 'no flutter sdk' editor notification, add a hyperlink to open the flutter settings (this parallels what the dart plugin does)
- add flutter icons to our editor notifications
- fix two analysis issues

@pq @skybrian @jwren 
<img width="742" alt="screen shot 2017-06-26 at 10 56 59 am" src="https://user-images.githubusercontent.com/1269969/27553251-1b3e99ce-5a5f-11e7-9793-628604b47f17.png">

