### PR TITLE
Make InspectorService supporting issuing most of its requests over the Flutter Daemon instead of observatory.

### DIFF
--- a/src/io/flutter/inspector/InspectorService.java
+++ b/src/io/flutter/inspector/InspectorService.java
@@ -17,6 +17,7 @@ import io.flutter.run.daemon.FlutterApp;
 import io.flutter.utils.VmServiceListenerAdapter;
 import org.dartlang.vm.service.VmService;
 import org.dartlang.vm.service.element.*;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
@@ -32,18 +33,60 @@ public class InspectorService implements Disposable {
    * Group name to to manage keeping alive nodes in the tree referenced by the inspector.
    */
   private final String groupName;
-  private final FlutterDebugProcess debugProcess;
-  private final VmService vmService;
-  private final Set<InspectorServiceClient> clients;
+  @NotNull private final FlutterDebugProcess debugProcess;
+  @NotNull private final VmService vmService;
+  @NotNull private final Set<InspectorServiceClient> clients;
   private EvalOnDartLibrary inspectorLibrary;
-  private CompletableFuture<Set<String>> supportedServiceMethods;
+  @NotNull private final Set<String> supportedServiceMethods;
 
-  public InspectorService(FlutterDebugProcess debugProcess, VmService vmService) {
+  // TODO(jacobr): remove this field as soon as
+  // `ext.flutter.debugCallWidgetInspectorService` has been in two revs of the
+  // Flutter Beta channel. The feature is expected to have landed in the
+  // Flutter dev chanel on March 22, 2018.
+  private final boolean isDaemonApiSupported;
+
+  public static CompletableFuture<InspectorService> create(@NotNull FlutterDebugProcess debugProcess, @NotNull VmService vmService) {
+    final EvalOnDartLibrary inspectorLibrary = new EvalOnDartLibrary(
+      "package:flutter/src/widgets/widget_inspector.dart",
+      debugProcess,
+      vmService
+    );
+    final CompletableFuture<Library> libraryFuture = inspectorLibrary.libraryRef.thenComposeAsync(inspectorLibrary::getLibrary);
+    return libraryFuture.thenComposeAsync((Library library) -> {
+      for (ClassRef classRef : library.getClasses()) {
+        if ("WidgetInspectorService".equals(classRef.getName())) {
+          return inspectorLibrary.getClass(classRef).thenApplyAsync((ClassObj classObj) -> {
+            final Set<String> functionNames = new HashSet<>();
+            for (FuncRef funcRef : classObj.getFunctions()) {
+              functionNames.add(funcRef.getName());
+            }
+            return functionNames;
+          });
+        }
+      }
+      throw new RuntimeException("WidgetInspectorService class not found");
+    }).thenApplyAsync(
+      (supportedServiceMethods) -> new InspectorService(debugProcess, vmService, inspectorLibrary, supportedServiceMethods));
+  }
+
+  private InspectorService(@NotNull FlutterDebugProcess debugProcess,
+                           @NotNull VmService vmService,
+                           EvalOnDartLibrary inspectorLibrary,
+                           Set<String> supportedServiceMethods) {
+    this.vmService = vmService;
+    this.debugProcess = debugProcess;
+    this.inspectorLibrary = inspectorLibrary;
+    this.supportedServiceMethods = supportedServiceMethods;
+
+    // TODO(jacobr): remove this field as soon as
+    // `ext.flutter.debugCallWidgetInspectorService` has been in two revs of the
+    // Flutter Beta channel. The feature is expected to have landed in the
+    // Flutter dev chanel on March 22, 2018.
+    this.isDaemonApiSupported = hasServiceMethod("callMethod");
+
     clients = new HashSet<>();
     groupName = "intellij_inspector_" + nextGroupId;
     nextGroupId++;
-    this.vmService = vmService;
-    this.debugProcess = debugProcess;
 
     vmService.addVmServiceListener(new VmServiceListenerAdapter() {
       @Override
@@ -65,7 +108,7 @@ public class InspectorService implements Disposable {
   }
 
   public FlutterApp getApp() {
-    return debugProcess != null ? debugProcess.getApp() : null;
+    return debugProcess.getApp();
   }
 
   public CompletableFuture<XSourcePosition> getPropertyLocation(InstanceRef instanceRef, String name) {
@@ -87,7 +130,6 @@ public class InspectorService implements Disposable {
       return superClass == null ? CompletableFuture.completedFuture(null) : getPropertyLocationHelper(superClass, name);
     });
   }
-
 
   public CompletableFuture<DiagnosticsNode> getRoot(FlutterTreeType type) {
     switch (type) {
@@ -120,11 +162,57 @@ public class InspectorService implements Disposable {
    * <p>
    * Intent is we could refactor how the API is invoked by only changing this call.
    */
-  CompletableFuture<InstanceRef> invokeServiceMethod(String methodName) {
+  // TODO(jacobr): remove this method as soon as
+  // `ext.flutter.debugCallWidgetInspectorService` has been in two revs of the
+  // Flutter Beta channel. The feature is expected to have landed in the
+  // Flutter dev chanel on March 22, 2018.
+  CompletableFuture<InstanceRef> invokeServiceMethodObservatory(String methodName) {
     return getInspectorLibrary().eval("WidgetInspectorService.instance." + methodName + "(\"" + groupName + "\")", null);
   }
 
-  CompletableFuture<InstanceRef> invokeServiceMethod(String methodName, InspectorInstanceRef arg) {
+  CompletableFuture<JsonElement> invokeServiceMethodDaemon(String methodName) {
+    return invokeServiceMethodDaemon(methodName, groupName);
+  }
+
+  CompletableFuture<JsonElement> invokeServiceMethodDaemon(String methodName, String arg1) {
+    final JsonArray args = new JsonArray();
+    args.add(arg1);
+    return invokeServiceMethodDaemon(methodName, args);
+  }
+
+  CompletableFuture<JsonElement> invokeServiceMethodDaemon(String methodName, String arg1, String arg2) {
+    final JsonArray args = new JsonArray();
+    args.add(arg1);
+    args.add(arg2);
+    return invokeServiceMethodDaemon(methodName, args);
+  }
+
+  CompletableFuture<JsonElement> invokeServiceMethodDaemon(String methodName, JsonArray args) {
+    final Map<String, Object> params = new HashMap<>();
+    params.put("method", methodName);
+    // The parameter map is from String->String so we have to JSON encode the args.
+    params.put("args", new Gson().toJson(args));
+    return getApp().callServiceExtension("ext.flutter.debugCallWidgetInspectorService", params).thenApply((JsonObject json) -> {
+      if (json.has("errorMessage")) {
+        String message = json.get("errorMessage").getAsString();
+        throw new RuntimeException(methodName + " -- " + message);
+      }
+      return json.get("result");
+    });
+  }
+
+  CompletableFuture<JsonElement> invokeServiceMethodDaemon(String methodName, InspectorInstanceRef arg) {
+    if (arg == null || arg.getId() == null) {
+      return invokeServiceMethodDaemon(methodName, null, groupName);
+    }
+    return invokeServiceMethodDaemon(methodName, arg.getId(), groupName);
+  }
+
+  // TODO(jacobr): remove this method as soon as
+  // `ext.flutter.debugCallWidgetInspectorService` has been in two revs of the
+  // Flutter Beta channel. The feature is expected to have landed in the
+  // Flutter dev chanel on March 22, 2018.
+  CompletableFuture<InstanceRef> invokeServiceMethodObservatory(String methodName, InspectorInstanceRef arg) {
     if (arg == null || arg.getId() == null) {
       return getInspectorLibrary().eval("WidgetInspectorService.instance." + methodName + "(null, \"" + groupName + "\")", null);
     }
@@ -132,7 +220,11 @@ public class InspectorService implements Disposable {
       .eval("WidgetInspectorService.instance." + methodName + "(\"" + arg.getId() + "\", \"" + groupName + "\")", null);
   }
 
-  CompletableFuture<InstanceRef> invokeServiceMethodOnRef(String methodName, InstanceRef arg) {
+  /**
+   * This API requires using the observatory service a the input parameter is an
+   * Observatory InstanceRef..
+   */
+  CompletableFuture<InstanceRef> invokeServiceMethodOnRefObservatory(String methodName, InstanceRef arg) {
     final HashMap<String, String> scope = new HashMap<>();
     if (arg == null) {
       return getInspectorLibrary().eval("WidgetInspectorService.instance." + methodName + "(null, \"" + groupName + "\")", scope);
@@ -146,23 +238,36 @@ public class InspectorService implements Disposable {
     // the `setPubRootDirectories` method has been in two revs of the Flutter Alpha
     // channel. The feature is expected to have landed in the Flutter dev
     // chanel on March 2, 2018.
+    if (!hasServiceMethod("setPubRootDirectories")) {
+      return CompletableFuture.completedFuture(null);
+    }
 
-    return hasServiceMethod("setPubRootDirectories").thenComposeAsync((Boolean hasMethod) -> {
-      if (!hasMethod) {
-        return null;
-      }
-      final JsonArray jsonArray = new JsonArray();
-      for (String rootDirectory : rootDirectories) {
-        jsonArray.add(rootDirectory);
-      }
+    final JsonArray jsonArray = new JsonArray();
+    for (String rootDirectory : rootDirectories) {
+      jsonArray.add(rootDirectory);
+    }
+    if (isDaemonApiSupported) {
+      final JsonArray args = new JsonArray();
+      args.add(jsonArray);
+      return invokeServiceMethodDaemon("setPubRootDirectories", args).thenApplyAsync((ignored) -> null);
+    }
+    else {
+      // TODO(jacobr): remove this call as soon as
+      // `ext.flutter.debugCallWidgetInspectorService` has been in two revs of the
+      // Flutter Beta channel. The feature is expected to have landed in the
+      // Flutter dev chanel on March 22, 2018.
       return getInspectorLibrary().eval(
         "WidgetInspectorService.instance.setPubRootDirectories(" + new Gson().toJson(jsonArray) + ")", null)
-        .thenApplyAsync((InstanceRef instance) -> null);
-    });
+        .thenApplyAsync((instance) -> null);
+    }
   }
 
-  CompletableFuture<DiagnosticsNode> parseDiagnosticsNode(CompletableFuture<InstanceRef> instanceRefFuture) {
-    return instanceRefFuture.thenComposeAsync(this::parseDiagnosticsNode);
+  // TODO(jacobr): remove this method as soon as
+  // `ext.flutter.debugCallWidgetInspectorService` has been in two revs of the
+  // Flutter Beta channel. The feature is expected to have landed in the
+  // Flutter dev chanel on March 22, 2018.
+  CompletableFuture<DiagnosticsNode> parseDiagnosticsNodeObservatory(CompletableFuture<InstanceRef> instanceRefFuture) {
+    return instanceRefFuture.thenComposeAsync(this::parseDiagnosticsNodeObservatory);
   }
 
   /**
@@ -212,7 +317,7 @@ public class InspectorService implements Disposable {
   }
 
   public CompletableFuture<InstanceRef> toObservatoryInstanceRef(InspectorInstanceRef inspectorInstanceRef) {
-    return invokeServiceMethod("toObject", inspectorInstanceRef);
+    return invokeServiceMethodObservatory("toObject", inspectorInstanceRef);
   }
 
   private CompletableFuture<Instance> getInstance(InstanceRef instanceRef) {
@@ -223,11 +328,16 @@ public class InspectorService implements Disposable {
     return instanceRefFuture.thenComposeAsync(this::getInstance);
   }
 
-  CompletableFuture<DiagnosticsNode> parseDiagnosticsNode(InstanceRef instanceRef) {
-    return instanceRefToJson(instanceRef).thenApplyAsync((JsonElement jsonElement) -> {
-      //noinspection CodeBlock2Expr
-      return new DiagnosticsNode(jsonElement.getAsJsonObject(), this);
-    });
+  CompletableFuture<DiagnosticsNode> parseDiagnosticsNodeObservatory(InstanceRef instanceRef) {
+    return instanceRefToJson(instanceRef).thenApplyAsync(this::parseDiagnosticsNodeHelper);
+  }
+
+  CompletableFuture<DiagnosticsNode> parseDiagnosticsNodeDaemon(CompletableFuture<JsonElement> json) {
+    return json.thenApplyAsync(this::parseDiagnosticsNodeHelper);
+  }
+
+  DiagnosticsNode parseDiagnosticsNodeHelper(JsonElement jsonElement) {
+    return new DiagnosticsNode(jsonElement.getAsJsonObject(), this);
   }
 
   /**
@@ -240,15 +350,19 @@ public class InspectorService implements Disposable {
     });
   }
 
-  CompletableFuture<ArrayList<DiagnosticsNode>> parseDiagnosticsNodes(InstanceRef instanceRef) {
+  CompletableFuture<ArrayList<DiagnosticsNode>> parseDiagnosticsNodesObservatory(InstanceRef instanceRef) {
     return instanceRefToJson(instanceRef).thenApplyAsync((JsonElement jsonElement) -> {
       final JsonArray jsonArray = jsonElement.getAsJsonArray();
-      final ArrayList<DiagnosticsNode> nodes = new ArrayList<>();
-      for (JsonElement element : jsonArray) {
-        nodes.add(new DiagnosticsNode(element.getAsJsonObject(), this));
-      }
-      return nodes;
+      return parseDiagnosticsNodesHelper(jsonArray);
     });
+  }
+
+  ArrayList<DiagnosticsNode> parseDiagnosticsNodesHelper(JsonArray jsonArray) {
+    final ArrayList<DiagnosticsNode> nodes = new ArrayList<>();
+    for (JsonElement element : jsonArray) {
+      nodes.add(new DiagnosticsNode(element.getAsJsonObject(), this));
+    }
+    return nodes;
   }
 
   /**
@@ -260,15 +374,19 @@ public class InspectorService implements Disposable {
    * handle reference expiration gracefully.
    */
   public CompletableFuture<DartVmServiceValue> toDartVmServiceValueForSourceLocation(InspectorInstanceRef inspectorInstanceRef) {
-    return invokeServiceMethod("toObjectForSourceLocation", inspectorInstanceRef).thenApplyAsync(
+    return invokeServiceMethodObservatory("toObjectForSourceLocation", inspectorInstanceRef).thenApplyAsync(
       (InstanceRef instanceRef) -> {
         //noinspection CodeBlock2Expr
         return new DartVmServiceValue(debugProcess, inspectorLibrary.getIsolateId(), "inspectedObject", instanceRef, null, null, false);
       });
   }
 
-  CompletableFuture<ArrayList<DiagnosticsNode>> parseDiagnosticsNodes(CompletableFuture<InstanceRef> instanceRefFuture) {
-    return instanceRefFuture.thenComposeAsync(this::parseDiagnosticsNodes);
+  CompletableFuture<ArrayList<DiagnosticsNode>> parseDiagnosticsNodesObservatory(CompletableFuture<InstanceRef> instanceRefFuture) {
+    return instanceRefFuture.thenComposeAsync(this::parseDiagnosticsNodesObservatory);
+  }
+
+  CompletableFuture<ArrayList<DiagnosticsNode>> parseDiagnosticsNodesDaemon(CompletableFuture<JsonElement> jsonFuture) {
+    return jsonFuture.thenApplyAsync((json) -> parseDiagnosticsNodesHelper(json.getAsJsonArray()));
   }
 
   CompletableFuture<ArrayList<DiagnosticsNode>> getChildren(InspectorInstanceRef instanceRef) {
@@ -286,97 +404,110 @@ public class InspectorService implements Disposable {
    * new frames will be triggered to draw unless something changes in the UI.
    */
   public CompletableFuture<Boolean> isWidgetTreeReady() {
-    // TODO(jacobr): remove call to hasServiceMethod("isWidgetTreeReady") after
-    // the `isWidgetTreeReady` method has been in two revs of the Flutter Alpha
-    // channel. The feature is expected to have landed in the Flutter dev
-    // channel on January 18, 2018.
-    return hasServiceMethod("isWidgetTreeReady").thenComposeAsync((Boolean hasMethod) -> {
-      if (!hasMethod) {
-        // Fallback if the InspectorService doesn't provide the
-        // isWidgetTreeReady method. In this case, we will fail gracefully
-        // risking not displaying the Widget tree but ensuring we do not throw
-        // exceptions due to accessing the widget tree before it is safe to.
-        final CompletableFuture<Boolean> value = new CompletableFuture<>();
-        value.complete(false);
-        return value;
-      }
-      return invokeServiceMethod("isWidgetTreeReady").thenApplyAsync((InstanceRef ref) -> "true".equals(ref.getValueAsString()));
-    });
+    if (isDaemonApiSupported) {
+      return invokeServiceMethodDaemon("isWidgetTreeReady").thenApplyAsync((JsonElement element) -> element.getAsBoolean() == true);
+    }
+    else {
+      return invokeServiceMethodObservatory("isWidgetTreeReady").thenApplyAsync((InstanceRef ref) -> "true".equals(ref.getValueAsString()));
+    }
   }
 
   /**
    * Use this method to write code that is backwards compatible with versions
    * of Flutter that are too old to contain specific service methods.
    */
-  private CompletableFuture<Boolean> hasServiceMethod(String methodName) {
-    if (supportedServiceMethods == null) {
-      final EvalOnDartLibrary inspectorLibrary = getInspectorLibrary();
-      final CompletableFuture<Library> libraryFuture = inspectorLibrary.libraryRef.thenComposeAsync(inspectorLibrary::getLibrary);
-      supportedServiceMethods = libraryFuture.thenComposeAsync((Library library) -> {
-        for (ClassRef classRef : library.getClasses()) {
-          if ("WidgetInspectorService".equals(classRef.getName())) {
-            return inspectorLibrary.getClass(classRef).thenApplyAsync((ClassObj classObj) -> {
-              final Set<String> functionNames = new HashSet<>();
-              for (FuncRef funcRef : classObj.getFunctions()) {
-                functionNames.add(funcRef.getName());
-              }
-              return functionNames;
-            });
-          }
-        }
-        throw new RuntimeException("WidgetInspectorService class not found");
-      });
-    }
-
-    return supportedServiceMethods.thenApplyAsync(methodNames -> methodNames.contains(methodName));
+  private boolean hasServiceMethod(String methodName) {
+    return supportedServiceMethods.contains(methodName);
   }
 
   private CompletableFuture<ArrayList<DiagnosticsNode>> getListHelper(
     InspectorInstanceRef instanceRef, String methodName) {
-    return parseDiagnosticsNodes(invokeServiceMethod(methodName, instanceRef));
+    if (isDaemonApiSupported) {
+      return parseDiagnosticsNodesDaemon(invokeServiceMethodDaemon(methodName, instanceRef));
+    }
+    else {
+      return parseDiagnosticsNodesObservatory(invokeServiceMethodObservatory(methodName, instanceRef));
+    }
+  }
+
+  public CompletableFuture<DiagnosticsNode> invokeServiceMethodReturningNode(String methodName) {
+    if (isDaemonApiSupported) {
+      return parseDiagnosticsNodeDaemon(invokeServiceMethodDaemon(methodName));
+    }
+    else {
+      return parseDiagnosticsNodeObservatory(invokeServiceMethodObservatory(methodName));
+    }
+  }
+
+  public CompletableFuture<DiagnosticsNode> invokeServiceMethodReturningNode(String methodName, InspectorInstanceRef ref) {
+    if (isDaemonApiSupported) {
+      return parseDiagnosticsNodeDaemon(invokeServiceMethodDaemon(methodName, ref));
+    }
+    else {
+      return parseDiagnosticsNodeObservatory(invokeServiceMethodObservatory(methodName, ref));
+    }
+  }
+
+  public CompletableFuture<Void> invokeVoidServiceMethod(String methodName, InspectorInstanceRef ref) {
+    if (isDaemonApiSupported) {
+      return invokeServiceMethodDaemon(methodName, ref).thenApply((ignored) -> null);
+    }
+    else {
+      return invokeServiceMethodObservatory(methodName, ref).thenApply((ignored) -> null);
+    }
   }
 
   public CompletableFuture<DiagnosticsNode> getRootWidget() {
-    return parseDiagnosticsNode(invokeServiceMethod("getRootWidget"));
+    return invokeServiceMethodReturningNode("getRootWidget");
   }
 
   public CompletableFuture<DiagnosticsNode> getRootRenderObject() {
-    return parseDiagnosticsNode(invokeServiceMethod("getRootRenderObject"));
+    return invokeServiceMethodReturningNode("getRootRenderObject");
   }
 
   public CompletableFuture<ArrayList<DiagnosticsPathNode>> getParentChain(DiagnosticsNode target) {
-    return parseDiagnosticsPath(invokeServiceMethod("getParentChain", target.getValueRef()));
+    if (isDaemonApiSupported) {
+      return parseDiagnosticsPathDaeomon(invokeServiceMethodDaemon("getParentChain", target.getValueRef()));
+    }
+    else {
+      return parseDiagnosticsPathObservatory(invokeServiceMethodObservatory("getParentChain", target.getValueRef()));
+    }
   }
 
-  CompletableFuture<ArrayList<DiagnosticsPathNode>> parseDiagnosticsPath(CompletableFuture<InstanceRef> instanceRefFuture) {
-    return instanceRefFuture.thenComposeAsync(this::parseDiagnosticsPath);
+  CompletableFuture<ArrayList<DiagnosticsPathNode>> parseDiagnosticsPathObservatory(CompletableFuture<InstanceRef> instanceRefFuture) {
+    return instanceRefFuture.thenComposeAsync(this::parseDiagnosticsPathObservatory);
   }
 
-  private CompletableFuture<ArrayList<DiagnosticsPathNode>> parseDiagnosticsPath(InstanceRef pathRef) {
-    return instanceRefToJson(pathRef).thenApplyAsync((JsonElement jsonElement) -> {
-      final JsonArray jsonArray = jsonElement.getAsJsonArray();
-      final ArrayList<DiagnosticsPathNode> pathNodes = new ArrayList<>();
-      for (JsonElement element : jsonArray) {
-        pathNodes.add(new DiagnosticsPathNode(element.getAsJsonObject(), this));
-      }
-      return pathNodes;
-    });
+  private CompletableFuture<ArrayList<DiagnosticsPathNode>> parseDiagnosticsPathObservatory(InstanceRef pathRef) {
+    return instanceRefToJson(pathRef).thenApplyAsync(this::parseDiagnosticsPathHelper);
+  }
+
+  CompletableFuture<ArrayList<DiagnosticsPathNode>> parseDiagnosticsPathDaeomon(CompletableFuture<JsonElement> jsonFuture) {
+    return jsonFuture.thenApplyAsync(this::parseDiagnosticsPathHelper);
+  }
+
+  private ArrayList<DiagnosticsPathNode> parseDiagnosticsPathHelper(JsonElement jsonElement) {
+    final JsonArray jsonArray = jsonElement.getAsJsonArray();
+    final ArrayList<DiagnosticsPathNode> pathNodes = new ArrayList<>();
+    for (JsonElement element : jsonArray) {
+      pathNodes.add(new DiagnosticsPathNode(element.getAsJsonObject(), this));
+    }
+    return pathNodes;
   }
 
   public CompletableFuture<DiagnosticsNode> getSelection(DiagnosticsNode previousSelection, FlutterTreeType treeType) {
-    CompletableFuture<InstanceRef> result = null;
+    CompletableFuture<DiagnosticsNode> result = null;
     final InspectorInstanceRef previousSelectionRef = previousSelection != null ? previousSelection.getDartDiagnosticRef() : null;
 
     switch (treeType) {
       case widget:
-        result = invokeServiceMethod("getSelectedWidget", previousSelectionRef);
+        result = invokeServiceMethodReturningNode("getSelectedWidget", previousSelectionRef);
         break;
       case renderObject:
-        result = invokeServiceMethod("getSelectedRenderObject", previousSelectionRef);
+        result = invokeServiceMethodReturningNode("getSelectedRenderObject", previousSelectionRef);
         break;
     }
-    assert (result != null);
-    return parseDiagnosticsNode(result).thenApplyAsync((DiagnosticsNode newSelection) -> {
+    return result.thenApplyAsync((DiagnosticsNode newSelection) -> {
       if (newSelection.getDartDiagnosticRef().equals(previousSelectionRef)) {
         return previousSelection;
       }
@@ -440,7 +571,12 @@ public class InspectorService implements Disposable {
   }
 
   public void setSelection(InspectorInstanceRef selection, boolean uiAlreadyUpdated) {
-    handleSetSelection(invokeServiceMethod("setSelectionById", selection), uiAlreadyUpdated);
+    if (isDaemonApiSupported) {
+      handleSetSelectionDaemon(invokeServiceMethodDaemon("setSelectionById", selection), uiAlreadyUpdated);
+    }
+    else {
+      handleSetSelectionObservatory(invokeServiceMethodObservatory("setSelectionById", selection), uiAlreadyUpdated);
+    }
   }
 
   /**
@@ -448,17 +584,27 @@ public class InspectorService implements Disposable {
    * instead of an InspectorInstanceRef.
    */
   public void setSelection(InstanceRef selection, boolean uiAlreadyUpdated) {
-    handleSetSelection(invokeServiceMethodOnRef("setSelection", selection), uiAlreadyUpdated);
+    // This call requires the observatory protocol as an observatory InstanceRef is specified.
+    handleSetSelectionObservatory(invokeServiceMethodOnRefObservatory("setSelection", selection), uiAlreadyUpdated);
   }
 
-  private void handleSetSelection(CompletableFuture<InstanceRef> setSelectionResult, boolean uiAlreadyUpdated) {
+  private void handleSetSelectionObservatory(CompletableFuture<InstanceRef> setSelectionResult, boolean uiAlreadyUpdated) {
     // TODO(jacobr): we need to cancel if another inspect request comes in while we are trying this one.
     setSelectionResult.thenAcceptAsync((InstanceRef instanceRef) -> {
-      if ("true".equals(instanceRef.getValueAsString())) {
-        if (!uiAlreadyUpdated) {
-          notifySelectionChanged();
-        }
-      }
+      handleSetSelectionHelper("true".equals(instanceRef.getValueAsString()), uiAlreadyUpdated);
+    });
+  }
+
+  private void handleSetSelectionHelper(boolean selectionChanged, boolean uiAlreadyUpdated) {
+    if (selectionChanged && !uiAlreadyUpdated) {
+      notifySelectionChanged();
+    }
+  }
+
+  private void handleSetSelectionDaemon(CompletableFuture<JsonElement> setSelectionResult, boolean uiAlreadyUpdated) {
+    // TODO(jacobr): we need to cancel if another inspect request comes in while we are trying this one.
+    setSelectionResult.thenAcceptAsync((JsonElement json) -> {
+      handleSetSelectionHelper(json.getAsBoolean(), uiAlreadyUpdated);
     });
   }
 

--- a/src/io/flutter/run/daemon/FlutterApp.java
+++ b/src/io/flutter/run/daemon/FlutterApp.java
@@ -75,7 +75,6 @@ public class FlutterApp {
   private final ObservatoryConnector myConnector;
   private FlutterDebugProcess myFlutterDebugProcess;
   private VmService myVmService;
-  private InspectorService myInspectorService;
   private PerfService myPerfService;
 
   FlutterApp(@NotNull Project project,
@@ -473,14 +472,6 @@ public class FlutterApp {
 
   public VmService getVmService() {
     return myVmService;
-  }
-
-  public InspectorService getInspectorService() {
-    return myInspectorService;
-  }
-
-  public void setInspectorService(InspectorService service) {
-    myInspectorService = service;
   }
 
   @Nullable

--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -212,7 +212,7 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
     whenCompleteUiThread(InspectorService.create(app.getFlutterDebugProcess(), app.getVmService()),
                          (InspectorService inspectorService, Throwable throwable) -> {
                            if (throwable != null) {
-                             LOG.error(throwable);
+                             LOG.warn(throwable);
                              return;
                            }
                            debugActiveHelper(app, inspectorService);

--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -18,6 +18,7 @@ import com.intellij.openapi.actionSystem.impl.ActionButton;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.PersistentStateComponent;
 import com.intellij.openapi.components.Storage;
+import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.SimpleToolWindowPanel;
 import com.intellij.openapi.util.Disposer;
@@ -52,6 +53,8 @@ import java.awt.*;
 import java.util.*;
 import java.util.List;
 
+import static io.flutter.utils.AsyncUtils.whenCompleteUiThread;
+
 // TODO(devoncarew): Display an fps graph.
 
 @com.intellij.openapi.components.State(
@@ -59,6 +62,8 @@ import java.util.List;
   storages = {@Storage("$WORKSPACE_FILE$")}
 )
 public class FlutterView implements PersistentStateComponent<FlutterViewState>, Disposable {
+
+  private static final Logger LOG = Logger.getInstance(FlutterView.class);
 
   private static class PerAppState {
     ArrayList<FlutterViewAction> flutterViewActions = new ArrayList<>();
@@ -151,7 +156,7 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
     return perAppViewState.computeIfAbsent(app, k -> new PerAppState());
   }
 
-  private void addInspector(FlutterApp app, ToolWindow toolWindow) {
+  private void addInspector(FlutterApp app, InspectorService inspectorService, ToolWindow toolWindow) {
     final ContentManager contentManager = toolWindow.getContentManager();
     final SimpleToolWindowPanel toolWindowPanel = new SimpleToolWindowPanel(true);
     final JBRunnerTabs tabs = new JBRunnerTabs(myProject, ActionManager.getInstance(), null, this);
@@ -171,8 +176,10 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
     final DefaultActionGroup toolbarGroup = createToolbar(toolWindow, app, tabs);
     toolWindowPanel.setToolbar(ActionManager.getInstance().createActionToolbar("FlutterViewToolbar", toolbarGroup, true).getComponent());
 
-    addInspectorPanel("Widgets", tabs, state, InspectorService.FlutterTreeType.widget, app, toolWindow, toolbarGroup, true);
-    addInspectorPanel("Render Tree", tabs, state, InspectorService.FlutterTreeType.renderObject, app, toolWindow, toolbarGroup, false);
+    addInspectorPanel("Widgets", tabs, state, InspectorService.FlutterTreeType.widget, app, inspectorService, toolWindow, toolbarGroup,
+                      true);
+    addInspectorPanel("Render Tree", tabs, state, InspectorService.FlutterTreeType.renderObject, app, inspectorService, toolWindow,
+                      toolbarGroup, false);
   }
 
   private void addInspectorPanel(String displayName,
@@ -180,11 +187,12 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
                                  PerAppState state,
                                  InspectorService.FlutterTreeType treeType,
                                  FlutterApp flutterApp,
+                                 InspectorService inspectorService,
                                  @NotNull ToolWindow toolWindow,
                                  DefaultActionGroup toolbarGroup,
                                  boolean selectedTab) {
     final OverflowAction overflowAction = new OverflowAction(this, flutterApp);
-    final InspectorPanel inspectorPanel = new InspectorPanel(this, flutterApp, flutterApp::isSessionActive, treeType);
+    final InspectorPanel inspectorPanel = new InspectorPanel(this, flutterApp, inspectorService, flutterApp::isSessionActive, treeType);
     final TabInfo tabInfo = new TabInfo(inspectorPanel).setActions(toolbarGroup, ActionPlaces.TOOLBAR)
       .append(displayName, SimpleTextAttributes.REGULAR_ATTRIBUTES)
       .setSideComponent(overflowAction.getActionButton());
@@ -199,11 +207,22 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
    * Called when a debug connection starts.
    */
   public void debugActive(@NotNull FlutterViewMessages.FlutterDebugEvent event) {
+    final FlutterApp app = event.app;
+
+    whenCompleteUiThread(InspectorService.create(app.getFlutterDebugProcess(), app.getVmService()),
+                         (InspectorService inspectorService, Throwable throwable) -> {
+                           if (throwable != null) {
+                             LOG.error(throwable);
+                             return;
+                           }
+                           debugActiveHelper(app, inspectorService);
+                         });
+  }
+
+  private void debugActiveHelper(@NotNull FlutterApp app, @NotNull InspectorService inspectorService) {
     if (FlutterSettings.getInstance().isOpenInspectorOnAppLaunch()) {
       autoActivateToolWindow();
     }
-
-    final FlutterApp app = event.app;
 
     final ToolWindowManager toolWindowManager = ToolWindowManager.getInstance(myProject);
     if (!(toolWindowManager instanceof ToolWindowManagerEx)) {
@@ -221,9 +240,9 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
 
     listenForRenderTreeActivations(toolWindow);
 
-    addInspector(app, toolWindow);
+    addInspector(app, inspectorService, toolWindow);
 
-    event.vmService.addVmServiceListener(new VmServiceListenerAdapter() {
+    app.getVmService().addVmServiceListener(new VmServiceListenerAdapter() {
       @Override
       public void connectionOpened() {
         onAppChanged(app);

--- a/src/io/flutter/view/FlutterViewMessages.java
+++ b/src/io/flutter/view/FlutterViewMessages.java
@@ -42,8 +42,8 @@ public class FlutterViewMessages {
     final FlutterDebugNotifier publisher = bus.syncPublisher(FLUTTER_DEBUG_TOPIC);
     app.setVmService(vmService);
     assert(app.getFlutterDebugProcess() != null);
-    app.setInspectorService( new InspectorService(app.getFlutterDebugProcess(), vmService));
     app.setPerfService(new PerfService(app.getFlutterDebugProcess(), vmService));
+
     publisher.debugActive(new FlutterDebugEvent(app, vmService));
   }
 }

--- a/src/io/flutter/view/InspectorPanel.java
+++ b/src/io/flutter/view/InspectorPanel.java
@@ -82,7 +82,7 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
   private final InspectorService.FlutterTreeType treeType;
   @NotNull
   private final FlutterApp flutterApp;
-  private final InspectorService inspectorService;
+  @NotNull private final InspectorService inspectorService;
   private CompletableFuture<DiagnosticsNode> rootFuture;
 
   private static final DataKey<Tree> INSPECTOR_KEY = DataKey.create("Flutter.InspectorKey");
@@ -193,7 +193,7 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
     setActivate(isApplicable.compute());
   }
 
-  @Nullable
+  @NotNull
   private InspectorService getInspectorService() {
     return inspectorService;
   }

--- a/src/io/flutter/view/InspectorPanel.java
+++ b/src/io/flutter/view/InspectorPanel.java
@@ -82,6 +82,7 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
   private final InspectorService.FlutterTreeType treeType;
   @NotNull
   private final FlutterApp flutterApp;
+  private final InspectorService inspectorService;
   private CompletableFuture<DiagnosticsNode> rootFuture;
 
   private static final DataKey<Tree> INSPECTOR_KEY = DataKey.create("Flutter.InspectorKey");
@@ -107,12 +108,14 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
 
   public InspectorPanel(FlutterView flutterView,
                         @NotNull FlutterApp flutterApp,
+                        @NotNull InspectorService inspectorService,
                         Computable<Boolean> isApplicable,
                         InspectorService.FlutterTreeType treeType) {
     super(new BorderLayout());
 
     this.treeType = treeType;
     this.flutterApp = flutterApp;
+    this.inspectorService = inspectorService;
     this.isApplicable = isApplicable;
 
     refreshRateLimiter = new AsyncRateLimiter(REFRESH_FRAMES_PER_SECOND, this::refresh);
@@ -192,7 +195,7 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
 
   @Nullable
   private InspectorService getInspectorService() {
-    return flutterApp.getInspectorService();
+    return inspectorService;
   }
 
   void setActivate(boolean enabled) {


### PR DESCRIPTION
This avoids problematic cases where the observatory protocol allowed
requests to issue at surprising times such as right in the middle of
a flutter method call.
It is expected this fixes many hard or impossible to reproduce inspector
bugs.

To simplify the code I have also changed the semantics so that
the supportedServiceMethods set is computed before an InspectorService
is considered ready. This reduces the number of future.thenCompose
calls within the InspectorService code dealing with functionality only
exposed by the latest version.