### PR TITLE
Fix example `main.dart` run config auto-creation.

### DIFF
--- a/src/io/flutter/pub/PubRoot.java
+++ b/src/io/flutter/pub/PubRoot.java
@@ -340,10 +340,7 @@ public class PubRoot {
    * Returns example/lib/main.dart if it exists.
    */
   public VirtualFile getExampleLibMain() {
-    if (lib == null) {
-      return null;
-    }
-    final VirtualFile exampleDir = lib.findChild("example");
+    final VirtualFile exampleDir = root.findChild("example");
     if (exampleDir != null) {
       final VirtualFile libDir = exampleDir.findChild("lib");
       if (libDir != null) {


### PR DESCRIPTION
Oddly we were looking for `lib/example/lib/main/dart` instead of the expected `example/lib/main.dart`.

@stevemessick @devoncarew 