### PR TITLE
tweak the reload action enablement

### DIFF
--- a/src/io/flutter/actions/FlutterRetargetAppAction.java
+++ b/src/io/flutter/actions/FlutterRetargetAppAction.java
@@ -60,6 +60,7 @@ public abstract class FlutterRetargetAppAction extends DumbAwareAction {
     }
 
     presentation.setVisible(true);
+    presentation.setEnabled(false);
 
     // Retargeted actions defer to their targets for presentation updates.
     final AnAction action = getAction();
@@ -70,9 +71,6 @@ public abstract class FlutterRetargetAppAction extends DumbAwareAction {
         presentation.setText(text, true);
       }
       action.update(e);
-    }
-    else {
-      presentation.setEnabled(false);
     }
   }
 

--- a/src/io/flutter/run/FlutterDebugProcess.java
+++ b/src/io/flutter/run/FlutterDebugProcess.java
@@ -90,9 +90,8 @@ public class FlutterDebugProcess extends DartVmServiceDebugProcessZ {
     }
 
     // Add actions common to the run and debug windows.
-
     final Computable<Boolean> isSessionActive = () -> app.isStarted() && getVmConnected() && !getSession().isStopped();
-    final Computable<Boolean> canReload = () -> app.getMode().isReloadEnabled() && isSessionActive.compute();
+    final Computable<Boolean> canReload = () -> app.getMode().isReloadEnabled() && isSessionActive.compute() && !app.isReloading();
 
     if (app.getMode() == RunMode.DEBUG) {
       topToolbar.addSeparator();

--- a/src/io/flutter/run/daemon/FlutterApp.java
+++ b/src/io/flutter/run/daemon/FlutterApp.java
@@ -182,7 +182,8 @@ public class FlutterApp {
   }
 
   public boolean isStarted() {
-    return myState.get() == State.STARTED;
+    final State state = myState.get();
+    return state != State.STARTING && state != State.TERMINATED;
   }
 
   public boolean isReloading() {


### PR DESCRIPTION
Some small tweaks the reload action enablement:
- disable the reload button if there's no action app session
- have the 'open flutter view' and 'open observatory' buttons be enabled if there's an open session (previously they were enabled and disabled during a reload)

@pq @stevemessick @jwren 
