### PR TITLE
work on regenerating .travis.yml

### DIFF
--- a/.travis.yml.template
+++ b/.travis.yml.template
@@ -1,5 +1,3 @@
-# Do not edit; instead, modify .travis.yml.template, and run './bin/plugin generate'.
-
 language: java
 
 jdk:
@@ -23,6 +21,3 @@ script: ./tool/travis.sh
 # Testing product matrix; the values are generated from product-matrix.json.
 env:
   - DART_BOT=true
-  - IDEA_VERSION=3.0
-  - IDEA_VERSION=3.1
-  - IDEA_VERSION=2018.1

--- a/tool/plugin/test/plugin_test.dart
+++ b/tool/plugin/test/plugin_test.dart
@@ -18,8 +18,8 @@ void main() {
     test('deploy', () {
       expect(new DeployCommand(new BuildCommandRunner()).name, "deploy");
     });
-    test('gen', () {
-      expect(new GenCommand(new BuildCommandRunner()).name, "gen");
+    test('generate', () {
+      expect(new GenerateCommand(new BuildCommandRunner()).name, "generate");
     });
   });
 
@@ -240,7 +240,7 @@ class TestDeployCommand extends DeployCommand {
   }
 }
 
-class TestGenCommand extends GenCommand {
+class TestGenCommand extends GenerateCommand {
   TestGenCommand(runner) : super(runner);
 
   bool get isTesting => true;


### PR DESCRIPTION
- fix some issues were we'd manually edited the (generated) .travis.yml file
- rename `plugin gen` to `plugin generate`
- put verbiage in to make manual edits of .travis.yml slightly less likely

@stevemessick 

We should likely have a step on travis that runs `plugin generate`, and fails if there are any git diffs to `.travis.yml`. This would help prevent manual edits in the future. (this would also help with plugin.xml + plugin.xml.template)

