### PR TITLE
re-enable flutter run in profile and release modes

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -317,16 +317,14 @@
         <keyboard-shortcut keymap="$default" first-keystroke="ctrl shift alt SEMICOLON"/>
         <keyboard-shortcut keymap="$default" first-keystroke="ctrl shift BACK_SLASH"/>
       </action>
-      <!-- Disabled pending fix (see #930)
       <action id="Flutter.Menu.RunProfileAction" class="io.flutter.actions.RunProfileFlutterApp"
-              description="Profile"
+              description="Flutter Run Profile Mode"
               icon="AllIcons.Actions.Profile">
       </action>
       <action id="Flutter.Menu.RunReleaseAction" class="io.flutter.actions.RunReleaseFlutterApp"
-              description="Release"
+              description="Flutter Run Release Mode"
               icon="AllIcons.Actions.Execute">
       </action>
-      -->
       <separator/>
       <add-to-group group-id="RunMenu" anchor="after" relative-to-action="Stop"/>
     </group>

--- a/src/io/flutter/FlutterBundle.properties
+++ b/src/io/flutter/FlutterBundle.properties
@@ -8,11 +8,11 @@ app.restart.action.text=Flutter Full Restart
 app.restart.action.description=Restart the Flutter app
 
 app.profile.action.text=Run in Flutter profile mode
-app.profile.config.action.text=Flutter Run ''{0}'' (Profile)
+app.profile.config.action.text=Flutter Run ''{0}'' in Profile Mode
 app.profile.action.description=Run Flutter app in profile mode
 
 app.release.action.text=Run in Flutter release mode
-app.release.config.action.text=Flutter Run ''{0}'' (Release)
+app.release.config.action.text=Flutter Run ''{0}'' in Release Mode
 app.release.action.description=Run Flutter app in release mode
 
 dart.plugin.update.action.label=Update Dart

--- a/src/io/flutter/actions/RunProfileFlutterApp.java
+++ b/src/io/flutter/actions/RunProfileFlutterApp.java
@@ -8,7 +8,7 @@ package io.flutter.actions;
 import com.intellij.icons.AllIcons;
 import com.intellij.openapi.wm.ToolWindowId;
 import io.flutter.FlutterBundle;
-
+import io.flutter.run.FlutterLaunchMode;
 
 @SuppressWarnings("ComponentNotRegistered")
 public class RunProfileFlutterApp extends RunFlutterAction {
@@ -17,7 +17,7 @@ public class RunProfileFlutterApp extends RunFlutterAction {
   private static final String TEXT_DETAIL_MSG_KEY = "app.profile.config.action.text";
 
   public RunProfileFlutterApp() {
-    super(TEXT, TEXT_DETAIL_MSG_KEY, DESCRIPTION, AllIcons.Actions.Execute, "--profile", ToolWindowId.RUN
+    super(TEXT, TEXT_DETAIL_MSG_KEY, DESCRIPTION, AllIcons.Actions.Execute, FlutterLaunchMode.PROFILE, ToolWindowId.RUN
     );
   }
 }

--- a/src/io/flutter/actions/RunReleaseFlutterApp.java
+++ b/src/io/flutter/actions/RunReleaseFlutterApp.java
@@ -8,7 +8,7 @@ package io.flutter.actions;
 import com.intellij.icons.AllIcons;
 import com.intellij.openapi.wm.ToolWindowId;
 import io.flutter.FlutterBundle;
-
+import io.flutter.run.FlutterLaunchMode;
 
 @SuppressWarnings("ComponentNotRegistered")
 public class RunReleaseFlutterApp extends RunFlutterAction {
@@ -17,7 +17,7 @@ public class RunReleaseFlutterApp extends RunFlutterAction {
   private static final String TEXT_DETAIL_MSG_KEY = "app.release.config.action.text";
 
   public RunReleaseFlutterApp() {
-    super(TEXT, TEXT_DETAIL_MSG_KEY, DESCRIPTION, AllIcons.Actions.Profile, "--release", ToolWindowId.RUN
+    super(TEXT, TEXT_DETAIL_MSG_KEY, DESCRIPTION, AllIcons.Actions.Profile, FlutterLaunchMode.RELEASE, ToolWindowId.RUN
     );
   }
 }

--- a/src/io/flutter/run/FlutterLaunchMode.java
+++ b/src/io/flutter/run/FlutterLaunchMode.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.run;
+
+import com.intellij.execution.runners.ExecutionEnvironment;
+import com.intellij.openapi.util.Key;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * The Flutter launch mode. This coresponds to the flutter run modes: --debug,
+ * --profile, and --release.
+ */
+public enum FlutterLaunchMode {
+  DEBUG("debug", true),
+
+  PROFILE("profile", false),
+
+  RELEASE("release", false);
+
+  public static final Key<FlutterLaunchMode> LAUNCH_MODE_KEY = Key.create("FlutterLaunchMode");
+
+  @NotNull
+  public static FlutterLaunchMode getMode(@NotNull ExecutionEnvironment env) {
+    final FlutterLaunchMode launchMode = env.getUserData(FlutterLaunchMode.LAUNCH_MODE_KEY);
+    return launchMode == null ? DEBUG : launchMode;
+  }
+
+  final private String myCliCommand;
+  final private boolean mySupportsDebugging;
+
+  FlutterLaunchMode(String cliCommand, boolean supportsDebugging) {
+    this.myCliCommand = cliCommand;
+    this.mySupportsDebugging = supportsDebugging;
+  }
+
+  public String getCliCommand() {
+    return myCliCommand;
+  }
+
+  public boolean supportsDebugging() {
+    return mySupportsDebugging;
+  }
+
+  public boolean supportsReload() {
+    return supportsDebugging();
+  }
+}

--- a/src/io/flutter/run/SdkRunConfig.java
+++ b/src/io/flutter/run/SdkRunConfig.java
@@ -87,7 +87,7 @@ public class SdkRunConfig extends LocatableConfigurationBase
 
     final LaunchState.Callback callback = (device) -> {
       final GeneralCommandLine command = fields.createFlutterSdkRunCommand(project, device, mode);
-      final FlutterApp app = FlutterApp.start(project, module, mode, command,
+      final FlutterApp app = FlutterApp.start(env, project, module, mode, command,
                                               StringUtil.capitalize(mode.mode()) + "App",
                                               "StopApp");
 

--- a/src/io/flutter/run/bazel/BazelFields.java
+++ b/src/io/flutter/run/bazel/BazelFields.java
@@ -283,10 +283,7 @@ public class BazelFields {
     if (target == null) return null;
     // Append _run[_hot] to bazelTarget.
     if (!target.endsWith("_run") && !target.endsWith(("_hot"))) {
-      target += "_run";
-      if (mode.isReloadEnabled()) {
-        target += "_hot";
-      }
+      target += "_run_hot";
     }
     return target;
   }

--- a/src/io/flutter/run/bazel/BazelRunConfig.java
+++ b/src/io/flutter/run/bazel/BazelRunConfig.java
@@ -71,7 +71,7 @@ public class BazelRunConfig extends RunConfigurationBase
 
     final LaunchState.Callback callback = (device) -> {
       final GeneralCommandLine command = launchFields.getLaunchCommand(env.getProject(), device, mode);
-      return FlutterApp.start(env.getProject(), module, mode, command,
+      return FlutterApp.start(env, env.getProject(), module, mode, command,
                               StringUtil.capitalize(mode.mode()) + "BazelApp", "StopBazelApp");
     };
 

--- a/src/io/flutter/run/daemon/RunMode.java
+++ b/src/io/flutter/run/daemon/RunMode.java
@@ -17,28 +17,19 @@ import org.jetbrains.annotations.NotNull;
  */
 public enum RunMode {
   @NonNls
-  DEBUG(DefaultDebugExecutor.EXECUTOR_ID, true),
+  DEBUG(DefaultDebugExecutor.EXECUTOR_ID),
 
   @NonNls
-  RUN(DefaultRunExecutor.EXECUTOR_ID, true);
+  RUN(DefaultRunExecutor.EXECUTOR_ID);
 
   private final String myModeString;
-  private final boolean myCanReload;
 
-  RunMode(String modeString, boolean canReload) {
+  RunMode(String modeString) {
     myModeString = modeString;
-    myCanReload = canReload;
   }
 
   public String mode() {
     return myModeString;
-  }
-
-  /**
-   * Returns true if this is a reload/restart enabled mode (run|debug).
-   */
-  public boolean isReloadEnabled() {
-    return myCanReload;
   }
 
   public static RunMode fromEnv(@NotNull ExecutionEnvironment env) throws ExecutionException {

--- a/src/io/flutter/run/test/DebugTestRunner.java
+++ b/src/io/flutter/run/test/DebugTestRunner.java
@@ -80,7 +80,7 @@ public class DebugTestRunner extends GenericProgramRunner {
       @Override
       @NotNull
       public XDebugProcess start(@NotNull final XDebugSession session) {
-        return new TestDebugProcess(session, executionResult, resolver, connector, mapper);
+        return new TestDebugProcess(env, session, executionResult, resolver, connector, mapper);
       }
     });
 

--- a/src/io/flutter/run/test/TestDebugProcess.java
+++ b/src/io/flutter/run/test/TestDebugProcess.java
@@ -6,6 +6,7 @@
 package io.flutter.run.test;
 
 import com.intellij.execution.ExecutionResult;
+import com.intellij.execution.runners.ExecutionEnvironment;
 import com.intellij.openapi.actionSystem.DefaultActionGroup;
 import com.intellij.xdebugger.XDebugSession;
 import com.jetbrains.lang.dart.ide.runner.ObservatoryConnector;
@@ -22,12 +23,13 @@ public class TestDebugProcess extends DartVmServiceDebugProcessZ {
   @NotNull
   private final ObservatoryConnector connector;
 
-  public TestDebugProcess(@NotNull XDebugSession session,
+  public TestDebugProcess(@NotNull ExecutionEnvironment executionEnvironment,
+                          @NotNull XDebugSession session,
                           @NotNull ExecutionResult executionResult,
                           @NotNull DartUrlResolver dartUrlResolver,
                           @NotNull ObservatoryConnector connector,
                           @NotNull PositionMapper mapper) {
-    super(session, executionResult, dartUrlResolver, connector, mapper);
+    super(executionEnvironment, session, executionResult, dartUrlResolver, connector, mapper);
     this.connector = connector;
   }
 

--- a/src/io/flutter/sdk/FlutterSdk.java
+++ b/src/io/flutter/sdk/FlutterSdk.java
@@ -137,9 +137,6 @@ public class FlutterSdk {
     if (mode == RunMode.DEBUG) {
       args.add("--start-paused");
     }
-    if (!mode.isReloadEnabled()) {
-      args.add("--no-hot");
-    }
     args.addAll(asList(additionalArgs));
 
     // Make the path to main relative (to make the command line prettier).


### PR DESCRIPTION
re-enable flutter run in profile and release modes (fix https://github.com/flutter/flutter-intellij/issues/930):
- re-enable launching in profile and release modes
- plumb the profile and release mode info down through the different debugger layers and abstractions
- ensure that we don't try and connect the debugger in profile or release mode
- ensure that the open observatory action is available in debug and profile modes, but not in release mode
- ensure that the reload action is available in debug mode, but not profile or release

@pq