### PR TITLE
Open correct file for plugin and packages; generate run config for pl…

### DIFF
--- a/src/io/flutter/pub/PubRoot.java
+++ b/src/io/flutter/pub/PubRoot.java
@@ -292,11 +292,46 @@ public class PubRoot {
   }
 
   /**
+   * Returns a file in lib if it exists.
+   */
+  @Nullable
+  public VirtualFile getFileToOpen() {
+    VirtualFile main = getLibMain();
+    if (main != null) {
+      return main;
+    }
+    if (lib != null) {
+      VirtualFile[] files = lib.getChildren();
+      if (files.length != 0) {
+        return files[0];
+      }
+    }
+    return null;
+  }
+
+  /**
    * Returns lib/main.dart if it exists.
    */
   @Nullable
   public VirtualFile getLibMain() {
     return lib == null ? null : lib.findChild("main.dart");
+  }
+
+  /**
+   * Returns example/lib/main.dart if it exists.
+   */
+  public VirtualFile getExampleLibMain() {
+    if (lib == null) {
+      return null;
+    }
+    VirtualFile exampleDir = lib.findChild("example");
+    if (exampleDir != null) {
+      VirtualFile libDir = exampleDir.findChild("lib");
+      if (libDir != null) {
+        return libDir.findChild("main.dart");
+      }
+    }
+    return null;
   }
 
   @Nullable

--- a/src/io/flutter/utils/FlutterModuleUtils.java
+++ b/src/io/flutter/utils/FlutterModuleUtils.java
@@ -166,8 +166,14 @@ public class FlutterModuleUtils {
   public static void autoCreateRunConfig(@NotNull Project project, @NotNull PubRoot root) {
     assert ApplicationManager.getApplication().isReadAccessAllowed();
 
-    final VirtualFile main = root.getLibMain();
-    if (main == null || !main.exists()) return;
+    VirtualFile main = root.getLibMain();
+    if (main == null || !main.exists()) {
+      // Check for example main.dart in plugins
+      main = root.getExampleLibMain();
+      if (main == null || !main.exists()) {
+        return;
+      }
+    }
 
     final FlutterRunConfigurationType configType = FlutterRunConfigurationType.getInstance();
 
@@ -197,7 +203,7 @@ public class FlutterModuleUtils {
    * If no files are open, show lib/main.dart for the given PubRoot.
    */
   public static void autoShowMain(@NotNull Project project, @NotNull PubRoot root) {
-    final VirtualFile main = root.getLibMain();
+    final VirtualFile main = root.getFileToOpen();
     if (main == null) return;
 
     DumbService.getInstance(project).runWhenSmart(() -> {


### PR DESCRIPTION
@devoncarew @pq 

While working on project generation for Android Studio I discovered some problems common to all versions of the plugin: no run config was being generated for plugin, and neither plugins nor projects were opening a file in the editor. This fixes both problems. It is independent of the work I'm doing for Android Studio (i.e. modifies the main plugin sources).