### PR TITLE
Intercept and redirect Project import actions (#1889).

### DIFF
--- a/flutter-studio/src/io/flutter/FlutterStudioStartupActivity.java
+++ b/flutter-studio/src/io/flutter/FlutterStudioStartupActivity.java
@@ -17,18 +17,6 @@ public class FlutterStudioStartupActivity implements StartupActivity {
   public void runActivity(@NotNull Project project) {
     // The IntelliJ version of this action spawns a new process for Android Studio.
     // Since we're already running Android Studio we want to simply open the project in the current process.
-    replaceAction("flutter.androidstudio.open", new OpenAndroidModule());
-  }
-
-  public static void replaceAction(@NotNull String actionId, @NotNull AnAction newAction) {
-    ActionManager actionManager = ActionManager.getInstance();
-    AnAction oldAction = actionManager.getAction(actionId);
-    if (oldAction != null) {
-      newAction.getTemplatePresentation().setIcon(oldAction.getTemplatePresentation().getIcon());
-      newAction.getTemplatePresentation().setText(oldAction.getTemplatePresentation().getTextWithMnemonic(), true);
-      newAction.getTemplatePresentation().setDescription(oldAction.getTemplatePresentation().getDescription());
-      actionManager.unregisterAction(actionId);
-    }
-    actionManager.registerAction(actionId, newAction);
+    FlutterUtils.replaceAction("flutter.androidstudio.open", new OpenAndroidModule());
   }
 }

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -15,6 +15,12 @@
 
   <depends>Dart</depends>
 
+  <application-components>
+    <component>
+      <implementation-class>io.flutter.FlutterInitialConfigurator</implementation-class>
+    </component>
+  </application-components>
+
   <!-- plugin compatibility -->
   <!-- see: http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html -->
 

--- a/resources/META-INF/plugin_template.xml
+++ b/resources/META-INF/plugin_template.xml
@@ -13,6 +13,12 @@
 
   <depends>Dart</depends>
 
+  <application-components>
+    <component>
+      <implementation-class>io.flutter.FlutterInitialConfigurator</implementation-class>
+    </component>
+  </application-components>
+
   <!-- plugin compatibility -->
   <!-- see: http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html -->
 

--- a/src/io/flutter/FlutterInitialConfigurator.java
+++ b/src/io/flutter/FlutterInitialConfigurator.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter;
+
+import com.intellij.icons.AllIcons;
+import com.intellij.ide.util.PropertiesComponent;
+import com.intellij.openapi.actionSystem.ActionManager;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.fileTypes.FileTypeManager;
+import com.intellij.util.messages.MessageBus;
+import io.flutter.actions.FlutterImportProjectAction;
+
+public class FlutterInitialConfigurator {
+  @SuppressWarnings("UnusedParameters")
+  public FlutterInitialConfigurator(final MessageBus bus,
+                                    final PropertiesComponent propertiesComponent,
+                                    final FileTypeManager fileTypeManager) {
+    // Intercept and redirect Import actions.
+    if (!FlutterUtils.isAndroidStudio()) {
+      // Replace the Welcome Screen Import action.
+      final AnAction welcomeImportAction = ActionManager.getInstance().getAction("WelcomeScreen.ImportProject");
+      if (welcomeImportAction != null) {
+        FlutterUtils.replaceAction("WelcomeScreen.ImportProject",
+                                   new FlutterImportProjectAction(welcomeImportAction, AllIcons.Welcome.ImportProject));
+      }
+      // Replace the IDE Import action.
+      final AnAction importAction = ActionManager.getInstance().getAction("ImportProject");
+      if (importAction != null) {
+        FlutterUtils.replaceAction("ImportProject",
+                                   new FlutterImportProjectAction(importAction));
+      }
+    }
+  }
+}

--- a/src/io/flutter/FlutterUtils.java
+++ b/src/io/flutter/FlutterUtils.java
@@ -10,6 +10,8 @@ import com.intellij.execution.configurations.GeneralCommandLine;
 import com.intellij.execution.util.ExecUtil;
 import com.intellij.ide.actions.ShowSettingsUtilImpl;
 import com.intellij.ide.util.PropertiesComponent;
+import com.intellij.openapi.actionSystem.ActionManager;
+import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.extensions.PluginId;
@@ -58,6 +60,12 @@ public class FlutterUtils {
     ApplicationManager.getApplication().invokeAndWait(
       runnable,
       ModalityState.defaultModalityState());
+  }
+
+  public static boolean isFlutterProjectRoot(@Nullable VirtualFile file) {
+    if (file == null) return false;
+    final PubRoot root = PubRoot.forDirectory(file);
+    return root != null && root.declaresFlutter();
   }
 
   @SuppressWarnings("BooleanMethodIsAlwaysInverted")
@@ -216,6 +224,18 @@ public class FlutterUtils {
     final PluginId pluginId = PluginId.findId("io.flutter");
     assert pluginId != null;
     return pluginId;
+  }
+
+  public static void replaceAction(@NotNull String actionId, @NotNull AnAction newAction) {
+    final ActionManager actionManager = ActionManager.getInstance();
+    final AnAction oldAction = actionManager.getAction(actionId);
+    if (oldAction != null) {
+      newAction.getTemplatePresentation().setIcon(oldAction.getTemplatePresentation().getIcon());
+      newAction.getTemplatePresentation().setText(oldAction.getTemplatePresentation().getTextWithMnemonic(), true);
+      newAction.getTemplatePresentation().setDescription(oldAction.getTemplatePresentation().getDescription());
+      actionManager.unregisterAction(actionId);
+    }
+    actionManager.registerAction(actionId, newAction);
   }
 
   /**

--- a/src/io/flutter/actions/FlutterImportProjectAction.java
+++ b/src/io/flutter/actions/FlutterImportProjectAction.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2018 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.actions;
+
+import com.intellij.ide.actions.ImportModuleAction;
+import com.intellij.ide.actions.OpenProjectFileChooserDescriptor;
+import com.intellij.ide.util.newProjectWizard.AddModuleWizard;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.CommonDataKeys;
+import com.intellij.openapi.fileChooser.FileChooser;
+import com.intellij.openapi.fileChooser.FileChooserDescriptor;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.platform.PlatformProjectOpenProcessor;
+import com.intellij.projectImport.ProjectImportProvider;
+import com.intellij.util.ArrayUtil;
+import io.flutter.FlutterUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+
+public class FlutterImportProjectAction extends AnAction {
+  @NotNull
+  private AnAction delegateAction;
+  @Nullable
+  private final Icon icon;
+
+  public FlutterImportProjectAction(@NotNull AnAction delegateAction) {
+    this(delegateAction, null);
+  }
+
+  public FlutterImportProjectAction(@NotNull AnAction delegateAction, @Nullable Icon icon) {
+    this.delegateAction = delegateAction;
+    this.icon = icon;
+  }
+
+  @Override
+  public void update(AnActionEvent e) {
+    // The action icon is lazily loaded and forcing a load in the Welcome Page does not work so if specified we
+    // set it ourselves.
+    if (icon != null) {
+      e.getPresentation().setIcon(icon);
+    }
+  }
+
+  @Override
+  public void actionPerformed(AnActionEvent e) {
+    final FileChooserDescriptor descriptor = new OpenProjectFileChooserDescriptor(false);
+    final Project project = e.getData(CommonDataKeys.PROJECT);
+
+    FileChooser
+      .chooseFiles(descriptor, project, null, files -> {
+        final VirtualFile selection = files.get(0);
+        if (FlutterUtils.isFlutterProjectRoot(selection)) {
+          PlatformProjectOpenProcessor.getInstance().doOpenProject(selection, project, false);
+        }
+        else {
+          if (delegateAction instanceof ImportModuleAction) {
+            AddModuleWizard wizard = ImportModuleAction.createImportWizard(project, null, selection, ArrayUtil
+              .toObjectArray(ImportModuleAction.getProviders(project), ProjectImportProvider.class));
+            if (wizard != null && (wizard.getStepCount() <= 0 || wizard.showAndGet())) {
+              ImportModuleAction.createFromWizard(project, wizard);
+              return;
+            }
+          }
+          // Fall back on delegate action.
+          delegateAction.actionPerformed(e);
+        }
+      });
+  }
+}

--- a/src/io/flutter/project/FlutterProjectOpenProcessor.java
+++ b/src/io/flutter/project/FlutterProjectOpenProcessor.java
@@ -14,6 +14,7 @@ import com.intellij.projectImport.ProjectOpenProcessor;
 import icons.FlutterIcons;
 import io.flutter.FlutterBundle;
 import io.flutter.FlutterMessages;
+import io.flutter.FlutterUtils;
 import io.flutter.ProjectOpenActivity;
 import io.flutter.pub.PubRoot;
 import io.flutter.utils.FlutterModuleUtils;
@@ -45,9 +46,7 @@ public class FlutterProjectOpenProcessor extends ProjectOpenProcessor {
 
   @Override
   public boolean canOpenProject(@Nullable VirtualFile file) {
-    if (file == null) return false;
-    final PubRoot root = PubRoot.forDirectory(file);
-    return root != null && root.declaresFlutter();
+    return FlutterUtils.isFlutterProjectRoot(file);
   }
 
   /**


### PR DESCRIPTION
Fixes: #1889.

In the case where you attempt to import a directory that defines a Flutter root, it works just like a project open (which is to say "it just works").  Otherwise, you're injected into the standard import flow where you're greeted with a wizard like this:

![image](https://user-images.githubusercontent.com/67586/37123482-3b885242-2219-11e8-95f8-545592cfca53.png)


Incidentally, this wizard highlights *why* we want to do something like this (and why taking on a little technical risk may well be worth it).  A common issue (encountered for example just this week by @Sfshaza) is that folks don't know what to do when confronted with this wizard.  Not only is that confusing, if they do the wrong thing, they are left with a project that won't work.

(FWIW still a WIP and more invasive than I'd hoped...  For now, just food for thought.)

/cc @devoncarew @stevemessick 



