### PR TITLE
allow running on a second device

### DIFF
--- a/src/io/flutter/run/SdkRunConfig.java
+++ b/src/io/flutter/run/SdkRunConfig.java
@@ -87,7 +87,7 @@ public class SdkRunConfig extends LocatableConfigurationBase
 
     final LaunchState.Callback callback = (device) -> {
       final GeneralCommandLine command = fields.createFlutterSdkRunCommand(project, device, mode);
-      final FlutterApp app = FlutterApp.start(env, project, module, mode, command,
+      final FlutterApp app = FlutterApp.start(env, project, module, mode, device, command,
                                               StringUtil.capitalize(mode.mode()) + "App",
                                               "StopApp");
 

--- a/src/io/flutter/run/bazel/BazelRunConfig.java
+++ b/src/io/flutter/run/bazel/BazelRunConfig.java
@@ -71,7 +71,7 @@ public class BazelRunConfig extends RunConfigurationBase
 
     final LaunchState.Callback callback = (device) -> {
       final GeneralCommandLine command = launchFields.getLaunchCommand(env.getProject(), device, mode);
-      return FlutterApp.start(env, env.getProject(), module, mode, command,
+      return FlutterApp.start(env, env.getProject(), module, mode, device, command,
                               StringUtil.capitalize(mode.mode()) + "BazelApp", "StopBazelApp");
     };
 

--- a/src/io/flutter/run/daemon/FlutterApp.java
+++ b/src/io/flutter/run/daemon/FlutterApp.java
@@ -49,6 +49,7 @@ public class FlutterApp {
   private final @NotNull Project myProject;
   private final @Nullable Module myModule;
   private final @NotNull RunMode myMode;
+  private final @NotNull String myDeviceId;
   private final @NotNull ProcessHandler myProcessHandler;
   private final @NotNull ExecutionEnvironment myExecutionEnvironment;
   private final @NotNull DaemonApi myDaemonApi;
@@ -73,12 +74,14 @@ public class FlutterApp {
   FlutterApp(@NotNull Project project,
              @Nullable Module module,
              @NotNull RunMode mode,
+             @NotNull String deviceId,
              @NotNull ProcessHandler processHandler,
              @NotNull ExecutionEnvironment executionEnvironment,
              @NotNull DaemonApi daemonApi) {
     myProject = project;
     myModule = module;
     myMode = mode;
+    myDeviceId = deviceId;
     myProcessHandler = processHandler;
     myProcessHandler.putUserData(FLUTTER_APP_KEY, this);
     myExecutionEnvironment = executionEnvironment;
@@ -139,6 +142,7 @@ public class FlutterApp {
                                  @NotNull Project project,
                                  @Nullable Module module,
                                  @NotNull RunMode mode,
+                                 @NotNull FlutterDevice device,
                                  @NotNull GeneralCommandLine command,
                                  @NotNull String analyticsStart,
                                  @NotNull String analyticsStop)
@@ -160,7 +164,7 @@ public class FlutterApp {
     });
 
     final DaemonApi api = new DaemonApi(process);
-    final FlutterApp app = new FlutterApp(project, module, mode, process, env, api);
+    final FlutterApp app = new FlutterApp(project, module, mode, device.deviceId(), process, env, api);
     api.listen(process, new FlutterAppListener(app, project));
     return app;
   }
@@ -420,6 +424,10 @@ public class FlutterApp {
 
   public FlutterLaunchMode getLaunchMode() {
     return FlutterLaunchMode.getMode(myExecutionEnvironment);
+  }
+
+  public String deviceId() {
+    return myDeviceId;
   }
 
   public interface StateListener {


### PR DESCRIPTION
- fix https://github.com/flutter/flutter-intellij/issues/1254

This fixes an issue with the run action when there is a currently running app, and the user has two devices connected. Previously we ignored the device selection when deciding to issue a restart command (the user hits running with a currently running app). We now pay attention to the device selection, and will instead launch an app on that second device.

As part of fixed that issue, I also fixed one where the retargetable actions (reload and restart) would send their command to the last launched app. They now target the foreground process (which we determine via the last process that queried for `update()` in their actions, there being no real API in IntelliJ to determine the active launched process).

@pq @stevemessick 