### PR TITLE
Harden "Open in Android Studio"

### DIFF
--- a/src/io/flutter/FlutterBundle.properties
+++ b/src/io/flutter/FlutterBundle.properties
@@ -150,3 +150,9 @@ module.wizard.plugin_step_title=New Flutter Plugin
 module.wizard.plugin_step_body=Configure the new Flutter plugin
 module.wizard.plugin_name=flutter_plugin
 module.wizard.plugin_text=A new Flutter plugin.
+
+old.android.studio.title=Wrong Version
+old.android.studio.message=Your path contains Android Studio 2.x,\n\
+  which does not support Flutter.\n\n\
+  You can change it using the flutter command-line tool via:\n\
+  flutter\u00a0config\u00a0--android-studio-dir\u00a0{0}path{0}to{0}Android\u00a0Studio\u00a03.x


### PR DESCRIPTION
Detect Android Studio 2.x and offer suggestion to fix path.
Ignore trailing slash in path.
No-break-space is used to keep the command on a single line in the message box.
The source got sorted when I reformatted. If you want the original sorting I'll re-do it.

Fixes #1372 
@devoncarew @pq