### PR TITLE
Icon completion improvements.

### DIFF
--- a/src/io/flutter/editor/FlutterCompletionContributor.java
+++ b/src/io/flutter/editor/FlutterCompletionContributor.java
@@ -6,7 +6,9 @@
 package io.flutter.editor;
 
 import com.intellij.codeInsight.lookup.LookupElementBuilder;
+import com.intellij.icons.AllIcons;
 import com.intellij.openapi.project.Project;
+import com.intellij.util.ReflectionUtil;
 import com.intellij.util.ui.ColorIcon;
 import com.intellij.util.ui.JBUI;
 import com.jetbrains.lang.dart.ide.completion.DartCompletionExtension;
@@ -18,6 +20,8 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.Objects;
 
 
@@ -27,11 +31,20 @@ public class FlutterCompletionContributor extends DartCompletionExtension {
   public LookupElementBuilder createLookupElement(@NotNull final Project project, @NotNull final CompletionSuggestion suggestion) {
     final Icon icon = findIcon(suggestion);
     if (icon != null) {
-      final LookupElementBuilder lookup = DartServerCompletionContributor.createLookupElement(project, suggestion);
-      // In 2018.1:
-      // lookup.withTypeText("", icon, false).withTypeIconRightAligned(true);
-      // TODO(pq): consider using reflection to invoke if available.
-      return lookup.withTypeText("", icon, false); //
+      final LookupElementBuilder lookup = DartServerCompletionContributor.createLookupElement(project, suggestion).withTypeText("", icon, false);
+
+      // 2018.1 introduces a new API to specify right alignment for type icons (the default previously).
+      // TODO(pq): remove reflective access when 2018.1 is our minimum.
+      final Method rightAligned = ReflectionUtil.getMethod(lookup.getClass(), "withTypeIconRightAligned");
+      if (rightAligned != null) {
+        try {
+          return (LookupElementBuilder)rightAligned.invoke(lookup, true);
+        }
+        catch (IllegalAccessException | InvocationTargetException e) {
+          // Shouldn't happen but if it does fall back on default.
+        }
+      }
+      return lookup;
     }
     return null;
   }
@@ -45,13 +58,15 @@ public class FlutterCompletionContributor extends DartCompletionExtension {
         if (name != null) {
           final String declaringType = suggestion.getDeclaringType();
           if (Objects.equals(declaringType, "Colors")) {
-            FlutterColors.FlutterColor color = FlutterColors.getColor(name);
+            final FlutterColors.FlutterColor color = FlutterColors.getColor(name);
             if (color != null) {
               return JBUI.scale(new ColorIcon(15, color.getAWTColor()));
             }
           }
           else if (Objects.equals(declaringType, "Icons")) {
-            return FlutterMaterialIcons.getMaterialIconForName(name);
+            final Icon icon = FlutterMaterialIcons.getMaterialIconForName(name);
+            // If we have no icon, show an empty node (which is preferable to the default "IconData" text).
+            return  icon != null ? icon : AllIcons.Nodes.EmptyNode;
           }
         }
       }

--- a/src/io/flutter/editor/FlutterCompletionContributor.java
+++ b/src/io/flutter/editor/FlutterCompletionContributor.java
@@ -6,10 +6,10 @@
 package io.flutter.editor;
 
 import com.intellij.codeInsight.lookup.LookupElementBuilder;
-import com.intellij.icons.AllIcons;
 import com.intellij.openapi.project.Project;
 import com.intellij.util.ReflectionUtil;
 import com.intellij.util.ui.ColorIcon;
+import com.intellij.util.ui.EmptyIcon;
 import com.intellij.util.ui.JBUI;
 import com.jetbrains.lang.dart.ide.completion.DartCompletionExtension;
 import com.jetbrains.lang.dart.ide.completion.DartServerCompletionContributor;
@@ -26,6 +26,9 @@ import java.util.Objects;
 
 
 public class FlutterCompletionContributor extends DartCompletionExtension {
+
+  private static final int ICON_SIZE = 15;
+  private static final Icon EMPTY_ICON = JBUI.scale(EmptyIcon.create(ICON_SIZE));
 
   @Nullable
   public LookupElementBuilder createLookupElement(@NotNull final Project project, @NotNull final CompletionSuggestion suggestion) {
@@ -60,13 +63,13 @@ public class FlutterCompletionContributor extends DartCompletionExtension {
           if (Objects.equals(declaringType, "Colors")) {
             final FlutterColors.FlutterColor color = FlutterColors.getColor(name);
             if (color != null) {
-              return JBUI.scale(new ColorIcon(15, color.getAWTColor()));
+              return JBUI.scale(new ColorIcon(ICON_SIZE, color.getAWTColor()));
             }
           }
           else if (Objects.equals(declaringType, "Icons")) {
             final Icon icon = FlutterMaterialIcons.getMaterialIconForName(name);
             // If we have no icon, show an empty node (which is preferable to the default "IconData" text).
-            return  icon != null ? icon : AllIcons.Nodes.EmptyNode;
+            return  icon != null ? icon : EMPTY_ICON;
           }
         }
       }

--- a/src/io/flutter/editor/FlutterCompletionContributor.java
+++ b/src/io/flutter/editor/FlutterCompletionContributor.java
@@ -27,7 +27,7 @@ import java.util.Objects;
 
 public class FlutterCompletionContributor extends DartCompletionExtension {
 
-  private static final int ICON_SIZE = 15;
+  private static final int ICON_SIZE = 16;
   private static final Icon EMPTY_ICON = JBUI.scale(EmptyIcon.create(ICON_SIZE));
 
   @Nullable

--- a/src/io/flutter/editor/FlutterMaterialIcons.java
+++ b/src/io/flutter/editor/FlutterMaterialIcons.java
@@ -45,6 +45,6 @@ public class FlutterMaterialIcons {
     if (path == null) {
       return null;
     }
-    return IconLoader.findIcon(path, FlutterEditorAnnotator.class);
+    return IconLoader.findIcon(path, FlutterMaterialIcons.class);
   }
 }


### PR DESCRIPTION
* adds reflective smarts for 2018.1+ APIs
* displays an empty node when Icons are not cached (rather than displaying the IconData type)

![image](https://user-images.githubusercontent.com/67586/37734847-a0f99334-2d09-11e8-864e-463f9c9e299c.png)

/cc @devoncarew 