### PR TITLE
fix launching android emulators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ out/
 artifacts/
 build/
 flutter-intellij.jar
+flutter-intellij.zip
 packages
 .DS_Store
 .packages

--- a/src/io/flutter/FlutterInitializer.java
+++ b/src/io/flutter/FlutterInitializer.java
@@ -20,7 +20,7 @@ import com.intellij.openapi.roots.ProjectRootManager;
 import com.intellij.openapi.startup.StartupActivity;
 import io.flutter.analytics.Analytics;
 import io.flutter.analytics.ToolWindowTracker;
-import io.flutter.android.AndroidSdk;
+import io.flutter.android.IntelliJAndroidSdk;
 import io.flutter.dart.DartfmtSettings;
 import io.flutter.pub.PubRoot;
 import io.flutter.run.FlutterRunNotifications;
@@ -198,7 +198,7 @@ public class FlutterInitializer implements StartupActivity {
       return; // Don't override user's settings.
     }
 
-    final AndroidSdk wanted = AndroidSdk.fromEnvironment();
+    final IntelliJAndroidSdk wanted = IntelliJAndroidSdk.fromEnvironment();
     if (wanted == null) {
       return; // ANDROID_HOME not set or Android SDK not created in IDEA; not clear what to do.
     }

--- a/src/io/flutter/actions/OpenEmulatorAction.java
+++ b/src/io/flutter/actions/OpenEmulatorAction.java
@@ -19,7 +19,7 @@ import static java.util.stream.Collectors.toList;
 @SuppressWarnings("ComponentNotRegistered")
 public class OpenEmulatorAction extends AnAction {
   public static List<OpenEmulatorAction> getEmulatorActions(Project project) {
-    final AndroidSdk sdk = AndroidSdk.chooseBestSdk(project);
+    final AndroidSdk sdk = AndroidSdk.createFromProject(project);
     if (sdk == null) {
       return Collections.emptyList();
     }

--- a/src/io/flutter/android/AndroidSdk.java
+++ b/src/io/flutter/android/AndroidSdk.java
@@ -24,6 +24,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+/**
+ * A wrapper around an Android sdk on disk.
+ */
 public class AndroidSdk {
   private static final Logger LOG = Logger.getInstance(AndroidSdk.class);
 

--- a/src/io/flutter/android/AndroidSdk.java
+++ b/src/io/flutter/android/AndroidSdk.java
@@ -25,7 +25,7 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * A wrapper around an Android sdk on disk.
+ * A wrapper around an Android SDK on disk.
  */
 public class AndroidSdk {
   private static final Logger LOG = Logger.getInstance(AndroidSdk.class);

--- a/src/io/flutter/android/AndroidSdk.java
+++ b/src/io/flutter/android/AndroidSdk.java
@@ -11,17 +11,12 @@ import com.intellij.execution.process.OSProcessHandler;
 import com.intellij.execution.process.ProcessAdapter;
 import com.intellij.execution.process.ProcessEvent;
 import com.intellij.execution.process.ProcessOutputTypes;
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.projectRoots.ProjectJdkTable;
-import com.intellij.openapi.projectRoots.Sdk;
-import com.intellij.openapi.roots.ProjectRootManager;
 import com.intellij.openapi.util.Key;
 import com.intellij.openapi.util.SystemInfo;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
-import com.intellij.util.EnvironmentUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -29,20 +24,26 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-/**
- * An Android SDK and its home directory.
- */
 public class AndroidSdk {
   private static final Logger LOG = Logger.getInstance(AndroidSdk.class);
 
-  @NotNull
-  private final Sdk sdk;
+  @Nullable
+  public static AndroidSdk createFromProject(@NotNull Project project) {
+    final String sdkPath = IntelliJAndroidSdk.chooseAndroidHome(project);
+    if (sdkPath == null) {
+      return null;
+    }
+    final VirtualFile file = LocalFileSystem.getInstance().findFileByPath(sdkPath);
+    if (file == null) {
+      return null;
+    }
+    return new AndroidSdk(file);
+  }
 
   @NotNull
   private final VirtualFile home;
 
-  private AndroidSdk(@NotNull Sdk sdk, @NotNull VirtualFile home) {
-    this.sdk = sdk;
+  AndroidSdk(@NotNull VirtualFile home) {
     this.home = home;
   }
 
@@ -52,111 +53,6 @@ public class AndroidSdk {
   @NotNull
   public VirtualFile getHome() {
     return home;
-  }
-
-  /**
-   * Changes the project's Java SDK to this one.
-   */
-  public void setCurrent(@NotNull Project project) {
-    assert ApplicationManager.getApplication().isWriteAccessAllowed();
-
-    final ProjectRootManager roots = ProjectRootManager.getInstance(project);
-    roots.setProjectSdk(sdk);
-  }
-
-  /**
-   * Returns the Java SDK in the project's configuration, or null if not an Android SDK.
-   */
-  @Nullable
-  public static AndroidSdk fromProject(@NotNull Project project) {
-    final Sdk candidate = ProjectRootManager.getInstance(project).getProjectSdk();
-    return fromSdk(candidate);
-  }
-
-  /**
-   * Returns the Android SDK that matches the ANDROID_HOME environment variable, provided it exists.
-   */
-  @Nullable
-  public static AndroidSdk fromEnvironment() {
-    final String path = EnvironmentUtil.getValue("ANDROID_HOME");
-    if (path == null) {
-      return null;
-    }
-
-    // TODO(skybrian) refresh?
-    final VirtualFile file = LocalFileSystem.getInstance().findFileByPath(path);
-    if (file == null) {
-      return null;
-    }
-
-    return fromHome(file);
-  }
-
-  /**
-   * Choose the best possible Android SDK value. Check if one is set for the current project; use that
-   * if possible, else fall back to checking the 'ANDROID_HOME' environment variable.
-   */
-  @Nullable
-  public static AndroidSdk chooseBestSdk(@NotNull Project project) {
-    final AndroidSdk sdk = fromProject(project);
-    return sdk == null ? fromEnvironment() : sdk;
-  }
-
-  /**
-   * Returns the Android SDK for the given home directory, or null if no SDK matches.
-   */
-  @Nullable
-  public static AndroidSdk fromHome(VirtualFile file) {
-    for (AndroidSdk candidate : findAll()) {
-      if (file.equals(candidate.getHome())) {
-        return candidate;
-      }
-    }
-
-    return null; // not found
-  }
-
-  /**
-   * Returns the best value of ANDROID_HOME to use.
-   * <p>
-   * If the given project has an Android SDK set, prefer that. Otherwise get it from the environment.
-   */
-  public static String chooseAndroidHome(@Nullable Project project) {
-    final AndroidSdk sdk = project == null ? null : fromProject(project);
-    return sdk == null ? EnvironmentUtil.getValue("ANDROID_HOME") : sdk.getHome().getPath();
-  }
-
-  /**
-   * Returns each SDK that's an Android SDK.
-   */
-  @NotNull
-  private static List<AndroidSdk> findAll() {
-    final List<AndroidSdk> result = new ArrayList<>();
-    for (Sdk sdk : ProjectJdkTable.getInstance().getAllJdks()) {
-      final AndroidSdk candidate = AndroidSdk.fromSdk(sdk);
-      if (candidate != null) {
-        result.add(candidate);
-      }
-    }
-    return result;
-  }
-
-  @Nullable
-  private static AndroidSdk fromSdk(@Nullable Sdk candidate) {
-    if (candidate == null) {
-      return null;
-    }
-
-    if (!"Android SDK".equals(candidate.getSdkType().getName())) {
-      return null;
-    }
-
-    final VirtualFile home = candidate.getHomeDirectory();
-    if (home == null) {
-      return null; // Skip; misconfigured SDK?
-    }
-
-    return new AndroidSdk(candidate, home);
   }
 
   @Nullable

--- a/src/io/flutter/android/IntelliJAndroidSdk.java
+++ b/src/io/flutter/android/IntelliJAndroidSdk.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2017 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.android;
+
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.projectRoots.ProjectJdkTable;
+import com.intellij.openapi.projectRoots.Sdk;
+import com.intellij.openapi.roots.ProjectRootManager;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.util.EnvironmentUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * An Android SDK and its home directory.
+ */
+public class IntelliJAndroidSdk {
+  private static final Logger LOG = Logger.getInstance(IntelliJAndroidSdk.class);
+
+  @NotNull
+  private final Sdk sdk;
+
+  @NotNull
+  private final VirtualFile home;
+
+  private IntelliJAndroidSdk(@NotNull Sdk sdk, @NotNull VirtualFile home) {
+    this.sdk = sdk;
+    this.home = home;
+  }
+
+  /**
+   * Returns android home directory for this SDK.
+   */
+  @NotNull
+  public VirtualFile getHome() {
+    return home;
+  }
+
+  /**
+   * Changes the project's Java SDK to this one.
+   */
+  public void setCurrent(@NotNull Project project) {
+    assert ApplicationManager.getApplication().isWriteAccessAllowed();
+
+    final ProjectRootManager roots = ProjectRootManager.getInstance(project);
+    roots.setProjectSdk(sdk);
+  }
+
+  /**
+   * Returns the Java SDK in the project's configuration, or null if not an Android SDK.
+   */
+  @Nullable
+  public static IntelliJAndroidSdk fromProject(@NotNull Project project) {
+    final Sdk candidate = ProjectRootManager.getInstance(project).getProjectSdk();
+    return fromSdk(candidate);
+  }
+
+  /**
+   * Returns the Android SDK that matches the ANDROID_HOME environment variable, provided it exists.
+   */
+  @Nullable
+  public static IntelliJAndroidSdk fromEnvironment() {
+    final String path = EnvironmentUtil.getValue("ANDROID_HOME");
+    if (path == null) {
+      return null;
+    }
+
+    // TODO(skybrian) refresh?
+    final VirtualFile file = LocalFileSystem.getInstance().findFileByPath(path);
+    if (file == null) {
+      return null;
+    }
+
+    return fromHome(file);
+  }
+
+  /**
+   * Returns the Android SDK for the given home directory, or null if no SDK matches.
+   */
+  @Nullable
+  public static IntelliJAndroidSdk fromHome(VirtualFile file) {
+    for (IntelliJAndroidSdk candidate : findAll()) {
+      if (file.equals(candidate.getHome())) {
+        return candidate;
+      }
+    }
+
+    return null; // not found
+  }
+
+  /**
+   * Returns the best value of ANDROID_HOME to use.
+   * <p>
+   * If the given project has an Android SDK set, prefer that. Otherwise get it from the environment.
+   */
+  public static String chooseAndroidHome(@Nullable Project project) {
+    final IntelliJAndroidSdk sdk = project == null ? null : fromProject(project);
+    return sdk == null ? EnvironmentUtil.getValue("ANDROID_HOME") : sdk.getHome().getPath();
+  }
+
+  /**
+   * Returns each SDK that's an Android SDK.
+   */
+  @NotNull
+  private static List<IntelliJAndroidSdk> findAll() {
+    final List<IntelliJAndroidSdk> result = new ArrayList<>();
+    for (Sdk sdk : ProjectJdkTable.getInstance().getAllJdks()) {
+      final IntelliJAndroidSdk candidate = IntelliJAndroidSdk.fromSdk(sdk);
+      if (candidate != null) {
+        result.add(candidate);
+      }
+    }
+    return result;
+  }
+
+  @Nullable
+  private static IntelliJAndroidSdk fromSdk(@Nullable Sdk candidate) {
+    if (candidate == null) {
+      return null;
+    }
+
+    if (!"Android SDK".equals(candidate.getSdkType().getName())) {
+      return null;
+    }
+
+    final VirtualFile home = candidate.getHomeDirectory();
+    if (home == null) {
+      return null; // Skip; misconfigured SDK?
+    }
+
+    return new IntelliJAndroidSdk(candidate, home);
+  }
+}

--- a/src/io/flutter/android/IntelliJAndroidSdk.java
+++ b/src/io/flutter/android/IntelliJAndroidSdk.java
@@ -21,7 +21,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * An Android SDK and its home directory.
+ * An Android SDK and its home directory; this references an IntelliJ @{@link Sdk} instance.
  */
 public class IntelliJAndroidSdk {
   private static final Logger LOG = Logger.getInstance(IntelliJAndroidSdk.class);

--- a/src/io/flutter/run/daemon/DeviceDaemon.java
+++ b/src/io/flutter/run/daemon/DeviceDaemon.java
@@ -17,7 +17,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.vfs.CharsetToolkit;
 import io.flutter.FlutterMessages;
-import io.flutter.android.AndroidSdk;
+import io.flutter.android.IntelliJAndroidSdk;
 import io.flutter.bazel.Workspace;
 import io.flutter.bazel.WorkspaceCache;
 import io.flutter.sdk.FlutterSdk;
@@ -120,7 +120,7 @@ class DeviceDaemon {
       return null;
     }
 
-    final String androidHome = AndroidSdk.chooseAndroidHome(project);
+    final String androidHome = IntelliJAndroidSdk.chooseAndroidHome(project);
 
     // See if the Bazel workspace provides a script.
     final Workspace w = WorkspaceCache.getInstance(project).getNow();

--- a/src/io/flutter/sdk/FlutterCommand.java
+++ b/src/io/flutter/sdk/FlutterCommand.java
@@ -18,7 +18,7 @@ import com.intellij.openapi.vfs.VirtualFile;
 import io.flutter.FlutterBundle;
 import io.flutter.FlutterInitializer;
 import io.flutter.FlutterMessages;
-import io.flutter.android.AndroidSdk;
+import io.flutter.android.IntelliJAndroidSdk;
 import io.flutter.console.FlutterConsoles;
 import io.flutter.dart.DartPlugin;
 import org.jetbrains.annotations.NotNull;
@@ -209,7 +209,7 @@ public class FlutterCommand {
 
     line.withEnvironment(FlutterSdkUtil.FLUTTER_HOST_ENV, FlutterSdkUtil.getFlutterHostEnvValue());
 
-    final String androidHome = AndroidSdk.chooseAndroidHome(project);
+    final String androidHome = IntelliJAndroidSdk.chooseAndroidHome(project);
     if (androidHome != null) {
       line.withEnvironment("ANDROID_HOME", androidHome);
     }


### PR DESCRIPTION
- fix an issue launching android emulators

We would only locate an android sdk if we could both locate the sdk, _and_ an `Sdk` for it had been configured in IntelliJ. We now separate out the concepts of a wrapper around an `AndroidSdk` on disk and the `IntelliJAndroidSdk` wrapper, that references IntelliJ's Sdk instance.

@pq 
