### PR TITLE
Register the outer panel as the widget component.

### DIFF
--- a/src/io/flutter/preview/PreviewArea.java
+++ b/src/io/flutter/preview/PreviewArea.java
@@ -278,7 +278,7 @@ public class PreviewArea {
     label.setForeground(labelColor);
     inner.add(label, BorderLayout.NORTH);
 
-    outlineToComponent.put(outline, inner);
+    outlineToComponent.put(outline, widget);
 
     inner.addMouseListener(new MouseAdapter() {
       @Override


### PR DESCRIPTION
I don't fully understand why, but otherwise the blue selection line disappears as you type in the widget.