### PR TITLE
rename 'Add widget padding' assist to 'Add padding'

### DIFF
--- a/src/io/flutter/preview/PreviewView.java
+++ b/src/io/flutter/preview/PreviewView.java
@@ -177,7 +177,7 @@ public class PreviewView implements PersistentStateComponent<PreviewViewState>, 
     final DefaultActionGroup toolbarGroup = new DefaultActionGroup();
 
     toolbarGroup.add(new QuickAssistAction(FlutterIcons.Center, "Center widget"));
-    toolbarGroup.add(new QuickAssistAction(FlutterIcons.Padding, "Add widget padding"));
+    toolbarGroup.add(new QuickAssistAction(FlutterIcons.Padding, "Add padding"));
     toolbarGroup.add(new QuickAssistAction(FlutterIcons.Column, "Wrap with Column"));
     toolbarGroup.add(new QuickAssistAction(FlutterIcons.Row, "Wrap with Row"));
     toolbarGroup.add(new QuickAssistAction(FlutterIcons.RemoveWidget, "Remove widget"));


### PR DESCRIPTION
- rename 'Add widget padding' assist to 'Add padding'
- this may conflict with https://github.com/flutter/flutter-intellij/pull/1769; I'll want to land this until after that lands

@scheglov 