### PR TITLE
Keep `Install SDK…` action visible (#1145).

### DIFF
--- a/src/io/flutter/module/FlutterGeneratorPeer.java
+++ b/src/io/flutter/module/FlutterGeneratorPeer.java
@@ -13,6 +13,7 @@ import com.intellij.openapi.ui.ComboBox;
 import com.intellij.openapi.ui.Messages;
 import com.intellij.openapi.ui.TextComponentAccessor;
 import com.intellij.openapi.ui.ValidationInfo;
+import com.intellij.openapi.util.IconLoader;
 import com.intellij.openapi.util.io.FileUtilRt;
 import com.intellij.ui.ComboboxWithBrowseButton;
 import com.intellij.ui.DocumentAdapter;
@@ -88,6 +89,8 @@ public class FlutterGeneratorPeer {
     });
 
     myInstallActionLink.setIcon(myInstallSdkAction.getLinkIcon());
+    myInstallActionLink.setDisabledIcon(IconLoader.getDisabledIcon(myInstallSdkAction.getLinkIcon()));
+
     myInstallActionLink.setText(myInstallSdkAction.getLinkText());
 
     //noinspection unchecked
@@ -125,7 +128,8 @@ public class FlutterGeneratorPeer {
     }
     errorIcon.setVisible(info != null);
     errorPane.setVisible(info != null);
-    myInstallActionLink.setVisible(info != null || getSdkComboPath().trim().isEmpty());
+
+    myInstallActionLink.setEnabled(info != null || getSdkComboPath().trim().isEmpty());
 
     return info == null;
   }


### PR DESCRIPTION
For reference,

disabled:

![image](https://user-images.githubusercontent.com/67586/27874492-92a20c10-6164-11e7-9dd5-e2f362b45895.png)

vs. enabled:

![image](https://user-images.githubusercontent.com/67586/27874503-9decaa9e-6164-11e7-84d1-11c96931b69f.png)

Note that the action is still clickable in either case, which is deliberate.  (Happy to discuss the rationale.)

Fixes: #1145

@devoncarew 