### PR TITLE
Restore New Project wizard

### DIFF
--- a/flutter-studio/README.md
+++ b/flutter-studio/README.md
@@ -14,5 +14,5 @@ To set up a development environment:
     - intellij-plugins/Dart/Dart-community.iml
     - flutter-intellij/flutter-intellij-community.iml
     - flutter-intellij/flutter-studio/flutter-studio.iml
-6. Select the `community-main` project and add module
-   dependencies to the three modules just imported.
+6. Select the `community-main` module and add a module
+   dependency to `flutter-studio`.

--- a/flutter-studio/flutter-studio.iml
+++ b/flutter-studio/flutter-studio.iml
@@ -5,6 +5,7 @@
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/testSrc/unit" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/resources" type="java-resource" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
@@ -16,5 +17,6 @@
     <orderEntry type="module" module-name="lang-impl" />
     <orderEntry type="module" module-name="xdebugger-api" />
     <orderEntry type="module" module-name="testFramework" scope="TEST" />
+    <orderEntry type="module" module-name="idea-ui" />
   </component>
 </module>

--- a/flutter-studio/resources/META-INF/plugin.xml
+++ b/flutter-studio/resources/META-INF/plugin.xml
@@ -1,0 +1,12 @@
+<idea-plugin>
+  <name>Flutter for Android Studio</name>
+  <id>io.flutter.studio</id>
+  <vendor url="https://github.com/flutter/flutter-intellij">flutter.io</vendor>
+  <module value="flutter-studio"/>
+
+  <extensions defaultExtensionNs="com.intellij">
+
+    <postStartupActivity implementation="io.flutter.startup.FlutterStudioInitializer"/>
+
+  </extensions>
+</idea-plugin>

--- a/flutter-studio/src/io/flutter/startup/FlutterStudioInitializer.java
+++ b/flutter-studio/src/io/flutter/startup/FlutterStudioInitializer.java
@@ -19,6 +19,7 @@ public class FlutterStudioInitializer implements StartupActivity {
     NewProjectAction newProject = new NewProjectAction();
     newProject.getTemplatePresentation().setText("New &Project...", true);
     newProject.getTemplatePresentation().setDescription("Create a new project from scratch");
+    // TODO(messick): Design a New Project wizard for Android Studio + Flutter.
     replaceAction("NewProject", newProject);
   }
 

--- a/flutter-studio/src/io/flutter/startup/FlutterStudioInitializer.java
+++ b/flutter-studio/src/io/flutter/startup/FlutterStudioInitializer.java
@@ -1,0 +1,34 @@
+package io.flutter.startup;
+
+import com.intellij.ide.actions.NewProjectAction;
+import com.intellij.openapi.actionSystem.ActionManager;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.startup.StartupActivity;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.projectImport.ProjectOpenProcessor;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+
+public class FlutterStudioInitializer implements StartupActivity {
+
+  @Override
+  public void runActivity(@NotNull Project project) {
+    NewProjectAction newProject = new NewProjectAction();
+    newProject.getTemplatePresentation().setText("New &Project...", true);
+    newProject.getTemplatePresentation().setDescription("Create a new project from scratch");
+    replaceAction("NewProject", newProject);
+  }
+
+  public static void replaceAction(@NotNull String actionId, @NotNull AnAction newAction) {
+    ActionManager actionManager = ActionManager.getInstance();
+    AnAction oldAction = actionManager.getAction(actionId);
+    if (oldAction != null) {
+      newAction.getTemplatePresentation().setIcon(oldAction.getTemplatePresentation().getIcon());
+      actionManager.unregisterAction(actionId);
+    }
+    actionManager.registerAction(actionId, newAction);
+  }
+}


### PR DESCRIPTION
@pq @devoncarew 
Replace the simplified 'New Project' wizard of Android Studio with the traditional IntelliJ one. This allows creation of Flutter projects (and many others) in addition to Android projects.

Consider this proof-of-concept and subject to revision as we understand the requirements better.