### PR TITLE
Make errors refer to proper project or module

### DIFF
--- a/flutter-studio/src/io/flutter/module/FlutterModuleStep.java
+++ b/flutter-studio/src/io/flutter/module/FlutterModuleStep.java
@@ -7,6 +7,7 @@ package io.flutter.module;
 
 import io.flutter.project.FlutterProjectModel;
 import io.flutter.project.FlutterProjectStep;
+import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
 
@@ -14,5 +15,11 @@ public class FlutterModuleStep extends FlutterProjectStep {
   public FlutterModuleStep(FlutterProjectModel model, String title, Icon icon, FlutterProjectType type) {
     super(model, title, icon, type);
     hideLocation();
+  }
+
+  @NotNull
+  @Override
+  public String getContainerName() {
+    return "module";
   }
 }

--- a/flutter-studio/src/io/flutter/project/FlutterProjectStep.java
+++ b/flutter-studio/src/io/flutter/project/FlutterProjectStep.java
@@ -213,21 +213,21 @@ public class FlutterProjectStep extends SkippableWizardStep<FlutterProjectModel>
   @NotNull
   private Validator.Result validateFlutterModuleName(@NotNull String moduleName) {
     if (moduleName.isEmpty()) {
-      return errorResult("Please enter a name for the project");
+      return errorResult("Please enter a name for the " + getContainerName());
     }
     if (!FlutterUtils.isValidPackageName(moduleName)) {
       return errorResult(
-        "Invalid module name: '" + moduleName + "' - must be a valid Dart package name (lower_case_with_underscores).");
+        "Invalid " + getContainerName() + " name: '" + moduleName + "' - must be a valid Dart package name (lower_case_with_underscores).");
     }
     if (FlutterUtils.isDartKeyword(moduleName)) {
       return errorResult("Invalid module name: '" + moduleName + "' - must not be a Dart keyword.");
     }
     // Package name is more restrictive than identifier, so no need to check for identifier validity.
     if (FlutterConstants.FLUTTER_PACKAGE_DEPENDENCIES.contains(moduleName)) {
-      return errorResult("Invalid module name: '" + moduleName + "' - this will conflict with Flutter package dependencies.");
+      return errorResult("Invalid " + getContainerName() + " name: '" + moduleName + "' - this will conflict with Flutter package dependencies.");
     }
     if (moduleName.length() > FlutterConstants.MAX_MODULE_NAME_LENGTH) {
-      return errorResult("Invalid module name - must be less than " +
+      return errorResult("Invalid " + getContainerName() + " name - must be less than " +
                          FlutterConstants.MAX_MODULE_NAME_LENGTH +
                          " characters.");
     }
@@ -250,6 +250,11 @@ public class FlutterProjectStep extends SkippableWizardStep<FlutterProjectModel>
 
   protected void hideLocation() {
     myLocationPanel.setVisible(false);
+  }
+
+  @NotNull
+  public String getContainerName() {
+    return "project";
   }
 
   @Override

--- a/flutter-studio/src/io/flutter/project/FlutterProjectStep.java
+++ b/flutter-studio/src/io/flutter/project/FlutterProjectStep.java
@@ -222,9 +222,7 @@ public class FlutterProjectStep extends SkippableWizardStep<FlutterProjectModel>
     if (FlutterUtils.isDartKeyword(moduleName)) {
       return errorResult("Invalid module name: '" + moduleName + "' - must not be a Dart keyword.");
     }
-    if (!FlutterUtils.isValidDartIdentifier(moduleName)) {
-      return errorResult("Invalid module name: '" + moduleName + "' - must be a valid Dart identifier.");
-    }
+    // Package name is more restrictive than identifier, so no need to check for identifier validity.
     if (FlutterConstants.FLUTTER_PACKAGE_DEPENDENCIES.contains(moduleName)) {
       return errorResult("Invalid module name: '" + moduleName + "' - this will conflict with Flutter package dependencies.");
     }

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -8,7 +8,7 @@
 
   <category>Custom Languages</category>
 
-  <version>18.1</version>
+  <version>18.2</version>
 
   <idea-version since-build="171.1" until-build="172.*"/>
 
@@ -21,6 +21,12 @@
 
   <change-notes>
     <![CDATA[
+
+18.2:
+<ul>
+  <li>fixed an issue where reload on save could not be disabled</li>
+  <li>fixed an exception that could occur on project creation</li>
+</ul>
 
 18.1:
 <ul>


### PR DESCRIPTION
Changes name-related error messages to use 'project' or 'module' as appropriate for the item being created. This is something that could confuse new users, while experienced devs won't even notice.

Something like this may be needed for the IntelliJ plugin -- I haven't checked.