### PR TITLE
fix an exception upgrading the module type in webstorm

### DIFF
--- a/src/io/flutter/FlutterBundle.properties
+++ b/src/io/flutter/FlutterBundle.properties
@@ -70,8 +70,8 @@ flutter.analytics.notification.accept=Sounds good!
 flutter.analytics.notification.decline=No thanks
 flutter.analytics.privacyUrl=http://www.google.com/policies/privacy/
 
-flutter.initializer.module.converted.title=Module Type Upgraded
-flutter.initializer.module.converted.content=Project converted from FLUTTER_MODULE_TYPE
+flutter.initializer.module.converted.title=Flutter module type updated
+flutter.initializer.module.converted.content=Converted from type 'FLUTTER_MODULE_TYPE'.
 
 flutter.reload.firstRun.title=Flutter supports hot reload!
 flutter.reload.firstRun.content=Apply changes to your app in place, instantly.

--- a/src/io/flutter/module/FlutterModuleBuilder.java
+++ b/src/io/flutter/module/FlutterModuleBuilder.java
@@ -227,7 +227,7 @@ public class FlutterModuleBuilder extends ModuleBuilder {
   @Override
   @NotNull
   public ModuleType getModuleType() {
-    return FlutterModuleUtils.getModuleTypeForFlutter();
+    return ModuleTypeManager.getInstance().findByID(FlutterModuleUtils.getModuleTypeIDForFlutter());
   }
 
   /**

--- a/src/io/flutter/module/FlutterModuleConfigurationEditorProvider.java
+++ b/src/io/flutter/module/FlutterModuleConfigurationEditorProvider.java
@@ -17,10 +17,12 @@ public class FlutterModuleConfigurationEditorProvider implements ModuleConfigura
   @Override
   public ModuleConfigurationEditor[] createEditors(ModuleConfigurationState state) {
     final Module module = state.getRootModel().getModule();
+    final ModuleType moduleType = ModuleType.get(module);
 
-    if (ModuleType.get(module) != FlutterModuleUtils.getModuleTypeForFlutter()) {
+    if (!moduleType.getId().equals(FlutterModuleUtils.getModuleTypeIDForFlutter())) {
       return ModuleConfigurationEditor.EMPTY;
     }
+
     return new ModuleConfigurationEditor[]{new CommonContentEntriesEditor(module.getName(), state)};
   }
 }

--- a/src/io/flutter/utils/FlutterModuleUtils.java
+++ b/src/io/flutter/utils/FlutterModuleUtils.java
@@ -9,7 +9,10 @@ import com.intellij.execution.RunManager;
 import com.intellij.execution.RunnerAndConfigurationSettings;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.fileEditor.FileEditorManager;
-import com.intellij.openapi.module.*;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleManager;
+import com.intellij.openapi.module.ModuleType;
+import com.intellij.openapi.module.ModuleUtil;
 import com.intellij.openapi.project.DumbService;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
@@ -44,14 +47,14 @@ public class FlutterModuleUtils {
   }
 
   /**
-   * This provides the {@link ModuleType} for Flutter modules to be assigned by the {@link io.flutter.module.FlutterModuleBuilder} and
+   * This provides the {@link ModuleType} ID for Flutter modules to be assigned by the {@link io.flutter.module.FlutterModuleBuilder} and
    * elsewhere in the Flutter plugin.
    * <p/>
    * For Flutter module detection however, {@link ModuleType}s should not be used to determine Flutterness.
    */
   @NotNull
-  public static ModuleType getModuleTypeForFlutter() {
-    return WebModuleType.getInstance();
+  public static String getModuleTypeIDForFlutter() {
+    return "WEB_MODULE";
   }
 
   /**
@@ -230,10 +233,10 @@ public class FlutterModuleUtils {
   }
 
   /**
-   * Set the passed module to the module type used by Flutter, defined by {@link #getModuleTypeForFlutter()}.
+   * Set the passed module to the module type used by Flutter, defined by {@link #getModuleTypeIDForFlutter()}.
    */
   public static void setFlutterModuleType(@NotNull Module module) {
-    module.setOption(Module.ELEMENT_TYPE, getModuleTypeForFlutter().getId());
+    module.setOption(Module.ELEMENT_TYPE, getModuleTypeIDForFlutter());
   }
 
   public static void setFlutterModuleAndReload(@NotNull Module module, @NotNull Project project) {


### PR DESCRIPTION
- fix an exception upgrading the module type in webstorm; the `WebModuleType.getInstance()` will always throw an exception in webstorm (2017.2?) - we work around the issue by using IDs
- fix https://github.com/flutter/flutter-intellij/issues/1239
- wordsmithing of the module upgrade text

@pq 