### PR TITLE
iterate on the reload on save UI

### DIFF
--- a/src/io/flutter/actions/FlutterAppAction.java
+++ b/src/io/flutter/actions/FlutterAppAction.java
@@ -6,7 +6,6 @@
 package io.flutter.actions;
 
 import com.intellij.openapi.actionSystem.ActionManager;
-import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.DumbAwareAction;
@@ -43,7 +42,7 @@ abstract public class FlutterAppAction extends DumbAwareAction {
     myIsApplicable = isApplicable;
     myActionId = actionId;
 
-    updateActionRegistration(myIsApplicable.compute());
+    updateActionRegistration(app.isConnected());
   }
 
   private void updateActionRegistration(boolean isConnected) {
@@ -66,8 +65,9 @@ abstract public class FlutterAppAction extends DumbAwareAction {
 
   @Override
   public void update(@NotNull final AnActionEvent e) {
+    updateActionRegistration(myApp.isConnected());
+
     final boolean isConnected = myIsApplicable.compute();
-    updateActionRegistration(isConnected);
     e.getPresentation().setEnabled(myApp.isStarted() && isConnected);
 
     if (isConnected) {

--- a/src/io/flutter/run/FlutterReloadManager.java
+++ b/src/io/flutter/run/FlutterReloadManager.java
@@ -16,34 +16,52 @@ import com.intellij.openapi.actionSystem.*;
 import com.intellij.openapi.actionSystem.ex.ActionManagerEx;
 import com.intellij.openapi.actionSystem.ex.AnActionListener;
 import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.editor.ex.EditorEx;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleUtil;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.wm.ToolWindowId;
 import com.intellij.psi.PsiDocumentManager;
 import com.intellij.psi.PsiErrorElement;
 import com.intellij.psi.PsiFile;
+import com.intellij.psi.search.GlobalSearchScope;
+import com.intellij.psi.search.SearchScope;
 import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.ui.LightweightHint;
+import com.intellij.util.ReflectionUtil;
 import com.jetbrains.lang.dart.DartPluginCapabilities;
+import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService;
+import com.jetbrains.lang.dart.analyzer.DartServerData;
+import com.jetbrains.lang.dart.ide.errorTreeView.DartProblemsView;
 import icons.FlutterIcons;
 import io.flutter.actions.FlutterAppAction;
 import io.flutter.actions.ReloadFlutterApp;
 import io.flutter.run.daemon.FlutterApp;
 import io.flutter.run.daemon.RunMode;
 import io.flutter.settings.FlutterSettings;
+import org.dartlang.analysis.server.protocol.AnalysisErrorSeverity;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 /**
  * Handle the mechanics of performing a hot reload on file save.
  */
 public class FlutterReloadManager {
+  private static final Logger LOG = Logger.getInstance(FlutterReloadManager.class.getName());
+
   private final @NotNull Project myProject;
   private final FlutterSettings mySettings;
 
@@ -64,25 +82,21 @@ public class FlutterReloadManager {
     this.mySettings = FlutterSettings.getInstance(myProject);
 
     ActionManagerEx.getInstanceEx().addAnActionListener(new AnActionListener.Adapter() {
-      boolean hadUnsavedDocuments;
-
-      @Override
-      public void beforeActionPerformed(AnAction action, DataContext dataContext, AnActionEvent event) {
-        if (action instanceof SaveAllAction) {
-          hadUnsavedDocuments = FileDocumentManager.getInstance().getUnsavedDocuments().length > 0;
-        }
-      }
-
       @Override
       public void afterActionPerformed(AnAction action, DataContext dataContext, AnActionEvent event) {
         if (action instanceof SaveAllAction) {
-          handleSaveAllNotification(hadUnsavedDocuments, event);
+          try {
+            handleSaveAllNotification(event);
+          }
+          catch (Throwable t) {
+            LOG.error(t);
+          }
         }
       }
     }, project);
   }
 
-  private void handleSaveAllNotification(boolean hadUnsavedDocuments, AnActionEvent event) {
+  private void handleSaveAllNotification(AnActionEvent event) {
     if (!mySettings.isReloadOnSave()) {
       return;
     }
@@ -98,31 +112,42 @@ public class FlutterReloadManager {
     }
 
     @Nullable final Editor editor = CommonDataKeys.EDITOR.getData(event.getDataContext());
-    if (editor != null) {
-      // Check for syntax errors in the file - we'll reload after they fix and save.
-      if (documentHasErrors(editor.getDocument())) {
-        return;
-      }
+    if (editor == null) {
+      return;
     }
 
-    // Reload if there are any unsaved files, or if there were any changed project
-    // files since the last reload.
-    if (hadUnsavedDocuments || app.hasChangesSinceLastReload()) {
-      if (editor != null) {
-        showNotification(editor, "Performing hot reload…", false);
-      }
+    if (!(editor instanceof EditorEx)) {
+      return;
+    }
+
+    final EditorEx editorEx = (EditorEx)editor;
+    final VirtualFile file = editorEx.getVirtualFile();
+    final Project project = editor.getProject();
+    if (file == null || project == null) {
+      return;
+    }
+    final Module module = ModuleUtil.findModuleForFile(file, project);
+    if (module == null) {
+      return;
+    }
+
+    // Only reload if it's in the same module.
+    if (!app.isSameModule(module)) {
+      return;
+    }
+
+    if (hasErrors(project, module, editor.getDocument())) {
+      showNotification(editor, "Reload not performed", true);
+      showAnalysisNotification("Analysis issues found");
+    }
+    else {
+      final LightweightHint hint = showNotification(editor, "Reloading…", false);
 
       app.performHotReload(supportsPauseAfterReload()).thenAccept(result -> {
-        if (result.ok()) {
-          return;
-        }
+        hint.hide();
 
-        if (editor != null) {
+        if (!result.ok()) {
           showNotification(editor, result.getMessage(), true);
-        }
-        else {
-          // TODO(devoncarew): Improve flutter_tools reload error messages.
-          showRunNotificationError(app, "Hot Reload", result.getMessage());
         }
       });
     }
@@ -158,6 +183,14 @@ public class FlutterReloadManager {
     return null;
   }
 
+  private void showAnalysisNotification(String message) {
+    final NotificationGroup notificationGroup =
+      NotificationGroup.toolWindowGroup(FlutterRunNotifications.GROUP_DISPLAY_ID, DartProblemsView.TOOLWINDOW_ID, false);
+    final Notification notification = notificationGroup.createNotification(message, NotificationType.ERROR);
+    notification.setIcon(FlutterIcons.Flutter);
+    notification.notify(myProject);
+  }
+
   private void showRunNotificationError(FlutterApp app, String title, String message) {
     final String toolWindowId = app.getMode() == RunMode.RUN ? ToolWindowId.RUN : ToolWindowId.DEBUG;
     final NotificationGroup notificationGroup =
@@ -177,24 +210,49 @@ public class FlutterReloadManager {
     return DartPluginCapabilities.isSupported("supports.pausePostRequest");
   }
 
-  // TODO(devoncarew): This technique still allows some syntax errors through; can we
-  // improve the IntelliJ grammer? Are there other issues in the AST we should look for?
-  private boolean documentHasErrors(@NotNull Document document) {
-    final PsiFile psiFile = PsiDocumentManager.getInstance(myProject).getPsiFile(document);
-    final PsiErrorElement firstError = PsiTreeUtil.findChildOfType(psiFile, PsiErrorElement.class, false);
-    return firstError != null;
+  private boolean hasErrors(@NotNull Project project, @NotNull Module module, @NotNull Document document) {
+    // For 2017.1, we use the IntelliJ parser and look for syntax errors in the current document.
+    // For 2017.2 and later, we instead rely on the analysis server's results for files in the app's module.
+
+    final DartAnalysisServerService analysisServerService = DartAnalysisServerService.getInstance(project);
+
+    // TODO(devoncarew): Remove the use of reflection when our minimum revs to 2017.2.
+    final Method getErrorsMethod = ReflectionUtil.getMethod(analysisServerService.getClass(), "getErrors", SearchScope.class);
+    if (getErrorsMethod == null) {
+      final PsiFile psiFile = PsiDocumentManager.getInstance(myProject).getPsiFile(document);
+      final PsiErrorElement firstError = PsiTreeUtil.findChildOfType(psiFile, PsiErrorElement.class, false);
+      return firstError != null;
+    }
+    else {
+      final GlobalSearchScope scope = module.getModuleContentScope();
+      try {
+        //List<DartServerData.DartError> errors = analysisServerService.getErrors(scope);
+        //noinspection unchecked
+        List<DartServerData.DartError> errors = (List<DartServerData.DartError>)getErrorsMethod.invoke(analysisServerService, scope);
+        errors = errors.stream().filter(error -> error.getSeverity().equals(AnalysisErrorSeverity.ERROR)).collect(Collectors.toList());
+        return !errors.isEmpty();
+      }
+      catch (IllegalAccessException | InvocationTargetException e) {
+        return false;
+      }
+    }
   }
 
-  private void showNotification(@NotNull Editor editor, String message, boolean isError) {
-    ApplicationManager.getApplication().invokeLater(() -> {
+  private LightweightHint showNotification(@NotNull Editor editor, String message, boolean isError) {
+    final AtomicReference<LightweightHint> ref = new AtomicReference<>();
+
+    ApplicationManager.getApplication().invokeAndWait(() -> {
       final JComponent component = isError
                                    ? HintUtil.createErrorLabel(message)
                                    : HintUtil.createInformationLabel(message);
       final LightweightHint hint = new LightweightHint(component);
+      ref.set(hint);
       HintManagerImpl.getInstanceImpl().showEditorHint(
         hint, editor, HintManager.UNDER,
         HintManager.HIDE_BY_ANY_KEY | HintManager.HIDE_BY_TEXT_CHANGE | HintManager.HIDE_BY_SCROLLING | HintManager.HIDE_BY_OTHER_HINT,
         isError ? 0 : 3000, false);
-    }, ModalityState.NON_MODAL, o -> editor.isDisposed() || !editor.getComponent().isShowing());
+    });
+
+    return ref.get();
   }
 }


### PR DESCRIPTION
Some iteration on the reload on save UI (fix https://github.com/flutter/flutter-intellij/issues/1215):
- fix an issue where the reload actions could become disabled when the run or debug views were not front-most
- remove the code to only reload on save if there had been changes since the last reload
- always provide reload UI feedback on save (if there is an open document and a flutter app is running)
- switch to using the information from the analysis server to determine whether to reload
- if there are errors, show an in-line notification (Reload not performed), and a decoration on the analysis view
- show 'reloading...' when starting a normal reload

![screen shot 2017-08-14 at 1 27 10 pm](https://user-images.githubusercontent.com/1269969/29290510-37045506-80f5-11e7-90ef-0c77186efa0e.png)

![screen shot 2017-08-14 at 1 27 15 pm](https://user-images.githubusercontent.com/1269969/29290516-3c34f6b6-80f5-11e7-8dba-78b7ff85317b.png)

@stevemessick 