### PR TITLE
measure users using reload vs restart

### DIFF
--- a/src/io/flutter/actions/ReloadFlutterApp.java
+++ b/src/io/flutter/actions/ReloadFlutterApp.java
@@ -37,17 +37,17 @@ public class ReloadFlutterApp extends FlutterAppAction {
       return;
     }
 
-    FlutterInitializer.sendAnalyticsAction(this);
-
     // If the shift key is held down, perform a restart. We check to see if we're being invoked from the
     // 'GoToAction' dialog. If so, the modifiers are for the command that opened the go to action dialog.
     final boolean shouldRestart = (e.getModifiers() & InputEvent.SHIFT_MASK) != 0 && !"GoToAction".equals(e.getPlace());
 
     if (shouldRestart) {
+      FlutterInitializer.sendAnalyticsAction(RestartFlutterApp.class.getSimpleName());
       FlutterReloadManager.getInstance(project).saveAllAndRestart(getApp());
     }
     else {
       // Else perform a hot reload.
+      FlutterInitializer.sendAnalyticsAction(this);
       FlutterReloadManager.getInstance(project).saveAllAndReload(getApp());
     }
   }


### PR DESCRIPTION
- measure the number of sessions using reload vs restart in their workflow (at the end of an app run, the session was a 'reload' session if they reloaded at least once; a 'restart' session if they restarted at least once; and otherwise, we record 'none' for that session)
- fix a bug where some restart events were recorded as reload (this only happened if the user had hit the reload button with the shift key pressed)

@stevemessick 