### PR TITLE
Improve Open In action

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -421,14 +421,14 @@
               description="Run 'flutter packages upgrade'"/>
       <separator/>
       <action id="flutter.androidstudio.open" class="io.flutter.actions.OpenInAndroidStudioAction"
-              text="Open Project in Android Studio…"
-              description="Open project in Android Studio"/>
+              text="Open Android module in Android Studio"
+              description="Launch Android Studio to edit the Android module as a top-level project"/>
       <action id="flutter.xcode.open" class="io.flutter.actions.OpenInXcodeAction"
-              text="Open Project in Xcode…"
-              description="Open project in Xcode"/>
+              text="Open iOS module in Xcode"
+              description="Launch Xcode to edit the iOS module as a top-level project"/>
       <separator/>
       <action id="flutter.submitFeedback" class="io.flutter.actions.FlutterSubmitFeedback"
-              text="Submit Feedback…"
+              text="Submit Feedback..."
               description="Provide feedback for the Flutter plugin"/>
     </group>
 

--- a/src/io/flutter/actions/FlutterExternalIdeActionGroup.java
+++ b/src/io/flutter/actions/FlutterExternalIdeActionGroup.java
@@ -16,15 +16,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class FlutterExternalIdeActionGroup extends DefaultActionGroup {
-  @Override
-  public void update(AnActionEvent event) {
-    final Presentation presentation = event.getPresentation();
-    final boolean enabled = isExternalIdeFile(event);
-    presentation.setEnabled(enabled);
-    presentation.setVisible(enabled);
-  }
-
-  private boolean isExternalIdeFile(AnActionEvent e) {
+  private static boolean isExternalIdeFile(AnActionEvent e) {
     final VirtualFile file = CommonDataKeys.VIRTUAL_FILE.getData(e.getDataContext());
     if (file == null || !file.exists()) {
       return false;
@@ -32,9 +24,8 @@ public class FlutterExternalIdeActionGroup extends DefaultActionGroup {
 
     final Project project = e.getProject();
     return
-      isProjectDirectory(file, project) ||
       isIOsDirectory(file) ||
-      (isAndroidDirectory(file) && !FlutterUtils.isAndroidStudio()) ||
+      isAndroidDirectory(file) ||
       FlutterUtils.isXcodeProjectFileName(file.getName()) || OpenInAndroidStudioAction.isProjectFileName(file.getName());
   }
 
@@ -53,5 +44,13 @@ public class FlutterExternalIdeActionGroup extends DefaultActionGroup {
 
     final VirtualFile baseDir = project.getBaseDir();
     return baseDir != null && baseDir.getPath().equals(file.getPath());
+  }
+
+  @Override
+  public void update(AnActionEvent event) {
+    final Presentation presentation = event.getPresentation();
+    final boolean enabled = isExternalIdeFile(event);
+    presentation.setEnabled(enabled);
+    presentation.setVisible(enabled);
   }
 }

--- a/src/io/flutter/actions/FlutterExternalIdeActionGroup.java
+++ b/src/io/flutter/actions/FlutterExternalIdeActionGroup.java
@@ -23,18 +23,50 @@ public class FlutterExternalIdeActionGroup extends DefaultActionGroup {
     }
 
     final Project project = e.getProject();
+    assert (project != null);
     return
-      isIOsDirectory(file) ||
-      isAndroidDirectory(file) ||
+      isProjectDirectory(file, project) ||
+      isWithinIOsDirectory(file, project) ||
+      isWithinAndroidDirectory(file, project) ||
       FlutterUtils.isXcodeProjectFileName(file.getName()) || OpenInAndroidStudioAction.isProjectFileName(file.getName());
   }
 
-  protected static boolean isAndroidDirectory(@NotNull VirtualFile file) {
+  private static boolean isAndroidDirectory(@NotNull VirtualFile file) {
     return file.isDirectory() && file.getName().equals("android");
   }
 
-  protected static boolean isIOsDirectory(@NotNull VirtualFile file) {
+  private static boolean isIOsDirectory(@NotNull VirtualFile file) {
     return file.isDirectory() && file.getName().equals("ios");
+  }
+
+  protected static boolean isWithinAndroidDirectory(@NotNull VirtualFile file, @NotNull Project project) {
+    final VirtualFile baseDir = project.getBaseDir();
+    if (baseDir == null) {
+      return false;
+    }
+    VirtualFile candidate = file;
+    while (candidate != null && !baseDir.equals(candidate)) {
+      if (isAndroidDirectory(candidate)) {
+        return true;
+      }
+      candidate = candidate.getParent();
+    }
+    return false;
+  }
+
+  protected static boolean isWithinIOsDirectory(@NotNull VirtualFile file, @NotNull Project project) {
+    final VirtualFile baseDir = project.getBaseDir();
+    if (baseDir == null) {
+      return false;
+    }
+    VirtualFile candidate = file;
+    while (candidate != null && !baseDir.equals(candidate)) {
+      if (isIOsDirectory(candidate)) {
+        return true;
+      }
+      candidate = candidate.getParent();
+    }
+    return false;
   }
 
   private static boolean isProjectDirectory(@NotNull VirtualFile file, @Nullable Project project) {

--- a/src/io/flutter/actions/OpenInAndroidStudioAction.java
+++ b/src/io/flutter/actions/OpenInAndroidStudioAction.java
@@ -111,8 +111,10 @@ public class OpenInAndroidStudioAction extends AnAction {
           return file;
         }
 
+        final Project project = e.getProject();
+        assert (project != null);
         // Return null if this is an ios folder.
-        if (FlutterExternalIdeActionGroup.isIOsDirectory(file)) {
+        if (FlutterExternalIdeActionGroup.isWithinIOsDirectory(file, project)) {
           return null;
         }
       }

--- a/src/io/flutter/actions/OpenInAndroidStudioAction.java
+++ b/src/io/flutter/actions/OpenInAndroidStudioAction.java
@@ -20,7 +20,6 @@ import com.intellij.openapi.util.SystemInfo;
 import com.intellij.openapi.vfs.VirtualFile;
 import io.flutter.FlutterBundle;
 import io.flutter.FlutterMessages;
-import io.flutter.FlutterUtils;
 import io.flutter.pub.PubRoot;
 import io.flutter.pub.PubRoots;
 import io.flutter.sdk.FlutterSdk;
@@ -128,7 +127,7 @@ public class OpenInAndroidStudioAction extends AnAction {
 
   @Override
   public void update(AnActionEvent event) {
-    final boolean enabled = !FlutterUtils.isAndroidStudio() && findProjectFile(event) != null;
+    final boolean enabled = findProjectFile(event) != null;
 
     final Presentation presentation = event.getPresentation();
     presentation.setEnabled(enabled);
@@ -137,10 +136,6 @@ public class OpenInAndroidStudioAction extends AnAction {
 
   @Override
   public void actionPerformed(AnActionEvent e) {
-    if (FlutterUtils.isAndroidStudio()) {
-      return;
-    }
-
     final String androidStudioPath = findAndroidStudio(e.getProject());
     if (androidStudioPath == null) {
       FlutterMessages.showError("Error Opening Android Studio", "Unable to locate Android Studio.");

--- a/src/io/flutter/actions/OpenInXcodeAction.java
+++ b/src/io/flutter/actions/OpenInXcodeAction.java
@@ -36,8 +36,11 @@ public class OpenInXcodeAction extends AnAction {
           return file;
         }
 
+        final Project project = e.getProject();
+        assert (project != null);
         // Return null if this is an android folder.
-        if (FlutterExternalIdeActionGroup.isAndroidDirectory(file) || OpenInAndroidStudioAction.isProjectFileName(file.getName())) {
+        if (FlutterExternalIdeActionGroup.isWithinAndroidDirectory(file, project) ||
+            OpenInAndroidStudioAction.isProjectFileName(file.getName())) {
           return null;
         }
       }

--- a/src/io/flutter/actions/OpenInXcodeAction.java
+++ b/src/io/flutter/actions/OpenInXcodeAction.java
@@ -21,39 +21,14 @@ import com.intellij.openapi.vfs.VirtualFile;
 import io.flutter.FlutterMessages;
 import io.flutter.FlutterUtils;
 import io.flutter.pub.PubRoot;
-import io.flutter.utils.ProgressHelper;
 import io.flutter.sdk.FlutterSdk;
 import io.flutter.utils.FlutterModuleUtils;
+import io.flutter.utils.ProgressHelper;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class OpenInXcodeAction extends AnAction {
-  @Override
-  public void update(AnActionEvent event) {
-    // Enable in global menu; action group controls context menu visibility.
-    if (!SystemInfo.isMac) {
-      event.getPresentation().setVisible(false);
-    }
-    else {
-      final Presentation presentation = event.getPresentation();
-      final boolean enabled = findProjectFile(event) != null;
-      presentation.setEnabled(enabled);
-      presentation.setVisible(enabled);
-    }
-  }
-
-  @Override
-  public void actionPerformed(AnActionEvent e) {
-    final VirtualFile projectFile = findProjectFile(e);
-    if (projectFile != null) {
-      openFile(projectFile);
-    }
-    else {
-      FlutterMessages.showError("Error Opening Xcode", "Project not found.");
-    }
-  }
-
-  private VirtualFile findProjectFile(@Nullable AnActionEvent e) {
+  private static VirtualFile findProjectFile(@Nullable AnActionEvent e) {
     if (e != null) {
       final VirtualFile file = CommonDataKeys.VIRTUAL_FILE.getData(e.getDataContext());
       if (file != null && file.exists()) {
@@ -62,7 +37,7 @@ public class OpenInXcodeAction extends AnAction {
         }
 
         // Return null if this is an android folder.
-        if (FlutterExternalIdeActionGroup.isAndroidDirectory(file)) {
+        if (FlutterExternalIdeActionGroup.isAndroidDirectory(file) || OpenInAndroidStudioAction.isProjectFileName(file.getName())) {
           return null;
         }
       }
@@ -136,6 +111,31 @@ public class OpenInXcodeAction extends AnAction {
       FlutterMessages.showError(
         "Error Opening",
         "Exception: " + ex.getMessage());
+    }
+  }
+
+  @Override
+  public void update(AnActionEvent event) {
+    // Enable in global menu; action group controls context menu visibility.
+    if (!SystemInfo.isMac) {
+      event.getPresentation().setVisible(false);
+    }
+    else {
+      final Presentation presentation = event.getPresentation();
+      final boolean enabled = findProjectFile(event) != null;
+      presentation.setEnabled(enabled);
+      presentation.setVisible(enabled);
+    }
+  }
+
+  @Override
+  public void actionPerformed(AnActionEvent e) {
+    final VirtualFile projectFile = findProjectFile(e);
+    if (projectFile != null) {
+      openFile(projectFile);
+    }
+    else {
+      FlutterMessages.showError("Error Opening Xcode", "Project not found.");
     }
   }
 }


### PR DESCRIPTION
Some changes to `Open Project in Android Studio/Xcode`

- Format, sort code; resolve warnings
- Disallow on project root (does not work for Xcode anyway)
- Do not allow opening *_android.iml in Xcode
- Allow opening Android project in Android Studio even if currently using Android Studio

The last one is significant because it is the only way to properly support editing of Java/Kotlin code within the Android module.

@devoncarew @pq 