### PR TITLE
additional changes to the reload on save workflow

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -403,7 +403,7 @@
 
     <projectService serviceImplementation="io.flutter.sdk.FlutterSdkManager"/>
 
-    <projectService serviceInterface="io.flutter.settings.FlutterSettings"
+    <applicationService serviceInterface="io.flutter.settings.FlutterSettings"
                     serviceImplementation="io.flutter.settings.FlutterSettings"
                     overrides="false"/>
 

--- a/src/io/flutter/FlutterBundle.properties
+++ b/src/io/flutter/FlutterBundle.properties
@@ -65,12 +65,9 @@ flutter.run.bazel.noLaunchingScript=no launching script specified
 flutter.run.bazel.launchingScriptNotFound=launching script not found: {0}
 flutter.run.bazel.noTargetSet=no Bazel target set
 
-flutter.analytics.notification.title=Welcome to Flutter!
 flutter.analytics.notification.content=The Flutter plugin anonymously reports feature usage statistics and crash reports to Google \
   in order to help Google contribute improvements to Flutter over time. See Google's privacy policy: \
   <a href="url">www.google.com/policies/privacy</a>.<br><br>Send anonymous usage statistics?
-flutter.analytics.notification.accept=Sounds good!
-flutter.analytics.notification.decline=No thanks
 flutter.analytics.privacyUrl=http://www.google.com/policies/privacy/
 
 flutter.initializer.module.converted.title=Flutter module type updated

--- a/src/io/flutter/FlutterInitializer.java
+++ b/src/io/flutter/FlutterInitializer.java
@@ -26,6 +26,7 @@ import io.flutter.pub.PubRoot;
 import io.flutter.run.FlutterReloadManager;
 import io.flutter.run.FlutterRunNotifications;
 import io.flutter.run.daemon.DeviceService;
+import io.flutter.settings.FlutterSettings;
 import io.flutter.utils.FlutterModuleUtils;
 import io.flutter.view.FlutterViewFactory;
 import org.jetbrains.annotations.NotNull;
@@ -44,8 +45,6 @@ public class FlutterInitializer implements StartupActivity {
   private static final String analyticsClientIdKey = "io.flutter.analytics.clientId";
   private static final String analyticsOptOutKey = "io.flutter.analytics.optOut";
   private static final String analyticsToastShown = "io.flutter.analytics.toastShown";
-  private static final String verboseLoggingKey = "io.flutter.verboseLogging";
-  private static final String memoryDashboardKey = "io.flutter.memoryDashboard";
 
   private static Analytics analytics;
 
@@ -70,6 +69,8 @@ public class FlutterInitializer implements StartupActivity {
 
       // Send initial loading hit.
       analytics.sendScreenView("main");
+
+      FlutterSettings.getInstance().sendSettingsToAnalytics(analytics);
     }
 
     return analytics;
@@ -102,26 +103,6 @@ public class FlutterInitializer implements StartupActivity {
 
   public static void sendAnalyticsAction(@NotNull String name) {
     getAnalytics().sendEvent("intellij", name);
-  }
-
-  public static boolean isVerboseLogging() {
-    final PropertiesComponent properties = PropertiesComponent.getInstance();
-    return properties.getBoolean(verboseLoggingKey, false);
-  }
-
-  public static void setVerboseLogging(boolean value) {
-    final PropertiesComponent properties = PropertiesComponent.getInstance();
-    properties.setValue(verboseLoggingKey, value);
-  }
-
-  public static boolean isMemoryDashboardEnabled() {
-    final PropertiesComponent properties = PropertiesComponent.getInstance();
-    return properties.getBoolean(memoryDashboardKey, false);
-  }
-
-  public static void setMemoryDashboardEnabled(boolean value) {
-    final PropertiesComponent properties = PropertiesComponent.getInstance();
-    properties.setValue(memoryDashboardKey, value);
   }
 
   @Override
@@ -174,7 +155,7 @@ public class FlutterInitializer implements StartupActivity {
 
       final Notification notification = new Notification(
         Analytics.GROUP_DISPLAY_ID,
-        FlutterBundle.message("flutter.analytics.notification.title"),
+        "Welcome to Flutter!",
         FlutterBundle.message("flutter.analytics.notification.content"),
         NotificationType.INFORMATION,
         (notification1, event) -> {
@@ -184,7 +165,7 @@ public class FlutterInitializer implements StartupActivity {
             }
           }
         });
-      notification.addAction(new AnAction(FlutterBundle.message("flutter.analytics.notification.accept")) {
+      notification.addAction(new AnAction("Sounds good!") {
         @Override
         public void actionPerformed(AnActionEvent event) {
           notification.expire();
@@ -195,7 +176,7 @@ public class FlutterInitializer implements StartupActivity {
           }
         }
       });
-      notification.addAction(new AnAction(FlutterBundle.message("flutter.analytics.notification.decline")) {
+      notification.addAction(new AnAction("No thanks") {
         @Override
         public void actionPerformed(AnActionEvent event) {
           notification.expire();

--- a/src/io/flutter/run/FlutterDebugProcess.java
+++ b/src/io/flutter/run/FlutterDebugProcess.java
@@ -17,11 +17,11 @@ import com.intellij.ui.content.Content;
 import com.intellij.xdebugger.XDebugSession;
 import com.jetbrains.lang.dart.ide.runner.server.vmService.DartVmServiceDebugProcessZ;
 import com.jetbrains.lang.dart.util.DartUrlResolver;
-import io.flutter.FlutterInitializer;
 import io.flutter.actions.ReloadFlutterApp;
 import io.flutter.actions.RestartFlutterApp;
 import io.flutter.run.daemon.FlutterApp;
 import io.flutter.run.daemon.RunMode;
+import io.flutter.settings.FlutterSettings;
 import io.flutter.view.FlutterViewMessages;
 import io.flutter.view.OpenFlutterViewAction;
 import org.dartlang.vm.service.VmService;
@@ -108,7 +108,7 @@ public class FlutterDebugProcess extends DartVmServiceDebugProcessZ {
     topToolbar.addSeparator();
     topToolbar.add(new OpenFlutterViewAction(isSessionActive));
     topToolbar.addAction(new OpenObservatoryAction(app.getConnector(), observatoryAvailable));
-    if (FlutterInitializer.isMemoryDashboardEnabled()) {
+    if (FlutterSettings.getInstance().isMemoryDashboardEnabled()) {
       topToolbar.addAction(new OpenMemoryDashboardAction(app.getConnector(), observatoryAvailable));
     }
 

--- a/src/io/flutter/run/FlutterReloadManager.java
+++ b/src/io/flutter/run/FlutterReloadManager.java
@@ -8,10 +8,14 @@ package io.flutter.run;
 import com.intellij.codeInsight.hint.HintManager;
 import com.intellij.codeInsight.hint.HintManagerImpl;
 import com.intellij.codeInsight.hint.HintUtil;
+import com.intellij.concurrency.JobScheduler;
+import com.intellij.ide.BrowserUtil;
 import com.intellij.ide.actions.SaveAllAction;
+import com.intellij.ide.util.PropertiesComponent;
 import com.intellij.notification.Notification;
 import com.intellij.notification.NotificationGroup;
 import com.intellij.notification.NotificationType;
+import com.intellij.notification.Notifications;
 import com.intellij.openapi.actionSystem.*;
 import com.intellij.openapi.actionSystem.ex.ActionManagerEx;
 import com.intellij.openapi.actionSystem.ex.AnActionListener;
@@ -40,6 +44,7 @@ import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService;
 import com.jetbrains.lang.dart.analyzer.DartServerData;
 import com.jetbrains.lang.dart.ide.errorTreeView.DartProblemsView;
 import icons.FlutterIcons;
+import io.flutter.FlutterMessages;
 import io.flutter.actions.FlutterAppAction;
 import io.flutter.actions.ReloadFlutterApp;
 import io.flutter.run.daemon.FlutterApp;
@@ -53,14 +58,19 @@ import javax.swing.*;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
+
+// TODO: show toast on first disable
 
 /**
  * Handle the mechanics of performing a hot reload on file save.
  */
 public class FlutterReloadManager {
   private static final Logger LOG = Logger.getInstance(FlutterReloadManager.class.getName());
+
+  private static final String reloadSaveFeedbackKey = "io.flutter.askedUserReloadSaveFeedback";
 
   private final @NotNull Project myProject;
   private final FlutterSettings mySettings;
@@ -79,7 +89,7 @@ public class FlutterReloadManager {
 
   private FlutterReloadManager(@NotNull Project project) {
     this.myProject = project;
-    this.mySettings = FlutterSettings.getInstance(myProject);
+    this.mySettings = FlutterSettings.getInstance();
 
     ActionManagerEx.getInstanceEx().addAnActionListener(new AnActionListener.Adapter() {
       @Override
@@ -94,9 +104,34 @@ public class FlutterReloadManager {
         }
       }
     }, project);
+
+    FlutterSettings.getInstance().addListener(new FlutterSettings.Listener() {
+      boolean reloadOnSave = FlutterSettings.getInstance().isReloadOnSave();
+
+      @Override
+      public void settingsChanged() {
+        final boolean newReloadOnSave = FlutterSettings.getInstance().isReloadOnSave();
+        if (reloadOnSave && !newReloadOnSave) {
+          // The user is turning off reload on save; see if we should ask why.
+          final PropertiesComponent properties = PropertiesComponent.getInstance();
+          if (!properties.getBoolean(reloadSaveFeedbackKey, false)) {
+            properties.setValue(reloadSaveFeedbackKey, true);
+
+            JobScheduler.getScheduler().schedule(() -> showDisableReloadSaveNotification(), 1, TimeUnit.SECONDS);
+          }
+        }
+        reloadOnSave = newReloadOnSave;
+      }
+    });
   }
 
+  private boolean handleingSave = false;
+
   private void handleSaveAllNotification(AnActionEvent event) {
+    if (handleingSave) {
+      return;
+    }
+
     if (!mySettings.isReloadOnSave()) {
       return;
     }
@@ -136,21 +171,27 @@ public class FlutterReloadManager {
       return;
     }
 
-    if (hasErrors(project, module, editor.getDocument())) {
-      showNotification(editor, "Reload not performed", true);
-      showAnalysisNotification("Analysis issues found");
-    }
-    else {
-      final LightweightHint hint = showNotification(editor, "Reloading…", false);
+    // Add an arbitrary 125ms delay to allow analysis to catch up.
+    handleingSave = true;
 
-      app.performHotReload(supportsPauseAfterReload()).thenAccept(result -> {
-        hint.hide();
+    JobScheduler.getScheduler().schedule(() -> {
+      handleingSave = false;
 
-        if (!result.ok()) {
-          showNotification(editor, result.getMessage(), true);
-        }
-      });
-    }
+      if (hasErrors(project, module, editor.getDocument())) {
+        showAnalysisNotification("Reload not performed", "Analysis issues found", true);
+      }
+      else {
+        final Notification notification = showRunNotification(app, null, "Reloading…", false);
+
+        app.performHotReload(supportsPauseAfterReload()).thenAccept(result -> {
+          notification.expire();
+
+          if (!result.ok()) {
+            showRunNotification(app, "Hot Reload Error", result.getMessage(), true);
+          }
+        });
+      }
+    }, 100, TimeUnit.MILLISECONDS);
   }
 
   public void saveAllAndReload(@NotNull FlutterApp app) {
@@ -158,7 +199,7 @@ public class FlutterReloadManager {
       FileDocumentManager.getInstance().saveAllDocuments();
       app.performHotReload(supportsPauseAfterReload()).thenAccept(result -> {
         if (!result.ok()) {
-          showRunNotificationError(app, "Hot Reload", result.getMessage());
+          showRunNotification(app, "Hot Reload", result.getMessage(), true);
         }
       });
     }
@@ -169,7 +210,7 @@ public class FlutterReloadManager {
       FileDocumentManager.getInstance().saveAllDocuments();
       app.performRestartApp().thenAccept(result -> {
         if (!result.ok()) {
-          showRunNotificationError(app, "Full Restart", result.getMessage());
+          showRunNotification(app, "Full Restart", result.getMessage(), true);
         }
       });
     }
@@ -183,22 +224,30 @@ public class FlutterReloadManager {
     return null;
   }
 
-  private void showAnalysisNotification(String message) {
+  private void showAnalysisNotification(String title, String content, boolean isError) {
     final NotificationGroup notificationGroup =
       NotificationGroup.toolWindowGroup(FlutterRunNotifications.GROUP_DISPLAY_ID, DartProblemsView.TOOLWINDOW_ID, false);
-    final Notification notification = notificationGroup.createNotification(message, NotificationType.ERROR);
+    final Notification notification =
+      notificationGroup.createNotification(title, content, isError ? NotificationType.ERROR : NotificationType.INFORMATION, null);
     notification.setIcon(FlutterIcons.Flutter);
     notification.notify(myProject);
   }
 
-  private void showRunNotificationError(FlutterApp app, String title, String message) {
+  private Notification showRunNotification(@NotNull FlutterApp app, @Nullable String title, @NotNull String content, boolean isError) {
     final String toolWindowId = app.getMode() == RunMode.RUN ? ToolWindowId.RUN : ToolWindowId.DEBUG;
     final NotificationGroup notificationGroup =
       NotificationGroup.toolWindowGroup(FlutterRunNotifications.GROUP_DISPLAY_ID, toolWindowId, false);
-
-    final Notification notification = notificationGroup.createNotification(title, message, NotificationType.ERROR, null);
+    final Notification notification;
+    if (title == null) {
+      notification = notificationGroup.createNotification(content, isError ? NotificationType.ERROR : NotificationType.INFORMATION);
+    }
+    else {
+      notification =
+        notificationGroup.createNotification(title, content, isError ? NotificationType.ERROR : NotificationType.INFORMATION, null);
+    }
     notification.setIcon(FlutterIcons.Flutter);
     notification.notify(myProject);
+    return notification;
   }
 
   private FlutterApp getApp() {
@@ -238,7 +287,7 @@ public class FlutterReloadManager {
     }
   }
 
-  private LightweightHint showNotification(@NotNull Editor editor, String message, boolean isError) {
+  private LightweightHint showEditorHint(@NotNull Editor editor, String message, boolean isError) {
     final AtomicReference<LightweightHint> ref = new AtomicReference<>();
 
     ApplicationManager.getApplication().invokeAndWait(() -> {
@@ -254,5 +303,28 @@ public class FlutterReloadManager {
     });
 
     return ref.get();
+  }
+
+  private void showDisableReloadSaveNotification() {
+    final Notification notification = new Notification(
+      FlutterMessages.FLUTTER_NOTIFICATION_GOUP_ID,
+      "Flutter Reload on Save",
+      "Disabling reload on save; consider providing feedback on this feature to help us improve future versions.",
+      NotificationType.INFORMATION);
+    notification.addAction(new AnAction("Provide Feedback") {
+      @Override
+      public void actionPerformed(AnActionEvent event) {
+        notification.expire();
+        // TODO: replace with the real url
+        BrowserUtil.browse("http://www.cheese.com/");
+      }
+    });
+    notification.addAction(new AnAction("No thanks") {
+      @Override
+      public void actionPerformed(AnActionEvent event) {
+        notification.expire();
+      }
+    });
+    Notifications.Bus.notify(notification);
   }
 }

--- a/src/io/flutter/run/FlutterReloadManager.java
+++ b/src/io/flutter/run/FlutterReloadManager.java
@@ -171,7 +171,11 @@ public class FlutterReloadManager {
       return;
     }
 
-    // Add an arbitrary 125ms delay to allow analysis to catch up.
+    // Add an arbitrary 125ms delay to allow analysis to catch up. This delay gives the analysis server a
+    // small pause to return error results in the (relatively infrequent) case where the user makes a bad
+    // edit and immediately hits save.
+    final int reloadDelayMs = 125;
+
     handleingSave = true;
 
     JobScheduler.getScheduler().schedule(() -> {
@@ -191,7 +195,7 @@ public class FlutterReloadManager {
           }
         });
       }
-    }, 100, TimeUnit.MILLISECONDS);
+    }, reloadDelayMs, TimeUnit.MILLISECONDS);
   }
 
   public void saveAllAndReload(@NotNull FlutterApp app) {
@@ -315,8 +319,7 @@ public class FlutterReloadManager {
       @Override
       public void actionPerformed(AnActionEvent event) {
         notification.expire();
-        // TODO: replace with the real url
-        BrowserUtil.browse("http://www.cheese.com/");
+        BrowserUtil.browse("https://goo.gl/Pab4Li");
       }
     });
     notification.addAction(new AnAction("No thanks") {

--- a/src/io/flutter/run/FlutterReloadManager.java
+++ b/src/io/flutter/run/FlutterReloadManager.java
@@ -62,12 +62,12 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
-// TODO: show toast on first disable
-
 /**
  * Handle the mechanics of performing a hot reload on file save.
  */
 public class FlutterReloadManager {
+  public static final String RELOAD_ON_SAVE_FEEDBACK_URL = "https://goo.gl/Pab4Li";
+
   private static final Logger LOG = Logger.getInstance(FlutterReloadManager.class.getName());
 
   private static final String reloadSaveFeedbackKey = "io.flutter.askedUserReloadSaveFeedback";
@@ -319,7 +319,7 @@ public class FlutterReloadManager {
       @Override
       public void actionPerformed(AnActionEvent event) {
         notification.expire();
-        BrowserUtil.browse("https://goo.gl/Pab4Li");
+        BrowserUtil.browse(RELOAD_ON_SAVE_FEEDBACK_URL);
       }
     });
     notification.addAction(new AnAction("No thanks") {

--- a/src/io/flutter/run/LaunchState.java
+++ b/src/io/flutter/run/LaunchState.java
@@ -35,10 +35,10 @@ import com.intellij.xdebugger.XDebugProcessStarter;
 import com.intellij.xdebugger.XDebugSession;
 import com.intellij.xdebugger.XDebuggerManager;
 import com.jetbrains.lang.dart.util.DartUrlResolver;
-import io.flutter.FlutterInitializer;
 import io.flutter.actions.OpenSimulatorAction;
 import io.flutter.dart.DartPlugin;
 import io.flutter.run.daemon.*;
+import io.flutter.settings.FlutterSettings;
 import io.flutter.view.OpenFlutterViewAction;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -218,7 +218,7 @@ public class LaunchState extends CommandLineState {
     actions.add(new Separator());
     actions.add(new OpenFlutterViewAction(() -> !app.getProcessHandler().isProcessTerminated()));
     actions.add(new OpenObservatoryAction(app.getConnector(), observatoryAvailable));
-    if (FlutterInitializer.isMemoryDashboardEnabled()) {
+    if (FlutterSettings.getInstance().isMemoryDashboardEnabled()) {
       actions.add(new OpenMemoryDashboardAction(app.getConnector(), observatoryAvailable));
     }
     return new DefaultExecutionResult(console, app.getProcessHandler(), actions.toArray(new AnAction[actions.size()]));

--- a/src/io/flutter/run/daemon/DaemonApi.java
+++ b/src/io/flutter/run/daemon/DaemonApi.java
@@ -13,7 +13,7 @@ import com.intellij.execution.process.ProcessHandler;
 import com.intellij.execution.process.ProcessOutputTypes;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.util.Key;
-import io.flutter.FlutterInitializer;
+import io.flutter.settings.FlutterSettings;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -120,7 +120,7 @@ public class DaemonApi {
 
         final String text = event.getText().trim();
 
-        if (FlutterInitializer.isVerboseLogging()) {
+        if (FlutterSettings.getInstance().isVerboseLogging()) {
           LOG.info("[<-- " + text + "]");
         }
 
@@ -242,7 +242,7 @@ public class DaemonApi {
     stdin.write(json);
     stdin.write("]\n");
 
-    if (FlutterInitializer.isVerboseLogging()) {
+    if (FlutterSettings.getInstance().isVerboseLogging()) {
       LOG.info("[--> " + json + "]");
     }
 

--- a/src/io/flutter/run/daemon/DaemonConsoleView.java
+++ b/src/io/flutter/run/daemon/DaemonConsoleView.java
@@ -19,7 +19,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.search.GlobalSearchScope;
 import com.jetbrains.lang.dart.ide.runner.DartRelativePathsConsoleFilter;
-import io.flutter.FlutterInitializer;
+import io.flutter.settings.FlutterSettings;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -56,7 +56,7 @@ public class DaemonConsoleView extends ConsoleViewImpl {
 
   @Override
   public void print(@NotNull String text, @NotNull ConsoleViewContentType contentType) {
-    if (FlutterInitializer.isVerboseLogging()) {
+    if (FlutterSettings.getInstance().isVerboseLogging()) {
       super.print(text, contentType);
       return;
     }

--- a/src/io/flutter/run/daemon/FlutterApp.java
+++ b/src/io/flutter/run/daemon/FlutterApp.java
@@ -20,7 +20,6 @@ import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Disposer;
 import com.intellij.openapi.util.Key;
-import com.intellij.util.ObjectUtils;
 import com.intellij.util.concurrency.AppExecutorUtil;
 import com.jetbrains.lang.dart.ide.runner.ObservatoryConnector;
 import io.flutter.FlutterInitializer;

--- a/src/io/flutter/run/daemon/FlutterAppListener.java
+++ b/src/io/flutter/run/daemon/FlutterAppListener.java
@@ -11,6 +11,7 @@ import com.intellij.execution.ui.ConsoleViewContentType;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import io.flutter.FlutterInitializer;
+import io.flutter.settings.FlutterSettings;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
@@ -109,7 +110,7 @@ class FlutterAppListener implements DaemonEvent.Listener {
     if (event.getType().startsWith("hot.")) {
       // We clear the console view in order to help indicate that a reload is happening.
       if (app.getConsole() != null) {
-        if (!FlutterInitializer.isVerboseLogging()) {
+        if (!FlutterSettings.getInstance().isVerboseLogging()) {
           app.getConsole().clear();
         }
       }

--- a/src/io/flutter/run/test/DebugTestRunner.java
+++ b/src/io/flutter/run/test/DebugTestRunner.java
@@ -23,9 +23,9 @@ import com.intellij.xdebugger.XDebugSession;
 import com.intellij.xdebugger.XDebuggerManager;
 import com.jetbrains.lang.dart.ide.runner.ObservatoryConnector;
 import com.jetbrains.lang.dart.util.DartUrlResolver;
-import io.flutter.FlutterInitializer;
 import io.flutter.run.PositionMapper;
 import io.flutter.sdk.FlutterSdk;
+import io.flutter.settings.FlutterSettings;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -103,7 +103,7 @@ public class DebugTestRunner extends GenericProgramRunner {
           }
 
           final String text = event.getText().trim();
-          if (FlutterInitializer.isVerboseLogging()) {
+          if (FlutterSettings.getInstance().isVerboseLogging()) {
             LOG.info("[<-- " + text + "]");
           }
 

--- a/src/io/flutter/sdk/FlutterSdk.java
+++ b/src/io/flutter/sdk/FlutterSdk.java
@@ -19,11 +19,11 @@ import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.vfs.VirtualFileManager;
 import com.jetbrains.lang.dart.sdk.DartSdk;
-import io.flutter.FlutterInitializer;
 import io.flutter.dart.DartPlugin;
 import io.flutter.pub.PubRoot;
 import io.flutter.run.daemon.FlutterDevice;
 import io.flutter.run.daemon.RunMode;
+import io.flutter.settings.FlutterSettings;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -150,7 +150,7 @@ public class FlutterSdk {
                                    @Nullable FlutterDevice device, @NotNull RunMode mode, String... additionalArgs) {
     final List<String> args = new ArrayList<>();
     args.add("--machine");
-    if (FlutterInitializer.isVerboseLogging()) {
+    if (FlutterSettings.getInstance().isVerboseLogging()) {
       args.add("--verbose");
     }
     if (device != null) {
@@ -185,7 +185,7 @@ public class FlutterSdk {
       }
       args.add("--start-paused");
     }
-    if (FlutterInitializer.isVerboseLogging()) {
+    if (FlutterSettings.getInstance().isVerboseLogging()) {
       args.add("--verbose");
     }
     if (testNameSubstring != null) {

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.form
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.form
@@ -63,7 +63,7 @@
         <border type="none"/>
         <children/>
       </grid>
-      <grid id="e885c" layout-manager="GridLayoutManager" row-count="3" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="e885c" layout-manager="GridLayoutManager" row-count="4" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -76,7 +76,7 @@
         <children>
           <component id="6304a" class="javax.swing.JCheckBox" binding="myReportUsageInformationCheckBox">
             <constraints>
-              <grid row="1" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="2" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text value="&amp;Report usage information to Google Analytics"/>
@@ -85,7 +85,7 @@
           </component>
           <component id="abbab" class="com.intellij.ui.components.labels.LinkLabel" binding="myPrivacyPolicy">
             <constraints>
-              <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="3" use-parent-layout="false"/>
+              <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="3" use-parent-layout="false"/>
             </constraints>
             <properties>
               <horizontalAlignment value="2"/>
@@ -96,11 +96,20 @@
           </component>
           <component id="be19f" class="javax.swing.JCheckBox" binding="myEnableVerboseLoggingCheckBox" default-binding="true">
             <constraints>
-              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text value="Enable &amp;verbose logging"/>
               <toolTipText value="Enables verbose logging (this can be useful for diagnostic purposes)."/>
+            </properties>
+          </component>
+          <component id="87b06" class="javax.swing.JCheckBox" binding="myHotReloadOnSaveCheckBox">
+            <constraints>
+              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Perform hot reload on save"/>
+              <toolTipText value="On save, hot reload changes into running Flutter apps."/>
             </properties>
           </component>
         </children>
@@ -116,15 +125,6 @@
         </clientProperties>
         <border type="etched" title="Experiments"/>
         <children>
-          <component id="87b06" class="javax.swing.JCheckBox" binding="myHotReloadOnSaveCheckBox">
-            <constraints>
-              <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <text value="Perform hot reload on save"/>
-              <toolTipText value="On save, hot reload changes into running Flutter apps."/>
-            </properties>
-          </component>
           <component id="7ec6e" class="javax.swing.JCheckBox" binding="myEnableMemoryDashboardCheckBox">
             <constraints>
               <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.form
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.form
@@ -3,7 +3,7 @@
   <grid id="27dc6" binding="mainPanel" layout-manager="GridLayoutManager" row-count="4" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="574" height="400"/>
+      <xy x="20" y="20" width="574" height="443"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -63,7 +63,7 @@
         <border type="none"/>
         <children/>
       </grid>
-      <grid id="e885c" layout-manager="GridLayoutManager" row-count="4" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="e885c" layout-manager="GridLayoutManager" row-count="5" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -94,15 +94,6 @@
               <toolTipText value="http://www.google.com/policies/privacy/"/>
             </properties>
           </component>
-          <component id="be19f" class="javax.swing.JCheckBox" binding="myEnableVerboseLoggingCheckBox" default-binding="true">
-            <constraints>
-              <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <text value="Enable &amp;verbose logging"/>
-              <toolTipText value="Enables verbose logging (this can be useful for diagnostic purposes)."/>
-            </properties>
-          </component>
           <component id="87b06" class="javax.swing.JCheckBox" binding="myHotReloadOnSaveCheckBox">
             <constraints>
               <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
@@ -110,6 +101,26 @@
             <properties>
               <text value="Perform hot reload on save"/>
               <toolTipText value="On save, hot reload changes into running Flutter apps."/>
+            </properties>
+          </component>
+          <component id="6698f" class="com.intellij.ui.components.labels.LinkLabel" binding="reloadOnSaveFeedbackUrl">
+            <constraints>
+              <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="3" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <horizontalAlignment value="2"/>
+              <horizontalTextPosition value="2"/>
+              <text value="Provide feedback on the reload on save feature (https://goo.gl/Pab4Li)."/>
+              <toolTipText value="https://goo.gl/Pab4Li"/>
+            </properties>
+          </component>
+          <component id="be19f" class="javax.swing.JCheckBox" binding="myEnableVerboseLoggingCheckBox" default-binding="true">
+            <constraints>
+              <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Enable &amp;verbose logging"/>
+              <toolTipText value="Enables verbose logging (this can be useful for diagnostic purposes)."/>
             </properties>
           </component>
         </children>

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.java
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.java
@@ -111,7 +111,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
   @Override
   public boolean isModified() {
     final FlutterSdk sdk = FlutterSdk.getFlutterSdk(myProject);
-    final FlutterSettings settings = FlutterSettings.getInstance(myProject);
+    final FlutterSettings settings = FlutterSettings.getInstance();
     final String sdkPathInModel = sdk == null ? "" : sdk.getHomePath();
     final String sdkPathInUI = FileUtilRt.toSystemIndependentName(getSdkPathText());
 
@@ -127,12 +127,12 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
       return true;
     }
 
-    if (FlutterInitializer.isMemoryDashboardEnabled() != myEnableMemoryDashboardCheckBox.isSelected()) {
+    if (settings.isMemoryDashboardEnabled() != myEnableMemoryDashboardCheckBox.isSelected()) {
       return true;
     }
 
     //noinspection RedundantIfStatement
-    if (FlutterInitializer.isVerboseLogging() != myEnableVerboseLoggingCheckBox.isSelected()) {
+    if (settings.isVerboseLogging() != myEnableVerboseLoggingCheckBox.isSelected()) {
       return true;
     }
 
@@ -155,10 +155,10 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     }
 
     FlutterInitializer.setCanReportAnalaytics(myReportUsageInformationCheckBox.isSelected());
-    FlutterInitializer.setVerboseLogging(myEnableVerboseLoggingCheckBox.isSelected());
-    FlutterInitializer.setMemoryDashboardEnabled(myEnableMemoryDashboardCheckBox.isSelected());
 
-    final FlutterSettings settings = FlutterSettings.getInstance(myProject);
+    final FlutterSettings settings = FlutterSettings.getInstance();
+    settings.setMemoryDashboardEnabled(myEnableMemoryDashboardCheckBox.isSelected());
+    settings.setVerboseLogging(myEnableVerboseLoggingCheckBox.isSelected());
     settings.setReloadOnSave(myHotReloadOnSaveCheckBox.isSelected());
 
     reset(); // because we rely on remembering initial state
@@ -178,10 +178,10 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
 
     myReportUsageInformationCheckBox.setSelected(FlutterInitializer.getCanReportAnalytics());
 
-    final FlutterSettings settings = FlutterSettings.getInstance(myProject);
+    final FlutterSettings settings = FlutterSettings.getInstance();
     myHotReloadOnSaveCheckBox.setSelected(settings.isReloadOnSave());
-    myEnableVerboseLoggingCheckBox.setSelected(FlutterInitializer.isVerboseLogging());
-    myEnableMemoryDashboardCheckBox.setSelected(FlutterInitializer.isMemoryDashboardEnabled());
+    myEnableVerboseLoggingCheckBox.setSelected(settings.isVerboseLogging());
+    myEnableMemoryDashboardCheckBox.setSelected(settings.isMemoryDashboardEnabled());
   }
 
   private void updateVersionText() {

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.java
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.java
@@ -26,6 +26,7 @@ import com.intellij.ui.components.labels.LinkLabel;
 import io.flutter.FlutterBundle;
 import io.flutter.FlutterConstants;
 import io.flutter.FlutterInitializer;
+import io.flutter.run.FlutterReloadManager;
 import io.flutter.settings.FlutterSettings;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
@@ -51,6 +52,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
   private JCheckBox myHotReloadOnSaveCheckBox;
   private JCheckBox myEnableVerboseLoggingCheckBox;
   private JCheckBox myEnableMemoryDashboardCheckBox;
+  private LinkLabel<String> reloadOnSaveFeedbackUrl;
   private final @NotNull Project myProject;
 
   FlutterSettingsConfigurable(@NotNull Project project) {
@@ -84,6 +86,15 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
       catch (URISyntaxException ignore) {
       }
     }, FlutterBundle.message("flutter.analytics.privacyUrl"));
+
+    reloadOnSaveFeedbackUrl.setIcon(null);
+    reloadOnSaveFeedbackUrl.setListener((label, linkUrl) -> {
+      try {
+        BrowserLauncher.getInstance().browse(new URI(linkUrl));
+      }
+      catch (URISyntaxException ignore) {
+      }
+    }, FlutterReloadManager.RELOAD_ON_SAVE_FEEDBACK_URL);
   }
 
   private void createUIComponents() {

--- a/src/io/flutter/settings/FlutterSettings.java
+++ b/src/io/flutter/settings/FlutterSettings.java
@@ -5,30 +5,44 @@
  */
 package io.flutter.settings;
 
-import com.intellij.openapi.components.*;
-import com.intellij.openapi.project.Project;
-import com.intellij.util.xmlb.XmlSerializerUtil;
-import org.jetbrains.annotations.NotNull;
+import com.intellij.ide.util.PropertiesComponent;
+import com.intellij.openapi.components.ServiceManager;
+import io.flutter.analytics.Analytics;
 
 import java.util.ArrayList;
 import java.util.List;
 
-@State(
-  name = "FlutterSettings",
-  storages = @Storage(StoragePathMacros.WORKSPACE_FILE)
-)
-public class FlutterSettings implements PersistentStateComponent<FlutterSettings> {
+public class FlutterSettings {
+  private static final String reloadOnSaveKey = "io.flutter.reloadOnSave";
+  private static final String verboseLoggingKey = "io.flutter.verboseLogging";
+  private static final String memoryDashboardKey = "io.flutter.memoryDashboard";
 
-  public static FlutterSettings getInstance(@NotNull Project project) {
-    return ServiceManager.getService(project, FlutterSettings.class);
+  public static FlutterSettings getInstance() {
+    return ServiceManager.getService(FlutterSettings.class);
+  }
+
+  protected static PropertiesComponent getPropertiesComponent() {
+    return PropertiesComponent.getInstance();
   }
 
   public interface Listener {
     void settingsChanged();
   }
 
-  @SuppressWarnings("MismatchedQueryAndUpdateOfCollection")
   private final List<Listener> listeners = new ArrayList<>();
+
+  public void sendSettingsToAnalytics(Analytics analytics) {
+    final PropertiesComponent properties = getPropertiesComponent();
+
+    // Send data on the number of experimental features enabled by users.
+    analytics.sendEvent("settings", "ping");
+    if (isReloadOnSave()) {
+      analytics.sendEvent("settings", afterLastPeriod(reloadOnSaveKey));
+    }
+    if (isMemoryDashboardEnabled()) {
+      analytics.sendEvent("settings", afterLastPeriod(memoryDashboardKey));
+    }
+  }
 
   public void addListener(Listener listener) {
     listeners.add(listener);
@@ -38,23 +52,44 @@ public class FlutterSettings implements PersistentStateComponent<FlutterSettings
     listeners.remove(listener);
   }
 
-  private boolean reloadOnSave = false;
-
   public boolean isReloadOnSave() {
-    return reloadOnSave;
+    return getPropertiesComponent().getBoolean(reloadOnSaveKey, false);
   }
 
   public void setReloadOnSave(boolean value) {
-    this.reloadOnSave = value;
+    getPropertiesComponent().setValue(reloadOnSaveKey, value);
+
+    fireEvent();
   }
 
-  // PersistentStateComponent interface
-
-  public FlutterSettings getState() {
-    return this;
+  public boolean isVerboseLogging() {
+    return getPropertiesComponent().getBoolean(verboseLoggingKey, false);
   }
 
-  public void loadState(FlutterSettings state) {
-    XmlSerializerUtil.copyBean(state, this);
+  public void setVerboseLogging(boolean value) {
+    getPropertiesComponent().setValue(verboseLoggingKey, value);
+
+    fireEvent();
+  }
+
+  public boolean isMemoryDashboardEnabled() {
+    return getPropertiesComponent().getBoolean(memoryDashboardKey, false);
+  }
+
+  public void setMemoryDashboardEnabled(boolean value) {
+    getPropertiesComponent().setValue(memoryDashboardKey, value);
+
+    fireEvent();
+  }
+
+  protected void fireEvent() {
+    for (Listener listener : listeners) {
+      listener.settingsChanged();
+    }
+  }
+
+  private static String afterLastPeriod(String str) {
+    final int index = str.lastIndexOf('.');
+    return index == -1 ? str : str.substring(index + 1);
   }
 }

--- a/testSrc/unit/io/flutter/utils/FlutterModuleUtilsTest.java
+++ b/testSrc/unit/io/flutter/utils/FlutterModuleUtilsTest.java
@@ -5,10 +5,8 @@
  */
 package io.flutter.utils;
 
-import com.intellij.openapi.Disposable;
 import com.intellij.openapi.module.Module;
 import io.flutter.testing.ProjectFixture;
-import io.flutter.testing.TestDir;
 import io.flutter.testing.Testing;
 import org.junit.Rule;
 import org.junit.Test;


### PR DESCRIPTION
additional changes to the reload on save workflow:
- send analytics information about what experimental features users have enabled (reload on save, improved memory view)
- ask the user for feedback the first time they disable reload on save
- provide info about reload-on-save reload starts and stops as balloons on the run/debug view, instead of as inline tooltips in the editor. The inline tooltips were a bit too distracting as you were typing, and made the UI seem a bit jerky.
- some refactoring of the code for how we persist user settings

<img width="408" alt="screen shot 2017-08-16 at 12 58 56 pm" src="https://user-images.githubusercontent.com/1269969/29383622-f09769e0-8285-11e7-9615-9516a85ddaed.png">

@stevemessick 

