### PR TITLE
Fix Open Module in AS

### DIFF
--- a/flutter-studio/src/io/flutter/FlutterStudioStartupActivity.java
+++ b/flutter-studio/src/io/flutter/FlutterStudioStartupActivity.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter;
+
+import com.intellij.openapi.actionSystem.ActionManager;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.startup.StartupActivity;
+import io.flutter.actions.OpenAndroidModule;
+import org.jetbrains.annotations.NotNull;
+
+public class FlutterStudioStartupActivity implements StartupActivity {
+  @Override
+  public void runActivity(@NotNull Project project) {
+    replaceAction("flutter.androidstudio.open", new OpenAndroidModule());
+  }
+
+  public static void replaceAction(@NotNull String actionId, @NotNull AnAction newAction) {
+    ActionManager actionManager = ActionManager.getInstance();
+    AnAction oldAction = actionManager.getAction(actionId);
+    if (oldAction != null) {
+      newAction.getTemplatePresentation().setIcon(oldAction.getTemplatePresentation().getIcon());
+      newAction.getTemplatePresentation().setText(oldAction.getTemplatePresentation().getTextWithMnemonic(), true);
+      newAction.getTemplatePresentation().setDescription(oldAction.getTemplatePresentation().getDescription());
+      actionManager.unregisterAction(actionId);
+    }
+    actionManager.registerAction(actionId, newAction);
+  }
+}

--- a/flutter-studio/src/io/flutter/actions/OpenAndroidModule.java
+++ b/flutter-studio/src/io/flutter/actions/OpenAndroidModule.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.actions;
+
+import com.intellij.ide.impl.ProjectUtil;
+import com.intellij.openapi.actionSystem.ActionPlaces;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.project.DumbAware;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.util.BitUtil;
+import io.flutter.FlutterMessages;
+import org.jetbrains.annotations.NotNull;
+
+import java.awt.event.InputEvent;
+
+public class OpenAndroidModule extends OpenInAndroidStudioAction implements DumbAware {
+  @Override
+  public void actionPerformed(AnActionEvent e) {
+    final VirtualFile projectFile = findProjectFile(e);
+    if (projectFile == null) {
+      FlutterMessages.showError("Error Opening Android Studio", "Project not found.");
+      return;
+    }
+    final int modifiers = e.getModifiers();
+    // From ReopenProjectAction.
+    final boolean forceOpenInNewFrame = BitUtil.isSet(modifiers, InputEvent.CTRL_MASK)
+                                        || BitUtil.isSet(modifiers, InputEvent.SHIFT_MASK)
+                                        || e.getPlace() == ActionPlaces.WELCOME_SCREEN;
+
+    ProjectUtil.openOrImport(projectFile.getPath(), e.getProject(), forceOpenInNewFrame);
+  }
+}

--- a/resources/META-INF/studio-contribs.xml
+++ b/resources/META-INF/studio-contribs.xml
@@ -11,8 +11,8 @@
   </extensions>
 
   <extensions defaultExtensionNs="com.intellij">
-    <!-- TODO(messick): Remove this extension if the class is never needed. -->
     <androidStudioInitializer implementation="io.flutter.FlutterStudioInitializer"/>
+    <postStartupActivity implementation="io.flutter.FlutterStudioStartupActivity"/>
   </extensions>
 
   <actions>

--- a/resources/META-INF/studio-contribs.xml.template
+++ b/resources/META-INF/studio-contribs.xml.template
@@ -11,8 +11,8 @@
   </extensions>
 
   <extensions defaultExtensionNs="com.intellij">
-    <!-- TODO(messick): Remove this extension if the class is never needed. -->
     <androidStudioInitializer implementation="io.flutter.FlutterStudioInitializer"/>
+    <postStartupActivity implementation="io.flutter.FlutterStudioStartupActivity"/>
   </extensions>
 
   <actions>


### PR DESCRIPTION
@devoncarew @pq 

I think Open in Android Studio has been broken for a while. Attempting to open the .iml file as a project does not work they way you'd expect. The parent directory gets opened, not the module defined by the .iml file.

Making this work from within Android Studio requires replacing the action object with one that does not try to spawn a new Android Studio.

Fixes #1820