### PR TITLE
Scope Flutter pubspec action contributions (#1445).

### DIFF
--- a/src/io/flutter/editor/FlutterPubspecNotificationProvider.java
+++ b/src/io/flutter/editor/FlutterPubspecNotificationProvider.java
@@ -56,7 +56,7 @@ public class FlutterPubspecNotificationProvider extends EditorNotifications.Prov
     }
 
     final Module module = ModuleUtilCore.findModuleForFile(file, project);
-    if (module == null || !FlutterModuleUtils.isFlutterModule(module)) {
+    if (module == null || !FlutterModuleUtils.usesFlutter(module)) {
       return null;
     }
 


### PR DESCRIPTION
Fixes: #1445.

@devoncarew @jwren 

FYI @jwren, @alexander-doroshko : we'll want to update the check in the Dart Plugin (if we haven't already) to make sure that it verifies that projects are declaring Flutter when we test for flutteriness.