### PR TITLE
Eliminate dep on commons-lang3

### DIFF
--- a/src/io/flutter/sdk/FlutterCreateAdditionalSettings.java
+++ b/src/io/flutter/sdk/FlutterCreateAdditionalSettings.java
@@ -6,12 +6,72 @@
 package io.flutter.sdk;
 
 import com.intellij.openapi.util.text.StringUtil;
-import org.apache.commons.lang3.BooleanUtils;
 import org.jetbrains.annotations.Nullable;
+
 import java.util.ArrayList;
 import java.util.List;
 
 public class FlutterCreateAdditionalSettings {
+  @Nullable
+  private Boolean includeDriverTest;
+  @Nullable
+  private Boolean generatePlugin;
+  @Nullable
+  private String description;
+  @Nullable
+  private String org;
+  @Nullable
+  private Boolean swift;
+  @Nullable
+  private Boolean kotlin;
+  private FlutterCreateAdditionalSettings(@Nullable Boolean includeDriverTest,
+                                          @Nullable Boolean generatePlugin,
+                                          @Nullable String description,
+                                          @Nullable String org,
+                                          @Nullable Boolean swift,
+                                          @Nullable Boolean kotlin) {
+    this.includeDriverTest = includeDriverTest;
+    this.generatePlugin = generatePlugin;
+    this.description = description;
+    this.org = org;
+    this.swift = swift;
+    this.kotlin = kotlin;
+  }
+
+  public List<String> getArgs() {
+    final List<String> args = new ArrayList<>();
+
+    if (Boolean.TRUE.equals(includeDriverTest)) {
+      args.add("--with-driver-test");
+    }
+
+    if (Boolean.TRUE.equals(generatePlugin)) {
+      args.add("--plugin");
+    }
+
+    if (!StringUtil.isEmptyOrSpaces(description)) {
+      args.add("--description");
+      args.add(description);
+    }
+
+    if (!StringUtil.isEmptyOrSpaces(org)) {
+      args.add("--org");
+      args.add(org);
+    }
+
+    if (Boolean.TRUE.equals(swift)) {
+      args.add("--ios-language");
+      args.add("swift");
+    }
+
+    if (Boolean.TRUE.equals(kotlin)) {
+      args.add("--android-language");
+      args.add("kotlin");
+    }
+
+    return args;
+  }
+
   public static class Builder {
     @Nullable
     private Boolean includeDriverTest;
@@ -62,66 +122,5 @@ public class FlutterCreateAdditionalSettings {
     public FlutterCreateAdditionalSettings build() {
       return new FlutterCreateAdditionalSettings(includeDriverTest, generatePlugin, description, org, swift, kotlin);
     }
-  }
-
-  @Nullable
-  private Boolean includeDriverTest;
-  @Nullable
-  private Boolean generatePlugin;
-  @Nullable
-  private String description;
-  @Nullable
-  private String org;
-  @Nullable
-  private Boolean swift;
-  @Nullable
-  private Boolean kotlin;
-
-  private FlutterCreateAdditionalSettings(Boolean includeDriverTest,
-                                          Boolean generatePlugin,
-                                          String description,
-                                          String org,
-                                          Boolean swift,
-                                          Boolean kotlin) {
-    this.includeDriverTest = includeDriverTest;
-    this.generatePlugin = generatePlugin;
-    this.description = description;
-    this.org = org;
-    this.swift = swift;
-    this.kotlin = kotlin;
-  }
-
-  public List<String> getArgs() {
-    final List<String> args = new ArrayList<>();
-
-    if (BooleanUtils.isTrue(includeDriverTest)) {
-      args.add("--with-driver-test");
-    }
-
-    if (BooleanUtils.isTrue(generatePlugin)) {
-      args.add("--plugin");
-    }
-
-    if (!StringUtil.isEmptyOrSpaces(description) ) {
-      args.add("--description");
-      args.add(description);
-    }
-
-    if (!StringUtil.isEmptyOrSpaces(org)) {
-      args.add("--org");
-      args.add(org);
-    }
-
-    if (BooleanUtils.isTrue(swift)) {
-      args.add("--ios-language");
-      args.add("swift");
-    }
-
-    if (BooleanUtils.isTrue(kotlin)) {
-      args.add("--android-language");
-      args.add("kotlin");
-    }
-
-    return args;
   }
 }


### PR DESCRIPTION
Android Studio 3.0 canary 9 does not include the Apache commons-lang3 library. We could distribute it, but it seems easier to in-line the single function that is used.

@pq @devoncarew 