### PR TITLE
move to using JAVA_MODULE for our module types

### DIFF
--- a/flutter-studio/src/io/flutter/project/FlutterProjectStep.java
+++ b/flutter-studio/src/io/flutter/project/FlutterProjectStep.java
@@ -235,7 +235,7 @@ public class FlutterProjectStep extends SkippableWizardStep<FlutterProjectModel>
   }
 
   /**
-   * @See: https://www.dartlang.org/tools/pub/pubspec#name
+   * @see <a href="www.dartlang.org/tools/pub/pubspec#name">https://www.dartlang.org/tools/pub/pubspec#name</a>
    */
   @NotNull
   private Validator.Result validateFlutterModuleName(@NotNull String moduleName) {

--- a/src/io/flutter/FlutterBundle.properties
+++ b/src/io/flutter/FlutterBundle.properties
@@ -76,7 +76,6 @@ flutter.analytics.notification.content=The Flutter plugin anonymously reports fe
 flutter.analytics.privacyUrl=https://www.google.com/policies/privacy/
 
 flutter.initializer.module.converted.title=Flutter module type updated
-flutter.initializer.module.converted.content=Converted from type 'FLUTTER_MODULE_TYPE'.
 
 flutter.reload.firstRun.title=Flutter supports hot reload!
 flutter.reload.firstRun.content=Apply changes to your app in place, instantly.

--- a/src/io/flutter/FlutterInitializer.java
+++ b/src/io/flutter/FlutterInitializer.java
@@ -110,9 +110,17 @@ public class FlutterInitializer implements StartupActivity {
     // Convert all modules of deprecated type FlutterModuleType.
     if (FlutterModuleUtils.convertFromDeprecatedModuleType(project)) {
       // If any modules were converted over, create a notification
-      FlutterMessages.showInfo(FlutterBundle.message("flutter.initializer.module.converted.title"),
-                               FlutterBundle.message("flutter.initializer.module.converted.content"));
+      FlutterMessages.showInfo(
+        FlutterBundle.message("flutter.initializer.module.converted.title"),
+        "Converted from '" +
+        FlutterModuleUtils.DEPRECATED_FLUTTER_MODULE_TYPE_ID +
+        "' to '" +
+        FlutterModuleUtils.getModuleTypeIDForFlutter() +
+        "'.");
     }
+
+    // Disable the 'Migrate Project to Gradle' notification.
+    FlutterUtils.disableGradleProjectMigrationNotification(project);
 
     // Start watching for devices.
     DeviceService.getInstance(project);

--- a/src/io/flutter/FlutterUtils.java
+++ b/src/io/flutter/FlutterUtils.java
@@ -5,10 +5,12 @@
  */
 package io.flutter;
 
+import com.android.annotations.NonNull;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configurations.GeneralCommandLine;
 import com.intellij.execution.util.ExecUtil;
 import com.intellij.ide.actions.ShowSettingsUtilImpl;
+import com.intellij.ide.util.PropertiesComponent;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.extensions.PluginId;
@@ -70,6 +72,20 @@ public class FlutterUtils {
 
   public static boolean isAndroidStudio() {
     return StringUtil.equals(PlatformUtils.getPlatformPrefix(), "AndroidStudio");
+  }
+
+  public static void disableGradleProjectMigrationNotification(@NonNull Project project) {
+    // TODO(devoncarew): In Android Studio, do we want to show this notification?
+    //if (isAndroidStudio()) {
+    //  return;
+    //}
+
+    final String showMigrateToGradlePopup = "show.migrate.to.gradle.popup";
+    final PropertiesComponent properties = PropertiesComponent.getInstance(project);
+
+    if (properties.getValue(showMigrateToGradlePopup) == null) {
+      properties.setValue(showMigrateToGradlePopup, "false");
+    }
   }
 
   public static boolean exists(@Nullable VirtualFile file) {
@@ -145,8 +161,7 @@ public class FlutterUtils {
   /**
    * Checks whether a given string is a valid Dart package name.
    * <p>
-   * See: https://www.dartlang.org/tools/pub/pubspec#name
-   *
+   * @see <a href="www.dartlang.org/tools/pub/pubspec#name">https://www.dartlang.org/tools/pub/pubspec#name</a>
    * @param name the string to check
    * @return true if a valid package name, false otherwise.
    */

--- a/src/io/flutter/FlutterUtils.java
+++ b/src/io/flutter/FlutterUtils.java
@@ -5,7 +5,6 @@
  */
 package io.flutter;
 
-import com.android.annotations.NonNull;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configurations.GeneralCommandLine;
 import com.intellij.execution.util.ExecUtil;
@@ -74,7 +73,7 @@ public class FlutterUtils {
     return StringUtil.equals(PlatformUtils.getPlatformPrefix(), "AndroidStudio");
   }
 
-  public static void disableGradleProjectMigrationNotification(@NonNull Project project) {
+  public static void disableGradleProjectMigrationNotification(@NotNull Project project) {
     // TODO(devoncarew): In Android Studio, do we want to show this notification?
     //if (isAndroidStudio()) {
     //  return;
@@ -161,9 +160,10 @@ public class FlutterUtils {
   /**
    * Checks whether a given string is a valid Dart package name.
    * <p>
-   * @see <a href="www.dartlang.org/tools/pub/pubspec#name">https://www.dartlang.org/tools/pub/pubspec#name</a>
+   *
    * @param name the string to check
    * @return true if a valid package name, false otherwise.
+   * @see <a href="www.dartlang.org/tools/pub/pubspec#name">https://www.dartlang.org/tools/pub/pubspec#name</a>
    */
   public static boolean isValidPackageName(@NotNull String name) {
     return VALID_PACKAGE.matcher(name).matches();

--- a/src/io/flutter/FlutterUtils.java
+++ b/src/io/flutter/FlutterUtils.java
@@ -74,11 +74,6 @@ public class FlutterUtils {
   }
 
   public static void disableGradleProjectMigrationNotification(@NotNull Project project) {
-    // TODO(devoncarew): In Android Studio, do we want to show this notification?
-    //if (isAndroidStudio()) {
-    //  return;
-    //}
-
     final String showMigrateToGradlePopup = "show.migrate.to.gradle.popup";
     final PropertiesComponent properties = PropertiesComponent.getInstance(project);
 

--- a/src/io/flutter/module/FlutterGeneratorPeer.form
+++ b/src/io/flutter/module/FlutterGeneratorPeer.form
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="io.flutter.module.FlutterGeneratorPeer">
   <grid id="27dc6" binding="myMainPanel" layout-manager="GridLayoutManager" row-count="5" column-count="10" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
-    <margin top="0" left="0" bottom="0" right="0"/>
+    <margin top="0" left="5" bottom="0" right="8"/>
     <constraints>
       <xy x="20" y="20" width="565" height="335"/>
     </constraints>

--- a/src/io/flutter/module/FlutterModuleBuilder.java
+++ b/src/io/flutter/module/FlutterModuleBuilder.java
@@ -48,8 +48,6 @@ import static java.util.Arrays.asList;
 public class FlutterModuleBuilder extends ModuleBuilder {
   private static final Logger LOG = Logger.getInstance(FlutterModuleBuilder.class);
 
-  private static final String DART_GROUP_NAME = "Static Web"; // == WebModuleBuilder.GROUP_NAME
-
   private FlutterModuleWizardStep myStep;
   @NotNull
   private final FlutterCreateAdditionalSettingsFields mySettingsFields =
@@ -203,7 +201,7 @@ public class FlutterModuleBuilder extends ModuleBuilder {
   }
 
   /**
-   * @See: https://www.dartlang.org/tools/pub/pubspec#name
+   * @see <a href="www.dartlang.org/tools/pub/pubspec#name">https://www.dartlang.org/tools/pub/pubspec#name</a>
    */
   @Override
   public boolean validateModuleName(@NotNull String moduleName) throws ConfigurationException {
@@ -255,11 +253,6 @@ public class FlutterModuleBuilder extends ModuleBuilder {
   }
 
   @Override
-  public String getParentGroup() {
-    return DART_GROUP_NAME;
-  }
-
-  @Override
   @NotNull
   public String getBuilderId() {
     // The builder id is used to distinguish between different builders with the same module type, see
@@ -286,6 +279,8 @@ public class FlutterModuleBuilder extends ModuleBuilder {
                                                       @Nullable FlutterCreateAdditionalSettings additionalSettings) {
     final ProgressManager progress = ProgressManager.getInstance();
     final AtomicReference<PubRoot> result = new AtomicReference<>(null);
+
+    FlutterUtils.disableGradleProjectMigrationNotification(project);
 
     progress.runProcessWithProgressSynchronously(() -> {
       progress.getProgressIndicator().setIndeterminate(true);
@@ -334,7 +329,7 @@ public class FlutterModuleBuilder extends ModuleBuilder {
     private FlutterSdk getFlutterSdk() {
       final String sdkPath = myPeer.getSdkComboPath();
 
-      //Ensure the local filesystem has caught up to external processes (e.g., git clone).
+      // Ensure the local filesystem has caught up to external processes (e.g., git clone).
       if (!sdkPath.isEmpty()) {
         try {
           LocalFileSystem

--- a/src/io/flutter/module/FlutterSmallIDEProjectGenerator.java
+++ b/src/io/flutter/module/FlutterSmallIDEProjectGenerator.java
@@ -19,6 +19,7 @@ import com.intellij.openapi.vfs.VirtualFile;
 import icons.FlutterIcons;
 import io.flutter.FlutterBundle;
 import io.flutter.FlutterMessages;
+import io.flutter.FlutterUtils;
 import io.flutter.dart.DartPlugin;
 import io.flutter.pub.PubRoot;
 import io.flutter.sdk.FlutterCreateAdditionalSettings;
@@ -47,6 +48,8 @@ public class FlutterSmallIDEProjectGenerator extends WebProjectTemplate<String> 
       FlutterMessages.showError("Error creating project", flutterSdkPath + " is not a valid Flutter SDK");
       return;
     }
+
+    FlutterUtils.disableGradleProjectMigrationNotification(project);
 
     // Run "flutter create".
     final OutputListener listener = new OutputListener();

--- a/src/io/flutter/utils/FlutterModuleUtils.java
+++ b/src/io/flutter/utils/FlutterModuleUtils.java
@@ -265,17 +265,24 @@ public class FlutterModuleUtils {
 
   public static boolean convertFromDeprecatedModuleType(@NotNull Project project) {
     boolean modulesConverted = false;
+
     for (Module module : getModules(project)) {
       if (isDeprecatedFlutterModuleType(module)) {
         setFlutterModuleType(module);
         modulesConverted = true;
       }
     }
+
     return modulesConverted;
   }
 
   public static boolean isDeprecatedFlutterModuleType(@NotNull Module module) {
-    return DEPRECATED_FLUTTER_MODULE_TYPE_ID.equals(module.getOptionValue("type"));
+    if (!DEPRECATED_FLUTTER_MODULE_TYPE_ID.equals(module.getOptionValue("type"))) {
+      return false;
+    }
+
+    // Validate that the pubspec references flutter.
+    return FlutterModuleUtils.usesFlutter(module);
   }
 
   /**

--- a/src/io/flutter/utils/FlutterModuleUtils.java
+++ b/src/io/flutter/utils/FlutterModuleUtils.java
@@ -40,8 +40,7 @@ import java.util.List;
 import static io.flutter.sdk.FlutterSdk.DART_SDK_SUFFIX;
 
 public class FlutterModuleUtils {
-
-  private static final String DEPRECATED_FLUTTER_MODULE_TYPE_ID = "FLUTTER_MODULE_TYPE";
+  public static final String DEPRECATED_FLUTTER_MODULE_TYPE_ID = "WEB_MODULE";
 
   private FlutterModuleUtils() {
   }
@@ -55,7 +54,7 @@ public class FlutterModuleUtils {
   @SuppressWarnings("SameReturnValue")
   @NotNull
   public static String getModuleTypeIDForFlutter() {
-    return "WEB_MODULE";
+    return "JAVA_MODULE";
   }
 
   /**

--- a/testSrc/unit/io/flutter/utils/FlutterModuleUtilsTest.java
+++ b/testSrc/unit/io/flutter/utils/FlutterModuleUtilsTest.java
@@ -24,12 +24,12 @@ public class FlutterModuleUtilsTest {
 
   @Test
   public void isDeprecatedFlutterModuleType_true() {
-    fixture.getModule().setOption(Module.ELEMENT_TYPE, "FLUTTER_MODULE_TYPE");
+    fixture.getModule().setOption(Module.ELEMENT_TYPE, "WEB_MODULE");
     assertTrue(FlutterModuleUtils.isDeprecatedFlutterModuleType(fixture.getModule()));
   }
 
   @Test
-  public void isDeprecatedFlutterModuleType_false_WEB_MODULE() {
+  public void isDeprecatedFlutterModuleType_false_JAVA_MODULE() {
     fixture.getModule().setOption(Module.ELEMENT_TYPE, FlutterModuleUtils.getModuleTypeIDForFlutter());
     assertFalse(FlutterModuleUtils.isDeprecatedFlutterModuleType(fixture.getModule()));
   }


### PR DESCRIPTION
- if we see a WEB_MODULE module type on project open, convert it to a JAVA_MODULE; display a notification when we do this
- no long check to try and convert the older FLUTTER_MODULE_TYPE module types
- when opening or creating projects, disable the `show.migrate.to.gradle.popup` toast notification (fix https://github.com/flutter/flutter-intellij/issues/1807)

Changing the module type means that we get a bit more (automatic UI) in the project wizard, in the page where we ask people for the path to the flutter sdk. They'll now also see a combo box for selecting the Java SDK to use for this project. From experimenting, it's ok if this field is not populating - we can still create Flutter projects that work.

<img width="843" alt="screen shot 2018-02-24 at 12 02 37 pm" src="https://user-images.githubusercontent.com/1269969/36638487-6dddc356-19ab-11e8-88d6-138ee72caae3.png">

<img width="390" alt="screen shot 2018-02-23 at 8 18 22 am" src="https://user-images.githubusercontent.com/1269969/36638489-7ad6790e-19ab-11e8-8af5-01204aeff2b5.png">

@stevemessick for review; @jwren for FYI re: the module type change