### PR TITLE
Migrate to a LinkLabel

### DIFF
--- a/src/io/flutter/FlutterBundle.properties
+++ b/src/io/flutter/FlutterBundle.properties
@@ -112,7 +112,7 @@ flutter.module.create.settings.includedriver.label=Include driver test:
 flutter.module.create.settings.includedriver.tip=Include generating a driver test.
 
 flutter.module.create.settings.help.label=Help:
-flutter.module.create.settings.help.getting_started_html=<html><a href="https://flutter.io/getting-started/">Getting started with your first Flutter app.</a></html>
+flutter.module.create.settings.help.getting_started_link_text=Getting started with your first Flutter app.
 flutter.module.create.settings.help.project_name.label=Project name:
 flutter.module.create.settings.help.project_name.description=Enter the project name with all lower case letters.
 flutter.module.create.settings.help.org.label=Organization:

--- a/src/io/flutter/module/settings/SettingsHelpForm.form
+++ b/src/io/flutter/module/settings/SettingsHelpForm.form
@@ -100,13 +100,11 @@
             <properties/>
             <border type="none"/>
             <children>
-              <component id="26e7" class="javax.swing.JTextPane" binding="gettingStartedUrl">
+              <component id="6a451" class="com.intellij.ui.components.labels.LinkLabel" binding="gettingStartedUrl">
                 <constraints>
                   <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="6" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
-                  <contentType value="text/html"/>
-                  <editable value="false"/>
                   <opaque value="false"/>
                 </properties>
               </component>

--- a/src/io/flutter/module/settings/SettingsHelpForm.java
+++ b/src/io/flutter/module/settings/SettingsHelpForm.java
@@ -5,16 +5,13 @@
  */
 package io.flutter.module.settings;
 
+import com.intellij.ide.browsers.BrowserLauncher;
+import com.intellij.ui.components.labels.LinkLabel;
 import io.flutter.FlutterBundle;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
 import java.awt.*;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
-import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
 
 /**
  * The settings panel that list helps.
@@ -35,7 +32,7 @@ public class SettingsHelpForm {
   private JLabel orgLabel;
   private JLabel orgDescription;
 
-  private JTextPane gettingStartedUrl;
+  private LinkLabel gettingStartedUrl;
 
   public SettingsHelpForm() {
     projectNameLabel.setText(FlutterBundle.message("flutter.module.create.settings.help.label"));
@@ -50,26 +47,14 @@ public class SettingsHelpForm {
     orgLabel.setText(FlutterBundle.message("flutter.module.create.settings.help.org.label"));
     orgDescription.setText(FlutterBundle.message("flutter.module.create.settings.help.org.description"));
 
-    gettingStartedUrl.setText(FlutterBundle.message("flutter.module.create.settings.help.getting_started_html"));
+    gettingStartedUrl.setText(FlutterBundle.message("flutter.module.create.settings.help.getting_started_link_text"));
     gettingStartedUrl.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
-    gettingStartedUrl.addMouseListener(new MouseAdapter() {
-      public void mouseClicked(MouseEvent e) {
-        if (e.getClickCount() > 0) {
-          if (Desktop.isDesktopSupported()) {
-            Desktop desktop = Desktop.getDesktop();
-            try {
-              URI uri = new URI("https://flutter.io/getting-started/");
-              desktop.browse(uri);
-            } catch (IOException | URISyntaxException ex) {
-              // do nothing
-            }
-          } else {
-            //do nothing
-          }
-        }
-      }
-    });
+    gettingStartedUrl.setIcon(null);
+    //noinspection unchecked
+    gettingStartedUrl
+      .setListener((label, linkUrl) -> BrowserLauncher.getInstance().browse("https://flutter.io/getting-started/", null), null);
   }
+
 
   @NotNull
   public JComponent getComponent() {


### PR DESCRIPTION
As per the discussion in https://github.com/flutter/flutter-intellij/pull/1232, migrates us to a LinkLabel.

![image](https://user-images.githubusercontent.com/67586/28795847-2f7d31f0-75f0-11e7-85bf-2a23f1f159f8.png)


@branflake2267 @devoncarew 