### PR TITLE
Property display cleanup.

### DIFF
--- a/src/io/flutter/utils/ColorIconMaker.java
+++ b/src/io/flutter/utils/ColorIconMaker.java
@@ -42,11 +42,11 @@ public class ColorIconMaker {
         }
 
         public int getIconWidth() {
-          return 22;
+          return 22; // TODO(jacob): customize the icon height based on the font size.
         }
 
         public int getIconHeight() {
-          return 22;
+          return 22; // TODO(jacob): customize the icon height based on the font size.
         }
       };
 

--- a/src/io/flutter/view/InspectorPanel.java
+++ b/src/io/flutter/view/InspectorPanel.java
@@ -658,11 +658,6 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
       final DiagnosticsNode node = (DiagnosticsNode)value;
       final SimpleTextAttributes textAttributes = textAttributesForLevel(node.getLevel());
 
-      if (!node.getShowName()) {
-        append(node.getName(), textAttributes);
-        append(" ", textAttributes);
-      }
-
       boolean appendDescription = true;
 
       if (node.getTooltip() != null) {


### PR DESCRIPTION
Showing the name in grey even when the name was supposed to be hidden was confusing.
Add todo that icons are the wrong size when the font size is changed.