### PR TITLE
Add preview area to the Preview view

### DIFF
--- a/src/io/flutter/preview/ModelUtils.java
+++ b/src/io/flutter/preview/ModelUtils.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.preview;
+
+import com.intellij.openapi.util.text.StringUtil;
+import org.dartlang.analysis.server.protocol.Element;
+import org.dartlang.analysis.server.protocol.FlutterOutline;
+
+import java.util.List;
+
+public class ModelUtils {
+  private ModelUtils() {
+  }
+
+  public static boolean isBuildMethod(Element element) {
+    return StringUtil.equals("build", element.getName()) &&
+           StringUtil.startsWith(element.getParameters(), "(BuildContext ");
+  }
+
+  public static boolean containsBuildMethod(FlutterOutline outline) {
+    final Element element = outline.getDartElement();
+    if (element == null) {
+      return false;
+    }
+
+    if (isBuildMethod(element)) {
+      return true;
+    }
+
+    final List<FlutterOutline> children = outline.getChildren();
+    if (children == null) {
+      return false;
+    }
+
+    for (FlutterOutline child : children) {
+      if (containsBuildMethod(child)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+}

--- a/src/io/flutter/preview/ModelUtils.java
+++ b/src/io/flutter/preview/ModelUtils.java
@@ -8,6 +8,7 @@ package io.flutter.preview;
 import com.intellij.openapi.util.text.StringUtil;
 import org.dartlang.analysis.server.protocol.Element;
 import org.dartlang.analysis.server.protocol.FlutterOutline;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
@@ -15,7 +16,7 @@ public class ModelUtils {
   private ModelUtils() {
   }
 
-  public static boolean isBuildMethod(Element element) {
+  public static boolean isBuildMethod(@NotNull Element element) {
     return StringUtil.equals("build", element.getName()) &&
            StringUtil.startsWith(element.getParameters(), "(BuildContext ");
   }

--- a/src/io/flutter/preview/PreviewAreaPanel.java
+++ b/src/io/flutter/preview/PreviewAreaPanel.java
@@ -10,7 +10,16 @@ import org.dartlang.analysis.server.protocol.Element;
 import javax.swing.*;
 import java.awt.*;
 
-// TODO: set is hidden or is shown
+// TODO: have a way to tell the panel whether it's hidden or shown
+
+// TODO: we'll need to know whether the preview element is stateless widget or a state of a stateful
+//       widget; for the 2nd case, we'll need to find the cooresponding stateful widget class
+
+// TODO: we want to preview anything in a state, stateful, or stateless class (not
+//       just things contained in a build method)
+
+// TODO: we should be bolding stateful and stateless (and state) classes, not build() methods
+//       or, show all elements of these classes with some additional emphasis (italic? background color?)
 
 public class PreviewAreaPanel extends JPanel {
   private final JLabel label;
@@ -23,15 +32,14 @@ public class PreviewAreaPanel extends JPanel {
     add(label, BorderLayout.CENTER);
   }
 
-  public void updatePreviewElement(Element element) {
+  public void updatePreviewElement(Element parentElement, Element methodElement) {
     // TODO:
 
-    if (element == null) {
+    if (parentElement == null) {
       setText("No widget selected");
     }
     else {
-      // TODO: how to find the parent?
-      setText(element.getName() + "(): " + element.getLocation());
+      setText(parentElement.getName() + "." + methodElement.getName() + "()");
     }
   }
 

--- a/src/io/flutter/preview/PreviewAreaPanel.java
+++ b/src/io/flutter/preview/PreviewAreaPanel.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.preview;
+
+import org.dartlang.analysis.server.protocol.Element;
+
+import javax.swing.*;
+import java.awt.*;
+
+// TODO: set is hidden or is shown
+
+public class PreviewAreaPanel extends JPanel {
+  private final JLabel label;
+
+  public PreviewAreaPanel() {
+    super(new BorderLayout());
+
+    label = new JLabel("TODO:", SwingConstants.CENTER);
+
+    add(label, BorderLayout.CENTER);
+  }
+
+  public void updatePreviewElement(Element element) {
+    // TODO:
+
+    if (element == null) {
+      setText("No widget selected");
+    }
+    else {
+      // TODO: how to find the parent?
+      setText(element.getName() + "(): " + element.getLocation());
+    }
+  }
+
+  void setText(String text) {
+    label.setText(text);
+  }
+}

--- a/src/io/flutter/preview/PreviewView.java
+++ b/src/io/flutter/preview/PreviewView.java
@@ -368,11 +368,10 @@ public class PreviewView implements PersistentStateComponent<PreviewViewState>, 
       }
 
       final FlutterOutline flutterOutline = outlineElement.outline;
+      final Element element = flutterOutline.getDartElement();
 
-      if (flutterOutline.getDartElement() != null) {
-        if (ModelUtils.isBuildMethod(flutterOutline.getDartElement())) {
-          return flutterOutline.getDartElement();
-        }
+      if (element != null && ModelUtils.isBuildMethod(element)) {
+        return element;
       }
     }
 

--- a/src/io/flutter/preview/PreviewViewState.java
+++ b/src/io/flutter/preview/PreviewViewState.java
@@ -5,10 +5,42 @@
  */
 package io.flutter.preview;
 
+import com.intellij.util.EventDispatcher;
+import com.intellij.util.xmlb.annotations.Attribute;
+
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
+
 /**
  * State for the Preview view.
  */
 public class PreviewViewState {
+  private final EventDispatcher<ChangeListener> dispatcher = EventDispatcher.create(ChangeListener.class);
+
+  @Attribute(value = "splitter-proportion")
+  public float splitterProportion;
+
   public PreviewViewState() {
+  }
+
+  public float getSplitterProportion() {
+    return splitterProportion <= 0.0f ? 0.7f : splitterProportion;
+  }
+
+  public void setSplitterProportion(float value) {
+    splitterProportion = value;
+    dispatcher.getMulticaster().stateChanged(new ChangeEvent(this));
+  }
+
+  public void addListener(ChangeListener listener) {
+    dispatcher.addListener(listener);
+  }
+
+  public void removeListener(ChangeListener listener) {
+    dispatcher.removeListener(listener);
+  }
+
+  void copyFrom(PreviewViewState other) {
+    splitterProportion = other.splitterProportion;
   }
 }


### PR DESCRIPTION
- add a splitter to the Preview view, and, when a file with a Flutter build() method is active, shows a JPanel there with the name of the currently selected Widget
- have a compile time flag to enable the panel; the panel doesn't do anything useful currently
- remember the splitter position in the view's persisted state
- render build() methods in bold, in order to highlight them in the UI

@scheglov, in the future, we use this to show a live preview of the current widget. That would likely be a ways out; we can choose to land the parts of this PR that are immediately useful, hold off on the PR, or commit it w/ the understanding that the panel might be refactored away if we don't go this direction.