### PR TITLE
shorter closures in the preview view

### DIFF
--- a/src/io/flutter/inspector/DiagnosticsNode.java
+++ b/src/io/flutter/inspector/DiagnosticsNode.java
@@ -491,7 +491,7 @@ public class DiagnosticsNode {
         return valueProperties;
       }
 
-      String[] propertyNames;
+      final String[] propertyNames;
       // Add more cases here as visual displays for additional Dart objects
       // are added.
       switch (getPropertyType()) {
@@ -595,26 +595,9 @@ public class DiagnosticsNode {
       icon = widget.getIcon();
     }
     if (icon == null) {
-      icon = getCustomIcon(getDescription());
+      icon = iconMaker.fromWidgetName(getDescription());
     }
     return icon;
-  }
-
-  private static Icon getCustomIcon(String text) {
-    if (text == null) {
-      return null;
-    }
-
-    final boolean isPrivate = text.startsWith("_");
-    while (!text.isEmpty() && !Character.isAlphabetic(text.charAt(0))) {
-      text = text.substring(1);
-    }
-
-    if (text.isEmpty()) {
-      return null;
-    }
-
-    return iconMaker.getCustomIcon(text, isPrivate ? CustomIconMaker.IconKind.kMethod : CustomIconMaker.IconKind.kClass);
   }
 
   /**

--- a/src/io/flutter/preview/PreviewViewState.java
+++ b/src/io/flutter/preview/PreviewViewState.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2018 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.preview;
+
+/**
+ * State for the Preview view.
+ */
+public class PreviewViewState {
+  public PreviewViewState() {
+  }
+}

--- a/src/io/flutter/utils/CustomIconMaker.java
+++ b/src/io/flutter/utils/CustomIconMaker.java
@@ -85,6 +85,23 @@ public class CustomIconMaker {
     return iconCache.get(mapKey);
   }
 
+  public Icon fromWidgetName(String name) {
+    if (name == null) {
+      return null;
+    }
+
+    final boolean isPrivate = name.startsWith("_");
+    while (!name.isEmpty() && !Character.isAlphabetic(name.charAt(0))) {
+      name = name.substring(1);
+    }
+
+    if (name.isEmpty()) {
+      return null;
+    }
+
+    return getCustomIcon(name, isPrivate ? CustomIconMaker.IconKind.kMethod : CustomIconMaker.IconKind.kClass);
+  }
+
   public enum IconKind {
     kClass("class", FlutterIcons.CustomClass, FlutterIcons.CustomClassAbstract),
     kField("fields", FlutterIcons.CustomFields),

--- a/src/org/dartlang/analysis/server/protocol/FlutterOutlineAttribute.java
+++ b/src/org/dartlang/analysis/server/protocol/FlutterOutlineAttribute.java
@@ -100,8 +100,9 @@ public class FlutterOutlineAttribute {
     if (jsonArray == null) {
       return EMPTY_LIST;
     }
-    ArrayList<FlutterOutlineAttribute> list = new ArrayList<FlutterOutlineAttribute>(jsonArray.size());
+    ArrayList<FlutterOutlineAttribute> list = new ArrayList<>(jsonArray.size());
     Iterator<JsonElement> iterator = jsonArray.iterator();
+    //noinspection WhileLoopReplaceableByForEach
     while (iterator.hasNext()) {
       list.add(fromJson(iterator.next().getAsJsonObject()));
     }


### PR DESCRIPTION
Several misc changes:
- shorter closures in the preview view in order to reduce the amount of horiz. scrolling
- collect some common code for creating icons
- update the code to handle saving / restoring the Preview view state

@scheglov 