### PR TITLE
Build for AS if -Dstudio=true on cmd line

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -4,7 +4,11 @@
      plugin in the IntelliJ sandbox in order to run Flutter IntelliJ unit tests. -->
 
 <!--suppress AntResolveInspection -->
-<project name="flutter-intellij" default="build">
+<project
+    name="flutter-intellij"
+    xmlns:if="ant:if"
+    xmlns:unless="ant:unless"
+    default="build">
   <property environment="env"/>
 
   <!-- defaults -->
@@ -113,6 +117,8 @@
         <include name="resources"/>
         <include name="gen"/>
         <include name="third_party/intellij-plugins-dart/src"/>
+        <include if:true="${studio}" name="flutter-studio/src"/>
+        <include if:true="${studio}" name="flutter-studio/resources"/>
       </dirset>
     </path>
 
@@ -156,6 +162,14 @@
         <type type="file"/>
       </fileset>
       <fileset dir="third_party/intellij-plugins-dart/src">
+        <patternset refid="compiler.resources"/>
+        <type type="file"/>
+      </fileset>
+      <fileset if:true="${studio}" dir="flutter-studio/src">
+        <patternset refid="compiler.resources"/>
+        <type type="file"/>
+      </fileset>
+      <fileset if:true="${studio}" dir="flutter-studio/resources">
         <patternset refid="compiler.resources"/>
         <type type="file"/>
       </fileset>

--- a/building.md
+++ b/building.md
@@ -21,6 +21,7 @@ build/flutter-intellij.jar
 - `ant build` - build the plugin and associated tests
 - `ant test` - run the unit tests
 - `ant all` - build the plugin and tests, and run the tests
+- `and -Dstudio=true` - build the plugin for Android Studio
 
 ## The build pre-reqs
 

--- a/building.md
+++ b/building.md
@@ -21,7 +21,7 @@ build/flutter-intellij.jar
 - `ant build` - build the plugin and associated tests
 - `ant test` - run the unit tests
 - `ant all` - build the plugin and tests, and run the tests
-- `and -Dstudio=true` - build the plugin for Android Studio
+- `ant -Dstudio=true` - build the plugin for Android Studio
 
 ## The build pre-reqs
 

--- a/flutter-studio/README.md
+++ b/flutter-studio/README.md
@@ -14,5 +14,5 @@ To set up a development environment:
     - intellij-plugins/Dart/Dart-community.iml
     - flutter-intellij/flutter-intellij-community.iml
     - flutter-intellij/flutter-studio/flutter-studio.iml
-6. Select the `community-main` project and add module
-   dependencies to the three modules just imported.
+6. Select the `community-main` module and add a module
+   dependency to `flutter-studio`.

--- a/flutter-studio/flutter-studio.iml
+++ b/flutter-studio/flutter-studio.iml
@@ -5,6 +5,7 @@
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/testSrc/unit" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/resources" type="java-resource" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
@@ -16,5 +17,6 @@
     <orderEntry type="module" module-name="lang-impl" />
     <orderEntry type="module" module-name="xdebugger-api" />
     <orderEntry type="module" module-name="testFramework" scope="TEST" />
+    <orderEntry type="module" module-name="idea-ui" />
   </component>
 </module>

--- a/flutter-studio/resources/META-INF/plugin.xml
+++ b/flutter-studio/resources/META-INF/plugin.xml
@@ -1,0 +1,12 @@
+<idea-plugin>
+  <name>Flutter for Android Studio</name>
+  <id>io.flutter.studio</id>
+  <vendor url="https://github.com/flutter/flutter-intellij">flutter.io</vendor>
+  <module value="flutter-studio"/>
+
+  <extensions defaultExtensionNs="com.intellij">
+
+    <postStartupActivity implementation="io.flutter.startup.FlutterStudioInitializer"/>
+
+  </extensions>
+</idea-plugin>

--- a/flutter-studio/src/io/flutter/startup/FlutterStudioInitializer.java
+++ b/flutter-studio/src/io/flutter/startup/FlutterStudioInitializer.java
@@ -1,0 +1,35 @@
+package io.flutter.startup;
+
+import com.intellij.ide.actions.NewProjectAction;
+import com.intellij.openapi.actionSystem.ActionManager;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.startup.StartupActivity;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.projectImport.ProjectOpenProcessor;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+
+public class FlutterStudioInitializer implements StartupActivity {
+
+  @Override
+  public void runActivity(@NotNull Project project) {
+    NewProjectAction newProject = new NewProjectAction();
+    newProject.getTemplatePresentation().setText("New &Project...", true);
+    newProject.getTemplatePresentation().setDescription("Create a new project from scratch");
+    // TODO(messick): Design a New Project wizard for Android Studio + Flutter.
+    replaceAction("NewProject", newProject);
+  }
+
+  public static void replaceAction(@NotNull String actionId, @NotNull AnAction newAction) {
+    ActionManager actionManager = ActionManager.getInstance();
+    AnAction oldAction = actionManager.getAction(actionId);
+    if (oldAction != null) {
+      newAction.getTemplatePresentation().setIcon(oldAction.getTemplatePresentation().getIcon());
+      actionManager.unregisterAction(actionId);
+    }
+    actionManager.registerAction(actionId, newAction);
+  }
+}


### PR DESCRIPTION
`ant -Dstudio-true` will build the plugin for Android Studio. This is not finished. The AS-specific plugin.xml entries still need to be merged into the main Flutter plugin.xml, and the name of the plugin should be changed (or not?). In any case, we will have different plugins for IntelliJ and Android Studio, but there will be only one that a user has to add to each platform.

@pq @devoncarew 