### PR TITLE
Fix provision; convert doc

### DIFF
--- a/product-matrix.json
+++ b/product-matrix.json
@@ -3,7 +3,7 @@
     {
       "name": "Android Studio",
       "version": "3.0",
-      "ideaProduct": "android-studio-ide",
+      "ideaProduct": "android-studio",
       "ideaVersion": "171.4408382",
       "dartPluginVersion": "171.4424.10",
       "sinceBuild": "171.1",

--- a/tool/plugin/README.md
+++ b/tool/plugin/README.md
@@ -1,8 +1,95 @@
-# plugin
 
-Flutter plugin tool.
+# Flutter Plugin Maintenance Tool
 
-The Flutter command-line tool `plugin` helps ensure the Flutter
-plugin is properly built and deployed.
+The previous builder for the Flutter plugin was written in Ant. An expert in Ant would probably have no trouble maintaining it, but we have no such expert available. In order to increase stability and productivity we transformed the builder into a Dart command line tool, inspired by the Flutter tool. The tool is named `plugin`, since it helps with plugin development.
 
-TODO(messick) Finish docs.
+
+## Functions
+
+The tool needs to perform several functions. Building is the basic one, but others are important too. Implementation note: these will be implemented as compound commands in the CLI tool (similar to `flutter doctor` or `flutter run` in the Flutter CLI tool).
+
+
+
+*   `build`
+*   `test`
+*   `deploy`
+*   `gen`
+*   `lint`
+
+Each command has its own set of optional arguments. If the CLI tool is invoked without a command then it will print its help message.
+
+There are two global options. On the command line these are given prior to the command name.
+
+
+
+*   `-r, --release=XX`
+Use "release mode." The `XX` value specifies the release identifier, like 18 or 19.1. It will be shown in the "version" field of the plugin manager's listing for the Flutter plugin. In this mode additional constraints must be satisfied. The current git branch must have no unsaved changes and must be named "release_XX". The `.travis.yml` file must be newer than the `product-matrix.json` file (see the `gen` command).
+*   `-d, --cwd=<working-directory>`
+Set the root directory to the `working-directory` value. This should not be used when running the tool from the command line. It is only intended to be used when running tests from IntelliJ run configurations that have no way to specify the working directory.
+
+
+### Build
+
+Builds may be targeted for local development or distribution.
+
+
+
+*   `-[no-]ij`
+Build for IntelliJ. Default is true; may be negated by including `no`.
+*   `-[no-]as`
+Build for Android Studio. Default is true; may be negated by including `no`.
+*   -u, --unpack
+Normally the archive files are not unpacked if the corresponding directory exists. This flag forces the archive files to be unpacked.
+
+
+The build function must generate the correct `plugin.xml` for each platform and generate the correct artifacts for each. In release mode the archive files are always unpacked (--unpack is implied). The plugin files are saved in the `artifacts` directory. In release mode a subdirectory of `artifacts` is created which has the name of the release and they are put there. During a local dev/test run the subdirectory is not created and the created files are children of `artifacts`.
+
+Returns a success or failure code to play nice with shell commands.
+
+
+### Test
+
+Both unit and integration tests need to run, and tests should work whether running locally or on Travis.
+
+
+
+*   `-u, --[no-]unit
+`Run unit tests (or not).
+*   `-i, --[no-]integration`
+Run GUI-based integration tests (or not).
+
+TBD: We may need some mechanism to automatically upload testing artifacts, since we can no longer attach zip files to email. This could also potentially be addressed by creating a 'dev' channel for the plugin on the JetBrains store, and publishing to it when we have release candidates.
+
+
+### Deploy
+
+Automatically upload all required artifacts to the JetBrains site. This function will print instructions to retrieve the password from valentine then prompt for the password to log into the JetBrains site. It has no options. Returns a success or failure code to play nice with shell commands.
+
+
+### Gen
+
+Generate a `plugin.xml` from `plugin.xml.template` to be used for launching a runtime workbench. This is different from the ones generated during building because it will have a version range that allows use in all targeted platforms.
+
+
+### Lint
+
+Run the lint tool. It checks for bad imports and prints a report of the Dart plugin API usage.
+
+
+## Examples
+
+Build the Flutter plugin for IntelliJ and Android Studio, in distribution mode.
+
+	`plugin -r19.2 build`
+
+Build a local version of the IntelliJ version of the plugin, not for distribution.
+
+	`plugin build --no-as`
+
+Run integration tests without doing a build, assuming an edit-build-test cycle during development.
+
+	`plugin test --no-unit`
+
+Build everything then run all tests. The big question here is: Can we get integration tests to run using the newly-built plugin rather than sources?
+
+	`plugin build && plugin test`

--- a/tool/plugin/compile.xml
+++ b/tool/plugin/compile.xml
@@ -13,7 +13,7 @@ Include -D arguments to define these properties: idea.product, idea.version.
   <property environment="env"/>
   <property name="idea.product" value="ideaIC"/>
   <property name="idea.version" value="2017.1.3"/>
-  <property name="idea.home" location="artifacts/${idea.product}-${idea.version}"/>
+  <property name="idea.home" location="artifacts/${idea.product}"/>
   <property name="javac2.home" value="artifacts/javac2"/>
 
   <condition property="build.studio">
@@ -47,9 +47,6 @@ Include -D arguments to define these properties: idea.product, idea.version.
   <target name="paths">
     <path id="idea.jars">
       <fileset dir="${idea.home}/lib">
-        <include name="*.jar"/>
-      </fileset>
-      <fileset dir="${idea.home}/plugins/Dart/lib">
         <include name="*.jar"/>
       </fileset>
       <fileset dir="${idea.home}/plugins">

--- a/tool/plugin/lib/plugin.dart
+++ b/tool/plugin/lib/plugin.dart
@@ -432,6 +432,13 @@ class ArtifactManager {
           log('download failed');
           break;
         }
+        var archiveFile = new File(path);
+        if (!archiveFile.existsSync() || archiveFile.lengthSync() < 200) {
+          log('archive file not found: $base/${artifact.file}');
+          archiveFile.deleteSync();
+          result = 1;
+          break;
+        }
       }
 
       // clear unpacked cache
@@ -471,6 +478,7 @@ class ArtifactManager {
       }
       if (result != 0) {
         log('unpacking failed');
+        await removeAll(artifact.output);
         break;
       }
 
@@ -555,6 +563,8 @@ class BuildCommand extends ProductCommand {
         log('zip failed: ${result.toString()}');
         return new Future(() => result);
       }
+      separator('BUILT');
+      log('${archiveFilePath(spec)}');
     }
     return 0;
   }
@@ -654,9 +664,9 @@ class BuildSpec {
   bool get isReleaseMode => release != null;
 
   void createArtifacts() {
-    if (ideaProduct == 'android-studio-ide') {
+    if (ideaProduct == 'android-studio') {
       product = artifacts.add(new Artifact(
-          '$ideaProduct-$ideaVersion-linux.zip',
+          '$ideaProduct-ide-$ideaVersion-linux.zip',
           output: ideaProduct));
     } else {
       product = artifacts.add(new Artifact('$ideaProduct-$ideaVersion.tar.gz',


### PR DESCRIPTION
@devoncarew @jacob314 @pq 

Fix various bugs in provisioning. Make it more resilient to errors.

It can still get into a bad state. The simplest fix is:
```shell
rm -rf artifacts
plugin build
```
Also, I converted the documentation to markdown and added it. I couldn't find an easy way to wrap the lines so the raw markdown is unreadable. However, it looks good in a proper reader. As I update it I will wrap the lines.