### PR TITLE
Add an Install SDK button to the new module wizard.

### DIFF
--- a/flutter-studio/src/io/flutter/actions/FlutterNewProjectAction.java
+++ b/flutter-studio/src/io/flutter/actions/FlutterNewProjectAction.java
@@ -23,6 +23,8 @@ import io.flutter.sdk.FlutterSdkUtil;
 import org.jetbrains.android.sdk.AndroidSdkUtils;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.NoSuchElementException;
+
 public class FlutterNewProjectAction extends AnAction implements DumbAware {
   public FlutterNewProjectAction() {
     this("New Flutter Project...");
@@ -39,23 +41,16 @@ public class FlutterNewProjectAction extends AnAction implements DumbAware {
 
   @Override
   public void actionPerformed(AnActionEvent e) {
-    String[] paths = FlutterSdkUtil.getKnownFlutterSdkPaths();
-    if (paths == null || paths.length == 0) {
-      // TODO(any): Add a link to download the SDK.
-      Messages.showErrorDialog("Please install the Flutter SDK", "No SDK Found");
-      return;
-    }
-    if (!AndroidSdkUtils.isAndroidSdkAvailable()) {
-      SdkQuickfixUtils.showSdkMissingDialog();
-      return;
-    }
-
     FlutterProjectModel model = new FlutterProjectModel(FlutterProjectType.APP);
     ModelWizard wizard = new ModelWizard.Builder()
       .addStep(new ChoseProjectTypeStep(model))
       .build();
     ModelWizardDialog dialog =
       new StudioWizardDialogBuilder(wizard, "Create New Flutter Project").setUseNewUx(true).build();
-    dialog.show();
+    try {
+      dialog.show();
+    } catch (NoSuchElementException ex) {
+      // This happens if no Flutter SDK is installed and the user cancels the FlutterProjectStep.
+    }
   }
 }

--- a/flutter-studio/src/io/flutter/project/FlutterProjectStep.form
+++ b/flutter-studio/src/io/flutter/project/FlutterProjectStep.form
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="io.flutter.project.FlutterProjectStep">
-  <grid id="27dc6" binding="myPanel" layout-manager="GridLayoutManager" row-count="12" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="myPanel" layout-manager="GridLayoutManager" row-count="13" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="5" bottom="0" right="5"/>
     <constraints>
-      <xy x="20" y="20" width="500" height="400"/>
+      <xy x="20" y="20" width="500" height="467"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -42,7 +42,7 @@
       </component>
       <component id="c8d10" class="javax.swing.JTextField" binding="myProjectName">
         <constraints>
-          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="3" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <toolTipText value="The name that will be shown in the launcher for this application"/>
@@ -56,7 +56,7 @@
       </component>
       <component id="6f10c" class="javax.swing.JTextField" binding="myDescription">
         <constraints>
-          <grid row="10" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="10" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
       </component>
@@ -93,7 +93,7 @@
       <grid id="cb520" binding="myLocationPanel" layout-manager="GridLayoutManager" row-count="3" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="7" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="7" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>
@@ -120,6 +120,78 @@
               </grid>
             </constraints>
           </vspacer>
+        </children>
+      </grid>
+      <component id="15a3a" class="com.intellij.ui.components.labels.LinkLabel" binding="myInstallActionLink">
+        <constraints>
+          <grid row="6" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="1" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="Install SDK"/>
+        </properties>
+      </component>
+      <grid id="4b98d" layout-manager="GridLayoutManager" row-count="3" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+        <margin top="0" left="0" bottom="0" right="0"/>
+        <constraints>
+          <grid row="12" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+        <border type="none"/>
+        <children>
+          <component id="b0f65" class="com.intellij.ui.JBProgressBar" binding="myProgressBar">
+            <constraints>
+              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <indeterminate value="true"/>
+            </properties>
+          </component>
+          <vspacer id="de6a3">
+            <constraints>
+              <grid row="2" column="1" row-span="1" col-span="2" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+            </constraints>
+          </vspacer>
+          <component id="e77ef" class="javax.swing.JLabel" binding="myCancelProgressButton">
+            <constraints>
+              <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <icon value="flutter/icons/navigation/cancel.png"/>
+              <text value=""/>
+            </properties>
+          </component>
+          <hspacer id="75cdb">
+            <constraints>
+              <grid row="0" column="3" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+            </constraints>
+          </hspacer>
+          <hspacer id="ad5ca">
+            <constraints>
+              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+            </constraints>
+          </hspacer>
+          <scrollpane id="c08a9">
+            <constraints>
+              <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="7" hsize-policy="7" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <verifyInputWhenFocusTarget value="true"/>
+              <visible value="true"/>
+            </properties>
+            <border type="empty"/>
+            <children>
+              <component id="5587f" class="javax.swing.JTextPane" binding="myProgressText">
+                <constraints/>
+                <properties>
+                  <editable value="false"/>
+                  <font style="2"/>
+                  <minimumSize width="71" height="32"/>
+                  <preferredSize width="170" height="32"/>
+                  <visible value="true"/>
+                </properties>
+              </component>
+            </children>
+          </scrollpane>
         </children>
       </grid>
     </children>

--- a/src/io/flutter/module/FlutterGeneratorPeer.java
+++ b/src/io/flutter/module/FlutterGeneratorPeer.java
@@ -37,7 +37,7 @@ import java.awt.event.MouseEvent;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
-public class FlutterGeneratorPeer {
+public class FlutterGeneratorPeer implements InstallSdkAction.Model {
   private final WizardContext myContext;
   private JPanel myMainPanel;
   private ComboboxWithBrowseButton mySdkPathComboWithBrowse;
@@ -88,6 +88,7 @@ public class FlutterGeneratorPeer {
       }
     });
 
+    // When this changes the corresponding parts of FlutterProjectStep should also be changed.
     myInstallActionLink.setIcon(myInstallSdkAction.getLinkIcon());
     myInstallActionLink.setDisabledIcon(IconLoader.getDisabledIcon(myInstallSdkAction.getLinkIcon()));
 
@@ -121,6 +122,7 @@ public class FlutterGeneratorPeer {
     mySdkPathComboWithBrowse = new ComboboxWithBrowseButton(new ComboBox<>());
   }
 
+  @Override
   public boolean validate() {
     final ValidationInfo info = validateSdk();
     if (info != null) {
@@ -155,27 +157,33 @@ public class FlutterGeneratorPeer {
     return mySdkPathComboWithBrowse.getComboBox().getEditor();
   }
 
+  @Override
   @NotNull
   public ComboboxWithBrowseButton getSdkComboBox() {
     return mySdkPathComboWithBrowse;
   }
 
+  @Override
   public void setSdkPath(@NotNull String sdkPath) {
     getSdkEditor().setItem(sdkPath);
   }
 
+  @Override
   public JBProgressBar getProgressBar() {
     return myProgressBar;
   }
 
+  @Override
   public LinkLabel getInstallActionLink() {
     return myInstallActionLink;
   }
 
+  @Override
   public JTextPane getProgressText() {
     return myProgressText;
   }
 
+  @Override
   public JLabel getCancelProgressButton() {
     return myCancelProgressButton;
   }
@@ -183,6 +191,7 @@ public class FlutterGeneratorPeer {
   /**
    * Set error details (pass null to hide).
    */
+  @Override
   public void setErrorDetails(@Nullable String details) {
     final boolean makeVisible = details != null;
     if (makeVisible) {
@@ -192,10 +201,12 @@ public class FlutterGeneratorPeer {
     errorPane.setVisible(makeVisible);
   }
 
+  @Override
   public void addCancelActionListener(InstallSdkAction.CancelActionListener listener) {
     myListener = listener;
   }
 
+  @Override
   public void requestNextStep() {
     final AbstractWizard wizard = myContext.getWizard();
     if (wizard != null) {


### PR DESCRIPTION
@devoncarew @pq 

Adds the same style of Install SDK button to the Android Studio wizards as is found in the IntelliJ wizards.

InstallSdkAction needed somne refactoring to become reusable. Getting the event-based validation in the new wizard framework to work required adding a few calls that could change how it behaves w.r.t. the old wizards. I verified that it still works, but I didn't check that cancelling has exactly the same before-and-after behavior. But it seems reasonable. It may look worse than it is because it got reorganized during reformating. Everything is still there.

Also, this removes the error message that @mit-mit found inhibiting his progress.

Static screenshot:
<img width="897" alt="screen shot 2017-09-26 at 1 35 13 pm" src="https://user-images.githubusercontent.com/8518285/30882982-a0d0df86-a2bf-11e7-9694-cb76be057af2.png">

Action-packed screenshot:
<img width="895" alt="screen shot 2017-09-26 at 1 32 35 pm" src="https://user-images.githubusercontent.com/8518285/30882893-57d8a656-a2bf-11e7-9c6e-7632599a70d3.png">

The validation error goes away once validation runs after the installation is finished, and the Next button is enabled.