### PR TITLE
Reapply property value cl

### DIFF
--- a/src/io/flutter/inspector/DiagnosticsNode.java
+++ b/src/io/flutter/inspector/DiagnosticsNode.java
@@ -20,6 +20,7 @@ import javax.swing.*;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
@@ -414,8 +415,6 @@ public class DiagnosticsNode {
 
   private CompletableFuture<ArrayList<DiagnosticsNode>> children;
 
-  private CompletableFuture<ArrayList<DiagnosticsNode>> properties;
-
   private CompletableFuture<Map<String, InstanceRef>> valueProperties;
 
   public String getStringMember(@NotNull String memberName) {
@@ -576,10 +575,7 @@ public class DiagnosticsNode {
   }
 
   public CompletableFuture<ArrayList<DiagnosticsNode>> getProperties() {
-    if (properties == null) {
-      properties = inspectorService.getProperties(getDartDiagnosticRef());
-    }
-    return properties;
+    return inspectorService.getProperties(getDartDiagnosticRef());
   }
 
   public InspectorService getInspectorService() {
@@ -619,5 +615,34 @@ public class DiagnosticsNode {
     }
 
     return iconMaker.getCustomIcon(text, isPrivate ? CustomIconMaker.IconKind.kMethod : CustomIconMaker.IconKind.kClass);
+  }
+
+  /**
+   * Returns true if two diagnostic nodes are indistinguishable from
+   * the perspective of a user debugging.
+   * <p>
+   * In practice this means that all fields but the objectId and valueId
+   * properties for the DiagnosticsNode objects are identical. The valueId
+   * field may change even for properties that have not changed because in
+   * some cases such as the 'created' property for an element, the property
+   * value is created dynamically each time 'getProperties' is called.
+   */
+  public boolean identicalDisplay(DiagnosticsNode node) {
+    if (node == null) {
+      return false;
+    }
+    Set<String> keys = json.keySet();
+    if (!keys.equals(node.json.keySet())) {
+      return false;
+    }
+    for (String key : keys) {
+      if (key.equals("objectId") || key.equals("valueId")) {
+        continue;
+      }
+      if (!json.get(key).equals(node.json.get(key))) {
+        return false;
+      }
+    }
+    return true;
   }
 }

--- a/src/io/flutter/inspector/DiagnosticsNode.java
+++ b/src/io/flutter/inspector/DiagnosticsNode.java
@@ -631,15 +631,16 @@ public class DiagnosticsNode {
     if (node == null) {
       return false;
     }
-    Set<String> keys = json.keySet();
-    if (!keys.equals(node.json.keySet())) {
+    final Set<Map.Entry<String, JsonElement>> entries = json.entrySet();
+    if (entries.size() != node.json.entrySet().size()) {
       return false;
     }
-    for (String key : keys) {
+    for (Map.Entry<String, JsonElement> entry : entries) {
+      final String key = entry.getKey();
       if (key.equals("objectId") || key.equals("valueId")) {
         continue;
       }
-      if (!json.get(key).equals(node.json.get(key))) {
+      if (entry.getValue().equals(node.json.get(key))) {
         return false;
       }
     }

--- a/src/io/flutter/inspector/JumpToSourceActionBase.java
+++ b/src/io/flutter/inspector/JumpToSourceActionBase.java
@@ -11,7 +11,7 @@ import com.intellij.ui.AppUIUtil;
 import com.intellij.xdebugger.frame.XNavigatable;
 import com.intellij.xdebugger.frame.XValue;
 import com.jetbrains.lang.dart.ide.runner.server.vmService.frame.DartVmServiceValue;
-import io.flutter.view.InspectorPanel;
+import io.flutter.utils.AsyncUtils;
 
 import javax.swing.tree.DefaultMutableTreeNode;
 import java.util.concurrent.CompletableFuture;
@@ -35,7 +35,7 @@ public abstract class JumpToSourceActionBase extends InspectorTreeActionBase {
     final InspectorService inspectorService = diagnosticsNode.getInspectorService();
     final CompletableFuture<DartVmServiceValue> valueFuture =
       inspectorService.toDartVmServiceValueForSourceLocation(diagnosticsNode.getValueRef());
-    InspectorPanel.whenCompleteUiThread(valueFuture, (DartVmServiceValue value, Throwable throwable) -> {
+    AsyncUtils.whenCompleteUiThread(valueFuture, (DartVmServiceValue value, Throwable throwable) -> {
       if (throwable != null) {
         return;
       }

--- a/src/io/flutter/utils/AsyncRateLimiter.java
+++ b/src/io/flutter/utils/AsyncRateLimiter.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2018 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.utils;
+
+import com.google.common.util.concurrent.RateLimiter;
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.util.Computable;
+import com.intellij.util.Alarm;
+
+import javax.swing.*;
+import java.util.concurrent.CompletableFuture;
+
+import static io.flutter.utils.AsyncUtils.whenCompleteUiThread;
+
+/**
+ * Rate limiter that issues requests asynchronously on the ui thread
+ * ensuring framesPerSecond rate is not exceeded and that no more than 1
+ * request is issued at a time.
+ * <p>
+ * Methods from this class must only be invoked from the main UI thread.
+ */
+public class AsyncRateLimiter implements Disposable {
+  private final RateLimiter rateLimiter;
+  private final Alarm requestScheduler;
+  private final Computable<CompletableFuture<?>> callback;
+  private CompletableFuture<?> pendingRequest;
+  /**
+   * A request has been scheduled to run but is not yet pending.
+   */
+  private boolean requestScheduledButNotStarted;
+
+  public AsyncRateLimiter(double framesPerSecond, Computable<CompletableFuture<?>> callback) {
+    this.callback = callback;
+    rateLimiter = RateLimiter.create(framesPerSecond);
+    requestScheduler = new Alarm(Alarm.ThreadToUse.POOLED_THREAD, this);
+  }
+
+  public void scheduleRequest() {
+    if (requestScheduledButNotStarted) {
+      // No need to schedule a request if one has already been scheduled but
+      // hasn't yet actually started executing.
+      return;
+    }
+
+    if (pendingRequest != null && !pendingRequest.isDone()) {
+      // Wait for the pending request to be done before scheduling the new
+      // request. The existing request has already started so may return state
+      // that is now out of date.
+      whenCompleteUiThread(pendingRequest, (Object ignored, Throwable error) -> {
+        pendingRequest = null;
+        scheduleRequest();
+      });
+      return;
+    }
+
+    if (rateLimiter.tryAcquire()) {
+      // Safe to perform the request immediately.
+      performRequest();
+    }
+    else {
+      // Track that we have sheduled a request and then schedule the request
+      // to occur once the rate limiter is available.
+      requestScheduledButNotStarted = true;
+      requestScheduler.addRequest(() -> {
+        rateLimiter.acquire();
+
+        Runnable doRun = () -> {
+          requestScheduledButNotStarted = false;
+          performRequest();
+        };
+        if (ApplicationManager.getApplication() != null) {
+          ApplicationManager.getApplication().invokeLater(doRun);
+        }
+        else {
+          // This case existing to support unittesting.
+          SwingUtilities.invokeLater(doRun);
+        }
+      }, 0);
+    }
+  }
+
+  private void performRequest() {
+    pendingRequest = callback.compute();
+  }
+
+  @Override
+  public void dispose() {
+  }
+}

--- a/src/io/flutter/utils/AsyncUtils.java
+++ b/src/io/flutter/utils/AsyncUtils.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.utils;
+
+import com.intellij.openapi.application.ApplicationManager;
+
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.BiConsumer;
+
+public class AsyncUtils {
+  /**
+   * Helper to get the value of a future on the UI thread.
+   * <p>
+   * The action will never be called if the future is cancelled.
+   */
+  public static <T> void whenCompleteUiThread(CompletableFuture<T> future, BiConsumer<? super T, ? super Throwable> action) {
+    future.whenCompleteAsync(
+      (T value, Throwable throwable) -> {
+        // Exceptions due to the Future being cancelled need to be treated
+        // differently as they indicate that no work should be done rather
+        // than that an error occurred.
+        // By convention we cancel Futures when the value to be computed
+        // would be obsolete. For example, the Future may be for a value from
+        // a previous Dart isolate or the user has already navigated somewhere
+        // else.
+        if (throwable instanceof CancellationException) {
+          return;
+        }
+        ApplicationManager.getApplication().invokeLater(() -> action.accept(value, throwable));
+      }
+    );
+  }
+}

--- a/src/io/flutter/view/InspectorPanel.java
+++ b/src/io/flutter/view/InspectorPanel.java
@@ -8,7 +8,6 @@ package io.flutter.view;
 import com.google.common.base.Joiner;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.actionSystem.*;
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.ui.Splitter;
 import com.intellij.openapi.util.Computable;
@@ -27,6 +26,7 @@ import io.flutter.FlutterBundle;
 import io.flutter.editor.FlutterMaterialIcons;
 import io.flutter.inspector.*;
 import io.flutter.run.daemon.FlutterApp;
+import io.flutter.utils.AsyncRateLimiter;
 import io.flutter.utils.ColorIconMaker;
 import org.dartlang.vm.service.element.InstanceRef;
 import org.jetbrains.annotations.NotNull;
@@ -47,16 +47,29 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.ArrayList;
 import java.util.Map;
-import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.BiConsumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import static io.flutter.utils.AsyncUtils.whenCompleteUiThread;
 
 // TODO(devoncarew): Should we filter out the CheckedModeBanner node type?
 // TODO(devoncarew): Should we filter out the WidgetInspector node type?
 
 public class InspectorPanel extends JPanel implements Disposable, InspectorService.InspectorServiceClient {
+
+  // TODO(jacobr): use a lower frame rate when the panel is hidden.
+  /**
+   * Maximum frame rate to refresh the inspector panel at to avoid taxing the
+   * physical device with too many requests to recompute properties and trees.
+   * <p>
+   * A value up to around 30 frames per second could be reasonable for
+   * debugging highly interactive cases particularly when the user is on a
+   * simulator or high powered native device. The frame rate is set low
+   * for now mainly to minimize the risk of unintended consequences.
+   */
+  public static final double REFRESH_FRAMES_PER_SECOND = 5.0;
+
   private final TreeDataProvider myRootsTree;
   private final PropertiesPanel myPropertiesPanel;
   private FlutterView view;
@@ -82,6 +95,8 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
   private boolean myIsListening = false;
   private boolean isActive = false;
 
+  private final AsyncRateLimiter refreshRateLimiter;
+
   private static final Logger LOG = Logger.getInstance(InspectorPanel.class);
 
   public InspectorPanel(FlutterView flutterView,
@@ -91,6 +106,8 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
     this.treeType = treeType;
     this.flutterView = flutterView;
     this.isApplicable = isApplicable;
+
+    refreshRateLimiter = new AsyncRateLimiter(REFRESH_FRAMES_PER_SECOND, this::refresh);
 
     myRootsTree = new TreeDataProvider(new DefaultMutableTreeNode(null), treeType.displayName);
     myRootsTree.addTreeExpansionListener(new MyTreeExpansionListener());
@@ -134,6 +151,11 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
     return (DefaultTreeModel)myRootsTree.getModel();
   }
 
+  private CompletableFuture<?> refresh() {
+    // TODO(jacobr): refresh the tree as well as just the properties.
+    return myPropertiesPanel.refresh();
+  }
+
   public void onIsolateStopped() {
     // Make sure we cleanup all references to objects from the stopped isolate as they are now obsolete.
     if (rootFuture != null && !rootFuture.isDone()) {
@@ -174,7 +196,7 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
     getInspectorService().addClient(this);
     getInspectorService().isWidgetTreeReady().thenAccept((Boolean ready) -> {
       if (ready) {
-        onFlutterFrame();
+        recomputeTreeRoot();
       }
     });
   }
@@ -183,14 +205,9 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
     return (DefaultMutableTreeNode)getTreeModel().getRoot();
   }
 
-  void recomputeTreeRoot() {
-    if (getRootNode().getUserObject() instanceof DiagnosticsNode) {
-      // May be stale but at least we have something.
-      // TODO(jacobr): actually recompute the tree root in this case.
-      return;
-    }
+  private CompletableFuture<DiagnosticsNode> recomputeTreeRoot() {
     if (rootFuture != null && !rootFuture.isDone()) {
-      return;
+      return rootFuture;
     }
     rootFuture = getInspectorService().getRoot(treeType);
 
@@ -204,6 +221,7 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
       maybeLoadChildren(rootNode);
       getTreeModel().setRoot(rootNode);
     });
+    return rootFuture;
   }
 
   void setupTreeNode(DefaultMutableTreeNode node, DiagnosticsNode diagnosticsNode) {
@@ -255,34 +273,21 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
     }
   }
 
-  /**
-   * Helper to get the value of a future on the UI thread.
-   * <p>
-   * The action will never be called if the future is cancelled.
-   */
-  public static <T> void whenCompleteUiThread(CompletableFuture<T> future, BiConsumer<? super T, ? super Throwable> action) {
-    future.whenCompleteAsync(
-      (T value, Throwable throwable) -> {
-        // Exceptions due to the Future being cancelled need to be treated
-        // differently as they indicate that no work should be done rather
-        // than that an error occurred.
-        // By convention we cancel Futures when the value to be computed
-        // would be obsolete. For example, the Future may be for a value from
-        // a previous Dart isolate or the user has already navigated somewhere
-        // else.
-        if (throwable instanceof CancellationException) {
-          return;
-        }
-        ApplicationManager.getApplication().invokeLater(() -> action.accept(value, throwable));
-      }
-    );
-  }
-
   public void onFlutterFrame() {
-    recomputeTreeRoot();
+    if (rootFuture == null) {
+      // This was the first frame.
+      recomputeTreeRoot();
+    }
+    refreshRateLimiter.scheduleRequest();
   }
 
   private boolean identicalDiagnosticsNodes(DiagnosticsNode a, DiagnosticsNode b) {
+    if (a == b) {
+      return true;
+    }
+    if (a == null || b == null) {
+      return false;
+    }
     return a.getDartDiagnosticRef().equals(b.getDartDiagnosticRef());
   }
 
@@ -530,6 +535,16 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
   }
 
   private static class PropertiesPanel extends TreeTableView {
+    /**
+     * Diagnostic we are displaying properties for.
+     */
+    private DiagnosticsNode diagnostic;
+
+    /**
+     * Current properties being displayed.
+     */
+    private ArrayList<DiagnosticsNode> currentProperties;
+
     PropertiesPanel() {
       super(new ListTreeTableModelOnColumns(
         new DefaultMutableTreeNode(),
@@ -555,55 +570,108 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
     }
 
     public void showProperties(DiagnosticsNode diagnostic) {
-      // Temporarily clear.
-      getTreeModel().setRoot(new DefaultMutableTreeNode());
+      this.diagnostic = diagnostic;
 
       if (diagnostic == null) {
         getEmptyText().setText(FlutterBundle.message("app.inspector.nothing_to_show"));
+        getTreeModel().setRoot(new DefaultMutableTreeNode());
         return;
       }
       getEmptyText().setText(FlutterBundle.message("app.inspector.loading_properties"));
       whenCompleteUiThread(diagnostic.getProperties(), (ArrayList<DiagnosticsNode> properties, Throwable throwable) -> {
         if (throwable != null) {
+          getTreeModel().setRoot(new DefaultMutableTreeNode());
           getEmptyText().setText(FlutterBundle.message("app.inspector.error_loading_properties"));
           LOG.error(throwable);
           return;
         }
+        showPropertiesHelper(properties);
+      });
+    }
 
-        if (properties.size() == 0) {
-          getEmptyText().setText(FlutterBundle.message("app.inspector.no_properties"));
+    private void showPropertiesHelper(ArrayList<DiagnosticsNode> properties) {
+      currentProperties = properties;
+      if (properties.size() == 0) {
+        getTreeModel().setRoot(new DefaultMutableTreeNode());
+        getEmptyText().setText(FlutterBundle.message("app.inspector.no_properties"));
+        return;
+      }
+      CompletableFuture<Void> loaded = loadPropertyMetadata(properties);
+
+      whenCompleteUiThread(loaded, (Void ignored, Throwable errorGettingInstances) -> {
+        if (errorGettingInstances != null) {
+          // TODO(jacobr): show error message explaining properties could not
+          // be loaded.
+          getTreeModel().setRoot(new DefaultMutableTreeNode());
+          LOG.error(errorGettingInstances);
+          getEmptyText().setText(FlutterBundle.message("app.inspector.error_loading_property_details"));
           return;
         }
-
-        // Preload all information we need about each property before instantiating
-        // the UI so that the property display UI does not have to deal with values
-        // that are not yet available. As the number of properties is small this is
-        // a reasonable tradeoff.
-        final CompletableFuture[] futures = new CompletableFuture[properties.size()];
-        int i = 0;
-        for (DiagnosticsNode property : properties) {
-          futures[i] = property.getValueProperties();
-          ++i;
-        }
-        whenCompleteUiThread(CompletableFuture.allOf(futures), (Void ignored, Throwable errorGettingInstances) -> {
-          if (errorGettingInstances != null) {
-            // TODO(jacobr): show error message explaining properties could not be loaded.
-            LOG.error(errorGettingInstances);
-            getEmptyText().setText(FlutterBundle.message("app.inspector.error_loading_property_details"));
-            return;
-          }
-
-          final ListTreeTableModelOnColumns model = getTreeModel();
-          final DefaultMutableTreeNode root = new DefaultMutableTreeNode();
-          for (DiagnosticsNode property : properties) {
-            if (property.getLevel() != DiagnosticLevel.hidden) {
-              root.add(new DefaultMutableTreeNode(property));
-            }
-          }
-          getEmptyText().setText(FlutterBundle.message("app.inspector.all_properties_hidden"));
-          model.setRoot(root);
-        });
+        setModelFromProperties(properties);
       });
+    }
+
+    private void setModelFromProperties(ArrayList<DiagnosticsNode> properties) {
+      final ListTreeTableModelOnColumns model = getTreeModel();
+      final DefaultMutableTreeNode root = new DefaultMutableTreeNode();
+      for (DiagnosticsNode property : properties) {
+        if (property.getLevel() != DiagnosticLevel.hidden) {
+          root.add(new DefaultMutableTreeNode(property));
+        }
+      }
+      getEmptyText().setText(FlutterBundle.message("app.inspector.all_properties_hidden"));
+      model.setRoot(root);
+    }
+
+    private CompletableFuture<Void> loadPropertyMetadata(ArrayList<DiagnosticsNode> properties) {
+      // Preload all information we need about each property before instantiating
+      // the UI so that the property display UI does not have to deal with values
+      // that are not yet available. As the number of properties is small this is
+      // a reasonable tradeoff.
+      final CompletableFuture[] futures = new CompletableFuture[properties.size()];
+      int i = 0;
+      for (DiagnosticsNode property : properties) {
+        futures[i] = property.getValueProperties();
+        ++i;
+      }
+      return CompletableFuture.allOf(futures);
+    }
+
+    private CompletableFuture<?> refresh() {
+      if (diagnostic == null) {
+        final CompletableFuture<Void> refreshComplete = new CompletableFuture<>();
+        refreshComplete.complete(null);
+        return refreshComplete;
+      }
+      CompletableFuture<ArrayList<DiagnosticsNode>> propertiesFuture = diagnostic.getProperties();
+      whenCompleteUiThread(propertiesFuture, (ArrayList<DiagnosticsNode> properties, Throwable throwable) -> {
+        if (throwable != null) {
+          return;
+        }
+        if (propertiesIdentical(properties, currentProperties)) {
+          return;
+        }
+        showPropertiesHelper(properties);
+      });
+      return propertiesFuture;
+    }
+
+    private boolean propertiesIdentical(ArrayList<DiagnosticsNode> a, ArrayList<DiagnosticsNode> b) {
+      if (a == b) {
+        return true;
+      }
+      if (a == null || b == null) {
+        return false;
+      }
+      if (a.size() != b.size()) {
+        return false;
+      }
+      for (int i = 0; i < a.size(); ++i) {
+        if (!a.get(i).identicalDisplay(b.get(i))) {
+          return false;
+        }
+      }
+      return true;
     }
   }
 

--- a/testSrc/unit/io/flutter/utils/AsyncRateLimiterTest.java
+++ b/testSrc/unit/io/flutter/utils/AsyncRateLimiterTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2018 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.utils;
+
+import com.google.common.collect.ImmutableList;
+import com.intellij.openapi.util.Computable;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.swing.*;
+import java.time.Clock;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import static java.util.concurrent.CompletableFuture.supplyAsync;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.*;
+
+public class AsyncRateLimiterTest {
+
+  final Clock clock = Clock.systemUTC();
+
+  private AsyncRateLimiter rateLimiter;
+
+  private final List<String> logEntries = new ArrayList<>();
+
+  private int futureCompleteDelay = 0;
+  private static final double TEST_FRAMES_PER_SECOND = 10.0;
+  private static final long MS_PER_EVENT = (long)(1000.0 / TEST_FRAMES_PER_SECOND);
+
+  private Computable<CompletableFuture<?>> callback;
+  private CompletableFuture<Void> callbacksDone;
+  private int expectedEvents;
+  private int numEvents;
+
+  @Before
+  public void setUp() {
+    callback = null;
+    numEvents = 0;
+
+    callbacksDone = new CompletableFuture<>();
+    rateLimiter = new AsyncRateLimiter(TEST_FRAMES_PER_SECOND, () -> {
+      if (!SwingUtilities.isEventDispatchThread()) {
+        log("subscriber should be called on Swing thread");
+        callbacksDone.complete(null);
+        return null;
+      }
+
+      log("EVENT");
+
+      CompletableFuture<?> ret = null;
+      if (callback != null) {
+        ret = callback.compute();
+      }
+      if (ret == null) {
+        ret = new CompletableFuture<>();
+        ret.complete(null);
+      }
+      numEvents++;
+      if (numEvents == expectedEvents) {
+        log("DONE");
+        callbacksDone.complete(null);
+      }
+      else if (numEvents > expectedEvents) {
+        log("unexpected number of events fired");
+      }
+      return ret;
+    });
+  }
+
+  void scheduleRequest() {
+    SwingUtilities.invokeLater(() -> {
+      rateLimiter.scheduleRequest();
+    });
+  }
+
+  @Test
+  public void rateLimited() {
+    final long start = clock.millis();
+    expectedEvents = 4;
+
+    while (!callbacksDone.isDone()) {
+      // Schedule requests at many times the rate limit.
+      scheduleRequest();
+      try {
+        Thread.sleep(1);
+      }
+      catch (InterruptedException e) {
+        e.printStackTrace();
+      }
+    }
+    final long current = clock.millis();
+    final long delta = current - start;
+
+    checkLog("EVENT", "EVENT", "EVENT", "EVENT", "DONE");
+
+    // First event should occur immediately so don't count it.
+    final double requestsPerSecond = (expectedEvents - 1) / (delta * 0.001);
+    assertTrue("Requests per second less than limit. Actual: " + requestsPerSecond, requestsPerSecond < TEST_FRAMES_PER_SECOND);
+    // We use a large delta so that tests run under load do not result in flakes.
+    assertTrue("Requests per second within 3 fps of rate limit:", requestsPerSecond + 3.0 > TEST_FRAMES_PER_SECOND);
+  }
+
+  @Test
+  public void rateLimitedSlowNetwork() {
+    // In this test we simulate the network requests triggered for each
+    // request being slow resulting in a lower frame rate as the network
+    // now becomes the limiting factor instead of the rate limiter
+    // as the rate limiter should never issue a request before the
+    // previous request completed.
+    final long start = clock.millis();
+    expectedEvents = 3;
+    callback = () -> {
+      // Delay 10 times the typical time between events before returning.
+      return supplyAsync(() -> {
+        try {
+          Thread.sleep(MS_PER_EVENT * 10);
+        }
+        catch (InterruptedException e) {
+          reportFailure(e);
+        }
+        return null;
+      });
+    };
+
+    while (!callbacksDone.isDone()) {
+      // Schedule requests at many times the rate limit.
+      scheduleRequest();
+      try {
+        Thread.sleep(1);
+      }
+      catch (InterruptedException e) {
+        reportFailure(e);
+      }
+    }
+    final long current = clock.millis();
+    final long delta = current - start;
+
+    checkLog("EVENT", "EVENT", "EVENT", "DONE");
+
+    // First event should occur immediately so don't count it.
+    final double requestsPerSecond = (expectedEvents - 1) / (delta * 0.001);
+    assertTrue("Requests per second less than 10 times limit. Actual: " + requestsPerSecond,
+               requestsPerSecond * 10 < TEST_FRAMES_PER_SECOND);
+    // We use a large delta so that tests run under load do not result in flakes.
+    assertTrue("Requests per second within 5 fps of rate limit. ACTUAL: " + requestsPerSecond,
+               requestsPerSecond * 10 + 5.0 > TEST_FRAMES_PER_SECOND);
+  }
+
+  private synchronized boolean log(String message) {
+    return logEntries.add(message);
+  }
+
+  private synchronized List<String> getLogEntries() {
+    return ImmutableList.copyOf(logEntries);
+  }
+
+  private void reportFailure(Exception e) {
+    fail("Exception: " + e + "\nLog: " + getLogEntries().toString());
+  }
+
+  private void checkLog(String... expectedEntries) {
+    assertThat("logEntries entries are different", getLogEntries(), is(ImmutableList.copyOf(expectedEntries)));
+    logEntries.clear();
+  }
+}


### PR DESCRIPTION
Avoid using keySet API on JsonObject as it is not supported by the version
of com.google.gson.JsonObject used on all platforms we support.

Change from the previously approved CL is just in the second hash part of this CL.