### PR TITLE
Scope Flutter test run config contrib (#1128).

### DIFF
--- a/src/io/flutter/run/test/TestConfigProducer.java
+++ b/src/io/flutter/run/test/TestConfigProducer.java
@@ -48,7 +48,7 @@ public class TestConfigProducer extends RunConfigurationProducer<TestConfig> {
     final PubRoot root = PubRoot.forPsiFile(file);
     if (root == null) return false;
 
-    if (!FlutterModuleUtils.hasFlutterModule(file.getProject())) return false;
+    if (!FlutterModuleUtils.isFlutterModule(context.getModule())) return false;
 
     final VirtualFile candidate = FlutterRunConfigurationProducer.getFlutterEntryFile(context, false);
     if (candidate == null) return false;
@@ -65,6 +65,8 @@ public class TestConfigProducer extends RunConfigurationProducer<TestConfig> {
   private boolean setupForDirectory(TestConfig config, PsiDirectory dir) {
     final PubRoot root = PubRoot.forDescendant(dir.getVirtualFile(), dir.getProject());
     if (root == null) return false;
+    
+    if (!FlutterModuleUtils.hasFlutterModule(dir.getProject())) return false;
 
     if (!root.hasTests(dir.getVirtualFile())) return false;
 

--- a/src/io/flutter/run/test/TestConfigProducer.java
+++ b/src/io/flutter/run/test/TestConfigProducer.java
@@ -16,6 +16,7 @@ import com.jetbrains.lang.dart.psi.DartFile;
 import io.flutter.dart.DartPlugin;
 import io.flutter.pub.PubRoot;
 import io.flutter.run.FlutterRunConfigurationProducer;
+import io.flutter.utils.FlutterModuleUtils;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -46,6 +47,8 @@ public class TestConfigProducer extends RunConfigurationProducer<TestConfig> {
   private boolean setupForDartFile(TestConfig config, ConfigurationContext context, DartFile file) {
     final PubRoot root = PubRoot.forPsiFile(file);
     if (root == null) return false;
+
+    if (!FlutterModuleUtils.hasFlutterModule(file.getProject())) return false;
 
     final VirtualFile candidate = FlutterRunConfigurationProducer.getFlutterEntryFile(context, false);
     if (candidate == null) return false;


### PR DESCRIPTION
Quick stab at scoping test config over-contribution.

I'm not sure `FlutterModuleUtils.hasFlutterModule` is the long-term fix but maybe OK short-term?

Fixes: #1128.

@skybrian @devoncarew 
