### PR TITLE
Re-implement the BazelPositionMapper

### DIFF
--- a/src/io/flutter/run/PositionMapper.java
+++ b/src/io/flutter/run/PositionMapper.java
@@ -26,8 +26,8 @@ import com.jetbrains.lang.dart.util.DartUrlResolver;
 import gnu.trove.THashMap;
 import io.flutter.dart.DartPlugin;
 import org.dartlang.vm.service.element.LibraryRef;
-import org.dartlang.vm.service.element.ScriptRef;
 import org.dartlang.vm.service.element.Script;
+import org.dartlang.vm.service.element.ScriptRef;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -103,6 +103,11 @@ public class PositionMapper implements DartVmServiceDebugProcessZ.PositionMapper
     this.sourceRoot = sourceRoot;
     this.resolver = resolver;
     this.analyzer = analyzer;
+  }
+
+  @NotNull
+  public Project getProject() {
+    return project;
   }
 
   public void onConnect(@NotNull DartVmServiceDebugProcessZ.ScriptProvider provider, @Nullable String remoteBaseUri) {
@@ -283,7 +288,7 @@ public class PositionMapper implements DartVmServiceDebugProcessZ.PositionMapper
    * Attempt to find a local Dart file corresponding to a script in Observatory.
    */
   @Nullable
-  private VirtualFile findLocalFile(@NotNull String uri) {
+  protected VirtualFile findLocalFile(@NotNull String uri) {
     return ApplicationManager.getApplication().runReadAction((Computable<VirtualFile>)() -> {
       // This can be a remote file or URI.
       final String remote = uri;

--- a/src/io/flutter/run/bazelTest/BazelTestRunner.java
+++ b/src/io/flutter/run/bazelTest/BazelTestRunner.java
@@ -16,24 +16,30 @@ import com.intellij.execution.process.*;
 import com.intellij.execution.runners.ExecutionEnvironment;
 import com.intellij.execution.runners.GenericProgramRunner;
 import com.intellij.execution.ui.RunContentDescriptor;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.ContentEntry;
+import com.intellij.openapi.roots.ModuleRootManager;
+import com.intellij.openapi.util.Computable;
 import com.intellij.openapi.util.Key;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
-import com.intellij.xdebugger.*;
+import com.intellij.xdebugger.XDebugProcess;
+import com.intellij.xdebugger.XDebugProcessStarter;
+import com.intellij.xdebugger.XDebugSession;
+import com.intellij.xdebugger.XDebuggerManager;
 import com.jetbrains.lang.dart.ide.runner.ObservatoryConnector;
+import com.jetbrains.lang.dart.sdk.DartSdkLibUtil;
 import com.jetbrains.lang.dart.util.DartUrlResolver;
-import gnu.trove.THashSet;
 import io.flutter.run.PositionMapper;
 import io.flutter.settings.FlutterSettings;
 import io.flutter.utils.StdoutJsonParser;
-import org.dartlang.vm.service.element.ScriptRef;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
-import java.util.Set;
 
 /**
  * The Bazel version of the {@link io.flutter.run.test.DebugTestRunner}. Runs a Bazel Flutter test configuration in the debugger.
@@ -234,10 +240,6 @@ public class BazelTestRunner extends GenericProgramRunner {
 
     @NotNull final Connector connector;
 
-    @NotNull Set<String> workspaceLocations = new THashSet<>(1);
-
-    public static final String RUNFILES_SLASH = "runfiles/";
-
     public BazelPositionMapper(@NotNull final Project project,
                                @NotNull final VirtualFile sourceRoot,
                                @NotNull final DartUrlResolver resolver,
@@ -252,67 +254,64 @@ public class BazelTestRunner extends GenericProgramRunner {
       // Get the results from superclass
       final Collection<String> results = super.getBreakpointUris(file);
 
-      // Get the runfiles directory and workspace directory name provided by the test harness.
-      final String runfilesDir = connector.getRunfilesDir();
+      // Get the workspace directory name provided by the test harness.
       final String workspaceDirName = connector.getWorkspaceDirName();
 
-      // Verify the returned runfiles directory and workspace directory name
-      if (!verifyRunFilesAndWorkspaceNameValues(runfilesDir, workspaceDirName)) {
-        return results;
-      }
+      // Verify the returned workspace directory name
+      if (!verifyWorkspaceNameValue(workspaceDirName)) return results;
 
       final String filePath = file.getPath();
-      final int workspaceOffset = filePath.lastIndexOf(workspaceDirName + "/");
-      if (workspaceOffset != -1) {
-        // Append the passed runfilesDir + path from workspace to the returned results, this will set an additional breakpoint in the
-        // generated runfiles directory
-        results.add(runfilesDir + filePath.substring(workspaceOffset, filePath.length()));
-
-        // Finally, add the path to the workspace to workspaceLocations so that the original path can be computed in getSourcePosition
-        // method below
-        workspaceLocations.add(filePath.substring(0, workspaceOffset));
+      int workspaceEndOffset = filePath.lastIndexOf(workspaceDirName + "/");
+      if (workspaceEndOffset != -1) {
+        workspaceEndOffset += workspaceDirName.length();
+        results.add(workspaceDirName + ":" + filePath.substring(workspaceEndOffset, filePath.length()));
       }
       return results;
     }
 
-    /**
-     * Returns the local position (to display to the user) corresponding to a token position in Observatory.
-     */
-    @Override
-    @Nullable
-    public XSourcePosition getSourcePosition(@NotNull final String isolateId, @NotNull final ScriptRef scriptRef, int tokenPos) {
-      final XSourcePosition xSourcePosition = super.getSourcePosition(isolateId, scriptRef, tokenPos);
-      if (xSourcePosition == null) return null;
 
-      // Get the runfiles directory and workspace directpory name provided by the test harness.
-      final String runfilesDir = connector.getRunfilesDir();
+    /**
+     * Attempt to find a local Dart file corresponding to a script in Observatory.
+     */
+    @Nullable
+    @Override
+    protected VirtualFile findLocalFile(@NotNull final String uri) {
+      // Get the workspace directory name provided by the test harness.
       final String workspaceDirName = connector.getWorkspaceDirName();
 
-      // Verify the returned runfiles directory and workspace directory name
-      if (!verifyRunFilesAndWorkspaceNameValues(runfilesDir, workspaceDirName)) return xSourcePosition;
+      // Verify the returned workspace directory name, we weren't passed a workspace name or if the valid workspace name does not start the
+      // uri then return the super invocation of this method. This prevents the unknown URI type from being passed to the analysis server.
+      if (!verifyWorkspaceNameValue(workspaceDirName) || !uri.startsWith(workspaceDirName + ":/")) return super.findLocalFile(uri);
 
-      // Get the virtual file computed by the super.getSourcePosition(...)
-      final VirtualFile superVirtualFile = xSourcePosition.getFile();
-      final String filePath = superVirtualFile.getPath();
-      final int workspaceOffset = filePath.lastIndexOf(workspaceDirName + "/");
-      if (filePath.startsWith(runfilesDir) && workspaceOffset != -1) {
-        for (String workspaceLoc : workspaceLocations) {
-          final VirtualFile virtualFileInProject =
-            LocalFileSystem.getInstance().findFileByPath(workspaceLoc + filePath.substring(workspaceOffset, filePath.length()));
-          if (virtualFileInProject != null) {
-            return XDebuggerUtil.getInstance().createPosition(virtualFileInProject, xSourcePosition.getLine(), xSourcePosition.getOffset());
+      final String pathFromWorkspace = uri.substring(workspaceDirName.length() + 1, uri.length());
+
+      // For each root in each module, look for a bazel workspace path, if found attempt to compute the VirtualFile, return when found.
+      return ApplicationManager.getApplication().runReadAction((Computable<VirtualFile>)() -> {
+        for (Module module : DartSdkLibUtil.getModulesWithDartSdkEnabled(getProject())) {
+          for (ContentEntry contentEntry : ModuleRootManager.getInstance(module).getContentEntries()) {
+            final VirtualFile includedRoot = contentEntry.getFile();
+            if (includedRoot == null) continue;
+
+            final String includedRootPath = includedRoot.getPath();
+            final int workspaceOffset = includedRootPath.indexOf(workspaceDirName);
+            if (workspaceOffset == -1) continue;
+
+            final String pathToWorkspace = includedRootPath.substring(0, workspaceOffset + workspaceDirName.length());
+            final VirtualFile virtualFile = LocalFileSystem.getInstance().findFileByPath(pathToWorkspace + pathFromWorkspace);
+            if (virtualFile != null) {
+              return virtualFile;
+            }
           }
         }
-      }
-      return xSourcePosition;
+        return super.findLocalFile(uri);
+      });
     }
 
     /**
-     * Return true if the passed runfilesDir and workspaceDirName are not null, are not empty, and the runfilesDir ends with
-     * {@value RUNFILES_SLASH}.
+     * Return true if the passed workspaceDirName is not null and is not empty.
      */
-    private boolean verifyRunFilesAndWorkspaceNameValues(@Nullable final String runfilesDir, @Nullable final String workspaceDirName) {
-      return runfilesDir != null && runfilesDir.endsWith(RUNFILES_SLASH) && workspaceDirName != null && !workspaceDirName.isEmpty();
+    private boolean verifyWorkspaceNameValue(@Nullable final String workspaceDirName) {
+      return workspaceDirName != null && !workspaceDirName.isEmpty();
     }
   }
 }

--- a/src/io/flutter/run/bazelTest/BazelTestRunner.java
+++ b/src/io/flutter/run/bazelTest/BazelTestRunner.java
@@ -36,6 +36,7 @@ import com.jetbrains.lang.dart.util.DartUrlResolver;
 import io.flutter.run.PositionMapper;
 import io.flutter.settings.FlutterSettings;
 import io.flutter.utils.StdoutJsonParser;
+import org.apache.commons.lang.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -258,7 +259,7 @@ public class BazelTestRunner extends GenericProgramRunner {
       final String workspaceDirName = connector.getWorkspaceDirName();
 
       // Verify the returned workspace directory name
-      if (!verifyWorkspaceNameValue(workspaceDirName)) return results;
+      if (StringUtils.isEmpty(workspaceDirName)) return results;
 
       final String filePath = file.getPath();
       int workspaceEndOffset = filePath.lastIndexOf(workspaceDirName + "/");
@@ -281,7 +282,7 @@ public class BazelTestRunner extends GenericProgramRunner {
 
       // Verify the returned workspace directory name, we weren't passed a workspace name or if the valid workspace name does not start the
       // uri then return the super invocation of this method. This prevents the unknown URI type from being passed to the analysis server.
-      if (!verifyWorkspaceNameValue(workspaceDirName) || !uri.startsWith(workspaceDirName + ":/")) return super.findLocalFile(uri);
+      if (StringUtils.isEmpty(workspaceDirName) || !uri.startsWith(workspaceDirName + ":/")) return super.findLocalFile(uri);
 
       final String pathFromWorkspace = uri.substring(workspaceDirName.length() + 1, uri.length());
 
@@ -305,13 +306,6 @@ public class BazelTestRunner extends GenericProgramRunner {
         }
         return super.findLocalFile(uri);
       });
-    }
-
-    /**
-     * Return true if the passed workspaceDirName is not null and is not empty.
-     */
-    private boolean verifyWorkspaceNameValue(@Nullable final String workspaceDirName) {
-      return workspaceDirName != null && !workspaceDirName.isEmpty();
     }
   }
 }


### PR DESCRIPTION
This change opens the io.flutter.run.PositionMapper for the subclass, PositionMapper.findLocalFile() is now overridable and there is not an accessor for the Project.