### PR TITLE
improve the set of flutter sdks we show in the flutter sdk path combo

### DIFF
--- a/src/io/flutter/utils/FlutterModuleUtils.java
+++ b/src/io/flutter/utils/FlutterModuleUtils.java
@@ -68,7 +68,6 @@ public class FlutterModuleUtils {
    * </code>
    */
   public static boolean isFlutterModule(@Nullable final Module module) {
-
     if (module == null) return false;
 
     // If not IntelliJ, assume a small IDE (no multi-module project support).
@@ -292,7 +291,7 @@ public class FlutterModuleUtils {
 
     if (sdkPath == null) {
       final String[] flutterSdkPaths = FlutterSdkUtil.getKnownFlutterSdkPaths();
-      if (flutterSdkPaths != null && flutterSdkPaths.length > 0) {
+      if (flutterSdkPaths.length > 0) {
         sdkPath = flutterSdkPaths[0];
       }
     }


### PR DESCRIPTION
- improve the set of flutter sdks we show in the flutter sdk path combo

This is to mitigate the chance that the flutter sdk path combo will be empty (in places like the new project wizards). When testing Android Studio, the combo was empty, even though another open project window did have a flutter sdk set.

@stevemessick @pq @jwren 