### PR TITLE
fix an npe in preview

### DIFF
--- a/src/io/flutter/preview/PreviewView.java
+++ b/src/io/flutter/preview/PreviewView.java
@@ -483,7 +483,11 @@ public class PreviewView implements PersistentStateComponent<PreviewViewState>, 
     return null;
   }
 
-  private void addOutlinesCoveredByRange(List<FlutterOutline> covered, int start, int end, FlutterOutline outline) {
+  private void addOutlinesCoveredByRange(List<FlutterOutline> covered, int start, int end, @Nullable FlutterOutline outline) {
+    if (outline == null) {
+      return;
+    }
+
     final int outlineStart = outline.getOffset();
     final int outlineEnd = outlineStart + outline.getLength();
     // The outline ends before, or starts after the selection.


### PR DESCRIPTION
This is for a dart sdk that does not have support for flutter outlines.

```
java.lang.NullPointerException
	at io.flutter.preview.PreviewView.addOutlinesCoveredByRange(PreviewView.java:487)
	at io.flutter.preview.PreviewView.applyEditorSelectionToTree(PreviewView.java:549)
```

@scheglov 