### PR TITLE
android emulator actions behind a submenu

### DIFF
--- a/src/io/flutter/actions/DeviceSelectorAction.java
+++ b/src/io/flutter/actions/DeviceSelectorAction.java
@@ -107,6 +107,9 @@ public class DeviceSelectorAction extends ComboBoxAction implements DumbAware {
       actions.add(new NoDevicesAction(message));
     }
 
+    // Show simulator and emulator actions.
+    final List<AnAction> additionalActions = new ArrayList<>();
+
     // Show the 'Open iOS Simulator' action.
     if (SystemInfo.isMac) {
       boolean simulatorOpen = false;
@@ -120,15 +123,20 @@ public class DeviceSelectorAction extends ComboBoxAction implements DumbAware {
         }
       }
 
-      actions.add(new Separator());
-      actions.add(new OpenSimulatorAction(!simulatorOpen));
+      additionalActions.add(new OpenSimulatorAction(!simulatorOpen));
     }
 
     // Add Open Android emulators actions.
     final List<OpenEmulatorAction> emulatorActions = OpenEmulatorAction.getEmulatorActions(project);
     if (!emulatorActions.isEmpty()) {
+      final DefaultActionGroup group = new DefaultActionGroup("Open Android Emulators", true);
+      group.addAll(emulatorActions);
+      additionalActions.add(group);
+    }
+
+    if (!additionalActions.isEmpty()) {
       actions.add(new Separator());
-      actions.addAll(emulatorActions);
+      actions.addAll(additionalActions);
     }
 
     final FlutterDevice selectedDevice = service.getSelectedDevice();

--- a/src/io/flutter/actions/OpenEmulatorAction.java
+++ b/src/io/flutter/actions/OpenEmulatorAction.java
@@ -25,13 +25,14 @@ public class OpenEmulatorAction extends AnAction {
     }
 
     final List<AndroidEmulator> emulators = sdk.getEmulators();
+    emulators.sort((emulator1, emulator2) -> emulator1.getName().compareToIgnoreCase(emulator2.getName()));
     return emulators.stream().map(OpenEmulatorAction::new).collect(toList());
   }
 
   final AndroidEmulator emulator;
 
   public OpenEmulatorAction(AndroidEmulator emulator) {
-    super("Open Android Emulator: " + emulator.getName());
+    super(emulator.getName() + "…");
 
     this.emulator = emulator;
   }

--- a/src/io/flutter/actions/OpenSimulatorAction.java
+++ b/src/io/flutter/actions/OpenSimulatorAction.java
@@ -20,7 +20,7 @@ public class OpenSimulatorAction extends AnAction {
   final boolean enabled;
 
   public OpenSimulatorAction(boolean enabled) {
-    super("Open iOS Simulator");
+    super("Open iOS Simulator…");
 
     this.enabled = enabled;
   }


### PR DESCRIPTION
- put android emulator actions behind a submenu
- fix https://github.com/flutter/flutter-intellij/issues/1136 (we're not going to be able to address the portion of the bug related to disabling menu items for open emulators)

I'm a bit torn about the UI - I'm not 100% sure it's better than what we have now. This PR:

<img width="417" alt="screen shot 2017-07-06 at 12 15 09 pm" src="https://user-images.githubusercontent.com/1269969/27928743-3b6e2410-6245-11e7-9a05-86a6d2376a03.png">

and the before:

<img width="346" alt="screen shot 2017-06-26 at 4 28 16 pm" src="https://user-images.githubusercontent.com/1269969/27928763-4ce1555a-6245-11e7-993b-431e307e938a.png">

Note that the user has to explicitly click on the `Open Android Emulators` submenu item for it to open - it doesn't auto-expand like a regular menu item  in the system menus.

@pq @skybrian @stevemessick thoughts?

