### PR TITLE
add local history labels on reloads and restarts

### DIFF
--- a/src/io/flutter/run/daemon/FlutterApp.java
+++ b/src/io/flutter/run/daemon/FlutterApp.java
@@ -17,6 +17,7 @@ import com.intellij.execution.process.ProcessHandler;
 import com.intellij.execution.runners.ExecutionEnvironment;
 import com.intellij.execution.ui.ConsoleView;
 import com.intellij.execution.ui.RunContentDescriptor;
+import com.intellij.history.LocalHistory;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
@@ -25,7 +26,6 @@ import com.intellij.openapi.util.Key;
 import com.intellij.util.concurrency.AppExecutorUtil;
 import com.jetbrains.lang.dart.ide.runner.ObservatoryConnector;
 import io.flutter.FlutterInitializer;
-import io.flutter.inspector.InspectorService;
 import io.flutter.perf.PerfService;
 import io.flutter.pub.PubRoot;
 import io.flutter.pub.PubRoots;
@@ -62,6 +62,7 @@ public class FlutterApp {
   private @Nullable List<PubRoot> myPubRoots;
 
   private int reloadCount;
+  private int userReloadCount;
   private int restartCount;
 
   /**
@@ -258,6 +259,9 @@ public class FlutterApp {
     }
 
     restartCount++;
+    userReloadCount = 0;
+
+    LocalHistory.getInstance().putSystemLabel(getProject(), "Flutter full restart");
 
     final long reloadTimestamp = System.currentTimeMillis();
     changeState(State.RELOADING);
@@ -295,6 +299,9 @@ public class FlutterApp {
     }
 
     reloadCount++;
+    userReloadCount++;
+
+    LocalHistory.getInstance().putSystemLabel(getProject(), "hot reload #" + userReloadCount);
 
     final long reloadTimestamp = System.currentTimeMillis();
     changeState(State.RELOADING);


### PR DESCRIPTION
- add local history labels on reloads and restarts

This makes is easier for users to experiment and revert speculative changes.

<img width="1307" alt="screen shot 2018-03-31 at 12 15 46 pm" src="https://user-images.githubusercontent.com/1269969/38201894-b8d8c5e4-364e-11e8-8a83-dc4d06f84269.png">
