### PR TITLE
Render generic label for outline items.

### DIFF
--- a/src/io/flutter/preview/PreviewView.java
+++ b/src/io/flutter/preview/PreviewView.java
@@ -707,14 +707,14 @@ class OutlineTreeCellRenderer extends ColoredTreeCellRenderer {
     // Render the variable.
     if (outline.getVariableName() != null) {
       append(" ");
-      appendSearch(outline.getVariableName(), SimpleTextAttributes.REGULAR_ATTRIBUTES);
+      appendSearch(outline.getVariableName(), SimpleTextAttributes.GRAYED_ATTRIBUTES);
     }
 
     // Render a generic label.
     if (outline.getKind().equals(FlutterOutlineKind.GENERIC) && outline.getLabel() != null) {
       append(" ");
       final String label = outline.getLabel();
-      appendSearch(label, SimpleTextAttributes.REGULAR_ATTRIBUTES);
+      appendSearch(label, SimpleTextAttributes.GRAYED_ATTRIBUTES);
     }
 
     // Append all attributes.

--- a/src/io/flutter/preview/PreviewView.java
+++ b/src/io/flutter/preview/PreviewView.java
@@ -710,6 +710,13 @@ class OutlineTreeCellRenderer extends ColoredTreeCellRenderer {
       appendSearch(outline.getVariableName(), SimpleTextAttributes.REGULAR_ATTRIBUTES);
     }
 
+    // Render a generic label.
+    if (outline.getKind().equals(FlutterOutlineKind.GENERIC) && outline.getLabel() != null) {
+      append(" ");
+      final String label = outline.getLabel();
+      appendSearch(label, SimpleTextAttributes.REGULAR_ATTRIBUTES);
+    }
+
     // Append all attributes.
     final List<FlutterOutlineAttribute> attributes = outline.getAttributes();
     if (attributes != null) {


### PR DESCRIPTION
These labels are long though.
We could shorten them on the client, e.g. leave first and last 50 characters.
Or we could shorten them on the server, e.g. omit long arguments.

![image](https://user-images.githubusercontent.com/384794/35826096-9796c8b2-0a6c-11e8-8844-54cc11b6b774.png)
