### PR TITLE
add an fps view; implement a larger memory view

### DIFF
--- a/src/io/flutter/inspector/FPSDisplay.java
+++ b/src/io/flutter/inspector/FPSDisplay.java
@@ -93,8 +93,7 @@ public class FPSDisplay {
   }
 
   public static class ToolbarComponentAction extends AnAction implements CustomComponentAction {
-    // The width of the drawable fps area.
-    private static final int HEAP_GRAPH_WIDTH = 60;
+    private static final int DRAWABLE_HEAP_WIDTH = 60;
 
     final @NotNull Disposable parent;
     final @NotNull FlutterApp app;
@@ -127,7 +126,7 @@ public class FPSDisplay {
 
       // Graph component.
       final FPSPanel fpsPanel = new FPSPanel(flutterFramesMonitor);
-      fpsPanel.setPreferredSize(new Dimension(HEAP_GRAPH_WIDTH, -1));
+      fpsPanel.setPreferredSize(new Dimension(DRAWABLE_HEAP_WIDTH, -1));
 
       final FlutterFramesMonitor.Listener listener = event -> {
         fpsPanel.update();

--- a/src/io/flutter/inspector/FPSDisplay.java
+++ b/src/io/flutter/inspector/FPSDisplay.java
@@ -1,0 +1,370 @@
+/*
+ * Copyright 2018 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.inspector;
+
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.Presentation;
+import com.intellij.openapi.actionSystem.ex.CustomComponentAction;
+import com.intellij.openapi.util.Disposer;
+import com.intellij.ui.IdeBorderFactory;
+import com.intellij.ui.SideBorder;
+import com.intellij.ui.components.JBLabel;
+import com.intellij.util.ui.JBUI;
+import com.intellij.util.ui.UIUtil;
+import io.flutter.perf.FlutterFramesMonitor;
+import io.flutter.run.daemon.FlutterApp;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.geom.Path2D;
+import java.text.DecimalFormat;
+import java.util.*;
+import java.util.List;
+
+// TODO(devoncarew): Have the preference to enable the view in the overflow menu.
+
+public class FPSDisplay {
+  static final DecimalFormat df = new DecimalFormat();
+
+  static {
+    df.setMaximumFractionDigits(1);
+  }
+
+  public static AnAction createToolbarAction(Disposable parentDisposable, FlutterApp app) {
+    return new FPSDisplay.ToolbarComponentAction(parentDisposable, app);
+  }
+
+  public static JPanel createJPanelView(Disposable parentDisposable, FlutterApp app) {
+    final JPanel panel = new JPanel(new StackLayout());
+    panel.setDoubleBuffered(true);
+    panel.setBorder(IdeBorderFactory.createBorder(SideBorder.TOP));
+    panel.setPreferredSize(new Dimension(100, HeapDisplay.PANEL_HEIGHT));
+
+    assert app.getPerfService() != null;
+    final FlutterFramesMonitor flutterFramesMonitor = app.getPerfService().getFlutterFramesMonitor();
+
+    final FPSPanel fpsPanel = new FPSPanel(flutterFramesMonitor);
+
+    final JPanel labelsPanel = new JPanel();
+    labelsPanel.setOpaque(false);
+    labelsPanel.setLayout(new BoxLayout(labelsPanel, BoxLayout.X_AXIS));
+    panel.add(fpsPanel);
+    panel.add(labelsPanel);
+
+    final JBLabel fpsLabel = new JBLabel();
+    fpsLabel.setAlignmentY(Component.TOP_ALIGNMENT);
+    fpsLabel.setFont(UIUtil.getLabelFont(UIUtil.FontSize.SMALL));
+    fpsLabel.setForeground(UIUtil.getLabelDisabledForeground());
+    fpsLabel.setOpaque(false);
+    fpsLabel.setBorder(JBUI.Borders.empty(4));
+
+    final JBLabel elapsedLabel = new JBLabel("", SwingConstants.RIGHT);
+    elapsedLabel.setAlignmentY(Component.TOP_ALIGNMENT);
+    elapsedLabel.setFont(UIUtil.getLabelFont(UIUtil.FontSize.SMALL));
+    elapsedLabel.setForeground(UIUtil.getLabelDisabledForeground());
+    elapsedLabel.setOpaque(false);
+    elapsedLabel.setBorder(JBUI.Borders.empty(4));
+
+    labelsPanel.add(fpsLabel);
+    labelsPanel.add(Box.createHorizontalGlue());
+    labelsPanel.add(elapsedLabel);
+
+    final FlutterFramesMonitor.Listener listener = event -> {
+      fpsPanel.update();
+
+      final int ms = Math.round(event.elapsedMicros / 1000.0f);
+      elapsedLabel.setText(ms + "ms");
+      SwingUtilities.invokeLater(elapsedLabel::repaint);
+
+      fpsLabel.setText(df.format(flutterFramesMonitor.getFPS()) + " FPS");
+      SwingUtilities.invokeLater(fpsLabel::repaint);
+    };
+
+    flutterFramesMonitor.addListener(listener);
+    Disposer.register(parentDisposable, () -> flutterFramesMonitor.removeListener(listener));
+
+    return panel;
+  }
+
+  public static class ToolbarComponentAction extends AnAction implements CustomComponentAction {
+    // The width of the drawable fps area.
+    private static final int HEAP_GRAPH_WIDTH = 60;
+
+    final @NotNull Disposable parent;
+    final @NotNull FlutterApp app;
+
+    public ToolbarComponentAction(@NotNull Disposable parent, @NotNull FlutterApp app) {
+      this.parent = parent;
+      this.app = app;
+    }
+
+    @Override
+    public void update(AnActionEvent e) {
+      // No-op.
+    }
+
+    @Override
+    public void actionPerformed(AnActionEvent e) {
+      // No-op.
+    }
+
+    @Override
+    public JComponent createCustomComponent(Presentation presentation) {
+      // Summary label.
+      final JBLabel fpsLabel = new JBLabel();
+      fpsLabel.setFont(UIUtil.getLabelFont(UIUtil.FontSize.SMALL));
+      fpsLabel.setForeground(UIUtil.getLabelDisabledForeground());
+      //fpsLabel.setPreferredSize(new Dimension(75, -1));
+
+      assert app.getPerfService() != null;
+      final FlutterFramesMonitor flutterFramesMonitor = app.getPerfService().getFlutterFramesMonitor();
+
+      // Graph component.
+      final FPSPanel fpsPanel = new FPSPanel(flutterFramesMonitor);
+      fpsPanel.setPreferredSize(new Dimension(HEAP_GRAPH_WIDTH, -1));
+
+      final FlutterFramesMonitor.Listener listener = event -> {
+        fpsPanel.update();
+
+        fpsLabel.setText(df.format(flutterFramesMonitor.getFPS()) + " FPS");
+        SwingUtilities.invokeLater(fpsLabel::repaint);
+      };
+
+      flutterFramesMonitor.addListener(listener);
+      Disposer.register(parent, () -> flutterFramesMonitor.removeListener(listener));
+
+      final JPanel container = new JPanel(new BorderLayout(5, 0));
+      container.add(fpsLabel, BorderLayout.WEST);
+      container.add(fpsPanel, BorderLayout.CENTER);
+      return container;
+    }
+  }
+}
+
+class FPSPanel extends JPanel {
+  private final FlutterFramesMonitor framesMonitor;
+
+  private final Map<FlutterFramesMonitor.FlutterFrameEvent, JComponent> frameWidgets = new HashMap<>();
+
+  private Rectangle lastSavedBounds;
+
+  FPSPanel(FlutterFramesMonitor framesMonitor) {
+    this.framesMonitor = framesMonitor;
+
+    setLayout(null);
+    final Color color = UIUtil.getLabelDisabledForeground();
+    //noinspection UseJBColor
+    setForeground(new Color(color.getRed(), color.getGreen(), color.getBlue(), 0x7f));
+  }
+
+  public void update() {
+    SwingUtilities.invokeLater(this::updateFromFramesMonitor);
+  }
+
+  public void doLayout() {
+    if (lastSavedBounds != null && !lastSavedBounds.equals(getBounds())) {
+      lastSavedBounds = null;
+
+      SwingUtilities.invokeLater(this::updateFromFramesMonitor);
+    }
+  }
+
+  private static final Stroke STROKE = new BasicStroke(
+    0.5f, BasicStroke.CAP_BUTT,
+    BasicStroke.JOIN_MITER, 10.0f, new float[]{2.0f, 2.0f}, 0.0f);
+
+  @Override
+  protected void paintComponent(Graphics g) {
+    super.paintComponent(g);
+
+    final Rectangle bounds = getBounds();
+    final int height = bounds.height;
+
+    if (height <= 20) {
+      return;
+    }
+
+    final Graphics2D g2 = (Graphics2D)g;
+
+    final float msPerPixel = (2.0f * 1000000.0f / 60.0f) / height;
+    final float y = FlutterFramesMonitor.microsPerFrame / msPerPixel;
+    final Stroke oldStroke = g2.getStroke();
+    try {
+      g2.setStroke(STROKE);
+      final Path2D path = new Path2D.Float();
+      path.moveTo(0, height - y);
+      path.lineTo(bounds.width, height - y);
+      g2.draw(path);
+    }
+    finally {
+      g2.setStroke(oldStroke);
+    }
+  }
+
+  void updateFromFramesMonitor() {
+    final Set<FlutterFramesMonitor.FlutterFrameEvent> frames = new HashSet<>(frameWidgets.keySet());
+
+    final Rectangle bounds = getBounds();
+    lastSavedBounds = bounds;
+
+    final int height = bounds.height;
+    final int inc = height <= 20 ? 1 : 2;
+
+    int x = bounds.width;
+
+    final int widgetWidth = Math.min(Math.max(Math.round(height / 8.0f), 2), 5);
+
+    synchronized (framesMonitor) {
+      for (FlutterFramesMonitor.FlutterFrameEvent frame : framesMonitor.frames) {
+        if (x + widgetWidth < 0) {
+          break;
+        }
+
+        x -= (widgetWidth + inc);
+
+        final float msPerPixel = (2.0f * 1000000.0f / 60.0f) / height;
+        JComponent widget = frameWidgets.get(frame);
+        if (widget != null) {
+          frames.remove(frame);
+        }
+        else {
+          widget = new JLabel();
+          widget.setOpaque(true);
+          widget.setBackground(frame.isSlowFrame() ? UIUtil.getLabelForeground() : UIUtil.getLabelDisabledForeground());
+          widget.setToolTipText(FPSDisplay.df.format(frame.elapsedMicros / 1000.0d) + "ms");
+          frameWidgets.put(frame, widget);
+          add(widget);
+        }
+
+        int pixelHeight = Math.round(frame.elapsedMicros / msPerPixel);
+        if (pixelHeight > height) {
+          pixelHeight = height;
+        }
+        pixelHeight = Math.max(1, pixelHeight);
+        widget.setPreferredSize(new Dimension(widgetWidth, pixelHeight));
+        widget.setBounds(x, height - pixelHeight, widgetWidth, pixelHeight);
+
+        // Add a gap between sets of frames.
+        if (frame.frameSetStart) {
+          x -= widgetWidth;
+        }
+      }
+    }
+
+    if (!frames.isEmpty()) {
+      for (FlutterFramesMonitor.FlutterFrameEvent frame : frames) {
+        final JComponent widget = frameWidgets.remove(frame);
+        remove(widget);
+      }
+    }
+  }
+}
+
+class StackLayout implements LayoutManager2 {
+  public static final String BOTTOM = "bottom";
+  public static final String TOP = "top";
+  private final List<Component> components = new LinkedList<>();
+
+  public StackLayout() {
+  }
+
+  public void addLayoutComponent(Component comp, Object constraints) {
+    synchronized (comp.getTreeLock()) {
+      if ("bottom".equals(constraints)) {
+        this.components.add(0, comp);
+      }
+      else if ("top".equals(constraints)) {
+        this.components.add(comp);
+      }
+      else {
+        this.components.add(comp);
+      }
+    }
+  }
+
+  public void addLayoutComponent(String name, Component comp) {
+    this.addLayoutComponent(comp, "top");
+  }
+
+  public void removeLayoutComponent(Component comp) {
+    synchronized (comp.getTreeLock()) {
+      this.components.remove(comp);
+    }
+  }
+
+  public float getLayoutAlignmentX(Container target) {
+    return 0.5F;
+  }
+
+  public float getLayoutAlignmentY(Container target) {
+    return 0.5F;
+  }
+
+  public void invalidateLayout(Container target) {
+  }
+
+  public Dimension preferredLayoutSize(Container parent) {
+    synchronized (parent.getTreeLock()) {
+      int width = 0;
+      int height = 0;
+
+      Dimension size;
+      for (final Iterator i$ = this.components.iterator(); i$.hasNext(); height = Math.max(size.height, height)) {
+        final Component comp = (Component)i$.next();
+        size = comp.getPreferredSize();
+        width = Math.max(size.width, width);
+      }
+
+      final Insets insets = parent.getInsets();
+      width += insets.left + insets.right;
+      height += insets.top + insets.bottom;
+      return new Dimension(width, height);
+    }
+  }
+
+  public Dimension minimumLayoutSize(Container parent) {
+    synchronized (parent.getTreeLock()) {
+      int width = 0;
+      int height = 0;
+
+      Dimension size;
+      for (final Iterator i$ = this.components.iterator(); i$.hasNext(); height = Math.max(size.height, height)) {
+        final Component comp = (Component)i$.next();
+        size = comp.getMinimumSize();
+        width = Math.max(size.width, width);
+      }
+
+      final Insets insets = parent.getInsets();
+      width += insets.left + insets.right;
+      height += insets.top + insets.bottom;
+      return new Dimension(width, height);
+    }
+  }
+
+  public Dimension maximumLayoutSize(Container target) {
+    return new Dimension(2147483647, 2147483647);
+  }
+
+  public void layoutContainer(Container parent) {
+    synchronized (parent.getTreeLock()) {
+      final Insets insets = parent.getInsets();
+
+      final int width = parent.getWidth() - insets.left - insets.right;
+      final int height = parent.getHeight() - insets.top - insets.bottom;
+      final Rectangle bounds = new Rectangle(insets.left, insets.top, width, height);
+      final int componentsCount = this.components.size();
+
+      for (int i = 0; i < componentsCount; ++i) {
+        final Component comp = this.components.get(i);
+        comp.setBounds(bounds);
+        parent.setComponentZOrder(comp, componentsCount - i - 1);
+      }
+    }
+  }
+}

--- a/src/io/flutter/inspector/HeapDisplay.java
+++ b/src/io/flutter/inspector/HeapDisplay.java
@@ -99,8 +99,7 @@ public class HeapDisplay extends JPanel {
   }
 
   public static class ToolbarComponentAction extends AnAction implements CustomComponentAction, HeapListener, Disposable {
-    // The width of the drawable heap area.
-    private static final int HEAP_GRAPH_WIDTH = 60;
+    private static final int DRAWABLE_HEAP_WIDTH = 60;
 
     private final List<JPanel> panels = new ArrayList<>();
     private final List<HeapDisplay> graphs = new ArrayList<>();
@@ -141,7 +140,7 @@ public class HeapDisplay extends JPanel {
         label.setText(state.getSimpleHeapSummary());
         SwingUtilities.invokeLater(label::repaint);
       });
-      graph.setPreferredSize(new Dimension(HEAP_GRAPH_WIDTH, -1));
+      graph.setPreferredSize(new Dimension(DRAWABLE_HEAP_WIDTH, -1));
       panel.add(graph, new GridBagConstraints(
         0, 0, 1, 1, 1, 1,
         GridBagConstraints.CENTER, GridBagConstraints.BOTH,

--- a/src/io/flutter/inspector/HeapDisplay.java
+++ b/src/io/flutter/inspector/HeapDisplay.java
@@ -11,6 +11,8 @@ import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.Presentation;
 import com.intellij.openapi.actionSystem.ex.CustomComponentAction;
 import com.intellij.openapi.util.Disposer;
+import com.intellij.ui.IdeBorderFactory;
+import com.intellij.ui.SideBorder;
 import com.intellij.ui.components.JBLabel;
 import com.intellij.util.ui.JBUI;
 import com.intellij.util.ui.UIUtil;
@@ -22,40 +24,96 @@ import io.flutter.perf.HeapMonitor.IsolateObject;
 import io.flutter.perf.PerfService;
 import io.flutter.run.daemon.FlutterApp;
 import org.dartlang.vm.service.element.IsolateRef;
+import org.dartlang.vm.service.element.VM;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 import java.awt.*;
+import java.awt.geom.Path2D;
 import java.text.DecimalFormat;
 import java.util.*;
 import java.util.List;
 
 // TODO(pq): make capacity setting dynamic
 public class HeapDisplay extends JPanel {
+  static final int PANEL_HEIGHT = 48;
 
-  // The width of the drawable heap area.
-  private static final int HEAP_GRAPH_WIDTH = 60;
-  // The height of the drawable heap area.
-  private static final int HEAP_GRAPH_HEIGHT = 16;
+  public static AnAction createToolbarAction(Disposable parentDisposable, FlutterApp app) {
+    return new HeapDisplay.ToolbarComponentAction(parentDisposable, app);
+  }
 
-  // TODO(pq): consider basing this on available space or user configuration.
-  private static final boolean SHOW_HEAP_SUMMARY = false;
+  public static JPanel createJPanelView(Disposable parentDisposable, FlutterApp app) {
+    final JPanel panel = new JPanel(new BorderLayout());
+    panel.setBorder(IdeBorderFactory.createBorder(SideBorder.TOP));
+    panel.setPreferredSize(new Dimension(100, PANEL_HEIGHT));
 
-  @Nullable
-  private final SummaryCallback summaryCallback;
+    final JBLabel rssLabel = new JBLabel();
+    rssLabel.setAlignmentY(Component.BOTTOM_ALIGNMENT);
+    rssLabel.setFont(UIUtil.getLabelFont(UIUtil.FontSize.SMALL));
+    rssLabel.setForeground(UIUtil.getLabelDisabledForeground());
+    rssLabel.setBorder(JBUI.Borders.empty(4));
+    final JBLabel heapLabel = new JBLabel("", SwingConstants.RIGHT);
+    heapLabel.setAlignmentY(Component.BOTTOM_ALIGNMENT);
+    heapLabel.setFont(UIUtil.getLabelFont(UIUtil.FontSize.SMALL));
+    heapLabel.setForeground(UIUtil.getLabelDisabledForeground());
+    heapLabel.setBorder(JBUI.Borders.empty(4));
+
+    final HeapState heapState = new HeapState(60 * 1000);
+    final HeapDisplay graph = new HeapDisplay(state -> {
+      rssLabel.setText(heapState.getRSSSummary());
+      heapLabel.setText(heapState.getHeapSummary());
+
+      SwingUtilities.invokeLater(rssLabel::repaint);
+      SwingUtilities.invokeLater(heapLabel::repaint);
+    });
+
+    graph.setLayout(new BoxLayout(graph, BoxLayout.X_AXIS));
+    graph.add(rssLabel);
+    graph.add(Box.createHorizontalGlue());
+    graph.add(heapLabel);
+
+    panel.add(graph, BorderLayout.CENTER);
+
+    final HeapListener listener = new HeapListener() {
+      @Override
+      public void handleIsolatesInfo(VM vm, List<IsolateObject> isolates) {
+        heapState.handleIsolatesInfo(vm, isolates);
+        graph.updateFrom(heapState);
+        SwingUtilities.invokeLater(panel::repaint);
+      }
+
+      @Override
+      public void handleGCEvent(IsolateRef iIsolateRef, HeapSpace newHeapSpace, HeapSpace oldHeapSpace) {
+        heapState.handleGCEvent(iIsolateRef, newHeapSpace, oldHeapSpace);
+        graph.updateFrom(heapState);
+        SwingUtilities.invokeLater(panel::repaint);
+      }
+    };
+
+    assert app.getPerfService() != null;
+    app.getPerfService().addListener(listener);
+    Disposer.register(parentDisposable, () -> app.getPerfService().removeListener(listener));
+
+    return panel;
+  }
 
   public static class ToolbarComponentAction extends AnAction implements CustomComponentAction, HeapListener, Disposable {
+    // The width of the drawable heap area.
+    private static final int HEAP_GRAPH_WIDTH = 60;
+
     private final List<JPanel> panels = new ArrayList<>();
     private final List<HeapDisplay> graphs = new ArrayList<>();
 
     final HeapState heapState = new HeapState(20 * 1000);
+    final @NotNull FlutterApp app;
 
     public ToolbarComponentAction(@NotNull Disposable parent, @NotNull FlutterApp app) {
+      this.app = app;
+
       final PerfService service = app.getPerfService();
       assert service != null;
-      service.addListener(this);
-      service.start();
+      app.getPerfService().addListener(this);
       Disposer.register(parent, this);
     }
 
@@ -71,43 +129,43 @@ public class HeapDisplay extends JPanel {
 
     @Override
     public JComponent createCustomComponent(Presentation presentation) {
-
       // Summary label.
-      JBLabel label = null;
-      if (SHOW_HEAP_SUMMARY) {
-        label = new JBLabel();
-        label.setFont(UIUtil.getLabelFont(UIUtil.FontSize.SMALL));
-        label.setForeground(getForegroundColor());
-      }
+      final JBLabel label = new JBLabel("", SwingConstants.RIGHT);
+      label.setFont(UIUtil.getLabelFont(UIUtil.FontSize.SMALL));
+      label.setForeground(getForegroundColor());
+      label.setMinimumSize(new Dimension(75, -1));
 
       // Graph component.
       final JPanel panel = new JPanel(new GridBagLayout());
-      final HeapDisplay graph = new HeapDisplay(SHOW_HEAP_SUMMARY ? label::setText : null);
-      panel.add(graph,
-                new GridBagConstraints(0, 0, 1, 1, 1, 1,
-                                       GridBagConstraints.CENTER, GridBagConstraints.BOTH,
-                                       JBUI.insets(0, 3, 0, 3), 0, 0));
+      final HeapDisplay graph = new HeapDisplay(state -> {
+        label.setText(state.getSimpleHeapSummary());
+        SwingUtilities.invokeLater(label::repaint);
+      });
+      graph.setPreferredSize(new Dimension(HEAP_GRAPH_WIDTH, -1));
+      panel.add(graph, new GridBagConstraints(
+        0, 0, 1, 1, 1, 1,
+        GridBagConstraints.CENTER, GridBagConstraints.BOTH,
+        JBUI.insets(0, 3, 0, 3), 0, 0));
       // Because there may be multiple toolbars, we need to store (and update) multiple panels.
       panels.add(panel);
       graphs.add(graph);
 
       final JPanel container = new JPanel(new BorderLayout(5, 0));
-      //noinspection ConstantConditions
-      if (label != null) {
-        container.add(label, BorderLayout.WEST);
-      }
+      container.add(label, BorderLayout.WEST);
       container.add(panel, BorderLayout.CENTER);
       return container;
     }
 
     @Override
     public void dispose() {
-      // TODO(pq): add any cleanup here.
+      if (app.getPerfService() != null) {
+        app.getPerfService().removeListener(this);
+      }
     }
 
     @Override
-    public void handleIsolatesInfo(List<IsolateObject> isolates) {
-      heapState.handleIsolatesInfo(isolates);
+    public void handleIsolatesInfo(VM vm, List<IsolateObject> isolates) {
+      heapState.handleIsolatesInfo(vm, isolates);
 
       for (HeapDisplay graph : graphs) {
         graph.updateFrom(heapState);
@@ -136,20 +194,18 @@ public class HeapDisplay extends JPanel {
 
   private static final Stroke GRAPH_STROKE = new BasicStroke(2f);
 
-  private static final DecimalFormat df = new DecimalFormat();
-
-  static {
-    df.setMaximumFractionDigits(1);
-  }
-
   private interface SummaryCallback {
-    void updatedSummary(String summary);
+    void updatedSummary(HeapState state);
   }
+
+  @Nullable
+  private final SummaryCallback summaryCallback;
 
   private @Nullable HeapState heapState;
 
   public HeapDisplay(@Nullable SummaryCallback summaryCallback) {
     this.summaryCallback = summaryCallback;
+
     setVisible(true);
   }
 
@@ -159,18 +215,9 @@ public class HeapDisplay extends JPanel {
     if (!heapState.getSamples().isEmpty()) {
       final HeapSample sample = heapState.getSamples().get(0);
       if (summaryCallback != null) {
-        summaryCallback.updatedSummary(printMb(sample.getBytes()));
-      }
-      else {
-        // TODO(pq): if the summary callback is defined, consider displaying a quick pointer or doc in the tooltip.
-        final String summary = printMb(sample.getBytes()) + " of " + printMb(heapState.getMaxHeapInBytes());
-        setToolTipText(summary);
+        summaryCallback.updatedSummary(state);
       }
     }
-  }
-
-  private static String printMb(int bytes) {
-    return df.format(bytes / (1024 * 1024.0)) + "MB";
   }
 
   @Override
@@ -181,37 +228,35 @@ public class HeapDisplay extends JPanel {
       return;
     }
 
-    final int height = getHeight();
+    final int height = getHeight() - 1;
     final int width = getWidth();
     final long now = System.currentTimeMillis();
 
-    final double maxDataSize = (Math.round(heapState.getMaxHeapInBytes() / TEN_MB)) * TEN_MB + TEN_MB;
+    final int maxDataSize = Math.round(heapState.getMaxHeapInBytes() / TEN_MB) * TEN_MB + TEN_MB;
 
     final Graphics2D graphics2D = (Graphics2D)g;
     graphics2D.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
 
-    final List<Point> graphPoints = new ArrayList<>();
-    for (HeapSample sample : heapState.getSamples()) {
-      final int x = width - (int)(((double)(now - sample.getSampleTime())) / ((double)heapState.getMaxSampleSizeMs()) * width);
-      // TODO(pq): consider a Y offset or scaling.
-      final int y = (int)(height * sample.getBytes() / maxDataSize);
-      graphPoints.add(new Point(x, y));
-    }
-
     graphics2D.setColor(getForegroundColor());
     graphics2D.setStroke(GRAPH_STROKE);
 
-    for (int i = 0; i < graphPoints.size() - 1; i++) {
-      final Point p1 = graphPoints.get(i);
-      final Point p2 = graphPoints.get(i + 1);
-      // TODO(pq): consider UIUtil.drawLine(...);
-      graphics2D.drawLine(p1.x, height - p1.y, p2.x, height - p2.y);
-    }
-  }
+    Path2D path = null;
 
-  @Override
-  public Dimension getPreferredSize() {
-    return new Dimension(HEAP_GRAPH_WIDTH, HEAP_GRAPH_HEIGHT);
+    for (HeapSample sample : heapState.getSamples()) {
+      final double x = width - (((double)(now - sample.getSampleTime())) / ((double)heapState.getMaxSampleSizeMs()) * width);
+      // TODO(pq): consider a Y offset or scaling.
+      final double y = (double)height * sample.getBytes() / maxDataSize;
+
+      if (path == null) {
+        path = new Path2D.Double();
+        path.moveTo(x, height - y + 1);
+      }
+      else {
+        path.lineTo(x, height - y + 1);
+      }
+    }
+
+    graphics2D.draw(path);
   }
 }
 
@@ -238,6 +283,16 @@ class HeapSamples {
 }
 
 class HeapState implements HeapListener {
+  private static final DecimalFormat df = new DecimalFormat();
+  private static final DecimalFormat df1 = new DecimalFormat();
+
+  static {
+    df.setMaximumFractionDigits(0);
+    df1.setMaximumFractionDigits(1);
+  }
+
+  private int rssBytes;
+
   // Running count of the max heap (in bytes).
   private int heapMaxInBytes;
 
@@ -266,12 +321,32 @@ class HeapState implements HeapListener {
     return max;
   }
 
+  private static String printMb(int bytes) {
+    return df.format(bytes / (1024 * 1024.0)) + "MB";
+  }
+
+  private static String printMb1(int bytes) {
+    return df1.format(bytes / (1024 * 1024.0)) + "MB";
+  }
+
+  public String getRSSSummary() {
+    return printMb(rssBytes) + " RSS";
+  }
+
+  public String getHeapSummary() {
+    return printMb1(samples.samples.getLast().getBytes()) + " of " + printMb1(heapMaxInBytes);
+  }
+
+  public String getSimpleHeapSummary() {
+    return printMb(samples.samples.getLast().getBytes());
+  }
+
   void addSample(HeapSample sample) {
     samples.add(sample);
   }
 
   @Override
-  public void handleIsolatesInfo(List<IsolateObject> isolates) {
+  public void handleIsolatesInfo(VM vm, List<IsolateObject> isolates) {
     int current = 0;
     int total = 0;
 
@@ -286,6 +361,7 @@ class HeapState implements HeapListener {
       }
     }
 
+    rssBytes = vm.getJson().get("_currentRSS").getAsInt();
     heapMaxInBytes = total;
 
     addSample(new HeapSample(current, false));

--- a/src/io/flutter/perf/FlutterFramesMonitor.java
+++ b/src/io/flutter/perf/FlutterFramesMonitor.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2018 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.perf;
+
+import com.google.gson.JsonObject;
+import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.util.EventDispatcher;
+import io.flutter.utils.VmServiceListenerAdapter;
+import org.dartlang.vm.service.VmService;
+import org.dartlang.vm.service.element.Event;
+import org.dartlang.vm.service.element.ExtensionData;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.EventListener;
+import java.util.LinkedList;
+import java.util.List;
+
+public class FlutterFramesMonitor {
+  public static final long microsPerFrame = 1000000 / 60;
+
+  static final int maxFrames = 200;
+
+  private final EventDispatcher<Listener> eventDispatcher = EventDispatcher.create(Listener.class);
+
+  private long lastEventFinished = 0;
+
+  public interface Listener extends EventListener {
+    void handleFrameEvent(FlutterFrameEvent event);
+  }
+
+  public static class FlutterFrameEvent {
+    public final int frameId;
+    public final long startTimeMicros;
+    public final long elapsedMicros;
+    public final boolean frameSetStart;
+
+    FlutterFrameEvent(ExtensionData data, long lastEventFinished) {
+      final JsonObject json = data.getJson();
+      frameId = json.get("number").getAsInt();
+      startTimeMicros = json.get("startTime").getAsLong();
+      elapsedMicros = json.get("elapsed").getAsLong();
+      frameSetStart = (startTimeMicros - lastEventFinished) > (FlutterFramesMonitor.microsPerFrame * 2);
+    }
+
+    public long getFrameFinishedMicros() {
+      return startTimeMicros + elapsedMicros;
+    }
+
+    public boolean isSlowFrame() {
+      return elapsedMicros > FlutterFramesMonitor.microsPerFrame;
+    }
+
+    public int hashCode() {
+      return frameId;
+    }
+
+    public boolean equals(Object other) {
+      return other instanceof FlutterFrameEvent && ((FlutterFrameEvent)other).frameId == frameId;
+    }
+
+    public String toString() {
+      return "#" + frameId + " " + elapsedMicros + "µs";
+    }
+  }
+
+  public List<FlutterFrameEvent> frames = new LinkedList<>();
+
+  FlutterFramesMonitor(@NotNull VmService vmService) {
+    vmService.addVmServiceListener(new VmServiceListenerAdapter() {
+      @Override
+      public void received(String streamId, Event event) {
+        onVmServiceReceived(streamId, event);
+      }
+
+      @Override
+      public void connectionClosed() {
+      }
+    });
+  }
+
+  private void onVmServiceReceived(String streamId, Event event) {
+    if (StringUtil.equals(streamId, VmService.EXTENSION_STREAM_ID)) {
+      if (StringUtil.equals("Flutter.Frame", event.getExtensionKind())) {
+        handleFlutterFrame(event);
+      }
+    }
+  }
+
+  public boolean hasFps() {
+    return !frames.isEmpty();
+  }
+
+  /**
+   * Return the most recent FPS value.
+   */
+  public double getFPS() {
+    int frameCount = 0;
+    int costCount = 0;
+
+    synchronized (this) {
+      for (FlutterFrameEvent frame : frames) {
+        frameCount++;
+
+        long thisCost = frame.elapsedMicros / microsPerFrame;
+        if (frame.elapsedMicros > (thisCost * microsPerFrame)) {
+          thisCost++;
+        }
+
+        costCount += thisCost;
+
+        if (frame.frameSetStart) {
+          break;
+        }
+      }
+    }
+
+    if (costCount == 0) {
+      return 0.0;
+    }
+
+    return frameCount * 60.0 / costCount;
+  }
+
+  public void addListener(Listener listener) {
+    eventDispatcher.addListener(listener);
+  }
+
+  public void removeListener(Listener listener) {
+    eventDispatcher.removeListener(listener);
+  }
+
+  private void handleFlutterFrame(Event event) {
+    final FlutterFrameEvent frameEvent = new FlutterFrameEvent(event.getExtensionData(), lastEventFinished);
+    lastEventFinished = frameEvent.getFrameFinishedMicros();
+
+    synchronized (this) {
+      frames.add(0, frameEvent);
+      if (frames.size() > maxFrames) {
+        frames.remove(frames.size() - 1);
+      }
+    }
+
+    eventDispatcher.getMulticaster().handleFrameEvent(frameEvent);
+  }
+}

--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -139,11 +139,12 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
       toolbarGroup.addSeparator();
       toolbarGroup.add(FPSDisplay.createToolbarAction(parentDisposable, app));
       toolbarGroup.addSeparator();
-      //toolbarGroup.add(new ObservatoryActionGroup(this, app));
+      toolbarGroup.add(new ObservatoryActionGroup(this, app));
     }
-
-    toolbarGroup.add(registerAction(new OpenTimelineViewAction(app)));
-    toolbarGroup.add(registerAction(new OpenObservatoryAction(app)));
+    else {
+      toolbarGroup.add(registerAction(new OpenTimelineViewAction(app)));
+      toolbarGroup.add(registerAction(new OpenObservatoryAction(app)));
+    }
 
     return toolbarGroup;
   }
@@ -766,8 +767,8 @@ class ObservatoryActionGroup extends AnAction implements CustomComponentAction {
 
   private static DefaultActionGroup createPopupActionGroup(FlutterView view, FlutterApp app) {
     final DefaultActionGroup group = new DefaultActionGroup();
-    group.add(view.registerAction(new OpenObservatoryAction(app)));
     group.add(view.registerAction(new OpenTimelineViewAction(app)));
+    group.add(view.registerAction(new OpenObservatoryAction(app)));
     return group;
   }
 }

--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -37,6 +37,7 @@ import com.intellij.util.ui.UIUtil;
 import icons.FlutterIcons;
 import io.flutter.FlutterBundle;
 import io.flutter.FlutterInitializer;
+import io.flutter.inspector.FPSDisplay;
 import io.flutter.inspector.HeapDisplay;
 import io.flutter.inspector.InspectorService;
 import io.flutter.run.daemon.FlutterApp;
@@ -103,7 +104,7 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
   }
 
   @Override
-  public void loadState(FlutterViewState state) {
+  public void loadState(@NotNull FlutterViewState state) {
     this.state.copyFrom(state);
   }
 
@@ -132,14 +133,18 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
     toolbarGroup.add(registerAction(new PerformanceOverlayAction(app)));
     toolbarGroup.addSeparator();
 
-    if (!FlutterSettings.getInstance().isShowHeapDisplay()) {
-      toolbarGroup.add(registerAction(new OpenTimelineViewAction(app)));
-      toolbarGroup.add(registerAction(new OpenObservatoryAction(app)));
+    final boolean isHorizontal = toolWindow.getAnchor().isHorizontal();
+    if (FlutterSettings.getInstance().isShowHeapDisplay() && isHorizontal) {
+      toolbarGroup.add(HeapDisplay.createToolbarAction(parentDisposable, app));
+      toolbarGroup.addSeparator();
+      toolbarGroup.add(FPSDisplay.createToolbarAction(parentDisposable, app));
+      toolbarGroup.addSeparator();
+      //toolbarGroup.add(new ObservatoryActionGroup(this, app));
     }
-    else {
-      toolbarGroup.add(new HeapDisplay.ToolbarComponentAction(parentDisposable, app));
-      toolbarGroup.add(new ObservatoryActionGroup(this, app));
-    }
+
+    toolbarGroup.add(registerAction(new OpenTimelineViewAction(app)));
+    toolbarGroup.add(registerAction(new OpenObservatoryAction(app)));
+
     return toolbarGroup;
   }
 
@@ -164,8 +169,10 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
     for (FlutterApp otherApp : perAppViewState.keySet()) {
       existingDevices.add(otherApp.device());
     }
+    final JPanel tabContainer = new JPanel(new BorderLayout());
     final Content content = contentManager.getFactory().createContent(null, app.device().getUniqueName(existingDevices), false);
-    content.setComponent(tabs.getComponent());
+    tabContainer.add(tabs.getComponent(), BorderLayout.CENTER);
+    content.setComponent(tabContainer);
     content.putUserData(ToolWindow.SHOW_CONTENT_ICON, Boolean.TRUE);
     content.setIcon(FlutterIcons.Phone);
     contentManager.addContent(content);
@@ -180,6 +187,17 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
                       true);
     addInspectorPanel("Render Tree", tabs, state, InspectorService.FlutterTreeType.renderObject, app, inspectorService, toolWindow,
                       toolbarGroup, false);
+
+    final boolean isVertical = !toolWindow.getAnchor().isHorizontal();
+    if (isVertical) {
+      final JPanel dashboardsPanel = new JPanel(new BorderLayout());
+      tabContainer.add(dashboardsPanel, BorderLayout.SOUTH);
+
+      if (FlutterSettings.getInstance().isShowHeapDisplay()) {
+        dashboardsPanel.add(FPSDisplay.createJPanelView(tabs, app), BorderLayout.NORTH);
+        dashboardsPanel.add(HeapDisplay.createJPanelView(tabs, app), BorderLayout.SOUTH);
+      }
+    }
   }
 
   private void addInspectorPanel(String displayName,


### PR DESCRIPTION
- add a larger version of the memory view at the bottom of the inspector
- implement an FPS view
- both memory and fps views show in the toolbar if the inspector tool window is in a horizontal orientation, and at the bottom of the view if in a vertical orientation

Still left to do (likely in a follow-up) is to make the preference to show opt-out, and move it to the overflow menu of the inspector view (or similar location).

<img width="540" alt="screen shot 2018-03-25 at 9 55 08 pm" src="https://user-images.githubusercontent.com/1269969/37887679-fac25808-3077-11e8-851e-5008b14ece4c.png">

<img width="353" alt="screen shot 2018-03-25 at 9 56 56 pm" src="https://user-images.githubusercontent.com/1269969/37887685-01746eca-3078-11e8-8df4-ecd660e75058.png">

