### PR TITLE
fix an npe in path selection

### DIFF
--- a/src/io/flutter/preview/PreviewView.java
+++ b/src/io/flutter/preview/PreviewView.java
@@ -292,6 +292,10 @@ public class PreviewView implements PersistentStateComponent<PreviewViewState>, 
 
   private void selectPath(TreePath selectionPath, boolean focusEditor) {
     final FlutterOutline outline = getOutlineOfPath(selectionPath);
+    if (outline == null) {
+      return;
+    }
+
     final int offset = outline.getDartElement() != null ? outline.getDartElement().getLocation().getOffset() : outline.getOffset();
     if (currentFile != null) {
       currentEditor.getCaretModel().removeCaretListener(caretListener);
@@ -432,7 +436,12 @@ public class PreviewView implements PersistentStateComponent<PreviewViewState>, 
     }
   }
 
-  private FlutterOutline getOutlineOfPath(TreePath path) {
+  @Nullable
+  private FlutterOutline getOutlineOfPath(@Nullable TreePath path) {
+    if (path == null) {
+      return null;
+    }
+
     final DefaultMutableTreeNode node = (DefaultMutableTreeNode)path.getLastPathComponent();
     final OutlineObject object = (OutlineObject)node.getUserObject();
     return object.outline;


### PR DESCRIPTION
Address an NPE:

```
java.lang.NullPointerException
	at io.flutter.preview.PreviewView.getOutlineOfPath(PreviewView.java:436)
	at io.flutter.preview.PreviewView.lambda$updateActionsForOutline$2(PreviewView.java:326)
	at com.intellij.openapi.application.impl.ApplicationImpl$1.run(ApplicationImpl.java:315)
	at java.util.concurrent.Executors$RunnableAdapter.call$$$capture(Executors.java:511)
```

@scheglov 