### PR TITLE
add shadows to the panels in the preview view

### DIFF
--- a/src/io/flutter/preview/PreviewArea.java
+++ b/src/io/flutter/preview/PreviewArea.java
@@ -10,10 +10,13 @@ import com.google.gson.JsonObject;
 import com.intellij.openapi.actionSystem.*;
 import com.intellij.openapi.actionSystem.ex.CustomComponentAction;
 import com.intellij.openapi.ui.SimpleToolWindowPanel;
-import com.intellij.ui.IdeBorderFactory;
+import com.intellij.ui.ColorUtil;
+import com.intellij.ui.components.JBLabel;
 import com.intellij.util.ui.JBUI;
+import com.intellij.util.ui.UIUtil;
 import org.dartlang.analysis.server.protocol.Element;
 import org.dartlang.analysis.server.protocol.FlutterOutline;
+import org.jdesktop.swingx.border.DropShadowBorder;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
@@ -41,16 +44,18 @@ import java.util.Map;
 // TODO: we need to take the layer (or z-index?) of the widget into account (see Scaffold and its FAB)
 
 public class PreviewArea {
-  public static int BORDER_WITH = 5;
+  public static int BORDER_WIDTH = 0;
 
   @SuppressWarnings("UseJBColor")
   private static final Color[] pastelColors = new Color[]{
-    new Color(255, 132, 203),
-    new Color(168, 231, 234),
-    new Color(251, 255, 147),
-    new Color(143, 255, 159),
-    new Color(193, 149, 255),
+    new Color(0x455A64),
+    new Color(0x546E7A),
+    new Color(0x607D8B),
+    new Color(0x78909C),
   };
+
+  @SuppressWarnings("UseJBColor") private static final Color labelDarkColor = new Color(0xcccccc);
+  @SuppressWarnings("UseJBColor") private static final Color labelLightColor = new Color(0x333333);
 
   private final Listener myListener;
 
@@ -102,8 +107,8 @@ public class PreviewArea {
           child.setBounds(0, 0, width, height);
         }
 
-        final int renderWidth = width - 2 * BORDER_WITH;
-        final int renderHeight = height - 2 * BORDER_WITH;
+        final int renderWidth = width - 2 * BORDER_WIDTH;
+        final int renderHeight = height - 2 * BORDER_WIDTH;
         listener.resized(renderWidth, renderHeight);
       }
     });
@@ -241,46 +246,67 @@ public class PreviewArea {
 
   private void renderWidgetOutline(@NotNull FlutterOutline outline, int widgetDepth) {
     final Integer id = outline.getId();
-    if (id != null) {
-      Rectangle rect = idToGlobalBounds.get(id);
-      if (rect != null) {
-        final int x = BORDER_WITH + rect.x - rootWidgetBounds.x;
-        final int y = BORDER_WITH + rect.y - rootWidgetBounds.y;
-        rect = new Rectangle(x, y, rect.width, rect.height);
+    if (id == null) {
+      return;
+    }
 
-        final JPanel widget = new JPanel(new BorderLayout());
-        final JLabel label = new JLabel(outline.getClassName());
-        label.setBorder(JBUI.Borders.empty(2, 4, 0, 0));
-        widget.add(label, BorderLayout.NORTH);
-        widget.setBackground(pastelColors[widgetDepth % pastelColors.length]);
-        widget.setBounds(rect);
-        widget.setBorder(IdeBorderFactory.createRoundedBorder(2));
+    final Rectangle rect = idToGlobalBounds.get(id);
+    if (rect == null) {
+      return;
+    }
 
-        outlineToComponent.put(outline, widget);
+    final boolean isDarkBackground = UIUtil.isUnderDarcula();
 
-        widget.addMouseListener(new MouseAdapter() {
-          @Override
-          public void mouseClicked(MouseEvent e) {
-            if (e.getClickCount() >= 2) {
-              myListener.doubleClicked(outline);
-            }
-          }
+    final int x = BORDER_WIDTH + rect.x - rootWidgetBounds.x;
+    final int y = BORDER_WIDTH + rect.y - rootWidgetBounds.y;
 
-          @Override
-          public void mousePressed(MouseEvent e) {
-            myListener.clicked(outline);
-          }
-        });
+    final JPanel widget = new JPanel(new BorderLayout());
+    final DropShadowBorder shadowBorder = new DropShadowBorder();
+    shadowBorder.setShadowSize(3);
+    shadowBorder.setShowRightShadow(true);
+    shadowBorder.setShowBottomShadow(true);
+    widget.setBorder(shadowBorder);
+    widget.setOpaque(false);
+    final Insets insets = shadowBorder.getBorderInsets(widget);
+    widget.setBounds(new Rectangle(x, y, rect.width + insets.right, rect.height + insets.bottom));
 
-        if (outline.getChildren() != null) {
-          for (FlutterOutline child : outline.getChildren()) {
-            renderWidgetOutline(child, widgetDepth + 1);
-          }
+    final JPanel inner = new JPanel(new BorderLayout());
+    inner.setBackground(pastelColors[widgetDepth % pastelColors.length]);
+    inner.setBorder(BorderFactory.createLineBorder(inner.getBackground().darker()));
+    widget.add(inner, BorderLayout.CENTER);
+
+    final JBLabel label = new JBLabel(outline.getClassName());
+    label.setBorder(JBUI.Borders.empty(2, 4, 0, 0));
+    label.setFont(UIUtil.getLabelFont(UIUtil.FontSize.SMALL));
+    final boolean widgetIsDark = ColorUtil.isDark(inner.getBackground());
+    if (widgetIsDark != isDarkBackground) {
+      label.setForeground(widgetIsDark ? labelDarkColor : labelLightColor);
+    }
+    inner.add(label, BorderLayout.NORTH);
+
+    outlineToComponent.put(outline, inner);
+
+    inner.addMouseListener(new MouseAdapter() {
+      @Override
+      public void mouseClicked(MouseEvent e) {
+        if (e.getClickCount() >= 2) {
+          myListener.doubleClicked(outline);
         }
+      }
 
-        primaryLayer.add(widget);
+      @Override
+      public void mousePressed(MouseEvent e) {
+        myListener.clicked(outline);
+      }
+    });
+
+    if (outline.getChildren() != null) {
+      for (FlutterOutline child : outline.getChildren()) {
+        renderWidgetOutline(child, widgetDepth + 1);
       }
     }
+
+    primaryLayer.add(widget);
   }
 
   private void setToolbarTitle(String text) {

--- a/src/io/flutter/preview/PreviewArea.java
+++ b/src/io/flutter/preview/PreviewArea.java
@@ -47,11 +47,13 @@ public class PreviewArea {
   public static int BORDER_WIDTH = 0;
 
   @SuppressWarnings("UseJBColor")
-  private static final Color[] pastelColors = new Color[]{
-    new Color(0x455A64),
+  private static final Color[] widgetColors = new Color[]{
     new Color(0x546E7A),
+    new Color(0x008975),
+    new Color(0x757575),
+    new Color(0x0288D1),
     new Color(0x607D8B),
-    new Color(0x78909C),
+    new Color(0x8D6E63),
   };
 
   @SuppressWarnings("UseJBColor") private static final Color labelDarkColor = new Color(0xcccccc);
@@ -78,6 +80,8 @@ public class PreviewArea {
 
   private final Map<FlutterOutline, JComponent> outlineToComponent = new HashMap<>();
   private final List<SelectionEditPolicy> selectionComponents = new ArrayList<>();
+
+  private int widgetIndex = 0;
 
   public PreviewArea(Listener listener) {
     this.myListener = listener;
@@ -177,7 +181,8 @@ public class PreviewArea {
     }
 
     outlineToComponent.clear();
-    renderWidgetOutline(rootOutline, 0);
+    widgetIndex = 0;
+    renderWidgetOutline(rootOutline);
 
     window.revalidate();
     window.repaint();
@@ -244,7 +249,7 @@ public class PreviewArea {
     }
   }
 
-  private void renderWidgetOutline(@NotNull FlutterOutline outline, int widgetDepth) {
+  private void renderWidgetOutline(@NotNull FlutterOutline outline) {
     final Integer id = outline.getId();
     if (id == null) {
       return;
@@ -271,13 +276,13 @@ public class PreviewArea {
     widget.setBounds(new Rectangle(x, y, rect.width + insets.right, rect.height + insets.bottom));
 
     final JPanel inner = new JPanel(new BorderLayout());
-    inner.setBackground(pastelColors[widgetDepth % pastelColors.length]);
+    inner.setBackground(widgetColors[widgetIndex % widgetColors.length]);
+    widgetIndex++;
     inner.setBorder(BorderFactory.createLineBorder(inner.getBackground().darker()));
     widget.add(inner, BorderLayout.CENTER);
 
     final JBLabel label = new JBLabel(outline.getClassName());
-    label.setBorder(JBUI.Borders.empty(2, 4, 0, 0));
-    label.setFont(UIUtil.getLabelFont(UIUtil.FontSize.SMALL));
+    label.setBorder(JBUI.Borders.empty(1, 4, 0, 0));
     final boolean widgetIsDark = ColorUtil.isDark(inner.getBackground());
     if (widgetIsDark != isDarkBackground) {
       label.setForeground(widgetIsDark ? labelDarkColor : labelLightColor);
@@ -302,7 +307,7 @@ public class PreviewArea {
 
     if (outline.getChildren() != null) {
       for (FlutterOutline child : outline.getChildren()) {
-        renderWidgetOutline(child, widgetDepth + 1);
+        renderWidgetOutline(child);
       }
     }
 


### PR DESCRIPTION
@scheglov, some UI adjustments to the preview area:

- don't have a border for the area
- give the panels for widgets a left-bottom shadow
- change the label color based on the container background color
- use new colors for the panels

<img width="343" alt="screen shot 2018-03-23 at 7 22 06 am" src="https://user-images.githubusercontent.com/1269969/37835552-a979c37a-2e6d-11e8-820f-787f329851c8.png">

Let's talk in person re: the colors. I'm not committed to these ones, but want to iterate a bit on what's currently in master.
