### PR TITLE
update our build versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 out/
 artifacts/
 build/
+releases/
 flutter-intellij.jar
 flutter-intellij.zip
 packages

--- a/product-matrix.json
+++ b/product-matrix.json
@@ -18,8 +18,8 @@
       "name": "IntelliJ",
       "version": "3.1",
       "ideaProduct": "android-studio",
-      "ideaVersion": "173.4595152",
-      "dartPluginVersion": "173.4301.22",
+      "ideaVersion": "173.4658569",
+      "dartPluginVersion": "173.4700",
       "sinceBuild": "173.0",
       "untilBuild": "173.*",
       "filesToSkip": [
@@ -30,8 +30,8 @@
       "name": "IntelliJ",
       "version": "2018.1",
       "ideaProduct": "ideaIC",
-      "ideaVersion": "181.3741.2",
-      "dartPluginVersion": "181.3741.1",
+      "ideaVersion": "181.4203.400",
+      "dartPluginVersion": "181.4203.498",
       "sinceBuild": "181.0",
       "untilBuild": "181.*"
     }

--- a/tool/plugin/lib/plugin.dart
+++ b/tool/plugin/lib/plugin.dart
@@ -205,7 +205,7 @@ Future<int> moveToArtifacts(ProductCommand cmd, BuildSpec spec) async {
   var file = plugins[spec.pluginId];
   var args = new List<String>();
   args.add(p.join(rootPath, 'build', file));
-  args.add(cmd.archiveFilePath(spec));
+  args.add(cmd.releasesFilePath(spec));
   return await exec('mv', args);
 }
 
@@ -562,13 +562,13 @@ class BuildCommand extends ProductCommand {
       }
 
       // zip it up
-      result = await zip('build/flutter-intellij', archiveFilePath(spec));
+      result = await zip('build/flutter-intellij', releasesFilePath(spec));
       if (result != 0) {
         log('zip failed: ${result.toString()}');
         return new Future(() => result);
       }
       separator('BUILT');
-      log('${archiveFilePath(spec)}');
+      log('${releasesFilePath(spec)}');
     }
 
     return 0;
@@ -768,7 +768,7 @@ class DeployCommand extends ProductCommand {
     var value = 0;
     try {
       for (var spec in specs) {
-        var filePath = archiveFilePath(spec);
+        var filePath = releasesFilePath(spec);
         value = await upload(filePath, plugins[spec.pluginId]);
         if (value != 0) {
           return value;
@@ -896,10 +896,10 @@ abstract class ProductCommand extends Command {
     return rel;
   }
 
-  String archiveFilePath(BuildSpec spec) {
-    var subDir = isReleaseMode ? 'release_$releaseMajor' : '';
+  String releasesFilePath(BuildSpec spec) {
+    var subDir = isReleaseMode ? 'release_$releaseMajor' : 'release_master';
     var filePath = p.join(
-        rootPath, 'artifacts', subDir, spec.version, 'flutter-intellij.zip');
+        rootPath, 'releases', subDir, spec.version, 'flutter-intellij.zip');
     return filePath;
   }
 

--- a/tool/plugin/test/plugin_test.dart
+++ b/tool/plugin/test/plugin_test.dart
@@ -117,11 +117,11 @@ void main() {
         cmd = (runner.commands['deploy'] as TestDeployCommand);
       });
       expect(
-          cmd.paths.map((p) => p.substring(p.indexOf('artifacts'))),
+          cmd.paths.map((p) => p.substring(p.indexOf('releases'))),
           orderedEquals([
-            'artifacts/release_19/3.0/flutter-intellij.zip',
-            'artifacts/release_19/3.1/flutter-intellij.zip',
-            'artifacts/release_19/2018.1/flutter-intellij.zip',
+            'releases/release_19/3.0/flutter-intellij.zip',
+            'releases/release_19/3.1/flutter-intellij.zip',
+            'releases/release_19/2018.1/flutter-intellij.zip',
           ]));
     });
   });


### PR DESCRIPTION
- update the various versions we build against
- build releases into a new `releases/` dir, instead of the `artifacts/` dir (which has downloaded artifacts as well)

@stevemessick 