### PR TITLE
add a ternary setting for the preview dart 2 flag

### DIFF
--- a/src/io/flutter/run/bazel/BazelFields.java
+++ b/src/io/flutter/run/bazel/BazelFields.java
@@ -266,7 +266,10 @@ public class BazelFields {
     // Tell the flutter command-line tools that we want a machine interface on stdio.
     commandLine.addParameter("--machine");
 
-    if (FlutterSettings.getInstance().isDisablePreviewDart2()) {
+    if (FlutterSettings.getInstance().isEnablePreviewDart2()) {
+      commandLine.addParameter("--preview-dart-2");
+    }
+    else if (FlutterSettings.getInstance().isDisablePreviewDart2()) {
       commandLine.addParameter("--no-preview-dart-2");
     }
 

--- a/src/io/flutter/sdk/FlutterSdk.java
+++ b/src/io/flutter/sdk/FlutterSdk.java
@@ -185,9 +185,14 @@ public class FlutterSdk {
     if (FlutterSettings.getInstance().isVerboseLogging()) {
       args.add("--verbose");
     }
-    if (FlutterSettings.getInstance().isDisablePreviewDart2()) {
+
+    if (FlutterSettings.getInstance().isEnablePreviewDart2()) {
+      args.add("--preview-dart-2");
+    }
+    else if (FlutterSettings.getInstance().isDisablePreviewDart2()) {
       args.add("--no-preview-dart-2");
     }
+
     if (device != null) {
       args.add("--device-id=" + device.deviceId());
     }
@@ -214,7 +219,10 @@ public class FlutterSdk {
       args.add("--machine");
       // Otherwise, just run it normally and show the output in a non-test console.
     }
-    if (FlutterSettings.getInstance().isDisablePreviewDart2()) {
+    if (FlutterSettings.getInstance().isEnablePreviewDart2()) {
+      args.add("--preview-dart-2");
+    }
+    else if (FlutterSettings.getInstance().isDisablePreviewDart2()) {
       args.add("--no-preview-dart-2");
     }
     if (mode == RunMode.DEBUG) {
@@ -382,9 +390,11 @@ public class FlutterSdk {
     final String platformString;
     if (SystemInfo.isMac) {
       platformString = "darwin-x64";
-    } else if (SystemInfo.isLinux) {
+    }
+    else if (SystemInfo.isLinux) {
       platformString = "linux-x64";
-    } else {
+    }
+    else {
       return null;
     }
 

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.form
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.form
@@ -3,7 +3,7 @@
   <grid id="27dc6" binding="mainPanel" layout-manager="GridLayoutManager" row-count="6" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="574" height="571"/>
+      <xy x="20" y="20" width="574" height="671"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -170,14 +170,6 @@
               <text value="Open Flutter Inspector view on app launch"/>
             </properties>
           </component>
-          <component id="4e9b" class="javax.swing.JCheckBox" binding="myPreviewDart2CheckBox">
-            <constraints>
-              <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <text value="Don't run applications in Dart 2.0 mode"/>
-            </properties>
-          </component>
           <component id="87b06" class="javax.swing.JCheckBox" binding="myHotReloadOnSaveCheckBox">
             <constraints>
               <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
@@ -187,6 +179,36 @@
               <toolTipText value="On save, hot reload changes into running Flutter apps."/>
             </properties>
           </component>
+          <grid id="8dda3" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+            <margin top="0" left="0" bottom="0" right="0"/>
+            <constraints>
+              <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties/>
+            <border type="none"/>
+            <children>
+              <component id="2c76c" class="javax.swing.JLabel">
+                <constraints>
+                  <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text value="Run applications in Dart 2.0 mode:"/>
+                </properties>
+              </component>
+              <component id="f8034" class="javax.swing.JComboBox" binding="myPreviewDart2Combo">
+                <constraints>
+                  <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="2" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <model>
+                    <item value="Use SDK default"/>
+                    <item value="Enable Dart 2"/>
+                    <item value="Disable Dart 2"/>
+                  </model>
+                </properties>
+              </component>
+            </children>
+          </grid>
         </children>
       </grid>
       <grid id="f89bc" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.java
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.java
@@ -56,11 +56,11 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
   private JCheckBox myHotReloadOnSaveCheckBox;
   private JCheckBox myEnableVerboseLoggingCheckBox;
   private JCheckBox myOpenInspectorOnAppLaunchCheckBox;
-  private JCheckBox myPreviewDart2CheckBox;
   private JCheckBox myFormatCodeOnSaveCheckBox;
   private JCheckBox myOrganizeImportsOnSaveCheckBox;
   private JCheckBox myShowPreviewAreaCheckBox;
   private JCheckBox myShowHeapDisplayCheckBox;
+  private JComboBox myPreviewDart2Combo;
   private final @NotNull Project myProject;
 
   FlutterSettingsConfigurable(@NotNull Project project) {
@@ -166,7 +166,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
       return true;
     }
 
-    if (settings.isDisablePreviewDart2() != myPreviewDart2CheckBox.isSelected()) {
+    if (settings.getDart2ModeSetting().getOrdinal() != myPreviewDart2Combo.getSelectedIndex()) {
       return true;
     }
 
@@ -202,8 +202,8 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     settings.setShowPreviewArea(myShowPreviewAreaCheckBox.isSelected());
     settings.setShowHeapDisplay(myShowHeapDisplayCheckBox.isSelected());
     settings.setOpenInspectorOnAppLaunch(myOpenInspectorOnAppLaunchCheckBox.isSelected());
+    settings.setDart2ModeSettingOrdinal(myPreviewDart2Combo.getSelectedIndex());
     settings.setVerboseLogging(myEnableVerboseLoggingCheckBox.isSelected());
-    settings.setDisablePreviewDart2(myPreviewDart2CheckBox.isSelected());
 
     reset(); // because we rely on remembering initial state
   }
@@ -229,8 +229,8 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     myShowPreviewAreaCheckBox.setSelected(settings.isShowPreviewArea());
     myShowHeapDisplayCheckBox.setSelected(settings.isShowHeapDisplay());
     myOpenInspectorOnAppLaunchCheckBox.setSelected(settings.isOpenInspectorOnAppLaunch());
+    myPreviewDart2Combo.setSelectedIndex(settings.getDart2ModeSetting().getOrdinal());
     myEnableVerboseLoggingCheckBox.setSelected(settings.isVerboseLogging());
-    myPreviewDart2CheckBox.setSelected(settings.isDisablePreviewDart2());
 
     myOrganizeImportsOnSaveCheckBox.setEnabled(myFormatCodeOnSaveCheckBox.isSelected());
   }


### PR DESCRIPTION
- add a ternary setting for the preview dart 2 flag; user's can take the sdk default, can explicitly enable it, or can explicitly disable it
- fixes https://github.com/flutter/flutter-intellij/issues/1963

<img width="412" alt="screen shot 2018-03-21 at 3 41 54 pm" src="https://user-images.githubusercontent.com/1269969/37741471-c22d81b8-2d1e-11e8-8192-d23e062e1a25.png">

