### PR TITLE
show flutter plugins as IntelliJ libraries

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -454,5 +454,7 @@
                     overrides="false"/>
 
     <iconProvider implementation="io.flutter.project.FlutterIconProvider" order="first"/>
+
+    <library.type implementation="io.flutter.sdk.FlutterPluginLibraryType"/>
   </extensions>
 </idea-plugin>

--- a/src/io/flutter/FlutterInitializer.java
+++ b/src/io/flutter/FlutterInitializer.java
@@ -26,6 +26,7 @@ import io.flutter.pub.PubRoot;
 import io.flutter.run.FlutterReloadManager;
 import io.flutter.run.FlutterRunNotifications;
 import io.flutter.run.daemon.DeviceService;
+import io.flutter.sdk.FlutterPluginsLibraryManager;
 import io.flutter.settings.FlutterSettings;
 import io.flutter.utils.FlutterModuleUtils;
 import io.flutter.view.FlutterViewFactory;
@@ -141,6 +142,9 @@ public class FlutterInitializer implements StartupActivity {
         DartfmtSettings.setDartfmtValue();
       }
     }
+
+    // TODO: temp
+    FlutterPluginsLibraryManager.updatePlugins(project);
 
     // Initialize the analytics notification group.
     NotificationsConfiguration.getNotificationsConfiguration().register(

--- a/src/io/flutter/FlutterInitializer.java
+++ b/src/io/flutter/FlutterInitializer.java
@@ -121,7 +121,7 @@ public class FlutterInitializer implements StartupActivity {
     // Start watching for Flutter debug active events.
     FlutterViewFactory.init(project);
 
-    final PubRoot root = PubRoot.forProjectWithRefresh(project);
+    final PubRoot root = PubRoot.singleForProjectWithRefresh(project);
     if (root != null) {
       if (root.hasAndroidModule(project)) {
         ensureAndroidSdk(project);
@@ -143,8 +143,9 @@ public class FlutterInitializer implements StartupActivity {
       }
     }
 
-    // TODO: temp
-    FlutterPluginsLibraryManager.updatePlugins(project);
+    // Start watching for project structure and .packages file changes.
+    final FlutterPluginsLibraryManager libraryManager = new FlutterPluginsLibraryManager(project);
+    libraryManager.startWatching();
 
     // Initialize the analytics notification group.
     NotificationsConfiguration.getNotificationsConfiguration().register(

--- a/src/io/flutter/ProjectOpenActivity.java
+++ b/src/io/flutter/ProjectOpenActivity.java
@@ -35,7 +35,7 @@ public class ProjectOpenActivity implements StartupActivity, DumbAware {
       return;
     }
 
-    PubRoot root = PubRoot.forProjectWithRefresh(project);
+    PubRoot root = PubRoot.singleForProjectWithRefresh(project);
     if (root == null) {
       return;
     }
@@ -117,7 +117,7 @@ public class ProjectOpenActivity implements StartupActivity, DumbAware {
             return;
           }
 
-          final PubRoot root = PubRoot.forProjectWithRefresh(project);
+          final PubRoot root = PubRoot.singleForProjectWithRefresh(project);
           if (root == null) {
             Messages.showErrorDialog("Pub root not found", "Error");
             return;

--- a/src/io/flutter/project/FlutterProjectOpenProcessor.java
+++ b/src/io/flutter/project/FlutterProjectOpenProcessor.java
@@ -87,7 +87,7 @@ public class FlutterProjectOpenProcessor extends ProjectOpenProcessor {
    * (It probably wasn't created with "flutter create" and probably didn't have any IntelliJ configuration before.)
    */
   private void convertToFlutterProject(@NotNull Project project) {
-    final PubRoot root = PubRoot.forProjectWithRefresh(project);
+    final PubRoot root = PubRoot.singleForProjectWithRefresh(project);
     if (root == null) {
       return; // Either no pub roots, or more than one.
     }

--- a/src/io/flutter/pub/PubRoot.java
+++ b/src/io/flutter/pub/PubRoot.java
@@ -5,7 +5,6 @@
  */
 package io.flutter.pub;
 
-import com.android.annotations.NonNull;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
 import com.intellij.openapi.actionSystem.LangDataKeys;
@@ -83,7 +82,7 @@ public class PubRoot {
     return root == null ? null : root.refresh();
   }
 
-  @NonNull
+  @NotNull
   public static List<PubRoot> multipleForProject(@NotNull Project project) {
     return PubRoots.forProject(project);
   }

--- a/src/io/flutter/pub/PubRoot.java
+++ b/src/io/flutter/pub/PubRoot.java
@@ -5,6 +5,7 @@
  */
 package io.flutter.pub;
 
+import com.android.annotations.NonNull;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
 import com.intellij.openapi.actionSystem.LangDataKeys;
@@ -18,10 +19,16 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
+import org.yaml.snakeyaml.nodes.Tag;
+import org.yaml.snakeyaml.representer.Representer;
+import org.yaml.snakeyaml.resolver.Resolver;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.regex.Pattern;
+import java.util.Map;
 
 /**
  * A snapshot of the root directory of a pub package.
@@ -55,7 +62,7 @@ public class PubRoot {
    * If there is more than one, returns null.
    */
   @Nullable
-  public static PubRoot forProject(@NotNull Project project) {
+  public static PubRoot singleForProject(@NotNull Project project) {
     final List<PubRoot> roots = PubRoots.forProject(project);
     if (roots.size() != 1) {
       return null;
@@ -71,9 +78,14 @@ public class PubRoot {
    * Refreshes the returned pubroot's directory. (Not any others.)
    */
   @Nullable
-  public static PubRoot forProjectWithRefresh(@NotNull Project project) {
-    final PubRoot root = forProject(project);
+  public static PubRoot singleForProjectWithRefresh(@NotNull Project project) {
+    final PubRoot root = singleForProject(project);
     return root == null ? null : root.refresh();
+  }
+
+  @NonNull
+  public static List<PubRoot> multipleForProject(@NotNull Project project) {
+    return PubRoots.forProject(project);
   }
 
   /**
@@ -112,7 +124,7 @@ public class PubRoot {
 
     final Project project = event.getData(CommonDataKeys.PROJECT);
     if (project != null) {
-      return forProjectWithRefresh(project);
+      return singleForProjectWithRefresh(project);
     }
 
     return null;
@@ -264,9 +276,52 @@ public class PubRoot {
    * Returns true if the pubspec declares a flutter dependency.
    */
   public boolean declaresFlutter() {
+    // It uses FLutter if it contains:
+    // dependencies:
+    //   flutter:
+
     try {
       final String contents = new String(pubspec.contentsToByteArray(true /* cache contents */));
-      return FLUTTER_SDK_DEP.matcher(contents).find();
+      final Map<String, Object> yaml = loadPubspecInfo(contents);
+      if (yaml == null) {
+        return false;
+      }
+
+      final Object flutterEntry = yaml.get("dependencies");
+      //noinspection SimplifiableIfStatement
+      if (flutterEntry instanceof Map) {
+        return ((Map)flutterEntry).containsKey("flutter");
+      }
+
+      return false;
+    }
+    catch (IOException e) {
+      return false;
+    }
+  }
+
+  /**
+   * Returns true if the pubspec indicates that it is a Flutter plugin.
+   */
+  public boolean isFlutterPlugin() {
+    // It's a plugin if it contains:
+    // flutter:
+    //   plugin:
+
+    try {
+      final String contents = new String(pubspec.contentsToByteArray(true /* cache contents */));
+      final Map<String, Object> yaml = loadPubspecInfo(contents);
+      if (yaml == null) {
+        return false;
+      }
+
+      final Object flutterEntry = yaml.get("flutter");
+      //noinspection SimplifiableIfStatement
+      if (flutterEntry instanceof Map) {
+        return ((Map)flutterEntry).containsKey("plugin");
+      }
+
+      return false;
     }
     catch (IOException e) {
       return false;
@@ -379,6 +434,26 @@ public class PubRoot {
     return false;
   }
 
+  private static Map<String, Object> loadPubspecInfo(@NotNull String yamlContents) {
+    final Yaml yaml = new Yaml(new SafeConstructor(), new Representer(), new DumperOptions(), new Resolver() {
+      protected void addImplicitResolvers() {
+        this.addImplicitResolver(Tag.BOOL, BOOL, "yYnNtTfFoO");
+        this.addImplicitResolver(Tag.NULL, NULL, "~nN\u0000");
+        this.addImplicitResolver(Tag.NULL, EMPTY, null);
+        this.addImplicitResolver(new Tag("tag:yaml.org,2002:value"), VALUE, "=");
+        this.addImplicitResolver(Tag.MERGE, MERGE, "<");
+      }
+    });
+
+    try {
+      //noinspection unchecked
+      return (Map)yaml.load(yamlContents);
+    }
+    catch (Exception var3) {
+      return null;
+    }
+  }
+
   /**
    * Returns the module containing this pub root, if any.
    */
@@ -410,6 +485,4 @@ public class PubRoot {
   public static boolean isPubspec(@NotNull VirtualFile file) {
     return !file.isDirectory() && file.getName().equals("pubspec.yaml");
   }
-
-  private static final Pattern FLUTTER_SDK_DEP = Pattern.compile(".*sdk:\\s*flutter"); //NON-NLS
 }

--- a/src/io/flutter/pub/PubRoot.java
+++ b/src/io/flutter/pub/PubRoot.java
@@ -275,7 +275,7 @@ public class PubRoot {
    * Returns true if the pubspec declares a flutter dependency.
    */
   public boolean declaresFlutter() {
-    // It uses FLutter if it contains:
+    // It uses Flutter if it contains:
     // dependencies:
     //   flutter:
 

--- a/src/io/flutter/run/FlutterReloadManager.java
+++ b/src/io/flutter/run/FlutterReloadManager.java
@@ -127,14 +127,14 @@ public class FlutterReloadManager {
     });
   }
 
-  private final AtomicBoolean handleingSave = new AtomicBoolean(false);
+  private final AtomicBoolean handlingSave = new AtomicBoolean(false);
 
   private void handleSaveAllNotification(AnActionEvent event) {
     if (!mySettings.isReloadOnSave()) {
       return;
     }
 
-    if (handleingSave.get()) {
+    if (handlingSave.get()) {
       return;
     }
 
@@ -178,11 +178,11 @@ public class FlutterReloadManager {
     // edit and immediately hits save.
     final int reloadDelayMs = 125;
 
-    handleingSave.set(true);
+    handlingSave.set(true);
 
     JobScheduler.getScheduler().schedule(() -> {
       if (hasErrors(project, module, editor.getDocument())) {
-        handleingSave.set(false);
+        handlingSave.set(false);
 
         showAnalysisNotification("Reload not performed", "Analysis issues found", true);
       }
@@ -196,7 +196,7 @@ public class FlutterReloadManager {
             showRunNotification(app, "Hot Reload Error", result.getMessage(), true);
           }
         }).whenComplete((aVoid, throwable) -> {
-          handleingSave.set(false);
+          handlingSave.set(false);
         });
       }
     }, reloadDelayMs, TimeUnit.MILLISECONDS);

--- a/src/io/flutter/sdk/FlutterPluginLibraryProperties.java
+++ b/src/io/flutter/sdk/FlutterPluginLibraryProperties.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.sdk;
+
+import com.intellij.openapi.roots.libraries.LibraryProperties;
+import com.intellij.util.xmlb.XmlSerializerUtil;
+import org.jetbrains.annotations.Nullable;
+
+public class FlutterPluginLibraryProperties extends LibraryProperties<FlutterPluginLibraryProperties> {
+  public FlutterPluginLibraryProperties() {
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    return other instanceof FlutterPluginLibraryProperties;
+  }
+
+  @Override
+  public int hashCode() {
+    return 0;
+  }
+
+  @Nullable
+  @Override
+  public FlutterPluginLibraryProperties getState() {
+    return this;
+  }
+
+  @Override
+  public void loadState(FlutterPluginLibraryProperties properties) {
+    XmlSerializerUtil.copyBean(properties, this);
+  }
+}

--- a/src/io/flutter/sdk/FlutterPluginLibraryType.java
+++ b/src/io/flutter/sdk/FlutterPluginLibraryType.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.sdk;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.libraries.LibraryType;
+import com.intellij.openapi.roots.libraries.NewLibraryConfiguration;
+import com.intellij.openapi.roots.libraries.PersistentLibraryKind;
+import com.intellij.openapi.roots.libraries.ui.LibraryEditorComponent;
+import com.intellij.openapi.roots.libraries.ui.LibraryPropertiesEditor;
+import com.intellij.openapi.vfs.VirtualFile;
+import icons.FlutterIcons;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+
+public class FlutterPluginLibraryType extends LibraryType<FlutterPluginLibraryProperties> {
+  public static final String FLUTTER_PLUGINS_LIBRARY_NAME = "Flutter Plugins";
+
+  public static final PersistentLibraryKind<FlutterPluginLibraryProperties> LIBRARY_KIND =
+    new PersistentLibraryKind<FlutterPluginLibraryProperties>("FlutterPluginsLibraryType") {
+      @Override
+      @NotNull
+      public FlutterPluginLibraryProperties createDefaultProperties() {
+        return new FlutterPluginLibraryProperties();
+      }
+    };
+
+  protected FlutterPluginLibraryType() {
+    super(LIBRARY_KIND);
+  }
+
+  @Nullable
+  @Override
+  public String getCreateActionName() {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public NewLibraryConfiguration createNewLibrary(@NotNull JComponent component, @Nullable VirtualFile file, @NotNull Project project) {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public LibraryPropertiesEditor createPropertiesEditor(@NotNull LibraryEditorComponent<FlutterPluginLibraryProperties> component) {
+    return null;
+  }
+
+  @Override
+  @Nullable
+  public Icon getIcon() {
+    return FlutterIcons.Flutter;
+  }
+}

--- a/src/io/flutter/sdk/FlutterPluginsLibraryManager.java
+++ b/src/io/flutter/sdk/FlutterPluginsLibraryManager.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2017 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.sdk;
+
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ModalityState;
+import com.intellij.openapi.application.WriteAction;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleManager;
+import com.intellij.openapi.project.DumbService;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.*;
+import com.intellij.openapi.roots.impl.libraries.LibraryEx;
+import com.intellij.openapi.roots.impl.libraries.LibraryTableBase;
+import com.intellij.openapi.roots.impl.libraries.ProjectLibraryTable;
+import com.intellij.openapi.roots.libraries.Library;
+import com.intellij.openapi.roots.libraries.LibraryTable;
+import com.intellij.openapi.roots.libraries.LibraryTablesRegistrar;
+import com.intellij.openapi.util.text.StringUtil;
+import io.flutter.utils.FlutterModuleUtils;
+import org.jetbrains.annotations.NotNull;
+
+// TODO: run this on pubspec file changes and project structure changes (new modules, removed modules, ...)
+
+// TODO: or, just watch for changes to the .packages file?
+
+public class FlutterPluginsLibraryManager {
+
+  public static void updatePlugins(@NotNull final Project project) {
+    final Runnable runnable = () -> {
+      updateFlutterPlugins(project);
+    };
+
+    DumbService.getInstance(project).smartInvokeLater(runnable, ModalityState.NON_MODAL);
+  }
+
+  @NotNull
+  private static Library updateFlutterPlugins(@NotNull final Project project) {
+    // , @NotNull final DartFileListener.DartLibInfo libInfo
+
+    final LibraryTable projectLibraryTable = ProjectLibraryTable.getInstance(project);
+    final Library existingLibrary = projectLibraryTable.getLibraryByName(FlutterPluginLibraryType.FLUTTER_PLUGINS_LIBRARY_NAME);
+    final Library library =
+      existingLibrary != null ? existingLibrary
+                              : WriteAction.compute(() -> {
+                                final LibraryTableBase.ModifiableModel libTableModel =
+                                  ProjectLibraryTable.getInstance(project).getModifiableModel();
+                                final Library lib = libTableModel
+                                  .createLibrary(FlutterPluginLibraryType.FLUTTER_PLUGINS_LIBRARY_NAME,
+                                                 FlutterPluginLibraryType.LIBRARY_KIND);
+                                libTableModel.commit();
+                                return lib;
+                              });
+
+    final String[] existingUrls = library.getUrls(OrderRootType.CLASSES);
+
+    //final Collection<String> libRootUrls = libInfo.getLibRootUrls();
+
+    //if ((!libInfo.isProjectWithoutPubspec() && isBrokenPackageMap(((LibraryEx)library).getProperties())) ||
+    //    existingUrls.length != libRootUrls.size() ||
+    //    !libRootUrls.containsAll(Arrays.asList(existingUrls))) {
+    ApplicationManager.getApplication().runWriteAction(() -> {
+      final LibraryEx.ModifiableModelEx model = (LibraryEx.ModifiableModelEx)library.getModifiableModel();
+
+      //for (String url : existingUrls) {
+      //  model.removeRoot(url, OrderRootType.CLASSES);
+      //}
+      //
+      ////for (String url : libRootUrls) {
+      ////  model.addRoot(url, OrderRootType.CLASSES);
+      ////}
+      //
+      //final FlutterPluginLibraryProperties properties = new FlutterPluginLibraryProperties();
+      //properties.setPath("/Users/devoncarew/.pub-cache/hosted/pub.dartlang.org/flutter_blue-0.2.2/");
+      //model.setProperties(properties);
+
+      model.commit();
+    });
+    //}
+
+    for (Module module : ModuleManager.getInstance(project).getModules()) {
+      if (FlutterModuleUtils.isFlutterModule(module)) {
+        addFlutterLibraryDependency(module, library);
+      }
+      // TODO: else, remove it?
+    }
+
+    return library;
+  }
+
+  private static void addFlutterLibraryDependency(@NotNull final Module module, @NotNull final Library library) {
+    final ModifiableRootModel modifiableModel = ModuleRootManager.getInstance(module).getModifiableModel();
+
+    try {
+      for (final OrderEntry orderEntry : modifiableModel.getOrderEntries()) {
+        if (orderEntry instanceof LibraryOrderEntry &&
+            LibraryTablesRegistrar.PROJECT_LEVEL.equals(((LibraryOrderEntry)orderEntry).getLibraryLevel()) &&
+            StringUtil.equals(library.getName(), ((LibraryOrderEntry)orderEntry).getLibraryName())) {
+          return; // dependency already exists
+        }
+      }
+
+      modifiableModel.addLibraryEntry(library);
+
+      ApplicationManager.getApplication().runWriteAction(modifiableModel::commit);
+    }
+    finally {
+      if (!modifiableModel.isDisposed()) {
+        modifiableModel.dispose();
+      }
+    }
+  }
+}

--- a/src/io/flutter/sdk/FlutterPluginsLibraryManager.java
+++ b/src/io/flutter/sdk/FlutterPluginsLibraryManager.java
@@ -35,6 +35,8 @@ import static com.jetbrains.lang.dart.util.PubspecYamlUtil.PUBSPEC_YAML;
 public class FlutterPluginsLibraryManager {
   private final Project project;
 
+  private final AtomicBoolean isUpdating = new AtomicBoolean(false);
+
   public FlutterPluginsLibraryManager(@NotNull Project project) {
     this.project = project;
   }
@@ -72,8 +74,6 @@ public class FlutterPluginsLibraryManager {
       scheduleUpdate();
     }
   }
-
-  private final AtomicBoolean isUpdating = new AtomicBoolean(false);
 
   private void scheduleUpdate() {
     if (isUpdating.get()) {

--- a/src/io/flutter/sdk/FlutterPluginsLibraryManager.java
+++ b/src/io/flutter/sdk/FlutterPluginsLibraryManager.java
@@ -5,7 +5,6 @@
  */
 package io.flutter.sdk;
 
-import com.android.annotations.NonNull;
 import com.intellij.ProjectTopics;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ModalityState;
@@ -36,7 +35,7 @@ import static com.jetbrains.lang.dart.util.PubspecYamlUtil.PUBSPEC_YAML;
 public class FlutterPluginsLibraryManager {
   private final Project project;
 
-  public FlutterPluginsLibraryManager(@NonNull Project project) {
+  public FlutterPluginsLibraryManager(@NotNull Project project) {
     this.project = project;
   }
 

--- a/src/io/flutter/sdk/FlutterPluginsLibraryManager.java
+++ b/src/io/flutter/sdk/FlutterPluginsLibraryManager.java
@@ -41,42 +41,14 @@ public class FlutterPluginsLibraryManager {
   }
 
   public void startWatching() {
-    VirtualFileManager.getInstance().addVirtualFileListener(new VirtualFileListener() {
+    VirtualFileManager.getInstance().addVirtualFileListener(new VirtualFileContentsChangedAdapter() {
       @Override
-      public void beforePropertyChange(@NotNull VirtualFilePropertyEvent event) {
-        propertyChanged(event);
+      protected void onFileChange(@NotNull VirtualFile file) {
+        fileChanged(project, file);
       }
 
       @Override
-      public void propertyChanged(@NotNull VirtualFilePropertyEvent event) {
-        if (VirtualFile.PROP_NAME.equals(event.getPropertyName())) {
-          fileChanged(project, event.getFile());
-        }
-      }
-
-      @Override
-      public void contentsChanged(@NotNull VirtualFileEvent event) {
-        fileChanged(project, event.getFile());
-      }
-
-      @Override
-      public void fileCreated(@NotNull VirtualFileEvent event) {
-        fileChanged(project, event.getFile());
-      }
-
-      @Override
-      public void fileDeleted(@NotNull VirtualFileEvent event) {
-        fileChanged(project, event.getFile());
-      }
-
-      @Override
-      public void fileMoved(@NotNull VirtualFileMoveEvent event) {
-        fileChanged(project, event.getFile());
-      }
-
-      @Override
-      public void fileCopied(@NotNull VirtualFileCopyEvent event) {
-        fileChanged(project, event.getFile());
+      protected void onBeforeFileChange(@NotNull VirtualFile file) {
       }
     }, project);
 


### PR DESCRIPTION
- show flutter plugins as IntelliJ libraries (fix https://github.com/flutter/flutter-intellij/issues/1090)

This shows shows flutter plugins in the `External libraries` section of the Project view ,as well as in the project structure dialog. You can expand these entries to dig into the android and ios code that makes up the plugin implementation. Some screenshots:

<img width="333" alt="screen shot 2017-09-21 at 1 32 04 pm" src="https://user-images.githubusercontent.com/1269969/30717507-e8bef356-9ed1-11e7-8ec6-a20d74f5ef6c.png">

<img width="1029" alt="screen shot 2017-09-21 at 1 32 15 pm" src="https://user-images.githubusercontent.com/1269969/30717513-ee3c7128-9ed1-11e7-9be1-db5c0d2391a3.png">

<img width="268" alt="screen shot 2017-09-21 at 1 32 53 pm" src="https://user-images.githubusercontent.com/1269969/30717520-f49b02a0-9ed1-11e7-80be-c8cc710f33c0.png">

@stevemessick @pq