### PR TITLE
allow to run package:flutter tests from IntelliJ

### DIFF
--- a/src/io/flutter/FlutterUtils.java
+++ b/src/io/flutter/FlutterUtils.java
@@ -222,10 +222,17 @@ public class FlutterUtils {
         return false;
       }
 
-      final Object flutterEntry = yaml.get("dependencies");
+      // Special case the 'flutter' package itself - this allows us to run their unit tests from IntelliJ.
+      final Object name = yaml.get("name");
+      if ("flutter".equals(name)) {
+        return true;
+      }
+
+      // Check for a dependency on the flutter package.
+      final Object dependencies = yaml.get("dependencies");
       //noinspection SimplifiableIfStatement
-      if (flutterEntry instanceof Map) {
-        return ((Map)flutterEntry).containsKey("flutter");
+      if (dependencies instanceof Map) {
+        return ((Map)dependencies).containsKey("flutter");
       }
 
       return false;

--- a/src/io/flutter/run/test/TestConfigProducer.java
+++ b/src/io/flutter/run/test/TestConfigProducer.java
@@ -42,7 +42,6 @@ public class TestConfigProducer extends RunConfigurationProducer<TestConfig> {
    */
   @Override
   protected boolean setupConfigurationFromContext(TestConfig config, ConfigurationContext context, Ref<PsiElement> sourceElement) {
-
     if (!isFlutterContext(context)) return false;
 
     final PsiElement elt = context.getPsiLocation();


### PR DESCRIPTION
@pq, expand our idea of what a flutter project is slightly to allow us to run unit tests from the //packages/flutter project in IntelliJ.