### PR TITLE
More incremental work for commented out Bazel test run config, new --enable-debugging flag

### DIFF
--- a/src/io/flutter/run/bazelTest/BazelTestFields.java
+++ b/src/io/flutter/run/bazelTest/BazelTestFields.java
@@ -227,16 +227,11 @@ public class BazelTestFields {
     commandLine.setCharset(CharsetToolkit.UTF8_CHARSET);
     commandLine.setExePath(FileUtil.toSystemDependentName(launchingScript));
 
-    // Set the mode.
-    // TODO (jwren) what should we send, anything?  When should we specify?
-    commandLine.addParameters("--define", "flutter_build_mode=" + mode.name());
-    //if(mode == RunMode.DEBUG) {
-    //  commandLine.addParameters("--define", "flutter_build_mode=" + mode.name());
-    //} else {//(mode != RunMode.DEBUG) {
-    //  commandLine.addParameters("--define", "flutter_build_mode=" + mode.name());
-    //}
-
     commandLine.addParameter(target);
+
+    if (mode == RunMode.DEBUG) {
+      commandLine.addParameters("--", "--enable-debugging");
+    }
     return commandLine;
   }
 }


### PR DESCRIPTION
Pass the new flag --enable-debugging as the last parameter, after the target, in the Flutter Test (Bazel) run configuration