### PR TITLE
Change build script to leave usable plugin.xml

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -194,11 +194,9 @@ ant -Ddart.plugin.version=171.4424.10 -Didea.version=171.4333198 -Didea.product=
     </copy>
 
     <delete file="build/src/META-INF/plugin.xml"/>
-    <copy todir="build/src/META-INF">
+    <delete file="build/src/META-INF/plugin.xml.template"/>
+    <copy file="resources/META-INF/plugin.xml.template" tofile="build/src/META-INF/plugin.xml">
       <filterset refid="plugin.filters"/>
-      <fileset dir="resources/META-INF">
-        <filename name="plugin.xml"/>
-      </fileset>
     </copy>
 
     <jar destfile="build/flutter-intellij.jar" duplicate="preserve">
@@ -344,6 +342,14 @@ ant -Ddart.plugin.version=171.4424.10 -Didea.version=171.4333198 -Didea.product=
 
   <target name="clean">
     <delete dir="build"/>
+  </target>
+
+  <target name="plugin.xml">
+    <move file="resources/META-INF/plugin.xml" tofile="resources/META-INF/plugin.xml.old"/>
+    <copy file="resources/META-INF/plugin.xml.template" tofile="resources/META-INF/plugin.xml">
+      <filterset refid="plugin.filters"/>
+    </copy>
+    <delete file="resources/META-INF/plugin.xml.old"/>
   </target>
 
 </project>

--- a/resources/META-INF/plugin.xml.template
+++ b/resources/META-INF/plugin.xml.template
@@ -1,5 +1,5 @@
 <idea-plugin>
-  <id>io.flutter</id>
+  <id>@PLUGINID@</id>
   <name>Flutter</name>
   <description>Support for developing Flutter applications. Flutter gives developers an easy and productive way to build and deploy
     cross-platform, high-performance mobile apps on both Android and iOS.
@@ -10,11 +10,11 @@
 
   <version>18.3</version>
 
-  <idea-version since-build="172.1" until-build="173.*"/>
+  <idea-version since-build="@SINCE@" until-build="@UNTIL@"/>
 
   <!-- plugin compatibility -->
   <!-- see: http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html -->
-  
+  @DEPENDS@
 
   <change-notes>
     <![CDATA[


### PR DESCRIPTION
Template plugin.xml added to ant script to produce usable plugin.xml. The args used in build-all.sh can be used to make a plugin.xml for Android Studio (no one but me needs to).

@devoncarew @pq @jwren 