### PR TITLE
some tweaks to the preview area title

### DIFF
--- a/src/io/flutter/preview/PreviewArea.java
+++ b/src/io/flutter/preview/PreviewArea.java
@@ -45,7 +45,7 @@ import java.util.Map;
 public class PreviewArea {
   public static int BORDER_WIDTH = 0;
   public static final String NOTHING_TO_SHOW = "Nothing to show";
-  public static final String NO_WIDGET_MESSAGE = "The selection does not correspond to a widget";
+  public static final String NO_WIDGET_MESSAGE = "No widget selected";
 
   private static final Color[] widgetColors = new Color[]{
     new JBColor(new Color(0xB8F1FF), new Color(0x546E7A)),
@@ -125,7 +125,7 @@ public class PreviewArea {
   }
 
   public void clear(String message) {
-    setToolbarTitle(" ");
+    setToolbarTitle(null);
 
     primaryLayer.removeAll();
 
@@ -174,7 +174,7 @@ public class PreviewArea {
     if (widgetClassElement != null) {
       final String widgetClassName = widgetClassElement.getName();
       final String stateClassName = widgetOutline.getStateClassName();
-      final String title = widgetClassName + (stateClassName != null ? " : " + stateClassName : "");
+      final String title = widgetClassName + (stateClassName != null ? " > " + stateClassName : "");
       setToolbarTitle(title);
     }
     else {
@@ -309,9 +309,7 @@ public class PreviewArea {
 
   private void setToolbarTitle(String text) {
     toolbarGroup.removeAll();
-    if (text != null) {
-      toolbarGroup.add(new TitleAction(text));
-    }
+    toolbarGroup.add(new TitleAction(text == null ? "Preview" : ("Preview: " + text)));
     windowToolbar.updateActionsImmediately();
   }
 

--- a/src/io/flutter/preview/PreviewView.java
+++ b/src/io/flutter/preview/PreviewView.java
@@ -185,7 +185,7 @@ public class PreviewView implements PersistentStateComponent<PreviewViewState>, 
               previewArea.clear(PreviewArea.NO_WIDGET_MESSAGE);
               break;
             case NOT_RENDERABLE_WIDGET:
-              previewArea.clear(PreviewArea.NO_WIDGET_MESSAGE);
+              previewArea.clear("The selection does not correspond to a renderable widget");
               break;
             case TIMEOUT:
               previewArea.clear("Timeout during rendering");

--- a/src/io/flutter/preview/PreviewView.java
+++ b/src/io/flutter/preview/PreviewView.java
@@ -179,13 +179,13 @@ public class PreviewView implements PersistentStateComponent<PreviewViewState>, 
           switch (kind) {
             case EXCEPTION:
             case NO_TEMPORARY_DIRECTORY:
-              previewArea.clear("There was an exception during rendering");
+              previewArea.clear("Encountered an exception during rendering");
               break;
             case NO_WIDGET:
               previewArea.clear(PreviewArea.NO_WIDGET_MESSAGE);
               break;
             case NOT_RENDERABLE_WIDGET:
-              previewArea.clear("The selection does not correspond to a renderable widget");
+              previewArea.clear(PreviewArea.NO_WIDGET_MESSAGE);
               break;
             case TIMEOUT:
               previewArea.clear("Timeout during rendering");

--- a/src/io/flutter/preview/PreviewView.java
+++ b/src/io/flutter/preview/PreviewView.java
@@ -185,7 +185,7 @@ public class PreviewView implements PersistentStateComponent<PreviewViewState>, 
               previewArea.clear(PreviewArea.NO_WIDGET_MESSAGE);
               break;
             case NOT_RENDERABLE_WIDGET:
-              previewArea.clear("The selection does not correspond to a renderable widget");
+              previewArea.clear("Selection does not correspond to a renderable widget");
               break;
             case TIMEOUT:
               previewArea.clear("Timeout during rendering");


### PR DESCRIPTION
- always have text in the title: `Preview` - so that title area doesn't look empty
- slight tweaks to some error messages for consistency and so they display in more narrow layouts

@scheglov 
