### PR TITLE
Do not validate module location

### DIFF
--- a/flutter-studio/src/io/flutter/module/FlutterModuleStep.java
+++ b/flutter-studio/src/io/flutter/module/FlutterModuleStep.java
@@ -22,4 +22,9 @@ public class FlutterModuleStep extends FlutterProjectStep {
   public String getContainerName() {
     return "module";
   }
+
+  @Override
+  protected boolean isProject() {
+    return false;
+  }
 }

--- a/flutter-studio/src/io/flutter/project/FlutterProjectStep.java
+++ b/flutter-studio/src/io/flutter/project/FlutterProjectStep.java
@@ -119,8 +119,10 @@ public class FlutterProjectStep extends SkippableWizardStep<FlutterProjectModel>
     myValidatorPanel.registerValidator(model.projectName(), this::validateFlutterModuleName);
     myValidatorPanel.registerMessageSource(myDownloadErrorMessage);
 
-    Expression<File> locationFile = model.projectLocation().transform(File::new);
-    myValidatorPanel.registerValidator(locationFile, PathValidator.createDefault("project location"));
+    if (isProject()) {
+      Expression<File> locationFile = model.projectLocation().transform(File::new);
+      myValidatorPanel.registerValidator(locationFile, PathValidator.createDefault("project location"));
+    }
 
     // Initialization of the SDK install UI was copied from FlutterGeneratorPeer.
 
@@ -255,6 +257,10 @@ public class FlutterProjectStep extends SkippableWizardStep<FlutterProjectModel>
   @NotNull
   public String getContainerName() {
     return "project";
+  }
+
+  protected boolean isProject() {
+    return true;
   }
 
   @Override


### PR DESCRIPTION
@pq @devoncarew 

You cannot modify the module location. Adding the validator can cause spurious errors when testing very long module names because the validator has a hard limit of 100 chars for project location paths.