### PR TITLE
tweak the message for non-renderable widgets

### DIFF
--- a/src/io/flutter/preview/PreviewView.java
+++ b/src/io/flutter/preview/PreviewView.java
@@ -185,7 +185,7 @@ public class PreviewView implements PersistentStateComponent<PreviewViewState>, 
               previewArea.clear(PreviewArea.NO_WIDGET_MESSAGE);
               break;
             case NOT_RENDERABLE_WIDGET:
-              previewArea.clear("Selection does not correspond to a renderable widget");
+              previewArea.clear("Selection not a renderable widget");
               break;
             case TIMEOUT:
               previewArea.clear("Timeout during rendering");

--- a/src/io/flutter/preview/PreviewView.java
+++ b/src/io/flutter/preview/PreviewView.java
@@ -185,7 +185,7 @@ public class PreviewView implements PersistentStateComponent<PreviewViewState>, 
               previewArea.clear(PreviewArea.NO_WIDGET_MESSAGE);
               break;
             case NOT_RENDERABLE_WIDGET:
-              previewArea.clear("Selection not a renderable widget");
+              previewArea.clear("Selection is not a renderable widget");
               break;
             case TIMEOUT:
               previewArea.clear("Timeout during rendering");


### PR DESCRIPTION
Make the text a bit shorter (so its less likely to be truncated in narrow layouts); @scheglov.