### PR TITLE
fix an NPE in the icon provider when deleting projects

### DIFF
--- a/src/io/flutter/actions/FlutterExternalIdeActionGroup.java
+++ b/src/io/flutter/actions/FlutterExternalIdeActionGroup.java
@@ -47,14 +47,11 @@ public class FlutterExternalIdeActionGroup extends DefaultActionGroup {
   }
 
   private static boolean isProjectDirectory(@NotNull VirtualFile file, @Nullable Project project) {
-    if (!file.isDirectory()) {
-      return false;
-    }
-    //noinspection SimplifiableIfStatement
-    if (project == null || project.getBaseDir() == null) {
+    if (!file.isDirectory() || project == null) {
       return false;
     }
 
-    return project.getBaseDir().getPath().equals(file.getPath());
+    final VirtualFile baseDir = project.getBaseDir();
+    return baseDir != null && baseDir.getPath().equals(file.getPath());
   }
 }

--- a/src/io/flutter/actions/FlutterExternalIdeActionGroup.java
+++ b/src/io/flutter/actions/FlutterExternalIdeActionGroup.java
@@ -47,6 +47,14 @@ public class FlutterExternalIdeActionGroup extends DefaultActionGroup {
   }
 
   private static boolean isProjectDirectory(@NotNull VirtualFile file, @Nullable Project project) {
-    return file.isDirectory() && project != null && project.getBaseDir().getPath().equals(file.getPath());
+    if (!file.isDirectory()) {
+      return false;
+    }
+    //noinspection SimplifiableIfStatement
+    if (project == null || project.getBaseDir() == null) {
+      return false;
+    }
+
+    return project.getBaseDir().getPath().equals(file.getPath());
   }
 }

--- a/src/io/flutter/project/FlutterIconProvider.java
+++ b/src/io/flutter/project/FlutterIconProvider.java
@@ -41,8 +41,10 @@ public class FlutterIconProvider extends IconProvider {
       if (!file.isInLocalFileSystem()) return null;
 
       // Project root.
-      if (Objects.equals(file.getPath(), project.getBaseDir().getPath())) {
-        return FlutterIcons.Flutter;
+      if (project.getBaseDir() != null) {
+        if (Objects.equals(file.getPath(), project.getBaseDir().getPath())) {
+          return FlutterIcons.Flutter;
+        }
       }
 
       final PubRoot root = PubRoot.forDirectory(file.getParent());

--- a/src/io/flutter/project/FlutterIconProvider.java
+++ b/src/io/flutter/project/FlutterIconProvider.java
@@ -41,10 +41,9 @@ public class FlutterIconProvider extends IconProvider {
       if (!file.isInLocalFileSystem()) return null;
 
       // Project root.
-      if (project.getBaseDir() != null) {
-        if (Objects.equals(file.getPath(), project.getBaseDir().getPath())) {
-          return FlutterIcons.Flutter;
-        }
+      final VirtualFile baseDir = project.getBaseDir();
+      if (baseDir != null && Objects.equals(file.getPath(), baseDir.getPath())) {
+        return FlutterIcons.Flutter;
       }
 
       final PubRoot root = PubRoot.forDirectory(file.getParent());

--- a/src/io/flutter/run/test/TestLaunchState.java
+++ b/src/io/flutter/run/test/TestLaunchState.java
@@ -110,20 +110,22 @@ class TestLaunchState extends CommandLineState {
     if (module != null) {
       console.addMessageFilter(new FlutterConsoleFilter(module));
     }
-    console.addMessageFilter(new DartRelativePathsConsoleFilter(project, getBaseDir()));
+    final String baseDir = getBaseDir();
+    if (baseDir != null) {
+      console.addMessageFilter(new DartRelativePathsConsoleFilter(project, baseDir));
+    }
     console.addMessageFilter(new UrlFilter());
     return console;
   }
 
+  @Nullable
   private String getBaseDir() {
     final PubRoot root = config.getFields().getPubRoot(config.getProject());
     if (root != null) {
       return root.getPath();
     }
-    if (config.getProject().getBaseDir() == null) {
-      return null;
-    }
-    return config.getProject().getBaseDir().getPath();
+    final VirtualFile baseDir = config.getProject().getBaseDir();
+    return baseDir == null ? null : baseDir.getPath();
   }
 
   @NotNull

--- a/src/io/flutter/run/test/TestLaunchState.java
+++ b/src/io/flutter/run/test/TestLaunchState.java
@@ -117,7 +117,13 @@ class TestLaunchState extends CommandLineState {
 
   private String getBaseDir() {
     final PubRoot root = config.getFields().getPubRoot(config.getProject());
-    return root != null ? root.getPath() : config.getProject().getBaseDir().getPath();
+    if (root != null) {
+      return root.getPath();
+    }
+    if (config.getProject().getBaseDir() == null) {
+      return null;
+    }
+    return config.getProject().getBaseDir().getPath();
   }
 
   @NotNull

--- a/src/io/flutter/sdk/FlutterSdk.java
+++ b/src/io/flutter/sdk/FlutterSdk.java
@@ -97,7 +97,7 @@ public class FlutterSdk {
     if (lib == null) {
       return null;
     }
-    return getFlutterFromDartSdkLibrary(lib, project.getBaseDir());
+    return getFlutterFromDartSdkLibrary(lib);
   }
 
   @Nullable
@@ -123,7 +123,7 @@ public class FlutterSdk {
   }
 
   @Nullable
-  private static FlutterSdk getFlutterFromDartSdkLibrary(Library lib, VirtualFile projectDir) {
+  private static FlutterSdk getFlutterFromDartSdkLibrary(Library lib) {
     final String[] urls = lib.getUrls(OrderRootType.CLASSES);
     for (String url : urls) {
       if (url.endsWith(DART_CORE_SUFFIX)) {


### PR DESCRIPTION
- guard against a null getBaseDir() from a Project when the user is deleting projects (fix https://github.com/flutter/flutter-intellij/issues/1513)

@pq @stevemessick 