### PR TITLE
Scope main test markers to mains w/ tests (#1202).

### DIFF
--- a/testSrc/unit/io/flutter/AbstractDartElementTest.java
+++ b/testSrc/unit/io/flutter/AbstractDartElementTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter;
+
+
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiFileFactory;
+import com.jetbrains.lang.dart.DartLanguage;
+import io.flutter.testing.ProjectFixture;
+import io.flutter.testing.Testing;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Rule;
+
+public class AbstractDartElementTest {
+  @Rule
+  public final ProjectFixture fixture = Testing.makeCodeInsightModule();
+
+  protected void run(Testing.RunnableThatThrows callback) throws Exception {
+    Testing.runOnDispatchThread(callback);
+  }
+
+  /**
+   * Creates the syntax tree for a Dart file and returns the innermost element with the given text.
+   */
+  @NotNull
+  protected <E extends PsiElement> E setUpDartElement(String fileText, String elementText, Class<E> expectedClass) {
+    final int offset = fileText.indexOf(elementText);
+    if (offset < 0) {
+      throw new IllegalArgumentException("'" + elementText + "' not found in '" + fileText + "'");
+    }
+
+    final PsiFile file = PsiFileFactory.getInstance(fixture.getProject())
+      .createFileFromText(DartLanguage.INSTANCE, fileText);
+
+    PsiElement elt = file.findElementAt(offset);
+    while (elt != null) {
+      if (elementText.equals(elt.getText())) {
+        return expectedClass.cast(elt);
+      }
+      elt = elt.getParent();
+    }
+
+    throw new RuntimeException("unable to find element with text: " + elementText);
+  }
+}

--- a/testSrc/unit/io/flutter/run/test/TestConfigUtilsTest.java
+++ b/testSrc/unit/io/flutter/run/test/TestConfigUtilsTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.run.test;
+
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.impl.source.tree.LeafPsiElement;
+import com.intellij.psi.util.PsiTreeUtil;
+import com.jetbrains.lang.dart.psi.DartFunctionDeclarationWithBodyOrNative;
+import io.flutter.AbstractDartElementTest;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class TestConfigUtilsTest extends AbstractDartElementTest {
+
+  @Test
+  public void mainTestCall() throws Exception {
+    run(() -> {
+      final PsiElement mainIdentifier = setUpDartElement("main() { test('my first test', () {} ); }", "main", LeafPsiElement.class);
+      final PsiElement main =
+        PsiTreeUtil.findFirstParent(mainIdentifier, element -> element instanceof DartFunctionDeclarationWithBodyOrNative);
+      assert main != null;
+      assertTrue(TestConfigUtils.isMainFunctionDeclarationWithTests(main));
+    });
+  }
+
+  @Test
+  public void mainTestCall_negative() throws Exception {
+    run(() -> {
+      final PsiElement mainIdentifier = setUpDartElement("main() { print('no tests here!'); }", "main", LeafPsiElement.class);
+      final PsiElement main =
+        PsiTreeUtil.findFirstParent(mainIdentifier, element -> element instanceof DartFunctionDeclarationWithBodyOrNative);
+      assert main != null;
+      assertFalse(TestConfigUtils.isMainFunctionDeclarationWithTests(main));
+    });
+  }
+
+}


### PR DESCRIPTION
* scans main for named test calls (`test('')` // `group('')`)
* adds new `TestConfigUtilsTest`

Fixes: #1202.

![image](https://user-images.githubusercontent.com/67586/28129338-caedc23e-66e7-11e7-814f-433054da9b33.png)

![image](https://user-images.githubusercontent.com/67586/28129367-e6125f02-66e7-11e7-8b68-5ea5c7edd135.png)

@stevemessick @jwren 


