### PR TITLE
Inspector stability improvements.

### DIFF
--- a/src/io/flutter/inspector/EvalOnDartLibrary.java
+++ b/src/io/flutter/inspector/EvalOnDartLibrary.java
@@ -41,7 +41,7 @@ public class EvalOnDartLibrary implements Disposable {
     this.myRequestsScheduler = new Alarm(Alarm.ThreadToUse.POOLED_THREAD, this);
     libraryRef = new CompletableFuture<>();
 
-    if (isolates.size() != 1) {
+    if (isolates.isEmpty()) {
       // Due to a race condition that would take fixing the Dart plugin to fix,
       // it is possible the debugProcess doesn't yet show any isolate infos
       // even though the isolates have started so we get the isolate info
@@ -50,9 +50,9 @@ public class EvalOnDartLibrary implements Disposable {
         @Override
         public void received(VM vm) {
           final ElementList<IsolateRef> isolatesList = vm.getIsolates();
-          if (isolatesList.size() != 1) {
-            libraryRef.completeExceptionally(new RuntimeException("Unexpected number of isolates:" + isolatesList.size()));
-          }
+          // If Flutter applications support multiple isolates we need to add
+          // logic to determine which isolate is running Flutter UI code.
+          assert(isolatesList.size() == 1);
           isolateId = isolatesList.get(0).getId();
           initialize();
         }
@@ -64,6 +64,9 @@ public class EvalOnDartLibrary implements Disposable {
       });
     }
     else {
+      // If Flutter applications support multiple isolates we need to add
+      // logic to determine which isolate is running Flutter UI code.
+      assert(isolates.size() == 1);
       isolateId = Iterables.get(isolates, 0).getIsolateId();
       initialize();
     }

--- a/src/io/flutter/inspector/EvalOnDartLibrary.java
+++ b/src/io/flutter/inspector/EvalOnDartLibrary.java
@@ -14,10 +14,7 @@ import com.intellij.util.ReflectionUtil;
 import com.jetbrains.lang.dart.ide.runner.server.vmService.IsolatesInfo;
 import io.flutter.run.FlutterDebugProcess;
 import org.dartlang.vm.service.VmService;
-import org.dartlang.vm.service.consumer.Consumer;
-import org.dartlang.vm.service.consumer.EvaluateConsumer;
-import org.dartlang.vm.service.consumer.GetIsolateConsumer;
-import org.dartlang.vm.service.consumer.GetObjectConsumer;
+import org.dartlang.vm.service.consumer.*;
 import org.dartlang.vm.service.element.*;
 
 import java.lang.reflect.InvocationTargetException;
@@ -30,27 +27,50 @@ import java.util.concurrent.CompletableFuture;
  * Invoke methods from a specified Dart library using the observatory protocol.
  */
 public class EvalOnDartLibrary implements Disposable {
-  private final IsolatesInfo.IsolateInfo isolateInfo;
+  private String isolateId;
   private final VmService vmService;
   private final String libraryName;
   final CompletableFuture<LibraryRef> libraryRef;
   private final Alarm myRequestsScheduler;
-
   private static final Logger LOG = Logger.getInstance(EvalOnDartLibrary.class);
 
   public EvalOnDartLibrary(String libraryName, FlutterDebugProcess debugProcess, VmService vmService) {
     this.vmService = vmService;
     final Collection<IsolatesInfo.IsolateInfo> isolates = debugProcess.getIsolateInfos();
-    assert (isolates.size() == 1);
-    isolateInfo = Iterables.get(isolates, 0);
     this.libraryName = libraryName;
     this.myRequestsScheduler = new Alarm(Alarm.ThreadToUse.POOLED_THREAD, this);
     libraryRef = new CompletableFuture<>();
-    initialize();
+
+    if (isolates.size() != 1) {
+      // Due to a race condition that would take fixing the Dart plugin to fix,
+      // it is possible the debugProcess doesn't yet show any isolate infos
+      // even though the isolates have started so we get the isolate info
+      // ourselves in that case.
+      vmService.getVM(new VMConsumer() {
+        @Override
+        public void received(VM vm) {
+          final ElementList<IsolateRef> isolatesList = vm.getIsolates();
+          if (isolatesList.size() != 1) {
+            libraryRef.completeExceptionally(new RuntimeException("Unexpected number of isolates:" + isolatesList.size()));
+          }
+          isolateId = isolatesList.get(0).getId();
+          initialize();
+        }
+
+        @Override
+        public void onError(RPCError error) {
+          libraryRef.completeExceptionally(new RuntimeException(error.toString()));
+        }
+      });
+    }
+    else {
+      isolateId = Iterables.get(isolates, 0).getIsolateId();
+      initialize();
+    }
   }
 
   public String getIsolateId() {
-    return isolateInfo.getIsolateId();
+    return isolateId;
   }
 
   public void dispose() {
@@ -85,7 +105,7 @@ public class EvalOnDartLibrary implements Disposable {
       //noinspection CodeBlock2Expr
       libraryRef.thenAcceptAsync((LibraryRef ref) -> {
         evaluateHelper(
-          isolateInfo.getIsolateId(), ref.getId(), expression, scope,
+          getIsolateId(), ref.getId(), expression, scope,
           new EvaluateConsumer() {
             @Override
             public void onError(RPCError error) {
@@ -115,12 +135,13 @@ public class EvalOnDartLibrary implements Disposable {
     return future;
   }
 
-  public CompletableFuture<Instance> getInstance(InstanceRef instance) {
-    final CompletableFuture<Instance> future = new CompletableFuture<>();
+  @SuppressWarnings("unchecked")
+  public <T extends Obj> CompletableFuture<T> getObjHelper(ObjRef instance) {
+    final CompletableFuture<T> future = new CompletableFuture<>();
     //noinspection CodeBlock2Expr
     myRequestsScheduler.addRequest(() -> {
       vmService.getObject(
-        isolateInfo.getIsolateId(), instance.getId(), new GetObjectConsumer() {
+        getIsolateId(), instance.getId(), new GetObjectConsumer() {
           @Override
           public void onError(RPCError error) {
             future.completeExceptionally(new RuntimeException(error.toString()));
@@ -128,7 +149,7 @@ public class EvalOnDartLibrary implements Disposable {
 
           @Override
           public void received(Obj response) {
-            future.complete((Instance)response);
+            future.complete((T)response);
           }
 
           @Override
@@ -139,6 +160,18 @@ public class EvalOnDartLibrary implements Disposable {
       );
     }, 0);
     return future;
+  }
+
+  public CompletableFuture<Instance> getInstance(InstanceRef instance) {
+    return getObjHelper(instance);
+  }
+
+  public CompletableFuture<Library> getLibrary(LibraryRef instance) {
+    return getObjHelper(instance);
+  }
+
+  public CompletableFuture<ClassObj> getClass(ClassRef instance) {
+    return getObjHelper(instance);
   }
 
   public CompletableFuture<Instance> getInstance(CompletableFuture<InstanceRef> instanceFuture) {
@@ -163,7 +196,7 @@ public class EvalOnDartLibrary implements Disposable {
   }
 
   private void initialize() {
-    vmService.getIsolate(isolateInfo.getIsolateId(), new GetIsolateConsumer() {
+    vmService.getIsolate(isolateId, new GetIsolateConsumer() {
 
       @Override
       public void received(Isolate response) {

--- a/src/io/flutter/inspector/InspectorService.java
+++ b/src/io/flutter/inspector/InspectorService.java
@@ -36,6 +36,7 @@ public class InspectorService implements Disposable {
   private final VmService vmService;
   private final Set<InspectorServiceClient> clients;
   private EvalOnDartLibrary inspectorLibrary;
+  private CompletableFuture<Set<String>> supportedServiceMethods;
 
   public InspectorService(FlutterDebugProcess debugProcess, VmService vmService) {
     clients = new HashSet<>();
@@ -119,7 +120,7 @@ public class InspectorService implements Disposable {
    * Returns a CompletableFuture with a Map of property names to Observatory
    * InstanceRef objects. This method is shorthand for individually evaluating
    * each of the getters specified by property names.
-   *
+   * <p>
    * It would be nice if the Observatory protocol provided a built in method
    * to get InstanceRef objects for a list of properties but this is
    * sufficient although slightly less efficient. The Observatory protocol
@@ -127,11 +128,11 @@ public class InspectorService implements Disposable {
    * but that is inadequate as for many Flutter data objects that we want
    * to display visually we care about properties that are not neccesarily
    * fields.
-   *
+   * <p>
    * The future will immediately complete to null if the inspectorInstanceRef is null.
    */
   public CompletableFuture<Map<String, InstanceRef>> getDartObjectProperties(
-      InspectorInstanceRef inspectorInstanceRef, final String[] propertyNames) {
+    InspectorInstanceRef inspectorInstanceRef, final String[] propertyNames) {
     return toObservatoryInstanceRef(inspectorInstanceRef).thenComposeAsync((InstanceRef instanceRef) -> {
       final StringBuilder sb = new StringBuilder();
       final List<String> propertyAccessors = new ArrayList<>();
@@ -146,18 +147,18 @@ public class InspectorService implements Disposable {
       scope.put(objectName, instanceRef.getId());
       return getInstance(inspectorLibrary.eval(sb.toString(), scope)).thenApplyAsync(
         (Instance instance) -> {
-        // We now have an instance object that is a Dart array of all the
-        // property values. Convert it back to a map from property name to
-        // property values.
+          // We now have an instance object that is a Dart array of all the
+          // property values. Convert it back to a map from property name to
+          // property values.
 
-        final Map<String, InstanceRef> properties = new HashMap<>();
-        final ElementList<InstanceRef> values = instance.getElements();
-        assert(values.size() == propertyNames.length);
-        for (int i = 0; i < propertyNames.length; ++i) {
-          properties.put(propertyNames[i], values.get(i));
-        }
-        return properties;
-      });
+          final Map<String, InstanceRef> properties = new HashMap<>();
+          final ElementList<InstanceRef> values = instance.getElements();
+          assert (values.size() == propertyNames.length);
+          for (int i = 0; i < propertyNames.length; ++i) {
+            properties.put(propertyNames[i], values.get(i));
+          }
+          return properties;
+        });
     });
   }
 
@@ -227,6 +228,56 @@ public class InspectorService implements Disposable {
 
   CompletableFuture<ArrayList<DiagnosticsNode>> getProperties(InspectorInstanceRef instanceRef) {
     return getListHelper(instanceRef, "getProperties");
+  }
+
+  /**
+   * If the widget tree is not ready, the application should wait for the next
+   * Flutter.Frame event before attempting to display the widget tree. If the
+   * application is ready, the next Flutter.Frame event may never come as no
+   * new frames will be triggered to draw unless something changes in the UI.
+   */
+  public CompletableFuture<Boolean> isWidgetTreeReady() {
+    return hasServiceMethod("isWidgetTreeReady").<Boolean>thenComposeAsync((Boolean hasMethod) -> {
+      if (!hasMethod) {
+        // Fallback if the InspectorService doesn't provide the
+        // isWidgetTreeReady method. In this case, we will fail gracefully
+        // risking not displaying the Widget tree but ensuring we do not throw
+        // exceptions due to accessing the widget tree before it is safe to.
+        CompletableFuture<Boolean> value = new CompletableFuture<>();
+        value.complete(false);
+        return value;
+      }
+      return invokeServiceMethod("isWidgetTreeReady").thenApplyAsync((InstanceRef ref) -> {
+        return "true".equals(ref.getValueAsString());
+      });
+    });
+  }
+
+  /**
+   * Use this method to write code that is backwards compatible with versions
+   * of Flutter that are too old to contain specific service methods.
+   */
+  private CompletableFuture<Boolean> hasServiceMethod(String methodName) {
+    if (supportedServiceMethods == null) {
+      EvalOnDartLibrary inspectorLibrary = getInspectorLibrary();
+      final CompletableFuture<Library> libraryFuture = inspectorLibrary.libraryRef.thenComposeAsync(inspectorLibrary::getLibrary);
+      supportedServiceMethods = libraryFuture.thenComposeAsync((Library library) -> {
+        for (ClassRef classRef : library.getClasses()) {
+          if ("WidgetInspectorService".equals(classRef.getName())) {
+            return inspectorLibrary.getClass(classRef).thenApplyAsync((ClassObj classObj) -> {
+              final Set<String> functionNames = new HashSet<>();
+              for (FuncRef funcRef : classObj.getFunctions()) {
+                functionNames.add(funcRef.getName());
+              }
+              return functionNames;
+            });
+          }
+        }
+        throw new RuntimeException("WidgetInspectorService class not found");
+      });
+    }
+
+    return supportedServiceMethods.thenApplyAsync(methodNames -> methodNames.contains(methodName));
   }
 
   private CompletableFuture<ArrayList<DiagnosticsNode>> getListHelper(

--- a/src/io/flutter/inspector/InspectorService.java
+++ b/src/io/flutter/inspector/InspectorService.java
@@ -237,6 +237,10 @@ public class InspectorService implements Disposable {
    * new frames will be triggered to draw unless something changes in the UI.
    */
   public CompletableFuture<Boolean> isWidgetTreeReady() {
+    // TODO(jacobr): remove call to hasServiceMethod("isWidgetTreeReady") after
+    // the `isWidgetTreeReady` method has been in two revs of the Flutter Alpha
+    // channel. The feature is expected to have landed in the Flutter dev
+    // chanel on January 18, 2018.
     return hasServiceMethod("isWidgetTreeReady").<Boolean>thenComposeAsync((Boolean hasMethod) -> {
       if (!hasMethod) {
         // Fallback if the InspectorService doesn't provide the


### PR DESCRIPTION
Fix multiple race conditions occurring when the inspector is executed
in run mode.
Fix case where isolate ids were not available and fix case where the inspector
is called after the first frame has already rendered.
Add ability to perform capability detection to determine whether the
inspector supports a specific service method.
Fix null property type case.

Combined with a package:flutter fix, this fixes all pending inspector crasher bugs.