### PR TITLE
some tweaks to the memory usage view

### DIFF
--- a/src/io/flutter/inspector/HeapDisplay.java
+++ b/src/io/flutter/inspector/HeapDisplay.java
@@ -13,6 +13,7 @@ import com.intellij.openapi.actionSystem.ex.CustomComponentAction;
 import com.intellij.openapi.util.Disposer;
 import com.intellij.ui.JBColor;
 import com.intellij.util.ui.JBUI;
+import io.flutter.perf.HeapMonitor;
 import io.flutter.perf.HeapMonitor.HeapListener;
 import io.flutter.perf.HeapMonitor.HeapSample;
 import io.flutter.perf.HeapMonitor.HeapSpace;
@@ -20,26 +21,25 @@ import io.flutter.perf.HeapMonitor.IsolateObject;
 import io.flutter.perf.PerfService;
 import io.flutter.run.daemon.FlutterApp;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 import java.awt.*;
-import java.util.*;
+import java.text.DecimalFormat;
+import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 
 // TODO(pq): make capacity setting dynamic
-// TODO(pq): add label displaying curent/total heap use
+// TODO(pq): add label displaying current/total heap use
 // TODO(pq): handle GCs
-// TODO(pq): tweak scaling
-// TODO(pq): fix duplicate value caching (remove int cache from graph)
 public class HeapDisplay extends JPanel {
 
   public static class ToolbarComponentAction extends AnAction implements CustomComponentAction, HeapListener, Disposable {
-
     private final List<JPanel> panels = new ArrayList<>();
     private final List<HeapDisplay> graphs = new ArrayList<>();
 
-    // TODO(pq): be smart about setting capacity based on available width.
-    final HeapState heapState = new HeapState(30);
+    final HeapState heapState = new HeapState(20 * 1000);
 
     public ToolbarComponentAction(@NotNull Disposable parent, @NotNull FlutterApp app) {
       final PerfService service = app.getPerfService();
@@ -82,153 +82,147 @@ public class HeapDisplay extends JPanel {
     @Override
     public void update(List<IsolateObject> isolates) {
       heapState.update(isolates);
+
       for (HeapDisplay graph : graphs) {
-        // TODO(pq): stop storing points in the graph and just use the samples directly.
-        heapState.getSamples().forEach(sample -> graph.addMeasure(scale(heapState, sample)));
+        graph.updateFrom(heapState);
       }
+
       panels.forEach(panel -> SwingUtilities.invokeLater(panel::repaint));
     }
   }
 
-  /**
-   * A fixed-length list of captured samples.
-   */
-  public static class HeapSamples {
-    private final LinkedList<HeapSample> samples = new LinkedList<>();
-    private final int capacity;
-
-    HeapSamples(int size) {
-      this.capacity = size;
-    }
-
-    void add(HeapSample sample) {
-      if (samples.size() == capacity) {
-        samples.removeFirst();
-      }
-      samples.add(sample);
-    }
-
-    int size() {
-      return samples.size();
-    }
-
-    HeapSample get(int index) {
-      return samples.get(index);
-    }
-  }
-
-  public static class HeapState implements HeapListener {
-    // Running count of the max heap (in bytes).
-    private int heapMaxInBytes;
-
-    private final HeapSamples samples;
-
-    HeapState(int sampleCapacity) {
-      samples = new HeapSamples(sampleCapacity);
-    }
-
-    public Iterable<HeapSample> getSamples() {
-      return samples.samples;
-    }
-
-    public int getMaxHeapInBytes() {
-      return heapMaxInBytes;
-    }
-
-    void addSample(HeapSample sample) {
-      samples.add(sample);
-    }
-
-    @Override
-    public void update(List<IsolateObject> isolates) {
-      int current = 0;
-      int total = 0;
-
-      for (IsolateObject isolate : isolates) {
-        for (HeapSpace heap : isolate.getHeaps()) {
-          current += heap.getUsed() + heap.getExternal();
-          total += heap.getCapacity() + heap.getExternal();
-        }
-      }
-
-      heapMaxInBytes = total;
-      addSample(new HeapSample(current, false));
-    }
-  }
-
   private static final int TEN_MB = 1024 * 1024 * 10;
-  private static final double GRAPH_PIXEL_HIGHT = 16.0;
-
-  private static int scale(HeapState state, HeapSample sample) {
-    final double maxDataSize = (Math.round(state.getMaxHeapInBytes() / TEN_MB)) * TEN_MB + TEN_MB;
-    return (int)(GRAPH_PIXEL_HIGHT * sample.getBytes() / maxDataSize);
-  }
-
-  // TODO(pq): remove in favor of just using the HeapSamples directly.
-  static class IntCache {
-    final LinkedList<Integer> list = new LinkedList<>();
-    private final int capacity;
-
-    IntCache(int size) {
-      this.capacity = size;
-    }
-
-    void add(int v) {
-      if (list.size() == capacity) {
-        list.removeFirst();
-      }
-      list.add(v);
-    }
-
-    int size() {
-      return list.size();
-    }
-
-    int get(int index) {
-      return list.get(index);
-    }
-  }
 
   private static final int PREFFERED_WIDTH = 60;
   private static final int PREFFERED_HEIGHT = 16;
 
-  private static final Color GRAPH_COLOR = JBColor.LIGHT_GRAY;
   private static final Stroke GRAPH_STROKE = new BasicStroke(2f);
 
-  private final IntCache measures = new IntCache(30);
+  private static final DecimalFormat df = new DecimalFormat();
+
+  static {
+    df.setMaximumFractionDigits(1);
+  }
+
+  private @Nullable HeapState heapState;
 
   public HeapDisplay() {
     setVisible(true);
   }
 
-  public void addMeasure(int measure) {
-    measures.add(measure);
+  private void updateFrom(HeapState state) {
+    this.heapState = state;
+
+    if (!heapState.getSamples().isEmpty()) {
+      final HeapSample sample = heapState.getSamples().get(0);
+      setToolTipText(printMb(sample.getBytes()) + " of " + printMb(heapState.getMaxHeapInBytes()));
+    }
+  }
+
+  private static String printMb(int bytes) {
+    return df.format(bytes / (1024 * 1024.0)) + "MB";
   }
 
   @Override
   protected void paintComponent(Graphics g) {
     super.paintComponent(g);
 
+    if (heapState == null) {
+      return;
+    }
+
+    final int height = getHeight();
+    final int width = getWidth();
+    final long now = System.currentTimeMillis();
+
+    final double maxDataSize = (Math.round(heapState.getMaxHeapInBytes() / TEN_MB)) * TEN_MB + TEN_MB;
+
     final Graphics2D graphics2D = (Graphics2D)g;
     graphics2D.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
 
     final List<Point> graphPoints = new ArrayList<>();
-    for (int i = 0; i < measures.size(); i++) {
-      graphPoints.add(new Point(i * 3, measures.get(i)));
+    for (HeapSample sample : heapState.getSamples()) {
+      final int x = width - (int)(((double)(now - sample.getSampleTime())) / ((double)heapState.getMaxSampleSizeMs()) * width);
+      final int y = (int)(height * sample.getBytes() / maxDataSize);
+      graphPoints.add(new Point(x, y));
     }
 
-    graphics2D.setColor(GRAPH_COLOR);
+    graphics2D.setColor(JBColor.LIGHT_GRAY);
     graphics2D.setStroke(GRAPH_STROKE);
 
     for (int i = 0; i < graphPoints.size() - 1; i++) {
       final Point p1 = graphPoints.get(i);
       final Point p2 = graphPoints.get(i + 1);
-      graphics2D.drawLine(p1.x, p1.y, p2.x, p2.y);
+      graphics2D.drawLine(p1.x, height - p1.y, p2.x, height - p2.y);
     }
   }
 
   @Override
   public Dimension getPreferredSize() {
     return new Dimension(PREFFERED_WIDTH, PREFFERED_HEIGHT);
+  }
+}
+
+/**
+ * A fixed-length list of captured samples.
+ */
+class HeapSamples {
+  final LinkedList<HeapSample> samples = new LinkedList<>();
+  final int maxSampleSizeMs;
+
+  HeapSamples(int maxSampleSizeMs) {
+    this.maxSampleSizeMs = maxSampleSizeMs;
+  }
+
+  void add(HeapMonitor.HeapSample sample) {
+    samples.add(sample);
+
+    final long oldestTime = System.currentTimeMillis() - maxSampleSizeMs;
+    while (!samples.isEmpty() && samples.get(0).getSampleTime() < oldestTime) {
+      samples.removeFirst();
+    }
+  }
+}
+
+class HeapState implements HeapListener {
+  // Running count of the max heap (in bytes).
+  private int heapMaxInBytes;
+
+  private final HeapSamples samples;
+
+  HeapState(int maxSampleSizeMs) {
+    samples = new HeapSamples(maxSampleSizeMs);
+  }
+
+  public int getMaxSampleSizeMs() {
+    return samples.maxSampleSizeMs;
+  }
+
+  public List<HeapSample> getSamples() {
+    return samples.samples;
+  }
+
+  public int getMaxHeapInBytes() {
+    return heapMaxInBytes;
+  }
+
+  void addSample(HeapSample sample) {
+    samples.add(sample);
+  }
+
+  @Override
+  public void update(List<IsolateObject> isolates) {
+    int current = 0;
+    int total = 0;
+
+    for (IsolateObject isolate : isolates) {
+      for (HeapSpace heap : isolate.getHeaps()) {
+        current += heap.getUsed() + heap.getExternal();
+        total += heap.getCapacity() + heap.getExternal();
+      }
+    }
+
+    heapMaxInBytes = total;
+    addSample(new HeapSample(current, false));
   }
 }

--- a/src/io/flutter/perf/HeapMonitor.java
+++ b/src/io/flutter/perf/HeapMonitor.java
@@ -26,7 +26,6 @@ import java.util.concurrent.TimeUnit;
 // TODO(pq): handle GC events
 // TODO(pq): improve error handling
 public class HeapMonitor {
-
   private static final Logger LOG = Logger.getInstance(HeapMonitor.class);
 
   private static final int POLL_PERIOD_IN_MS = 1000;
@@ -93,9 +92,17 @@ public class HeapMonitor {
     final int bytes;
     final boolean isGC;
 
+    public long getSampleTime() {
+      return sampleTime;
+    }
+
+    final long sampleTime;
+
     public HeapSample(int bytes, boolean isGC) {
       this.bytes = bytes;
       this.isGC = isGC;
+
+      this.sampleTime = System.currentTimeMillis();
     }
 
     public int getBytes() {
@@ -134,7 +141,6 @@ public class HeapMonitor {
   }
 
   private void poll() {
-
     final Collection<IsolatesInfo.IsolateInfo> isolateInfos = debugProcess.getIsolateInfos();
     // Stash count so we can know when we've processed them all.
     final int isolateCount = isolateInfos.size();

--- a/src/io/flutter/perf/PerfService.java
+++ b/src/io/flutter/perf/PerfService.java
@@ -17,7 +17,6 @@ import org.jetbrains.annotations.NotNull;
 // TODO(pq): improve error handling
 // TODO(pq): change mode for opting in (preference or inspector view menu)
 public class PerfService {
-
   // Enable to see experimental heap status panel in the inspector view.
   public static final boolean DISPLAY_HEAP_USE = false;
 
@@ -26,6 +25,7 @@ public class PerfService {
     public void received(String streamId, Event event) {
       onVmServiceReceived(streamId, event);
     }
+
     @Override
     public void connectionClosed() {
       onVmConnectionClosed();


### PR DESCRIPTION
A follow up to https://github.com/flutter/flutter-intellij/pull/1921, some tweaks to the memory usage view:

- track and graph samples by sample time (setting us up to be able to record GC events)
- dock the view samples to the right, so the samples always grow out of the right hand side
- switch the y axis (to account for the swing coordinate system)
- add a tooltip for the memory used

@pq 