### PR TITLE
Fix test source path for community IML.

### DIFF
--- a/flutter-intellij-community.iml
+++ b/flutter-intellij-community.iml
@@ -4,7 +4,8 @@
     <exclude-output />
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/testSrc" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/testSrc/unit" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/testSrc/integration" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/resources" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/gen" isTestSource="false" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/third_party/intellij-plugins-dart/src" isTestSource="false" />


### PR DESCRIPTION
Needed to get tests working in `flutter-intellij-community.iml` (note this is consistent w/ `flutter-intellij.iml`).

(Open question whether we still need this distinct IML file?)

@stevemessick 