### PR TITLE
Widget test discovery and execution (#1181).

### DIFF
--- a/src/io/flutter/run/test/FlutterTestEventsConverter.java
+++ b/src/io/flutter/run/test/FlutterTestEventsConverter.java
@@ -15,14 +15,37 @@ import com.jetbrains.lang.dart.util.DartUrlResolver;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.text.ParseException;
 import java.util.Objects;
 
 public class FlutterTestEventsConverter extends DartTestEventsConverterZ {
+
+  /**
+   * Name of the synthetic group created dynamically by package:flutter_test when wrapping calls to test().
+   */
+  public static final String SYNTHETIC_WIDGET_GROUP_NAME = "-";
 
   public FlutterTestEventsConverter(@NotNull String testFrameworkName,
                                     @NotNull TestConsoleProperties consoleProperties,
                                     @NotNull DartUrlResolver urlResolver) {
     super(testFrameworkName, consoleProperties, urlResolver);
+  }
+
+  /**
+   * Checks if the given group is one created dynamically by flutter_test in the widget_tester
+   * widget test wrapper.
+   */
+  private static boolean isSyntheticWidgetTestGroup(@NotNull Group group) {
+    return Objects.equals(group.getUrl(), "package:flutter_test/src/widget_tester.dart") &&
+           Objects.equals(group.getName(), SYNTHETIC_WIDGET_GROUP_NAME);
+  }
+
+  @Nullable
+  private static JsonElement getValue(@NotNull JsonElement element, @NotNull String member) {
+    if (!(element instanceof JsonObject)) return null;
+
+    final JsonObject object = (JsonObject)element;
+    return object.has(member) ? object.get(member) : null;
   }
 
   @Override
@@ -46,11 +69,35 @@ public class FlutterTestEventsConverter extends DartTestEventsConverterZ {
     return false;
   }
 
-  @Nullable
-  private static JsonElement getValue(@NotNull JsonElement element, @NotNull String member) {
-    if (!(element instanceof JsonObject)) return null;
+  @Override
+  protected void preprocessTestStart(@NotNull Test test) {
+    // Reparent tests who are in a synthetic widget test group.
+    // This (and the special treatment in #handleGroup()):
+    //   * gets rid of a needless extra group in the result tree, and
+    //   * properly wires up the test's location URL
+    if (isSyntheticWidgetTestGroup(test.myParent)) {
+      // Skip the synthetic parent -- For example,
+      //   my_test.dart
+      //    "-"
+      //       "my first test"
+      // becomes:
+      //   my_test.dart
+      //     "my first test"
+      test.myParent = test.myParent.myParent;
+      // Fix the URL to point to local source (and not the wrapped call in
+      // "package:flutter_test/src/widget_tester.dart")
+      test.myUrl = test.getSuite().myUrl;
+      // Doctor the test name which is prefixed with the bogus group.
+      if (test.myName.startsWith(SYNTHETIC_WIDGET_GROUP_NAME)) {
+        // e.g., "- my first test" => "my first test"
+        test.myName = test.myName.substring(2);
+      }
+    }
+  }
 
-    final JsonObject object = (JsonObject)element;
-    return object.has(member) ? object.get(member) : null;
+  @Override
+  protected boolean handleGroup(@NotNull Group group) throws ParseException {
+    // Special case synthetic widget test groups.
+    return isSyntheticWidgetTestGroup(group) || super.handleGroup(group);
   }
 }

--- a/src/io/flutter/run/test/FlutterTestLocationProvider.java
+++ b/src/io/flutter/run/test/FlutterTestLocationProvider.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.run.test;
+
+
+import com.jetbrains.lang.dart.ide.runner.util.DartTestLocationProviderZ;
+import com.jetbrains.lang.dart.psi.DartCallExpression;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
+
+import static io.flutter.run.test.TestConfigUtils.WIDGET_TEST_FUNCTION;
+
+public class FlutterTestLocationProvider extends DartTestLocationProviderZ {
+  public static final FlutterTestLocationProvider INSTANCE = new FlutterTestLocationProvider();
+
+  @Override
+  protected boolean isTest(@NotNull DartCallExpression expression) {
+    return super.isTest(expression) || Objects.equals(WIDGET_TEST_FUNCTION, expression.getExpression().getText());
+  }
+}

--- a/src/io/flutter/run/test/TestConfigUtils.java
+++ b/src/io/flutter/run/test/TestConfigUtils.java
@@ -25,6 +25,11 @@ import java.util.List;
 
 public class TestConfigUtils {
 
+  /**
+   * Widget test function as defined in package:flutter_test/src/widget_tester.dart.
+   */
+  public static final String WIDGET_TEST_FUNCTION = "testWidgets";
+
   @Nullable
   public static TestType asTestCall(@NotNull PsiElement element) {
     final DartFile file = FlutterUtils.getDartFile(element);
@@ -94,10 +99,7 @@ public class TestConfigUtils {
         return "Run Tests";
       }
     },
-    SINGLE(AllIcons.RunConfigurations.TestState.Run, "test"
-           //TODO(pq): add to enable support for widget tests (pending fixing location issues).
-           //,  "testWidgets"
-    );
+    SINGLE(AllIcons.RunConfigurations.TestState.Run, "test", WIDGET_TEST_FUNCTION);
 
     @NotNull
     private final Icon myIcon;

--- a/src/io/flutter/run/test/TestLaunchState.java
+++ b/src/io/flutter/run/test/TestLaunchState.java
@@ -26,7 +26,6 @@ import com.intellij.openapi.module.ModuleUtil;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.jetbrains.lang.dart.ide.runner.DartRelativePathsConsoleFilter;
-import com.jetbrains.lang.dart.ide.runner.util.DartTestLocationProvider;
 import com.jetbrains.lang.dart.util.DartUrlResolver;
 import io.flutter.console.FlutterConsoleFilter;
 import io.flutter.pub.PubRoot;
@@ -39,7 +38,7 @@ import org.jetbrains.annotations.Nullable;
 /**
  * A launcher that starts a process to run flutter tests, created from a run configuration.
  */
-class TestLaunchState extends CommandLineState  {
+class TestLaunchState extends CommandLineState {
   @NotNull
   private final TestConfig config;
 
@@ -55,7 +54,7 @@ class TestLaunchState extends CommandLineState  {
   private final boolean testConsoleEnabled;
 
   private TestLaunchState(@NotNull ExecutionEnvironment env, @NotNull TestConfig config, @NotNull VirtualFile testFileOrDir,
-                         @NotNull PubRoot pubRoot, boolean testConsoleEnabled) {
+                          @NotNull PubRoot pubRoot, boolean testConsoleEnabled) {
     super(env);
     this.config = config;
     this.fields = config.getFields();
@@ -74,13 +73,13 @@ class TestLaunchState extends CommandLineState  {
     }
 
     final VirtualFile fileOrDir = fields.getFileOrDir();
-    assert(fileOrDir != null);
+    assert (fileOrDir != null);
 
     final PubRoot pubRoot = fields.getPubRoot(env.getProject());
-    assert(pubRoot != null);
+    assert (pubRoot != null);
 
     final FlutterSdk sdk = FlutterSdk.getFlutterSdk(env.getProject());
-    assert(sdk != null);
+    assert (sdk != null);
     final boolean testConsoleEnabled = sdk.getVersion().flutterTestSupportsMachineMode();
 
     final TestLaunchState launcher = new TestLaunchState(env, config, fileOrDir, pubRoot, testConsoleEnabled);
@@ -150,7 +149,7 @@ class TestLaunchState extends CommandLineState  {
     @Nullable
     @Override
     public SMTestLocator getTestLocator() {
-      return DartTestLocationProvider.INSTANCE;
+      return FlutterTestLocationProvider.INSTANCE;
     }
 
     @Override
@@ -165,5 +164,4 @@ class TestLaunchState extends CommandLineState  {
       return null; // TODO(skybrian) implement
     }
   }
-
 }

--- a/third_party/intellij-plugins-dart/src/com/jetbrains/lang/dart/ide/runner/util/DartTestLocationProviderZ.java
+++ b/third_party/intellij-plugins-dart/src/com/jetbrains/lang/dart/ide/runner/util/DartTestLocationProviderZ.java
@@ -1,0 +1,161 @@
+package com.jetbrains.lang.dart.ide.runner.util;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import com.intellij.execution.Location;
+import com.intellij.execution.PsiLocation;
+import com.intellij.execution.testframework.sm.runner.SMTestLocator;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.project.DumbAware;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiDocumentManager;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiManager;
+import com.intellij.psi.search.GlobalSearchScope;
+import com.intellij.psi.search.PsiElementProcessor;
+import com.intellij.psi.util.PsiTreeUtil;
+import com.jetbrains.lang.dart.psi.*;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@SuppressWarnings("Duplicates")
+public class DartTestLocationProviderZ implements SMTestLocator, DumbAware {
+  private static final List<Location> NONE = Collections.emptyList();
+  private static final Gson GSON = new Gson();
+
+  public static final DartTestLocationProviderZ
+    INSTANCE = new DartTestLocationProviderZ();
+  public static final Type STRING_LIST_TYPE = new TypeToken<List<String>>() {}.getType();
+
+  @NotNull
+  @Override
+  public List<Location> getLocation(@NotNull String protocol,
+                                    @NotNull String path,
+                                    @NotNull Project project,
+                                    @NotNull GlobalSearchScope scope) {
+    // see DartTestEventsConverterZ.addLocationHint()
+    // path is like /Users/x/projects/foo/test/foo_test.dart,35,12,["main tests","calculate_fail"]
+
+    final int commaIdx1 = path.indexOf(',');
+    final int commaIdx2 = path.indexOf(',', commaIdx1 + 1);
+    final int commaIdx3 = path.indexOf(',', commaIdx2 + 1);
+    if (commaIdx3 < 0) return NONE;
+
+    final String filePath = path.substring(0, commaIdx1);
+    final int line = Integer.parseInt(path.substring(commaIdx1 + 1, commaIdx2));
+    final int column = Integer.parseInt(path.substring(commaIdx2 + 1, commaIdx3));
+    final String names = path.substring(commaIdx3 + 1);
+
+    final VirtualFile file = LocalFileSystem.getInstance().findFileByPath(filePath);
+    final PsiFile psiFile = file == null ? null : PsiManager.getInstance(project).findFile(file);
+    if (!(psiFile instanceof DartFile)) return NONE;
+
+    if (line >= 0 && column >= 0) {
+      final Location<PsiElement> location = getLocationByLineAndColumn(psiFile, line, column);
+      if (location != null) {
+        return Collections.singletonList(location);
+      }
+    }
+
+    final List<String> nodes = pathToNodes(names);
+    if (nodes.isEmpty()) {
+      return Collections.singletonList(new PsiLocation<PsiElement>(psiFile));
+    }
+
+    return getLocationByGroupAndTestNames(psiFile, nodes);
+  }
+
+  @Nullable
+  private static Location<PsiElement> getLocationByLineAndColumn(@NotNull final PsiFile file, final int line, final int column) {
+    final Document document = PsiDocumentManager.getInstance(file.getProject()).getDocument(file);
+    if (document == null) return null;
+
+    final int offset = document.getLineStartOffset(line) + column;
+    final PsiElement element = file.findElementAt(offset);
+    final PsiElement parent1 = element == null ? null : element.getParent();
+    final PsiElement parent2 = parent1 instanceof DartId ? parent1.getParent() : null;
+    final PsiElement parent3 = parent2 instanceof DartReferenceExpression ? parent2.getParent() : null;
+    if (parent3 instanceof DartCallExpression) {
+      if (TestUtil.isTest((DartCallExpression)parent3) || TestUtil.isGroup((DartCallExpression)parent3)) {
+        return new PsiLocation<>(parent3);
+      }
+    }
+    return null;
+  }
+
+  private static List<String> pathToNodes(final String element) {
+    return GSON.fromJson(element, STRING_LIST_TYPE);
+  }
+
+  @VisibleForTesting
+  public List<Location> getLocationForTest(@NotNull final PsiFile psiFile, @NotNull final String testPath) {
+    return getLocationByGroupAndTestNames(psiFile, pathToNodes(testPath));
+  }
+
+  protected List<Location> getLocationByGroupAndTestNames(final PsiFile psiFile, final List<String> nodes) {
+    final List<Location> locations = new ArrayList<>();
+
+    if (psiFile instanceof DartFile && !nodes.isEmpty()) {
+      final PsiElementProcessor<PsiElement> collector = new PsiElementProcessor<PsiElement>() {
+        @Override
+        public boolean execute(@NotNull final PsiElement element) {
+          if (element instanceof DartCallExpression) {
+            DartCallExpression expression = (DartCallExpression)element;
+            if (isTest(expression) || TestUtil.isGroup(expression)) {
+              if (nodes.get(nodes.size() - 1).equals(getTestLabel(expression))) {
+                boolean matches = true;
+                for (int i = nodes.size() - 2; i >= 0 && matches; --i) {
+                  expression = getGroup(expression);
+                  if (expression == null || !nodes.get(i).equals(getTestLabel(expression))) {
+                    matches = false;
+                  }
+                }
+                if (matches) {
+                  locations.add(new PsiLocation<>(element));
+                  return false;
+                }
+              }
+            }
+          }
+
+          return true;
+        }
+
+        @Nullable
+        private DartCallExpression getGroup(final DartCallExpression expression) {
+          return (DartCallExpression)PsiTreeUtil.findFirstParent(expression, true,
+                                                                 element -> element instanceof DartCallExpression &&
+                                                                            TestUtil.isGroup((DartCallExpression)element));
+        }
+      };
+
+      PsiTreeUtil.processElements(psiFile, collector);
+    }
+
+    return locations;
+  }
+
+  protected boolean isTest(@NotNull DartCallExpression expression) {
+    return TestUtil.isTest(expression);
+  }
+
+  @Nullable
+  public static String getTestLabel(@NotNull final DartCallExpression testCallExpression) {
+    final DartArguments arguments = testCallExpression.getArguments();
+    final DartArgumentList argumentList = arguments == null ? null : arguments.getArgumentList();
+    final List<DartExpression> argExpressions = argumentList == null ? null : argumentList.getExpressionList();
+    return argExpressions != null && !argExpressions.isEmpty() && argExpressions.get(0) instanceof DartStringLiteralExpression
+           ? StringUtil.unquoteString(argExpressions.get(0).getText())
+           : null;
+  }
+}


### PR DESCRIPTION
Adds:
  * line marker support for `testWidgets`
  * test tree rewriting to elide synthetic framework-generated test groups and fix location mapping

Fixes: #1181.

![image](https://user-images.githubusercontent.com/67586/28322361-c18126a8-6b8a-11e7-87cc-a935ca216c57.png)


![image](https://user-images.githubusercontent.com/67586/28322190-53b1856e-6b8a-11e7-877c-b3821e493052.png)

![image](https://user-images.githubusercontent.com/67586/28322402-dde0114c-6b8a-11e7-9763-72b4f76e3ecc.png)


@stevemessick 