### PR TITLE
Gen plugin

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -9,7 +9,7 @@
 
   <category>Custom Languages</category>
 
-  <version>20.0</version>
+  
 
   <idea-version since-build="171.1" until-build="181.*"/>
 
@@ -23,8 +23,6 @@
 
   <!-- Contributes Android Studio-specific features and implementations. -->
   <!--suppress PluginXmlValidity -->
-  <!-- depends optional="true" config-file="studio-contribs.xml">com.android.tools.apk</depends -->
-  <!-- note that com.android.tools.apk also implies com.intellij.modules.androidstudio but it is not available in sources -->
   <depends optional="true" config-file="studio-contribs.xml">com.intellij.modules.androidstudio</depends>
 
   <change-notes>

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -9,7 +9,7 @@
 
   <category>Custom Languages</category>
 
-  
+  <version>20.0</version>
 
   <idea-version since-build="171.1" until-build="181.*"/>
 
@@ -23,6 +23,8 @@
 
   <!-- Contributes Android Studio-specific features and implementations. -->
   <!--suppress PluginXmlValidity -->
+  <!-- depends optional="true" config-file="studio-contribs.xml">com.android.tools.apk</depends -->
+  <!-- note that com.android.tools.apk also implies com.intellij.modules.androidstudio but it is not available in sources -->
   <depends optional="true" config-file="studio-contribs.xml">com.intellij.modules.androidstudio</depends>
 
   <change-notes>

--- a/resources/META-INF/plugin.xml.template
+++ b/resources/META-INF/plugin.xml.template
@@ -23,9 +23,7 @@
 
   <!-- Contributes Android Studio-specific features and implementations. -->
   <!--suppress PluginXmlValidity -->
-  <depends optional="true" config-file="studio-contribs.xml">com.android.tools.apk</depends>
-  <!-- note that com.android.tools.apk also implies com.intellij.modules.androidstudio but it is not available in sources -->
-  <!-- depends optional="true" config-file="studio-contribs.xml">com.intellij.modules.androidstudio</depends -->
+  <depends optional="true" config-file="studio-contribs.xml">@DEPEND@</depends>
 
   <change-notes>
     <![CDATA[


### PR DESCRIPTION
@devoncarew @pq 

Fix `plugin gen` so it creates a plugin.xml that will correctly launch Android Studio with the Flutter plugin extension enabled. (Verified that `plugin build` is not affected.)

Also, the --no-ij and --no-as flags were not being checked. If you're debugging a build issue specific to one platform you can stop building the other. Note that --ij and --as are both assumed so specifying either does nothing. (And yes, --no-as will still build two ij versions.)