### PR TITLE
Fix for https://github.com/flutter/flutter-intellij/issues/1449

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -5,7 +5,7 @@
       <property name="BorderFactoryClass" class="java.lang.String" />
     </properties>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="IntelliJ IDEA Community Edition" project-jdk-type="IDEA JDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="IDEA Ultimate" project-jdk-type="IDEA JDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/src/io/flutter/editor/FlutterPubspecNotificationProvider.java
+++ b/src/io/flutter/editor/FlutterPubspecNotificationProvider.java
@@ -55,13 +55,12 @@ public class FlutterPubspecNotificationProvider extends EditorNotifications.Prov
       return null;
     }
 
-    final Module module = ModuleUtilCore.findModuleForFile(file, project);
-    if (module == null || !FlutterModuleUtils.usesFlutter(module)) {
+    // Check that this pubspec file declares flutter
+    if (!PubRoot.declaresFlutter(file)) {
       return null;
     }
 
-    final FlutterSdk sdk = FlutterSdk.getFlutterSdk(project);
-    if (sdk == null) {
+    if(FlutterSdk.getFlutterSdk(project) == null) {
       return null;
     }
 

--- a/src/io/flutter/editor/FlutterPubspecNotificationProvider.java
+++ b/src/io/flutter/editor/FlutterPubspecNotificationProvider.java
@@ -18,6 +18,7 @@ import com.intellij.ui.EditorNotificationPanel;
 import com.intellij.ui.EditorNotifications;
 import com.intellij.ui.HyperlinkLabel;
 import icons.FlutterIcons;
+import io.flutter.FlutterUtils;
 import io.flutter.pub.PubRoot;
 import io.flutter.sdk.FlutterSdk;
 import io.flutter.utils.FlutterModuleUtils;
@@ -56,11 +57,11 @@ public class FlutterPubspecNotificationProvider extends EditorNotifications.Prov
     }
 
     // Check that this pubspec file declares flutter
-    if (!PubRoot.declaresFlutter(file)) {
+    if (!FlutterUtils.declaresFlutter(file)) {
       return null;
     }
 
-    if(FlutterSdk.getFlutterSdk(project) == null) {
+    if (FlutterSdk.getFlutterSdk(project) == null) {
       return null;
     }
 

--- a/src/io/flutter/pub/PubRoot.java
+++ b/src/io/flutter/pub/PubRoot.java
@@ -16,6 +16,7 @@ import com.intellij.openapi.roots.ProjectFileIndex;
 import com.intellij.openapi.roots.ProjectRootManager;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
+import io.flutter.FlutterUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.yaml.snakeyaml.DumperOptions;
@@ -275,63 +276,14 @@ public class PubRoot {
    * Returns true if the pubspec declares a flutter dependency.
    */
   public boolean declaresFlutter() {
-    return declaresFlutter(pubspec);
-  }
-
-  /**
-   * Returns true if passed pubspec declares a flutter dependency.
-   */
-  public static boolean declaresFlutter(@NotNull final VirtualFile pubspec) {
-    // It uses Flutter if it contains:
-    // dependencies:
-    //   flutter:
-
-    try {
-      final String contents = new String(pubspec.contentsToByteArray(true /* cache contents */));
-      final Map<String, Object> yaml = loadPubspecInfo(contents);
-      if (yaml == null) {
-        return false;
-      }
-
-      final Object flutterEntry = yaml.get("dependencies");
-      //noinspection SimplifiableIfStatement
-      if (flutterEntry instanceof Map) {
-        return ((Map)flutterEntry).containsKey("flutter");
-      }
-
-      return false;
-    }
-    catch (IOException e) {
-      return false;
-    }
+    return FlutterUtils.declaresFlutter(pubspec);
   }
 
   /**
    * Returns true if the pubspec indicates that it is a Flutter plugin.
    */
   public boolean isFlutterPlugin() {
-    // It's a plugin if it contains:
-    // flutter:
-    //   plugin:
-
-    try {
-      final String contents = new String(pubspec.contentsToByteArray(true /* cache contents */));
-      final Map<String, Object> yaml = loadPubspecInfo(contents);
-      if (yaml == null) {
-        return false;
-      }
-
-      final Object flutterEntry = yaml.get("flutter");
-      //noinspection SimplifiableIfStatement
-      if (flutterEntry instanceof Map) {
-        return ((Map)flutterEntry).containsKey("plugin");
-      }
-
-      return false;
-    }
-    catch (IOException e) {
-      return false;
-    }
+    return FlutterUtils.isFlutterPlugin(pubspec);
   }
 
   @Nullable
@@ -438,27 +390,6 @@ public class PubRoot {
       }
     }
     return false;
-  }
-
-  private static Map<String, Object> loadPubspecInfo(@NotNull String yamlContents) {
-    final Yaml yaml = new Yaml(new SafeConstructor(), new Representer(), new DumperOptions(), new Resolver() {
-      @Override
-      protected void addImplicitResolvers() {
-        this.addImplicitResolver(Tag.BOOL, BOOL, "yYnNtTfFoO");
-        this.addImplicitResolver(Tag.NULL, NULL, "~nN\u0000");
-        this.addImplicitResolver(Tag.NULL, EMPTY, null);
-        this.addImplicitResolver(new Tag("tag:yaml.org,2002:value"), VALUE, "=");
-        this.addImplicitResolver(Tag.MERGE, MERGE, "<");
-      }
-    });
-
-    try {
-      //noinspection unchecked
-      return (Map)yaml.load(yamlContents);
-    }
-    catch (Exception e) {
-      return null;
-    }
   }
 
   /**

--- a/src/io/flutter/pub/PubRoot.java
+++ b/src/io/flutter/pub/PubRoot.java
@@ -275,6 +275,13 @@ public class PubRoot {
    * Returns true if the pubspec declares a flutter dependency.
    */
   public boolean declaresFlutter() {
+    return declaresFlutter(pubspec);
+  }
+
+  /**
+   * Returns true if passed pubspec declares a flutter dependency.
+   */
+  public static boolean declaresFlutter(@NotNull final VirtualFile pubspec) {
     // It uses Flutter if it contains:
     // dependencies:
     //   flutter:
@@ -449,7 +456,7 @@ public class PubRoot {
       //noinspection unchecked
       return (Map)yaml.load(yamlContents);
     }
-    catch (Exception var3) {
+    catch (Exception e) {
       return null;
     }
   }

--- a/src/io/flutter/utils/FlutterModuleUtils.java
+++ b/src/io/flutter/utils/FlutterModuleUtils.java
@@ -216,6 +216,8 @@ public class FlutterModuleUtils {
   /**
    * Introspect into the module's content roots, looking for flutter.yaml or a pubspec.yaml that
    * references flutter.
+   * <p/>
+   * True is returned if any of the PubRoots associated with the {@link Module} have a pubspec that declares flutter.
    */
   public static boolean usesFlutter(@NotNull Module module) {
     for (PubRoot root : PubRoots.forModule(module)) {


### PR DESCRIPTION
Fix for https://github.com/flutter/flutter-intellij/issues/1449 and a change to the Dart Plugin and Flutter Plugin to check for the flutteriness of a pubspec.  We now look to see if the individual pubspec declares flutter when determining if a notification should appear for a pubspec, _instead_ of asking the module if some pubspec.yaml declares flutter.

Nit: when comparing a file name to "pubspec.yaml" the two plugins are not consistent in _not_ ignoring the case of the filename.

Corresponding PR: https://github.com/JetBrains/intellij-plugins/pull/557