### PR TITLE
fix how we retarget flutter actions

### DIFF
--- a/src/io/flutter/actions/FlutterAppAction.java
+++ b/src/io/flutter/actions/FlutterAppAction.java
@@ -5,10 +5,10 @@
  */
 package io.flutter.actions;
 
-import com.intellij.openapi.actionSystem.ActionManager;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.DumbAwareAction;
+import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Computable;
 import io.flutter.run.daemon.FlutterApp;
 import org.jetbrains.annotations.NotNull;
@@ -46,19 +46,17 @@ abstract public class FlutterAppAction extends DumbAwareAction {
   }
 
   private void updateActionRegistration(boolean isConnected) {
-    final ActionManager actionManager = ActionManager.getInstance();
+    final Project project = getApp().getProject();
 
     if (!isConnected) {
       // Unregister ourselves if we're the current action.
-      if (actionManager.getAction(myActionId) == this) {
-        actionManager.unregisterAction(myActionId);
+      if (ProjectActions.getAction(project, myActionId) == this) {
+        ProjectActions.unregisterAction(project, myActionId);
       }
     }
     else {
-      // We have to unregister the previous action, otherwise we get an exception from the framework.
-      if (actionManager.getAction(myActionId) != this) {
-        actionManager.unregisterAction(myActionId);
-        actionManager.registerAction(myActionId, this);
+      if (ProjectActions.getAction(project, myActionId) != this) {
+        ProjectActions.registerAction(project, myActionId, this);
       }
     }
   }

--- a/src/io/flutter/actions/FlutterRetargetAppAction.java
+++ b/src/io/flutter/actions/FlutterRetargetAppAction.java
@@ -5,7 +5,6 @@
  */
 package io.flutter.actions;
 
-import com.intellij.openapi.actionSystem.ActionManager;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.Presentation;
@@ -43,7 +42,7 @@ public abstract class FlutterRetargetAppAction extends DumbAwareAction {
 
   @Override
   public void actionPerformed(AnActionEvent e) {
-    final AnAction action = getAction();
+    final AnAction action = getAction(e.getProject());
     if (action != null) {
       action.actionPerformed(e);
     }
@@ -63,7 +62,7 @@ public abstract class FlutterRetargetAppAction extends DumbAwareAction {
     presentation.setEnabled(false);
 
     // Retargeted actions defer to their targets for presentation updates.
-    final AnAction action = getAction();
+    final AnAction action = getAction(project);
     if (action != null) {
       final Presentation template = action.getTemplatePresentation();
       final String text = template.getTextWithMnemonic();
@@ -74,7 +73,7 @@ public abstract class FlutterRetargetAppAction extends DumbAwareAction {
     }
   }
 
-  private AnAction getAction() {
-    return ActionManager.getInstance().getAction(myActionId);
+  private AnAction getAction(@Nullable Project project) {
+    return project == null ? null : ProjectActions.getAction(project, myActionId);
   }
 }

--- a/src/io/flutter/actions/ProjectActions.java
+++ b/src/io/flutter/actions/ProjectActions.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.actions;
+
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Key;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Store and retrieve actions relative to a Project.
+ */
+public class ProjectActions {
+  private static final Key<Map<String, AnAction>> PROJECT_ACTIONS_KEY = Key.create("ProjectActions");
+
+  public static void registerAction(@NotNull Project project, @NotNull String id, @NotNull AnAction action) {
+    Map<String, AnAction> actions = project.getUserData(PROJECT_ACTIONS_KEY);
+    if (actions == null) {
+      actions = new HashMap<>();
+      project.putUserData(PROJECT_ACTIONS_KEY, actions);
+    }
+    actions.put(id, action);
+  }
+
+  @Nullable
+  public static AnAction getAction(@NotNull Project project, @NotNull String id) {
+    final Map<String, AnAction> actions = project.getUserData(PROJECT_ACTIONS_KEY);
+    return actions == null ? null : actions.get(id);
+  }
+
+  public static void unregisterAction(@NotNull Project project, @NotNull String id) {
+    final Map<String, AnAction> actions = project.getUserData(PROJECT_ACTIONS_KEY);
+    if (actions != null) {
+      actions.remove(id);
+    }
+  }
+
+  private ProjectActions() {
+
+  }
+}

--- a/src/io/flutter/run/FlutterReloadManager.java
+++ b/src/io/flutter/run/FlutterReloadManager.java
@@ -5,7 +5,6 @@
  */
 package io.flutter.run;
 
-import com.android.annotations.NonNull;
 import com.intellij.codeInsight.hint.HintManager;
 import com.intellij.codeInsight.hint.HintManagerImpl;
 import com.intellij.codeInsight.hint.HintUtil;
@@ -319,7 +318,7 @@ public class FlutterReloadManager {
     }
   }
 
-  private static boolean shouldBlockReload(@NotNull DartServerData.DartError error, @NonNull Project project, @Nullable Module module) {
+  private static boolean shouldBlockReload(@NotNull DartServerData.DartError error, @NotNull Project project, @Nullable Module module) {
     // Only block on errors.
     if (!error.getSeverity().equals(AnalysisErrorSeverity.ERROR)) return false;
 

--- a/src/io/flutter/run/FlutterReloadManager.java
+++ b/src/io/flutter/run/FlutterReloadManager.java
@@ -5,6 +5,7 @@
  */
 package io.flutter.run;
 
+import com.android.annotations.NonNull;
 import com.intellij.codeInsight.hint.HintManager;
 import com.intellij.codeInsight.hint.HintManagerImpl;
 import com.intellij.codeInsight.hint.HintUtil;
@@ -13,7 +14,10 @@ import com.intellij.ide.BrowserUtil;
 import com.intellij.ide.actions.SaveAllAction;
 import com.intellij.ide.util.PropertiesComponent;
 import com.intellij.notification.*;
-import com.intellij.openapi.actionSystem.*;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.CommonDataKeys;
+import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.actionSystem.ex.ActionManagerEx;
 import com.intellij.openapi.actionSystem.ex.AnActionListener;
 import com.intellij.openapi.application.ApplicationManager;
@@ -24,7 +28,6 @@ import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.editor.ex.EditorEx;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.module.Module;
-import com.intellij.openapi.module.ModuleUtil;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Computable;
 import com.intellij.openapi.vfs.VfsUtil;
@@ -35,6 +38,7 @@ import com.intellij.psi.PsiDocumentManager;
 import com.intellij.psi.PsiErrorElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.search.GlobalSearchScope;
+import com.intellij.psi.search.ProjectAndLibrariesScope;
 import com.intellij.psi.search.SearchScope;
 import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.ui.LightweightHint;
@@ -47,6 +51,7 @@ import icons.FlutterIcons;
 import io.flutter.FlutterMessages;
 import io.flutter.actions.FlutterAppAction;
 import io.flutter.actions.OpenSimulatorAction;
+import io.flutter.actions.ProjectActions;
 import io.flutter.actions.ReloadFlutterApp;
 import io.flutter.pub.PubRoot;
 import io.flutter.pub.PubRoots;
@@ -107,7 +112,7 @@ public class FlutterReloadManager {
         }
 
         // If this save all action is not for the current project, return.
-        if (myProject != CommonDataKeys.PROJECT.getData(event.getDataContext())) {
+        if (myProject != event.getProject()) {
           return;
         }
 
@@ -151,7 +156,7 @@ public class FlutterReloadManager {
       return;
     }
 
-    final AnAction reloadAction = ActionManager.getInstance().getAction(ReloadFlutterApp.ID);
+    final AnAction reloadAction = ProjectActions.getAction(myProject, ReloadFlutterApp.ID);
     final FlutterApp app = getApp(reloadAction);
     if (app == null) {
       return;
@@ -172,19 +177,6 @@ public class FlutterReloadManager {
 
     final EditorEx editorEx = (EditorEx)editor;
     final VirtualFile file = editorEx.getVirtualFile();
-    final Project project = editor.getProject();
-    if (file == null || project == null) {
-      return;
-    }
-    final Module module = ModuleUtil.findModuleForFile(file, project);
-    if (module == null) {
-      return;
-    }
-
-    // Only reload if it's in the same module.
-    if (!app.isSameModule(module)) {
-      return;
-    }
 
     // Add an arbitrary 125ms delay to allow analysis to catch up. This delay gives the analysis server a
     // small pause to return error results in the (relatively infrequent) case where the user makes a bad
@@ -194,7 +186,7 @@ public class FlutterReloadManager {
     handlingSave.set(true);
 
     JobScheduler.getScheduler().schedule(() -> {
-      if (hasErrors(project, module, editor.getDocument())) {
+      if (hasErrors(app.getProject(), app.getModule(), editor.getDocument())) {
         handlingSave.set(false);
 
         showAnalysisNotification("Reload not performed", "Analysis issues found", true);
@@ -289,7 +281,7 @@ public class FlutterReloadManager {
   }
 
   private FlutterApp getApp() {
-    final AnAction action = ActionManager.getInstance().getAction(ReloadFlutterApp.ID);
+    final AnAction action = ProjectActions.getAction(myProject, ReloadFlutterApp.ID);
     return action instanceof FlutterAppAction ? ((FlutterAppAction)action).getApp() : null;
   }
 
@@ -297,7 +289,7 @@ public class FlutterReloadManager {
     return DartPluginCapabilities.isSupported("supports.pausePostRequest");
   }
 
-  private boolean hasErrors(@NotNull Project project, @NotNull Module module, @NotNull Document document) {
+  private boolean hasErrors(@NotNull Project project, @Nullable Module module, @NotNull Document document) {
     // For 2017.1, we use the IntelliJ parser and look for syntax errors in the current document.
     // For 2017.2 and later, we instead rely on the analysis server's results for files in the app's module.
 
@@ -313,12 +305,12 @@ public class FlutterReloadManager {
       return firstError != null;
     }
     else {
-      final GlobalSearchScope scope = module.getModuleContentScope();
+      final GlobalSearchScope scope = module == null ? new ProjectAndLibrariesScope(project) : module.getModuleContentScope();
       try {
         //List<DartServerData.DartError> errors = analysisServerService.getErrors(scope);
         //noinspection unchecked
         List<DartServerData.DartError> errors = (List<DartServerData.DartError>)getErrorsMethod.invoke(analysisServerService, scope);
-        errors = errors.stream().filter(error -> shouldBlockReload(error, module)).collect(Collectors.toList());
+        errors = errors.stream().filter(error -> shouldBlockReload(error, project, module)).collect(Collectors.toList());
         return !errors.isEmpty();
       }
       catch (IllegalAccessException | InvocationTargetException e) {
@@ -327,14 +319,14 @@ public class FlutterReloadManager {
     }
   }
 
-  private static boolean shouldBlockReload(@NotNull DartServerData.DartError error, @NotNull Module module) {
+  private static boolean shouldBlockReload(@NotNull DartServerData.DartError error, @NonNull Project project, @Nullable Module module) {
     // Only block on errors.
     if (!error.getSeverity().equals(AnalysisErrorSeverity.ERROR)) return false;
 
     final File file = new File(error.getAnalysisErrorFileSD());
     final VirtualFile virtualFile = VfsUtil.findFileByIoFile(file, false);
     if (virtualFile != null) {
-      final List<PubRoot> roots = PubRoots.forModule(module);
+      final List<PubRoot> roots = module == null ? PubRoots.forProject(project) : PubRoots.forModule(module);
       for (PubRoot root : roots) {
         // Skip errors in test files.
         final String relativePath = root.getRelativePath(virtualFile);

--- a/src/io/flutter/run/daemon/FlutterApp.java
+++ b/src/io/flutter/run/daemon/FlutterApp.java
@@ -438,6 +438,16 @@ public class FlutterApp {
     myInspectorService = service;
   }
 
+  @NotNull
+  public Project getProject() {
+    return myProject;
+  }
+
+  @Nullable
+  public Module getModule() {
+    return myModule;
+  }
+
   public interface StateListener {
     void stateChanged(State newState);
   }

--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -21,16 +21,15 @@ import com.intellij.openapi.ui.SimpleToolWindowPanel;
 import com.intellij.openapi.util.Computable;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowManager;
-import com.intellij.psi.PsiElement;
 import com.intellij.ui.content.Content;
 import com.intellij.ui.content.ContentFactory;
 import com.intellij.ui.content.ContentManager;
 import icons.FlutterIcons;
 import io.flutter.FlutterBundle;
 import io.flutter.FlutterInitializer;
+import io.flutter.inspector.InspectorService;
 import io.flutter.run.daemon.FlutterApp;
 import io.flutter.settings.FlutterSettings;
-import io.flutter.inspector.InspectorService;
 import org.dartlang.vm.service.VmServiceListener;
 import org.dartlang.vm.service.element.Event;
 import org.jetbrains.annotations.NotNull;
@@ -61,11 +60,10 @@ public class FlutterView implements PersistentStateComponent<FlutterView.State>,
   @Nullable
   FlutterApp app;
 
-  private ArrayList<InspectorPanel> inspectorPanels;
+  private final ArrayList<InspectorPanel> inspectorPanels = new ArrayList<>();
 
   public FlutterView(@NotNull Project project) {
     myProject = project;
-    inspectorPanels = new ArrayList<>();
   }
 
   @Override
@@ -122,7 +120,7 @@ public class FlutterView implements PersistentStateComponent<FlutterView.State>,
       final ContentManager contentManager = toolWindow.getContentManager();
       final ContentFactory contentFactory = ContentFactory.SERVICE.getInstance();
       final Computable<Boolean> isSessionActive = () -> {
-        FlutterApp app = getFlutterApp();
+        final FlutterApp app = getFlutterApp();
         return app != null && app.isStarted() && app.getFlutterDebugProcess().getVmConnected() &&
                !app.getFlutterDebugProcess().getSession().isStopped();
       };
@@ -132,7 +130,7 @@ public class FlutterView implements PersistentStateComponent<FlutterView.State>,
       final SimpleToolWindowPanel windowPanel = new SimpleToolWindowPanel(true, true);
       content.setComponent(windowPanel);
 
-      InspectorPanel inspectorPanel = new InspectorPanel(this, isSessionActive, treeType);
+      final InspectorPanel inspectorPanel = new InspectorPanel(this, isSessionActive, treeType);
       windowPanel.setContent(inspectorPanel);
       windowPanel.setToolbar(ActionManager.getInstance().createActionToolbar("FlutterViewToolbar", toolbarGroup, true).getComponent());
 


### PR DESCRIPTION
This addresses an issue I saw this weekend. I had two project windows open against two separate flutter projects. I hit run in one project; when the app came up, the reload icon became enabled both in the current project, but also in the 2nd open project window. Hitting reload in either window would reload the app running for the first window.

- switch from using `ActionManager` to track globally registered actions, to using a new tracker that's scoped to projects
- additionally, fix an issue in reload on save where we didn't reload when the focused dart editor wasn't in the module for the app currently running. From dogfooding, it's surprising when the app doesn't reload (users get a sense that cmd-s means reload).

@pq
