### PR TITLE
Harden error reporting on iOS simulator start failures (#1647).

### DIFF
--- a/src/io/flutter/actions/OpenSimulatorAction.java
+++ b/src/io/flutter/actions/OpenSimulatorAction.java
@@ -39,7 +39,8 @@ public class OpenSimulatorAction extends AnAction {
         @Override
         public void processTerminated(final ProcessEvent event) {
           if (event.getExitCode() != 0) {
-            FlutterMessages.showError("Error Opening Simulator", event.getText());
+            final String msg = event.getText() != null ? event.getText() : "Process error - exit code: (" + event.getExitCode() + ")";
+            FlutterMessages.showError("Error Opening Simulator", msg);
           }
         }
       });


### PR DESCRIPTION
I can't repro w/o an incomplete Xcode upgrade but it looks like the issue stems from a `null` error message in case of a process failure.  This should work around that case.

Fixes: #1647.


@devoncarew 