### PR TITLE
handle tree selection event

### DIFF
--- a/src/io/flutter/preview/PreviewView.java
+++ b/src/io/flutter/preview/PreviewView.java
@@ -476,11 +476,6 @@ class OutlineObject {
     else {
       builder.append(outline.getClassName());
     }
-    if (outline.getParentAssociationLabel() != null) {
-      builder.append('|');
-      builder.append(outline.getParentAssociationLabel());
-      builder.append(": ");
-    }
     if (outline.getVariableName() != null) {
       builder.append('|');
       builder.append(outline.getVariableName());

--- a/src/io/flutter/preview/PreviewView.java
+++ b/src/io/flutter/preview/PreviewView.java
@@ -15,6 +15,7 @@ import com.intellij.openapi.actionSystem.ActionManager;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.DefaultActionGroup;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.PersistentStateComponent;
 import com.intellij.openapi.components.Storage;
 import com.intellij.openapi.editor.Caret;
@@ -94,7 +95,7 @@ public class PreviewView implements PersistentStateComponent<PreviewView.State>,
     @Override
     public void outlineUpdated(@NotNull String filePath, @NotNull FlutterOutline outline) {
       if (currentFile != null && Objects.equals(currentFile.getPath(), filePath)) {
-        SwingUtilities.invokeLater(() -> {
+        ApplicationManager.getApplication().invokeLater(() -> {
           currentOutline = outline;
 
           final DefaultMutableTreeNode rootNode = getRootNode();
@@ -249,24 +250,19 @@ public class PreviewView implements PersistentStateComponent<PreviewView.State>,
     tree.addMouseListener(new MouseAdapter() {
       @Override
       public void mouseClicked(MouseEvent e) {
-        if (e.getClickCount() > 0) {
+        if (e.getClickCount() > 1) {
           final TreePath selectionPath = tree.getSelectionPath();
           if (selectionPath != null) {
-            final DefaultMutableTreeNode node = (DefaultMutableTreeNode)selectionPath.getLastPathComponent();
-            final OutlineObject object = (OutlineObject)node.getUserObject();
-            final FlutterOutline outline = object.outline;
-            final int offset = outline.getDartElement() != null ? outline.getDartElement().getLocation().getOffset() : outline.getOffset();
-            if (currentFile != null) {
-              isTreeClicking = true;
-              try {
-                new OpenFileDescriptor(project, currentFile, offset).navigate(e.getClickCount() > 1);
-              }
-              finally {
-                isTreeClicking = false;
-              }
-            }
+            selectPath(selectionPath, true);
           }
         }
+      }
+    });
+
+    tree.addTreeSelectionListener(e -> {
+      final TreePath selectionPath = e.getNewLeadSelectionPath();
+      if (selectionPath != null) {
+        ApplicationManager.getApplication().invokeLater(() -> selectPath(selectionPath, false));
       }
     });
 
@@ -275,6 +271,22 @@ public class PreviewView implements PersistentStateComponent<PreviewView.State>,
 
     contentManager.addContent(content);
     contentManager.setSelectedContent(content);
+  }
+
+  private void selectPath(TreePath selectionPath, boolean focusEditor) {
+    final DefaultMutableTreeNode node = (DefaultMutableTreeNode)selectionPath.getLastPathComponent();
+    final OutlineObject object = (OutlineObject)node.getUserObject();
+    final FlutterOutline outline = object.outline;
+    final int offset = outline.getDartElement() != null ? outline.getDartElement().getLocation().getOffset() : outline.getOffset();
+    if (currentFile != null) {
+      isTreeClicking = true;
+      try {
+        new OpenFileDescriptor(project, currentFile, offset).navigate(focusEditor);
+      }
+      finally {
+        isTreeClicking = false;
+      }
+    }
   }
 
   private DefaultTreeModel getTreeModel() {
@@ -504,7 +516,6 @@ class OutlineObject {
   }
 }
 
-
 class OutlineTreeCellRenderer extends ColoredTreeCellRenderer {
   private JTree tree;
   private boolean selected;
@@ -545,13 +556,8 @@ class OutlineTreeCellRenderer extends ColoredTreeCellRenderer {
       setIcon(icon);
     }
 
-    // Render the parent/child association.
-    if (outline.getParentAssociationLabel() != null) {
-      appendSearch(outline.getParentAssociationLabel() + ": ", SimpleTextAttributes.REGULAR_ATTRIBUTES);
-    }
-
     // Render the widget class.
-    appendSearch(outline.getClassName(), SimpleTextAttributes.REGULAR_BOLD_ATTRIBUTES);
+    appendSearch(outline.getClassName(), SimpleTextAttributes.REGULAR_ATTRIBUTES);
 
     // Render the variable.
     if (outline.getVariableName() != null) {
@@ -589,7 +595,7 @@ class OutlineTreeCellRenderer extends ColoredTreeCellRenderer {
   }
 
   private static boolean isAttributeElidable(String name) {
-    return StringUtil.equals("text", name);
+    return StringUtil.equals("text", name) || StringUtil.equals("icon", name);
   }
 
   private void appendSearch(@NotNull String text, @NotNull SimpleTextAttributes attributes) {


### PR DESCRIPTION
- handle the general tree selection event (sync the editor position with tree selection changes, like those from key events)
- elide `icon` param names - this makes `Icon` nodes look better
- don't show the parent association label; this is generally `child:` or `children:`. There's a little less noise in the tree w/o the labels, and the tree looks a bit more like a hierarchical representation of the widgets. @scheglov, I'm happy to discuss more in the office if you have concerns about this change

<img width="324" alt="screen shot 2018-02-01 at 7 37 34 pm" src="https://user-images.githubusercontent.com/1269969/35715964-8f1e68aa-078a-11e8-9e3e-01ec7e462d54.png">

<img width="367" alt="screen shot 2018-02-01 at 7 35 49 pm" src="https://user-images.githubusercontent.com/1269969/35715972-9cbeb776-078a-11e8-9b0d-4a927744b713.png">

@scheglov 