### PR TITLE
Heap use display initial implementation.

### DIFF
--- a/src/io/flutter/inspector/HeapDisplay.java
+++ b/src/io/flutter/inspector/HeapDisplay.java
@@ -118,7 +118,7 @@ public class HeapDisplay extends JPanel {
   }
 
   public static class HeapState implements HeapListener {
-    // Running count of the max help (in bytes).
+    // Running count of the max heap (in bytes).
     private int heapMaxInBytes;
 
     private final HeapSamples samples;

--- a/src/io/flutter/inspector/HeapDisplay.java
+++ b/src/io/flutter/inspector/HeapDisplay.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright 2018 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.inspector;
+
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.Presentation;
+import com.intellij.openapi.actionSystem.ex.CustomComponentAction;
+import com.intellij.openapi.util.Disposer;
+import com.intellij.ui.JBColor;
+import com.intellij.util.ui.JBUI;
+import io.flutter.perf.HeapMonitor.HeapListener;
+import io.flutter.perf.HeapMonitor.HeapSample;
+import io.flutter.perf.HeapMonitor.HeapSpace;
+import io.flutter.perf.HeapMonitor.IsolateObject;
+import io.flutter.perf.PerfService;
+import io.flutter.run.daemon.FlutterApp;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+import java.awt.*;
+import java.util.*;
+import java.util.List;
+
+// TODO(pq): make capacity setting dynamic
+// TODO(pq): add label displaying curent/total heap use
+// TODO(pq): handle GCs
+// TODO(pq): tweak scaling
+// TODO(pq): fix duplicate value caching (remove int cache from graph)
+public class HeapDisplay extends JPanel {
+
+  public static class ToolbarComponentAction extends AnAction implements CustomComponentAction, HeapListener, Disposable {
+
+    private final List<JPanel> panels = new ArrayList<>();
+    private final List<HeapDisplay> graphs = new ArrayList<>();
+
+    // TODO(pq): be smart about setting capacity based on available width.
+    final HeapState heapState = new HeapState(30);
+
+    public ToolbarComponentAction(@NotNull Disposable parent, @NotNull FlutterApp app) {
+      final PerfService service = app.getPerfService();
+      assert service != null;
+      service.addListener(this);
+      service.start();
+      Disposer.register(parent, this);
+    }
+
+    @Override
+    public void update(AnActionEvent e) {
+      // No-op.
+    }
+
+    @Override
+    public void actionPerformed(AnActionEvent e) {
+      // No-op.
+    }
+
+    @Override
+    public JComponent createCustomComponent(Presentation presentation) {
+      final JPanel panel = new JPanel(new GridBagLayout());
+      final HeapDisplay graph = new HeapDisplay();
+
+      panel.add(graph,
+                new GridBagConstraints(0, 0, 1, 1, 1, 1,
+                                       GridBagConstraints.CENTER, GridBagConstraints.BOTH,
+                                       JBUI.insets(0, 3, 0, 3), 0, 0));
+      // Because there may be multiple toolbars, we need to store (and update) multiple panels.
+      panels.add(panel);
+      graphs.add(graph);
+      return panel;
+    }
+
+    @Override
+    public void dispose() {
+      // TODO(pq): add any cleanup here.
+    }
+
+    @Override
+    public void update(List<IsolateObject> isolates) {
+      heapState.update(isolates);
+      for (HeapDisplay graph : graphs) {
+        // TODO(pq): stop storing points in the graph and just use the samples directly.
+        heapState.getSamples().forEach(sample -> graph.addMeasure(scale(heapState, sample)));
+      }
+      panels.forEach(panel -> SwingUtilities.invokeLater(panel::repaint));
+    }
+  }
+
+  /**
+   * A fixed-length list of captured samples.
+   */
+  public static class HeapSamples {
+    private final LinkedList<HeapSample> samples = new LinkedList<>();
+    private final int capacity;
+
+    HeapSamples(int size) {
+      this.capacity = size;
+    }
+
+    void add(HeapSample sample) {
+      if (samples.size() == capacity) {
+        samples.removeFirst();
+      }
+      samples.add(sample);
+    }
+
+    int size() {
+      return samples.size();
+    }
+
+    HeapSample get(int index) {
+      return samples.get(index);
+    }
+  }
+
+  public static class HeapState implements HeapListener {
+    // Running count of the max help (in bytes).
+    private int heapMaxInBytes;
+
+    private final HeapSamples samples;
+
+    HeapState(int sampleCapacity) {
+      samples = new HeapSamples(sampleCapacity);
+    }
+
+    public Iterable<HeapSample> getSamples() {
+      return samples.samples;
+    }
+
+    public int getMaxHeapInBytes() {
+      return heapMaxInBytes;
+    }
+
+    void addSample(HeapSample sample) {
+      samples.add(sample);
+    }
+
+    @Override
+    public void update(List<IsolateObject> isolates) {
+      int current = 0;
+      int total = 0;
+
+      for (IsolateObject isolate : isolates) {
+        for (HeapSpace heap : isolate.getHeaps()) {
+          current += heap.getUsed() + heap.getExternal();
+          total += heap.getCapacity() + heap.getExternal();
+        }
+      }
+
+      heapMaxInBytes = total;
+      addSample(new HeapSample(current, false));
+    }
+  }
+
+  private static final int TEN_MB = 1024 * 1024 * 10;
+  private static final double GRAPH_PIXEL_HIGHT = 16.0;
+
+  private static int scale(HeapState state, HeapSample sample) {
+    final double maxDataSize = (Math.round(state.getMaxHeapInBytes() / TEN_MB)) * TEN_MB + TEN_MB;
+    return (int)(GRAPH_PIXEL_HIGHT * sample.getBytes() / maxDataSize);
+  }
+
+  // TODO(pq): remove in favor of just using the HeapSamples directly.
+  static class IntCache {
+    final LinkedList<Integer> list = new LinkedList<>();
+    private final int capacity;
+
+    IntCache(int size) {
+      this.capacity = size;
+    }
+
+    void add(int v) {
+      if (list.size() == capacity) {
+        list.removeFirst();
+      }
+      list.add(v);
+    }
+
+    int size() {
+      return list.size();
+    }
+
+    int get(int index) {
+      return list.get(index);
+    }
+  }
+
+  private static final int PREFFERED_WIDTH = 60;
+  private static final int PREFFERED_HEIGHT = 16;
+
+  private static final Color GRAPH_COLOR = JBColor.LIGHT_GRAY;
+  private static final Stroke GRAPH_STROKE = new BasicStroke(2f);
+
+  private final IntCache measures = new IntCache(30);
+
+  public HeapDisplay() {
+    setVisible(true);
+  }
+
+  public void addMeasure(int measure) {
+    measures.add(measure);
+  }
+
+  @Override
+  protected void paintComponent(Graphics g) {
+    super.paintComponent(g);
+
+    final Graphics2D graphics2D = (Graphics2D)g;
+    graphics2D.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+
+    final List<Point> graphPoints = new ArrayList<>();
+    for (int i = 0; i < measures.size(); i++) {
+      graphPoints.add(new Point(i * 3, measures.get(i)));
+    }
+
+    graphics2D.setColor(GRAPH_COLOR);
+    graphics2D.setStroke(GRAPH_STROKE);
+
+    for (int i = 0; i < graphPoints.size() - 1; i++) {
+      final Point p1 = graphPoints.get(i);
+      final Point p2 = graphPoints.get(i + 1);
+      graphics2D.drawLine(p1.x, p1.y, p2.x, p2.y);
+    }
+  }
+
+  @Override
+  public Dimension getPreferredSize() {
+    return new Dimension(PREFFERED_WIDTH, PREFFERED_HEIGHT);
+  }
+}

--- a/src/io/flutter/perf/HeapMonitor.java
+++ b/src/io/flutter/perf/HeapMonitor.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2018 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.perf;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.intellij.openapi.diagnostic.Logger;
+import com.jetbrains.lang.dart.ide.runner.server.vmService.IsolatesInfo;
+import io.flutter.run.FlutterDebugProcess;
+import org.dartlang.vm.service.VmService;
+import org.dartlang.vm.service.consumer.GetIsolateConsumer;
+import org.dartlang.vm.service.element.Isolate;
+import org.dartlang.vm.service.element.Obj;
+import org.dartlang.vm.service.element.RPCError;
+import org.dartlang.vm.service.element.Sentinel;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.*;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+// TODO(pq): handle GC events
+// TODO(pq): improve error handling
+public class HeapMonitor {
+
+  private static final Logger LOG = Logger.getInstance(HeapMonitor.class);
+
+  private static final int POLL_PERIOD_IN_MS = 1000;
+
+  public interface HeapListener {
+    void update(List<IsolateObject> isolates);
+  }
+
+  static class HeapObject extends Obj {
+    HeapObject(@NotNull JsonObject json) {
+      super(json);
+    }
+
+    int getAsInt(String memberName) {
+      return json.get(memberName).getAsInt();
+    }
+
+    String getAsString(String memberName) {
+      return json.get(memberName).getAsString();
+    }
+
+    JsonObject getAsJsonObject(String memberName) {
+      return json.get(memberName).getAsJsonObject();
+    }
+
+    Set<Map.Entry<String, JsonElement>> getEntries(String memberName) {
+      return getAsJsonObject(memberName).entrySet();
+    }
+  }
+
+  public static class HeapSpace extends HeapObject {
+    HeapSpace(@NotNull JsonObject json) {
+      super(json);
+    }
+
+    public int getUsed() {
+      return getAsInt("used");
+    }
+
+    public int getCapacity() {
+      return getAsInt("capacity");
+    }
+
+    public int getExternal() {
+      return getAsInt("external");
+    }
+  }
+
+  public static class IsolateObject extends HeapObject {
+    IsolateObject(@NotNull JsonObject json) {
+      super(json);
+    }
+
+    public Iterable<HeapSpace> getHeaps() {
+      final List<HeapSpace> heaps = new ArrayList<>();
+      for (Map.Entry<String, JsonElement> entry : getEntries("_heaps")) {
+        heaps.add(new HeapSpace(entry.getValue().getAsJsonObject()));
+      }
+      return heaps;
+    }
+  }
+
+  public static class HeapSample {
+    final int bytes;
+    final boolean isGC;
+
+    public HeapSample(int bytes, boolean isGC) {
+      this.bytes = bytes;
+      this.isGC = isGC;
+    }
+
+    public int getBytes() {
+      return bytes;
+    }
+
+    @Override
+    public String toString() {
+      return "bytes: " + bytes + (isGC ? " (GC)" : "");
+    }
+  }
+
+  private final ScheduledExecutorService executor = Executors.newScheduledThreadPool(1);
+  private final List<HeapMonitor.HeapListener> heapListeners = new ArrayList<>();
+
+  @NotNull
+  private final VmService vmService;
+  @NotNull
+  private final FlutterDebugProcess debugProcess;
+
+  public HeapMonitor(@NotNull VmService vmService, @NotNull FlutterDebugProcess debugProcess) {
+    this.vmService = vmService;
+    this.debugProcess = debugProcess;
+  }
+
+  public void addListener(@NotNull HeapMonitor.HeapListener listener) {
+    heapListeners.add(listener);
+  }
+
+  public void removeListener(@NotNull HeapMonitor.HeapListener listener) {
+    heapListeners.add(listener);
+  }
+
+  void start() {
+    executor.scheduleAtFixedRate(this::poll, 0, POLL_PERIOD_IN_MS, TimeUnit.MILLISECONDS);
+  }
+
+  private void poll() {
+
+    final Collection<IsolatesInfo.IsolateInfo> isolateInfos = debugProcess.getIsolateInfos();
+    // Stash count so we can know when we've processed them all.
+    final int isolateCount = isolateInfos.size();
+
+    final List<IsolateObject> isolates = new ArrayList<>();
+    for (IsolatesInfo.IsolateInfo info : isolateInfos) {
+      vmService.getIsolate(info.getIsolateId(), new GetIsolateConsumer() {
+        @Override
+        public void received(Isolate isolateResponse) {
+          isolates.add(new IsolateObject(isolateResponse.getJson()));
+
+          // Only update when we're done collecting from all isolates.
+          if (isolates.size() == isolateCount) {
+            notifyListeners(isolates);
+          }
+        }
+
+        @Override
+        public void received(Sentinel sentinel) {
+          // Ignored.
+        }
+
+        @Override
+        public void onError(RPCError error) {
+          // TODO(pq): handle?
+        }
+      });
+    }
+  }
+
+  private void notifyListeners(List<IsolateObject> isolates) {
+    heapListeners.forEach(listener -> listener.update(isolates));
+  }
+
+  void stop() {
+    try {
+      if (!executor.isShutdown()) {
+        executor.shutdown();
+      }
+    }
+    catch (SecurityException e) {
+      // TODO(pq): ignore?
+      LOG.warn(e);
+    }
+  }
+}

--- a/src/io/flutter/perf/PerfService.java
+++ b/src/io/flutter/perf/PerfService.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2018 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.perf;
+
+import io.flutter.perf.HeapMonitor.HeapListener;
+import io.flutter.run.FlutterDebugProcess;
+import io.flutter.utils.VmServiceListenerAdapter;
+import org.dartlang.vm.service.VmService;
+import org.dartlang.vm.service.VmServiceListener;
+import org.dartlang.vm.service.element.Event;
+import org.jetbrains.annotations.NotNull;
+
+// TODO(pq): rename
+// TODO(pq): improve error handling
+// TODO(pq): change mode for opting in (preference or inspector view menu)
+public class PerfService {
+
+  // Enable to see experimental heap status panel in the inspector view.
+  public static final boolean DISPLAY_HEAP_USE = false;
+
+  private final VmServiceListener vmServiceListener = new VmServiceListenerAdapter() {
+    @Override
+    public void received(String streamId, Event event) {
+      onVmServiceReceived(streamId, event);
+    }
+    @Override
+    public void connectionClosed() {
+      onVmConnectionClosed();
+    }
+  };
+
+  @NotNull
+  private final HeapMonitor heapMonitor;
+  @NotNull
+  private final VmService vmService;
+
+  private boolean isRunning;
+
+  public PerfService(@NotNull FlutterDebugProcess debugProcess, @NotNull VmService vmService) {
+    this.heapMonitor = new HeapMonitor(vmService, debugProcess);
+    this.vmService = vmService;
+  }
+
+  /**
+   * Start the Perf service.
+   */
+  public void start() {
+    if (!isRunning) {
+      // Start polling.
+      vmService.addVmServiceListener(vmServiceListener);
+      heapMonitor.start();
+      isRunning = true;
+    }
+  }
+
+  /**
+   * Stop the Perf service.
+   */
+  public void stop() {
+    if (isRunning) {
+      // The vmService does not have a way to remove listeners, so we can only stop paying attention.
+      heapMonitor.stop();
+    }
+  }
+
+  private void onVmConnectionClosed() {
+    if (isRunning) {
+      heapMonitor.stop();
+    }
+  }
+
+  @SuppressWarnings("EmptyMethod")
+  private void onVmServiceReceived(String id, Event event) {
+    // TODO(pq): handle receive -- errors in particular.
+  }
+
+  /**
+   * Add a listener for heap state updates.
+   */
+  public void addListener(@NotNull HeapListener listener) {
+    heapMonitor.addListener(listener);
+  }
+
+  /**
+   * Remove a heap listener.
+   */
+  public void removeListener(@NotNull HeapListener listener) {
+    heapMonitor.removeListener(listener);
+  }
+}

--- a/src/io/flutter/run/daemon/FlutterApp.java
+++ b/src/io/flutter/run/daemon/FlutterApp.java
@@ -26,6 +26,7 @@ import com.intellij.util.concurrency.AppExecutorUtil;
 import com.jetbrains.lang.dart.ide.runner.ObservatoryConnector;
 import io.flutter.FlutterInitializer;
 import io.flutter.inspector.InspectorService;
+import io.flutter.perf.PerfService;
 import io.flutter.pub.PubRoot;
 import io.flutter.pub.PubRoots;
 import io.flutter.run.FlutterDebugProcess;
@@ -75,6 +76,7 @@ public class FlutterApp {
   private FlutterDebugProcess myFlutterDebugProcess;
   private VmService myVmService;
   private InspectorService myInspectorService;
+  private PerfService myPerfService;
 
   FlutterApp(@NotNull Project project,
              @Nullable Module module,
@@ -479,6 +481,15 @@ public class FlutterApp {
 
   public void setInspectorService(InspectorService service) {
     myInspectorService = service;
+  }
+
+  @Nullable
+  public PerfService getPerfService() {
+    return myPerfService;
+  }
+
+  public void setPerfService(PerfService perfService) {
+    myPerfService = perfService;
   }
 
   @NotNull

--- a/src/io/flutter/view/FlutterViewMessages.java
+++ b/src/io/flutter/view/FlutterViewMessages.java
@@ -8,6 +8,7 @@ package io.flutter.view;
 import com.intellij.openapi.project.Project;
 import com.intellij.util.messages.MessageBus;
 import com.intellij.util.messages.Topic;
+import io.flutter.perf.PerfService;
 import io.flutter.run.daemon.FlutterApp;
 import io.flutter.inspector.InspectorService;
 import org.dartlang.vm.service.VmService;
@@ -42,6 +43,7 @@ public class FlutterViewMessages {
     app.setVmService(vmService);
     assert(app.getFlutterDebugProcess() != null);
     app.setInspectorService( new InspectorService(app.getFlutterDebugProcess(), vmService));
+    app.setPerfService(new PerfService(app.getFlutterDebugProcess(), vmService));
     publisher.debugActive(new FlutterDebugEvent(app, vmService));
   }
 }


### PR DESCRIPTION
A work in progress but ready for iteration.

Currently enabled with a compile time flag (`PerfService. DISPLAY_HEAP_USE`) but will be promoted to a preference or menu enablement down the road.  Lots of TODOs captured in the source.

Disabled state:

![image](https://user-images.githubusercontent.com/67586/37482767-50d16a6a-2842-11e8-85fb-d7f6668c41d0.png)

Enabled:

![image](https://user-images.githubusercontent.com/67586/37482829-7bddfd18-2842-11e8-8241-1d9c7e5ca8b3.png)

(This is the sample app and so not a lot of heap use; nonetheless, scaling needs work and that dip is odd.)

Lots of next steps documented in the source but a few immediate ones include:

* tweaking scaling
* refactoring value caching
* adding a label for current/total heap
* handling GCs
* consolidating observatory actions into the panel (maybe into one combined over-flow style action)

@devoncarew 
