### PR TITLE
Check top-level outline getChildren() for null.

### DIFF
--- a/src/io/flutter/preview/PreviewView.java
+++ b/src/io/flutter/preview/PreviewView.java
@@ -398,7 +398,9 @@ public class PreviewView implements PersistentStateComponent<PreviewViewState>, 
     rootNode.removeAllChildren();
 
     outlineToNodeMap.clear();
-    updateOutlineImpl(rootNode, outline.getChildren());
+    if (outline.getChildren() != null) {
+      updateOutlineImpl(rootNode, outline.getChildren());
+    }
 
     getTreeModel().reload(rootNode);
     tree.expandAll();


### PR DESCRIPTION
It might be `null` if the file does not have any top-level declarations, e.g. a library that just reexports other libraries.