### PR TITLE
Fix bugs in StdoutJsonParser when a line spanned multiple calls to appendOutput.

### DIFF
--- a/src/io/flutter/run/daemon/DaemonConsoleView.java
+++ b/src/io/flutter/run/daemon/DaemonConsoleView.java
@@ -70,7 +70,6 @@ public class DaemonConsoleView extends ConsoleViewImpl {
     }
 
     if (contentType != ConsoleViewContentType.NORMAL_OUTPUT) {
-      stdoutParser.flush();
       writeAvailableLines();
 
       super.print(text, contentType);

--- a/src/io/flutter/utils/StdoutJsonParser.java
+++ b/src/io/flutter/utils/StdoutJsonParser.java
@@ -10,59 +10,50 @@ import java.util.List;
 
 /**
  * A class to process regular text output intermixed with newline-delimited JSON.
+ *
+ * JSON lines starting with [{ are never be split into multiple lines even
+ * if they are emitted over the course of multiple calls to appendOutput.
+ * Regular lines on the other hand are emitted immediately so that debug output
+ * always shows up when expected..
  */
 public class StdoutJsonParser {
   private final StringBuilder buffer = new StringBuilder();
+  private boolean bufferIsJson = false;
   private final List<String> lines = new ArrayList<>();
 
   /**
    * Write new output to this [StdoutJsonParser].
    */
   public void appendOutput(String output) {
-    buffer.append(output);
+    for (int i = 0; i < output.length(); ++i) {
+      final char c = output.charAt(i);
+      buffer.append(c);
+      if (!bufferIsJson && buffer.length() == 2 && buffer.charAt(0) == '[' && c == '{') {
+        bufferIsJson = true;
+      }
+      if (c == '\n') {
+        flushLine();
+      }
+    }
 
-    while (buffer.length() > 0) {
-      if (buffer.length() >= 2 && buffer.charAt(0) == '[' && buffer.charAt(1) == '{') {
-        final int endIndex = buffer.indexOf("}]");
-        if (endIndex != -1) {
-          String line = buffer.substring(0, endIndex + 2);
-          buffer.delete(0, endIndex + 2);
-          if (buffer.length() > 0 && buffer.charAt(0) == '\n') {
-            line += "\n";
-            buffer.delete(0, 1);
-          }
-          lines.add(line);
-        }
-        else {
-          // Wait for a json terminator.
-          break;
-        }
-      }
-      else if (buffer.indexOf("\n") != -1) {
-        final int endIndex = buffer.indexOf("\n");
-        final String line = buffer.substring(0, endIndex + 1);
-        buffer.delete(0, endIndex + 1);
-        lines.add(line);
-      }
-      else {
-        break;
-      }
+    // Eagerly flush if we are not within JSON so regular log text is written
+    // as soon as possible.
+    if (!bufferIsJson) {
+      flushLine();
     }
   }
 
-  /**
-   * Flush any written but un-consumed output to [getAvailableLines].
-   */
-  public void flush() {
+  private void flushLine() {
     if (buffer.length() > 0) {
       lines.add(buffer.toString());
       buffer.setLength(0);
     }
+    bufferIsJson = false;
   }
 
-  /**
-   * Read any lines available from the processed output.
-   */
+    /**
+     * Read any lines available from the processed output.
+     */
   public List<String> getAvailableLines() {
     final List<String> copy = new ArrayList<>(lines);
     lines.clear();

--- a/src/io/flutter/utils/StdoutJsonParser.java
+++ b/src/io/flutter/utils/StdoutJsonParser.java
@@ -11,10 +11,10 @@ import java.util.List;
 /**
  * A class to process regular text output intermixed with newline-delimited JSON.
  *
- * JSON lines starting with [{ are never be split into multiple lines even
- * if they are emitted over the course of multiple calls to appendOutput.
- * Regular lines on the other hand are emitted immediately so that debug output
- * always shows up when expected..
+ * JSON lines starting with [{ are never split into multiple lines even if they
+ * are emitted over the course of multiple calls to appendOutput. Regular lines
+ * on the other hand are emitted immediately so users do not have to wait for
+ * debug output.
  */
 public class StdoutJsonParser {
   private final StringBuilder buffer = new StringBuilder();

--- a/testSrc/unit/io/flutter/utils/StdoutJsonParserTest.java
+++ b/testSrc/unit/io/flutter/utils/StdoutJsonParserTest.java
@@ -17,7 +17,6 @@ public class StdoutJsonParserTest {
     parser.appendOutput("there\n");
     parser.appendOutput("[{'foo':'bar'}]\n");
     parser.appendOutput("bye\n");
-    parser.flush();
 
     assertArrayEquals(
       "validating parser results",
@@ -27,15 +26,15 @@ public class StdoutJsonParserTest {
   }
 
   @Test
-  public void flush() throws Exception {
+  public void appends_without_line_breaks() throws Exception {
     StdoutJsonParser parser = new StdoutJsonParser();
-    parser.appendOutput("hello\n");
+    parser.appendOutput("hello\nnow\n");
     parser.appendOutput("there");
-    parser.flush();
+    parser.appendOutput("world");
 
     assertArrayEquals(
       "validating parser results",
-      new String[]{"hello\n", "there"},
+      new String[]{"hello\n", "now\n", "there", "world"},
       parser.getAvailableLines().toArray()
     );
 
@@ -45,7 +44,7 @@ public class StdoutJsonParserTest {
 
     assertArrayEquals(
       "validating parser results",
-      new String[]{"hello\n"},
+      new String[]{"hello\n", "there"},
       parser.getAvailableLines().toArray()
     );
   }
@@ -58,11 +57,42 @@ public class StdoutJsonParserTest {
     parser.appendOutput("[{'foo':");
     parser.appendOutput("'bar'}]\n");
     parser.appendOutput("bye\n");
-    parser.flush();
 
     assertArrayEquals(
       "validating parser results",
       new String[]{"hello\n", "there\n", "[{'foo':'bar'}]\n", "bye\n"},
+      parser.getAvailableLines().toArray()
+    );
+  }
+
+  @Test
+  public void deep_nested_json() throws Exception {
+    final StdoutJsonParser parser = new StdoutJsonParser();
+    parser.appendOutput("hello\n");
+    parser.appendOutput("there\n");
+    parser.appendOutput("[{'foo':");
+    parser.appendOutput("[{'bar':'baz'}]}]\n");
+    parser.appendOutput("bye\n");
+
+    assertArrayEquals(
+      "validating parser results",
+      new String[]{"hello\n", "there\n", "[{'foo':[{'bar':'baz'}]}]\n", "bye\n"},
+      parser.getAvailableLines().toArray()
+    );
+  }
+
+  @Test
+  public void unterminated_json() throws Exception {
+    final StdoutJsonParser parser = new StdoutJsonParser();
+    parser.appendOutput("hello\n");
+    parser.appendOutput("there\n");
+    parser.appendOutput("[{'foo':");
+    parser.appendOutput("[{'bar':'baz'}]");
+    // The JSON has not yet terminated with a \n.
+
+    assertArrayEquals(
+      "validating parser results",
+      new String[]{"hello\n", "there\n"},
       parser.getAvailableLines().toArray()
     );
   }

--- a/testSrc/unit/io/flutter/utils/StdoutJsonParserTest.java
+++ b/testSrc/unit/io/flutter/utils/StdoutJsonParserTest.java
@@ -26,7 +26,7 @@ public class StdoutJsonParserTest {
   }
 
   @Test
-  public void appends_without_line_breaks() throws Exception {
+  public void appendsWithoutLineBreaks() throws Exception {
     StdoutJsonParser parser = new StdoutJsonParser();
     parser.appendOutput("hello\nnow\n");
     parser.appendOutput("there");
@@ -50,7 +50,7 @@ public class StdoutJsonParserTest {
   }
 
   @Test
-  public void split_json() throws Exception {
+  public void splitJson() throws Exception {
     final StdoutJsonParser parser = new StdoutJsonParser();
     parser.appendOutput("hello\n");
     parser.appendOutput("there\n");
@@ -66,7 +66,7 @@ public class StdoutJsonParserTest {
   }
 
   @Test
-  public void deep_nested_json() throws Exception {
+  public void deepNestedJson() throws Exception {
     final StdoutJsonParser parser = new StdoutJsonParser();
     parser.appendOutput("hello\n");
     parser.appendOutput("there\n");
@@ -82,7 +82,7 @@ public class StdoutJsonParserTest {
   }
 
   @Test
-  public void unterminated_json() throws Exception {
+  public void unterminatedJson() throws Exception {
     final StdoutJsonParser parser = new StdoutJsonParser();
     parser.appendOutput("hello\n");
     parser.appendOutput("there\n");


### PR DESCRIPTION
The downside of this approach is we will not display a line until a \n occurs but that appears to be fine.

An alternate robust approach would be to use an actual streaming JSON parser to track when the JSON blocks are complete.

The previous approach failed if the JSON had an }] too early in the block and failed on json responses larger than a single call to appendOutput.