### PR TITLE
add a notification for reloaded but not run elements

### DIFF
--- a/src/io/flutter/run/FlutterReloadManager.java
+++ b/src/io/flutter/run/FlutterReloadManager.java
@@ -29,6 +29,7 @@ import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Computable;
+import com.intellij.openapi.util.SystemInfo;
 import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.wm.ToolWindowId;
@@ -78,6 +79,10 @@ import java.util.stream.Collectors;
  */
 public class FlutterReloadManager {
   public static final String RELOAD_ON_SAVE_FEEDBACK_URL = "https://goo.gl/Pab4Li";
+
+  private static final String RESTART_SUGGESTED_TEXT =
+    "Not all changed program elements ran during view reassembly; consider restarting ("
+    + (SystemInfo.isMac ? "⇧⌘S" : "⇧^S") + ").";
 
   private static final Logger LOG = Logger.getInstance(FlutterReloadManager.class);
 
@@ -215,6 +220,9 @@ public class FlutterReloadManager {
           if (!result.ok()) {
             showRunNotification(app, "Hot Reload Error", result.getMessage(), true);
           }
+          else if (result.isRestartRecommended()) {
+            showRunNotification(app, "Reloading…", RESTART_SUGGESTED_TEXT, false);
+          }
         }).whenComplete((aVoid, throwable) -> handlingSave.set(false));
       }
     }, reloadDelayMs, TimeUnit.MILLISECONDS);
@@ -226,6 +234,9 @@ public class FlutterReloadManager {
       app.performHotReload(supportsPauseAfterReload()).thenAccept(result -> {
         if (!result.ok()) {
           showRunNotification(app, "Hot Reload", result.getMessage(), true);
+        }
+        else if (result.isRestartRecommended()) {
+          showRunNotification(app, "Reloading…", RESTART_SUGGESTED_TEXT, false);
         }
       });
     }

--- a/src/io/flutter/run/daemon/DaemonApi.java
+++ b/src/io/flutter/run/daemon/DaemonApi.java
@@ -273,6 +273,8 @@ public class DaemonApi {
   public static class RestartResult {
     private int code;
     private String message;
+    private String hint;
+    private String hintId;
 
     public boolean ok() {
       return code == 0;
@@ -284,6 +286,18 @@ public class DaemonApi {
 
     public String getMessage() {
       return message;
+    }
+
+    public String getHint() {
+      return hint;
+    }
+
+    public String getHintId() {
+      return hintId;
+    }
+
+    public boolean isRestartRecommended() {
+      return "restartRecommended".equals(hintId);
     }
 
     @Override

--- a/src/io/flutter/run/daemon/DaemonApi.java
+++ b/src/io/flutter/run/daemon/DaemonApi.java
@@ -273,7 +273,7 @@ public class DaemonApi {
   public static class RestartResult {
     private int code;
     private String message;
-    private String hint;
+    private String hintMessage;
     private String hintId;
 
     public boolean ok() {
@@ -288,8 +288,8 @@ public class DaemonApi {
       return message;
     }
 
-    public String getHint() {
-      return hint;
+    public String getHintMessage() {
+      return hintMessage;
     }
 
     public String getHintId() {

--- a/src/io/flutter/run/daemon/FlutterApp.java
+++ b/src/io/flutter/run/daemon/FlutterApp.java
@@ -178,7 +178,7 @@ public class FlutterApp {
 
     process.addProcessListener(new ProcessAdapter() {
       @Override
-      public void processTerminated(ProcessEvent event) {
+      public void processTerminated(@NotNull ProcessEvent event) {
         LOG.info(analyticsStop + " " + project.getName() + " (" + mode.mode() + ")");
         FlutterInitializer.sendAnalyticsAction(analyticsStop);
 


### PR DESCRIPTION
- show a notification when a reload indicates that not all reload elements ran after view reassembly
- fix https://github.com/flutter/flutter-intellij/issues/1398

@pq @jacob314 @mit @InMatrix 

The notification shows once per reload, for each reload that has un-run, reloaded program elements. The message is longer than I'd want, but I had trouble creating a shorter message that was still clear.

<img width="627" alt="screen shot 2018-01-09 at 4 57 12 pm" src="https://user-images.githubusercontent.com/1269969/34751018-0d9a485e-f55f-11e7-990f-86823916d5ad.png">

Dependent on https://github.com/flutter/flutter/pull/13996 (or similar) landing.

  