### PR TITLE
Refactoring and cleanup in Flutter Bazel configurations

### DIFF
--- a/src/io/flutter/run/bazel/FlutterBazelRunConfigurationType.java
+++ b/src/io/flutter/run/bazel/FlutterBazelRunConfigurationType.java
@@ -26,6 +26,14 @@ public class FlutterBazelRunConfigurationType extends ConfigurationTypeBase {
     addFactory(new Factory(this));
   }
 
+  /**
+   * Defined here for all Flutter Bazel run configurations.
+   */
+  public static boolean doShowBazelRunConfigurationForProject(@NotNull Project project) {
+    return FileTypeIndex.containsFileOfType(DartFileType.INSTANCE, GlobalSearchScope.projectScope(project)) &&
+           FlutterModuleUtils.isFlutterBazelProject(project);
+  }
+
   private static class Factory extends ConfigurationFactory {
     public Factory(FlutterBazelRunConfigurationType type) {
       super(type);
@@ -68,8 +76,7 @@ public class FlutterBazelRunConfigurationType extends ConfigurationTypeBase {
 
     @Override
     public boolean isApplicable(@NotNull Project project) {
-      return FileTypeIndex.containsFileOfType(DartFileType.INSTANCE, GlobalSearchScope.projectScope(project)) &&
-             FlutterModuleUtils.isFlutterBazelProject(project);
+      return FlutterBazelRunConfigurationType.doShowBazelRunConfigurationForProject(project);
     }
   }
 }

--- a/src/io/flutter/run/bazelTest/FlutterBazelTestConfigurationType.java
+++ b/src/io/flutter/run/bazelTest/FlutterBazelTestConfigurationType.java
@@ -15,6 +15,7 @@ import com.intellij.psi.search.GlobalSearchScope;
 import com.jetbrains.lang.dart.DartFileType;
 import icons.FlutterIcons;
 import io.flutter.FlutterBundle;
+import io.flutter.run.bazel.FlutterBazelRunConfigurationType;
 import io.flutter.utils.FlutterModuleUtils;
 import org.jetbrains.annotations.NotNull;
 
@@ -68,8 +69,7 @@ public class FlutterBazelTestConfigurationType extends ConfigurationTypeBase {
 
     @Override
     public boolean isApplicable(@NotNull Project project) {
-      return FileTypeIndex.containsFileOfType(DartFileType.INSTANCE, GlobalSearchScope.projectScope(project)) &&
-             FlutterModuleUtils.isFlutterBazelProject(project);
+      return FlutterBazelRunConfigurationType.doShowBazelRunConfigurationForProject(project);
     }
   }
 }


### PR DESCRIPTION
Refactoring and cleanup in Flutter Bazel configurations: have all Flutter Bazel run configurations use the same method to determine the isApplicable return value.