### PR TITLE
Prepare for 'openSourceLocation' service registration

### DIFF
--- a/third_party/intellij-plugins-dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcessZ.java
+++ b/third_party/intellij-plugins-dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcessZ.java
@@ -405,6 +405,11 @@ public class DartVmServiceDebugProcessZ extends DartVmServiceDebugProcess {
     return mapper.getSourcePosition(isolateId, scriptRef, tokenPos);
   }
 
+  @Nullable
+  public XSourcePosition getSourcePosition(@NotNull final String isolateId, @NotNull final Script script, int tokenPos) {
+    return mapper.getSourcePosition(isolateId, script, tokenPos);
+  }
+
   public boolean getVmConnected() {
     return myVmConnected;
   }
@@ -438,6 +443,11 @@ public class DartVmServiceDebugProcessZ extends DartVmServiceDebugProcess {
      * Returns the local position (to display to the user) corresponding to a token position in Observatory.
      */
     XSourcePosition getSourcePosition(String isolateId, ScriptRef scriptRef, int tokenPos);
+
+    /**
+     * Returns the local position (to display to the user) corresponding to a token position in Observatory.
+     */
+    XSourcePosition getSourcePosition(String isolateId, Script script, int tokenPos);
 
     void shutdown();
   }


### PR DESCRIPTION
Non breaking change to the `DartVmServiceDebugProcessZ` in order to get ready for the introduction of the `openSourceLocation` service.

Related https://github.com/dart-lang/sdk/issues/30023
Related https://github.com/B3rn475/intellij-plugins/tree/172