### PR TITLE
add the ability to start android emulators from the device pulldown

### DIFF
--- a/src/io/flutter/actions/DeviceSelectorAction.java
+++ b/src/io/flutter/actions/DeviceSelectorAction.java
@@ -124,6 +124,13 @@ public class DeviceSelectorAction extends ComboBoxAction implements DumbAware {
       actions.add(new OpenSimulatorAction(!simulatorOpen));
     }
 
+    // Add Open Android emulators actions.
+    final List<OpenEmulatorAction> emulatorActions = OpenEmulatorAction.getEmulatorActions(project);
+    if (!emulatorActions.isEmpty()) {
+      actions.add(new Separator());
+      actions.addAll(emulatorActions);
+    }
+
     final FlutterDevice selectedDevice = service.getSelectedDevice();
     for (AnAction action : actions) {
       if (action instanceof SelectDeviceAction) {
@@ -141,7 +148,8 @@ public class DeviceSelectorAction extends ComboBoxAction implements DumbAware {
 
     if (devices.isEmpty()) {
       presentation.setText("<no devices>");
-    } else {
+    }
+    else {
       presentation.setText(null);
     }
   }

--- a/src/io/flutter/actions/OpenEmulatorAction.java
+++ b/src/io/flutter/actions/OpenEmulatorAction.java
@@ -12,34 +12,49 @@ import com.intellij.execution.process.ProcessAdapter;
 import com.intellij.execution.process.ProcessEvent;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.project.Project;
 import io.flutter.FlutterBundle;
 import io.flutter.FlutterMessages;
+import io.flutter.android.AndroidEmulator;
+import io.flutter.android.AndroidSdk;
+
+import java.util.Collections;
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
 
 @SuppressWarnings("ComponentNotRegistered")
-public class OpenSimulatorAction extends AnAction {
-  final boolean enabled;
+public class OpenEmulatorAction extends AnAction {
+  public static List<OpenEmulatorAction> getEmulatorActions(Project project) {
+    final AndroidSdk sdk = AndroidSdk.fromProject(project);
+    if (sdk == null) {
+      return Collections.emptyList();
+    }
 
-  public OpenSimulatorAction(boolean enabled) {
-    super("iOS: Open Simulator");
-
-    this.enabled = enabled;
+    final List<AndroidEmulator> emulators = sdk.getEmulators();
+    return emulators.stream().map(OpenEmulatorAction::new).collect(toList());
   }
 
-  @Override
-  public void update(AnActionEvent e) {
-    e.getPresentation().setEnabled(enabled);
+  final AndroidEmulator emulator;
+
+  public OpenEmulatorAction(AndroidEmulator emulator) {
+    super("Android: Open Emulator " + emulator.getName());
+
+    this.emulator = emulator;
   }
 
   @Override
   public void actionPerformed(AnActionEvent event) {
     try {
+      // TODO: start the emulator, check for errors
+
       final GeneralCommandLine cmd = new GeneralCommandLine().withExePath("open").withParameters("-a", "Simulator.app");
       final OSProcessHandler handler = new OSProcessHandler(cmd);
       handler.addProcessListener(new ProcessAdapter() {
         @Override
         public void processTerminated(final ProcessEvent event) {
           if (event.getExitCode() != 0) {
-            FlutterMessages.showError("Error Opening Simulator", event.getText());
+            FlutterMessages.showError("Error Opening Emulator", event.getText());
           }
         }
       });

--- a/src/io/flutter/actions/OpenEmulatorAction.java
+++ b/src/io/flutter/actions/OpenEmulatorAction.java
@@ -5,16 +5,9 @@
  */
 package io.flutter.actions;
 
-import com.intellij.execution.ExecutionException;
-import com.intellij.execution.configurations.GeneralCommandLine;
-import com.intellij.execution.process.OSProcessHandler;
-import com.intellij.execution.process.ProcessAdapter;
-import com.intellij.execution.process.ProcessEvent;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.project.Project;
-import io.flutter.FlutterBundle;
-import io.flutter.FlutterMessages;
 import io.flutter.android.AndroidEmulator;
 import io.flutter.android.AndroidSdk;
 
@@ -26,7 +19,7 @@ import static java.util.stream.Collectors.toList;
 @SuppressWarnings("ComponentNotRegistered")
 public class OpenEmulatorAction extends AnAction {
   public static List<OpenEmulatorAction> getEmulatorActions(Project project) {
-    final AndroidSdk sdk = AndroidSdk.fromProject(project);
+    final AndroidSdk sdk = AndroidSdk.chooseBestSdk(project);
     if (sdk == null) {
       return Collections.emptyList();
     }
@@ -38,32 +31,13 @@ public class OpenEmulatorAction extends AnAction {
   final AndroidEmulator emulator;
 
   public OpenEmulatorAction(AndroidEmulator emulator) {
-    super("Android: Open Emulator " + emulator.getName());
+    super("Open Android Emulator: " + emulator.getName());
 
     this.emulator = emulator;
   }
 
   @Override
   public void actionPerformed(AnActionEvent event) {
-    try {
-      // TODO: start the emulator, check for errors
-
-      final GeneralCommandLine cmd = new GeneralCommandLine().withExePath("open").withParameters("-a", "Simulator.app");
-      final OSProcessHandler handler = new OSProcessHandler(cmd);
-      handler.addProcessListener(new ProcessAdapter() {
-        @Override
-        public void processTerminated(final ProcessEvent event) {
-          if (event.getExitCode() != 0) {
-            FlutterMessages.showError("Error Opening Emulator", event.getText());
-          }
-        }
-      });
-      handler.startNotify();
-    }
-    catch (ExecutionException e) {
-      FlutterMessages.showError(
-        "Error Opening Simulator",
-        FlutterBundle.message("flutter.command.exception.message", e.getMessage()));
-    }
+    emulator.startEmulator();
   }
 }

--- a/src/io/flutter/actions/OpenSimulatorAction.java
+++ b/src/io/flutter/actions/OpenSimulatorAction.java
@@ -20,7 +20,7 @@ public class OpenSimulatorAction extends AnAction {
   final boolean enabled;
 
   public OpenSimulatorAction(boolean enabled) {
-    super("iOS: Open Simulator");
+    super("Open iOS Simulator");
 
     this.enabled = enabled;
   }

--- a/src/io/flutter/android/AndroidEmulator.java
+++ b/src/io/flutter/android/AndroidEmulator.java
@@ -5,19 +5,75 @@
  */
 package io.flutter.android;
 
+import com.intellij.execution.ExecutionException;
+import com.intellij.execution.configurations.GeneralCommandLine;
+import com.intellij.execution.process.OSProcessHandler;
+import com.intellij.execution.process.ProcessAdapter;
+import com.intellij.execution.process.ProcessEvent;
+import com.intellij.execution.process.ProcessOutputTypes;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.util.Key;
+import com.intellij.openapi.vfs.VirtualFile;
+import io.flutter.FlutterMessages;
+
 public class AndroidEmulator {
+  private static final Logger LOG = Logger.getInstance(AndroidEmulator.class);
+
   final AndroidSdk androidSdk;
   final String id;
-  final String name;
 
   AndroidEmulator(AndroidSdk androidSdk, String id) {
     this.androidSdk = androidSdk;
     this.id = id;
-    // TODO: How to best clean up the name?
-    this.name = id.replaceAll("_", "-");
   }
 
   public String getName() {
-    return name;
+    return id.replaceAll("_", " ");
+  }
+
+  public void startEmulator() {
+    final VirtualFile emulator = androidSdk.getEmulatorToolExecutable();
+    if (emulator == null) {
+      FlutterMessages.showError(
+        "Error Opening Emulator",
+        "Unable to locate the emulator tool in the Android SDK.");
+      return;
+    }
+
+    final String emulatorPath = emulator.getCanonicalPath();
+    assert (emulatorPath != null);
+
+    final GeneralCommandLine cmd = new GeneralCommandLine()
+      .withParentEnvironmentType(GeneralCommandLine.ParentEnvironmentType.CONSOLE)
+      .withWorkDirectory(androidSdk.getHome().getCanonicalPath())
+      .withExePath(emulatorPath)
+      .withParameters("-avd", this.id);
+
+    try {
+      final StringBuilder stdout = new StringBuilder();
+      final OSProcessHandler process = new OSProcessHandler(cmd);
+      process.addProcessListener(new ProcessAdapter() {
+        @Override
+        public void onTextAvailable(ProcessEvent event, Key outputType) {
+          if (outputType == ProcessOutputTypes.STDERR || outputType == ProcessOutputTypes.STDOUT) {
+            stdout.append(event.getText());
+          }
+        }
+
+        public void processTerminated(ProcessEvent event) {
+          final int exitCode = event.getExitCode();
+          if (exitCode != 0) {
+            final String message = stdout.length() == 0
+                                   ? "Android emulator terminated with exit code " + exitCode
+                                   : stdout.toString().trim();
+            FlutterMessages.showError("Error Opening Emulator", message);
+          }
+        }
+      });
+      process.startNotify();
+    }
+    catch (ExecutionException | RuntimeException e) {
+      FlutterMessages.showError("Error Opening Emulator", e.toString());
+    }
   }
 }

--- a/src/io/flutter/android/AndroidEmulator.java
+++ b/src/io/flutter/android/AndroidEmulator.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2017 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.android;
+
+public class AndroidEmulator {
+  final AndroidSdk androidSdk;
+  final String id;
+  final String name;
+
+  AndroidEmulator(AndroidSdk androidSdk, String id) {
+    this.androidSdk = androidSdk;
+    this.id = id;
+    // TODO: How to best clean up the name?
+    this.name = id.replaceAll("_", "-");
+  }
+
+  public String getName() {
+    return name;
+  }
+}

--- a/src/io/flutter/android/AndroidSdk.java
+++ b/src/io/flutter/android/AndroidSdk.java
@@ -28,6 +28,7 @@ public class AndroidSdk {
 
   @NotNull
   private final VirtualFile home;
+  private List<AndroidEmulator> myEmulators;
 
   private AndroidSdk(@NotNull Sdk sdk, @NotNull VirtualFile home) {
     this.sdk = sdk;
@@ -135,5 +136,16 @@ public class AndroidSdk {
     }
 
     return new AndroidSdk(candidate, home);
+  }
+
+  public List<AndroidEmulator> getEmulators() {
+    // TODO: execute $ANDROID_HOME/tools/emulator -list-avds, parse the results
+    // Nexus_5X_API_23_x86_64
+    // Nexus_5X_API_N
+    // Nexus_S_API_N
+
+    // TODO: and the windows path name...
+
+    return myEmulators;
   }
 }


### PR DESCRIPTION
- use the `AndroidSdk` class to find the best android sdk for a paritcular project
- look for the `tools/emulator` binary inside the sdk
- list and display any existing emulator avds in the device pulldown menu
- on selection, launch the indicated avd; display errors as appropriate on launching
- fix https://github.com/flutter/flutter-intellij/issues/536

@skybrian @pq 

<img width="346" alt="screen shot 2017-06-26 at 4 28 16 pm" src="https://user-images.githubusercontent.com/1269969/27564557-6062fbca-5a8d-11e7-84f6-de3ac80569c3.png">

