### PR TITLE
handle updates to the flutter version file

### DIFF
--- a/src/io/flutter/inspections/SdkConfigurationNotificationProvider.java
+++ b/src/io/flutter/inspections/SdkConfigurationNotificationProvider.java
@@ -73,7 +73,7 @@ public class SdkConfigurationNotificationProvider extends EditorNotifications.Pr
     if (flutterSdk == null) {
       return createNoFlutterSdkPanel(project);
     }
-    else if (!flutterSdk.getVersion().isSupported()) {
+    else if (!flutterSdk.getVersion().isMinRecommendedSupported()) {
       return createOutOfDateFlutterSdkPanel(flutterSdk);
     }
 

--- a/src/io/flutter/sdk/FlutterSdkVersion.java
+++ b/src/io/flutter/sdk/FlutterSdkVersion.java
@@ -66,12 +66,11 @@ public class FlutterSdkVersion {
   }
 
   public boolean flutterTestSupportsMachineMode() {
-    return version.compareTo(MIN_SUPPORTED_SDK.version) >= 0;
+    return isMinRecommendedSupported();
   }
 
-  @SuppressWarnings("BooleanMethodIsAlwaysInverted")
   public boolean flutterTestSupportsFiltering() {
-    return version.compareTo(MIN_SUPPORTED_SDK.version) >= 0;
+    return isMinRecommendedSupported();
   }
 
   @Override

--- a/src/io/flutter/sdk/FlutterSdkVersion.java
+++ b/src/io/flutter/sdk/FlutterSdkVersion.java
@@ -6,39 +6,18 @@
 package io.flutter.sdk;
 
 
-import com.intellij.openapi.diagnostic.Logger;
-import com.intellij.openapi.util.Pair;
 import com.intellij.openapi.util.Version;
-import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import org.jetbrains.annotations.NotNull;
 
-import java.io.File;
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
+import java.nio.charset.StandardCharsets;
 
 public class FlutterSdkVersion {
-
   /**
-   * The minimum version known to support hot reload.
+   * The minimum version we suggest people use.
    */
-  private static final FlutterSdkVersion MIN_SUPPORTED_SDK = new FlutterSdkVersion("0.0.3");
-
-  /**
-   * The minimum version where the 'flutter test' supports --machine.
-   */
-  private static final FlutterSdkVersion MIN_TEST_MACHINE_MODE = new FlutterSdkVersion("0.0.11");
-
-  /**
-   * The minimum version where the 'flutter test' supports filtering via --name and --plain-name.
-   */
-  private static final FlutterSdkVersion MIN_TEST_FILTERING = new FlutterSdkVersion("0.0.12");
-
-  /**
-   * Cache from version file and its modification date to its contents.
-   */
-  private static final Map<Pair<File, Long>, FlutterSdkVersion> cache = new HashMap<>();
+  private static final FlutterSdkVersion MIN_SUPPORTED_SDK = new FlutterSdkVersion("0.0.12");
 
   private final Version version;
 
@@ -48,62 +27,55 @@ public class FlutterSdkVersion {
 
   @NotNull
   public static FlutterSdkVersion readFromSdk(@NotNull VirtualFile sdkHome) {
-    final File versionFile = new File(sdkHome.getPath() + "/VERSION");
+    final VirtualFile file = sdkHome.findChild("version");
 
-    // Use the cache if the file's last modfication date didn't change.
-    // But we still stat the file every time this is called. Not sure the cache saves us much?
-    // TODO(skybrian) should we use the VirtualFile cache instead?
-    final Pair<File, Long> key = Pair.create(versionFile, versionFile.lastModified());
-    if (cache.containsKey(key)) {
-      return cache.get(key);
+    if (file == null) {
+      return MIN_SUPPORTED_SDK;
     }
 
-    final String versionString = readVersionFromFile(versionFile);
+    final String versionString = readVersionString(file);
+
     if (versionString == null) {
-      LOG.warn("Unable to find Flutter SDK version at " + sdkHome.getPath());
+      return MIN_SUPPORTED_SDK;
     }
 
-    // If we don't have a version file at all, assume it's a supported version and don't complain.
-    final FlutterSdkVersion version = versionString == null ? MIN_SUPPORTED_SDK : new FlutterSdkVersion(versionString);
-
-    cache.put(Pair.create(versionFile, versionFile.lastModified()), version);
-    return version;
+    return new FlutterSdkVersion(versionString);
   }
 
-  public boolean isSupported() {
+  private static String readVersionString(VirtualFile file) {
+    try {
+      final String data = new String(file.contentsToByteArray(), StandardCharsets.UTF_8);
+      for (String line : data.split("\n")) {
+        line = line.trim();
+
+        if (line.isEmpty() || line.startsWith("#")) {
+          continue;
+        }
+
+        return line;
+      }
+      return null;
+    }
+    catch (IOException e) {
+      return null;
+    }
+  }
+
+  public boolean isMinRecommendedSupported() {
     return version.compareTo(MIN_SUPPORTED_SDK.version) >= 0;
   }
 
   public boolean flutterTestSupportsMachineMode() {
-    return version.compareTo(MIN_TEST_MACHINE_MODE.version) >= 0;
+    return version.compareTo(MIN_SUPPORTED_SDK.version) >= 0;
   }
 
   @SuppressWarnings("BooleanMethodIsAlwaysInverted")
   public boolean flutterTestSupportsFiltering() {
-    return version.compareTo(MIN_TEST_FILTERING.version) >= 0;
+    return version.compareTo(MIN_SUPPORTED_SDK.version) >= 0;
   }
 
   @Override
   public String toString() {
     return version.toCompactString();
   }
-
-  private static String readVersionFromFile(File versionFile) {
-    if (!versionFile.isFile() || versionFile.length() >= 1000) {
-      return null;
-    }
-
-    try {
-      final String content = FileUtil.loadFile(versionFile).trim();
-      final int index = content.lastIndexOf('\n');
-      if (index < 0) return content;
-      return content.substring(index + 1).trim();
-    }
-    catch (IOException e) {
-      /* ignore */
-      return null;
-    }
-  }
-
-  private static final Logger LOG = Logger.getInstance(FlutterSdkVersion.class);
 }


### PR DESCRIPTION
The flutter version file was renamed from `VERSION` to `version` (and the contents changed slightly). We received a crash report in https://github.com/flutter/flutter-intellij/issues/1646; the existing code should have been hardened against the name change - I don't see a clear reason for the crash - but this PR does update to pull from the new file name.

Also, this PR removes several (now pretty old) version numbers.

@pq @jwren 