### PR TITLE
Write safe

### DIFF
--- a/flutter-intellij-community.iml
+++ b/flutter-intellij-community.iml
@@ -44,5 +44,7 @@
       </library>
     </orderEntry>
     <orderEntry type="library" name="snakeyaml" level="project" />
+    <orderEntry type="library" name="Dart SDK" level="project" />
+    <orderEntry type="library" name="Dart Packages" level="project" />
   </component>
 </module>

--- a/flutter-intellij-community.iml
+++ b/flutter-intellij-community.iml
@@ -44,7 +44,5 @@
       </library>
     </orderEntry>
     <orderEntry type="library" name="snakeyaml" level="project" />
-    <orderEntry type="library" name="Dart SDK" level="project" />
-    <orderEntry type="library" name="Dart Packages" level="project" />
   </component>
 </module>

--- a/flutter-studio/flutter-studio.iml
+++ b/flutter-studio/flutter-studio.iml
@@ -34,5 +34,6 @@
     <orderEntry type="module" module-name="gradle" scope="TEST" />
     <orderEntry type="library" scope="TEST" name="truth" level="project" />
     <orderEntry type="module" module-name="flutter-intellij-community" />
+    <orderEntry type="module" module-name="android-ndk" />
   </component>
 </module>

--- a/flutter-studio/src/io/flutter/FlutterStudioInitializer.java
+++ b/flutter-studio/src/io/flutter/FlutterStudioInitializer.java
@@ -14,10 +14,6 @@ public class FlutterStudioInitializer implements Runnable {
     Messages.showErrorDialog("The Flutter plugin requires a more recent version of Android Studio.", "Version Mismatch");
   }
 
-  private static void reportCanaryIncompatibility() {
-    Messages.showErrorDialog("The Flutter plugin does not work properly with Canary versions of Android Studio.", "Version Mismatch");
-  }
-
   @Override
   public void run() {
     // Unlike StartupActivity, this runs before the welcome screen (FlatWelcomeFrame) is displayed.
@@ -25,11 +21,8 @@ public class FlutterStudioInitializer implements Runnable {
     ApplicationInfo info = ApplicationInfo.getInstance();
     if ("Google".equals(info.getCompanyName())) {
       String version = info.getFullVersion();
-      if (version.startsWith("2.") || (version.contains("Beta") && !version.endsWith("7"))) {
+      if (version.startsWith("2.")) {
         reportVersionIncompatibility(info);
-      }
-      else if (version.contains("Canary")) {
-        reportCanaryIncompatibility();
       }
     }
   }

--- a/flutter-studio/src/io/flutter/project/FlutterProjectCreator.java
+++ b/flutter-studio/src/io/flutter/project/FlutterProjectCreator.java
@@ -6,8 +6,9 @@
 package io.flutter.project;
 
 import com.android.repository.io.FileOpUtils;
-import com.intellij.conversion.ConversionListener;
-import com.intellij.conversion.ConversionService;
+import com.android.tools.idea.run.AndroidRunConfiguration;
+import com.android.tools.ndk.run.AndroidRunConfigurationConverter;
+import com.intellij.conversion.*;
 import com.intellij.facet.FacetManager;
 import com.intellij.facet.ModifiableFacetModel;
 import com.intellij.ide.RecentProjectsManager;
@@ -22,7 +23,6 @@ import com.intellij.idea.ActionsBundle;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ModalityState;
-import com.intellij.openapi.application.TransactionGuard;
 import com.intellij.openapi.command.WriteCommandAction;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.progress.ProgressIndicator;
@@ -243,11 +243,8 @@ public class FlutterProjectCreator {
           // The IDE has already created some files. Flutter won't overwrite them, but we want the versions provided by Flutter.
           deleteDirectoryContents(location);
 
-          TransactionGuard.getInstance().submitTransactionAndWait(
-            () ->
-              FlutterSmallIDEProjectGenerator
-                .generateProject(project, baseDir, myModel.flutterSdk().get(), module,
-                                 makeAdditionalSettings()));
+          FlutterSmallIDEProjectGenerator
+            .generateProject(project, baseDir, myModel.flutterSdk().get(), module, makeAdditionalSettings());
 
           // Reload the project to use the configuration written by Flutter.
           VfsUtil.markDirtyAndRefresh(false, true, true, baseDir);

--- a/src/io/flutter/module/FlutterSmallIDEProjectGenerator.java
+++ b/src/io/flutter/module/FlutterSmallIDEProjectGenerator.java
@@ -11,6 +11,7 @@ import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.TransactionGuard;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.module.Module;
+import com.intellij.openapi.progress.ProcessCanceledException;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ModifiableModelsProvider;
 import com.intellij.openapi.roots.ModifiableRootModel;
@@ -27,7 +28,6 @@ import io.flutter.utils.FlutterModuleUtils;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
-import java.lang.reflect.InvocationTargetException;
 
 // TODO(devoncarew): It would be nice to show a hyperlink in the upper right of this wizard.
 // https://youtrack.jetbrains.com/issue/WEB-27537
@@ -58,7 +58,12 @@ public class FlutterSmallIDEProjectGenerator extends WebProjectTemplate<String> 
       return;
     }
     final Runnable runnable = () -> applyDartModule(sdk, project, module, root);
-    TransactionGuard.getInstance().submitTransactionAndWait(runnable);
+    try {
+      TransactionGuard.getInstance().submitTransactionAndWait(runnable);
+    }
+    catch (ProcessCanceledException e) {
+      LOG.error(e);
+    }
   }
 
   private static void applyDartModule(FlutterSdk sdk, Project project, Module module, PubRoot root) {

--- a/src/io/flutter/module/FlutterSmallIDEProjectGenerator.java
+++ b/src/io/flutter/module/FlutterSmallIDEProjectGenerator.java
@@ -8,6 +8,7 @@ package io.flutter.module;
 import com.intellij.execution.OutputListener;
 import com.intellij.ide.util.projectWizard.WebProjectTemplate;
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.TransactionGuard;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
@@ -57,17 +58,7 @@ public class FlutterSmallIDEProjectGenerator extends WebProjectTemplate<String> 
       return;
     }
     final Runnable runnable = () -> applyDartModule(sdk, project, module, root);
-    if (SwingUtilities.isEventDispatchThread()) {
-      runnable.run();
-    }
-    else {
-      try {
-        SwingUtilities.invokeAndWait(runnable);
-      }
-      catch (InvocationTargetException | InterruptedException e) {
-        LOG.error(e);
-      }
-    }
+    TransactionGuard.getInstance().submitTransactionAndWait(runnable);
   }
 
   private static void applyDartModule(FlutterSdk sdk, Project project, Module module, PubRoot root) {


### PR DESCRIPTION
@devoncarew @pq

AS 3.1 and later require creating a write-safe context to make model modifications. This changes the explicit (simple) thread management to use TransactionGuard, which does the right thing.

Also runs the migrate-to-gradle converter immediately after creating an Android Studio project to eliminate the AS-specific prompt to do so. (Does not address IJ-specific prompt, which I did investigate w/o resolution.)

Tested in 2017.3, 3.0.1, 3.1.

Even so, do not cherry-pick into M22. AS 3.1 still has a number of problems.