### PR TITLE
update the idea iml file

### DIFF
--- a/flutter-intellij.iml
+++ b/flutter-intellij.iml
@@ -15,6 +15,7 @@
       <excludeFolder url="file://$MODULE_DIR$/artifacts" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
       <excludeFolder url="file://$MODULE_DIR$/material-design-icons" />
+      <excludeFolder url="file://$MODULE_DIR$/testSrc/integration/io/flutter/gui" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />


### PR DESCRIPTION
- update the idea iml file to exclude AS specific source

@stevemessick - I'm not entirely sure that this is the best fix, but it does allow the `flutter-intellij.iml` file to build successfully