### PR TITLE
Cleanup code to display colors nicely so that it depends on getting the

### DIFF
--- a/src/io/flutter/FlutterBundle.properties
+++ b/src/io/flutter/FlutterBundle.properties
@@ -15,6 +15,12 @@ app.release.action.text=Run in Flutter release mode
 app.release.config.action.text=Flutter Run ''{0}'' in Release Mode
 app.release.action.description=Run Flutter app in release mode
 
+app.inspector.no_properties=Selected node has no properties
+app.inspector.all_properties_hidden=All properties of the selected node are hidden
+app.inspector.error_loading_properties=Error loading properties
+app.inspector.error_loading_property_details=Error loading property details
+app.inspector.loading_properties=Loading properties
+
 dart.plugin.update.action.label=Update Dart
 dart.sdk.is.not.configured=Dart SDK is not configured
 

--- a/src/io/flutter/inspector/InspectorService.java
+++ b/src/io/flutter/inspector/InspectorService.java
@@ -118,7 +118,8 @@ public class InspectorService implements Disposable {
 
   /**
    * Returns a CompletableFuture with a Map of property names to Observatory
-   * InstanceRef objects.
+   * InstanceRef objects. This method is shorthand for individually evaluating
+   * each of the getters specified by property names.
    *
    * It would be nice if the Observatory protocol provided a built in method
    * to get InstanceRef objects for a list of properties but this is

--- a/src/io/flutter/inspector/InspectorService.java
+++ b/src/io/flutter/inspector/InspectorService.java
@@ -5,6 +5,7 @@
  */
 package io.flutter.inspector;
 
+import com.google.common.base.Joiner;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
@@ -16,15 +17,9 @@ import io.flutter.run.FlutterDebugProcess;
 import io.flutter.utils.VmServiceListenerAdapter;
 import org.dartlang.vm.service.VmService;
 import org.dartlang.vm.service.VmServiceListener;
-import org.dartlang.vm.service.element.Event;
-import org.dartlang.vm.service.element.EventKind;
-import org.dartlang.vm.service.element.Instance;
-import org.dartlang.vm.service.element.InstanceRef;
+import org.dartlang.vm.service.element.*;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -119,6 +114,55 @@ public class InspectorService implements Disposable {
 
   CompletableFuture<DiagnosticsNode> parseDiagnosticsNode(CompletableFuture<InstanceRef> instanceRefFuture) {
     return instanceRefFuture.thenComposeAsync(this::parseDiagnosticsNode);
+  }
+
+  /**
+   * Returns a CompletableFuture with a Map of property names to Observatory
+   * InstanceRef objects.
+   *
+   * It would be nice if the Observatory protocol provided a built in method
+   * to get InstanceRef objects for a list of properties but this is
+   * sufficient although slightly less efficient. The Observatory protocol
+   * does provide fast access to all fields as part of an Instance object
+   * but that is inadequate as for many Flutter data objects that we want
+   * to display visually we care about properties that are not neccesarily
+   * fields.
+   *
+   * The future will immediately complete to null if the inspectorInstanceRef is null.
+   */
+  public CompletableFuture<Map<String, InstanceRef>> getDartObjectProperties(
+      InspectorInstanceRef inspectorInstanceRef, final String[] propertyNames) {
+    return toObservatoryInstanceRef(inspectorInstanceRef).thenComposeAsync((InstanceRef instanceRef) -> {
+      final StringBuilder sb = new StringBuilder();
+      final List<String> propertyAccessors = new ArrayList<>();
+      final String objectName = "that";
+      for (String propertyName : propertyNames) {
+        propertyAccessors.add(objectName + "." + propertyName);
+      }
+      sb.append("<Object>[");
+      sb.append(Joiner.on(',').join(propertyAccessors));
+      sb.append("]");
+      final Map<String, String> scope = new HashMap<>();
+      scope.put(objectName, instanceRef.getId());
+      return getInstance(inspectorLibrary.eval(sb.toString(), scope)).thenApplyAsync(
+        (Instance instance) -> {
+        // We now have an instance object that is a Dart array of all the
+        // property values. Convert it back to a map from property name to
+        // property values.
+
+        final Map<String, InstanceRef> properties = new HashMap<>();
+        final ElementList<InstanceRef> values = instance.getElements();
+        assert(values.size() == propertyNames.length);
+        for (int i = 0; i < propertyNames.length; ++i) {
+          properties.put(propertyNames[i], values.get(i));
+        }
+        return properties;
+      });
+    });
+  }
+
+  public CompletableFuture<InstanceRef> toObservatoryInstanceRef(InspectorInstanceRef inspectorInstanceRef) {
+    return invokeServiceMethod("toObject", inspectorInstanceRef);
   }
 
   private CompletableFuture<Instance> getInstance(InstanceRef instanceRef) {

--- a/src/io/flutter/view/InspectorPanel.java
+++ b/src/io/flutter/view/InspectorPanel.java
@@ -647,10 +647,10 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
         final Map<String, InstanceRef> properties = propertiesFuture.getNow(null);
         switch (node.getPropertyType()) {
           case "Color": {
-            int alpha = getIntProperty(properties, "alpha");;
-            int red = getIntProperty(properties, "red");;
-            int green = getIntProperty(properties, "green");;
-            int blue = getIntProperty(properties, "blue");;
+            final int alpha = getIntProperty(properties, "alpha");;
+            final int red = getIntProperty(properties, "red");;
+            final int green = getIntProperty(properties, "green");;
+            final int blue = getIntProperty(properties, "blue");;
 
             final Color color = new Color(red, green, blue, alpha);
             this.setIcon(colorIconMaker.getCustomIcon(color));

--- a/src/io/flutter/view/InspectorPanel.java
+++ b/src/io/flutter/view/InspectorPanel.java
@@ -18,10 +18,12 @@ import com.intellij.ui.treeStructure.Tree;
 import com.intellij.ui.treeStructure.treetable.ListTreeTableModelOnColumns;
 import com.intellij.util.ui.ColumnInfo;
 import com.intellij.util.ui.JBUI;
+import com.intellij.util.ui.StatusText;
 import com.intellij.util.ui.UIUtil;
 import com.intellij.util.ui.tree.TreeUtil;
 import com.intellij.xdebugger.impl.ui.DebuggerUIUtil;
 import com.intellij.xdebugger.impl.ui.tree.nodes.XValueNodeImpl;
+import io.flutter.FlutterBundle;
 import io.flutter.inspector.*;
 import io.flutter.run.daemon.FlutterApp;
 import io.flutter.utils.ColorIconMaker;
@@ -532,20 +534,21 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
     public void showProperties(DiagnosticsNode diagnostic) {
       // Temporarily clear.
       getTreeModel().setRoot(new DefaultMutableTreeNode());
+
       if (diagnostic == null) {
+        getTree().setToolTipText(null); // Nothing to show here.
         return;
       }
+      getEmptyText().setText(FlutterBundle.message("app.inspector.loading_properties"));
       whenCompleteUiThread(diagnostic.getProperties(), (ArrayList<DiagnosticsNode> properties, Throwable throwable) -> {
         if (throwable != null) {
-          // TODO(jacobr): show error message explaining properties could not
-          // be loaded.
+          getEmptyText().setText(FlutterBundle.message("app.inspector.error_loading_properties"));
           LOG.error(throwable);
           return;
         }
 
         if (properties.size() == 0) {
-          // TODO(jacobr): display message that there are no properties
-          // and that no errors occurred.
+          getEmptyText().setText(FlutterBundle.message("app.inspector.no_properties"));
           return;
         }
 
@@ -564,6 +567,7 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
             // TODO(jacobr): show error message explaining properties could not
             // be loaded.
             LOG.error(errorGettingInstances);
+            getEmptyText().setText(FlutterBundle.message("app.inspector.error_loading_property_details"));
             return;
           }
 
@@ -574,6 +578,7 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
               root.add(new DefaultMutableTreeNode(property));
             }
           }
+          getEmptyText().setText(FlutterBundle.message("app.inspector.all_properties_hidden"));
           model.setRoot(root);
         });
       });


### PR DESCRIPTION
actual Dart properties of the Color object instead of depending on parsing
the toString output for Color objects.

The code to get the Dart properties is ugly. Unfortunately we can't just use the Dart fields which would be more cleanly exposed through the Observatory protocol because many common objects we care about use properties not fields for the relevant data. If it becomes a performance bottlekneck (unlikely given this is just for properties) we could get a built in observatory protocol method to access a specified list of Dart properties for an object.

One valid design question is why these properties aren't just specified in the DiagnosticsNode protocol. The answer is that it could be but there are some nice advantages of this approach.  With this method, we can iterate on visual display of property values pretty much arbitrarily from the intellij plugin without having to worry about waiting for matching changes to the flutter repo or version skew issues.