### PR TITLE
Fix Swift button

### DIFF
--- a/flutter-studio/src/io/flutter/project/FlutterProjectModel.java
+++ b/flutter-studio/src/io/flutter/project/FlutterProjectModel.java
@@ -53,8 +53,8 @@ public class FlutterProjectModel extends WizardModel {
     myKotlin.set(getInitialKotlinSupport());
     myKotlin.addListener(sender -> setInitialKotlinSupport(myKotlin.get()));
 
-    mySwift.set(getInitialKotlinSupport());
-    mySwift.addListener(sender -> setInitialKotlinSupport(mySwift.get()));
+    mySwift.set(getInitialSwiftSupport());
+    mySwift.addListener(sender -> setInitialSwiftSupport(mySwift.get()));
   }
 
   @NotNull


### PR DESCRIPTION
The Swift button should be independent of the Kotlin button. Apparently, during manual testing I always changed them both.

@pq @devoncarew 