### PR TITLE
Rearrange the configuration page for modules

### DIFF
--- a/flutter-studio/src/io/flutter/module/AdditionalLanguageSettings.form
+++ b/flutter-studio/src/io/flutter/module/AdditionalLanguageSettings.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="io.flutter.module.AdditionalLanguageSettings">
-  <grid id="27dc6" binding="myPanel" layout-manager="GridLayoutManager" row-count="4" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="myPanel" layout-manager="GridLayoutManager" row-count="5" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="500" height="400"/>
@@ -10,7 +10,7 @@
     <children>
       <vspacer id="d58b3">
         <constraints>
-          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
       <component id="73839" class="com.intellij.ui.components.JBLabel">
@@ -31,7 +31,7 @@
       </component>
       <component id="da20c" class="javax.swing.JLabel" binding="myAndroidLanguageLabel">
         <constraints>
-          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Android language:"/>
@@ -39,7 +39,7 @@
       </component>
       <component id="84704" class="javax.swing.JLabel">
         <constraints>
-          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="iOS language:"/>
@@ -47,7 +47,7 @@
       </component>
       <component id="12d7d" class="javax.swing.JRadioButton" binding="myJavaRadioButton" default-binding="true">
         <constraints>
-          <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Java"/>
@@ -55,7 +55,7 @@
       </component>
       <component id="b933f" class="javax.swing.JRadioButton" binding="myKotlinRadioButton" default-binding="true">
         <constraints>
-          <grid row="1" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="2" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Kotlin"/>
@@ -63,7 +63,7 @@
       </component>
       <component id="ea254" class="javax.swing.JRadioButton" binding="myObjectiveCRadioButton" default-binding="true">
         <constraints>
-          <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Objective C"/>
@@ -71,7 +71,7 @@
       </component>
       <component id="b47a9" class="javax.swing.JRadioButton" binding="mySwiftRadioButton" default-binding="true">
         <constraints>
-          <grid row="2" column="2" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="3" column="2" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Swift"/>
@@ -79,9 +79,18 @@
       </component>
       <hspacer id="1c98b">
         <constraints>
-          <grid row="1" column="3" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="2" column="3" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
       </hspacer>
+      <component id="370a4" class="javax.swing.JLabel" binding="myOrgDescription">
+        <constraints>
+          <grid row="1" column="1" row-span="1" col-span="3" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="2" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <font size="11"/>
+          <text value="Label"/>
+        </properties>
+      </component>
     </children>
   </grid>
 </form>

--- a/flutter-studio/src/io/flutter/module/AdditionalLanguageSettings.java
+++ b/flutter-studio/src/io/flutter/module/AdditionalLanguageSettings.java
@@ -15,6 +15,7 @@
  */
 package io.flutter.module;
 
+import io.flutter.FlutterBundle;
 import io.flutter.sdk.FlutterCreateAdditionalSettings;
 
 import javax.swing.*;
@@ -28,6 +29,7 @@ public class AdditionalLanguageSettings {
   private JRadioButton myObjectiveCRadioButton;
   private JRadioButton mySwiftRadioButton;
   private JLabel myAndroidLanguageLabel;
+  private JLabel myOrgDescription;
 
   public AdditionalLanguageSettings() {
     ButtonGroup group = new ButtonGroup();
@@ -36,6 +38,7 @@ public class AdditionalLanguageSettings {
     group = new ButtonGroup();
     group.add(myObjectiveCRadioButton);
     group.add(mySwiftRadioButton);
+    myOrgDescription.setText(FlutterBundle.message("flutter.module.create.settings.help.org.description"));
   }
 
   public JTextField getOrganizationField() {

--- a/flutter-studio/src/io/flutter/module/FlutterPackageStep.form
+++ b/flutter-studio/src/io/flutter/module/FlutterPackageStep.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="io.flutter.module.FlutterPackageStep">
-  <grid id="27dc6" binding="myPanel" layout-manager="GridLayoutManager" row-count="5" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="myPanel" layout-manager="GridLayoutManager" row-count="5" column-count="5" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="500" height="457"/>
@@ -10,13 +10,13 @@
     <children>
       <vspacer id="5f412">
         <constraints>
-          <grid row="4" column="0" row-span="1" col-span="2" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="4" column="0" row-span="1" col-span="5" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
       <grid id="b493b" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="1" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="true"/>
+          <grid row="2" column="0" row-span="1" col-span="5" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="true"/>
         </constraints>
         <properties/>
         <border type="none"/>
@@ -56,15 +56,15 @@
           </component>
         </children>
       </grid>
-      <grid id="87225" binding="myModulePanel" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="87225" binding="myModulePanel" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="0" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="true"/>
+          <grid row="1" column="0" row-span="1" col-span="5" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="true"/>
         </constraints>
         <properties/>
         <border type="none"/>
         <children>
-          <component id="30ce3" class="javax.swing.JLabel">
+          <component id="30ce3" class="javax.swing.JLabel" binding="myModuleNameLabel">
             <constraints>
               <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
@@ -81,91 +81,39 @@
             </constraints>
             <properties/>
           </component>
+          <component id="d5ac9" class="javax.swing.JLabel" binding="myProjectNameDescription">
+            <constraints>
+              <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="2" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <font size="11"/>
+              <text value="Label"/>
+            </properties>
+          </component>
         </children>
       </grid>
       <nested-form id="c6189" form-file="io/flutter/module/AdditionalLanguageSettings.form" binding="myAdditionalSettings">
         <constraints>
-          <grid row="2" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="3" column="0" row-span="1" col-span="5" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
       </nested-form>
-      <grid id="956a" layout-manager="GridLayoutManager" row-count="5" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
-        <margin top="10" left="10" bottom="10" right="10"/>
+      <component id="cf749" class="javax.swing.JLabel" binding="myModuleDescription">
         <constraints>
-          <grid row="3" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="0" column="0" row-span="1" col-span="3" vsize-policy="0" hsize-policy="6" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
-        <properties/>
-        <border type="etched"/>
-        <children>
-          <component id="83e98" class="javax.swing.JLabel">
-            <constraints>
-              <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <font style="1"/>
-              <text value="Help:"/>
-            </properties>
-          </component>
-          <hspacer id="54056">
-            <constraints>
-              <grid row="1" column="2" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
-            </constraints>
-          </hspacer>
-          <vspacer id="aa7e0">
-            <constraints>
-              <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
-            </constraints>
-          </vspacer>
-          <component id="f38a3" class="com.intellij.ui.components.labels.LinkLabel" binding="myFlutterDocsUrl">
-            <constraints>
-              <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties/>
-          </component>
-          <component id="50436" class="javax.swing.JLabel" binding="myProjectNameLabel">
-            <constraints>
-              <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <font style="1"/>
-              <text value="Project name:"/>
-            </properties>
-          </component>
-          <component id="8a961" class="javax.swing.JLabel" binding="myOrgLabel">
-            <constraints>
-              <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <font style="1"/>
-              <text value="Organization:"/>
-            </properties>
-          </component>
-          <component id="1398a" class="javax.swing.JLabel" binding="myProjectNameDescription">
-            <constraints>
-              <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <text value="Label"/>
-            </properties>
-          </component>
-          <component id="6e721" class="javax.swing.JLabel" binding="myOrgDescription">
-            <constraints>
-              <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <text value="Label"/>
-            </properties>
-          </component>
-          <component id="e8124" class="javax.swing.JLabel" binding="myModuleDescription">
-            <constraints>
-              <grid row="0" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <font style="1"/>
-              <text value="Description"/>
-            </properties>
-          </component>
-        </children>
-      </grid>
+        <properties>
+          <font size="14"/>
+          <text value="Description"/>
+        </properties>
+      </component>
+      <component id="5569d" class="com.intellij.ui.components.labels.LinkLabel" binding="myFlutterDocsUrl">
+        <constraints>
+          <grid row="0" column="3" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <toolTipText value="Open Flutter docs in browser"/>
+        </properties>
+      </component>
     </children>
   </grid>
 </form>

--- a/flutter-studio/src/io/flutter/module/FlutterPackageStep.java
+++ b/flutter-studio/src/io/flutter/module/FlutterPackageStep.java
@@ -78,11 +78,9 @@ public class FlutterPackageStep extends SkippableWizardStep<FlutterModuleModel> 
   private JTextField myDescription;
   private LinkLabel<String> myFlutterDocsUrl;
   private JLabel myProjectNameDescription;
-  private JLabel myOrgDescription;
-  private JLabel myOrgLabel;
-  private JLabel myProjectNameLabel;
   private JLabel myModuleDescription;
   private JLabel mySdkPathLabel;
+  private JLabel myModuleNameLabel;
   private String myModuleContentPath = "";
 
   public FlutterPackageStep(@NotNull FlutterModuleModel model,
@@ -101,13 +99,13 @@ public class FlutterPackageStep extends SkippableWizardStep<FlutterModuleModel> 
     bindModuleSettings(namePathComponent);
     model.setModuleComponent(this);
     if (isPlugin) {
+      myModuleNameLabel.setPreferredSize(myAdditionalSettings.getLabelColumnSize());
       mySdkPathLabel.setPreferredSize(myAdditionalSettings.getLabelColumnSize());
       myAdditionalSettings.setInitialValues(settings);
     }
     else {
+      myModuleNameLabel.setPreferredSize(mySdkPathLabel.getPreferredSize());
       myAdditionalSettings.getComponent().setVisible(false);
-      myOrgLabel.setVisible(false);
-      myOrgDescription.setVisible(false);
     }
 
     model.setBuilder(myBuilder);
@@ -186,12 +184,9 @@ public class FlutterPackageStep extends SkippableWizardStep<FlutterModuleModel> 
     myFlutterDocsUrl
       .setListener((label, linkUrl) -> BrowserLauncher.getInstance().browse("https://flutter.io/developing-packages/", null), null);
 
-    myProjectNameLabel.setText(FlutterBundle.message("flutter.module.create.settings.help.module_name.label"));
     myProjectNameDescription.setText(FlutterBundle.message("flutter.module.create.settings.help.module_name.description"));
     if (isPlugin) {
       myModuleDescription.setText(FlutterBundle.message("flutter.module.create.settings.help.type.plugin"));
-      myOrgLabel.setText(FlutterBundle.message("flutter.module.create.settings.help.org.label"));
-      myOrgDescription.setText(FlutterBundle.message("flutter.module.create.settings.help.org.description"));
     } else {
       myModuleDescription.setText(FlutterBundle.message("flutter.module.create.settings.help.type.package"));
     }


### PR DESCRIPTION
@devoncarew @pq 

Change the layout a bit. Instead of a separate help section distribute those texts throughout the form.

The package page is identical except it doesn't have any fields below description.

<img width="884" alt="screen shot 2017-09-06 at 2 10 19 pm" src="https://user-images.githubusercontent.com/8518285/30134798-39bcdfdc-930d-11e7-89ed-9d1210ee2d5b.png">
