### PR TITLE
add a feedback link for the widget inspector

### DIFF
--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.form
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.form
@@ -3,7 +3,7 @@
   <grid id="27dc6" binding="mainPanel" layout-manager="GridLayoutManager" row-count="4" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="574" height="443"/>
+      <xy x="20" y="20" width="574" height="448"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -114,7 +114,7 @@
           </component>
         </children>
       </grid>
-      <grid id="23e52" layout-manager="GridLayoutManager" row-count="4" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="23e52" layout-manager="GridLayoutManager" row-count="5" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -149,6 +149,17 @@
             </constraints>
             <properties>
               <text value="Try out features still under development (a restart may be required)."/>
+            </properties>
+          </component>
+          <component id="129f" class="com.intellij.ui.components.labels.LinkLabel" binding="myInspectorFeedbackLink">
+            <constraints>
+              <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="3" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <horizontalAlignment value="2"/>
+              <horizontalTextPosition value="2"/>
+              <text value="Provide feedback on the widget inspector (https://todo)."/>
+              <toolTipText value=""/>
             </properties>
           </component>
         </children>

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.form
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.form
@@ -153,12 +153,12 @@
           </component>
           <component id="129f" class="com.intellij.ui.components.labels.LinkLabel" binding="myInspectorFeedbackLink">
             <constraints>
-              <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="3" use-parent-layout="false"/>
+              <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="4" use-parent-layout="false"/>
             </constraints>
             <properties>
               <horizontalAlignment value="2"/>
               <horizontalTextPosition value="2"/>
-              <text value="Provide feedback on the widget inspector (https://todo)."/>
+              <text value="Provide feedback on the widget inspector (https://goo.gl/WrMB43)."/>
               <toolTipText value=""/>
             </properties>
           </component>

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.java
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.java
@@ -54,6 +54,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
   private JCheckBox myEnableVerboseLoggingCheckBox;
   private JCheckBox myEnableMemoryDashboardCheckBox;
   private JCheckBox myEnableWidgetInspectorCheckBox;
+  private LinkLabel<String> myInspectorFeedbackLink;
   private final @NotNull Project myProject;
 
   FlutterSettingsConfigurable(@NotNull Project project) {
@@ -64,9 +65,8 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     myVersionLabel.setText("");
     myVersionLabel.setCopyable(true);
 
-    if (DISABLE_INSPECTOR) {
-      myEnableWidgetInspectorCheckBox.setVisible(false);
-    }
+    myEnableWidgetInspectorCheckBox.setVisible(!DISABLE_INSPECTOR);
+    myInspectorFeedbackLink.setVisible(!DISABLE_INSPECTOR);
   }
 
   private void init() {
@@ -91,6 +91,16 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
       catch (URISyntaxException ignore) {
       }
     }, FlutterBundle.message("flutter.analytics.privacyUrl"));
+
+    myInspectorFeedbackLink.setIcon(null);
+    myInspectorFeedbackLink.setListener((label, linkUrl) -> {
+      try {
+        BrowserLauncher.getInstance().browse(new URI(linkUrl));
+      }
+      catch (URISyntaxException ignore) {
+      }
+      // TODO(devoncarew): Replace with a goo.gl short link.
+    }, "https://www.cheese.com");
   }
 
   private void createUIComponents() {

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.java
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.java
@@ -38,7 +38,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 
 public class FlutterSettingsConfigurable implements SearchableConfigurable {
-  private static final boolean DISABLE_INSPECTOR = false;
+  private static final boolean DISABLE_INSPECTOR = true;
 
   private static final Logger LOG = Logger.getInstance(FlutterSettingsConfigurable.class);
 

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.java
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.java
@@ -38,7 +38,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 
 public class FlutterSettingsConfigurable implements SearchableConfigurable {
-  private static final boolean DISABLE_INSPECTOR = true;
+  private static final boolean DISABLE_INSPECTOR = false;
 
   private static final Logger LOG = Logger.getInstance(FlutterSettingsConfigurable.class);
 
@@ -99,8 +99,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
       }
       catch (URISyntaxException ignore) {
       }
-      // TODO(devoncarew): Replace with a goo.gl short link.
-    }, "https://www.cheese.com");
+    }, "https://goo.gl/WrMB43");
   }
 
   private void createUIComponents() {


### PR DESCRIPTION
- add a placeholder for a feedback link for the widget inspector (fix https://github.com/flutter/flutter-intellij/issues/1418)

Note: I won't land this until we have a goo.gl short link for the feedback.

@jacob314 @InMatrix 