### PR TITLE
fix a project use after dispose

### DIFF
--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -373,6 +373,10 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
     }
 
     ApplicationManager.getApplication().invokeLater(() -> {
+      if (myProject.isDisposed()) {
+        return;
+      }
+
       final ToolWindowManager toolWindowManager = ToolWindowManager.getInstance(myProject);
       final ToolWindow flutterToolWindow = toolWindowManager.getToolWindow(FlutterView.TOOL_WINDOW_ID);
 


### PR DESCRIPTION
A fix for:

```
Already disposed: Project (Disposed) conference_app
java.lang.AssertionError: Already disposed: Project (Disposed) conference_app
	at com.intellij.openapi.components.impl.ComponentManagerImpl.lambda$getComponent$1(ComponentManagerImpl.java:166)
	at com.intellij.openapi.application.ReadAction.run(ReadAction.java:37)
	at com.intellij.openapi.components.impl.ComponentManagerImpl.getComponent(ComponentManagerImpl.java:164)
	at com.intellij.openapi.wm.ToolWindowManager.getInstance(ToolWindowManager.java:37)
	at io.flutter.view.FlutterView.lambda$restorePreviousToolWindow$1(FlutterView.java:376)
	at com.intellij.openapi.application.TransactionGuardImpl$2.run(TransactionGuardImpl.java:315)
	at com.intellij.openapi.application.impl.LaterInvocator$FlushQueue.runNextEvent(LaterInvocator.java:424)
	at com.intellij.openapi.application.impl.LaterInvocator$FlushQueue.run(LaterInvocator.java:407)
```