### PR TITLE
update the build to allow the android studio zip file binary to work for IntelliJ as well

### DIFF
--- a/build-all.sh
+++ b/build-all.sh
@@ -1,15 +1,30 @@
 #!/bin/bash
 
-# Build two distribution files
+# Build two distribution files:
 #   artifacts/flutter-intellij.jar
 #   artifacts/flutter-studio.zip
 
+# fast fail the script on failures.
+set -e
+
+# clean the build
 rm -rf build/*
-ant -Ddart.plugin.version=171.4424.10 -Didea.version=171.4408382 -Didea.product=android-studio-ide \
-  -DDEPENDS=\<depends\>com.android.tools.apk\</depends\> \
-  -DPLUGINID=io.flutter.as -DSINCE=171.1 -DUNTIL=171.\*
+
+# build for Android Studio
+# TODO(devoncarew): The version range below (supported for Android Studio) is
+# a temporary measure.
+ant \
+  -Ddart.plugin.version=171.4424.10 \
+  -Didea.version=171.4408382 \
+  -Didea.product=android-studio-ide \
+  -DSINCE=171.1 -DUNTIL="173.*"
 mv build/flutter-studio.zip artifacts
 
+# build for IntelliJ
+# Note: built against IntelliJ 2017.1 for runtime compatibility with Android Studio.
 rm -rf build/*
-ant -Ddart.plugin.version=172.3317.48 -Didea.version=2017.2 -Didea.product=ideaIC
+ant \
+  -Ddart.plugin.version=172.3317.48 \
+  -Didea.version=2017.1 \
+  -Didea.product=ideaIC
 mv build/flutter-intellij.jar artifacts

--- a/build.xml
+++ b/build.xml
@@ -27,7 +27,7 @@ ant -Ddart.plugin.version=171.4424.10 -Didea.version=171.4408382 -Didea.product=
   <property name="UNTIL" value="173.*"/> <!-- 171.* -->
   <filterset id="plugin.filters">
     <propertyset>
-      <propertyref name="DEPENDS"/>
+      <!-- <propertyref name="DEPENDS"/> -->
       <propertyref name="PLUGINID"/>
       <propertyref name="SINCE"/>
       <propertyref name="UNTIL"/>

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -8,20 +8,35 @@
 
   <category>Custom Languages</category>
 
-  <version>18.3</version>
+  <version>18.4</version>
 
   <idea-version since-build="171.1" until-build="173.*"/>
 
+  <depends>Dart</depends>
+
   <!-- plugin compatibility -->
   <!-- see: http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html -->
-  
+
+  <!-- Contributes IDEA-specific features and implementations. -->
+  <depends optional="true" config-file="idea-contribs.xml">com.intellij.modules.java</depends>
+
+  <!-- Contributes Android Studio-specific features and implementations. -->
+  <!--suppress PluginXmlValidity -->
+  <depends optional="true" config-file="studio-contribs.xml">com.android.tools.apk</depends>
+  <!-- note that com.android.tools.apk as implies com.intellij.modules.androidstudio -->
 
   <change-notes>
     <![CDATA[
 
+18.4:
+<ul>
+  <li>Revert to 18.1 to address an NPE in the FlutterInitializer class</li>
+  <li>fixed an issue where reload on save could not be disabled</li>
+</ul>
+
 18.3:
 <ul>
-  <li>fixed a build problem that prevented the Android Studio plugin from creating projects
+  <li>fixed a build problem that prevented the Android Studio plugin from creating projects</li>
 </ul>
 
 18.2:
@@ -293,16 +308,6 @@
 </ul>
  ]]>
   </change-notes>
-
-  <depends>Dart</depends>
-
-  <!-- Contributes IDEA-specific features and implementations. -->
-  <depends optional="true" config-file="idea-contribs.xml">com.intellij.modules.java</depends>
-
-  <!-- Contributes Android Studio-specific features and implementations. -->
-  <!--suppress PluginXmlValidity -->
-  <depends optional="true" config-file="studio-contribs.xml">com.intellij.modules.androidstudio</depends>
-  <!-- depends optional="true" config-file="studio-contribs.xml">com.android.tools.apk</depends --><!-- dev-channel sources only -->
 
   <!-- Everything following should be SmallIDE-friendly.-->
   <!-- See: http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html -->

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -23,7 +23,7 @@
   <!-- Contributes Android Studio-specific features and implementations. -->
   <!--suppress PluginXmlValidity -->
   <depends optional="true" config-file="studio-contribs.xml">com.android.tools.apk</depends>
-  <!-- note that com.android.tools.apk as implies com.intellij.modules.androidstudio -->
+  <!-- note that com.android.tools.apk also implies com.intellij.modules.androidstudio -->
 
   <change-notes>
     <![CDATA[

--- a/resources/META-INF/plugin.xml.template
+++ b/resources/META-INF/plugin.xml.template
@@ -23,7 +23,7 @@
   <!-- Contributes Android Studio-specific features and implementations. -->
   <!--suppress PluginXmlValidity -->
   <depends optional="true" config-file="studio-contribs.xml">com.android.tools.apk</depends>
-  <!-- note that com.android.tools.apk as implies com.intellij.modules.androidstudio -->
+  <!-- note that com.android.tools.apk also implies com.intellij.modules.androidstudio -->
 
   <change-notes>
     <![CDATA[

--- a/resources/META-INF/plugin.xml.template
+++ b/resources/META-INF/plugin.xml.template
@@ -8,20 +8,35 @@
 
   <category>Custom Languages</category>
 
-  <version>18.3</version>
+  <version>19.0</version>
 
   <idea-version since-build="@SINCE@" until-build="@UNTIL@"/>
 
+  <depends>Dart</depends>
+
   <!-- plugin compatibility -->
   <!-- see: http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html -->
-  @DEPENDS@
+
+  <!-- Contributes IDEA-specific features and implementations. -->
+  <depends optional="true" config-file="idea-contribs.xml">com.intellij.modules.java</depends>
+
+  <!-- Contributes Android Studio-specific features and implementations. -->
+  <!--suppress PluginXmlValidity -->
+  <depends optional="true" config-file="studio-contribs.xml">com.android.tools.apk</depends>
+  <!-- note that com.android.tools.apk as implies com.intellij.modules.androidstudio -->
 
   <change-notes>
     <![CDATA[
 
+18.4:
+<ul>
+  <li>Revert to 18.1 to address an NPE in the FlutterInitializer class</li>
+  <li>fixed an issue where reload on save could not be disabled</li>
+</ul>
+
 18.3:
 <ul>
-  <li>fixed a build problem that prevented the Android Studio plugin from creating projects
+  <li>fixed a build problem that prevented the Android Studio plugin from creating projects</li>
 </ul>
 
 18.2:
@@ -293,16 +308,6 @@
 </ul>
  ]]>
   </change-notes>
-
-  <depends>Dart</depends>
-
-  <!-- Contributes IDEA-specific features and implementations. -->
-  <depends optional="true" config-file="idea-contribs.xml">com.intellij.modules.java</depends>
-
-  <!-- Contributes Android Studio-specific features and implementations. -->
-  <!--suppress PluginXmlValidity -->
-  <depends optional="true" config-file="studio-contribs.xml">com.intellij.modules.androidstudio</depends>
-  <!-- depends optional="true" config-file="studio-contribs.xml">com.android.tools.apk</depends --><!-- dev-channel sources only -->
 
   <!-- Everything following should be SmallIDE-friendly.-->
   <!-- See: http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html -->

--- a/resources/META-INF/plugin.xml.template
+++ b/resources/META-INF/plugin.xml.template
@@ -8,7 +8,7 @@
 
   <category>Custom Languages</category>
 
-  <version>19.0</version>
+  <version>18.4</version>
 
   <idea-version since-build="@SINCE@" until-build="@UNTIL@"/>
 

--- a/src/io/flutter/FlutterUtils.java
+++ b/src/io/flutter/FlutterUtils.java
@@ -200,7 +200,9 @@ public class FlutterUtils {
 
   @NotNull
   public static PluginId getPluginId() {
-    final PluginId pluginId = PluginId.findId(isAndroidStudio() ? "io.flutter.as" : "io.flutter");
+    // TODO(devoncarew): Update this as we converge on a new build system.
+    //final PluginId pluginId = PluginId.findId(isAndroidStudio() ? "io.flutter.as" : "io.flutter");
+    final PluginId pluginId = PluginId.findId("io.flutter");
     assert pluginId != null;
     return pluginId;
   }


### PR DESCRIPTION
- update the build to allow the android studio zip file binary to work for IntelliJ as well
- extend the version range of the AS binary to span 2017.1 through 2017.3
- ensure that the intellij source are compiled against 2017.1
- make the AS module dep listed in plugin.xml be the `com.android.tools.apk` one (important for the wizard dialog to function)

@stevemessick 

Steve, this is a bit of a pragmatic change, but does get us though the next release.
