### PR TITLE
add a keybinding for shift-cmd-s

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -394,7 +394,6 @@
             description="Reload"
             icon="FlutterIcons.HotReload">
       <add-to-group group-id="ToolbarRunGroup" anchor="after" relative-to-action="RunnerActions"/>
-      <keyboard-shortcut keymap="$default" first-keystroke="ctrl alt SEMICOLON"/>
       <keyboard-shortcut keymap="$default" first-keystroke="ctrl BACK_SLASH"/>
     </action>
 
@@ -405,8 +404,8 @@
       <action id="Flutter.Toolbar.RestartAction" class="io.flutter.actions.RestartFlutterAppRetarget"
               description="Restart"
               icon="FlutterIcons.FullRestart">
-        <keyboard-shortcut keymap="$default" first-keystroke="ctrl shift alt SEMICOLON"/>
         <keyboard-shortcut keymap="$default" first-keystroke="ctrl shift BACK_SLASH"/>
+        <keyboard-shortcut keymap="$default" first-keystroke="ctrl shift S"/>
       </action>
       <action id="Flutter.Menu.RunProfileAction" class="io.flutter.actions.RunProfileFlutterApp"
               description="Flutter Run Profile Mode"

--- a/resources/META-INF/plugin.xml.template
+++ b/resources/META-INF/plugin.xml.template
@@ -394,7 +394,6 @@
             description="Reload"
             icon="FlutterIcons.HotReload">
       <add-to-group group-id="ToolbarRunGroup" anchor="after" relative-to-action="RunnerActions"/>
-      <keyboard-shortcut keymap="$default" first-keystroke="ctrl alt SEMICOLON"/>
       <keyboard-shortcut keymap="$default" first-keystroke="ctrl BACK_SLASH"/>
     </action>
 
@@ -405,8 +404,8 @@
       <action id="Flutter.Toolbar.RestartAction" class="io.flutter.actions.RestartFlutterAppRetarget"
               description="Restart"
               icon="FlutterIcons.FullRestart">
-        <keyboard-shortcut keymap="$default" first-keystroke="ctrl shift alt SEMICOLON"/>
         <keyboard-shortcut keymap="$default" first-keystroke="ctrl shift BACK_SLASH"/>
+        <keyboard-shortcut keymap="$default" first-keystroke="ctrl shift S"/>
       </action>
       <action id="Flutter.Menu.RunProfileAction" class="io.flutter.actions.RunProfileFlutterApp"
               description="Flutter Run Profile Mode"


### PR DESCRIPTION
- add add a keybinding for shift-cmd-s (for a full restart - a companion to cmd-s and hot reload on save). While writing Flutter code I found myself wanting this :)
- remove the semi-colon keybinding for reload and restart; we now have three keybinding and this one seems the most esoteric. perhaps a resolution is to update the docs to mention the two keybindings, and to point people to existing intellij docs on customizing keybindings if the existing ones don't work for them

@pq @mit-mit 

