### PR TITLE
Update module file

### DIFF
--- a/flutter-intellij-community.iml
+++ b/flutter-intellij-community.iml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module type="JAVA_MODULE" version="4">
+<module type="PLUGIN_MODULE" version="4">
+  <component name="DevKit.ModuleBuildProperties" url="file://$MODULE_DIR$/resources/META-INF/plugin.xml" />
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">


### PR DESCRIPTION
Change from java module to plugin module. That adds the Build>Prepare Plugin Module menu item. It still doesn't work due to an error encountered when building, but at least it's there.

@devoncarew @pq 