### PR TITLE
fix an exception in ProgressHelper

### DIFF
--- a/src/io/flutter/run/daemon/ProgressHelper.java
+++ b/src/io/flutter/run/daemon/ProgressHelper.java
@@ -74,8 +74,10 @@ class ProgressHelper {
    */
   public void done() {
     synchronized (myTasks) {
-      myTasks.remove(myTasks.size() - 1);
-      myTasks.notifyAll();
+      if (!myTasks.isEmpty()) {
+        myTasks.remove(myTasks.size() - 1);
+        myTasks.notifyAll();
+      }
     }
   }
 


### PR DESCRIPTION
Fix a (relatively rare) exception that happens when closing a device.

@stevemessick 

```
null
java.lang.reflect.InvocationTargetException
	at sun.reflect.GeneratedMethodAccessor42.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at com.intellij.execution.process.ProcessHandler$4.invoke(ProcessHandler.java:227)
	at com.sun.proxy.$Proxy16.onTextAvailable(Unknown Source)
	at com.intellij.execution.process.ProcessHandler.notifyTextAvailable(ProcessHandler.java:201)
	at com.intellij.execution.process.BaseOSProcessHandler$SimpleOutputReader.onTextAvailable(BaseOSProcessHandler.java:295)
	at com.intellij.util.io.BaseOutputReader.sendText(BaseOutputReader.java:202)
	at com.intellij.util.io.BaseOutputReader.processInput(BaseOutputReader.java:186)
	at com.intellij.util.io.BaseOutputReader.readAvailableNonBlocking(BaseOutputReader.java:105)
	at com.intellij.util.io.BaseDataReader.readAvailable(BaseDataReader.java:85)
	at com.intellij.util.io.BaseDataReader.doRun(BaseDataReader.java:163)
	at com.intellij.util.io.BaseDataReader$1$1.run(BaseDataReader.java:66)
	at com.intellij.util.ConcurrencyUtil.runUnderThreadName(ConcurrencyUtil.java:194)
	at com.intellij.util.io.BaseDataReader$1.run(BaseDataReader.java:63)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.lang.ArrayIndexOutOfBoundsException: -1
	at java.util.ArrayList.elementData(ArrayList.java:418)
	at java.util.ArrayList.remove(ArrayList.java:495)
	at io.flutter.run.daemon.ProgressHelper.done(ProgressHelper.java:77)
	at io.flutter.run.daemon.FlutterAppListener.onAppProgressFinished(FlutterAppListener.java:128)
	at io.flutter.run.daemon.DaemonEvent$AppProgress.accept(DaemonEvent.java:246)
	at io.flutter.run.daemon.DaemonEvent.dispatch(DaemonEvent.java:52)
	at io.flutter.run.daemon.DaemonApi.dispatch(DaemonApi.java:169)
	at io.flutter.run.daemon.DaemonApi$1.onTextAvailable(DaemonApi.java:132)
	... 20 more
```
