### PR TITLE
Track creation locations.

### DIFF
--- a/src/io/flutter/inspector/DiagnosticsNode.java
+++ b/src/io/flutter/inspector/DiagnosticsNode.java
@@ -50,6 +50,8 @@ import static io.flutter.sdk.FlutterSettingsConfigurable.WIDGET_FILTERING_ENABLE
 public class DiagnosticsNode {
   private static final CustomIconMaker iconMaker = new CustomIconMaker();
 
+  private Location location;
+
   public DiagnosticsNode(JsonObject json, InspectorService inspectorService) {
     this.inspectorService = inspectorService;
     this.json = json;
@@ -364,10 +366,14 @@ public class DiagnosticsNode {
   }
 
   public Location getCreationLocation() {
+    if (location != null) {
+      return location;
+    }
     if (!hasCreationLocation()) {
       return null;
     }
-    return new Location(json.getAsJsonObject("creationLocation"), null);
+    location = new Location(json.getAsJsonObject("creationLocation"), null);
+    return location;
   }
 
   /**

--- a/src/io/flutter/inspector/DiagnosticsNode.java
+++ b/src/io/flutter/inspector/DiagnosticsNode.java
@@ -359,6 +359,17 @@ public class DiagnosticsNode {
     return json.has("exception");
   }
 
+  public boolean hasCreationLocation() {
+    return json.has("creationLocation");
+  }
+
+  public Location getCreationLocation() {
+    if (!hasCreationLocation()) {
+      return null;
+    }
+    return new Location(json.getAsJsonObject("creationLocation"), null);
+  }
+
   /**
    * String representation of the type of the property [value].
    * <p>

--- a/src/io/flutter/inspector/InspectorService.java
+++ b/src/io/flutter/inspector/InspectorService.java
@@ -140,7 +140,7 @@ public class InspectorService implements Disposable {
       for (String propertyName : propertyNames) {
         propertyAccessors.add(objectName + "." + propertyName);
       }
-      sb.append("<Object>[");
+      sb.append("[");
       sb.append(Joiner.on(',').join(propertyAccessors));
       sb.append("]");
       final Map<String, String> scope = new HashMap<>();

--- a/src/io/flutter/inspector/InspectorTreeActionBase.java
+++ b/src/io/flutter/inspector/InspectorTreeActionBase.java
@@ -35,7 +35,11 @@ public abstract class InspectorTreeActionBase extends AnAction {
   }
 
   protected boolean isEnabled(final DefaultMutableTreeNode node, AnActionEvent e) {
-    return node.getUserObject() instanceof DiagnosticsNode;
+    return node.getUserObject() instanceof DiagnosticsNode && isSupported((DiagnosticsNode)node.getUserObject());
+  }
+
+  protected boolean isSupported(DiagnosticsNode diagnosticsNode) {
+    return true;
   }
 
   public static DefaultMutableTreeNode getSelectedNode(final DataContext dataContext) {

--- a/src/io/flutter/inspector/JumpToSourceAction.java
+++ b/src/io/flutter/inspector/JumpToSourceAction.java
@@ -5,12 +5,30 @@
  */
 package io.flutter.inspector;
 
+import com.intellij.xdebugger.XSourcePosition;
 import com.intellij.xdebugger.frame.XNavigatable;
 import com.intellij.xdebugger.frame.XValue;
 
 public class JumpToSourceAction extends JumpToSourceActionBase {
   @Override
+  protected XSourcePosition getSourcePosition(DiagnosticsNode node) {
+    if (!node.hasCreationLocation()) {
+      return null;
+    }
+    return node.getCreationLocation().getXSourcePosition();
+  }
+
+  @Override
   protected void startComputingSourcePosition(XValue value, XNavigatable navigatable) {
+    // This case only typically works for Function objects where the source
+    // position is available.
     value.computeSourcePosition(navigatable);
+  }
+
+  protected boolean isSupported(DiagnosticsNode diagnosticsNode) {
+    // TODO(jacobr): also return true if the value of the DiagnosticsNode is
+    // a Function object as we can get a source position through the
+    // Observatory protocol in that case.
+    return diagnosticsNode.hasCreationLocation();
   }
 }

--- a/src/io/flutter/inspector/JumpToSourceActionBase.java
+++ b/src/io/flutter/inspector/JumpToSourceActionBase.java
@@ -8,6 +8,7 @@ package io.flutter.inspector;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.project.Project;
 import com.intellij.ui.AppUIUtil;
+import com.intellij.xdebugger.XSourcePosition;
 import com.intellij.xdebugger.frame.XNavigatable;
 import com.intellij.xdebugger.frame.XValue;
 import com.jetbrains.lang.dart.ide.runner.server.vmService.frame.DartVmServiceValue;
@@ -31,7 +32,13 @@ public abstract class JumpToSourceActionBase extends InspectorTreeActionBase {
         }, project.getDisposed());
       }
     };
-
+    final XSourcePosition sourcePosition = getSourcePosition(diagnosticsNode);
+    if (sourcePosition != null) {
+      // Source position is available immediately.
+      navigatable.setSourcePosition(sourcePosition);
+      return;
+    }
+    // We have to get a DartVmServiceValue to compute the source position.
     final InspectorService inspectorService = diagnosticsNode.getInspectorService();
     final CompletableFuture<DartVmServiceValue> valueFuture =
       inspectorService.toDartVmServiceValueForSourceLocation(diagnosticsNode.getValueRef());
@@ -43,5 +50,13 @@ public abstract class JumpToSourceActionBase extends InspectorTreeActionBase {
     });
   }
 
+  /**
+   * Implement if the source position is available directly from the diagnostics node.
+   */
+  protected abstract XSourcePosition getSourcePosition(DiagnosticsNode node);
+
+  /**
+   * Implement if the source position is available from the XValue of the diagnostics node.
+   */
   protected abstract void startComputingSourcePosition(XValue value, XNavigatable navigatable);
 }

--- a/src/io/flutter/inspector/JumpToTypeSourceAction.java
+++ b/src/io/flutter/inspector/JumpToTypeSourceAction.java
@@ -5,6 +5,7 @@
  */
 package io.flutter.inspector;
 
+import com.intellij.xdebugger.XSourcePosition;
 import com.intellij.xdebugger.frame.XNavigatable;
 import com.intellij.xdebugger.frame.XValue;
 
@@ -12,5 +13,10 @@ public class JumpToTypeSourceAction extends JumpToSourceActionBase {
   @Override
   protected void startComputingSourcePosition(XValue value, XNavigatable navigatable) {
     value.computeTypeSourcePosition(navigatable);
+  }
+
+  @Override
+  protected XSourcePosition getSourcePosition(DiagnosticsNode node) {
+    return null;
   }
 }

--- a/src/io/flutter/inspector/Location.java
+++ b/src/io/flutter/inspector/Location.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2018 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.inspector;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.xdebugger.XSourcePosition;
+import com.intellij.xdebugger.impl.XSourcePositionImpl;
+import io.flutter.utils.JsonUtils;
+
+import java.util.ArrayList;
+
+public class Location {
+  final JsonObject json;
+  Location parent;
+
+  public Location(JsonObject json, Location parent) {
+    this.json = json;
+  }
+
+  public VirtualFile getFile() {
+    String fileName = JsonUtils.getStringMember(json, "file");
+    if (fileName == null) {
+      return parent != null ? parent.getFile() : null;
+    }
+
+    // We have to strip the file:// prefix from the Dart file path for compatibility.
+    final String filePrefix = "file://";
+    if (fileName.startsWith(filePrefix)) {
+      fileName = fileName.substring(filePrefix.length());
+    }
+
+    final VirtualFile virtualFile = LocalFileSystem.getInstance().findFileByPath(fileName);
+    if (!virtualFile.exists()) {
+      return null;
+    }
+    return virtualFile;
+  }
+
+  public int getLine() {
+    return JsonUtils.getIntMember(json, "line");
+  }
+
+  public int getColumn() {
+    return JsonUtils.getIntMember(json, "column");
+  }
+
+  public XSourcePosition getXSourcePosition() {
+    final VirtualFile file = getFile();
+    if (file == null) {
+      return null;
+    }
+    int line = getLine();
+    int column = getColumn();
+    if (line < 0 || column < 0) {
+      return null;
+    }
+    return XSourcePositionImpl.create(file, line - 1, column - 1);
+  }
+
+  ArrayList<Location> getParameterLocations() {
+    if (json.has("parameterLocations")) {
+      final JsonArray parametersJson = json.getAsJsonArray("parameterLocations");
+      final ArrayList<Location> ret = new ArrayList<>();
+      for (int i = 0; i < parametersJson.size(); ++i) {
+        ret.add(new Location(parametersJson.get(i).getAsJsonObject(), this));
+      }
+      return ret;
+    }
+    return null;
+  }
+}

--- a/src/io/flutter/run/daemon/FlutterApp.java
+++ b/src/io/flutter/run/daemon/FlutterApp.java
@@ -26,6 +26,8 @@ import com.intellij.util.concurrency.AppExecutorUtil;
 import com.jetbrains.lang.dart.ide.runner.ObservatoryConnector;
 import io.flutter.FlutterInitializer;
 import io.flutter.inspector.InspectorService;
+import io.flutter.pub.PubRoot;
+import io.flutter.pub.PubRoots;
 import io.flutter.run.FlutterDebugProcess;
 import io.flutter.run.FlutterLaunchMode;
 import org.dartlang.vm.service.VmService;
@@ -55,6 +57,8 @@ public class FlutterApp {
   private @Nullable String myWsUrl;
   private @Nullable String myBaseUri;
   private @Nullable ConsoleView myConsole;
+
+  private @Nullable List<PubRoot> myPubRoots;
 
   private int reloadCount;
   private int restartCount;
@@ -475,6 +479,14 @@ public class FlutterApp {
   @NotNull
   public Project getProject() {
     return myProject;
+  }
+
+  @NotNull
+  public List<PubRoot> getPubRoots() {
+    if (myPubRoots == null) {
+      myPubRoots = PubRoots.forProject(myProject);
+    }
+    return myPubRoots;
   }
 
   @Nullable

--- a/src/io/flutter/utils/JsonUtils.java
+++ b/src/io/flutter/utils/JsonUtils.java
@@ -29,6 +29,13 @@ public class JsonUtils {
     return value instanceof JsonNull ? null : value.getAsString();
   }
 
+  public static int getIntMember(@NotNull JsonObject json, @NotNull String memberName) {
+    if (!json.has(memberName)) return -1;
+
+    final JsonElement value = json.get(memberName);
+    return value instanceof JsonNull ? -1: value.getAsInt();
+  }
+
   @NotNull
   public static List<String> getValues(@NotNull JsonObject json, @NotNull String member) {
     if (!json.has(member)) {

--- a/src/io/flutter/view/InspectorPanel.java
+++ b/src/io/flutter/view/InspectorPanel.java
@@ -99,7 +99,6 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
   private boolean isActive = false;
 
   private final AsyncRateLimiter refreshRateLimiter;
-  private List<PubRoot> pubRoots;
 
   private static final Logger LOG = Logger.getInstance(InspectorPanel.class);
 
@@ -189,14 +188,6 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
   }
 
   void setActivate(boolean enabled) {
-    // TODO(jacobr): where is the right place to be caching the pub roots.
-    if (flutterView != null && flutterView.getFlutterApp() != null) {
-      pubRoots = PubRoots.forProject(flutterView.getFlutterApp().getProject());
-    }
-    else {
-      pubRoots = null;
-    }
-
     if (!enabled) {
       onIsolateStopped();
       isActive = false;
@@ -874,7 +865,7 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
   }
 
   boolean isCreatedByLocalProject(DiagnosticsNode node) {
-    if (pubRoots == null) {
+    if (getFlutterApp() == null) {
       return false;
     }
     final Location location = node.getCreationLocation();
@@ -886,7 +877,7 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
       return false;
     }
     String filePath = file.getCanonicalPath();
-    for (PubRoot root : pubRoots) {
+    for (PubRoot root : getFlutterApp().getPubRoots()) {
       if (filePath.startsWith(root.getRoot().getCanonicalPath())) {
         return true;
       }

--- a/src/io/flutter/view/InspectorPanel.java
+++ b/src/io/flutter/view/InspectorPanel.java
@@ -12,6 +12,7 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.ui.Splitter;
 import com.intellij.openapi.util.Computable;
 import com.intellij.openapi.util.Disposer;
+import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.ui.*;
 import com.intellij.ui.dualView.TreeTableView;
 import com.intellij.ui.treeStructure.Tree;
@@ -25,6 +26,8 @@ import com.intellij.xdebugger.impl.ui.tree.nodes.XValueNodeImpl;
 import io.flutter.FlutterBundle;
 import io.flutter.editor.FlutterMaterialIcons;
 import io.flutter.inspector.*;
+import io.flutter.pub.PubRoot;
+import io.flutter.pub.PubRoots;
 import io.flutter.run.daemon.FlutterApp;
 import io.flutter.utils.AsyncRateLimiter;
 import io.flutter.utils.ColorIconMaker;
@@ -46,6 +49,7 @@ import java.awt.*;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.regex.Matcher;
@@ -72,7 +76,6 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
 
   private final TreeDataProvider myRootsTree;
   private final PropertiesPanel myPropertiesPanel;
-  private FlutterView view;
   private final Computable<Boolean> isApplicable;
   private final InspectorService.FlutterTreeType treeType;
   private final FlutterView flutterView;
@@ -96,6 +99,7 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
   private boolean isActive = false;
 
   private final AsyncRateLimiter refreshRateLimiter;
+  private List<PubRoot> pubRoots;
 
   private static final Logger LOG = Logger.getInstance(InspectorPanel.class);
 
@@ -185,6 +189,14 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
   }
 
   void setActivate(boolean enabled) {
+    // TODO(jacobr): where is the right place to be caching the pub roots.
+    if (flutterView != null && flutterView.getFlutterApp() != null) {
+      pubRoots = PubRoots.forProject(flutterView.getFlutterApp().getProject());
+    }
+    else {
+      pubRoots = null;
+    }
+
     if (!enabled) {
       onIsolateStopped();
       isActive = false;
@@ -416,6 +428,12 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
       final Object userObject = selectedNodes[0].getUserObject();
       if (userObject instanceof DiagnosticsNode) {
         final DiagnosticsNode diagnostic = (DiagnosticsNode)userObject;
+        if (diagnostic != null) {
+          if (isCreatedByLocalProject(diagnostic)) {
+            diagnostic.getCreationLocation().getXSourcePosition().createNavigatable(flutterView.getFlutterApp().getProject())
+              .navigate(false);
+          }
+        }
         myPropertiesPanel.showProperties(diagnostic);
         if (getInspectorService() != null) {
           getInspectorService().setSelection(diagnostic.getValueRef(), false);
@@ -437,11 +455,8 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
   private ActionGroup createTreePopupActions() {
     final DefaultActionGroup group = new DefaultActionGroup();
     final ActionManager actionManager = ActionManager.getInstance();
+    group.add(actionManager.getAction(InspectorActions.JUMP_TO_SOURCE));
     group.add(actionManager.getAction(InspectorActions.JUMP_TO_TYPE_SOURCE));
-    // TODO(jacobr): add JUMP_TO_SOURCE once we have actual source locations
-    // as well as type source locations. This will require at minimum adding
-    // a Dart kernel code transformer to track creation locations for widgets.
-    /// group.add(actionManager.getAction(InspectorActions.JUMP_TO_SOURCE));
     return group;
   }
 
@@ -789,7 +804,7 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
     }
   }
 
-  private static class DiagnosticsTreeCellRenderer extends ColoredTreeCellRenderer {
+  private class DiagnosticsTreeCellRenderer extends ColoredTreeCellRenderer {
     /**
      * Split text into two groups, word characters at the start of a string
      * and all other chracters. Skip an <code>-</code> or <code>#</code> between the
@@ -814,7 +829,7 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
       if (!(userObject instanceof DiagnosticsNode)) return;
       final DiagnosticsNode node = (DiagnosticsNode)userObject;
       final String name = node.getName();
-      final SimpleTextAttributes textAttributes = textAttributesForLevel(node.getLevel());
+      SimpleTextAttributes textAttributes = textAttributesForLevel(node.getLevel());
       if (name != null && !name.isEmpty() && node.getShowName()) {
         // color in name?
         if (name.equals("child") || name.startsWith("child ")) {
@@ -823,11 +838,16 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
         else {
           append(name, textAttributes);
         }
+
         if (node.getShowSeparator()) {
           // Is this good?
           append(node.getSeparator(), SimpleTextAttributes.GRAY_ATTRIBUTES);
         }
         append(" ");
+      }
+
+      if (isCreatedByLocalProject(node)) {
+        textAttributes = textAttributes.derive(SimpleTextAttributes.REGULAR_BOLD_ATTRIBUTES.getStyle(), null, null, null);
       }
 
       // TODO(jacobr): custom display for units, colors, iterables, and icons.
@@ -851,6 +871,27 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
         setIcon(icon);
       }
     }
+  }
+
+  boolean isCreatedByLocalProject(DiagnosticsNode node) {
+    if (pubRoots == null) {
+      return false;
+    }
+    final Location location = node.getCreationLocation();
+    if (location == null) {
+      return false;
+    }
+    VirtualFile file = location.getFile();
+    if (file == null) {
+      return false;
+    }
+    String filePath = file.getCanonicalPath();
+    for (PubRoot root : pubRoots) {
+      if (filePath.startsWith(root.getRoot().getCanonicalPath())) {
+        return true;
+      }
+    }
+    return false;
   }
 
   boolean placeholderChildren(DefaultMutableTreeNode node) {


### PR DESCRIPTION
This CL is fine to land before the corresponding changes in Flutter or
Flutter Engine as without those changes source locations just show
up as missing. The source location menu item shows up as disabled
for widgets or render objects without a source location.
Note that RenderObjects will not have source locations even after the
Flutter change as there isn't a clear benefit in tracking them.