### PR TITLE
add some descriptive text to the flutter run launch config

### DIFF
--- a/src/io/flutter/run/FlutterConfigurationEditorForm.form
+++ b/src/io/flutter/run/FlutterConfigurationEditorForm.form
@@ -54,6 +54,7 @@
           <grid row="5" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
+          <enabled value="false"/>
           <text value="An optional build flavor; either a Gradle product flavor or an XCode custom scheme."/>
         </properties>
       </component>
@@ -62,6 +63,7 @@
           <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
+          <enabled value="false"/>
           <text value="The entry-point for the application. Generally, something like lib/main.dart."/>
         </properties>
       </component>
@@ -86,6 +88,7 @@
           <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
+          <enabled value="false"/>
           <text value="Additional arguments to flutter run."/>
         </properties>
       </component>

--- a/src/io/flutter/run/FlutterConfigurationEditorForm.form
+++ b/src/io/flutter/run/FlutterConfigurationEditorForm.form
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="io.flutter.run.FlutterConfigurationEditorForm">
-  <grid id="27dc6" binding="myMainPanel" default-binding="true" layout-manager="GridLayoutManager" row-count="4" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="myMainPanel" default-binding="true" layout-manager="GridLayoutManager" row-count="7" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="500" height="320"/>
+      <xy x="20" y="20" width="698" height="320"/>
     </constraints>
     <properties/>
     <border type="none"/>
     <children>
       <vspacer id="3f5de">
         <constraints>
-          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
       <component id="17e7a" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="myFileField">
@@ -32,6 +32,45 @@
           <toolTipText value="The main Dart entrypoint script."/>
         </properties>
       </component>
+      <component id="efe47" class="javax.swing.JLabel">
+        <constraints>
+          <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="Build flavor:"/>
+          <toolTipText value="The build flavor. This is either a gradle product flavor or an XCode custom scheme."/>
+        </properties>
+      </component>
+      <component id="14837" class="javax.swing.JTextField" binding="myBuildFlavorField">
+        <constraints>
+          <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+            <preferred-size width="150" height="-1"/>
+          </grid>
+        </constraints>
+        <properties/>
+      </component>
+      <component id="9a5c8" class="javax.swing.JLabel">
+        <constraints>
+          <grid row="5" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="An optional build flavor; either a Gradle product flavor or an XCode custom scheme."/>
+        </properties>
+      </component>
+      <component id="45360" class="javax.swing.JLabel">
+        <constraints>
+          <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="The entry-point for the application. Generally, something like lib/main.dart."/>
+        </properties>
+      </component>
+      <component id="e7876" class="javax.swing.JTextField" binding="myAdditionalArgumentsField">
+        <constraints>
+          <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+      </component>
       <component id="7656f" class="javax.swing.JLabel">
         <constraints>
           <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
@@ -42,28 +81,13 @@
           <toolTipText value="Additional command-line arguments to pass into 'flutter run'."/>
         </properties>
       </component>
-      <component id="e7876" class="javax.swing.JTextField" binding="myAdditionalArgumentsField">
+      <component id="5f9bb" class="javax.swing.JLabel">
         <constraints>
-          <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties/>
-      </component>
-      <component id="efe47" class="javax.swing.JLabel">
-        <constraints>
-          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
-          <text value="Build flavor:"/>
-          <toolTipText value="The build flavor. This is either a gradle product flavor or an XCode custom scheme."/>
+          <text value="Additional arguments to flutter run."/>
         </properties>
-      </component>
-      <component id="14837" class="javax.swing.JTextField" binding="myBuildFlavorField">
-        <constraints>
-          <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
-            <preferred-size width="150" height="-1"/>
-          </grid>
-        </constraints>
-        <properties/>
       </component>
     </children>
   </grid>


### PR DESCRIPTION
- add descriptive text to the flutter run launch config; this is to help clarify that 'build flavors' are optionsl
- sort the build flavor last in the dialog

@pq @stevemessick @mit-mit 

<img width="754" alt="screen shot 2017-10-24 at 1 18 37 pm" src="https://user-images.githubusercontent.com/1269969/31966027-2d4567a2-b8be-11e7-8115-450eead09fb0.png">
