### PR TITLE
Make the Flutter Inspector use two levels of nested tabs.

### DIFF
--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -45,14 +45,9 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 
 // TODO(devoncarew): Display an fps graph.
-
-// TODO(devoncarew): Ensure all actions in this class send analytics.
 
 @com.intellij.openapi.components.State(
   name = "FlutterView",
@@ -156,7 +151,7 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
     final ContentFactory contentFactory = ContentFactory.SERVICE.getInstance();
     final SimpleToolWindowPanel toolWindowPanel = new SimpleToolWindowPanel(true);
     final JBRunnerTabs tabs = new JBRunnerTabs(myProject, ActionManager.getInstance(), null, this);
-    ArrayList<FlutterDevice> existingDevices = new ArrayList<>();
+    final List<FlutterDevice> existingDevices = new ArrayList<>();
     for (FlutterApp otherApp : perAppViewState.keySet()) {
       existingDevices.add(otherApp.device());
     }

--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -7,6 +7,7 @@ package io.flutter.view;
 
 import com.intellij.execution.runners.ExecutionUtil;
 import com.intellij.execution.ui.ConsoleViewContentType;
+import com.intellij.execution.ui.layout.impl.JBRunnerTabs;
 import com.intellij.icons.AllIcons;
 import com.intellij.ide.BrowserUtil;
 import com.intellij.ide.browsers.BrowserLauncher;
@@ -25,6 +26,11 @@ import com.intellij.openapi.wm.ToolWindowManager;
 import com.intellij.openapi.wm.ex.ToolWindowEx;
 import com.intellij.openapi.wm.ex.ToolWindowManagerEx;
 import com.intellij.ui.content.*;
+import com.intellij.ui.*;
+import com.intellij.ui.content.Content;
+import com.intellij.ui.content.ContentFactory;
+import com.intellij.ui.content.ContentManager;
+import com.intellij.ui.tabs.TabInfo;
 import icons.FlutterIcons;
 import io.flutter.FlutterBundle;
 import io.flutter.FlutterInitializer;
@@ -57,7 +63,7 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
   private static class PerAppState {
     ArrayList<FlutterViewAction> flutterViewActions = new ArrayList<>();
     ArrayList<InspectorPanel> inspectorPanels = new ArrayList<>();
-    ArrayList<Content> contents = new ArrayList<>();
+    Content content;
     boolean sendRestartNotificationOnNextFrame = false;
   }
 
@@ -145,31 +151,46 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
     return state;
   }
 
+  private void addInspector(FlutterApp app, ToolWindow toolWindow) {
+    final ContentManager contentManager = toolWindow.getContentManager();
+    final ContentFactory contentFactory = ContentFactory.SERVICE.getInstance();
+    final SimpleToolWindowPanel toolWindowPanel = new SimpleToolWindowPanel(true);
+    final JBRunnerTabs tabs = new JBRunnerTabs(myProject, ActionManager.getInstance(), null, this);
+    ArrayList<FlutterDevice> existingDevices = new ArrayList<>();
+    for (FlutterApp otherApp : perAppViewState.keySet()) {
+      existingDevices.add(otherApp.device());
+    }
+    final Content content = contentFactory.createContent(null, app.device().getUniqueName(existingDevices), false);
+    content.setComponent(tabs.getComponent());
+    contentManager.addContent(content);
+    PerAppState state = getOrCreateStateForApp(app);
+    assert (state.content == null);
+    state.content = content;
+
+    DefaultActionGroup toolbarGroup = createToolbar(toolWindow, app);
+    toolWindowPanel.setToolbar(ActionManager.getInstance().createActionToolbar("FlutterViewToolbar", toolbarGroup, true).getComponent());
+
+    addInspectorPanel("Widgets", tabs, state, InspectorService.FlutterTreeType.widget, app, toolWindow, toolbarGroup, true);
+    addInspectorPanel("Render Tree", tabs, state, InspectorService.FlutterTreeType.renderObject, app, toolWindow, toolbarGroup, false);
+  }
+
   private void addInspectorPanel(String displayName,
+                                 JBRunnerTabs tabs,
+                                 PerAppState state,
                                  InspectorService.FlutterTreeType treeType,
                                  FlutterApp flutterApp,
                                  @NotNull ToolWindow toolWindow,
                                  DefaultActionGroup toolbarGroup,
-                                 boolean selectedContent) {
+                                 boolean selectedTab) {
     {
-      final ContentManager contentManager = toolWindow.getContentManager();
-      final ContentFactory contentFactory = ContentFactory.SERVICE.getInstance();
-      final Content content = contentFactory.createContent(null, displayName, false);
-      content.setCloseable(true);
-      final SimpleToolWindowPanel windowPanel = new SimpleToolWindowPanel(true, true);
-      content.setComponent(windowPanel);
-
       final InspectorPanel inspectorPanel = new InspectorPanel(this, flutterApp, flutterApp::isSessionActive, treeType);
-      windowPanel.setContent(inspectorPanel);
-      windowPanel.setToolbar(ActionManager.getInstance().createActionToolbar("FlutterViewToolbar", toolbarGroup, true).getComponent());
-      contentManager.addContent(content);
-      final PerAppState state = getOrCreateStateForApp(flutterApp);
-      state.contents.add(content);
-      if (selectedContent) {
-        contentManager.setSelectedContent(content);
-      }
-
+      TabInfo tabInfo = new TabInfo(inspectorPanel).setActions(toolbarGroup, ActionPlaces.TOOLBAR)
+        .append(displayName, SimpleTextAttributes.REGULAR_ATTRIBUTES);
+      tabs.addTab(tabInfo);
       state.inspectorPanels.add(inspectorPanel);
+      if (selectedTab) {
+        tabs.select(tabInfo, false);
+      }
     }
   }
 
@@ -193,12 +214,8 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
       return;
     }
 
-    final DefaultActionGroup toolbarGroup = createToolbar(toolWindow, app);
-
-    addInspectorPanel(WIDGET_TREE_LABEL, InspectorService.FlutterTreeType.widget, app, toolWindow, toolbarGroup, true);
-    addInspectorPanel(RENDER_TREE_LABEL, InspectorService.FlutterTreeType.renderObject, app, toolWindow, toolbarGroup, false);
-
     listenForRenderTreeActivations(toolWindow);
+    addInspector(app, toolWindow);
 
     event.vmService.addVmServiceListener(new VmServiceListenerAdapter() {
       @Override
@@ -222,10 +239,8 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
           final ContentManager contentManager = toolWindow.getContentManager();
           onAppChanged(app);
           final PerAppState state = perAppViewState.remove(app);
-          if (state != null) {
-            for (Content content : state.contents) {
-              contentManager.removeContent(content, true);
-            }
+          if (state != null && state.content != null) {
+            contentManager.removeContent(state.content, true);
           }
           if (perAppViewState.isEmpty()) {
             // No more applications are running.
@@ -466,7 +481,8 @@ class TogglePlatformAction extends FlutterViewAction {
   private Boolean isCurrentlyAndroid;
 
   TogglePlatformAction(@NotNull FlutterApp app) {
-    super(app, FlutterBundle.message("flutter.view.togglePlatform.text"), FlutterBundle.message("flutter.view.togglePlatform.description"),
+    super(app, FlutterBundle.message("flutter.view.togglePlatform.text"),
+          FlutterBundle.message("flutter.view.togglePlatform.description"),
           AllIcons.RunConfigurations.Application);
   }
 

--- a/src/io/flutter/view/InspectorPanel.java
+++ b/src/io/flutter/view/InspectorPanel.java
@@ -78,6 +78,7 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
   private final Computable<Boolean> isApplicable;
   private final InspectorService.FlutterTreeType treeType;
   private final FlutterView flutterView;
+  @NotNull
   private final FlutterApp flutterApp;
   private CompletableFuture<DiagnosticsNode> rootFuture;
 
@@ -107,6 +108,7 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
                         Computable<Boolean> isApplicable,
                         InspectorService.FlutterTreeType treeType) {
     super(new BorderLayout());
+
     this.treeType = treeType;
     this.flutterView = flutterView;
     this.flutterApp = flutterApp;
@@ -185,8 +187,7 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
 
   @Nullable
   private InspectorService getInspectorService() {
-    final FlutterApp app = getFlutterApp();
-    return (app != null) ? app.getInspectorService() : null;
+    return flutterApp.getInspectorService();
   }
 
   void setActivate(boolean enabled) {
@@ -896,9 +897,6 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
   }
 
   boolean isCreatedByLocalProject(DiagnosticsNode node) {
-    if (getFlutterApp() == null) {
-      return false;
-    }
     final Location location = node.getCreationLocation();
     if (location == null) {
       return false;

--- a/src/io/flutter/view/OpenFlutterViewAction.java
+++ b/src/io/flutter/view/OpenFlutterViewAction.java
@@ -21,7 +21,7 @@ public class OpenFlutterViewAction extends DumbAwareAction {
   private final Computable<Boolean> myIsApplicable;
 
   public OpenFlutterViewAction(@NotNull final Computable<Boolean> isApplicable) {
-    super("Open Flutter View", "Open Flutter View", FlutterIcons.Flutter_inspect);
+    super("Open Flutter Inspector", "Open Flutter Inspector", FlutterIcons.Flutter_inspect);
 
     myIsApplicable = isApplicable;
   }


### PR DESCRIPTION
This makes the multiple app case look much better compared to having a
confusing single list of Widgets and Render Tree tabs for all the running
apps.

Any ideas on the right way to add a separator between the words Flutter Inspector and the device name?
I tried to add the Flutter icon but it doesn't show unless the icon is clicked so doesn't help.

Here I want a separator between the words
`Flutter Inspector` and `Pixel 2 XL`
![image](https://user-images.githubusercontent.com/1226812/36572854-cf9841e4-17f2-11e8-8b16-2d3b2cd26969.png)

The multi tab case works well. The problem is the IntelliJ UI is clever and doesn't show a single tab like a tab which looks bad as I can't see how to give the content an icon... Probably there is something obvious I'm just missing or maybe someone has a better idea than showing redundant Flutter icons.
![image](https://user-images.githubusercontent.com/1226812/36572899-ff3f6882-17f2-11e8-92ea-17d401de960d.png)

Note that if you had multiple devices with the same name I am able to reuse existing code to give unique names for the tabs.


