### PR TITLE
Check that Android Studio is up-to-date

### DIFF
--- a/flutter-studio/src/io/flutter/FlutterStudioInitializer.java
+++ b/flutter-studio/src/io/flutter/FlutterStudioInitializer.java
@@ -5,11 +5,25 @@
  */
 package io.flutter;
 
+import com.intellij.openapi.application.ApplicationInfo;
+import com.intellij.openapi.ui.Messages;
+
 public class FlutterStudioInitializer implements Runnable {
+
+  private static void reportVersionIncompatibility(ApplicationInfo info) {
+    Messages.showErrorDialog("The Flutter plugin requires a more recent version of Android Studio.", "Version Mesmatch");
+  }
+
   @Override
   public void run() {
-    // TODO(messick): Remove this class if it is never needed.
     // Unlike StartupActivity, this runs before the welcome screen (FlatWelcomeFrame) is displayed.
     // StartupActivity runs just before a project is opened.
+    ApplicationInfo info = ApplicationInfo.getInstance();
+    if ("Google".equals(info.getCompanyName())) {
+      String version = info.getFullVersion();
+      if (version.startsWith("2.") || version.contains("Canary") || (version.contains("Beta") && !version.endsWith("7"))) {
+        reportVersionIncompatibility(info);
+      }
+    }
   }
 }

--- a/flutter-studio/src/io/flutter/FlutterStudioInitializer.java
+++ b/flutter-studio/src/io/flutter/FlutterStudioInitializer.java
@@ -11,7 +11,7 @@ import com.intellij.openapi.ui.Messages;
 public class FlutterStudioInitializer implements Runnable {
 
   private static void reportVersionIncompatibility(ApplicationInfo info) {
-    Messages.showErrorDialog("The Flutter plugin requires a more recent version of Android Studio.", "Version Mesmatch");
+    Messages.showErrorDialog("The Flutter plugin requires a more recent version of Android Studio.", "Version Mismatch");
   }
 
   @Override


### PR DESCRIPTION
Check to see if the version of Android Studio is too old to use. This check runs before the splash screen is removed. The error will be displayed even if the welcome screen is the only UI that is shown. Currently, beta 7 and later are acceptable.

Ideally, we'd disable the plugin. I experimented with that but it is hard to get working. It would require shutdown and restart anyway, so doesn't actually prevent the user from doing things that will generate stack traces as in #1395.

Fixes #1396
@devoncarew @pq