### PR TITLE
Fix error due to duplicate actions

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -25,7 +25,7 @@
   <!--suppress PluginXmlValidity -->
   <depends optional="true" config-file="studio-contribs.xml">com.android.tools.apk</depends>
   <!-- note that com.android.tools.apk also implies com.intellij.modules.androidstudio but it is not available in sources -->
-  <depends optional="true" config-file="studio-contribs.xml">com.intellij.modules.androidstudio</depends>
+  <!-- depends optional="true" config-file="studio-contribs.xml">com.intellij.modules.androidstudio</depends -->
 
   <change-notes>
     <![CDATA[

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -23,9 +23,9 @@
 
   <!-- Contributes Android Studio-specific features and implementations. -->
   <!--suppress PluginXmlValidity -->
-  <depends optional="true" config-file="studio-contribs.xml">com.android.tools.apk</depends>
+  <!-- depends optional="true" config-file="studio-contribs.xml">com.android.tools.apk</depends -->
   <!-- note that com.android.tools.apk also implies com.intellij.modules.androidstudio but it is not available in sources -->
-  <!-- depends optional="true" config-file="studio-contribs.xml">com.intellij.modules.androidstudio</depends -->
+  <depends optional="true" config-file="studio-contribs.xml">com.intellij.modules.androidstudio</depends>
 
   <change-notes>
     <![CDATA[

--- a/resources/META-INF/plugin.xml.template
+++ b/resources/META-INF/plugin.xml.template
@@ -25,7 +25,7 @@
   <!--suppress PluginXmlValidity -->
   <depends optional="true" config-file="studio-contribs.xml">com.android.tools.apk</depends>
   <!-- note that com.android.tools.apk also implies com.intellij.modules.androidstudio but it is not available in sources -->
-  <depends optional="true" config-file="studio-contribs.xml">com.intellij.modules.androidstudio</depends>
+  <!-- depends optional="true" config-file="studio-contribs.xml">com.intellij.modules.androidstudio</depends -->
 
   <change-notes>
     <![CDATA[

--- a/src/io/flutter/inspector/FlutterWidget.java
+++ b/src/io/flutter/inspector/FlutterWidget.java
@@ -9,6 +9,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.intellij.openapi.diagnostic.Logger;
 import icons.FlutterIcons;
 import io.flutter.utils.JsonUtils;
 import org.jetbrains.annotations.Contract;
@@ -29,6 +30,7 @@ import java.util.regex.Pattern;
  * Categorization of a Flutter widget.
  */
 public class FlutterWidget {
+  private static final Logger LOG = Logger.getInstance(FlutterWidget.class);
 
   enum Category {
     ACCESSIBILITY("Accessibility", FlutterIcons.Accessibility),
@@ -173,6 +175,7 @@ public class FlutterWidget {
       }
       catch (IOException | URISyntaxException e) {
         // Ignored -- json will be null.
+        LOG.error(e);
       }
     }
 


### PR DESCRIPTION
Causing a conditionally-included file to get loaded twice is a bad idea. It creates duplicate actions, which cause errors, which prevents the UI from starting when there is nothing other than the Welcome screen to display.

I also added a logger that might help with resource loading issues.

I need to extend `build gen` to do the right thing for the plugin.xml used for debugging.

@devoncarew @jacob314 