### PR TITLE
misc inspector work

### DIFF
--- a/src/io/flutter/inspector/InspectorService.java
+++ b/src/io/flutter/inspector/InspectorService.java
@@ -424,9 +424,15 @@ public class InspectorService implements Disposable {
   }
 
   public enum FlutterTreeType {
-    widget,
-    renderObject,
+    widget("Widget"),
+    renderObject("Render");
     // TODO(jacobr): add semantics, and layer trees.
+
+    public final String displayName;
+
+    FlutterTreeType(String displayName) {
+      this.displayName = displayName;
+    }
   }
 
   public interface InspectorServiceClient {

--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -48,11 +48,11 @@ import java.util.Map;
   name = "FlutterView",
   storages = {@Storage("$WORKSPACE_FILE$")}
 )
-public class FlutterView implements PersistentStateComponent<FlutterView.State>, Disposable {
+public class FlutterView implements PersistentStateComponent<FlutterViewState>, Disposable {
   public static final String TOOL_WINDOW_ID = "Flutter Inspector";
 
   @NotNull
-  private FlutterView.State state = new FlutterView.State();
+  private final FlutterViewState state = new FlutterViewState();
 
   @NotNull
   private final Project myProject;
@@ -72,21 +72,22 @@ public class FlutterView implements PersistentStateComponent<FlutterView.State>,
 
   @NotNull
   @Override
-  public FlutterView.State getState() {
+  public FlutterViewState getState() {
     return this.state;
   }
 
   @Override
-  public void loadState(FlutterView.State state) {
-    this.state = state;
+  public void loadState(FlutterViewState state) {
+    this.state.copyFrom(state);
   }
 
   public void initToolWindow(@NotNull ToolWindow toolWindow) {
     final ContentFactory contentFactory = ContentFactory.SERVICE.getInstance();
 
     final DefaultActionGroup toolbarGroup = new DefaultActionGroup();
-    toolbarGroup.add(new DebugDrawAction(this));
     toolbarGroup.add(new ToggleInspectModeAction(this));
+    toolbarGroup.addSeparator();
+    toolbarGroup.add(new DebugDrawAction(this));
     toolbarGroup.add(new TogglePlatformAction(this));
     toolbarGroup.addSeparator();
     toolbarGroup.add(new OpenObservatoryAction(this));
@@ -182,12 +183,6 @@ public class FlutterView implements PersistentStateComponent<FlutterView.State>,
 
   private boolean hasFlutterApp() {
     return getFlutterApp() != null;
-  }
-
-  /**
-   * State for the view.
-   */
-  class State {
   }
 }
 
@@ -290,7 +285,7 @@ class TimeDilationAction extends AbstractToggleableAction {
 
 class ToggleInspectModeAction extends AbstractToggleableAction {
   ToggleInspectModeAction(@NotNull FlutterView view) {
-    super(view, "Toggle Inspect Mode", "Toggle Inspect Mode", AllIcons.General.LocateHover);
+    super(view, "Toggle Select Widget Mode", "Toggle Select Widget Mode", AllIcons.General.LocateHover);
   }
 
   protected void perform(AnActionEvent event) {

--- a/src/io/flutter/view/FlutterViewState.java
+++ b/src/io/flutter/view/FlutterViewState.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.view;
+
+import com.intellij.util.EventDispatcher;
+import com.intellij.util.xmlb.annotations.Attribute;
+
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
+
+/**
+ * State for the Flutter view.
+ */
+public class FlutterViewState {
+  private final EventDispatcher<ChangeListener> dispatcher = EventDispatcher.create(ChangeListener.class);
+
+  @Attribute(value = "splitter-proportion")
+  public float splitterProportion;
+
+  public FlutterViewState() {
+  }
+
+  public float getSplitterProportion() {
+    return splitterProportion <= 0.0f ? 0.8f : splitterProportion;
+  }
+
+  public void setSplitterProportion(float value) {
+    splitterProportion = value;
+    dispatcher.getMulticaster().stateChanged(new ChangeEvent(this));
+  }
+
+  public void addListener(ChangeListener listener) {
+    dispatcher.addListener(listener);
+  }
+
+  public void removeListener(ChangeListener listener) {
+    dispatcher.removeListener(listener);
+  }
+
+  void copyFrom(FlutterViewState other) {
+    splitterProportion = other.splitterProportion;
+  }
+}


### PR DESCRIPTION
- restore inspector splitter position between IntelliJ sessions
- show text `'Widget tree for the running app'` when there is no content in the widget / element tree view. This is to help the user know that an app must be running for content to display
- rename the 'Toggle Inspect Mode' toolbar button to 'Toggle Select Widget Mode'. I think the new name makes more sense now that the view has been renamed to 'Flutter Inspector'
- reorder the toolbar icons so the inspect mode action comes first

<img width="330" alt="screen shot 2018-01-27 at 10 39 54 pm" src="https://user-images.githubusercontent.com/1269969/35517437-49db8698-04c3-11e8-9387-7844dffe9934.png">

<img width="365" alt="screen shot 2018-01-28 at 9 17 53 am" src="https://user-images.githubusercontent.com/1269969/35517428-4295876c-04c3-11e8-83ff-519f5589b822.png">

@jacob314 @pq 