### PR TITLE
Fix help text for Package

### DIFF
--- a/src/io/flutter/FlutterBundle.properties
+++ b/src/io/flutter/FlutterBundle.properties
@@ -119,11 +119,9 @@ flutter.module.create.settings.help.org.description=Enter the organization domai
 flutter.module.create.settings.help.project_type.label=Project type:
 flutter.module.create.settings.help.project_type.description.app=Select an "Application" when building for end users.
 flutter.module.create.settings.help.project_type.description.plugin=Select a "Plugin" when exposing an Android or iOS API for developers.
-flutter.module.create.settings.help.project_type.description.package=Select a "Package" when creating a cross-platform component, like a new Widget.
+flutter.module.create.settings.help.project_type.description.package=Select a "Package" when creating a pure Dart component, like a new Widget.
 
 module.wizard.package_title=Flutter Package
 module.wizard.package_description=Creates a Flutter package
 module.wizard.package_step_title=New Flutter Package
 module.wizard.package_step_body=Configure the new Flutter package
-flutter.wizard.please_select_content_root=Please select the content root directory
-flutter.wizard.please_select_package_file_location=Please select the package file location


### PR DESCRIPTION
@devoncarew @mit-mit New help text for the Package option in module creation.

The cli help message uses "project" in a much different way than IntelliJ. IMO that text isn't a good fit here.