### PR TITLE
misc inspector UI tweaks

### DIFF
--- a/src/io/flutter/inspector/DiagnosticsNode.java
+++ b/src/io/flutter/inspector/DiagnosticsNode.java
@@ -10,6 +10,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
+import io.flutter.utils.CustomIconMaker;
 import io.flutter.utils.JsonUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -38,12 +39,14 @@ import static io.flutter.sdk.FlutterSettingsConfigurable.WIDGET_FILTERING_ENABLE
  * * DiagnosticsNode class defined at https://github.com/flutter/flutter/blob/master/packages/flutter/lib/src/foundation/diagnostics.dart
  * The difference is the class hierarchy is collapsed on the Java side as
  * the class hierarchy on the Dart side exists more to simplify creation
- * of Diagnostics  than because the class hierarchy of Diagnostics is
+ * of Diagnostics than because the class hierarchy of Diagnostics is
  * important. If you need to determine the exact Diagnostic class on the
  * Dart side you can use the value of type. The raw Dart object value is
  * also available via the getValue() method.
  */
 public class DiagnosticsNode {
+  private static final CustomIconMaker iconMaker = new CustomIconMaker();
+
   public DiagnosticsNode(JsonObject json, InspectorService inspectorService) {
     this.inspectorService = inspectorService;
     this.json = json;
@@ -69,7 +72,7 @@ public class DiagnosticsNode {
   }
 
   /**
-   * Seperator text to show between propert names and values.
+   * Seperator text to show between property names and values.
    */
   public String getSeparator() {
     return getShowSeparator() ? ":" : "";
@@ -505,9 +508,9 @@ public class DiagnosticsNode {
                 final CompletableFuture<ArrayList<DiagnosticsNode>> future = nodes.get(0).getChildren();
                 for (int i = 1; i < nodes.size(); ++i) {
                   future.thenCombine(nodes.get(i).getChildren(),
-                                       (nodes1, nodes2) -> Stream.of(nodes1, nodes2)
-                                         .flatMap(Collection::stream)
-                                         .collect(Collectors.toList()));
+                                     (nodes1, nodes2) -> Stream.of(nodes1, nodes2)
+                                       .flatMap(Collection::stream)
+                                       .collect(Collectors.toList()));
                 }
                 return future;
               }
@@ -552,7 +555,31 @@ public class DiagnosticsNode {
 
   @Nullable
   public Icon getIcon() {
+    Icon icon = null;
     final FlutterWidget widget = getWidget();
-    return widget != null ? widget.getIcon() : null;
+    if (widget != null) {
+      icon = widget.getIcon();
+    }
+    if (icon == null) {
+      icon = getCustomIcon(getDescription());
+    }
+    return icon;
+  }
+
+  private static Icon getCustomIcon(String text) {
+    if (text == null) {
+      return null;
+    }
+
+    final boolean isPrivate = text.startsWith("_");
+    while (!text.isEmpty() && !Character.isAlphabetic(text.charAt(0))) {
+      text = text.substring(1);
+    }
+
+    if (text.isEmpty()) {
+      return null;
+    }
+
+    return iconMaker.getCustomIcon(text, isPrivate ? CustomIconMaker.IconKind.kMethod : CustomIconMaker.IconKind.kClass);
   }
 }

--- a/src/io/flutter/run/FlutterReloadManager.java
+++ b/src/io/flutter/run/FlutterReloadManager.java
@@ -49,7 +49,6 @@ import com.jetbrains.lang.dart.ide.errorTreeView.DartProblemsView;
 import icons.FlutterIcons;
 import io.flutter.FlutterMessages;
 import io.flutter.actions.FlutterAppAction;
-import io.flutter.actions.OpenSimulatorAction;
 import io.flutter.actions.ProjectActions;
 import io.flutter.actions.ReloadFlutterApp;
 import io.flutter.pub.PubRoot;
@@ -240,10 +239,9 @@ public class FlutterReloadManager {
           showRunNotification(app, "Full Restart", result.getMessage(), true);
         }
       });
-      // Bring iOS simulator to front.
       final FlutterDevice device = DeviceService.getInstance(myProject).getSelectedDevice();
-      if (device != null && device.emulator() && device.isIOS()) {
-        new OpenSimulatorAction(true).actionPerformed(null);
+      if (device != null) {
+        device.bringToFront();
       }
     }
   }

--- a/src/io/flutter/run/LaunchState.java
+++ b/src/io/flutter/run/LaunchState.java
@@ -104,10 +104,7 @@ public class LaunchState extends CommandLineState {
 
     final ExecutionResult result = setUpConsoleAndActions(app);
 
-    if (device.emulator() && device.isIOS()) {
-      // Bring simulator to front.
-      new OpenSimulatorAction(true).actionPerformed(null);
-    }
+    device.bringToFront();
 
     // Check for and display any analysis errors when we launch an app.
     if (env.getRunProfile() instanceof SdkRunConfig) {

--- a/src/io/flutter/run/daemon/FlutterApp.java
+++ b/src/io/flutter/run/daemon/FlutterApp.java
@@ -44,7 +44,7 @@ public class FlutterApp {
   private final @NotNull Project myProject;
   private final @Nullable Module myModule;
   private final @NotNull RunMode myMode;
-  private final @NotNull String myDeviceId;
+  private final @NotNull FlutterDevice myDevice;
   private final @NotNull ProcessHandler myProcessHandler;
   private final @NotNull ExecutionEnvironment myExecutionEnvironment;
   private final @NotNull DaemonApi myDaemonApi;
@@ -73,14 +73,14 @@ public class FlutterApp {
   FlutterApp(@NotNull Project project,
              @Nullable Module module,
              @NotNull RunMode mode,
-             @NotNull String deviceId,
+             @NotNull FlutterDevice device,
              @NotNull ProcessHandler processHandler,
              @NotNull ExecutionEnvironment executionEnvironment,
              @NotNull DaemonApi daemonApi) {
     myProject = project;
     myModule = module;
     myMode = mode;
-    myDeviceId = deviceId;
+    myDevice = device;
     myProcessHandler = processHandler;
     myProcessHandler.putUserData(FLUTTER_APP_KEY, this);
     myExecutionEnvironment = executionEnvironment;
@@ -154,7 +154,7 @@ public class FlutterApp {
     FlutterInitializer.sendAnalyticsAction(analyticsStart);
 
     final DaemonApi api = new DaemonApi(process);
-    final FlutterApp app = new FlutterApp(project, module, mode, device.deviceId(), process, env, api);
+    final FlutterApp app = new FlutterApp(project, module, mode, device, process, env, api);
 
     process.addProcessListener(new ProcessAdapter() {
       @Override
@@ -410,8 +410,12 @@ public class FlutterApp {
     return FlutterLaunchMode.getMode(myExecutionEnvironment);
   }
 
+  public FlutterDevice device() {
+    return myDevice;
+  }
+
   public String deviceId() {
-    return myDeviceId;
+    return myDevice.deviceId();
   }
 
   public void setFlutterDebugProcess(FlutterDebugProcess flutterDebugProcess) {

--- a/src/io/flutter/run/daemon/FlutterDevice.java
+++ b/src/io/flutter/run/daemon/FlutterDevice.java
@@ -5,6 +5,7 @@
  */
 package io.flutter.run.daemon;
 
+import io.flutter.actions.OpenSimulatorAction;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -83,5 +84,16 @@ public class FlutterDevice {
       }
     }
     return deviceName();
+  }
+
+  /**
+   * Bring the window representing this device to the foreground. This is a no-op for
+   * non-emulator, non-iOS devices.
+   */
+  public void bringToFront() {
+    if (emulator() && isIOS()) {
+      // Bring the iOS simulator to front.
+      new OpenSimulatorAction(true).actionPerformed(null);
+    }
   }
 }

--- a/src/io/flutter/utils/CustomIconMaker.java
+++ b/src/io/flutter/utils/CustomIconMaker.java
@@ -85,7 +85,7 @@ public class CustomIconMaker {
     return iconCache.get(mapKey);
   }
 
-  enum IconKind {
+  public enum IconKind {
     kClass("class", FlutterIcons.CustomClass, FlutterIcons.CustomClassAbstract),
     kField("fields", FlutterIcons.CustomFields),
     kInterface("interface", FlutterIcons.CustomInterface),
@@ -105,7 +105,7 @@ public class CustomIconMaker {
     IconKind(String name, Icon icon, Icon abstractIcon) {
       this.name = name;
       this.icon = icon;
-      this.abstractIcon = icon;
+      this.abstractIcon = abstractIcon;
     }
   }
 }

--- a/src/io/flutter/view/AbstractToggleableAction.java
+++ b/src/io/flutter/view/AbstractToggleableAction.java
@@ -11,6 +11,7 @@ import com.intellij.openapi.actionSystem.Toggleable;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.DumbAwareAction;
 import io.flutter.FlutterInitializer;
+import io.flutter.run.daemon.FlutterDevice;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -72,5 +73,10 @@ abstract class AbstractToggleableAction extends DumbAwareAction implements Toggl
     this.selected = selected;
 
     ApplicationManager.getApplication().invokeLater(() -> this.update(event));
+  }
+
+  @Nullable
+  protected FlutterDevice getDevice() {
+    return view.getFlutterApp() == null ? null : view.getFlutterApp().device();
   }
 }

--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -29,10 +29,9 @@ import io.flutter.FlutterBundle;
 import io.flutter.FlutterInitializer;
 import io.flutter.inspector.InspectorService;
 import io.flutter.run.daemon.FlutterApp;
+import io.flutter.run.daemon.FlutterDevice;
 import io.flutter.settings.FlutterSettings;
 import io.flutter.utils.VmServiceListenerAdapter;
-import org.dartlang.vm.service.VmServiceListener;
-import org.dartlang.vm.service.element.Event;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -101,7 +100,8 @@ public class FlutterView implements PersistentStateComponent<FlutterView.State>,
     if (FlutterSettings.getInstance().isWidgetInspectorEnabled()) {
       addInspectorPanel("Widgets", InspectorService.FlutterTreeType.widget, toolWindow, toolbarGroup, true);
       addInspectorPanel("Render Tree", InspectorService.FlutterTreeType.renderObject, toolWindow, toolbarGroup, false);
-    } else {
+    }
+    else {
       // Legacy case showing just an empty tool window panel.
       final Content toolContent = contentFactory.createContent(null, "Main", false);
       final SimpleToolWindowPanel toolWindowPanel = new SimpleToolWindowPanel(true, false);
@@ -115,7 +115,11 @@ public class FlutterView implements PersistentStateComponent<FlutterView.State>,
     }
   }
 
-  private void addInspectorPanel(String displayName, InspectorService.FlutterTreeType treeType, @NotNull ToolWindow toolWindow, DefaultActionGroup toolbarGroup, boolean selectedContent) {
+  private void addInspectorPanel(String displayName,
+                                 InspectorService.FlutterTreeType treeType,
+                                 @NotNull ToolWindow toolWindow,
+                                 DefaultActionGroup toolbarGroup,
+                                 boolean selectedContent) {
     {
       final ContentManager contentManager = toolWindow.getContentManager();
       final ContentFactory contentFactory = ContentFactory.SERVICE.getInstance();
@@ -166,6 +170,7 @@ public class FlutterView implements PersistentStateComponent<FlutterView.State>,
     onAppChanged();
   }
 
+  @Nullable
   FlutterApp getFlutterApp() {
     return app;
   }
@@ -280,6 +285,14 @@ class ToggleInspectModeAction extends AbstractToggleableAction {
 
   protected void perform(AnActionEvent event) {
     view.getFlutterApp().callBooleanExtension("ext.flutter.debugWidgetInspector", isSelected(event));
+
+    // If toggling inspect mode on, bring any device to the forground.
+    if (isSelected(event)) {
+      final FlutterDevice device = getDevice();
+      if (device != null) {
+        device.bringToFront();
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Misc inspector UI tweaks:
- add generated icons for widgets without specific icons
- bug fix to the CustomIcon class
- move the ability to bring a simulator to the foreground into a new `bringToFront()` method
- when the user starts inspect mode, bring the ios simulator to the foreground
- don't show the top level `[root]` node
- reduce the width of the 'Properties' table (give more space to the values)
- give the table rows slightly more vertical space
- in the elements tab, have `child n` prefixes have the same look as the `child` prefix
- tweak the look of nodes in the widget tree; node types are no longer bold, and the suffix id has a space between he name, and shows as gray (supplemental information)
- null values show as empty instead of w/ text `null`

<img width="332" alt="screen shot 2017-12-03 at 12 42 33 pm" src="https://user-images.githubusercontent.com/1269969/33566938-6c74d61e-d8d6-11e7-9828-45e7c553a0f5.png">

<img width="348" alt="screen shot 2017-12-03 at 12 42 38 pm" src="https://user-images.githubusercontent.com/1269969/33566944-717ae6e4-d8d6-11e7-83ae-4dbeb17c0566.png">

<img width="340" alt="screen shot 2017-12-03 at 12 49 12 pm" src="https://user-images.githubusercontent.com/1269969/33566953-75ac883a-d8d6-11e7-99aa-b7eba7dc3762.png">

Comments and thoughts welcome, esp. wrt whether the icon changes are improvements, and the table l+f changes :)

@jacob314 @pq 
