### PR TITLE
Smarts to run `flutter build` before trying open Xcode (#1373).

### DIFF
--- a/src/io/flutter/actions/FlutterSdkAction.java
+++ b/src/io/flutter/actions/FlutterSdkAction.java
@@ -71,7 +71,7 @@ public abstract class FlutterSdkAction extends DumbAwareAction {
     return false;
   }
 
-  private static void showMissingSdkDialog(Project project) {
+  public static void showMissingSdkDialog(Project project) {
     final int response = FlutterMessages.showDialog(project, FlutterBundle.message("flutter.sdk.notAvailable.message"),
                                                     FlutterBundle.message("flutter.sdk.notAvailable.title"),
                                                     new String[]{"Yes, configure", "No, thanks"}, -1);

--- a/src/io/flutter/actions/OpenInXcodeAction.java
+++ b/src/io/flutter/actions/OpenInXcodeAction.java
@@ -97,12 +97,18 @@ public class OpenInXcodeAction extends AnAction {
       sdk.flutterBuild(pubRoot, "ios", "--debug").start(null, new ProcessAdapter() {
         @Override
         public void processTerminated(@NotNull ProcessEvent event) {
-          super.processTerminated(event);
           progressHelper.done();
+
+          if (event.getExitCode() != 0) {
+            FlutterMessages.showError("Error Opening Xcode", "`flutter build` returned: " + event.getExitCode());
+            return;
+          }
+
           openWithXcode(file.getPath());
         }
       });
-    } else {
+    }
+    else {
       openWithXcode(file.getPath());
     }
   }

--- a/src/io/flutter/actions/OpenInXcodeAction.java
+++ b/src/io/flutter/actions/OpenInXcodeAction.java
@@ -15,10 +15,14 @@ import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
 import com.intellij.openapi.actionSystem.Presentation;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectUtil;
 import com.intellij.openapi.util.SystemInfo;
 import com.intellij.openapi.vfs.VirtualFile;
 import io.flutter.FlutterMessages;
 import io.flutter.FlutterUtils;
+import io.flutter.pub.PubRoot;
+import io.flutter.run.daemon.ProgressHelper;
+import io.flutter.sdk.FlutterSdk;
 import io.flutter.utils.FlutterModuleUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -72,7 +76,43 @@ public class OpenInXcodeAction extends AnAction {
   }
 
   private static void openFile(@NotNull VirtualFile file) {
-    final String path = file.getPath();
+    final Project project = ProjectUtil.guessProjectForFile(file);
+    final FlutterSdk sdk = project != null ? FlutterSdk.getFlutterSdk(project) : null;
+    if (sdk == null) {
+      FlutterSdkAction.showMissingSdkDialog(project);
+      return;
+    }
+
+    final PubRoot pubRoot = PubRoot.forFile(file);
+    if (pubRoot == null) {
+      FlutterMessages.showError("Error Opening Xcode", "Unable to run `flutter build` (no pub root found)");
+      return;
+    }
+
+    // Trigger an iOS build if necessary.
+    if (!hasBeenBuilt(pubRoot)) {
+      final ProgressHelper progressHelper = new ProgressHelper(project);
+      progressHelper.start("Building for iOS");
+
+      sdk.flutterBuild(pubRoot, "ios", "--debug").start(null, new ProcessAdapter() {
+        @Override
+        public void processTerminated(@NotNull ProcessEvent event) {
+          super.processTerminated(event);
+          progressHelper.done();
+          openWithXcode(file.getPath());
+        }
+      });
+    } else {
+      openWithXcode(file.getPath());
+    }
+  }
+
+  private static boolean hasBeenBuilt(@NotNull PubRoot pubRoot) {
+    final VirtualFile buildDir = pubRoot.getRoot().findChild("build");
+    return buildDir != null && buildDir.isDirectory() && buildDir.findChild("ios") != null;
+  }
+
+  private static void openWithXcode(String path) {
     try {
       final GeneralCommandLine cmd = new GeneralCommandLine().withExePath("open").withParameters(path);
       final OSProcessHandler handler = new OSProcessHandler(cmd);

--- a/src/io/flutter/actions/OpenInXcodeAction.java
+++ b/src/io/flutter/actions/OpenInXcodeAction.java
@@ -21,7 +21,7 @@ import com.intellij.openapi.vfs.VirtualFile;
 import io.flutter.FlutterMessages;
 import io.flutter.FlutterUtils;
 import io.flutter.pub.PubRoot;
-import io.flutter.run.daemon.ProgressHelper;
+import io.flutter.utils.ProgressHelper;
 import io.flutter.sdk.FlutterSdk;
 import io.flutter.utils.FlutterModuleUtils;
 import org.jetbrains.annotations.NotNull;

--- a/src/io/flutter/run/daemon/FlutterAppListener.java
+++ b/src/io/flutter/run/daemon/FlutterAppListener.java
@@ -12,6 +12,7 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import io.flutter.FlutterInitializer;
 import io.flutter.settings.FlutterSettings;
+import io.flutter.utils.ProgressHelper;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;

--- a/src/io/flutter/run/daemon/ProgressHelper.java
+++ b/src/io/flutter/run/daemon/ProgressHelper.java
@@ -15,13 +15,13 @@ import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 import java.util.List;
 
-class ProgressHelper {
+public class ProgressHelper {
   final Project myProject;
   final List<String> myTasks = new ArrayList<>();
 
   private Task.Backgroundable myTask;
 
-  ProgressHelper(@NotNull Project project) {
+  public ProgressHelper(@NotNull Project project) {
     this.myProject = project;
   }
 

--- a/src/io/flutter/sdk/FlutterCommand.java
+++ b/src/io/flutter/sdk/FlutterCommand.java
@@ -262,6 +262,7 @@ public class FlutterCommand {
   }
 
   enum Type {
+    BUILD("Flutter build", "build"),
     CONFIG("Flutter config", "config"),
     CREATE("Flutter create", "create"),
     DOCTOR("Flutter doctor", "doctor"),

--- a/src/io/flutter/sdk/FlutterSdk.java
+++ b/src/io/flutter/sdk/FlutterSdk.java
@@ -169,6 +169,10 @@ public class FlutterSdk {
     return new FlutterCommand(this, root.getRoot(), FlutterCommand.Type.PACKAGES_UPGRADE);
   }
 
+  public FlutterCommand flutterBuild(@NotNull PubRoot root, String... additionalArgs) {
+    return new FlutterCommand(this, root.getRoot(), FlutterCommand.Type.BUILD, additionalArgs);
+  }
+
   public FlutterCommand flutterConfig(String... additionalArgs) {
     return new FlutterCommand(this, getHome(), FlutterCommand.Type.CONFIG, additionalArgs);
   }

--- a/src/io/flutter/utils/ProgressHelper.java
+++ b/src/io/flutter/utils/ProgressHelper.java
@@ -3,7 +3,7 @@
  * Use of this source code is governed by a BSD-style license that can be
  * found in the LICENSE file.
  */
-package io.flutter.run.daemon;
+package io.flutter.utils;
 
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.progress.ProgressIndicator;


### PR DESCRIPTION
Checks for `build/ios` and in it's absence kicks off a `flutter build --debug`, showing progress in the status line.

![image](https://user-images.githubusercontent.com/67586/35592028-a1895804-05c0-11e8-8340-1ac9ce3a399b.png)

Otherwise, simply opens.

Fixes: #1373

@devoncarew 

