### PR TITLE
explore building for AS 3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,6 @@ script: ./tool/travis.sh
 # Testing product matrix; the values should match the version field in the
 # product-matrix.json file.
 env:
-  - IDEA_VERSION=3.0
+  - IDEA_VERSION=2017.1
   - IDEA_VERSION=2017.3
   - IDEA_VERSION=2018.1

--- a/product-matrix.json
+++ b/product-matrix.json
@@ -2,7 +2,7 @@
   "list": [
     {
       "name": "Android Studio",
-      "version": "3.0",
+      "version": "2017.1",
       "ideaProduct": "android-studio",
       "ideaVersion": "171.4408382",
       "dartPluginVersion": "171.4424.10",
@@ -12,8 +12,8 @@
     {
       "name": "IntelliJ",
       "version": "2017.3",
-      "ideaProduct": "ideaIC",
-      "ideaVersion": "2017.3",
+      "ideaProduct": "android-studio",
+      "ideaVersion": "173.4580418",
       "dartPluginVersion": "173.3302.13",
       "sinceBuild": "173.0",
       "untilBuild": "173.*"


### PR DESCRIPTION
- explore building for AS 3.1 (not for landing)

This PR updates our 2017.3 build to build against Android Studio Beta 1. @stevemessick, this doesn't try to address the compile issues, mostly just flush out where we are.