### PR TITLE
Add a template variable for version

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -4,6 +4,7 @@
   <description>Support for developing Flutter applications. Flutter gives developers an easy and productive way to build and deploy
     cross-platform, high-performance mobile apps on both Android and iOS.
   </description>
+  <!--suppress PluginXmlValidity -->
   <vendor url="https://github.com/flutter/flutter-intellij">flutter.io</vendor>
 
   <category>Custom Languages</category>
@@ -23,7 +24,8 @@
   <!-- Contributes Android Studio-specific features and implementations. -->
   <!--suppress PluginXmlValidity -->
   <depends optional="true" config-file="studio-contribs.xml">com.android.tools.apk</depends>
-  <!-- note that com.android.tools.apk also implies com.intellij.modules.androidstudio -->
+  <!-- note that com.android.tools.apk also implies com.intellij.modules.androidstudio but it is not available in sources -->
+  <depends optional="true" config-file="studio-contribs.xml">com.intellij.modules.androidstudio</depends>
 
   <change-notes>
     <![CDATA[

--- a/resources/META-INF/plugin.xml.template
+++ b/resources/META-INF/plugin.xml.template
@@ -4,11 +4,12 @@
   <description>Support for developing Flutter applications. Flutter gives developers an easy and productive way to build and deploy
     cross-platform, high-performance mobile apps on both Android and iOS.
   </description>
+  <!--suppress PluginXmlValidity -->
   <vendor url="https://github.com/flutter/flutter-intellij">flutter.io</vendor>
 
   <category>Custom Languages</category>
 
-  <version>19.1</version>
+  @VERSION@
 
   <idea-version since-build="@SINCE@" until-build="@UNTIL@"/>
 
@@ -23,7 +24,8 @@
   <!-- Contributes Android Studio-specific features and implementations. -->
   <!--suppress PluginXmlValidity -->
   <depends optional="true" config-file="studio-contribs.xml">com.android.tools.apk</depends>
-  <!-- note that com.android.tools.apk also implies com.intellij.modules.androidstudio -->
+  <!-- note that com.android.tools.apk also implies com.intellij.modules.androidstudio but it is not available in sources -->
+  <depends optional="true" config-file="studio-contribs.xml">com.intellij.modules.androidstudio</depends>
 
   <change-notes>
     <![CDATA[

--- a/tool/plugin/lib/plugin.dart
+++ b/tool/plugin/lib/plugin.dart
@@ -287,13 +287,15 @@ String substitueTemplateVariables(String line, BuildSpec spec) {
         return spec.sinceBuild;
       case 'UNTIL':
         return spec.untilBuild;
+      case 'VERSION':
+        return spec.release == null ? '' : '<version>${spec.release}</version>';
       default:
         throw 'unknown template variable: $name';
     }
   }
 
   var start = line.indexOf('@');
-  while (start >= 0) {
+  while (start >= 0 && start < line.length) {
     var end = line.indexOf('@', start + 1);
     var name = line.substring(start + 1, end);
     line = line.replaceRange(start, end + 1, valueOf(name));

--- a/tool/plugin/lib/plugin.dart
+++ b/tool/plugin/lib/plugin.dart
@@ -78,7 +78,6 @@ Future<int> ant(BuildSpec spec) async {
   args.add('-Didea.product=${spec.ideaProduct}');
   args.add('-DSINCE=${spec.sinceBuild}');
   args.add('-DUNTIL=${spec.untilBuild}');
-  // TODO(messick) Add version to plugin.xml.template.
   return await exec('ant', args, cwd: directory);
 }
 
@@ -152,7 +151,7 @@ Future<File> genPluginXml(BuildSpec spec, String destDir) async {
   var file = await new File(p.join(rootPath, destDir, 'META-INF/plugin.xml'))
       .create(recursive: true);
   var dest = file.openWrite();
-  // TODO(devoncarew): Move the change log to a separate file and insert it here.
+  //TODO(devoncarew): Move the change log to a separate file and insert it here.
   await new File(p.join(rootPath, 'resources/META-INF/plugin.xml.template'))
       .openRead()
       .transform(UTF8.decoder)
@@ -881,13 +880,13 @@ class TestCommand extends ProductCommand {
     for (var spec in specs) {
       await spec.artifacts.provision();
 
-      // TODO(messick) Finish the implementation of TestCommand.
+      //TODO(messick) Finish the implementation of TestCommand.
       separator('Compiling test sources');
 
       var jars = []
         ..addAll(findJars('${spec.dartPlugin.outPath}/lib'))
         ..addAll(
-            findJars('${spec.product.outPath}/lib')); // TODO: also, plugins
+            findJars('${spec.product.outPath}/lib')); //TODO: also, plugins
 
       var sourcepath = [
         'testSrc',


### PR DESCRIPTION
The value of the --release argument will be used as the version number. If there is no --release argument then the version tag will be omitted. Also, fix a range error.

Apparently, if all the TODOs in a file have a space before TODO then the TODO viewer of IntelliJ won't find any of them. In other words, do this:
`//TODO`
and not this:
`// TODO`
Fixed that, too.

@devoncarew @pq 