### PR TITLE
fix an issue with plugin build

### DIFF
--- a/tool/plugin/lib/plugin.dart
+++ b/tool/plugin/lib/plugin.dart
@@ -867,7 +867,7 @@ abstract class ProductCommand extends Command {
     if (rel != null) {
       var idx = rel.indexOf('.');
       if (idx > 0) {
-        rel = rel.substring(0, idx - 1);
+        rel = rel.substring(0, idx);
       }
     }
     return rel;


### PR DESCRIPTION
When on the wrong branch, I see the error message: `the current git branch must be named "release_2"` (I'm on release_21.0).

@stevemessick 