### PR TITLE
update when we use the flutter icon for modules

### DIFF
--- a/src/io/flutter/project/FlutterIconProvider.java
+++ b/src/io/flutter/project/FlutterIconProvider.java
@@ -40,9 +40,9 @@ public class FlutterIconProvider extends IconProvider {
       final VirtualFile file = ((PsiDirectory)element).getVirtualFile();
       if (!file.isInLocalFileSystem()) return null;
 
-      // Project root.
-      final VirtualFile baseDir = project.getBaseDir();
-      if (baseDir != null && Objects.equals(file.getPath(), baseDir.getPath())) {
+      // Show an icon for flutter modules.
+      final PubRoot pubRoot = PubRoot.forDirectory(file);
+      if (pubRoot != null && pubRoot.declaresFlutter()) {
         return FlutterIcons.Flutter;
       }
 


### PR DESCRIPTION
- update when we use the flutter icon for modules

I noticed in some situations the icons was not showing for flutter modules, and was instead showing for non-flutter ones. Before this change:

<img width="284" alt="screen shot 2018-02-18 at 7 13 24 pm" src="https://user-images.githubusercontent.com/1269969/36367245-a8654868-1506-11e8-8cbc-b32377e8b577.png">

(perf_tool is a web module, and conference_app is a flutter one); after this change:

<img width="249" alt="screen shot 2018-02-18 at 7 22 41 pm" src="https://user-images.githubusercontent.com/1269969/36367260-bcbd4fc2-1506-11e8-942c-f1ee9eddb1d6.png">

@pq 
