### PR TITLE
Test state icons.

### DIFF
--- a/src/io/flutter/run/test/FlutterTestLineMarkerContributor.java
+++ b/src/io/flutter/run/test/FlutterTestLineMarkerContributor.java
@@ -36,7 +36,7 @@ import java.util.Map;
 
 public class FlutterTestLineMarkerContributor extends RunLineMarkerContributor {
 
-  private static final int TEST_LIMIT = 1024;
+  private static final int SCANNED_TEST_RESULT_LIMIT = 1024;
 
   @Nullable
   @Override
@@ -52,6 +52,7 @@ public class FlutterTestLineMarkerContributor extends RunLineMarkerContributor {
     return null;
   }
 
+  @NotNull
   private static Icon getTestStateIcon(@NotNull PsiElement element) {
 
     // SMTTestProxy maps test run data to a URI derived from a location hint produced by `package:test`.
@@ -81,8 +82,9 @@ public class FlutterTestLineMarkerContributor extends RunLineMarkerContributor {
       final TestStateStorage storage = TestStateStorage.getInstance(project);
       if (storage != null) {
         final Map<String, TestStateStorage.Record> tests =
-          storage.getRecentTests(TEST_LIMIT, getSinceDate());
+          storage.getRecentTests(SCANNED_TEST_RESULT_LIMIT, getSinceDate());
         if (tests != null) {
+          //TODO(pq): investigate performance implications.
           for (Map.Entry<String, TestStateStorage.Record> entry : tests.entrySet()) {
             if (entry.getKey().startsWith(testLocationPrefix)) {
               final TestStateStorage.Record state = entry.getValue();

--- a/src/io/flutter/run/test/FlutterTestLineMarkerContributor.java
+++ b/src/io/flutter/run/test/FlutterTestLineMarkerContributor.java
@@ -5,13 +5,22 @@
  */
 package io.flutter.run.test;
 
+import com.intellij.execution.TestStateStorage;
 import com.intellij.execution.lineMarker.ExecutorAction;
 import com.intellij.execution.lineMarker.RunLineMarkerContributor;
+import com.intellij.execution.testframework.TestIconMapper;
+import com.intellij.execution.testframework.sm.runner.states.TestStateInfo;
 import com.intellij.icons.AllIcons;
 import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.psi.PsiDocumentManager;
 import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiInvalidElementAccessException;
 import com.intellij.util.Function;
+import com.intellij.util.Time;
 import com.intellij.util.containers.ContainerUtil;
 import com.jetbrains.lang.dart.psi.DartFile;
 import io.flutter.FlutterUtils;
@@ -20,19 +29,84 @@ import io.flutter.run.FlutterRunConfigurationProducer;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import javax.swing.*;
+import java.util.Date;
+import java.util.Map;
+
 
 public class FlutterTestLineMarkerContributor extends RunLineMarkerContributor {
+
+  private static final int TEST_LIMIT = 1024;
+
   @Nullable
   @Override
   public Info getInfo(@NotNull PsiElement element) {
     if (isTestCall(element)) {
+      final Icon icon = getTestStateIcon(element);
       final AnAction[] actions = ExecutorAction.getActions();
       final Function<PsiElement, String> tooltipProvider =
         psiElement -> StringUtil.join(ContainerUtil.mapNotNull(actions, action -> getText(action, element)), "\n");
-      return new Info(AllIcons.RunConfigurations.TestState.Run, tooltipProvider, actions);
+      return new Info(icon, tooltipProvider, actions);
     }
 
     return null;
+  }
+
+  private static Icon getTestStateIcon(@NotNull PsiElement element) {
+
+    // SMTTestProxy maps test run data to a URI derived from a location hint produced by `package:test`.
+    // If we can find corresponding data, we can provide state-aware icons.  If not, we default to
+    // a standard Run state.
+
+    PsiFile containingFile;
+    try {
+      containingFile = element.getContainingFile();
+    }
+    catch (PsiInvalidElementAccessException e) {
+      containingFile = null;
+    }
+
+    final Project project = element.getProject();
+    final PsiDocumentManager psiDocumentManager = PsiDocumentManager.getInstance(project);
+
+    final Document document = containingFile == null ? null : psiDocumentManager.getDocument(containingFile);
+    if (document != null) {
+      final int textOffset = element.getTextOffset();
+      final int lineNumber = document.getLineNumber(textOffset);
+
+      // e.g., dart_location:///Users/pq/IdeaProjects/untitled1298891289891/test/unit_test.dart,3,2,["my first unit test"]
+      final String path = containingFile.getVirtualFile().getPath();
+      final String testLocationPrefix = "dart_location://" + path + "," + lineNumber;
+
+      final TestStateStorage storage = TestStateStorage.getInstance(project);
+      if (storage != null) {
+        final Map<String, TestStateStorage.Record> tests =
+          storage.getRecentTests(TEST_LIMIT, getSinceDate());
+        if (tests != null) {
+          for (Map.Entry<String, TestStateStorage.Record> entry : tests.entrySet()) {
+            if (entry.getKey().startsWith(testLocationPrefix)) {
+              final TestStateStorage.Record state = entry.getValue();
+              final TestStateInfo.Magnitude magnitude = TestIconMapper.getMagnitude(state.magnitude);
+              if (magnitude != null) {
+                switch (magnitude) {
+                  case IGNORED_INDEX:
+                    return AllIcons.RunConfigurations.TestState.Yellow2;
+                  case ERROR_INDEX:
+                  case FAILED_INDEX:
+                    return AllIcons.RunConfigurations.TestState.Red2;
+                  case PASSED_INDEX:
+                  case COMPLETE_INDEX:
+                    return AllIcons.RunConfigurations.TestState.Green2;
+                  default:
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    return AllIcons.RunConfigurations.TestState.Run;
   }
 
   private static boolean isTestCall(@NotNull PsiElement element) {
@@ -40,5 +114,9 @@ public class FlutterTestLineMarkerContributor extends RunLineMarkerContributor {
 
     final DartFile file = FlutterRunConfigurationProducer.getDartFile(element);
     return file != null && FlutterUtils.isInTestDir(file);
+  }
+
+  private static Date getSinceDate() {
+    return new Date(System.currentTimeMillis() - Time.DAY);
   }
 }


### PR DESCRIPTION
Follow-up from #1180 and continuing #1174, adds state awareness to run marker icons to distinguish:

1. previously green tests
1. unrun tests
1. previously red tests
1. previously skipped tests

For example:

![image](https://user-images.githubusercontent.com/67586/27944571-ab541c4c-629c-11e7-97b1-2e4a40969cea.png)

A future arc of work would get this under test but I think we have some integration test fleshing out for that.

@devoncarew @stevemessick 
