### PR TITLE
Minor clean up

### DIFF
--- a/flutter-studio/flutter-studio.iml
+++ b/flutter-studio/flutter-studio.iml
@@ -16,8 +16,6 @@
     <orderEntry type="module" module-name="adt-ui" />
     <orderEntry type="module" module-name="observable" />
     <orderEntry type="module" module-name="observable-ui" />
-    <orderEntry type="module" module-name="project-system" />
-    <orderEntry type="module" module-name="project-system-gradle" />
     <orderEntry type="module" module-name="flutter-intellij-community" />
     <orderEntry type="module" module-name="Dart-community" />
     <orderEntry type="module" module-name="platform-api" />

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -10,7 +10,7 @@
 
   <version>18.3</version>
 
-  <idea-version since-build="172.1" until-build="173.*"/>
+  <idea-version since-build="171.1" until-build="173.*"/>
 
   <!-- plugin compatibility -->
   <!-- see: http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html -->


### PR DESCRIPTION
@devoncarew @pq 

Adjust the lower-bound version in plugin.xml so it works for Android Studio. Once we get back to using a script this won't matter. Also remove some AS dependencies that aren't needed.