### PR TITLE
notify the user if the flutter daemon dies

### DIFF
--- a/src/io/flutter/FlutterMessages.java
+++ b/src/io/flutter/FlutterMessages.java
@@ -16,7 +16,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class FlutterMessages {
-  public static final String FLUTTER_NOTIFICATION_GOUP_ID = "Flutter Commands";
+  public static final String FLUTTER_NOTIFICATION_GOUP_ID = "Flutter Messages";
 
   private FlutterMessages() {
   }

--- a/src/io/flutter/run/FlutterRunNotifications.java
+++ b/src/io/flutter/run/FlutterRunNotifications.java
@@ -14,18 +14,17 @@ import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
 import icons.FlutterIcons;
 import io.flutter.FlutterBundle;
+import io.flutter.FlutterMessages;
 import io.flutter.view.FlutterViewMessages;
 import org.jetbrains.annotations.NotNull;
 
 public class FlutterRunNotifications {
-  public static final String GROUP_DISPLAY_ID = "Flutter App Run";
-
   private static final String RELOAD_ALREADY_RUN = "io.flutter.reload.alreadyRun";
 
   public static void init(@NotNull Project project) {
     // Initialize the flutter run notification group.
     NotificationsConfiguration.getNotificationsConfiguration().register(
-      FlutterRunNotifications.GROUP_DISPLAY_ID,
+      FlutterMessages.FLUTTER_NOTIFICATION_GOUP_ID,
       NotificationDisplayType.BALLOON,
       false);
 
@@ -53,7 +52,7 @@ public class FlutterRunNotifications {
       properties.setValue(RELOAD_ALREADY_RUN, true);
 
       final Notification notification = new Notification(
-        GROUP_DISPLAY_ID,
+        FlutterMessages.FLUTTER_NOTIFICATION_GOUP_ID,
         FlutterBundle.message("flutter.reload.firstRun.title"),
         FlutterBundle.message("flutter.reload.firstRun.content"),
         NotificationType.INFORMATION);


### PR DESCRIPTION
- unify some of our IntelliJ notifications under the name 'Flutter Messages' (visible in the notifications prefs)
- remove a log.error() when the flutter daemon terminates (instead, choose to notify the user)

This addresses an exception seen in analytics (instead of sending an exception to analytics, show a notification to the user).
