### PR TITLE
Flutter test run line markers (#1174).

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -355,6 +355,7 @@
     <configurationType implementation="io.flutter.run.test.TestConfigType"/>
     <runConfigurationProducer implementation="io.flutter.run.test.TestConfigProducer"/>
     <programRunner implementation="io.flutter.run.test.DebugTestRunner"/>
+    <runLineMarkerContributor language="Dart" implementationClass="io.flutter.run.test.FlutterTestLineMarkerContributor"/>
 
     <defaultLiveTemplatesProvider implementation="io.flutter.template.FlutterLiveTemplatesProvider"/>
     <liveTemplateContext implementation="io.flutter.template.DartToplevelTemplateContextType"/>

--- a/src/io/flutter/FlutterUtils.java
+++ b/src/io/flutter/FlutterUtils.java
@@ -70,7 +70,6 @@ public class FlutterUtils {
     return relativePath != null && relativePath.startsWith("test/");
   }
 
-
   @Nullable
   public static VirtualFile getRealVirtualFile(@Nullable PsiFile psiFile) {
     return psiFile != null ? psiFile.getOriginalFile().getVirtualFile() : null;

--- a/src/io/flutter/FlutterUtils.java
+++ b/src/io/flutter/FlutterUtils.java
@@ -16,7 +16,10 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
 import com.jetbrains.lang.dart.DartFileType;
+import com.jetbrains.lang.dart.psi.DartFile;
 import io.flutter.pub.PubRoot;
+import io.flutter.run.FlutterRunConfigurationProducer;
+import io.flutter.utils.FlutterModuleUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -53,6 +56,20 @@ public class FlutterUtils {
   public static boolean exists(@Nullable VirtualFile file) {
     return file != null && file.exists();
   }
+
+  public static boolean isInTestDir(DartFile file) {
+    final PubRoot root = PubRoot.forPsiFile(file);
+    if (root == null) return false;
+
+    if (!FlutterModuleUtils.isFlutterModule(root.getModule(file.getProject()))) return false;
+
+    final VirtualFile candidate = FlutterRunConfigurationProducer.getFlutterEntryFile(file, false);
+    if (candidate == null) return false;
+
+    final String relativePath = root.getRelativePath(candidate);
+    return relativePath != null && relativePath.startsWith("test/");
+  }
+
 
   @Nullable
   public static VirtualFile getRealVirtualFile(@Nullable PsiFile psiFile) {

--- a/src/io/flutter/FlutterUtils.java
+++ b/src/io/flutter/FlutterUtils.java
@@ -63,7 +63,7 @@ public class FlutterUtils {
 
     if (!FlutterModuleUtils.isFlutterModule(root.getModule(file.getProject()))) return false;
 
-    final VirtualFile candidate = FlutterRunConfigurationProducer.getFlutterEntryFile(file, false);
+    final VirtualFile candidate = FlutterRunConfigurationProducer.getFlutterEntryFile(file, false, false);
     if (candidate == null) return false;
 
     final String relativePath = root.getRelativePath(candidate);

--- a/src/io/flutter/dart/DartSyntax.java
+++ b/src/io/flutter/dart/DartSyntax.java
@@ -86,7 +86,7 @@ public class DartSyntax {
   }
 
   @Nullable
-  private static String getCalledFunctionName(@NotNull DartCallExpression call) {
+  public static String getCalledFunctionName(@NotNull DartCallExpression call) {
     if (!(call.getFirstChild() instanceof DartReference)) return null;
     return call.getFirstChild().getText();
   }

--- a/src/io/flutter/dart/DartSyntax.java
+++ b/src/io/flutter/dart/DartSyntax.java
@@ -13,6 +13,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Finds Dart PSI elements in IntelliJ's syntax tree.
@@ -65,6 +66,20 @@ public class DartSyntax {
   }
 
   /**
+   * Check if the given element is a call to a flutter test.
+   *
+   * @param element the element to check
+   * @return true if the given element is a test call, false otherwise
+   */
+  public static boolean isTestCall(@Nullable PsiElement element) {
+    //TODO(pq): ensure we're in a 'package:test' context.
+    //TODO(pq): add support for "testWidgets".
+    if (!(element instanceof DartCallExpression)) return false;
+    final String name = getCalledFunctionName((DartCallExpression)element);
+    return Objects.equals(name, "test");
+  }
+
+  /**
    * Returns the contents of a Dart string literal, provided that it doesn't do any interpolation.
    * <p>
    * Returns null if there is any string interpolation.
@@ -86,7 +101,7 @@ public class DartSyntax {
   }
 
   @Nullable
-  public static String getCalledFunctionName(@NotNull DartCallExpression call) {
+  private static String getCalledFunctionName(@NotNull DartCallExpression call) {
     if (!(call.getFirstChild() instanceof DartReference)) return null;
     return call.getFirstChild().getText();
   }

--- a/src/io/flutter/run/FlutterRunConfigurationProducer.java
+++ b/src/io/flutter/run/FlutterRunConfigurationProducer.java
@@ -84,6 +84,14 @@ public class FlutterRunConfigurationProducer extends RunConfigurationProducer<Sd
   @Nullable
   public static VirtualFile getFlutterEntryFile(final @NotNull ConfigurationContext context, boolean requireFlutterImport) {
     final DartFile dart = getDartFile(context);
+    return getFlutterEntryFile(dart, requireFlutterImport);
+  }
+
+  /**
+   * Returns the corresponding virtual file containing a Flutter app's main() function, or null if not a match.
+   */
+  @Nullable
+  public static VirtualFile getFlutterEntryFile(final @Nullable DartFile dart , boolean requireFlutterImport) {
     if (dart == null) return null;
 
     if (DartResolveUtil.getMainFunction(dart) == null) return null;
@@ -94,7 +102,7 @@ public class FlutterRunConfigurationProducer extends RunConfigurationProducer<Sd
     final VirtualFile virtual = DartResolveUtil.getRealVirtualFile(dart);
     if (virtual == null) return null;
 
-    if (!ProjectRootManager.getInstance(context.getProject()).getFileIndex().isInContent(virtual)) {
+    if (!ProjectRootManager.getInstance(dart.getProject()).getFileIndex().isInContent(virtual)) {
       return null;
     }
 
@@ -122,7 +130,13 @@ public class FlutterRunConfigurationProducer extends RunConfigurationProducer<Sd
    * Returns the Dart file at the current location, or null if not a match.
    */
   public static @Nullable DartFile getDartFile(final @NotNull ConfigurationContext context) {
-    final PsiElement elt = context.getPsiLocation();
+    return getDartFile(context.getPsiLocation());
+  }
+
+  /**
+   * Returns the Dart file for the given PsiElement, or null if not a match.
+   */
+  public static @Nullable DartFile getDartFile(final @Nullable PsiElement elt) {
     if (elt == null) return null;
 
     final PsiFile psiFile = elt.getContainingFile();

--- a/src/io/flutter/run/FlutterRunConfigurationProducer.java
+++ b/src/io/flutter/run/FlutterRunConfigurationProducer.java
@@ -91,7 +91,7 @@ public class FlutterRunConfigurationProducer extends RunConfigurationProducer<Sd
    * Returns the corresponding virtual file containing a Flutter app's main() function, or null if not a match.
    */
   @Nullable
-  public static VirtualFile getFlutterEntryFile(final @Nullable DartFile dart , boolean requireFlutterImport, boolean omitTests) {
+  public static VirtualFile getFlutterEntryFile(final @Nullable DartFile dart, boolean requireFlutterImport, boolean omitTests) {
     if (dart == null) return null;
 
     if (DartResolveUtil.getMainFunction(dart) == null) return null;

--- a/src/io/flutter/run/FlutterRunConfigurationProducer.java
+++ b/src/io/flutter/run/FlutterRunConfigurationProducer.java
@@ -84,14 +84,14 @@ public class FlutterRunConfigurationProducer extends RunConfigurationProducer<Sd
   @Nullable
   public static VirtualFile getFlutterEntryFile(final @NotNull ConfigurationContext context, boolean requireFlutterImport, boolean omitTests) {
     final DartFile dart = getDartFile(context);
-    return getFlutterEntryFile(dart, requireFlutterImport);
+    return getFlutterEntryFile(dart, requireFlutterImport, omitTests);
   }
 
   /**
    * Returns the corresponding virtual file containing a Flutter app's main() function, or null if not a match.
    */
   @Nullable
-  public static VirtualFile getFlutterEntryFile(final @Nullable DartFile dart , boolean requireFlutterImport) {
+  public static VirtualFile getFlutterEntryFile(final @Nullable DartFile dart , boolean requireFlutterImport, boolean omitTests) {
     if (dart == null) return null;
 
     if (DartResolveUtil.getMainFunction(dart) == null) return null;

--- a/src/io/flutter/run/test/FlutterTestLineMarkerContributor.java
+++ b/src/io/flutter/run/test/FlutterTestLineMarkerContributor.java
@@ -13,7 +13,10 @@ import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.psi.PsiElement;
 import com.intellij.util.Function;
 import com.intellij.util.containers.ContainerUtil;
+import com.jetbrains.lang.dart.psi.DartFile;
+import io.flutter.FlutterUtils;
 import io.flutter.dart.DartSyntax;
+import io.flutter.run.FlutterRunConfigurationProducer;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -22,7 +25,7 @@ public class FlutterTestLineMarkerContributor extends RunLineMarkerContributor {
   @Nullable
   @Override
   public Info getInfo(@NotNull PsiElement element) {
-    if (DartSyntax.isTestCall(element)) {
+    if (isTestCall(element)) {
       final AnAction[] actions = ExecutorAction.getActions();
       final Function<PsiElement, String> tooltipProvider =
         psiElement -> StringUtil.join(ContainerUtil.mapNotNull(actions, action -> getText(action, element)), "\n");
@@ -30,5 +33,12 @@ public class FlutterTestLineMarkerContributor extends RunLineMarkerContributor {
     }
 
     return null;
+  }
+
+  private static boolean isTestCall(@NotNull PsiElement element) {
+    if (!DartSyntax.isTestCall(element)) return false;
+
+    final DartFile file = FlutterRunConfigurationProducer.getDartFile(element);
+    return file != null && FlutterUtils.isInTestDir(file);
   }
 }

--- a/src/io/flutter/run/test/FlutterTestLineMarkerContributor.java
+++ b/src/io/flutter/run/test/FlutterTestLineMarkerContributor.java
@@ -13,19 +13,16 @@ import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.psi.PsiElement;
 import com.intellij.util.Function;
 import com.intellij.util.containers.ContainerUtil;
-import com.jetbrains.lang.dart.psi.DartCallExpression;
 import io.flutter.dart.DartSyntax;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
-import java.util.Objects;
 
 
 public class FlutterTestLineMarkerContributor extends RunLineMarkerContributor {
   @Nullable
   @Override
   public Info getInfo(@NotNull PsiElement element) {
-    if (isTestCall(element)) {
+    if (DartSyntax.isTestCall(element)) {
       final AnAction[] actions = ExecutorAction.getActions();
       final Function<PsiElement, String> tooltipProvider =
         psiElement -> StringUtil.join(ContainerUtil.mapNotNull(actions, action -> getText(action, element)), "\n");
@@ -33,13 +30,5 @@ public class FlutterTestLineMarkerContributor extends RunLineMarkerContributor {
     }
 
     return null;
-  }
-
-  private static boolean isTestCall(PsiElement element) {
-    //TODO(pq): ensure we're in a 'package:test' context.
-    //TODO(pq): add support for "testWidgets".
-    if (!(element instanceof DartCallExpression)) return false;
-    final String name = DartSyntax.getCalledFunctionName((DartCallExpression)element);
-    return Objects.equals(name, "test");
   }
 }

--- a/src/io/flutter/run/test/FlutterTestLineMarkerContributor.java
+++ b/src/io/flutter/run/test/FlutterTestLineMarkerContributor.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.run.test;
+
+import com.intellij.execution.lineMarker.ExecutorAction;
+import com.intellij.execution.lineMarker.RunLineMarkerContributor;
+import com.intellij.icons.AllIcons;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.psi.PsiElement;
+import com.intellij.util.Function;
+import com.intellij.util.containers.ContainerUtil;
+import com.jetbrains.lang.dart.psi.DartCallExpression;
+import io.flutter.dart.DartSyntax;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Objects;
+
+
+public class FlutterTestLineMarkerContributor extends RunLineMarkerContributor {
+  @Nullable
+  @Override
+  public Info getInfo(@NotNull PsiElement element) {
+    if (isTestCall(element)) {
+      final AnAction[] actions = ExecutorAction.getActions();
+      final Function<PsiElement, String> tooltipProvider =
+        psiElement -> StringUtil.join(ContainerUtil.mapNotNull(actions, action -> getText(action, element)), "\n");
+      return new Info(AllIcons.RunConfigurations.TestState.Run, tooltipProvider, actions);
+    }
+
+    return null;
+  }
+
+  private static boolean isTestCall(PsiElement element) {
+    //TODO(pq): ensure we're in a 'package:test' context.
+    //TODO(pq): add support for "testWidgets".
+    if (!(element instanceof DartCallExpression)) return false;
+    final String name = DartSyntax.getCalledFunctionName((DartCallExpression)element);
+    return Objects.equals(name, "test");
+  }
+}

--- a/testSrc/unit/io/flutter/dart/DartSyntaxTest.java
+++ b/testSrc/unit/io/flutter/dart/DartSyntaxTest.java
@@ -21,11 +21,21 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class DartSyntaxTest {
 
   @Rule
   public final ProjectFixture fixture = Testing.makeCodeInsightModule();
+
+  @Test
+  public void isTestCall() throws Exception {
+    Testing.runOnDispatchThread(() -> {
+      final PsiElement testIdentifier = setUpDartElement("main() { test('my first test', () {} ); }", "test", LeafPsiElement.class);
+      final DartCallExpression call = DartSyntax.findEnclosingFunctionCall(testIdentifier, "test");
+      assertTrue(DartSyntax.isTestCall(call));
+    });
+  }
 
   @Test
   public void shouldFindEnclosingFunctionCall() throws Exception {


### PR DESCRIPTION
Basic support for running tests from editor line markers.

![image](https://user-images.githubusercontent.com/67586/27914333-a2d49aa4-6217-11e7-9c07-63ec2c572c5f.png)

In general, we should add some better scoping to our test discovery (at the moment we're not picky about the provenance of functions called `test`); TODO added and I'll follow-up with a fix, as well as some noodling on support, in general, for `testWidgets`.

Fixes: #1174.

@devoncarew 