### PR TITLE
Track the pub root directories on the device so that Flutter code knows which widgets were actually created on the device.

### DIFF
--- a/src/io/flutter/inspector/DiagnosticsNode.java
+++ b/src/io/flutter/inspector/DiagnosticsNode.java
@@ -529,6 +529,10 @@ public class DiagnosticsNode {
     return getBooleanMember("hasChildren", false);
   }
 
+  public boolean isCreatedByLocalProject() {
+    return getBooleanMember("createdByLocalProject", false);
+  }
+
   /**
    * Check whether children are already available.
    */

--- a/src/io/flutter/inspector/InspectorService.java
+++ b/src/io/flutter/inspector/InspectorService.java
@@ -6,9 +6,7 @@
 package io.flutter.inspector;
 
 import com.google.common.base.Joiner;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonParser;
+import com.google.gson.*;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.application.ApplicationManager;
 import com.jetbrains.lang.dart.ide.runner.server.vmService.VmServiceConsumers;
@@ -110,6 +108,26 @@ public class InspectorService implements Disposable {
     }
     scope.put("arg1", arg.getId());
     return getInspectorLibrary().eval("WidgetInspectorService.instance." + methodName + "(arg1, \"" + groupName + "\")", scope);
+  }
+
+  public CompletableFuture<Void> setPubRootDirectories(List<String> rootDirectories) {
+    // TODO(jacobr): remove call to hasServiceMethod("setPubRootDirectories") after
+    // the `setPubRootDirectories` method has been in two revs of the Flutter Alpha
+    // channel. The feature is expected to have landed in the Flutter dev
+    // chanel on March 2, 2018.
+
+    return hasServiceMethod("setPubRootDirectories").thenComposeAsync((Boolean hasMethod) -> {
+      if (!hasMethod) {
+        return null;
+      }
+      JsonArray jsonArray = new JsonArray(rootDirectories.size());
+      for (String rootDirectory : rootDirectories) {
+        jsonArray.add(rootDirectory);
+      }
+      return getInspectorLibrary().eval(
+        "WidgetInspectorService.instance.setPubRootDirectories(" + new Gson().toJson(jsonArray) + ")", null)
+        .thenApplyAsync((InstanceRef instance) -> null);
+    });
   }
 
   CompletableFuture<DiagnosticsNode> parseDiagnosticsNode(CompletableFuture<InstanceRef> instanceRefFuture) {

--- a/src/io/flutter/inspector/InspectorService.java
+++ b/src/io/flutter/inspector/InspectorService.java
@@ -120,7 +120,7 @@ public class InspectorService implements Disposable {
       if (!hasMethod) {
         return null;
       }
-      JsonArray jsonArray = new JsonArray(rootDirectories.size());
+      JsonArray jsonArray = new JsonArray();
       for (String rootDirectory : rootDirectories) {
         jsonArray.add(rootDirectory);
       }

--- a/src/io/flutter/view/InspectorPanel.java
+++ b/src/io/flutter/view/InspectorPanel.java
@@ -205,6 +205,12 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
     isActive = true;
     assert (getInspectorService() != null);
     getInspectorService().addClient(this);
+    ArrayList<String> rootDirectories = new ArrayList<>();
+    for (PubRoot root : getFlutterApp().getPubRoots()) {
+      rootDirectories.add(root.getRoot().getCanonicalPath());
+    }
+    getInspectorService().setPubRootDirectories(rootDirectories);
+
     getInspectorService().isWidgetTreeReady().thenAccept((Boolean ready) -> {
       if (ready) {
         recomputeTreeRoot();
@@ -901,6 +907,13 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
   }
 
   boolean isCreatedByLocalProject(DiagnosticsNode node) {
+    if (node.isCreatedByLocalProject()) {
+      return true;
+    }
+    // TODO(jacobr): remove the following code once the
+    // `setPubRootDirectories` method has been in two revs of the Flutter Alpha
+    // channel. The feature is expected to have landed in the Flutter dev
+    // chanel on March 2, 2018.
     final Location location = node.getCreationLocation();
     if (location == null) {
       return false;


### PR DESCRIPTION
This CL doesn't do much on its own but will enable efficient filtering on the device of widgets based on their creation locations.

Depends on 
https://github.com/flutter/flutter/pull/15041