### PR TITLE
Basic speed search for the Inspector Tree.

### DIFF
--- a/src/io/flutter/view/InspectorPanel.java
+++ b/src/io/flutter/view/InspectorPanel.java
@@ -426,6 +426,20 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
     TreeUtil.installActions(tree);
 
     PopupHandler.installUnknownPopupHandler(tree, createTreePopupActions(), ActionManager.getInstance());
+
+    new TreeSpeedSearch(tree) {
+      @Override
+      protected String getElementText(Object element) {
+        final TreePath path = (TreePath)element;
+        final DefaultMutableTreeNode node = (DefaultMutableTreeNode)path.getLastPathComponent();
+        final Object object = node.getUserObject();
+        if (object instanceof DiagnosticsNode) {
+          // TODO(pq): consider a specialized String for matching.
+          return object.toString();
+        }
+        return null;
+      }
+    };
   }
 
   private ActionGroup createTreePopupActions() {

--- a/src/io/flutter/view/InspectorPanel.java
+++ b/src/io/flutter/view/InspectorPanel.java
@@ -761,7 +761,7 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
 
       final Object userObject = ((DefaultMutableTreeNode)value).getUserObject();
       if (userObject instanceof String) {
-        appendSearch((String)userObject, SimpleTextAttributes.GRAYED_ATTRIBUTES);
+        appendText((String)userObject, SimpleTextAttributes.GRAYED_ATTRIBUTES);
         return;
       }
       if (!(userObject instanceof DiagnosticsNode)) return;
@@ -771,28 +771,28 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
       if (name != null && !name.isEmpty() && node.getShowName()) {
         // color in name?
         if (name.equals("child") || name.startsWith("child ")) {
-          appendSearch(name, SimpleTextAttributes.GRAYED_ATTRIBUTES);
+          appendText(name, SimpleTextAttributes.GRAYED_ATTRIBUTES);
         }
         else {
-          appendSearch(name, textAttributes);
+          appendText(name, textAttributes);
         }
         if (node.getShowSeparator()) {
           // Is this good?
-          appendSearch(node.getSeparator(), SimpleTextAttributes.GRAY_ATTRIBUTES);
+          appendText(node.getSeparator(), SimpleTextAttributes.GRAY_ATTRIBUTES);
         }
-        appendSearch(" ", SimpleTextAttributes.GRAY_ATTRIBUTES);
+        appendText(" ", SimpleTextAttributes.GRAY_ATTRIBUTES);
       }
 
       // TODO(jacobr): custom display for units, colors, iterables, and icons.
       final String description = node.getDescription();
       final Matcher match = primaryDescriptionPattern.matcher(description);
       if (match.matches()) {
-        appendSearch(match.group(1), textAttributes);
-        appendSearch(" ", textAttributes);
-        appendSearch(match.group(2), SimpleTextAttributes.GRAYED_ATTRIBUTES);
+        appendText(match.group(1), textAttributes);
+        appendText(" ", textAttributes);
+        appendText(match.group(2), SimpleTextAttributes.GRAYED_ATTRIBUTES);
       }
       else {
-        appendSearch(node.getDescription(), textAttributes);
+        appendText(node.getDescription(), textAttributes);
       }
 
       if (node.hasTooltip()) {
@@ -805,7 +805,7 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
       }
     }
 
-    private void appendSearch(@NotNull String text, @NotNull SimpleTextAttributes attributes) {
+    private void appendText(@NotNull String text, @NotNull SimpleTextAttributes attributes) {
       SpeedSearchUtil.appendFragmentsForSpeedSearch(tree, text, attributes, selected, this);
     }
   }


### PR DESCRIPTION
Fixes: #1697

![image](https://user-images.githubusercontent.com/67586/36235642-bbb55560-11a6-11e8-85f0-d1306ee6d7a1.png)

This gets us simple search using Widget `toString()`s.  The Preview View takes it further (supporting path searches and more).  If we want to do that, we should consider adding something like a `getSpeedSearch()` method to `DiagnosticNode`.  Happy to follow-up some refinements if there's interest!

@jacob314 @scheglov 

