### PR TITLE
New initial "Flutter Test (Bazel)" run configuration boiler plate code

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -574,6 +574,9 @@ miscellaneous:
     <configurationType implementation="io.flutter.run.bazel.FlutterBazelRunConfigurationType"/>
     <programRunner implementation="io.flutter.run.bazel.BazelRunner"/>
 
+    <!--<configurationType implementation="io.flutter.run.bazelTest.FlutterBazelTestConfigurationType"/>-->
+    <!--<programRunner implementation="io.flutter.run.bazelTest.BazelTestRunner"/>-->
+
     <configurationType implementation="io.flutter.run.test.TestConfigType"/>
     <runConfigurationProducer implementation="io.flutter.run.test.TestConfigProducer"/>
     <programRunner implementation="io.flutter.run.test.DebugTestRunner"/>

--- a/resources/META-INF/plugin_template.xml
+++ b/resources/META-INF/plugin_template.xml
@@ -572,6 +572,9 @@ miscellaneous:
     <configurationType implementation="io.flutter.run.bazel.FlutterBazelRunConfigurationType"/>
     <programRunner implementation="io.flutter.run.bazel.BazelRunner"/>
 
+    <!--<configurationType implementation="io.flutter.run.bazelTest.FlutterBazelTestConfigurationType"/>-->
+    <!--<programRunner implementation="io.flutter.run.bazelTest.BazelTestRunner"/>-->
+
     <configurationType implementation="io.flutter.run.test.TestConfigType"/>
     <runConfigurationProducer implementation="io.flutter.run.test.TestConfigProducer"/>
     <programRunner implementation="io.flutter.run.test.DebugTestRunner"/>

--- a/src/io/flutter/FlutterBundle.properties
+++ b/src/io/flutter/FlutterBundle.properties
@@ -56,6 +56,7 @@ runner.flutter.configuration.description=Flutter run configuration
 runner.flutter.configuration.name=Flutter
 runner.flutter.bazel.configuration.description=Flutter Bazel run configuration
 runner.flutter.bazel.configuration.name=Flutter (Bazel)
+runner.flutter.bazel.test.configuration.name=Flutter Test (Bazel)
 
 waiting.for.flutter=Waiting for debug connection...
 

--- a/src/io/flutter/run/bazelTest/BazelTestConfig.java
+++ b/src/io/flutter/run/bazelTest/BazelTestConfig.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2018 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.run.bazelTest;
+
+import com.intellij.execution.ExecutionException;
+import com.intellij.execution.Executor;
+import com.intellij.execution.configurations.*;
+import com.intellij.execution.runners.ExecutionEnvironment;
+import com.intellij.execution.runners.RunConfigurationWithSuppressedDefaultRunAction;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleUtil;
+import com.intellij.openapi.options.SettingsEditor;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.InvalidDataException;
+import com.intellij.openapi.util.WriteExternalException;
+import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.util.xmlb.SkipDefaultValuesSerializationFilters;
+import com.intellij.util.xmlb.XmlSerializer;
+import io.flutter.run.LaunchState;
+import io.flutter.run.MainFile;
+import io.flutter.run.daemon.FlutterApp;
+import io.flutter.run.daemon.RunMode;
+import org.jdom.Element;
+import org.jetbrains.annotations.NotNull;
+
+public class BazelTestConfig extends RunConfigurationBase
+  implements RunConfigurationWithSuppressedDefaultRunAction, LaunchState.RunConfig {
+  @NotNull private BazelTestFields fields = new BazelTestFields();
+
+  BazelTestConfig(final @NotNull Project project, final @NotNull ConfigurationFactory factory, @NotNull final String name) {
+    super(project, factory, name);
+  }
+
+  @NotNull
+  BazelTestFields getFields() {
+    return fields;
+  }
+
+  void setFields(@NotNull BazelTestFields newFields) {
+    fields = newFields;
+  }
+
+  @Override
+  public void checkConfiguration() throws RuntimeConfigurationException {
+    fields.checkRunnable(getProject());
+  }
+
+  @NotNull
+  @Override
+  public SettingsEditor<? extends RunConfiguration> getConfigurationEditor() {
+    return new FlutterBazelTestConfigurationEditorForm(getProject());
+  }
+
+  @NotNull
+  @Override
+  public LaunchState getState(@NotNull Executor executor, @NotNull ExecutionEnvironment env) throws ExecutionException {
+    final BazelTestFields launchFields = fields.copy();
+    try {
+      launchFields.checkRunnable(env.getProject());
+    }
+    catch (RuntimeConfigurationError e) {
+      throw new ExecutionException(e);
+    }
+
+    final MainFile main = MainFile.verify(launchFields.getEntryFile(), env.getProject()).get();
+    final RunMode mode = RunMode.fromEnv(env);
+    final Module module = ModuleUtil.findModuleForFile(main.getFile(), env.getProject());
+
+    final LaunchState.Callback callback = (device) -> {
+      if (device == null) return null;
+
+      final GeneralCommandLine command = launchFields.getLaunchCommand(env.getProject(), device, mode);
+      System.out.println("BazelRunConfig.getState " + command.toString());
+      return FlutterApp.start(env, env.getProject(), module, mode, device, command,
+                              StringUtil.capitalize(mode.mode()) + "BazelApp", "StopBazelApp");
+    };
+
+    return new LaunchState(env, main.getAppDir(), main.getFile(), this, callback);
+  }
+
+  public BazelTestConfig clone() {
+    final BazelTestConfig clone = (BazelTestConfig)super.clone();
+    clone.fields = fields.copy();
+    return clone;
+  }
+
+  RunConfiguration copyTemplateToNonTemplate(String name) {
+    final BazelTestConfig copy = (BazelTestConfig)super.clone();
+    copy.setName(name);
+    copy.fields = fields.copyTemplateToNonTemplate(getProject());
+    return copy;
+  }
+
+  @Override
+  public void writeExternal(final Element element) throws WriteExternalException {
+    super.writeExternal(element);
+    XmlSerializer.serializeInto(fields, element, new SkipDefaultValuesSerializationFilters());
+  }
+
+  @Override
+  public void readExternal(final Element element) throws InvalidDataException {
+    super.readExternal(element);
+    XmlSerializer.deserializeInto(fields, element);
+  }
+}

--- a/src/io/flutter/run/bazelTest/BazelTestFields.java
+++ b/src/io/flutter/run/bazelTest/BazelTestFields.java
@@ -33,6 +33,7 @@ public class BazelTestFields {
 
   private @Nullable String entryFile;
   private @Nullable String launchScript;
+  // TODO(jwren) figure out if we want additionalArgs as part this configuration
   //private @Nullable String additionalArgs;
   private @Nullable String bazelTarget;
 
@@ -45,6 +46,7 @@ public class BazelTestFields {
   private BazelTestFields(@NotNull BazelTestFields original) {
     entryFile = original.entryFile;
     launchScript = original.launchScript;
+    // TODO(jwren) figure out if we want additionalArgs as part this configuration
     //additionalArgs = original.additionalArgs;
     bazelTarget = original.bazelTarget;
   }
@@ -102,11 +104,13 @@ public class BazelTestFields {
     this.launchScript = launchScript;
   }
 
+  // TODO(jwren) figure out if we want additionalArgs as part this configuration
   //@Nullable
   //public String getAdditionalArgs() {
   //  return additionalArgs;
   //}
-  //
+
+  // TODO(jwren) figure out if we want additionalArgs as part this configuration
   //public void setAdditionalArgs(@Nullable String additionalArgs) {
   //  this.additionalArgs = additionalArgs;
   //}
@@ -154,7 +158,7 @@ public class BazelTestFields {
     //  throw new RuntimeConfigurationError(main.getError());
     //}
 
-    // check launcher script
+    // Check launcher script
     if (StringUtil.isEmptyOrSpaces(launchScript)) {
       throw new RuntimeConfigurationError(FlutterBundle.message("flutter.run.bazel.noLaunchingScript"));
     }
@@ -165,11 +169,11 @@ public class BazelTestFields {
         FlutterBundle.message("flutter.run.bazel.launchingScriptNotFound", FileUtil.toSystemDependentName(launchScript)));
     }
 
-    // check that bazel target is not empty
+    // Check that bazel target is not empty
     if (StringUtil.isEmptyOrSpaces(bazelTarget)) {
       throw new RuntimeConfigurationError(FlutterBundle.message("flutter.run.bazel.noTargetSet"));
     }
-    // check that the bazel target starts with "//"
+    // Check that the bazel target starts with "//"
     else if (!bazelTarget.startsWith("//")) {
       throw new RuntimeConfigurationError(FlutterBundle.message("flutter.run.bazel.startWithSlashSlash"));
     }
@@ -197,6 +201,7 @@ public class BazelTestFields {
     final String target = getBazelTarget();
     assert target != null; // already checked
 
+    // TODO(jwren) figure out if we want additionalArgs as part this configuration
     //final String additionalArgs = getAdditionalArgs();
 
     final GeneralCommandLine commandLine = new GeneralCommandLine().withWorkDirectory(appDir.getPath());
@@ -208,7 +213,7 @@ public class BazelTestFields {
       commandLine.addParameters("--define", "flutter_build_mode=" + mode.name());
     }
 
-
+    // TODO(jwren) currently a work in progress
     //// User specified additional arguments.
     //final CommandLineTokenizer argumentsTokenizer = new CommandLineTokenizer(StringUtil.notNullize(additionalArgs));
     //while (argumentsTokenizer.hasMoreTokens()) {
@@ -221,6 +226,7 @@ public class BazelTestFields {
 
     commandLine.addParameter(target);
 
+    // TODO(jwren) currently a work in progress
     //// Pass additional args to bazel (we currently don't pass --device-id with bazel targets).
     //commandLine.addParameter("--");
     //

--- a/src/io/flutter/run/bazelTest/BazelTestFields.java
+++ b/src/io/flutter/run/bazelTest/BazelTestFields.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright 2018 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.run.bazelTest;
+
+import com.intellij.execution.ExecutionException;
+import com.intellij.execution.configurations.GeneralCommandLine;
+import com.intellij.execution.configurations.RuntimeConfigurationError;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.io.FileUtil;
+import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.openapi.vfs.CharsetToolkit;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.jetbrains.lang.dart.sdk.DartConfigurable;
+import com.jetbrains.lang.dart.sdk.DartSdk;
+import io.flutter.FlutterBundle;
+import io.flutter.bazel.Workspace;
+import io.flutter.bazel.WorkspaceCache;
+import io.flutter.dart.DartPlugin;
+import io.flutter.run.MainFile;
+import io.flutter.run.daemon.FlutterDevice;
+import io.flutter.run.daemon.RunMode;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * The fields in a Bazel test configuration.
+ */
+public class BazelTestFields {
+
+  private @Nullable String entryFile;
+  private @Nullable String launchScript;
+  //private @Nullable String additionalArgs;
+  private @Nullable String bazelTarget;
+
+  BazelTestFields() {
+  }
+
+  /**
+   * Copy constructor
+   */
+  private BazelTestFields(@NotNull BazelTestFields original) {
+    entryFile = original.entryFile;
+    launchScript = original.launchScript;
+    //additionalArgs = original.additionalArgs;
+    bazelTarget = original.bazelTarget;
+  }
+
+  /**
+   * Create non-template from template.
+   */
+  private BazelTestFields(@NotNull BazelTestFields template, Workspace w) {
+    this(template);
+    if (StringUtil.isEmptyOrSpaces(launchScript)) {
+      launchScript = w.getLaunchScript();
+      if (launchScript != null && !launchScript.startsWith("/")) {
+        launchScript = w.getRoot().getPath() + "/" + launchScript;
+      }
+    }
+  }
+
+  /**
+   * The file containing the main function that starts the Flutter app.
+   */
+  @Nullable
+  public String getEntryFile() {
+    return entryFile;
+  }
+
+  public void setEntryFile(final @Nullable String entryFile) {
+    this.entryFile = entryFile;
+  }
+
+  /**
+   * Present only for deserializing old run configs.
+   */
+  @SuppressWarnings("SameReturnValue")
+  @Deprecated
+  public String getWorkingDirectory() {
+    return null;
+  }
+
+  /**
+   * Used only for deserializing old run configs.
+   */
+  @Deprecated
+  public void setWorkingDirectory(final @Nullable String workDir) {
+    if (entryFile == null && workDir != null) {
+      entryFile = workDir + "/lib/main.dart";
+    }
+  }
+
+  @Nullable
+  public String getLaunchingScript() {
+    return launchScript;
+  }
+
+  public void setLaunchingScript(@Nullable String launchScript) {
+    this.launchScript = launchScript;
+  }
+
+  //@Nullable
+  //public String getAdditionalArgs() {
+  //  return additionalArgs;
+  //}
+  //
+  //public void setAdditionalArgs(@Nullable String additionalArgs) {
+  //  this.additionalArgs = additionalArgs;
+  //}
+
+  @Nullable
+  public String getBazelTarget() {
+    return bazelTarget;
+  }
+
+  public void setBazelTarget(@Nullable String bazelTarget) {
+    this.bazelTarget = bazelTarget;
+  }
+
+  BazelTestFields copy() {
+    return new BazelTestFields(this);
+  }
+
+  @NotNull
+  BazelTestFields copyTemplateToNonTemplate(@NotNull final Project project) {
+    final Workspace workspace = WorkspaceCache.getInstance(project).getNow();
+    if (workspace == null) return new BazelTestFields(this);
+    return new BazelTestFields(this, workspace);
+  }
+
+  /**
+   * Reports an error in the run config that the user should correct.
+   * <p>
+   * This will be called while the user is typing into a non-template run config.
+   * (See RunConfiguration.checkConfiguration.)
+   *
+   * @throws RuntimeConfigurationError for an error that that the user must correct before running.
+   */
+  void checkRunnable(final @NotNull Project project) throws RuntimeConfigurationError {
+    // The UI only shows one error message at a time.
+    // The order we do the checks here determines priority.
+
+    final DartSdk sdk = DartPlugin.getDartSdk(project);
+    if (sdk == null) {
+      throw new RuntimeConfigurationError(FlutterBundle.message("dart.sdk.is.not.configured"),
+                                          () -> DartConfigurable.openDartSettings(project));
+    }
+
+    //final MainFile.Result main = MainFile.verify(entryFile, project);
+    //if (!main.canLaunch()) {
+    //  throw new RuntimeConfigurationError(main.getError());
+    //}
+
+    // check launcher script
+    if (StringUtil.isEmptyOrSpaces(launchScript)) {
+      throw new RuntimeConfigurationError(FlutterBundle.message("flutter.run.bazel.noLaunchingScript"));
+    }
+
+    final VirtualFile scriptFile = LocalFileSystem.getInstance().findFileByPath(launchScript);
+    if (scriptFile == null) {
+      throw new RuntimeConfigurationError(
+        FlutterBundle.message("flutter.run.bazel.launchingScriptNotFound", FileUtil.toSystemDependentName(launchScript)));
+    }
+
+    // check that bazel target is not empty
+    if (StringUtil.isEmptyOrSpaces(bazelTarget)) {
+      throw new RuntimeConfigurationError(FlutterBundle.message("flutter.run.bazel.noTargetSet"));
+    }
+    // check that the bazel target starts with "//"
+    else if (!bazelTarget.startsWith("//")) {
+      throw new RuntimeConfigurationError(FlutterBundle.message("flutter.run.bazel.startWithSlashSlash"));
+    }
+  }
+
+  /**
+   * Returns the command to use to launch the Flutter app. (Via running the Bazel target.)
+   */
+  GeneralCommandLine getLaunchCommand(@NotNull Project project,
+                                      @Nullable FlutterDevice device,
+                                      @NotNull RunMode mode)
+    throws ExecutionException {
+    try {
+      checkRunnable(project);
+    }
+    catch (RuntimeConfigurationError e) {
+      throw new ExecutionException(e);
+    }
+
+    final VirtualFile appDir = MainFile.verify(entryFile, project).get().getAppDir();
+
+    final String launchingScript = getLaunchingScript();
+    assert launchingScript != null; // already checked
+
+    final String target = getBazelTarget();
+    assert target != null; // already checked
+
+    //final String additionalArgs = getAdditionalArgs();
+
+    final GeneralCommandLine commandLine = new GeneralCommandLine().withWorkDirectory(appDir.getPath());
+    commandLine.setCharset(CharsetToolkit.UTF8_CHARSET);
+    commandLine.setExePath(FileUtil.toSystemDependentName(launchingScript));
+
+    // Set the mode.
+    if (mode != RunMode.DEBUG) {
+      commandLine.addParameters("--define", "flutter_build_mode=" + mode.name());
+    }
+
+
+    //// User specified additional arguments.
+    //final CommandLineTokenizer argumentsTokenizer = new CommandLineTokenizer(StringUtil.notNullize(additionalArgs));
+    //while (argumentsTokenizer.hasMoreTokens()) {
+    //  final String token = argumentsTokenizer.nextToken();
+    //  if (token.equals("--")) {
+    //    break;
+    //  }
+    //  commandLine.addParameter(token);
+    //}
+
+    commandLine.addParameter(target);
+
+    //// Pass additional args to bazel (we currently don't pass --device-id with bazel targets).
+    //commandLine.addParameter("--");
+    //
+    //// Tell the flutter command-line tools that we want a machine interface on stdio.
+    //commandLine.addParameter("--machine");
+    //
+    //if (FlutterSettings.getInstance().getPreviewDart2()) {
+    //  commandLine.addParameter("--preview-dart-2");
+    //}
+    //
+    //// Pause the app at startup in order to set breakpoints.
+    //if (mode == RunMode.DEBUG) {
+    //  commandLine.addParameter("--start-paused");
+    //}
+    //
+    //// More user-specified args.
+    //while (argumentsTokenizer.hasMoreTokens()) {
+    //  commandLine.addParameter(argumentsTokenizer.nextToken());
+    //}
+    //
+    //// Send in the deviceId.
+    //if (device != null) {
+    //  commandLine.addParameter("-d");
+    //  commandLine.addParameter(device.deviceId());
+    //}
+
+    return commandLine;
+  }
+}

--- a/src/io/flutter/run/bazelTest/BazelTestRunner.java
+++ b/src/io/flutter/run/bazelTest/BazelTestRunner.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2018 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.run.bazelTest;
+
+import io.flutter.run.LaunchState;
+import org.jetbrains.annotations.NotNull;
+
+public class BazelTestRunner extends LaunchState.Runner<BazelTestConfig> {
+
+  public BazelTestRunner() {
+    super(BazelTestConfig.class);
+  }
+
+  @NotNull
+  @Override
+  public String getRunnerId() {
+    return "FlutterBazelTestRunner";
+  }
+}

--- a/src/io/flutter/run/bazelTest/FlutterBazelTestConfigurationEditorForm.form
+++ b/src/io/flutter/run/bazelTest/FlutterBazelTestConfigurationEditorForm.form
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="io.flutter.run.bazelTest.FlutterBazelTestConfigurationEditorForm">
+  <grid id="27dc6" binding="myMainPanel" default-binding="true" layout-manager="GridLayoutManager" row-count="6" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+    <margin top="0" left="0" bottom="0" right="0"/>
+    <constraints>
+      <xy x="20" y="20" width="500" height="320"/>
+    </constraints>
+    <properties/>
+    <border type="none"/>
+    <children>
+      <component id="55076" class="javax.swing.JLabel" binding="myEntryFileLabel">
+        <constraints>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <inheritsPopupMenu value="true"/>
+          <labelFor value=""/>
+          <text value="Dart entrypoint:"/>
+        </properties>
+      </component>
+      <component id="17e7a" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="myEntryFile">
+        <constraints>
+          <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <focusable value="true"/>
+        </properties>
+      </component>
+      <vspacer id="a7255">
+        <constraints>
+          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="2" hsize-policy="1" anchor="0" fill="2" indent="1" use-parent-layout="false">
+            <preferred-size width="-1" height="20"/>
+          </grid>
+        </constraints>
+      </vspacer>
+      <component id="55077" class="javax.swing.JLabel" binding="myLaunchingScriptLabel">
+        <constraints>
+          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <inheritsPopupMenu value="true"/>
+          <labelFor value="17e7b"/>
+          <text value="Launching &amp;script:"/>
+        </properties>
+      </component>
+      <component id="17e7b" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="myLaunchingScript">
+        <constraints>
+          <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <focusable value="true"/>
+        </properties>
+      </component>
+      <component id="7b562" class="javax.swing.JLabel">
+        <constraints>
+          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <labelFor value="ada9e"/>
+          <text value="Additional &amp;args:"/>
+        </properties>
+      </component>
+      <!--<component id="ada9e" class="javax.swing.JTextField" binding="myAdditionalArgs">
+        <constraints>
+          <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+      </component>-->
+      <component id="7b563" class="javax.swing.JLabel">
+        <constraints>
+          <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <labelFor value="ada9f"/>
+          <text value="Bazel run &amp;target:"/>
+        </properties>
+      </component>
+      <component id="ada9f" class="javax.swing.JTextField" binding="myBuildTarget">
+        <constraints>
+          <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+      </component>
+      <vspacer id="3f5de">
+        <constraints>
+          <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+        </constraints>
+      </vspacer>
+    </children>
+  </grid>
+</form>

--- a/src/io/flutter/run/bazelTest/FlutterBazelTestConfigurationEditorForm.java
+++ b/src/io/flutter/run/bazelTest/FlutterBazelTestConfigurationEditorForm.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2018 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.run.bazelTest;
+
+import com.intellij.openapi.fileChooser.FileChooserDescriptor;
+import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory;
+import com.intellij.openapi.options.ConfigurationException;
+import com.intellij.openapi.options.SettingsEditor;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.TextFieldWithBrowseButton;
+import com.intellij.openapi.util.io.FileUtil;
+import com.intellij.openapi.util.text.StringUtil;
+import com.jetbrains.lang.dart.ide.runner.server.ui.DartCommandLineConfigurationEditorForm;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+
+public class FlutterBazelTestConfigurationEditorForm extends SettingsEditor<BazelTestConfig> {
+  private JPanel myMainPanel;
+
+  private JLabel myEntryFileLabel;
+  private TextFieldWithBrowseButton myEntryFile;
+
+  private JLabel myLaunchingScriptLabel;
+  private TextFieldWithBrowseButton myLaunchingScript;
+  //private JTextField myAdditionalArgs;
+  private JTextField myBuildTarget;
+
+  public FlutterBazelTestConfigurationEditorForm(final Project project) {
+    final FileChooserDescriptor descriptor = FileChooserDescriptorFactory.createSingleFileDescriptor();
+    myLaunchingScript.addBrowseFolderListener("Select Launching Script", "Choose launching script", project, descriptor);
+
+    DartCommandLineConfigurationEditorForm.initDartFileTextWithBrowse(project, myEntryFile);
+  }
+
+  @Override
+  protected void resetEditorFrom(@NotNull final BazelTestConfig configuration) {
+    final BazelTestFields fields = configuration.getFields();
+    myEntryFile.setText(FileUtil.toSystemDependentName(StringUtil.notNullize(fields.getEntryFile())));
+    myBuildTarget.setText(StringUtil.notNullize(fields.getBazelTarget()));
+    myLaunchingScript.setText(FileUtil.toSystemDependentName(StringUtil.notNullize(fields.getLaunchingScript())));
+    //myAdditionalArgs.setText(StringUtil.notNullize(fields.getAdditionalArgs()));
+  }
+
+  @Override
+  protected void applyEditorTo(@NotNull final BazelTestConfig configuration) throws ConfigurationException {
+    final BazelTestFields fields = new BazelTestFields();
+    fields.setEntryFile(StringUtil.nullize(FileUtil.toSystemIndependentName(myEntryFile.getText().trim()), true));
+    fields.setBazelTarget(StringUtil.nullize(myBuildTarget.getText().trim(), true));
+    fields.setLaunchingScript(StringUtil.nullize(FileUtil.toSystemIndependentName(myLaunchingScript.getText().trim()), true));
+    //fields.setAdditionalArgs(StringUtil.nullize(myAdditionalArgs.getText().trim(), true));
+    configuration.setFields(fields);
+  }
+
+  @NotNull
+  @Override
+  protected JComponent createEditor() {
+    return myMainPanel;
+  }
+}

--- a/src/io/flutter/run/bazelTest/FlutterBazelTestConfigurationType.java
+++ b/src/io/flutter/run/bazelTest/FlutterBazelTestConfigurationType.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2018 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.run.bazelTest;
+
+import com.intellij.execution.ExecutionBundle;
+import com.intellij.execution.configurations.ConfigurationFactory;
+import com.intellij.execution.configurations.ConfigurationTypeBase;
+import com.intellij.execution.configurations.RunConfiguration;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.search.FileTypeIndex;
+import com.intellij.psi.search.GlobalSearchScope;
+import com.jetbrains.lang.dart.DartFileType;
+import icons.FlutterIcons;
+import io.flutter.FlutterBundle;
+import io.flutter.utils.FlutterModuleUtils;
+import org.jetbrains.annotations.NotNull;
+
+public class FlutterBazelTestConfigurationType extends ConfigurationTypeBase {
+
+  public FlutterBazelTestConfigurationType() {
+    super("FlutterBazelTestConfigurationType", FlutterBundle.message("runner.flutter.bazel.test.configuration.name"),
+          FlutterBundle.message("runner.flutter.bazel.configuration.description"), FlutterIcons.BazelRun);
+    addFactory(new Factory(this));
+  }
+
+  private static class Factory extends ConfigurationFactory {
+    public Factory(FlutterBazelTestConfigurationType type) {
+      super(type);
+    }
+
+    @Override
+    @NotNull
+    public RunConfiguration createTemplateConfiguration(@NotNull Project project) {
+      // This is always called first when loading a run config, even when it's a non-template config.
+      // See RunManagerImpl.doCreateConfiguration
+      return new BazelTestConfig(project, this, FlutterBundle.message("runner.flutter.bazel.test.configuration.name"));
+    }
+
+    @Override
+    @NotNull
+    public RunConfiguration createConfiguration(String name, RunConfiguration template) {
+      // Called in two cases:
+      //   - When creating a non-template config from a template.
+      //   - whenever the run configuration editor is open (for creating snapshots).
+      // In the first case, we want to override the defaults from the template.
+      // In the second case, don't change anything.
+      if (isNewlyGeneratedName(name) && template instanceof BazelTestConfig) {
+        // TODO(skybrian) is this really a good name for a new run config? Not sure why we override this.
+        // Note that if the user creates more than one run config, they will need to rename it manually.
+        name = template.getProject().getName();
+        return ((BazelTestConfig)template).copyTemplateToNonTemplate(name);
+      }
+      else {
+        return super.createConfiguration(name, template);
+      }
+    }
+
+    private boolean isNewlyGeneratedName(String name) {
+      // Try to determine if this we are creating a non-template configuration from a template.
+      // This is a hack based on what the code does in RunConfigurable.createUniqueName().
+      // If it fails to match, the new run config still works, just without any defaults set.
+      final String baseName = ExecutionBundle.message("run.configuration.unnamed.name.prefix");
+      return name.equals(baseName) || name.startsWith(baseName + " (");
+    }
+
+    @Override
+    public boolean isApplicable(@NotNull Project project) {
+      return FileTypeIndex.containsFileOfType(DartFileType.INSTANCE, GlobalSearchScope.projectScope(project)) &&
+             FlutterModuleUtils.isFlutterBazelProject(project);
+    }
+  }
+}


### PR DESCRIPTION
New initial "Flutter Test (Bazel)" run configuration boiler plate code; currently this new configuration is commented out in the plugin.xml and in a work-in-progress state; currently running a test works, debugging does not; by landing this initial CL follow on CLs can be smaller and incremental.