### PR TITLE
Stop unzip from hanging if files exist

### DIFF
--- a/tool/plugin/lib/plugin.dart
+++ b/tool/plugin/lib/plugin.dart
@@ -443,6 +443,9 @@ class ArtifactManager {
       }
 
       // expand
+      if (new Directory(artifact.outPath).existsSync()) {
+        await removeAll(artifact.outPath);
+      }
       createDir(artifact.outPath);
 
       if (artifact.isZip) {
@@ -887,8 +890,7 @@ class TestCommand extends ProductCommand {
 
       var jars = []
         ..addAll(findJars('${spec.dartPlugin.outPath}/lib'))
-        ..addAll(
-            findJars('${spec.product.outPath}/lib')); //TODO: also, plugins
+        ..addAll(findJars('${spec.product.outPath}/lib')); //TODO: also, plugins
 
       var sourcepath = [
         'testSrc',


### PR DESCRIPTION
unzip hangs if a file exists that it is trying to write. There may be a flag for that, but we should be cleaning out the destination anyway. Reformatting changed another line.

@devoncarew @jacob314 