### PR TITLE
remove the memory dashboard reference; add an open obs. action

### DIFF
--- a/gen/icons/FlutterIcons.java
+++ b/gen/icons/FlutterIcons.java
@@ -21,8 +21,6 @@ public class FlutterIcons {
   public static final Icon Phone = load("/icons/phone.png");
 
   public static final Icon OpenObservatory = load("/icons/observatory.png");
-  public static final Icon OpenTimelineDashboard = AllIcons.Nodes.DataSchema;
-  public static final Icon OpenMemoryDashboard = AllIcons.Nodes.DataView;
 
   public static final Icon HotReload = load("/icons/hot-reload.png");
   public static final Icon FullRestart = AllIcons.Actions.Restart;

--- a/src/io/flutter/FlutterBundle.properties
+++ b/src/io/flutter/FlutterBundle.properties
@@ -44,9 +44,6 @@ flutter.sdk.notAvailable.message=This action requires a Flutter SDK to be config
 open.observatory.action.text=Open Observatory
 open.observatory.action.description=Open Observatory: a Profiler for Dart apps
 
-open.memorydashboard.action.text=Open Memory Dashboard
-open.memorydashboard.action.description=Open Memory Dashboard: a Memory Profiler tool for Dart apps
-
 outdated.dependencies.inspection.name=Outdated package dependencies
 packages.get.never.done='Packages get' has not been run
 pubspec.edited=Pubspec has been edited

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.form
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.form
@@ -114,7 +114,7 @@
           </component>
         </children>
       </grid>
-      <grid id="23e52" layout-manager="GridLayoutManager" row-count="5" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="23e52" layout-manager="GridLayoutManager" row-count="4" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -125,18 +125,9 @@
         </clientProperties>
         <border type="etched" title="Experiments"/>
         <children>
-          <component id="7ec6e" class="javax.swing.JCheckBox" binding="myEnableMemoryDashboardCheckBox">
-            <constraints>
-              <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <text value="Enable memory dashboard"/>
-              <toolTipText value="A tool for analyzing your application's memory usage."/>
-            </properties>
-          </component>
           <component id="af6ca" class="javax.swing.JCheckBox" binding="myEnableWidgetInspectorCheckBox">
             <constraints>
-              <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text value="Enable widget inspector"/>
@@ -153,7 +144,7 @@
           </component>
           <component id="129f" class="com.intellij.ui.components.labels.LinkLabel" binding="myInspectorFeedbackLink">
             <constraints>
-              <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="4" use-parent-layout="false"/>
+              <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="4" use-parent-layout="false"/>
             </constraints>
             <properties>
               <horizontalAlignment value="2"/>

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.java
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.java
@@ -52,7 +52,6 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
   private LinkLabel<String> myPrivacyPolicy;
   private JCheckBox myHotReloadOnSaveCheckBox;
   private JCheckBox myEnableVerboseLoggingCheckBox;
-  private JCheckBox myEnableMemoryDashboardCheckBox;
   private JCheckBox myEnableWidgetInspectorCheckBox;
   private LinkLabel<String> myInspectorFeedbackLink;
   private final @NotNull Project myProject;
@@ -140,10 +139,6 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
       return true;
     }
 
-    if (settings.isMemoryDashboardEnabled() != myEnableMemoryDashboardCheckBox.isSelected()) {
-      return true;
-    }
-
     if (settings.isWidgetInspectorEnabled() != myEnableWidgetInspectorCheckBox.isSelected()) {
       return true;
     }
@@ -176,7 +171,6 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     final FlutterSettings settings = FlutterSettings.getInstance();
     settings.setReloadOnSave(myHotReloadOnSaveCheckBox.isSelected());
     settings.setVerboseLogging(myEnableVerboseLoggingCheckBox.isSelected());
-    settings.setMemoryDashboardEnabled(myEnableMemoryDashboardCheckBox.isSelected());
     settings.setWidgetInspectorEnabled(myEnableWidgetInspectorCheckBox.isSelected());
 
     reset(); // because we rely on remembering initial state
@@ -199,7 +193,6 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     final FlutterSettings settings = FlutterSettings.getInstance();
     myHotReloadOnSaveCheckBox.setSelected(settings.isReloadOnSave());
     myEnableVerboseLoggingCheckBox.setSelected(settings.isVerboseLogging());
-    myEnableMemoryDashboardCheckBox.setSelected(settings.isMemoryDashboardEnabled());
     myEnableWidgetInspectorCheckBox.setSelected(settings.isWidgetInspectorEnabled());
   }
 

--- a/src/io/flutter/settings/FlutterSettings.java
+++ b/src/io/flutter/settings/FlutterSettings.java
@@ -15,7 +15,6 @@ import java.util.List;
 public class FlutterSettings {
   private static final String reloadOnSaveKey = "io.flutter.reloadOnSave";
   private static final String verboseLoggingKey = "io.flutter.verboseLogging";
-  private static final String memoryDashboardKey = "io.flutter.memoryDashboard";
   private static final String widgetInspectorKey = "io.flutter.widgetInspector";
 
   public static FlutterSettings getInstance() {
@@ -39,9 +38,6 @@ public class FlutterSettings {
     analytics.sendEvent("settings", "ping");
     if (isReloadOnSave()) {
       analytics.sendEvent("settings", afterLastPeriod(reloadOnSaveKey));
-    }
-    if (isMemoryDashboardEnabled()) {
-      analytics.sendEvent("settings", afterLastPeriod(memoryDashboardKey));
     }
     if (isWidgetInspectorEnabled()) {
       analytics.sendEvent("settings", afterLastPeriod(widgetInspectorKey));
@@ -72,16 +68,6 @@ public class FlutterSettings {
 
   public void setVerboseLogging(boolean value) {
     getPropertiesComponent().setValue(verboseLoggingKey, value, false);
-
-    fireEvent();
-  }
-
-  public boolean isMemoryDashboardEnabled() {
-    return getPropertiesComponent().getBoolean(memoryDashboardKey, false);
-  }
-
-  public void setMemoryDashboardEnabled(boolean value) {
-    getPropertiesComponent().setValue(memoryDashboardKey, value, false);
 
     fireEvent();
   }


### PR DESCRIPTION
- remove specific references to the timeline and memory views (the memory view was not complete)
- add a reference in the flutter view to the observatory; this mirrors what people see in the run and debug views

@pq, @jacob314, /cc @mit-mit 