### PR TITLE
improve our support of --profile mode

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -183,7 +183,7 @@
       </action>
       <action id="Flutter.Menu.RunProfileAction" class="io.flutter.actions.RunProfileFlutterApp"
               description="Flutter Run Profile Mode"
-              icon="AllIcons.Actions.Profile">
+              icon="AllIcons.Actions.Execute">
       </action>
       <action id="Flutter.Menu.RunReleaseAction" class="io.flutter.actions.RunReleaseFlutterApp"
               description="Flutter Run Release Mode"

--- a/resources/META-INF/plugin_template.xml
+++ b/resources/META-INF/plugin_template.xml
@@ -134,7 +134,7 @@
       </action>
       <action id="Flutter.Menu.RunProfileAction" class="io.flutter.actions.RunProfileFlutterApp"
               description="Flutter Run Profile Mode"
-              icon="AllIcons.Actions.Profile">
+              icon="AllIcons.Actions.Execute">
       </action>
       <action id="Flutter.Menu.RunReleaseAction" class="io.flutter.actions.RunReleaseFlutterApp"
               description="Flutter Run Release Mode"

--- a/src/io/flutter/actions/FlutterAppAction.java
+++ b/src/io/flutter/actions/FlutterAppAction.java
@@ -66,7 +66,8 @@ abstract public class FlutterAppAction extends DumbAwareAction {
     updateActionRegistration(myApp.isConnected());
 
     final boolean isConnected = myIsApplicable.compute();
-    e.getPresentation().setEnabled(myApp.isStarted() && isConnected);
+    final boolean supportsReload = myApp.getMode().supportsReload();
+    e.getPresentation().setEnabled(myApp.isStarted() && isConnected && supportsReload);
 
     if (isConnected) {
       if (!myIsListening) {

--- a/src/io/flutter/actions/RunFlutterAction.java
+++ b/src/io/flutter/actions/RunFlutterAction.java
@@ -27,7 +27,6 @@ import org.jetbrains.annotations.Nullable;
 import javax.swing.*;
 
 public abstract class RunFlutterAction extends AnAction {
-
   private final @NotNull String myDetailedTextKey;
   private final @NotNull FlutterLaunchMode myLaunchMode;
   private final @NotNull String myExecutorId;
@@ -123,9 +122,12 @@ public abstract class RunFlutterAction extends AnAction {
   }
 
   @Nullable
-  private static RunnerAndConfigurationSettings getRunConfigSettings(@Nullable AnActionEvent e) {
-    if (e == null) return null;
-    final Project project = e.getProject();
+  private static RunnerAndConfigurationSettings getRunConfigSettings(@Nullable AnActionEvent event) {
+    if (event == null) {
+      return null;
+    }
+
+    final Project project = event.getProject();
     if (project == null) {
       return null;
     }

--- a/src/io/flutter/actions/RunProfileFlutterApp.java
+++ b/src/io/flutter/actions/RunProfileFlutterApp.java
@@ -17,7 +17,6 @@ public class RunProfileFlutterApp extends RunFlutterAction {
   private static final String TEXT_DETAIL_MSG_KEY = "app.profile.config.action.text";
 
   public RunProfileFlutterApp() {
-    super(TEXT, TEXT_DETAIL_MSG_KEY, DESCRIPTION, AllIcons.Actions.Execute, FlutterLaunchMode.PROFILE, ToolWindowId.RUN
-    );
+    super(TEXT, TEXT_DETAIL_MSG_KEY, DESCRIPTION, AllIcons.Actions.Execute, FlutterLaunchMode.PROFILE, ToolWindowId.RUN);
   }
 }

--- a/src/io/flutter/actions/RunReleaseFlutterApp.java
+++ b/src/io/flutter/actions/RunReleaseFlutterApp.java
@@ -17,7 +17,7 @@ public class RunReleaseFlutterApp extends RunFlutterAction {
   private static final String TEXT_DETAIL_MSG_KEY = "app.release.config.action.text";
 
   public RunReleaseFlutterApp() {
-    super(TEXT, TEXT_DETAIL_MSG_KEY, DESCRIPTION, AllIcons.Actions.Profile, FlutterLaunchMode.RELEASE, ToolWindowId.RUN
+    super(TEXT, TEXT_DETAIL_MSG_KEY, DESCRIPTION, AllIcons.Actions.Execute, FlutterLaunchMode.RELEASE, ToolWindowId.RUN
     );
   }
 }

--- a/src/io/flutter/inspector/EvalOnDartLibrary.java
+++ b/src/io/flutter/inspector/EvalOnDartLibrary.java
@@ -214,7 +214,6 @@ public class EvalOnDartLibrary implements Disposable {
 
   private void initialize() {
     vmService.getIsolate(isolateId, new GetIsolateConsumer() {
-
       @Override
       public void received(Isolate response) {
         for (LibraryRef library : response.getLibraries()) {

--- a/src/io/flutter/inspector/InspectorService.java
+++ b/src/io/flutter/inspector/InspectorService.java
@@ -100,7 +100,7 @@ public class InspectorService implements Disposable {
       }
     });
 
-    vmService.streamListen("Extension", VmServiceConsumers.EMPTY_SUCCESS_CONSUMER);
+    vmService.streamListen(VmService.EXTENSION_STREAM_ID, VmServiceConsumers.EMPTY_SUCCESS_CONSUMER);
   }
 
   public FlutterDebugProcess getDebugProcess() {
@@ -226,11 +226,11 @@ public class InspectorService implements Disposable {
 
   /**
    * Call a service method passing in an observatory instance reference.
-   *
+   * <p>
    * This call is useful when receiving an "inspect" event from the
    * observatory and future use cases such as inspecting a Widget from the
    * IntelliJ watch window.
-   *
+   * <p>
    * This method will always need to use the observatory service as the input
    * parameter is an Observatory InstanceRef..
    */
@@ -527,7 +527,6 @@ public class InspectorService implements Disposable {
 
   @Override
   public void dispose() {
-    vmService.streamCancel("Extension", VmServiceConsumers.EMPTY_SUCCESS_CONSUMER);
     // TODO(jacobr): dispose everything that needs to be disposed of.
   }
 

--- a/src/io/flutter/perf/PerfService.java
+++ b/src/io/flutter/perf/PerfService.java
@@ -7,6 +7,7 @@ package io.flutter.perf;
 
 import com.intellij.openapi.util.text.StringUtil;
 import com.jetbrains.lang.dart.ide.runner.server.vmService.VmServiceConsumers;
+import gnu.trove.THashSet;
 import io.flutter.perf.HeapMonitor.HeapListener;
 import io.flutter.run.FlutterDebugProcess;
 import io.flutter.utils.VmServiceListenerAdapter;
@@ -16,7 +17,6 @@ import org.dartlang.vm.service.consumer.VMConsumer;
 import org.dartlang.vm.service.element.*;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.HashSet;
 import java.util.Set;
 
 // TODO(pq): rename
@@ -26,7 +26,7 @@ import java.util.Set;
 public class PerfService {
   @NotNull private final HeapMonitor heapMonitor;
   @NotNull private final FlutterFramesMonitor flutterFramesMonitor;
-  @NotNull private Set<String> serviceExtensions = new HashSet<>();
+  @NotNull private final Set<String> serviceExtensions = new THashSet<>();
 
   private boolean isRunning;
 

--- a/src/io/flutter/perf/PerfService.java
+++ b/src/io/flutter/perf/PerfService.java
@@ -11,9 +11,13 @@ import io.flutter.perf.HeapMonitor.HeapListener;
 import io.flutter.run.FlutterDebugProcess;
 import io.flutter.utils.VmServiceListenerAdapter;
 import org.dartlang.vm.service.VmService;
-import org.dartlang.vm.service.element.Event;
-import org.dartlang.vm.service.element.IsolateRef;
+import org.dartlang.vm.service.consumer.GetIsolateConsumer;
+import org.dartlang.vm.service.consumer.VMConsumer;
+import org.dartlang.vm.service.element.*;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.HashSet;
+import java.util.Set;
 
 // TODO(pq): rename
 // TODO(pq): improve error handling
@@ -22,6 +26,7 @@ import org.jetbrains.annotations.NotNull;
 public class PerfService {
   @NotNull private final HeapMonitor heapMonitor;
   @NotNull private final FlutterFramesMonitor flutterFramesMonitor;
+  @NotNull private Set<String> serviceExtensions = new HashSet<>();
 
   private boolean isRunning;
 
@@ -40,7 +45,37 @@ public class PerfService {
         onVmConnectionClosed();
       }
     });
-    vmService.streamListen("GC", VmServiceConsumers.EMPTY_SUCCESS_CONSUMER);
+
+    vmService.streamListen(VmService.GC_STREAM_ID, VmServiceConsumers.EMPTY_SUCCESS_CONSUMER);
+    vmService.streamListen(VmService.EXTENSION_STREAM_ID, VmServiceConsumers.EMPTY_SUCCESS_CONSUMER);
+    vmService.streamListen(VmService.ISOLATE_STREAM_ID, VmServiceConsumers.EMPTY_SUCCESS_CONSUMER);
+
+    // Populate the service extensions info.
+    vmService.getVM(new VMConsumer() {
+      @Override
+      public void received(VM vm) {
+        for (IsolateRef ref : vm.getIsolates()) {
+          vmService.getIsolate(ref.getId(), new GetIsolateConsumer() {
+            @Override
+            public void onError(RPCError error) {
+            }
+
+            @Override
+            public void received(Isolate isolate) {
+              serviceExtensions.addAll(isolate.getExtensionRPCs());
+            }
+
+            @Override
+            public void received(Sentinel sentinel) {
+            }
+          });
+        }
+      }
+
+      @Override
+      public void onError(RPCError error) {
+      }
+    });
   }
 
   /**
@@ -85,6 +120,9 @@ public class PerfService {
 
       heapMonitor.handleGCEvent(isolateRef, newHeapSpace, oldHeapSpace);
     }
+    else if (StringUtil.equals(streamId, VmService.ISOLATE_STREAM_ID) && event.getKind() == EventKind.ServiceExtensionAdded) {
+      serviceExtensions.add(event.getExtensionRPC());
+    }
   }
 
   @NotNull
@@ -114,5 +152,9 @@ public class PerfService {
     if (!heapMonitor.hasListeners()) {
       stop();
     }
+  }
+
+  public boolean hasServiceExtension(String name) {
+    return serviceExtensions.contains(name);
   }
 }

--- a/src/io/flutter/run/FlutterDebugProcess.java
+++ b/src/io/flutter/run/FlutterDebugProcess.java
@@ -112,6 +112,8 @@ public class FlutterDebugProcess extends DartVmServiceDebugProcessZ {
     topToolbar.addAction(new RestartFlutterApp(app, canReload));
     topToolbar.addSeparator();
     topToolbar.addAction(new OpenObservatoryAction(app.getConnector(), observatoryAvailable));
+    topToolbar.addAction(new OpenTimelineViewAction(app.getConnector(), observatoryAvailable));
+    topToolbar.addSeparator();
     topToolbar.addAction(new OpenFlutterViewAction(isSessionActive));
 
     // Don't call super since we have our own observatory action.

--- a/src/io/flutter/run/FlutterLaunchMode.java
+++ b/src/io/flutter/run/FlutterLaunchMode.java
@@ -14,11 +14,11 @@ import org.jetbrains.annotations.NotNull;
  * --profile, and --release.
  */
 public enum FlutterLaunchMode {
-  DEBUG("debug", true),
+  DEBUG("debug"),
 
-  PROFILE("profile", false),
+  PROFILE("profile"),
 
-  RELEASE("release", false);
+  RELEASE("release");
 
   public static final Key<FlutterLaunchMode> LAUNCH_MODE_KEY = Key.create("FlutterLaunchMode");
 
@@ -29,22 +29,27 @@ public enum FlutterLaunchMode {
   }
 
   final private String myCliCommand;
-  final private boolean mySupportsDebugging;
 
-  FlutterLaunchMode(String cliCommand, boolean supportsDebugging) {
+  FlutterLaunchMode(String cliCommand) {
     this.myCliCommand = cliCommand;
-    this.mySupportsDebugging = supportsDebugging;
   }
 
   public String getCliCommand() {
     return myCliCommand;
   }
 
-  public boolean supportsDebugging() {
-    return mySupportsDebugging;
+  /**
+   * This mode supports a debug connection (but, doesn't necessarily support breakpoints and debugging).
+   */
+  public boolean supportsDebugConnection() {
+    return this == DEBUG || this == PROFILE;
   }
 
   public boolean supportsReload() {
-    return supportsDebugging();
+    return this == DEBUG;
+  }
+
+  public boolean isProfiling() {
+    return this == PROFILE;
   }
 }

--- a/src/io/flutter/run/FlutterReloadManager.java
+++ b/src/io/flutter/run/FlutterReloadManager.java
@@ -279,7 +279,7 @@ public class FlutterReloadManager {
   }
 
   private Notification showRunNotification(@NotNull FlutterApp app, @Nullable String title, @NotNull String content, boolean isError) {
-    final String toolWindowId = app.getMode() == RunMode.RUN ? ToolWindowId.RUN : ToolWindowId.DEBUG;
+    final String toolWindowId = app.getMode() == RunMode.DEBUG ? ToolWindowId.DEBUG : ToolWindowId.RUN;
     final NotificationGroup notificationGroup = getNotificationGroup(toolWindowId);
     final Notification notification;
     if (title == null) {

--- a/src/io/flutter/run/OpenTimelineViewAction.java
+++ b/src/io/flutter/run/OpenTimelineViewAction.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.run;
+
+import com.intellij.ide.browsers.BrowserLauncher;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.project.DumbAwareAction;
+import com.intellij.openapi.util.Computable;
+import com.jetbrains.lang.dart.ide.runner.ObservatoryConnector;
+import icons.FlutterIcons;
+import io.flutter.FlutterInitializer;
+import org.jetbrains.annotations.NotNull;
+
+@SuppressWarnings("ComponentNotRegistered")
+public class OpenTimelineViewAction extends DumbAwareAction {
+  private final @NotNull ObservatoryConnector myConnector;
+  private final Computable<Boolean> myIsApplicable;
+
+  public OpenTimelineViewAction(@NotNull final ObservatoryConnector connector, @NotNull final Computable<Boolean> isApplicable) {
+    super("Open Timeline View", "Open Timeline View", FlutterIcons.OpenTimeline);
+    myConnector = connector;
+    myIsApplicable = isApplicable;
+  }
+
+  @Override
+  public void update(@NotNull final AnActionEvent e) {
+    e.getPresentation().setEnabled(myIsApplicable.compute());
+  }
+
+  @Override
+  public void actionPerformed(@NotNull final AnActionEvent e) {
+    FlutterInitializer.sendAnalyticsAction(this);
+
+    final String url = myConnector.getBrowserUrl();
+    if (url != null) {
+      BrowserLauncher.getInstance().browse(url + "/#/timeline-dashboard", null);
+    }
+  }
+}

--- a/src/io/flutter/run/SdkRunner.java
+++ b/src/io/flutter/run/SdkRunner.java
@@ -12,7 +12,6 @@ import org.jetbrains.annotations.NotNull;
  * Runner for non-Bazel run configurations (using the Flutter SDK).
  */
 public class SdkRunner extends LaunchState.Runner<SdkRunConfig> {
-
   public SdkRunner() {
     super(SdkRunConfig.class);
   }

--- a/src/io/flutter/run/daemon/FlutterApp.java
+++ b/src/io/flutter/run/daemon/FlutterApp.java
@@ -354,6 +354,10 @@ public class FlutterApp {
     });
   }
 
+  public boolean hasServiceExtension(String name) {
+    return getPerfService().hasServiceExtension(name);
+  }
+
   public void setConsole(@Nullable ConsoleView console) {
     myConsole = console;
   }

--- a/src/io/flutter/run/daemon/RunMode.java
+++ b/src/io/flutter/run/daemon/RunMode.java
@@ -9,6 +9,7 @@ import com.intellij.execution.ExecutionException;
 import com.intellij.execution.executors.DefaultDebugExecutor;
 import com.intellij.execution.executors.DefaultRunExecutor;
 import com.intellij.execution.runners.ExecutionEnvironment;
+import io.flutter.run.LaunchState;
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 
@@ -17,19 +18,32 @@ import org.jetbrains.annotations.NotNull;
  */
 public enum RunMode {
   @NonNls
-  DEBUG(DefaultDebugExecutor.EXECUTOR_ID),
+  DEBUG(DefaultDebugExecutor.EXECUTOR_ID, true),
 
   @NonNls
-  RUN(DefaultRunExecutor.EXECUTOR_ID);
+  RUN(DefaultRunExecutor.EXECUTOR_ID, true),
+
+  @NonNls
+  PROFILE("PROFILE", false);
 
   private final String myModeString;
+  private final boolean mySupportsReload;
 
-  RunMode(String modeString) {
+  RunMode(String modeString, boolean supportsReload) {
     myModeString = modeString;
+    mySupportsReload = supportsReload;
   }
 
   public String mode() {
     return myModeString;
+  }
+
+  public boolean supportsReload() {
+    return mySupportsReload;
+  }
+
+  public boolean isProfiling() {
+    return this == PROFILE;
   }
 
   @NotNull
@@ -40,6 +54,9 @@ public enum RunMode {
     }
     else if (DefaultDebugExecutor.EXECUTOR_ID.equals(mode)) {
       return DEBUG;
+    }
+    else if (LaunchState.ANDROID_PROFILER_EXECUTOR_ID.equals(mode)) {
+      return PROFILE;
     }
     else {
       throw new ExecutionException("unsupported run mode: " + mode);

--- a/src/io/flutter/sdk/FlutterSdk.java
+++ b/src/io/flutter/sdk/FlutterSdk.java
@@ -199,6 +199,9 @@ public class FlutterSdk {
     if (mode == RunMode.DEBUG) {
       args.add("--start-paused");
     }
+    if (mode == RunMode.PROFILE) {
+      args.add("--profile");
+    }
     args.addAll(asList(additionalArgs));
 
     // Make the path to main relative (to make the command line prettier).

--- a/src/io/flutter/view/FlutterViewToggleableAction.java
+++ b/src/io/flutter/view/FlutterViewToggleableAction.java
@@ -17,6 +17,7 @@ import javax.swing.*;
 
 abstract class FlutterViewToggleableAction extends FlutterViewAction implements Toggleable {
   private boolean selected = false;
+  private String extensionCommand;
 
   FlutterViewToggleableAction(@NotNull FlutterApp app, @Nullable String text) {
     super(app, text);
@@ -26,9 +27,16 @@ abstract class FlutterViewToggleableAction extends FlutterViewAction implements 
     super(app, text, description, icon);
   }
 
+  protected void setExtensionCommand(String extensionCommand) {
+    this.extensionCommand = extensionCommand;
+  }
+
   @Override
   public final void update(@NotNull AnActionEvent e) {
-    final boolean hasFlutterApp = app.isSessionActive();
+    boolean enabled = app.isSessionActive();
+    if (enabled && extensionCommand != null) {
+      enabled = app.hasServiceExtension(extensionCommand);
+    }
 
     // selected
     final boolean selected = this.isSelected();
@@ -36,7 +44,7 @@ abstract class FlutterViewToggleableAction extends FlutterViewAction implements 
     presentation.putClientProperty("selected", selected);
 
     // enabled
-    e.getPresentation().setEnabled(hasFlutterApp);
+    e.getPresentation().setEnabled(enabled);
   }
 
   @Override

--- a/third_party/intellij-plugins-dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcessZ.java
+++ b/third_party/intellij-plugins-dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcessZ.java
@@ -262,7 +262,7 @@ public class DartVmServiceDebugProcessZ extends DartVmServiceDebugProcess {
     remoteDebug = false;
 
     final FlutterLaunchMode launchMode = FlutterLaunchMode.getMode(executionEnvironment);
-    if (launchMode.supportsDebugging()) {
+    if (launchMode.supportsDebugConnection()) {
       myVmServiceWrapper.handleDebuggerConnected();
     }
 


### PR DESCRIPTION
We're going to want to recommend that users primarily view the memory and frame perf info in the profile builds of their apps. This improves the support for `--profile` in the plugin:

- add an action to open the timeline page to the run and debug views
- support the use of the Android plugins 'profile' launch type; this allows us to use their profile button to launch (contributed next to the regular run and debug buttons). User's can still launch using the 'Run' top-level menu contributiom
- some fixes to allow us to get notifications when the debugger connection connects in profile builds
- swizzle the inspector UI so that the service extension toolbar items show up when the inspector view is shown in profile mode; also, don't contribute the regular inspector panels, and do contribute the perf panels
- make the service ext. actions enabled based on whether their backing command is present in the service protocol

@jwren @jacob314 