### PR TITLE
Reduce inspector tree indent.

### DIFF
--- a/src/io/flutter/view/InspectorPanel.java
+++ b/src/io/flutter/view/InspectorPanel.java
@@ -435,9 +435,9 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
       setRootVisible(false);
       registerShortcuts();
 
-      // Decrease indent.
-      final BasicTreeUI treeUI = (BasicTreeUI) getUI();
-      treeUI.setRightChildIndent(3);
+      // Decrease indent, scaled for different display types.
+      final BasicTreeUI ui = (BasicTreeUI) getUI();
+      ui.setRightChildIndent(JBUI.scale(3));
     }
 
     void registerShortcuts() {

--- a/src/io/flutter/view/InspectorPanel.java
+++ b/src/io/flutter/view/InspectorPanel.java
@@ -37,6 +37,7 @@ import org.jetbrains.annotations.Nullable;
 import javax.swing.*;
 import javax.swing.event.TreeExpansionEvent;
 import javax.swing.event.TreeExpansionListener;
+import javax.swing.plaf.basic.BasicTreeUI;
 import javax.swing.table.JTableHeader;
 import javax.swing.table.TableCellRenderer;
 import javax.swing.tree.DefaultMutableTreeNode;
@@ -433,6 +434,10 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
 
       setRootVisible(false);
       registerShortcuts();
+
+      // Decrease indent.
+      final BasicTreeUI treeUI = (BasicTreeUI) getUI();
+      treeUI.setRightChildIndent(3);
     }
 
     void registerShortcuts() {


### PR DESCRIPTION
Gives us, for example, a tree like this:

![image](https://user-images.githubusercontent.com/67586/34551748-6732f42a-f0d1-11e7-99bc-afa6aa6db16b.png)

and

![image](https://user-images.githubusercontent.com/67586/34575047-2f502c82-f12e-11e7-9295-d75fb6367ebe.png)


compared to the current default:

![image](https://user-images.githubusercontent.com/67586/34551694-0e9f1faa-f0d1-11e7-9b0a-a9c5dfe3aa76.png)

Happy to nudge out a bit if this looks too tight.

cc @jacob314 @devoncarew 
  