### PR TITLE
Index less

### DIFF
--- a/flutter-intellij-community.iml
+++ b/flutter-intellij-community.iml
@@ -14,10 +14,6 @@
       <excludeFolder url="file://$MODULE_DIR$/.pub" />
       <excludeFolder url="file://$MODULE_DIR$/artifacts" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
-      <excludeFolder url="file://$MODULE_DIR$/packages" />
-      <excludeFolder url="file://$MODULE_DIR$/tool/colors/packages" />
-      <excludeFolder url="file://$MODULE_DIR$/tool/icons/packages" />
-      <excludeFolder url="file://$MODULE_DIR$/tool/packages" />
       <excludeFolder url="file://$MODULE_DIR$/tool/plugin/.pub" />
       <excludeFolder url="file://$MODULE_DIR$/tool/plugin/build" />
     </content>
@@ -44,7 +40,5 @@
       </library>
     </orderEntry>
     <orderEntry type="library" name="snakeyaml" level="project" />
-    <orderEntry type="library" name="Dart SDK" level="project" />
-    <orderEntry type="library" name="Dart Packages" level="project" />
   </component>
 </module>

--- a/flutter-studio/src/io/flutter/FlutterStudioStartupActivity.java
+++ b/flutter-studio/src/io/flutter/FlutterStudioStartupActivity.java
@@ -13,13 +13,6 @@ import io.flutter.actions.OpenAndroidModule;
 import org.jetbrains.annotations.NotNull;
 
 public class FlutterStudioStartupActivity implements StartupActivity {
-  @Override
-  public void runActivity(@NotNull Project project) {
-    // The IntelliJ version of this action spawns a new process for Android Studio.
-    // Since we're already running Android Studio we want to simply open the project in the current process.
-    replaceAction("flutter.androidstudio.open", new OpenAndroidModule());
-  }
-
   public static void replaceAction(@NotNull String actionId, @NotNull AnAction newAction) {
     ActionManager actionManager = ActionManager.getInstance();
     AnAction oldAction = actionManager.getAction(actionId);
@@ -30,5 +23,12 @@ public class FlutterStudioStartupActivity implements StartupActivity {
       actionManager.unregisterAction(actionId);
     }
     actionManager.registerAction(actionId, newAction);
+  }
+
+  @Override
+  public void runActivity(@NotNull Project project) {
+    // The IntelliJ version of this action spawns a new process for Android Studio.
+    // Since we're already running Android Studio we want to simply open the project in the current process.
+    replaceAction("flutter.androidstudio.open", new OpenAndroidModule());
   }
 }

--- a/flutter-studio/src/io/flutter/project/FlutterProjectCreator.java
+++ b/flutter-studio/src/io/flutter/project/FlutterProjectCreator.java
@@ -6,13 +6,13 @@
 package io.flutter.project;
 
 import com.android.repository.io.FileOpUtils;
-import com.android.tools.idea.run.AndroidRunConfiguration;
-import com.android.tools.ndk.run.AndroidRunConfigurationConverter;
-import com.intellij.conversion.*;
+import com.intellij.conversion.ConversionListener;
+import com.intellij.conversion.ConversionService;
 import com.intellij.facet.FacetManager;
 import com.intellij.facet.ModifiableFacetModel;
 import com.intellij.ide.RecentProjectsManager;
 import com.intellij.ide.highlighter.ModuleFileType;
+import com.intellij.ide.impl.ProjectUtil;
 import com.intellij.ide.projectView.ProjectView;
 import com.intellij.ide.projectView.impl.ProjectViewPane;
 import com.intellij.ide.util.projectWizard.ModuleWizardStep;
@@ -25,6 +25,8 @@ import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.command.WriteCommandAction;
 import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleManager;
 import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.progress.Task;
@@ -41,11 +43,13 @@ import com.intellij.openapi.wm.IdeFocusManager;
 import com.intellij.openapi.wm.IdeFrame;
 import com.intellij.platform.PlatformProjectOpenProcessor;
 import com.intellij.projectImport.ProjectOpenedCallback;
+import io.flutter.FlutterUtils;
 import io.flutter.module.FlutterModuleBuilder;
 import io.flutter.module.FlutterProjectType;
 import io.flutter.module.FlutterSmallIDEProjectGenerator;
 import io.flutter.sdk.FlutterCreateAdditionalSettings;
 import io.flutter.sdk.FlutterSdk;
+import io.flutter.utils.FlutterModuleUtils;
 import org.jetbrains.android.facet.AndroidFacet;
 import org.jetbrains.android.facet.AndroidFacetType;
 import org.jetbrains.android.facet.IdeaSourceProvider;
@@ -79,6 +83,18 @@ public class FlutterProjectCreator {
 
   public FlutterProjectCreator(@NotNull FlutterProjectModel model) {
     myModel = model;
+  }
+
+  public static void disableUserConfig(Project project) {
+    if (FlutterModuleUtils.usesFlutter(project)) {
+      for (Module module : ModuleManager.getInstance(project).getModules()) {
+        final AndroidFacet facet = AndroidFacet.getInstance(module);
+        if (facet == null) {
+          continue;
+        }
+        facet.getProperties().ALLOW_USER_CONFIGURATION = false;
+      }
+    }
   }
 
   public static boolean finalValidityCheckPassed(@NotNull String projectLocation) {
@@ -116,14 +132,15 @@ public class FlutterProjectCreator {
     }
   }
 
-  private static void configureFacet(@NotNull AndroidFacet facet, @NotNull File location) {
+  private static void configureFacet(@NotNull AndroidFacet facet, @NotNull File location, @NotNull String dirName) {
     JpsAndroidModuleProperties facetProperties = facet.getProperties();
 
-    File modulePath = new File(location, "android");
+    File modulePath = new File(location, dirName);
     IdeaSourceProvider sourceProvider = IdeaSourceProvider.create(facet);
     facetProperties.MANIFEST_FILE_RELATIVE_PATH = relativePath(modulePath, sourceProvider.getManifestFile());
     facetProperties.RES_FOLDER_RELATIVE_PATH = relativePath(modulePath, sourceProvider.getResDirectories());
     facetProperties.ASSETS_FOLDER_RELATIVE_PATH = relativePath(modulePath, sourceProvider.getAssetsDirectories());
+    facetProperties.ALLOW_USER_CONFIGURATION = false;
   }
 
   @NotNull
@@ -149,6 +166,38 @@ public class FlutterProjectCreator {
       return packageName;
     }
     return packageName.substring(0, idx);
+  }
+
+  private static Project waitForProjectReload(Project project, VirtualFile baseDir) {
+    Project[] openProjects = ProjectManager.getInstance().getOpenProjects();
+    Project[] newProjectRef = new Project[1];
+    newProjectRef[0] = project;
+    ApplicationManager.getApplication().invokeAndWait(() -> {
+      loop:
+      for (int i = 0; i < 100; i++) {
+        Thread.yield();
+        try {
+          //noinspection BusyWait
+          Thread.sleep(200);
+        }
+        catch (InterruptedException e) {
+          LOG.error("Process not reloaded", e);
+          break loop;
+        }
+        for (Project p : openProjects) {
+          if (p.getBaseDir().equals(baseDir)) {
+            newProjectRef[0] = p;
+          }
+        }
+        if (newProjectRef[0] != project) {
+          break loop;
+        }
+      }
+    }, ModalityState.NON_MODAL);
+    if (newProjectRef[0] == project) {
+      LOG.error("Timeout during process reload");
+    }
+    return newProjectRef[0];
   }
 
   public void createModule() {
@@ -225,11 +274,15 @@ public class FlutterProjectCreator {
 
     RecentProjectsManager.getInstance().setLastProjectCreationLocation(location.getParent());
 
+    Project[] newProjectRef = new Project[1];
     ProjectOpenedCallback callback =
       (project, module) -> ProgressManager.getInstance().run(new Task.Modal(null, "Creating Flutter Project", false) {
         @Override
         public void run(@NotNull ProgressIndicator indicator) {
           indicator.setIndeterminate(true);
+
+          // The IDE has already created some files. Flutter won't overwrite them, but we want the versions provided by Flutter.
+          deleteDirectoryContents(location);
 
           // Add an Android facet if needed by the project type.
           if (myModel.projectType().getValue() != FlutterProjectType.PACKAGE) {
@@ -237,11 +290,14 @@ public class FlutterProjectCreator {
             AndroidFacetType facetType = AndroidFacet.getFacetType();
             AndroidFacet facet = facetType.createFacet(module, AndroidFacet.NAME, facetType.createDefaultConfiguration(), null);
             model.addFacet(facet);
-            configureFacet(facet, location);
+            configureFacet(facet, location, "android");
+            File appLocation = new File(location, "android");
+            //noinspection ResultOfMethodCallIgnored
+            appLocation.mkdirs();
+            AndroidFacet appFacet = facetType.createFacet(module, AndroidFacet.NAME, facetType.createDefaultConfiguration(), null);
+            model.addFacet(appFacet);
+            configureFacet(appFacet, appLocation, "app");
           }
-
-          // The IDE has already created some files. Flutter won't overwrite them, but we want the versions provided by Flutter.
-          deleteDirectoryContents(location);
 
           FlutterSmallIDEProjectGenerator
             .generateProject(project, baseDir, myModel.flutterSdk().get(), module, makeAdditionalSettings());
@@ -250,16 +306,20 @@ public class FlutterProjectCreator {
           VfsUtil.markDirtyAndRefresh(false, true, true, baseDir);
           ConversionService.getInstance().convertSilently(baseDir.getPath(), new MyConversionListener());
           VfsUtil.markDirtyAndRefresh(false, true, true, baseDir);
-          ProjectManager.getInstance().reloadProject(project);
+          reloadProjectNow(project);
         }
       });
 
     EnumSet<PlatformProjectOpenProcessor.Option> options = EnumSet.noneOf(PlatformProjectOpenProcessor.Option.class);
-    Project newProject = PlatformProjectOpenProcessor.doOpenProject(baseDir, projectToClose, -1, callback, options);
+    PlatformProjectOpenProcessor.doOpenProject(baseDir, projectToClose, -1, callback, options);
+    // The project was reloaded by the callback. Find the new Project object.
+    Project newProject = FlutterUtils.findProject(baseDir.getPath());
     if (newProject != null) {
       StartupManager.getInstance(newProject).registerPostStartupActivity(() -> ApplicationManager.getApplication().invokeLater(() -> {
+        disableUserConfig(newProject);
         // We want to show the Project view, not the Android view since it doesn't make the Dart code visible.
         ProjectView.getInstance(newProject).changeView(ProjectViewPane.ID);
+        //ProjectManager.getInstance().reloadProject(newProject);
       }, ModalityState.NON_MODAL));
     }
   }
@@ -272,6 +332,16 @@ public class FlutterProjectCreator {
       .setKotlin(myModel.useKotlin().get() ? true : null)
       .setSwift(myModel.useSwift().get() ? true : null)
       .build();
+  }
+
+  private static void reloadProjectNow(Project project) {
+    ApplicationManager.getApplication().invokeAndWait(() -> {
+      String presentableUrl = project.getPresentableUrl();
+      if (!ProjectUtil.closeAndDispose(project)) {
+        return;
+      }
+      ProjectUtil.openProject(presentableUrl, null, true);
+    });
   }
 
   public static class MyConversionListener implements ConversionListener {

--- a/flutter-studio/src/io/flutter/project/FlutterStudioProjectOpenProcessor.java
+++ b/flutter-studio/src/io/flutter/project/FlutterStudioProjectOpenProcessor.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.project;
+
+import com.intellij.openapi.application.ApplicationInfo;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import io.flutter.FlutterUtils;
+import io.flutter.pub.PubRoot;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class FlutterStudioProjectOpenProcessor extends FlutterProjectOpenProcessor {
+  @Override
+  public String getName() {
+    return "Flutter Studio";
+  }
+
+  @Override
+  public boolean canOpenProject(@Nullable VirtualFile file) {
+    if (file == null) return false;
+    ApplicationInfo info = ApplicationInfo.getInstance();
+    final PubRoot root = PubRoot.forDirectory(file);
+    return root != null && root.declaresFlutter();
+  }
+
+  @Nullable
+  @Override
+  public Project doOpenProject(@NotNull VirtualFile virtualFile, @Nullable Project projectToClose, boolean forceOpenInNewFrame) {
+    if (super.doOpenProject(virtualFile, projectToClose, forceOpenInNewFrame) == null) return null;
+    // The superclass may have caused the project to be reloaded. Find the new Project object.
+    Project project = FlutterUtils.findProject(virtualFile.getPath());
+    if (project != null) {
+      FlutterProjectCreator.disableUserConfig(project);
+      return project;
+    }
+    return null;
+  }
+}

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -23,7 +23,9 @@
 
   <!-- Contributes Android Studio-specific features and implementations. -->
   <!--suppress PluginXmlValidity -->
-  <depends optional="true" config-file="studio-contribs.xml">com.intellij.modules.androidstudio</depends>
+  <!-- depends optional="true" config-file="studio-contribs.xml">com.android.tools.apk</depends -->
+  <!-- note that com.android.tools.apk also implies com.intellij.modules.androidstudio but it is not available in sources -->
+  <depends optional="true" config-file="studio-contribs.xml">com.intellij.modules.java</depends>> <!-- androidstudio</depends -->
 
   <change-notes>
     <![CDATA[
@@ -615,7 +617,7 @@ miscellaneous:
     <projectService serviceInterface="io.flutter.view.FlutterView"
                     serviceImplementation="io.flutter.view.FlutterView"
                     overrides="false"/>
-    <projectOpenProcessor implementation="io.flutter.project.FlutterProjectOpenProcessor" order="first"/>
+    <projectOpenProcessor id="flutter" implementation="io.flutter.project.FlutterProjectOpenProcessor" order="first"/>
 
     <localInspection bundle="io.flutter.FlutterBundle" key="outdated.dependencies.inspection.name"
                      groupName="Flutter" enabledByDefault="true" level="WARNING" language="Dart"

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -23,9 +23,7 @@
 
   <!-- Contributes Android Studio-specific features and implementations. -->
   <!--suppress PluginXmlValidity -->
-  <!-- depends optional="true" config-file="studio-contribs.xml">com.android.tools.apk</depends -->
-  <!-- note that com.android.tools.apk also implies com.intellij.modules.androidstudio but it is not available in sources -->
-  <depends optional="true" config-file="studio-contribs.xml">com.intellij.modules.java</depends>> <!-- androidstudio</depends -->
+  <depends optional="true" config-file="studio-contribs.xml">com.intellij.modules.androidstudio</depends>
 
   <change-notes>
     <![CDATA[

--- a/resources/META-INF/plugin_template.xml
+++ b/resources/META-INF/plugin_template.xml
@@ -613,7 +613,7 @@ miscellaneous:
     <projectService serviceInterface="io.flutter.view.FlutterView"
                     serviceImplementation="io.flutter.view.FlutterView"
                     overrides="false"/>
-    <projectOpenProcessor implementation="io.flutter.project.FlutterProjectOpenProcessor" order="first"/>
+    <projectOpenProcessor id="flutter" implementation="io.flutter.project.FlutterProjectOpenProcessor" order="first"/>
 
     <localInspection bundle="io.flutter.FlutterBundle" key="outdated.dependencies.inspection.name"
                      groupName="Flutter" enabledByDefault="true" level="WARNING" language="Dart"

--- a/resources/META-INF/studio-contribs.xml
+++ b/resources/META-INF/studio-contribs.xml
@@ -15,6 +15,7 @@
   <extensions defaultExtensionNs="com.intellij">
     <androidStudioInitializer implementation="io.flutter.FlutterStudioInitializer"/>
     <postStartupActivity implementation="io.flutter.FlutterStudioStartupActivity"/>
+    <projectOpenProcessor implementation="io.flutter.project.FlutterStudioProjectOpenProcessor" order="after flutter"/>
   </extensions>
 
   <actions>

--- a/resources/META-INF/studio-contribs_template.xml
+++ b/resources/META-INF/studio-contribs_template.xml
@@ -13,6 +13,7 @@
   <extensions defaultExtensionNs="com.intellij">
     <androidStudioInitializer implementation="io.flutter.FlutterStudioInitializer"/>
     <postStartupActivity implementation="io.flutter.FlutterStudioStartupActivity"/>
+    <projectOpenProcessor implementation="io.flutter.project.FlutterStudioProjectOpenProcessor" order="after flutter"/>
   </extensions>
 
   <actions>

--- a/src/io/flutter/FlutterUtils.java
+++ b/src/io/flutter/FlutterUtils.java
@@ -9,6 +9,7 @@ import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configurations.GeneralCommandLine;
 import com.intellij.execution.util.ExecUtil;
 import com.intellij.ide.actions.ShowSettingsUtilImpl;
+import com.intellij.ide.impl.ProjectUtil;
 import com.intellij.ide.util.PropertiesComponent;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ModalityState;
@@ -17,6 +18,7 @@ import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleUtil;
 import com.intellij.openapi.progress.ProcessCanceledException;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectManager;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiElement;
@@ -279,6 +281,22 @@ public class FlutterUtils {
     catch (IOException e) {
       return false;
     }
+  }
+
+  /**
+   * Return the project located at the <code>path</code> or containing it.
+   *
+   * @param path The path to a project or one of its files
+   * @return The Project located at the path
+   */
+  @Nullable
+  public static Project findProject(@NotNull String path) {
+    for (Project project : ProjectManager.getInstance().getOpenProjects()) {
+      if (ProjectUtil.isSameProject(path, project)) {
+        return project;
+      }
+    }
+    return null;
   }
 
   private static Map<String, Object> loadPubspecInfo(@NotNull String yamlContents) {

--- a/src/io/flutter/project/FlutterProjectOpenProcessor.java
+++ b/src/io/flutter/project/FlutterProjectOpenProcessor.java
@@ -5,6 +5,7 @@
  */
 package io.flutter.project;
 
+import com.intellij.openapi.application.ApplicationInfo;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.extensions.Extensions;
 import com.intellij.openapi.module.Module;
@@ -14,6 +15,7 @@ import com.intellij.projectImport.ProjectOpenProcessor;
 import icons.FlutterIcons;
 import io.flutter.FlutterBundle;
 import io.flutter.FlutterMessages;
+import io.flutter.FlutterUtils;
 import io.flutter.ProjectOpenActivity;
 import io.flutter.pub.PubRoot;
 import io.flutter.utils.FlutterModuleUtils;
@@ -23,7 +25,6 @@ import org.jetbrains.annotations.Nullable;
 import javax.swing.*;
 import java.util.Arrays;
 import java.util.Objects;
-
 
 public class FlutterProjectOpenProcessor extends ProjectOpenProcessor {
 
@@ -46,6 +47,10 @@ public class FlutterProjectOpenProcessor extends ProjectOpenProcessor {
   @Override
   public boolean canOpenProject(@Nullable VirtualFile file) {
     if (file == null) return false;
+    ApplicationInfo info = ApplicationInfo.getInstance();
+    if (FlutterUtils.isAndroidStudio()) {
+      return false;
+    }
     final PubRoot root = PubRoot.forDirectory(file);
     return root != null && root.declaresFlutter();
   }
@@ -86,7 +91,7 @@ public class FlutterProjectOpenProcessor extends ProjectOpenProcessor {
    * <p>
    * (It probably wasn't created with "flutter create" and probably didn't have any IntelliJ configuration before.)
    */
-  private void convertToFlutterProject(@NotNull Project project) {
+  private static void convertToFlutterProject(@NotNull Project project) {
     final PubRoot root = PubRoot.singleForProjectWithRefresh(project);
     if (root == null) {
       return; // Either no pub roots, or more than one.


### PR DESCRIPTION
@pq @devoncarew 

For Flutter projects created with Android Studio, project creation should be quiet:
- Android framework is not detected, so there is no notification to configure it
- Constant 2-sec refresh is disabled
- "Migrate to Gradle" is not suggested

Opening a Flutter project created in IntelliJ:
- Constant 2-sec refresh is disabled
- "Migrate to Gradle" is suggested only first time the first time a project is opened -- `FlutterUtils.disableGradleProjectMigrationNotification()` is not run until after the notification is displayed, but does work for subsequent openings

That last item needs further work. The user won't see the prompt twice, even if no action is taken, but they should not even see it once. I think it is a problem that needs to be solved in IntelliJ.
