### PR TITLE
Don’t filter tests by name if it’s not supported.

### DIFF
--- a/src/io/flutter/run/test/TestConfig.java
+++ b/src/io/flutter/run/test/TestConfig.java
@@ -13,6 +13,7 @@ import com.intellij.openapi.options.SettingsEditor;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.InvalidDataException;
 import com.intellij.openapi.util.WriteExternalException;
+import io.flutter.sdk.FlutterSdk;
 import org.jdom.Element;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -72,6 +73,11 @@ public class TestConfig extends LocatableConfigurationBase {
   @Override
   public void checkConfiguration() throws RuntimeConfigurationException {
     fields.checkRunnable(getProject());
+  }
+
+  @Nullable
+  public FlutterSdk getSdk() {
+    return FlutterSdk.getFlutterSdk(getProject());
   }
 
   @NotNull


### PR DESCRIPTION
Currently, we default to creating a test config based on filtering by name which is not yet supported in alpha and so we get this error:

![image](https://user-images.githubusercontent.com/67586/27885398-c6a68cde-618c-11e7-963e-a3fbca8e3210.png)

This changes the default in that case to a file-based config which runs happily.

@devoncarew 
