### PR TITLE
Add product-matrix.json

### DIFF
--- a/flutter-intellij-community.iml
+++ b/flutter-intellij-community.iml
@@ -14,6 +14,8 @@
       <excludeFolder url="file://$MODULE_DIR$/.pub" />
       <excludeFolder url="file://$MODULE_DIR$/artifacts" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
+      <excludeFolder url="file://$MODULE_DIR$/tool/plugin/.pub" />
+      <excludeFolder url="file://$MODULE_DIR$/tool/plugin/build" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/product-matrix.json
+++ b/product-matrix.json
@@ -1,0 +1,31 @@
+{
+  "list": [
+    {
+      "name": "Android Studio",
+      "version": "3.0",
+      "ideaProduct": "android-studio-ide",
+      "ideaVersion": "171.4408382",
+      "dartPluginVersion": "171.4424.10",
+      "sinceBuild": "171.1",
+      "untilBuild": "171.*"
+    },
+    {
+      "name": "IntelliJ",
+      "version": "2017.2",
+      "ideaProduct": "ideaIC",
+      "ideaVersion": "2017.2",
+      "dartPluginVersion": "172.3317.48",
+      "sinceBuild": "172.1",
+      "untilBuild": "172.*"
+    },
+    {
+      "name": "IntelliJ",
+      "version": "2017.3",
+      "ideaProduct": "ideaIC",
+      "ideaVersion": "2017.3",
+      "dartPluginVersion": "173.3302.13",
+      "sinceBuild": "173.1",
+      "untilBuild": "173.*"
+    }
+  ]
+}

--- a/tool/plugin/test/plugin_test.dart
+++ b/tool/plugin/test/plugin_test.dart
@@ -33,7 +33,7 @@ void main() {
         var specs = (runner.commands['abuild'] as ProductCommand).specs;
         expect(specs, isNotNull);
         expect(specs.map((spec) => spec.ideaProduct),
-            orderedEquals(['android-studio-ide', 'ideaIC']));
+            orderedEquals(['android-studio-ide', 'ideaIC', 'ideaIC']));
       });
     });
     test('build', () {
@@ -42,7 +42,7 @@ void main() {
         var specs = (runner.commands['build'] as ProductCommand).specs;
         expect(specs, isNotNull);
         expect(specs.map((spec) => spec.ideaProduct),
-            orderedEquals(['android-studio-ide', 'ideaIC']));
+            orderedEquals(['android-studio-ide', 'ideaIC', 'ideaIC']));
       });
     });
     test('test', () {
@@ -51,7 +51,7 @@ void main() {
         var specs = (runner.commands['test'] as ProductCommand).specs;
         expect(specs, isNotNull);
         expect(specs.map((spec) => spec.ideaProduct),
-            orderedEquals(['android-studio-ide', 'ideaIC']));
+            orderedEquals(['android-studio-ide', 'ideaIC', 'ideaIC']));
       });
     });
     test('deploy', () {
@@ -60,7 +60,7 @@ void main() {
         var specs = (runner.commands['deploy'] as ProductCommand).specs;
         expect(specs, isNotNull);
         expect(specs.map((spec) => spec.ideaProduct),
-            orderedEquals(['android-studio-ide', 'ideaIC']));
+            orderedEquals(['android-studio-ide', 'ideaIC', 'ideaIC']));
       });
     });
   });
@@ -68,7 +68,13 @@ void main() {
   group('deploy', () {
     test('clean', () {
       var runner = makeTestRunner();
-      runner.run(["-r=19", "-d../..", "deploy", "--no-as", "--no-ij"]).whenComplete(() {
+      runner.run([
+        "-r=19",
+        "-d../..",
+        "deploy",
+        "--no-as",
+        "--no-ij"
+      ]).whenComplete(() {
         String dir = (runner.commands['deploy'] as DeployCommand).tempDir;
         expectAsync0(() => new Directory(dir).existsSync() == false);
       });
@@ -90,8 +96,9 @@ void main() {
       expect(
           cmd.paths.map((p) => p.substring(p.indexOf('artifacts'))),
           orderedEquals([
-            'artifacts/release_19/flutter-studio.zip',
-            'artifacts/release_19/flutter-intellij.jar',
+            'artifacts/release_19/3.0/flutter-intellij.zip',
+            'artifacts/release_19/2017.2/flutter-intellij.zip',
+            'artifacts/release_19/2017.3/flutter-intellij.zip',
           ]));
     });
   });


### PR DESCRIPTION
Add a plugin-matrix.json and drive the build from it. Change BuildSpec creation and update tests. Format the code. (Sorted in a previous PR)

Still working on `plugin build`. It will put the built file into a subdirectory of either artifacts or artifacts/release_NN, named after the platform version (3.0, 2017.2, 2017.3). All the files will be zip files, to reduce bandwidth.

@pq @devoncarew 