### PR TITLE
Validate the SDK when selected from the file chooser

### DIFF
--- a/flutter-studio/src/io/flutter/project/FlutterProjectStep.java
+++ b/flutter-studio/src/io/flutter/project/FlutterProjectStep.java
@@ -95,6 +95,9 @@ public class FlutterProjectStep extends SkippableWizardStep<FlutterProjectModel>
     myBindings.bind(model.description(), new TextProperty(myDescription));
 
     myFlutterSdkPath.getComboBox().setEditable(true);
+    myFlutterSdkPath.getButton().addActionListener((e) -> {
+      myFlutterSdkPath.getComboBox().setSelectedItem(myFlutterSdkPath.getComboBox().getEditor().getItem());
+    });
     myBindings.bind(
       model.flutterSdk(),
       new TransformOptionalExpression<String, String>("", new SelectedItemProperty<>(myFlutterSdkPath.getComboBox())) {


### PR DESCRIPTION
@devoncarew @pq 

Just as the title says.

Event-driven validation is cool, but some components don't seem to generate all the events they should.