### PR TITLE
Update FlutterBundle.properties

### DIFF
--- a/src/io/flutter/FlutterBundle.properties
+++ b/src/io/flutter/FlutterBundle.properties
@@ -106,7 +106,7 @@ flutter.module.create.settings.radios.android.java=Java
 flutter.module.create.settings.radios.android.kotlin=Kotlin
 flutter.module.create.settings.radios.android.tip=Select an Android language.
 flutter.module.create.settings.radios.ios.label=iOS language:
-flutter.module.create.settings.radios.ios.object_c=Objective C
+flutter.module.create.settings.radios.ios.object_c=Objective-C
 flutter.module.create.settings.radios.ios.swift=Swift
 flutter.module.create.settings.radios.ios.tip=Select an iOS language.
 


### PR DESCRIPTION
tweak to the name for `Objective-C`

@stevemessick 