### PR TITLE
Restore Project Structure editor

### DIFF
--- a/flutter-studio/flutter-studio.iml
+++ b/flutter-studio/flutter-studio.iml
@@ -25,6 +25,7 @@
     <orderEntry type="module" module-name="xdebugger-api" />
     <orderEntry type="module" module-name="idea-ui" />
     <orderEntry type="module" module-name="gradle" />
+    <orderEntry type="module" module-name="flags" />
     <orderEntry type="module" module-name="android-uitests" scope="TEST" />
     <orderEntry type="module" module-name="fest-swing" scope="TEST" />
     <orderEntry type="module" module-name="testFramework" scope="TEST" />
@@ -37,5 +38,6 @@
     <orderEntry type="module" module-name="project-system" />
     <orderEntry type="module" module-name="project-system-gradle" />
     <orderEntry type="module" module-name="android-ndk" />
+    <orderEntry type="module" module-name="android-common" />
   </component>
 </module>

--- a/flutter-studio/src/io/flutter/FlutterStudioStartupActivity.java
+++ b/flutter-studio/src/io/flutter/FlutterStudioStartupActivity.java
@@ -9,6 +9,7 @@ import com.intellij.openapi.actionSystem.ActionManager;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.startup.StartupActivity;
+import io.flutter.actions.FlutterShowStructureSettingsAction;
 import io.flutter.actions.OpenAndroidModule;
 import org.jetbrains.annotations.NotNull;
 
@@ -30,5 +31,6 @@ public class FlutterStudioStartupActivity implements StartupActivity {
     // The IntelliJ version of this action spawns a new process for Android Studio.
     // Since we're already running Android Studio we want to simply open the project in the current process.
     replaceAction("flutter.androidstudio.open", new OpenAndroidModule());
+    replaceAction("ShowProjectStructureSettings", new FlutterShowStructureSettingsAction());
   }
 }

--- a/flutter-studio/src/io/flutter/actions/FlutterShowStructureSettingsAction.java
+++ b/flutter-studio/src/io/flutter/actions/FlutterShowStructureSettingsAction.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.actions;
+
+import com.android.tools.idea.gradle.actions.AndroidShowStructureSettingsAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.project.Project;
+import io.flutter.utils.FlutterModuleUtils;
+
+// This restores the Project Structure editor but does not convert it to use the
+// new version defined by Android Studio. That one needs a lot of work to function
+// with Flutter projects.
+public class FlutterShowStructureSettingsAction extends AndroidShowStructureSettingsAction {
+
+  @Override
+  public void update(AnActionEvent e) {
+    Project project = e.getProject();
+    if (project != null && FlutterModuleUtils.hasFlutterModule(project)) {
+      e.getPresentation().setEnabledAndVisible(true);
+    }
+    else {
+      super.update(e);
+    }
+  }
+
+  @Override
+  public void actionPerformed(AnActionEvent e) {
+    //Project project = e.getProject();
+    //if (project == null && IdeInfo.getInstance().isAndroidStudio()) {
+    //  project = ProjectManager.getInstance().getDefaultProject();
+    //  showAndroidProjectStructure(project);
+    //  return;
+    //}
+    //
+    //if (project != null) {
+    //  showAndroidProjectStructure(project);
+    //  return;
+    //}
+
+    super.actionPerformed(e);
+  }
+
+  //private static void showAndroidProjectStructure(@NotNull Project project) {
+  //  if (StudioFlags.NEW_PSD_ENABLED.get()) {
+  //    ProjectStructureConfigurable projectStructure = ProjectStructureConfigurable.getInstance(project);
+  //    AtomicBoolean needsSync = new AtomicBoolean();
+  //    ProjectStructureConfigurable.ProjectStructureChangeListener changeListener = () -> needsSync.set(true);
+  //    projectStructure.add(changeListener);
+  //    projectStructure.showDialog();
+  //    projectStructure.remove(changeListener);
+  //    if (needsSync.get()) {
+  //      GradleSyncInvoker.getInstance().requestProjectSyncAndSourceGeneration(project, TRIGGER_PROJECT_MODIFIED);
+  //    }
+  //    return;
+  //  }
+  //  AndroidProjectStructureConfigurable.getInstance(project).showDialog();
+  //}
+}


### PR DESCRIPTION
Allow the Project Structure menu item to show up in Android Studio. Tested by building a 3.0 plugin and installing it into AS 3.0.1, and by running debuggable AS from sources.

It still uses the one that comes with IntelliJ, so needs some work, but at least it can be used to add (non-Dart) dependencies to Flutter modules. There is some code that is commented-out that will be useful in fixing up support for the new one (I hope).

@devoncarew @pq 