### PR TITLE
improve parsing of the daemon json stream

### DIFF
--- a/src/io/flutter/utils/StdoutJsonParser.java
+++ b/src/io/flutter/utils/StdoutJsonParser.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2017 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.utils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A class to process regular text output intermixed with newline-delimited JSON.
+ */
+public class StdoutJsonParser {
+  private final StringBuilder buffer = new StringBuilder();
+  private final List<String> lines = new ArrayList<>();
+
+  /**
+   * Write new output to this [StdoutJsonParser].
+   */
+  public void appendOutput(String output) {
+    buffer.append(output);
+
+    while (buffer.length() > 0) {
+      if (buffer.length() >= 2 && buffer.charAt(0) == '[' && buffer.charAt(1) == '{') {
+        final int endIndex = buffer.indexOf("}]");
+        if (endIndex != -1) {
+          String line = buffer.substring(0, endIndex + 2);
+          buffer.delete(0, endIndex + 2);
+          if (buffer.length() > 0 && buffer.charAt(0) == '\n') {
+            line += "\n";
+            buffer.delete(0, 1);
+          }
+          lines.add(line);
+        }
+        else {
+          // Wait for a json terminator.
+          break;
+        }
+      }
+      else if (buffer.indexOf("\n") != -1) {
+        final int endIndex = buffer.indexOf("\n");
+        final String line = buffer.substring(0, endIndex + 1);
+        buffer.delete(0, endIndex + 1);
+        lines.add(line);
+      }
+      else {
+        break;
+      }
+    }
+  }
+
+  /**
+   * Flush any written but un-consumed output to [getAvailableLines].
+   */
+  public void flush() {
+    if (buffer.length() > 0) {
+      lines.add(buffer.toString());
+      buffer.setLength(0);
+    }
+  }
+
+  /**
+   * Read any lines available from the processed output.
+   */
+  public List<String> getAvailableLines() {
+    final List<String> copy = new ArrayList<>(lines);
+    lines.clear();
+    return copy;
+  }
+}

--- a/testSrc/unit/io/flutter/utils/StdoutJsonParserTest.java
+++ b/testSrc/unit/io/flutter/utils/StdoutJsonParserTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2017 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.utils;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+
+public class StdoutJsonParserTest {
+  @Test
+  public void simple() throws Exception {
+    final StdoutJsonParser parser = new StdoutJsonParser();
+    parser.appendOutput("hello\n");
+    parser.appendOutput("there\n");
+    parser.appendOutput("[{'foo':'bar'}]\n");
+    parser.appendOutput("bye\n");
+    parser.flush();
+
+    assertArrayEquals(
+      "validating parser results",
+      new String[]{"hello\n", "there\n", "[{'foo':'bar'}]\n", "bye\n"},
+      parser.getAvailableLines().toArray()
+    );
+  }
+
+  @Test
+  public void flush() throws Exception {
+    StdoutJsonParser parser = new StdoutJsonParser();
+    parser.appendOutput("hello\n");
+    parser.appendOutput("there");
+    parser.flush();
+
+    assertArrayEquals(
+      "validating parser results",
+      new String[]{"hello\n", "there"},
+      parser.getAvailableLines().toArray()
+    );
+
+    parser = new StdoutJsonParser();
+    parser.appendOutput("hello\n");
+    parser.appendOutput("there");
+
+    assertArrayEquals(
+      "validating parser results",
+      new String[]{"hello\n"},
+      parser.getAvailableLines().toArray()
+    );
+  }
+
+  @Test
+  public void split_json() throws Exception {
+    final StdoutJsonParser parser = new StdoutJsonParser();
+    parser.appendOutput("hello\n");
+    parser.appendOutput("there\n");
+    parser.appendOutput("[{'foo':");
+    parser.appendOutput("'bar'}]\n");
+    parser.appendOutput("bye\n");
+    parser.flush();
+
+    assertArrayEquals(
+      "validating parser results",
+      new String[]{"hello\n", "there\n", "[{'foo':'bar'}]\n", "bye\n"},
+      parser.getAvailableLines().toArray()
+    );
+  }
+}


### PR DESCRIPTION
Improve parsing of the daemon json stream:
- we now handle cases where larger json blobs would be split across two or more messages; previously we'd drop the messages on the floor; now we combine and parse correctly
- handle a case where flutter_tools occasionally sends a newline before any other output when starting an app

@stevemessick @jwren @pq 
