### PR TITLE
handle apps with multiple isolates in the inspector

### DIFF
--- a/src/io/flutter/inspector/HeapDisplay.java
+++ b/src/io/flutter/inspector/HeapDisplay.java
@@ -92,8 +92,8 @@ public class HeapDisplay extends JPanel {
     };
 
     assert app.getPerfService() != null;
-    app.getPerfService().addListener(listener);
-    Disposer.register(parentDisposable, () -> app.getPerfService().removeListener(listener));
+    app.getPerfService().addHeapListener(listener);
+    Disposer.register(parentDisposable, () -> app.getPerfService().removeHeapListener(listener));
 
     return panel;
   }
@@ -112,7 +112,7 @@ public class HeapDisplay extends JPanel {
 
       final PerfService service = app.getPerfService();
       assert service != null;
-      app.getPerfService().addListener(this);
+      app.getPerfService().addHeapListener(this);
       Disposer.register(parent, this);
     }
 
@@ -158,7 +158,7 @@ public class HeapDisplay extends JPanel {
     @Override
     public void dispose() {
       if (app.getPerfService() != null) {
-        app.getPerfService().removeListener(this);
+        app.getPerfService().removeHeapListener(this);
       }
     }
 

--- a/src/io/flutter/perf/PerfService.java
+++ b/src/io/flutter/perf/PerfService.java
@@ -60,7 +60,10 @@ public class PerfService {
     vmService.streamListen(VmService.EXTENSION_STREAM_ID, VmServiceConsumers.EMPTY_SUCCESS_CONSUMER);
     vmService.streamListen(VmService.GC_STREAM_ID, VmServiceConsumers.EMPTY_SUCCESS_CONSUMER);
 
-    // Populate the service extensions info.
+    // Populate the service extensions info and look for any Flutter views.
+    // TODO(devoncarew): This currently returns the first Flutter view found as the
+    // current Flutter isolate, and ignores any other Flutter views running in the app.
+    // In the future, we could add more first class support for multiple Flutter views.
     vmService.getVM(new VMConsumer() {
       @Override
       public void received(VM vm) {

--- a/src/io/flutter/perf/PerfService.java
+++ b/src/io/flutter/perf/PerfService.java
@@ -6,6 +6,7 @@
 package io.flutter.perf;
 
 import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.util.EventDispatcher;
 import com.jetbrains.lang.dart.ide.runner.server.vmService.VmServiceConsumers;
 import gnu.trove.THashSet;
 import io.flutter.perf.HeapMonitor.HeapListener;
@@ -16,7 +17,9 @@ import org.dartlang.vm.service.consumer.GetIsolateConsumer;
 import org.dartlang.vm.service.consumer.VMConsumer;
 import org.dartlang.vm.service.element.*;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
+import java.util.EventListener;
 import java.util.Set;
 
 // TODO(pq): rename
@@ -24,10 +27,17 @@ import java.util.Set;
 // TODO(pq): change mode for opting in (preference or inspector view menu)
 
 public class PerfService {
+  public interface FlutterIsolateListener extends EventListener {
+    void handleFutterIsolateChanged(@Nullable IsolateRef isolateRef);
+  }
+
   @NotNull private final HeapMonitor heapMonitor;
   @NotNull private final FlutterFramesMonitor flutterFramesMonitor;
   @NotNull private final Set<String> serviceExtensions = new THashSet<>();
 
+  private final EventDispatcher<FlutterIsolateListener> myIsolateEventDispatcher = EventDispatcher.create(FlutterIsolateListener.class);
+
+  private IsolateRef flutterIsolateRef;
   private boolean isRunning;
 
   public PerfService(@NotNull FlutterDebugProcess debugProcess, @NotNull VmService vmService) {
@@ -46,22 +56,33 @@ public class PerfService {
       }
     });
 
-    vmService.streamListen(VmService.GC_STREAM_ID, VmServiceConsumers.EMPTY_SUCCESS_CONSUMER);
-    vmService.streamListen(VmService.EXTENSION_STREAM_ID, VmServiceConsumers.EMPTY_SUCCESS_CONSUMER);
     vmService.streamListen(VmService.ISOLATE_STREAM_ID, VmServiceConsumers.EMPTY_SUCCESS_CONSUMER);
+    vmService.streamListen(VmService.EXTENSION_STREAM_ID, VmServiceConsumers.EMPTY_SUCCESS_CONSUMER);
+    vmService.streamListen(VmService.GC_STREAM_ID, VmServiceConsumers.EMPTY_SUCCESS_CONSUMER);
 
     // Populate the service extensions info.
     vmService.getVM(new VMConsumer() {
       @Override
       public void received(VM vm) {
-        for (IsolateRef ref : vm.getIsolates()) {
-          vmService.getIsolate(ref.getId(), new GetIsolateConsumer() {
+        for (final IsolateRef isolateRef : vm.getIsolates()) {
+          vmService.getIsolate(isolateRef.getId(), new GetIsolateConsumer() {
             @Override
             public void onError(RPCError error) {
             }
 
             @Override
             public void received(Isolate isolate) {
+              // Populate flutter isolate info.
+              if (flutterIsolateRef == null) {
+                for (String extensionName : isolate.getExtensionRPCs()) {
+                  if (extensionName.startsWith("ext.flutter.")) {
+                    flutterIsolateRef = isolateRef;
+                    myIsolateEventDispatcher.getMulticaster().handleFutterIsolateChanged(flutterIsolateRef);
+                    break;
+                  }
+                }
+              }
+
               serviceExtensions.addAll(isolate.getExtensionRPCs());
             }
 
@@ -90,6 +111,16 @@ public class PerfService {
   }
 
   /**
+   * Return the current Flutter isolate.
+   * <p>
+   * This can be null occasionally during initial application startup and for a brief time when doing a full restart.
+   */
+  @Nullable
+  public IsolateRef getCurrentFlutterIsolate() {
+    return flutterIsolateRef;
+  }
+
+  /**
    * Stop the Perf service.
    */
   public void stop() {
@@ -109,6 +140,34 @@ public class PerfService {
 
   @SuppressWarnings("EmptyMethod")
   private void onVmServiceReceived(String streamId, Event event) {
+    // Check for the current Flutter isolate exiting.
+    if (flutterIsolateRef != null) {
+      if (event.getKind() == EventKind.IsolateExit && StringUtil.equals(event.getIsolate().getId(), flutterIsolateRef.getId())) {
+        flutterIsolateRef = null;
+        myIsolateEventDispatcher.getMulticaster().handleFutterIsolateChanged(flutterIsolateRef);
+      }
+    }
+
+    // Check to see if there's a new Flutter isolate.
+    if (flutterIsolateRef == null) {
+      // Check for Flutter frame events.
+      if (event.getKind() == EventKind.Extension && event.getExtensionKind().startsWith("Flutter.")) {
+        // Flutter.FrameworkInitialization, Flutter.FirstFrame, Flutter.Frame
+        flutterIsolateRef = event.getIsolate();
+        myIsolateEventDispatcher.getMulticaster().handleFutterIsolateChanged(flutterIsolateRef);
+      }
+
+      // Check for service extension registrations.
+      if (event.getKind() == EventKind.ServiceExtensionAdded) {
+        final String extensionName = event.getExtensionRPC();
+
+        if (extensionName.startsWith("ext.flutter.")) {
+          flutterIsolateRef = event.getIsolate();
+          myIsolateEventDispatcher.getMulticaster().handleFutterIsolateChanged(flutterIsolateRef);
+        }
+      }
+    }
+
     if (!isRunning) {
       return;
     }
@@ -133,7 +192,7 @@ public class PerfService {
   /**
    * Add a listener for heap state updates.
    */
-  public void addListener(@NotNull HeapListener listener) {
+  public void addHeapListener(@NotNull HeapListener listener) {
     final boolean hadListeners = heapMonitor.hasListeners();
 
     heapMonitor.addListener(listener);
@@ -146,12 +205,20 @@ public class PerfService {
   /**
    * Remove a heap listener.
    */
-  public void removeListener(@NotNull HeapListener listener) {
+  public void removeHeapListener(@NotNull HeapListener listener) {
     heapMonitor.removeListener(listener);
 
     if (!heapMonitor.hasListeners()) {
       stop();
     }
+  }
+
+  public void addFlutterIsolateListener(@NotNull FlutterIsolateListener listener) {
+    myIsolateEventDispatcher.addListener(listener);
+  }
+
+  public void removeFlutterIsolateListener(@NotNull FlutterIsolateListener listener) {
+    myIsolateEventDispatcher.removeListener(listener);
   }
 
   public boolean hasServiceExtension(String name) {

--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -255,7 +255,7 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
     }
     else {
       whenCompleteUiThread(
-        InspectorService.create(app.getFlutterDebugProcess(), app.getVmService()),
+        InspectorService.create(app, app.getFlutterDebugProcess(), app.getVmService()),
         (InspectorService inspectorService, Throwable throwable) -> {
           if (throwable != null) {
             LOG.warn(throwable);

--- a/third_party/intellij-plugins-dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcessZ.java
+++ b/third_party/intellij-plugins-dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcessZ.java
@@ -159,6 +159,9 @@ public class DartVmServiceDebugProcessZ extends DartVmServiceDebugProcess {
 
       @Override
       public void logError(final String message, final Throwable exception) {
+        if (!getVmConnected()) {
+          return;
+        }
         getSession().getConsoleView().print(message.trim() + "\n", ConsoleViewContentType.ERROR_OUTPUT);
         LOG.warn(message, exception);
       }


### PR DESCRIPTION
- add logic in `PerfService` (as a singleton that already has knowledge of the service protocol and events) to track the current flutter isolate (at app startup, and during full retarts)
- have it fire events for when the isolate id for the flutter app's isolate changes
- have the inspector listen to those events; fix https://github.com/flutter/flutter-intellij/issues/1806 - the inspector would assert for apps that started isolates

@jacob314, I know you have a big refactor out. If this would conflict, I can roll back the inspector portions, land the rest, and re-apply once your work lands. We will want to get your changes in soon however, so we can resolve this issue as well as https://github.com/flutter/flutter-intellij/issues/2016 (which will require some UI work in the inspector view).

