### PR TITLE
Make FlutterCommand.startProcess() return details to handle specific issues in clients.

### DIFF
--- a/src/io/flutter/run/test/TestFields.java
+++ b/src/io/flutter/run/test/TestFields.java
@@ -15,6 +15,7 @@ import com.intellij.openapi.vfs.VirtualFile;
 import io.flutter.pub.PubRoot;
 import io.flutter.run.MainFile;
 import io.flutter.run.daemon.RunMode;
+import io.flutter.sdk.FlutterCommandStartResult;
 import io.flutter.sdk.FlutterSdk;
 import org.jdom.Element;
 import org.jetbrains.annotations.NotNull;
@@ -211,7 +212,8 @@ public class TestFields {
   /**
    * Starts running the tests.
    */
-  ProcessHandler run(@NotNull Project project, @NotNull RunMode mode) throws ExecutionException {
+  @NotNull
+  FlutterCommandStartResult run(@NotNull Project project, @NotNull RunMode mode) throws ExecutionException {
     final FlutterSdk sdk = FlutterSdk.getFlutterSdk(project);
     if (sdk == null) {
       throw new ExecutionException("The Flutter SDK is not configured");

--- a/src/io/flutter/run/test/TestLaunchState.java
+++ b/src/io/flutter/run/test/TestLaunchState.java
@@ -99,7 +99,7 @@ class TestLaunchState extends CommandLineState {
         assert result.processHandler != null;
         return result.processHandler;
       case ANOTHER_RUNNING:
-        throw new ExecutionException("There is another Flutter command running");
+        throw new ExecutionException("Flutter instance already running");
       case EXCEPTION:
         assert result.exception != null;
         throw new ExecutionException(FlutterBundle.message("flutter.command.exception.message" + result.exception.getMessage()));

--- a/src/io/flutter/run/test/TestLaunchState.java
+++ b/src/io/flutter/run/test/TestLaunchState.java
@@ -27,10 +27,12 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.jetbrains.lang.dart.ide.runner.DartRelativePathsConsoleFilter;
 import com.jetbrains.lang.dart.util.DartUrlResolver;
+import io.flutter.FlutterBundle;
 import io.flutter.console.FlutterConsoleFilter;
 import io.flutter.pub.PubRoot;
 import io.flutter.run.daemon.DaemonConsoleView;
 import io.flutter.run.daemon.RunMode;
+import io.flutter.sdk.FlutterCommandStartResult;
 import io.flutter.sdk.FlutterSdk;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -91,7 +93,19 @@ class TestLaunchState extends CommandLineState {
   @Override
   protected ProcessHandler startProcess() throws ExecutionException {
     final RunMode mode = RunMode.fromEnv(getEnvironment());
-    return fields.run(getEnvironment().getProject(), mode);
+    final FlutterCommandStartResult result = fields.run(getEnvironment().getProject(), mode);
+    switch (result.status) {
+      case OK:
+        assert result.processHandler != null;
+        return result.processHandler;
+      case ANOTHER_RUNNING:
+        throw new ExecutionException("There is another Flutter command running");
+      case EXCEPTION:
+        assert result.exception != null;
+        throw new ExecutionException(FlutterBundle.message("flutter.command.exception.message" + result.exception.getMessage()));
+      default:
+        throw new ExecutionException("Unexpected state");
+    }
   }
 
   @Nullable

--- a/src/io/flutter/sdk/FlutterCommand.java
+++ b/src/io/flutter/sdk/FlutterCommand.java
@@ -81,7 +81,7 @@ public class FlutterCommand {
    */
   public Process start(@Nullable Consumer<ProcessOutput> onDone, @Nullable ProcessListener processListener) {
     // TODO(skybrian) add Project parameter if it turns out later that we need to set ANDROID_HOME.
-    final OSProcessHandler handler = startProcess(null);
+    final OSProcessHandler handler = startProcessOrShowError(null);
     if (handler == null) {
       return null;
     }
@@ -117,7 +117,7 @@ public class FlutterCommand {
    * If unable to start (for example, if a command is already running), returns null.
    */
   public Process startInConsole(@NotNull Project project) {
-    final OSProcessHandler handler = startProcess(project);
+    final OSProcessHandler handler = startProcessOrShowError(project);
     if (handler == null) {
       return null;
     }
@@ -134,7 +134,7 @@ public class FlutterCommand {
    * If unable to start (for example, if a command is already running), returns null.
    */
   public Process startInModuleConsole(@NotNull Module module, @Nullable Runnable onDone, @Nullable ProcessListener processListener) {
-    final OSProcessHandler handler = startProcess(module.getProject());
+    final OSProcessHandler handler = startProcessOrShowError(module.getProject());
     if (handler == null) {
       return null;
     }
@@ -196,11 +196,11 @@ public class FlutterCommand {
    * <p>
    * Returns the handler if successfully started.
    */
-  @Nullable
-  public OSProcessHandler startProcess(@Nullable Project project) {
+  @NotNull
+  public FlutterCommandStartResult startProcess(@Nullable Project project) {
     // TODO(devoncarew): Many flutter commands can legitimately be run in parallel.
     if (!inProgress.compareAndSet(null, this)) {
-      return null;
+      return new FlutterCommandStartResult(FlutterCommandStartResultStatus.ANOTHER_RUNNING, null, null);
     }
 
     if (isPubRelatedCommand()) {
@@ -222,18 +222,33 @@ public class FlutterCommand {
         }
       });
       type.sendAnalyticsEvent();
-      return handler;
+      return new FlutterCommandStartResult(FlutterCommandStartResultStatus.OK, handler, null);
     }
     catch (ExecutionException e) {
       inProgress.compareAndSet(this, null);
       if (isPubRelatedCommand()) {
         DartPlugin.setPubActionInProgress(false);
       }
+      return new FlutterCommandStartResult(FlutterCommandStartResultStatus.EXCEPTION, null, e);
+    }
+  }
+
+  /**
+   * Starts a process that runs a flutter command, unless one is already running.
+   * <p>
+   * If a project is supplied, it will be used to determine the ANDROID_HOME variable for the subprocess.
+   * <p>
+   * Returns the handler if successfully started, or null if there was a problem.
+   */
+  @Nullable
+  public OSProcessHandler startProcessOrShowError(@Nullable Project project)  {
+    final FlutterCommandStartResult result = startProcess(project);
+    if (result.status == FlutterCommandStartResultStatus.EXCEPTION && result.exception != null) {
       FlutterMessages.showError(
         type.title,
-        FlutterBundle.message("flutter.command.exception.message", e.getMessage()));
-      return null;
+        FlutterBundle.message("flutter.command.exception.message", result.exception.getMessage()));
     }
+    return result.processHandler;
   }
 
   /**

--- a/src/io/flutter/sdk/FlutterCommand.java
+++ b/src/io/flutter/sdk/FlutterCommand.java
@@ -200,7 +200,7 @@ public class FlutterCommand {
   public FlutterCommandStartResult startProcess(@Nullable Project project) {
     // TODO(devoncarew): Many flutter commands can legitimately be run in parallel.
     if (!inProgress.compareAndSet(null, this)) {
-      return new FlutterCommandStartResult(FlutterCommandStartResultStatus.ANOTHER_RUNNING, null, null);
+      return new FlutterCommandStartResult(FlutterCommandStartResultStatus.ANOTHER_RUNNING);
     }
 
     if (isPubRelatedCommand()) {
@@ -222,14 +222,14 @@ public class FlutterCommand {
         }
       });
       type.sendAnalyticsEvent();
-      return new FlutterCommandStartResult(FlutterCommandStartResultStatus.OK, handler, null);
+      return new FlutterCommandStartResult(handler);
     }
     catch (ExecutionException e) {
       inProgress.compareAndSet(this, null);
       if (isPubRelatedCommand()) {
         DartPlugin.setPubActionInProgress(false);
       }
-      return new FlutterCommandStartResult(FlutterCommandStartResultStatus.EXCEPTION, null, e);
+      return new FlutterCommandStartResult(e);
     }
   }
 

--- a/src/io/flutter/sdk/FlutterCommandStartResult.java
+++ b/src/io/flutter/sdk/FlutterCommandStartResult.java
@@ -8,8 +8,7 @@ package io.flutter.sdk;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.process.OSProcessHandler;
 import org.jetbrains.annotations.NotNull;
-
-import javax.annotation.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 public class FlutterCommandStartResult {
   @NotNull

--- a/src/io/flutter/sdk/FlutterCommandStartResult.java
+++ b/src/io/flutter/sdk/FlutterCommandStartResult.java
@@ -20,6 +20,18 @@ public class FlutterCommandStartResult {
   @Nullable
   public final ExecutionException exception;
 
+  public FlutterCommandStartResult(@NotNull FlutterCommandStartResultStatus status) {
+    this(status, null, null);
+  }
+
+  public FlutterCommandStartResult(@Nullable OSProcessHandler processHandler) {
+    this(FlutterCommandStartResultStatus.OK, processHandler, null);
+  }
+
+  public FlutterCommandStartResult(@Nullable ExecutionException exception) {
+    this(FlutterCommandStartResultStatus.EXCEPTION, null, exception);
+  }
+
   public FlutterCommandStartResult(@NotNull FlutterCommandStartResultStatus status,
                                    @Nullable OSProcessHandler processHandler,
                                    @Nullable ExecutionException exception) {

--- a/src/io/flutter/sdk/FlutterCommandStartResult.java
+++ b/src/io/flutter/sdk/FlutterCommandStartResult.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.sdk;
+
+import com.intellij.execution.ExecutionException;
+import com.intellij.execution.process.OSProcessHandler;
+import org.jetbrains.annotations.NotNull;
+
+import javax.annotation.Nullable;
+
+public class FlutterCommandStartResult {
+  @NotNull
+  public final FlutterCommandStartResultStatus status;
+
+  @Nullable
+  public final OSProcessHandler processHandler;
+
+  @Nullable
+  public final ExecutionException exception;
+
+  public FlutterCommandStartResult(@NotNull FlutterCommandStartResultStatus status,
+                                   @Nullable OSProcessHandler processHandler,
+                                   @Nullable ExecutionException exception) {
+    this.status = status;
+    this.processHandler = processHandler;
+    this.exception = exception;
+  }
+}

--- a/src/io/flutter/sdk/FlutterCommandStartResultStatus.java
+++ b/src/io/flutter/sdk/FlutterCommandStartResultStatus.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2018 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.sdk;
+
+public enum FlutterCommandStartResultStatus {
+  OK, ANOTHER_RUNNING, EXCEPTION
+}


### PR DESCRIPTION
This fixes https://github.com/flutter/flutter-intellij/issues/1622 by showing a meaningful error instead of `@NotNull` failure.

![image](https://user-images.githubusercontent.com/384794/38217872-b2ee3db8-3684-11e8-8ef2-d7ef7b318484.png)
