### PR TITLE
adjust device list refresh

### DIFF
--- a/src/io/flutter/run/daemon/DeviceDaemon.java
+++ b/src/io/flutter/run/daemon/DeviceDaemon.java
@@ -219,11 +219,6 @@ class DeviceDaemon {
           try {
             ready.get(100, TimeUnit.MILLISECONDS);
 
-            // Try not to show a partial device list.
-            // It currently takes 4+ seconds for the devices to show up.
-            // Remove when fixed: https://github.com/flutter/flutter/issues/8439
-            Thread.sleep(4200);
-
             succeeded = true;
             return new DeviceDaemon(daemonId, this, process, listener, devices);
           }

--- a/src/io/flutter/run/daemon/DeviceService.java
+++ b/src/io/flutter/run/daemon/DeviceService.java
@@ -28,6 +28,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
+// TODO(devoncarew): This class performs blocking work on the UI thread; we should fix.
+
 /**
  * Provides the list of available devices (mobile phones or emulators) that appears in the dropdown menu.
  */
@@ -209,7 +211,7 @@ public class DeviceService {
     // immediately kill it. Also, delay a bit in case the flutter tool just upgraded the sdk;
     // we'll need a bit more time to start up.
     try {
-      Thread.sleep(2000);
+      Thread.sleep(100);
     }
     catch (InterruptedException e) {
       return previous;

--- a/src/io/flutter/run/daemon/DeviceService.java
+++ b/src/io/flutter/run/daemon/DeviceService.java
@@ -229,9 +229,12 @@ public class DeviceService {
   public void restart() {
     if (project.isDisposed()) return;
 
-    deviceDaemon.refresh(this::shutDownDaemon);
+    JobScheduler.getScheduler().schedule(this::shutDown, 0, TimeUnit.SECONDS);
+    JobScheduler.getScheduler().schedule(this::refreshDeviceDaemon, 4, TimeUnit.SECONDS);
+  }
 
-    JobScheduler.getScheduler().schedule(this::refreshDeviceDaemon, 1, TimeUnit.SECONDS);
+  private void shutDown() {
+    deviceDaemon.refresh(this::shutDownDaemon);
   }
 
   private DeviceDaemon shutDownDaemon(Refreshable.Request<DeviceDaemon> request) {


### PR DESCRIPTION
- adjust the device list refresh (some work towards https://github.com/flutter/flutter/issues/8439)
- don't use a fixed delay before we show devices in the pulldown
- do introduce a bit more delay when restarting the deamon process

@stevemessick @pq