### PR TITLE
flip the meaning of the preview dart 2 flag

### DIFF
--- a/src/io/flutter/run/bazel/BazelFields.java
+++ b/src/io/flutter/run/bazel/BazelFields.java
@@ -263,8 +263,8 @@ public class BazelFields {
     // Tell the flutter command-line tools that we want a machine interface on stdio.
     commandLine.addParameter("--machine");
 
-    if (FlutterSettings.getInstance().getPreviewDart2()) {
-      commandLine.addParameter("--preview-dart-2");
+    if (FlutterSettings.getInstance().isDisablePreviewDart2()) {
+      commandLine.addParameter("--no-preview-dart-2");
     }
 
     // Pause the app at startup in order to set breakpoints.

--- a/src/io/flutter/sdk/FlutterSdk.java
+++ b/src/io/flutter/sdk/FlutterSdk.java
@@ -185,8 +185,8 @@ public class FlutterSdk {
     if (FlutterSettings.getInstance().isVerboseLogging()) {
       args.add("--verbose");
     }
-    if (FlutterSettings.getInstance().getPreviewDart2()) {
-      args.add("--preview-dart-2");
+    if (FlutterSettings.getInstance().isDisablePreviewDart2()) {
+      args.add("--no-preview-dart-2");
     }
     if (device != null) {
       args.add("--device-id=" + device.deviceId());
@@ -214,8 +214,8 @@ public class FlutterSdk {
       args.add("--machine");
       // Otherwise, just run it normally and show the output in a non-test console.
     }
-    if (FlutterSettings.getInstance().getPreviewDart2()) {
-      args.add("--preview-dart-2");
+    if (FlutterSettings.getInstance().isDisablePreviewDart2()) {
+      args.add("--no-preview-dart-2");
     }
     if (mode == RunMode.DEBUG) {
       if (!myVersion.flutterTestSupportsMachineMode()) {

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.form
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.form
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="io.flutter.sdk.FlutterSettingsConfigurable">
-  <grid id="27dc6" binding="mainPanel" layout-manager="GridLayoutManager" row-count="4" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="mainPanel" layout-manager="GridLayoutManager" row-count="5" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="574" height="498"/>
+      <xy x="20" y="20" width="574" height="561"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -57,13 +57,13 @@
       <grid id="fac23" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>
         <children/>
       </grid>
-      <grid id="e885c" layout-manager="GridLayoutManager" row-count="5" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="e885c" layout-manager="GridLayoutManager" row-count="4" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -76,7 +76,7 @@
         <children>
           <component id="6304a" class="javax.swing.JCheckBox" binding="myReportUsageInformationCheckBox">
             <constraints>
-              <grid row="2" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="0" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text value="&amp;Report usage information to Google Analytics"/>
@@ -85,7 +85,7 @@
           </component>
           <component id="99e58" class="javax.swing.JLabel" binding="myPrivacyPolicy">
             <constraints>
-              <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="3" use-parent-layout="false"/>
+              <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="3" use-parent-layout="false"/>
             </constraints>
             <properties>
               <horizontalAlignment value="2"/>
@@ -96,36 +96,19 @@
           </component>
           <component id="be19f" class="javax.swing.JCheckBox" binding="myEnableVerboseLoggingCheckBox" default-binding="true">
             <constraints>
-              <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text value="Enable &amp;verbose logging"/>
               <toolTipText value="Enables verbose logging (this can be useful for diagnostic purposes)."/>
             </properties>
           </component>
-          <component id="356a" class="javax.swing.JCheckBox" binding="myOpenInspectorOnAppLaunchCheckBox">
-            <constraints>
-              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <text value="Open Flutter Inspector view on app launch"/>
-            </properties>
-          </component>
-          <component id="87b06" class="javax.swing.JCheckBox" binding="myHotReloadOnSaveCheckBox">
-            <constraints>
-              <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <text value="Perform hot reload on save"/>
-              <toolTipText value="On save, hot reload changes into running Flutter apps."/>
-            </properties>
-          </component>
         </children>
       </grid>
-      <grid id="23e52" layout-manager="GridLayoutManager" row-count="5" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="23e52" layout-manager="GridLayoutManager" row-count="4" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <clientProperties>
@@ -138,7 +121,7 @@
               <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
-              <text value="Try out features still under development (a restart may be required)."/>
+              <text value="Try out features still under development (a restart may be required)"/>
             </properties>
           </component>
           <component id="8bd46" class="javax.swing.JCheckBox" binding="myOrganizeImportsOnSaveCheckBox" default-binding="true">
@@ -159,20 +142,55 @@
               <toolTipText value="On save, run dartfmt on changed Dart files."/>
             </properties>
           </component>
-          <component id="4e9b" class="javax.swing.JCheckBox" binding="myPreviewDart2CheckBox">
+          <component id="39243" class="javax.swing.JCheckBox" binding="myShowPreviewAreaCheckBox">
             <constraints>
               <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
-              <text value="Run applications with --preview-dart-2"/>
+              <text value="Show a live preview area in Flutter Outline"/>
             </properties>
           </component>
-          <component id="39243" class="javax.swing.JCheckBox" binding="myShowPreviewAreaCheckBox">
+        </children>
+      </grid>
+      <grid id="919ec" layout-manager="GridLayoutManager" row-count="3" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+        <margin top="0" left="0" bottom="0" right="0"/>
+        <constraints>
+          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+        <clientProperties>
+          <BorderFactoryClass class="java.lang.String" value="com.intellij.ui.IdeBorderFactory$PlainSmallWithIndent"/>
+        </clientProperties>
+        <border type="none" title="App Execution"/>
+        <children>
+          <component id="356a" class="javax.swing.JCheckBox" binding="myOpenInspectorOnAppLaunchCheckBox">
             <constraints>
-              <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
-              <text value="Show preview area in Flutter Outline"/>
+              <text value="Open Flutter Inspector view on app launch"/>
+            </properties>
+          </component>
+          <hspacer id="7e70d">
+            <constraints>
+              <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+            </constraints>
+          </hspacer>
+          <component id="4e9b" class="javax.swing.JCheckBox" binding="myPreviewDart2CheckBox">
+            <constraints>
+              <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Don't run applications in Dart 2.0 mode"/>
+            </properties>
+          </component>
+          <component id="87b06" class="javax.swing.JCheckBox" binding="myHotReloadOnSaveCheckBox">
+            <constraints>
+              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Perform hot reload on save"/>
+              <toolTipText value="On save, hot reload changes into running Flutter apps."/>
             </properties>
           </component>
         </children>

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.java
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.java
@@ -161,7 +161,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
       return true;
     }
 
-    if (settings.getPreviewDart2() != myPreviewDart2CheckBox.isSelected()) {
+    if (settings.isDisablePreviewDart2() != myPreviewDart2CheckBox.isSelected()) {
       return true;
     }
 
@@ -197,7 +197,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     settings.setShowPreviewAreaKey(myShowPreviewAreaCheckBox.isSelected());
     settings.setOpenInspectorOnAppLaunch(myOpenInspectorOnAppLaunchCheckBox.isSelected());
     settings.setVerboseLogging(myEnableVerboseLoggingCheckBox.isSelected());
-    settings.setPreviewDart2(myPreviewDart2CheckBox.isSelected());
+    settings.setDisablePreviewDart2(myPreviewDart2CheckBox.isSelected());
 
     reset(); // because we rely on remembering initial state
   }
@@ -223,7 +223,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     myShowPreviewAreaCheckBox.setSelected(settings.isShowPreviewArea());
     myOpenInspectorOnAppLaunchCheckBox.setSelected(settings.isOpenInspectorOnAppLaunch());
     myEnableVerboseLoggingCheckBox.setSelected(settings.isVerboseLogging());
-    myPreviewDart2CheckBox.setSelected(settings.getPreviewDart2());
+    myPreviewDart2CheckBox.setSelected(settings.isDisablePreviewDart2());
 
     myOrganizeImportsOnSaveCheckBox.setEnabled(myFormatCodeOnSaveCheckBox.isSelected());
   }

--- a/src/io/flutter/settings/FlutterSettings.java
+++ b/src/io/flutter/settings/FlutterSettings.java
@@ -18,7 +18,7 @@ public class FlutterSettings {
   private static final String reloadOnSaveKey = "io.flutter.reloadOnSave";
   private static final String openInspectorOnAppLaunchKey = "io.flutter.openInspectorOnAppLaunch";
   private static final String verboseLoggingKey = "io.flutter.verboseLogging";
-  private static final String previewDart2Key = "io.flutter.getPreviewDart2";
+  private static final String disablePreviewDart2Key = "io.flutter.disablePreviewDart2";
   private static final String formatCodeOnSaveKey = "io.flutter.formatCodeOnSave";
   private static final String organizeImportsOnSaveKey = "io.flutter.organizeImportsOnSave";
   private static final String showPreviewAreaKey = "io.flutter.showPreviewArea";
@@ -43,8 +43,8 @@ public class FlutterSettings {
     // Send data on the number of experimental features enabled by users.
     analytics.sendEvent("settings", "ping");
 
-    if (getPreviewDart2()) {
-      analytics.sendEvent("settings", afterLastPeriod(previewDart2Key));
+    if (isDisablePreviewDart2()) {
+      analytics.sendEvent("settings", afterLastPeriod(disablePreviewDart2Key));
     }
     if (isReloadOnSave()) {
       analytics.sendEvent("settings", afterLastPeriod(reloadOnSaveKey));
@@ -72,12 +72,12 @@ public class FlutterSettings {
     listeners.remove(listener);
   }
 
-  public boolean getPreviewDart2() {
-    return getPropertiesComponent().getBoolean(previewDart2Key, false);
+  public boolean isDisablePreviewDart2() {
+    return getPropertiesComponent().getBoolean(disablePreviewDart2Key, false);
   }
 
-  public void setPreviewDart2(boolean value) {
-    getPropertiesComponent().setValue(previewDart2Key, value, false);
+  public void setDisablePreviewDart2(boolean value) {
+    getPropertiesComponent().setValue(disablePreviewDart2Key, value, false);
 
     updateAnalysisServerArgs(value);
 


### PR DESCRIPTION
- flip the meaning of the preview dart 2 flag (fix https://github.com/flutter/flutter-intellij/issues/1910)
- change the name to `Don't run applications in Dart 2.0 mode`
- some UI refactoring in the settings page

<img width="530" alt="screen shot 2018-03-14 at 12 54 08 pm" src="https://user-images.githubusercontent.com/1269969/37428072-64398994-2788-11e8-8fb7-f7ca15bc5430.png">
