### PR TITLE
compile against AS 3.1 when building 2017.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,6 @@ script: ./tool/travis.sh
 # Testing product matrix; the values should match the version field in the
 # product-matrix.json file.
 env:
-  - IDEA_VERSION=2017.1
-  - IDEA_VERSION=2017.3
+  - IDEA_VERSION=3.0
+  - IDEA_VERSION=3.1
   - IDEA_VERSION=2018.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,6 @@ script: ./tool/travis.sh
 # Testing product matrix; the values should match the version field in the
 # product-matrix.json file.
 env:
-  - IDEA_VERSION=3.0
+  - IDEA_VERSION=2017.1
   - IDEA_VERSION=2017.3
   - IDEA_VERSION=2018.1

--- a/product-matrix.json
+++ b/product-matrix.json
@@ -2,7 +2,7 @@
   "list": [
     {
       "name": "Android Studio",
-      "version": "3.0",
+      "version": "2017.1",
       "ideaProduct": "android-studio",
       "ideaVersion": "171.4408382",
       "dartPluginVersion": "171.4424.10",
@@ -10,20 +10,11 @@
       "untilBuild": "171.*"
     },
     {
-      "name": "Android Studio",
-      "version": "3.1",
-      "ideaProduct": "android-studio",
-      "ideaVersion": "173.4595152",
-      "dartPluginVersion": "173.4301.22",
-      "sinceBuild": "173.0",
-      "untilBuild": "173.*"
-    },
-    {
       "name": "IntelliJ",
       "version": "2017.3",
-      "ideaProduct": "ideaIC",
-      "ideaVersion": "2017.3",
-      "dartPluginVersion": "173.3302.13",
+      "ideaProduct": "android-studio",
+      "ideaVersion": "173.4595152",
+      "dartPluginVersion": "173.4548.30",
       "sinceBuild": "173.0",
       "untilBuild": "173.*"
     },

--- a/product-matrix.json
+++ b/product-matrix.json
@@ -2,7 +2,7 @@
   "list": [
     {
       "name": "Android Studio",
-      "version": "2017.1",
+      "version": "3.0",
       "ideaProduct": "android-studio",
       "ideaVersion": "171.4408382",
       "dartPluginVersion": "171.4424.10",
@@ -11,7 +11,7 @@
     },
     {
       "name": "IntelliJ",
-      "version": "2017.3",
+      "version": "3.1",
       "ideaProduct": "android-studio",
       "ideaVersion": "173.4595152",
       "dartPluginVersion": "173.4301.22",

--- a/product-matrix.json
+++ b/product-matrix.json
@@ -14,7 +14,7 @@
       "version": "2017.3",
       "ideaProduct": "android-studio",
       "ideaVersion": "173.4595152",
-      "dartPluginVersion": "173.4548.30",
+      "dartPluginVersion": "173.4301.22",
       "sinceBuild": "173.0",
       "untilBuild": "173.*"
     },


### PR DESCRIPTION
- compile against AS 3.1 when building 2017.3 (follow up from https://github.com/flutter/flutter-intellij/pull/1785)
- rename the `3.0` artifact directory to `2017.1` (for similarity with the 2017.3 and 2018.1 directories)

w/ this change, we now build:
- 2017.1 (IntelliJ and Android Studio)
- 2017.3 (IntelliJ and Android Studio)
- 2018.1 (IntelliJ)

@stevemessick 