### PR TITLE
open the inspector view at app launch

### DIFF
--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.form
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.form
@@ -63,7 +63,7 @@
         <border type="none"/>
         <children/>
       </grid>
-      <grid id="e885c" layout-manager="GridLayoutManager" row-count="4" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="e885c" layout-manager="GridLayoutManager" row-count="5" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -76,7 +76,7 @@
         <children>
           <component id="6304a" class="javax.swing.JCheckBox" binding="myReportUsageInformationCheckBox">
             <constraints>
-              <grid row="1" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="2" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text value="&amp;Report usage information to Google Analytics"/>
@@ -85,7 +85,7 @@
           </component>
           <component id="abbab" class="com.intellij.ui.components.labels.LinkLabel" binding="myPrivacyPolicy">
             <constraints>
-              <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="3" use-parent-layout="false"/>
+              <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="3" use-parent-layout="false"/>
             </constraints>
             <properties>
               <horizontalAlignment value="2"/>
@@ -105,11 +105,19 @@
           </component>
           <component id="be19f" class="javax.swing.JCheckBox" binding="myEnableVerboseLoggingCheckBox" default-binding="true">
             <constraints>
-              <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text value="Enable &amp;verbose logging"/>
               <toolTipText value="Enables verbose logging (this can be useful for diagnostic purposes)."/>
+            </properties>
+          </component>
+          <component id="356a" class="javax.swing.JCheckBox" binding="myOpenInspectorOnAppLaunchCheckBox">
+            <constraints>
+              <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Open Flutter Inspector view on app launch"/>
             </properties>
           </component>
         </children>

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.java
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.java
@@ -52,6 +52,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
   private LinkLabel<String> myPrivacyPolicy;
   private JCheckBox myHotReloadOnSaveCheckBox;
   private JCheckBox myEnableVerboseLoggingCheckBox;
+  private JCheckBox myOpenInspectorOnAppLaunchCheckBox;
   private final @NotNull Project myProject;
 
   FlutterSettingsConfigurable(@NotNull Project project) {
@@ -128,6 +129,10 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
       return true;
     }
 
+    if (settings.isOpenInspectorOnAppLaunch() != myOpenInspectorOnAppLaunchCheckBox.isSelected()) {
+      return true;
+    }
+
     //noinspection RedundantIfStatement
     if (settings.isVerboseLogging() != myEnableVerboseLoggingCheckBox.isSelected()) {
       return true;
@@ -155,6 +160,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
 
     final FlutterSettings settings = FlutterSettings.getInstance();
     settings.setReloadOnSave(myHotReloadOnSaveCheckBox.isSelected());
+    settings.setOpenInspectorOnAppLaunch(myOpenInspectorOnAppLaunchCheckBox.isSelected());
     settings.setVerboseLogging(myEnableVerboseLoggingCheckBox.isSelected());
 
     reset(); // because we rely on remembering initial state
@@ -176,6 +182,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
 
     final FlutterSettings settings = FlutterSettings.getInstance();
     myHotReloadOnSaveCheckBox.setSelected(settings.isReloadOnSave());
+    myOpenInspectorOnAppLaunchCheckBox.setSelected(settings.isOpenInspectorOnAppLaunch());
     myEnableVerboseLoggingCheckBox.setSelected(settings.isVerboseLogging());
   }
 

--- a/src/io/flutter/settings/FlutterSettings.java
+++ b/src/io/flutter/settings/FlutterSettings.java
@@ -14,6 +14,7 @@ import java.util.List;
 
 public class FlutterSettings {
   private static final String reloadOnSaveKey = "io.flutter.reloadOnSave";
+  private static final String openInspectorOnAppLaunchKey = "io.flutter.openInspectorOnAppLaunch";
   private static final String verboseLoggingKey = "io.flutter.verboseLogging";
 
   public static FlutterSettings getInstance() {
@@ -52,8 +53,18 @@ public class FlutterSettings {
     return getPropertiesComponent().getBoolean(reloadOnSaveKey, true);
   }
 
+  public boolean isOpenInspectorOnAppLaunch() {
+    return getPropertiesComponent().getBoolean(openInspectorOnAppLaunchKey, true);
+  }
+
   public void setReloadOnSave(boolean value) {
     getPropertiesComponent().setValue(reloadOnSaveKey, value, true);
+
+    fireEvent();
+  }
+
+  public void setOpenInspectorOnAppLaunch(boolean value) {
+    getPropertiesComponent().setValue(openInspectorOnAppLaunchKey, value, true);
 
     fireEvent();
   }


### PR DESCRIPTION
- add a preference to open the inspector view at app launch (fix https://github.com/flutter/flutter-intellij/issues/1618)
- when the app closes, re-show the previously active view, unless the user has manually selected other views in the interim

<img width="421" alt="screen shot 2018-01-27 at 8 35 23 pm" src="https://user-images.githubusercontent.com/1269969/35479081-a91bb5a0-03a2-11e8-9e74-0c23a25a2f7a.png">

@pq @jacob314 