### PR TITLE
Open plugin modules in AS

### DIFF
--- a/flutter-studio/flutter-studio.iml
+++ b/flutter-studio/flutter-studio.iml
@@ -24,6 +24,7 @@
     <orderEntry type="module" module-name="lang-impl" />
     <orderEntry type="module" module-name="xdebugger-api" />
     <orderEntry type="module" module-name="idea-ui" />
+    <orderEntry type="module" module-name="gradle" />
     <orderEntry type="module" module-name="android-uitests" scope="TEST" />
     <orderEntry type="module" module-name="fest-swing" scope="TEST" />
     <orderEntry type="module" module-name="testFramework" scope="TEST" />
@@ -31,7 +32,6 @@
     <orderEntry type="module" module-name="android-test-framework" scope="TEST" />
     <orderEntry type="module" module-name="external-system-rt" scope="TEST" />
     <orderEntry type="module" module-name="designer" scope="TEST" />
-    <orderEntry type="module" module-name="gradle" scope="TEST" />
     <orderEntry type="library" scope="TEST" name="truth" level="project" />
     <orderEntry type="module" module-name="flutter-intellij-community" />
     <orderEntry type="module" module-name="project-system" />

--- a/flutter-studio/src/io/flutter/actions/OpenAndroidModule.java
+++ b/flutter-studio/src/io/flutter/actions/OpenAndroidModule.java
@@ -17,11 +17,11 @@ import com.intellij.util.BitUtil;
 import io.flutter.FlutterMessages;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.plugins.gradle.util.GradleConstants;
 
 import java.awt.event.InputEvent;
 
 import static com.android.tools.idea.gradle.project.ProjectImportUtil.findImportTarget;
-import static com.android.tools.idea.gradle.util.GradleProjects.canImportAsGradleProject;
 import static com.intellij.ide.impl.ProjectUtil.*;
 
 /**
@@ -54,6 +54,11 @@ public class OpenAndroidModule extends OpenInAndroidStudioAction implements Dumb
       }
     }
     openOrImport(file.getPath(), project, false);
+  }
+
+  public static boolean canImportAsGradleProject(@NotNull VirtualFile importSource) {
+    VirtualFile target = findImportTarget(importSource);
+    return target != null && GradleConstants.EXTENSION.equals(target.getExtension());
   }
 
   @Override

--- a/flutter-studio/src/io/flutter/actions/OpenAndroidModule.java
+++ b/flutter-studio/src/io/flutter/actions/OpenAndroidModule.java
@@ -5,24 +5,57 @@
  */
 package io.flutter.actions;
 
-import com.intellij.ide.impl.ProjectUtil;
+import com.android.tools.idea.gradle.project.importing.GradleProjectImporter;
+import com.intellij.ide.GeneralSettings;
 import com.intellij.openapi.actionSystem.ActionPlaces;
-import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectManager;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.util.BitUtil;
 import io.flutter.FlutterMessages;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.awt.event.InputEvent;
+
+import static com.android.tools.idea.gradle.project.ProjectImportUtil.findImportTarget;
+import static com.android.tools.idea.gradle.util.GradleProjects.canImportAsGradleProject;
+import static com.intellij.ide.impl.ProjectUtil.*;
 
 /**
  * Open the selected module in Android Studio, re-using the current process
  * rather than spawning a new process (as IntelliJ does).
  */
 public class OpenAndroidModule extends OpenInAndroidStudioAction implements DumbAware {
+  private static void openOrImportProject(@NotNull VirtualFile file, @Nullable Project project, boolean forceOpenInNewFrame) {
+    // This is very similar to AndroidOpenFileAction.openOrImportProject().
+    if (canImportAsGradleProject(file)) {
+      VirtualFile target = findImportTarget(file);
+      if (target != null) {
+        Project[] openProjects = ProjectManager.getInstance().getOpenProjects();
+        if (openProjects.length > 0) {
+          int exitCode = forceOpenInNewFrame ? GeneralSettings.OPEN_PROJECT_NEW_WINDOW : confirmOpenNewProject(false);
+          if (exitCode == GeneralSettings.OPEN_PROJECT_SAME_WINDOW) {
+            Project toClose = ((project != null) && !project.isDefault()) ? project : openProjects[openProjects.length - 1];
+            if (!closeAndDispose(toClose)) {
+              return;
+            }
+          }
+          else if (exitCode != GeneralSettings.OPEN_PROJECT_NEW_WINDOW) {
+            return;
+          }
+        }
+
+        GradleProjectImporter gradleImporter = GradleProjectImporter.getInstance();
+        gradleImporter.importProject(file);
+        return;
+      }
+    }
+    openOrImport(file.getPath(), project, false);
+  }
+
   @Override
   public void actionPerformed(AnActionEvent e) {
     final VirtualFile projectFile = findProjectFile(e);
@@ -36,6 +69,9 @@ public class OpenAndroidModule extends OpenInAndroidStudioAction implements Dumb
                                         || BitUtil.isSet(modifiers, InputEvent.SHIFT_MASK)
                                         || e.getPlace() == ActionPlaces.WELCOME_SCREEN;
 
-    ProjectUtil.openOrImport(projectFile.getPath(), e.getProject(), forceOpenInNewFrame);
+    // Using:
+    //ProjectUtil.openOrImport(projectFile.getPath(), e.getProject(), forceOpenInNewFrame);
+    // presents the user with a really imposing Gradle project import dialog.
+    openOrImportProject(projectFile, e.getProject(), forceOpenInNewFrame);
   }
 }

--- a/flutter-studio/src/io/flutter/project/FlutterProjectModel.java
+++ b/flutter-studio/src/io/flutter/project/FlutterProjectModel.java
@@ -140,6 +140,9 @@ public class FlutterProjectModel extends WizardModel {
     assert (!myProjectName.get().isEmpty());
     assert (!myFlutterSdk.get().isEmpty());
     assert (!location.isEmpty());
+    if (location.endsWith("/")) {
+      location = location.substring(0, location.length() - 1);
+    }
     if (!FlutterProjectCreator.finalValidityCheckPassed(location)) {
       // TODO(messick): Navigate to the step that sets location (if that becomes possible in the AS wizard framework).
       // See NewProjectModel.doDryRun();

--- a/src/io/flutter/actions/OpenInAndroidStudioAction.java
+++ b/src/io/flutter/actions/OpenInAndroidStudioAction.java
@@ -124,10 +124,13 @@ public class OpenInAndroidStudioAction extends AnAction {
     return null;
   }
 
+  // Return true if the directory is named android and contains either an app (for applications) or a src (for plugins) directory.
   private static boolean isAndroidWithApp(@NotNull VirtualFile file) {
     return file.getName().equals("android") && (file.findChild("app") != null || file.findChild("src") != null);
   }
 
+  // Return true if the directory has the structure of a plugin example application: a pubspec.yaml and an
+  // android directory with an app. The example app directory name is not specified in case it gets renamed.
   private static boolean isExampleWithAndroidWithApp(@NotNull VirtualFile file) {
     boolean hasPubspec = false;
     boolean hasAndroid = false;
@@ -141,10 +144,9 @@ public class OpenInAndroidStudioAction extends AnAction {
     return false;
   }
 
-  // A Flutter app may contain a plugin. Which project to open if menu invoked on root?
   // A plugin contains an example app, which needs to be opened when the native Android is to be edited.
   // In the case of an app that contains a plugin the flutter_app/flutter_plugin/example/android should be opened when
-  // Open in Android Studio is requested for anything in the plugin, and flutter_app/android for the app.
+  // 'Open in Android Studio' is requested.
   protected static VirtualFile findProjectFile(@Nullable AnActionEvent e) {
     if (e != null) {
       final VirtualFile file = CommonDataKeys.VIRTUAL_FILE.getData(e.getDataContext());
@@ -159,7 +161,7 @@ public class OpenInAndroidStudioAction extends AnAction {
             VirtualFile aFile = file;
             while (aFile != null) {
               if (aFile.equals(rootFile)) {
-                // We know a plugin resource is selected. Find the eample app for it.
+                // We know a plugin resource is selected. Find the example app for it.
                 for (VirtualFile child : rootFile.getChildren()) {
                   if (isExampleWithAndroidWithApp(child)) {
                     return child.findChild("android");

--- a/src/io/flutter/actions/OpenInAndroidStudioAction.java
+++ b/src/io/flutter/actions/OpenInAndroidStudioAction.java
@@ -42,7 +42,7 @@ public class OpenInAndroidStudioAction extends AnAction {
       final OSProcessHandler handler = new OSProcessHandler(cmd);
       handler.addProcessListener(new ProcessAdapter() {
         @Override
-        public void processTerminated(final ProcessEvent event) {
+        public void processTerminated(@NotNull final ProcessEvent event) {
           if (event.getExitCode() != 0) {
             FlutterMessages.showError("Error Opening", file.getPath());
           }
@@ -125,19 +125,60 @@ public class OpenInAndroidStudioAction extends AnAction {
   }
 
   private static boolean isAndroidWithApp(@NotNull VirtualFile file) {
-    return file.getName().equals("android") && file.findChild("app") != null;
+    return file.getName().equals("android") && (file.findChild("app") != null || file.findChild("src") != null);
   }
 
+  private static boolean isExampleWithAndroidWithApp(@NotNull VirtualFile file) {
+    boolean hasPubspec = false;
+    boolean hasAndroid = false;
+    for (VirtualFile candidate : file.getChildren()) {
+      if (isAndroidWithApp(candidate)) hasAndroid = true;
+      if (candidate.getName().equals("pubspec.yaml")) hasPubspec = true;
+      if (hasAndroid && hasPubspec) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  // A Flutter app may contain a plugin. Which project to open if menu invoked on root?
+  // A plugin contains an example app, which needs to be opened when the native Android is to be edited.
+  // In the case of an app that contains a plugin the flutter_app/flutter_plugin/example/android should be opened when
+  // Open in Android Studio is requested for anything in the plugin, and flutter_app/android for the app.
   protected static VirtualFile findProjectFile(@Nullable AnActionEvent e) {
     if (e != null) {
       final VirtualFile file = CommonDataKeys.VIRTUAL_FILE.getData(e.getDataContext());
       if (file != null && file.exists()) {
+        // We have a selection. Check if it is within a plugin.
+        final Project project = e.getProject();
+        assert (project != null);
+        final VirtualFile projectDir = project.getBaseDir();
+        for (PubRoot root : PubRoots.forProject(project)) {
+          if (root.isFlutterPlugin()) {
+            VirtualFile rootFile = root.getRoot();
+            VirtualFile aFile = file;
+            while (aFile != null) {
+              if (aFile.equals(rootFile)) {
+                // We know a plugin resource is selected. Find the eample app for it.
+                for (VirtualFile child : rootFile.getChildren()) {
+                  if (isExampleWithAndroidWithApp(child)) {
+                    return child.findChild("android");
+                  }
+                }
+              }
+              if (aFile.equals(projectDir)) {
+                aFile = null;
+              }
+              else {
+                aFile = aFile.getParent();
+              }
+            }
+          }
+        }
         if (isProjectFileName(file.getName())) {
           return getProjectForFile(file);
         }
 
-        final Project project = e.getProject();
-        assert (project != null);
         // Return null if this is an ios folder.
         if (FlutterExternalIdeActionGroup.isWithinIOsDirectory(file, project)) {
           return null;


### PR DESCRIPTION
`Open Android module in Android Studio` needs special handling when working with plugins. There are two Android modules, one for the plugin and another for the example app. However, opening the plugin's module directly is not useful since class paths are not set correctly. Therefore, always open the module defined by the example app when editing Android modules in plugins.

There are some side-issues here. We don't want to display the Gradle project-import dialog, which asks for the location of Gradle. That's solved. What isn't solved is the way the importer changes the default project creation location. After opening a module, new Flutter projects default to that modules's location for their default directory. Fixing that problem will come later.

Fixes https://github.com/flutter/flutter-intellij/issues/1936

@pq @devoncarew 