### PR TITLE
add an open in android studio action

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -312,6 +312,9 @@
               text="Flutter Packages Upgrade"
               description="Run 'flutter packages upgrade'"/>
       <separator/>
+      <action id="flutter.androidstudio.open" class="io.flutter.actions.OpenInAndroidStudioAction"
+              text="Open Project in Android Studio…"
+              description="Open project in Android Studio"/>
       <action id="flutter.xcode.open" class="io.flutter.actions.OpenInXcodeAction"
               text="Open Project in Xcode…"
               description="Open project in Xcode"/>
@@ -326,24 +329,26 @@
       <separator/>
       <group text="Flutter" description="Flutter Tools" icon="FlutterIcons.Flutter" popup="true">
         <separator/>
-        <reference ref="flutter.packages.get"/> 
-        <reference ref="flutter.packages.upgrade"/> 
+        <reference ref="flutter.packages.get"/>
+        <reference ref="flutter.packages.upgrade"/>
         <separator/>
-        <reference ref="flutter.xcode.open"/> 
+        <reference ref="flutter.androidstudio.open"/>
+        <reference ref="flutter.xcode.open"/>
         <separator/>
-        <reference ref="flutter.upgrade"/> 
-        <reference ref="flutter.doctor"/> 
+        <reference ref="flutter.upgrade"/>
+        <reference ref="flutter.doctor"/>
       </group>
       <separator/>
-      <add-to-group group-id="ProjectViewPopupMenu" relative-to-action="CutCopyPasteGroup" anchor="before"/>
+      <add-to-group group-id="ProjectViewPopupMenu" relative-to-action="AddToFavorites" anchor="before"/>
     </group>
-    <group id="FlutterExternalIdeActionGroup" class="io.flutter.actions.FlutterExternalIdeActionGroup"> 
+    <group id="FlutterExternalIdeActionGroup" class="io.flutter.actions.FlutterExternalIdeActionGroup">
       <separator/>
       <group text="Flutter" description="Flutter Tools" icon="FlutterIcons.Flutter" popup="true">
-        <reference ref="flutter.xcode.open"/> 
+        <reference ref="flutter.androidstudio.open"/>
+        <reference ref="flutter.xcode.open"/>
       </group>
       <separator/>
-      <add-to-group group-id="ProjectViewPopupMenu" relative-to-action="CutCopyPasteGroup" anchor="before"/>
+      <add-to-group group-id="ProjectViewPopupMenu" relative-to-action="AddToFavorites" anchor="before"/>
     </group>
 
     <!-- main toolbar run actions -->

--- a/src/io/flutter/actions/FlutterExternalIdeActionGroup.java
+++ b/src/io/flutter/actions/FlutterExternalIdeActionGroup.java
@@ -10,35 +10,43 @@ import com.intellij.openapi.actionSystem.CommonDataKeys;
 import com.intellij.openapi.actionSystem.DefaultActionGroup;
 import com.intellij.openapi.actionSystem.Presentation;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.util.SystemInfo;
 import com.intellij.openapi.vfs.VirtualFile;
 import io.flutter.FlutterUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-
 public class FlutterExternalIdeActionGroup extends DefaultActionGroup {
   @Override
-  public void update(AnActionEvent e) {
-    final boolean enabled = SystemInfo.isMac && isXcodeFile(e);
-    final Presentation presentation = e.getPresentation();
+  public void update(AnActionEvent event) {
+    final Presentation presentation = event.getPresentation();
+    final boolean enabled = isExternalIdeFile(event);
     presentation.setEnabled(enabled);
     presentation.setVisible(enabled);
   }
 
-  private boolean isXcodeFile(AnActionEvent e) {
+  private boolean isExternalIdeFile(AnActionEvent e) {
     final VirtualFile file = CommonDataKeys.VIRTUAL_FILE.getData(e.getDataContext());
-    if (file == null || !file.exists()) return false;
+    if (file == null || !file.exists()) {
+      return false;
+    }
+
     final Project project = e.getProject();
     return
-      isProjectDirectory(file, project) || isIOsDirectory(file) || FlutterUtils.isXcodeProjectFileName(file.getName());
+      isProjectDirectory(file, project) ||
+      isIOsDirectory(file) ||
+      isAndroidDirectory(file) ||
+      FlutterUtils.isXcodeProjectFileName(file.getName()) || OpenInAndroidStudioAction.isProjectFileName(file.getName());
   }
 
-  private boolean isIOsDirectory(@NotNull VirtualFile file) {
+  protected static boolean isAndroidDirectory(@NotNull VirtualFile file) {
+    return file.isDirectory() && file.getName().equals("android");
+  }
+
+  protected static boolean isIOsDirectory(@NotNull VirtualFile file) {
     return file.isDirectory() && file.getName().equals("ios");
   }
 
-  private boolean isProjectDirectory(@NotNull VirtualFile file, @Nullable Project project) {
+  private static boolean isProjectDirectory(@NotNull VirtualFile file, @Nullable Project project) {
     return file.isDirectory() && project != null && project.getBaseDir().getPath().equals(file.getPath());
   }
 }

--- a/src/io/flutter/actions/OpenInAndroidStudioAction.java
+++ b/src/io/flutter/actions/OpenInAndroidStudioAction.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2017 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.actions;
+
+import com.intellij.execution.ExecutionException;
+import com.intellij.execution.configurations.GeneralCommandLine;
+import com.intellij.execution.process.OSProcessHandler;
+import com.intellij.execution.process.ProcessAdapter;
+import com.intellij.execution.process.ProcessEvent;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.CommonDataKeys;
+import com.intellij.openapi.actionSystem.Presentation;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.SystemInfo;
+import com.intellij.openapi.vfs.VirtualFile;
+import io.flutter.FlutterMessages;
+import io.flutter.pub.PubRoot;
+import io.flutter.pub.PubRoots;
+import io.flutter.sdk.FlutterSdk;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+// TODO: locate the correct .iml file (app vs. plugin)
+
+public class OpenInAndroidStudioAction extends AnAction {
+  @Override
+  public void update(AnActionEvent event) {
+    final Presentation presentation = event.getPresentation();
+    final boolean enabled = findProjectFile(event) != null;
+    presentation.setEnabled(enabled);
+    presentation.setVisible(enabled);
+  }
+
+  @Override
+  public void actionPerformed(AnActionEvent e) {
+    final String androidStudioPath = findAndroidStudio(e.getProject());
+    if (androidStudioPath == null) {
+      FlutterMessages.showError("Error Opening Android Studio", "Unable to locate Android Studio.");
+      return;
+    }
+
+    final VirtualFile projectFile = findProjectFile(e);
+    if (projectFile == null) {
+      FlutterMessages.showError("Error Opening Android Studio", "Project not found.");
+      return;
+    }
+
+    openFileInStudio(projectFile, androidStudioPath);
+  }
+
+  @Nullable
+  private String findAndroidStudio(@Nullable Project project) {
+    if (project == null) {
+      return null;
+    }
+
+    final FlutterSdk flutterSdk = FlutterSdk.getFlutterSdk(project);
+    if (flutterSdk != null) {
+      final String androidSdkLocation = flutterSdk.queryFlutterConfig("android-studio-dir", true);
+      if (androidSdkLocation != null) {
+        final String contents = "/Contents";
+        // On a mac, trim off "/Contents".
+        if (SystemInfo.isMac && androidSdkLocation.endsWith(contents)) {
+          return androidSdkLocation.substring(0, androidSdkLocation.length() - contents.length());
+        }
+        return androidSdkLocation;
+      }
+    }
+    return null;
+  }
+
+  private VirtualFile findProjectFile(@Nullable AnActionEvent e) {
+    if (e != null) {
+      final VirtualFile file = CommonDataKeys.VIRTUAL_FILE.getData(e.getDataContext());
+      if (file != null && file.exists()) {
+        if (isProjectFileName(file.getName())) {
+          return file;
+        }
+
+        // Return null if this is an ios folder.
+        if (FlutterExternalIdeActionGroup.isIOsDirectory(file)) {
+          return null;
+        }
+      }
+
+      final Project project = e.getProject();
+      if (project != null) {
+        return findStudioProjectFile(project);
+      }
+    }
+    return null;
+  }
+
+  private static void openFileInStudio(@NotNull VirtualFile file, @NotNull String androidStudioPath) {
+    try {
+      final GeneralCommandLine cmd;
+      if (SystemInfo.isMac) {
+        cmd = new GeneralCommandLine().withExePath("open").withParameters("-a", androidStudioPath, file.getPath());
+      }
+      else {
+        cmd = new GeneralCommandLine().withExePath(androidStudioPath).withParameters(file.getPath());
+      }
+      final OSProcessHandler handler = new OSProcessHandler(cmd);
+      handler.addProcessListener(new ProcessAdapter() {
+        @Override
+        public void processTerminated(final ProcessEvent event) {
+          if (event.getExitCode() != 0) {
+            FlutterMessages.showError("Error Opening", file.getPath());
+          }
+        }
+      });
+      handler.startNotify();
+    }
+    catch (ExecutionException ex) {
+      FlutterMessages.showError(
+        "Error Opening",
+        "Exception: " + ex.getMessage());
+    }
+  }
+
+  protected static boolean isProjectFileName(String name) {
+    return name.endsWith("_android.iml");
+  }
+
+  @Nullable
+  private static VirtualFile findStudioProjectFile(@NotNull Project project) {
+    for (PubRoot root : PubRoots.forProject(project)) {
+      for (VirtualFile child : root.getRoot().getChildren()) {
+        if (isProjectFileName(child.getName())) {
+          return child;
+        }
+      }
+    }
+
+    return null;
+  }
+}

--- a/src/io/flutter/actions/OpenInAndroidStudioAction.java
+++ b/src/io/flutter/actions/OpenInAndroidStudioAction.java
@@ -24,8 +24,6 @@ import io.flutter.sdk.FlutterSdk;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-// TODO: locate the correct .iml file (app vs. plugin)
-
 public class OpenInAndroidStudioAction extends AnAction {
   @Override
   public void update(AnActionEvent event) {


### PR DESCRIPTION
- add an open in android studio action (fix https://github.com/flutter/flutter-intellij/issues/1063, fix #1118)
- adjust slightly where in the context menu we contribute the `open in...` actions
- make the open in xcode action not show when the android folder is selected; make the open in android studio action not selected when the ios folder is selected

@stevemessick @pq