### PR TITLE
Suppress missing (optional) androidstudio module error.

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -300,6 +300,7 @@
   <depends optional="true" config-file="idea-contribs.xml">com.intellij.modules.java</depends>
 
   <!-- Contributes Android Studio-specific features and implementations. -->
+  <!--suppress PluginXmlValidity -->
   <depends optional="true" config-file="studio-contribs.xml">com.intellij.modules.androidstudio</depends>
   <!-- depends optional="true" config-file="studio-contribs.xml">com.android.tools.apk</depends --><!-- dev-channel sources only -->
 


### PR DESCRIPTION
This error appears to prevent sources from loading in a runtime workbench and occurs when the androidstudio is not installed.

@stevemessick 