### PR TITLE
experiment with different colors for the preview

### DIFF
--- a/src/io/flutter/preview/PreviewArea.java
+++ b/src/io/flutter/preview/PreviewArea.java
@@ -39,13 +39,13 @@ import java.util.Map;
 public class PreviewArea {
   public static int BORDER_WITH = 5;
 
-  // https://material.io/guidelines/style/color.html#color-color-tool
   @SuppressWarnings("UseJBColor")
-  private static final Color[] widgetColors = new Color[]{
-    Color.decode("#0D47A1"),
-    Color.decode("#1976D2"),
-    Color.decode("#2196F3"),
-    Color.decode("#64B5F6")
+  private static final Color[] pastelColors = new Color[]{
+    new Color(255, 132, 203),
+    new Color(168, 231, 234),
+    new Color(251, 255, 147),
+    new Color(143, 255, 159),
+    new Color(193, 149, 255),
   };
 
   private final Listener myListener;
@@ -224,11 +224,9 @@ public class PreviewArea {
         final JLabel label = new JLabel(outline.getClassName());
         label.setBorder(JBUI.Borders.empty(2, 4, 0, 0));
         widget.add(label, BorderLayout.NORTH);
-        widget.setBackground(widgetColors[widgetDepth % widgetColors.length]);
+        widget.setBackground(pastelColors[widgetDepth % pastelColors.length]);
         widget.setBounds(rect);
-        //widget.setBorder(new EtchedBorder());
         widget.setBorder(IdeBorderFactory.createRoundedBorder(2));
-        //widget.validate();
 
         outlineToComponent.put(outline, widget);
 

--- a/src/io/flutter/preview/PreviewArea.java
+++ b/src/io/flutter/preview/PreviewArea.java
@@ -7,6 +7,8 @@ package io.flutter.preview;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.intellij.ui.IdeBorderFactory;
+import com.intellij.util.ui.JBUI;
 import org.dartlang.analysis.server.protocol.FlutterOutline;
 import org.jetbrains.annotations.NotNull;
 
@@ -32,16 +34,18 @@ import java.util.Map;
 // TODO: we should be bolding stateful and stateless (and state) classes, not build() methods
 //       or, show all elements of these classes with some additional emphasis (italic? background color?)
 
+// TODO: we need to take the layer (or z-index?) of the widget into account (see Scaffold and its FAB)
+
 public class PreviewArea {
   public static int BORDER_WITH = 5;
 
+  // https://material.io/guidelines/style/color.html#color-color-tool
   @SuppressWarnings("UseJBColor")
-  private static final Color[] pastelColors = new Color[]{
-    new Color(255, 132, 203),
-    new Color(168, 231, 234),
-    new Color(251, 255, 147),
-    new Color(143, 255, 159),
-    new Color(193, 149, 255),
+  private static final Color[] widgetColors = new Color[]{
+    Color.decode("#0D47A1"),
+    Color.decode("#1976D2"),
+    Color.decode("#2196F3"),
+    Color.decode("#64B5F6")
   };
 
   private final Listener myListener;
@@ -60,8 +64,6 @@ public class PreviewArea {
 
   private final Map<FlutterOutline, JComponent> outlineToComponent = new HashMap<>();
   private final List<SelectionEditPolicy> selectionComponents = new ArrayList<>();
-
-  private int colorIndex = 0;
 
   public PreviewArea(Listener listener) {
     this.myListener = listener;
@@ -142,9 +144,9 @@ public class PreviewArea {
       return;
     }
 
-    colorIndex = 0;
     outlineToComponent.clear();
-    renderWidgetOutline(rootOutline);
+    renderWidgetOutline(rootOutline, 0);
+    primaryLayer.revalidate();
     primaryLayer.repaint();
   }
 
@@ -209,7 +211,7 @@ public class PreviewArea {
     }
   }
 
-  private void renderWidgetOutline(@NotNull FlutterOutline outline) {
+  private void renderWidgetOutline(@NotNull FlutterOutline outline, int widgetDepth) {
     final Integer id = outline.getId();
     if (id != null) {
       Rectangle rect = idToGlobalBounds.get(id);
@@ -218,9 +220,15 @@ public class PreviewArea {
         final int y = BORDER_WITH + rect.y - rootWidgetBounds.y;
         rect = new Rectangle(x, y, rect.width, rect.height);
 
-        final JPanel widget = new JPanel();
-        widget.setBackground(pastelColors[(colorIndex++) % pastelColors.length]);
+        final JPanel widget = new JPanel(new BorderLayout());
+        final JLabel label = new JLabel(outline.getClassName());
+        label.setBorder(JBUI.Borders.empty(2, 4, 0, 0));
+        widget.add(label, BorderLayout.NORTH);
+        widget.setBackground(widgetColors[widgetDepth % widgetColors.length]);
         widget.setBounds(rect);
+        //widget.setBorder(new EtchedBorder());
+        widget.setBorder(IdeBorderFactory.createRoundedBorder(2));
+        //widget.validate();
 
         outlineToComponent.put(outline, widget);
 
@@ -240,7 +248,7 @@ public class PreviewArea {
 
         if (outline.getChildren() != null) {
           for (FlutterOutline child : outline.getChildren()) {
-            renderWidgetOutline(child);
+            renderWidgetOutline(child, widgetDepth + 1);
           }
         }
 

--- a/src/io/flutter/preview/RenderHelper.java
+++ b/src/io/flutter/preview/RenderHelper.java
@@ -153,6 +153,7 @@ public class RenderHelper {
       return;
     }
 
+    // TODO: Expose this as an error to the user.
     if (myTesterPath == null) {
       return;
     }

--- a/src/io/flutter/preview/RenderHelper.java
+++ b/src/io/flutter/preview/RenderHelper.java
@@ -153,6 +153,10 @@ public class RenderHelper {
       return;
     }
 
+    if (myTesterPath == null) {
+      return;
+    }
+
     final String widgetClass = myWidgetOutline.getDartElement().getName();
     final String constructor = myWidgetOutline.getRenderConstructor();
     final RenderRequest request =


### PR DESCRIPTION
- experiment with different colors for the preview
- use the classname as a label in the widget preview
- rotate colors for different depths in the tree; sibling nodes will share the same color
- add a border to help separate adjacent widgets

Happy to iterate on this, or remove portions of the PR.

<img width="319" alt="screen shot 2018-03-15 at 1 55 31 am" src="https://user-images.githubusercontent.com/1269969/37453723-d11a391a-27f5-11e8-947f-3b7e8b27fb59.png">

<img width="319" alt="screen shot 2018-03-15 at 1 55 12 am" src="https://user-images.githubusercontent.com/1269969/37453731-d8508a90-27f5-11e8-939e-43ea50a287ac.png">
