### PR TITLE
de-dupe device names

### DIFF
--- a/src/io/flutter/actions/DeviceSelectorAction.java
+++ b/src/io/flutter/actions/DeviceSelectorAction.java
@@ -99,8 +99,8 @@ public class DeviceSelectorAction extends ComboBoxAction implements DumbAware {
 
     final Collection<FlutterDevice> devices = service.getConnectedDevices();
 
-    for (FlutterDevice item : devices) {
-      actions.add(new SelectDeviceAction(item));
+    for (FlutterDevice device : devices) {
+      actions.add(new SelectDeviceAction(device, devices));
     }
 
     if (actions.isEmpty()) {
@@ -145,7 +145,7 @@ public class DeviceSelectorAction extends ComboBoxAction implements DumbAware {
 
           final Presentation template = action.getTemplatePresentation();
           presentation.setIcon(template.getIcon());
-          presentation.setText(template.getText());
+          presentation.setText(deviceAction.deviceName());
           presentation.setEnabled(true);
           return;
         }
@@ -187,9 +187,13 @@ public class DeviceSelectorAction extends ComboBoxAction implements DumbAware {
     @NotNull
     private final FlutterDevice device;
 
-    SelectDeviceAction(@NotNull FlutterDevice device) {
-      super(device.deviceName(), null, FlutterIcons.Phone);
+    SelectDeviceAction(@NotNull FlutterDevice device, @NotNull Collection<FlutterDevice> devices) {
+      super(device.getUniqueName(devices), null, FlutterIcons.Phone);
       this.device = device;
+    }
+
+    public String deviceName() {
+      return device.deviceName();
     }
 
     @Override

--- a/src/io/flutter/run/daemon/FlutterDevice.java
+++ b/src/io/flutter/run/daemon/FlutterDevice.java
@@ -8,6 +8,7 @@ package io.flutter.run.daemon;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
 import java.util.Objects;
 
 public class FlutterDevice {
@@ -23,15 +24,18 @@ public class FlutterDevice {
     myEmulator = emulator;
   }
 
-  public @NotNull String deviceId() {
+  @NotNull
+  public String deviceId() {
     return myDeviceId;
   }
 
-  public @NotNull String deviceName() {
+  @NotNull
+  public String deviceName() {
     return myDeviceName;
   }
 
-  public @Nullable String platform() {
+  @Nullable
+  public String platform() {
     return myPlatform;
   }
 
@@ -64,5 +68,20 @@ public class FlutterDevice {
   @Override
   public String toString() {
     return myDeviceName;
+  }
+
+  /**
+   * Given a collection of devices, return a unique name for this device.
+   */
+  public String getUniqueName(Collection<FlutterDevice> devices) {
+    for (final FlutterDevice other : devices) {
+      if (other == this) {
+        continue;
+      }
+      if (other.deviceName().equals(deviceName())) {
+        return deviceName() + " (" + deviceId() + ")";
+      }
+    }
+    return deviceName();
   }
 }


### PR DESCRIPTION
- ensure that we show a unique name in the device dropdown - if there are different devices with the same name, display the name with the device id as well (some work towards https://github.com/flutter/flutter-intellij/issues/1244)

So, Instead of `Foo Device`, show `Foo Device (device-id)`.