### PR TITLE
Provide better feedback when installing into canary AS

### DIFF
--- a/flutter-intellij-community.iml
+++ b/flutter-intellij-community.iml
@@ -12,6 +12,7 @@
       <sourceFolder url="file://$MODULE_DIR$/third_party/intellij-plugins-dart/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/third_party/intellij-plugins-dart/testSrc" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/.pub" />
+      <excludeFolder url="file://$MODULE_DIR$/artifacts" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
     </content>
     <orderEntry type="inheritedJdk" />

--- a/flutter-studio/src/io/flutter/FlutterStudioInitializer.java
+++ b/flutter-studio/src/io/flutter/FlutterStudioInitializer.java
@@ -14,6 +14,10 @@ public class FlutterStudioInitializer implements Runnable {
     Messages.showErrorDialog("The Flutter plugin requires a more recent version of Android Studio.", "Version Mismatch");
   }
 
+  private static void reportCanaryIncompatibility() {
+    Messages.showErrorDialog("The Flutter plugin does not work properly with Canary versions of Android Studio.", "Version Mismatch");
+  }
+
   @Override
   public void run() {
     // Unlike StartupActivity, this runs before the welcome screen (FlatWelcomeFrame) is displayed.
@@ -21,8 +25,10 @@ public class FlutterStudioInitializer implements Runnable {
     ApplicationInfo info = ApplicationInfo.getInstance();
     if ("Google".equals(info.getCompanyName())) {
       String version = info.getFullVersion();
-      if (version.startsWith("2.") || version.contains("Canary") || (version.contains("Beta") && !version.endsWith("7"))) {
+      if (version.startsWith("2.") || (version.contains("Beta") && !version.endsWith("7"))) {
         reportVersionIncompatibility(info);
+      } else if (version.contains("Canary")) {
+        reportCanaryIncompatibility();
       }
     }
   }


### PR DESCRIPTION
The message was just plain wrong. Now it is better. I'm still looking for a way to prevent installation into 3.1 but haven't found it. This message shows up while the splash screen is still visible, so it is impossible to miss.

@devoncarew @pq 