### PR TITLE
Use Color.BLUE for selection feedback.

### DIFF
--- a/src/io/flutter/preview/MoveHandle.java
+++ b/src/io/flutter/preview/MoveHandle.java
@@ -5,8 +5,6 @@
  */
 package io.flutter.preview;
 
-import com.intellij.ui.JBColor;
-
 import java.awt.*;
 
 /**
@@ -16,8 +14,11 @@ public class MoveHandle extends Handle {
   @Override
   public void paint(Graphics g) {
     final Graphics2D g2 = (Graphics2D)g;
-    g2.setStroke(new BasicStroke(2));
-    g2.setColor(JBColor.BLUE);
+
+    //noinspection UseJBColor
+    g2.setColor(Color.BLUE);
+
+    g2.setStroke(new BasicStroke(3));
     g2.drawRect(0, 0, getWidth(), getHeight());
   }
 


### PR DESCRIPTION
I tried several colors, including list/tree selection background.

Unfortunately list/tree selection colors look well for large rectangles, but not for thin lines - they are hardly distinguishable from the color we use for colors rectangle borders.

![image](https://user-images.githubusercontent.com/384794/37679549-752290c4-2c3e-11e8-89de-1f9607f3d596.png)

![image](https://user-images.githubusercontent.com/384794/37679499-573f584e-2c3e-11e8-83fb-5a41ac29463b.png)
