### PR TITLE
Ensure vanilla dart tests are not mis-indentified as fluttery (#1371).

### DIFF
--- a/src/io/flutter/FlutterUtils.java
+++ b/src/io/flutter/FlutterUtils.java
@@ -67,6 +67,9 @@ public class FlutterUtils {
     return file != null && file.exists();
   }
 
+  /**
+   * Test if the given element is contained in a module with a pub root that declares a flutter dependency.
+   */
   public static boolean isInFlutterProject(@NotNull PsiElement element) {
     final Module module = ModuleUtil.findModuleForPsiElement(element);
     if (module != null) {

--- a/src/io/flutter/FlutterUtils.java
+++ b/src/io/flutter/FlutterUtils.java
@@ -11,6 +11,8 @@ import com.intellij.execution.util.ExecUtil;
 import com.intellij.ide.actions.ShowSettingsUtilImpl;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ModalityState;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleUtil;
 import com.intellij.openapi.progress.ProcessCanceledException;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.text.StringUtil;
@@ -21,6 +23,7 @@ import com.intellij.util.PlatformUtils;
 import com.jetbrains.lang.dart.DartFileType;
 import com.jetbrains.lang.dart.psi.DartFile;
 import io.flutter.pub.PubRoot;
+import io.flutter.pub.PubRoots;
 import io.flutter.run.FlutterRunConfigurationProducer;
 import io.flutter.utils.FlutterModuleUtils;
 import org.jetbrains.annotations.NotNull;
@@ -62,6 +65,16 @@ public class FlutterUtils {
 
   public static boolean exists(@Nullable VirtualFile file) {
     return file != null && file.exists();
+  }
+
+  public static boolean isInFlutterProject(@NotNull PsiElement element) {
+    final Module module = ModuleUtil.findModuleForPsiElement(element);
+    if (module != null) {
+      for (PubRoot root : PubRoots.forModule(module)) {
+        if (root.declaresFlutter()) return true;
+      }
+    }
+    return false;
   }
 
   public static boolean isInTestDir(DartFile file) {

--- a/src/io/flutter/run/test/TestConfigProducer.java
+++ b/src/io/flutter/run/test/TestConfigProducer.java
@@ -13,11 +13,11 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiDirectory;
 import com.intellij.psi.PsiElement;
 import com.jetbrains.lang.dart.psi.DartFile;
+import io.flutter.FlutterUtils;
 import io.flutter.dart.DartPlugin;
 import io.flutter.pub.PubRoot;
 import io.flutter.run.FlutterRunConfigurationProducer;
 import io.flutter.sdk.FlutterSdk;
-import io.flutter.utils.FlutterModuleUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -32,7 +32,7 @@ public class TestConfigProducer extends RunConfigurationProducer<TestConfig> {
 
   private static boolean isFlutterContext(@NotNull ConfigurationContext context) {
     final PsiElement location = context.getPsiLocation();
-    return location != null && FlutterModuleUtils.isInFlutterModule(location);
+    return location != null && FlutterUtils.isInFlutterProject(location);
   }
 
   /**

--- a/src/io/flutter/run/test/TestConfigUtils.java
+++ b/src/io/flutter/run/test/TestConfigUtils.java
@@ -33,7 +33,7 @@ public class TestConfigUtils {
   @Nullable
   public static TestType asTestCall(@NotNull PsiElement element) {
     final DartFile file = FlutterUtils.getDartFile(element);
-    if (file != null && FlutterUtils.isInTestDir(file)) {
+    if (file != null && FlutterUtils.isInTestDir(file) && FlutterUtils.isInFlutterProject(element)) {
       // Named tests.
       final TestType namedTestCall = findNamedTestCall(element);
       if (namedTestCall != null) return namedTestCall;


### PR DESCRIPTION
Ensures tests run in a vanilla dart project (with nonetheless an SDK vended into a Flutter install) are not run w/ `flutter test` and that new test run configs are only fluttery if they should be.

Fixes: #1371 

@devoncarew 