### PR TITLE
Fix race condition in DartVmServiceDebugProcessZ

### DIFF
--- a/src/io/flutter/perf/PerfService.java
+++ b/src/io/flutter/perf/PerfService.java
@@ -5,44 +5,42 @@
  */
 package io.flutter.perf;
 
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.util.text.StringUtil;
-import com.intellij.util.EventDispatcher;
 import com.jetbrains.lang.dart.ide.runner.server.vmService.VmServiceConsumers;
-import gnu.trove.THashSet;
+import gnu.trove.THashMap;
 import io.flutter.perf.HeapMonitor.HeapListener;
 import io.flutter.run.FlutterDebugProcess;
+import io.flutter.utils.EventStream;
+import io.flutter.utils.StreamSubscription;
 import io.flutter.utils.VmServiceListenerAdapter;
 import org.dartlang.vm.service.VmService;
 import org.dartlang.vm.service.consumer.GetIsolateConsumer;
 import org.dartlang.vm.service.consumer.VMConsumer;
 import org.dartlang.vm.service.element.*;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
-import java.util.EventListener;
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.function.Consumer;
 
 // TODO(pq): rename
 // TODO(pq): improve error handling
 // TODO(pq): change mode for opting in (preference or inspector view menu)
 
 public class PerfService {
-  public interface FlutterIsolateListener extends EventListener {
-    void handleFutterIsolateChanged(@Nullable IsolateRef isolateRef);
-  }
-
   @NotNull private final HeapMonitor heapMonitor;
   @NotNull private final FlutterFramesMonitor flutterFramesMonitor;
-  @NotNull private final Set<String> serviceExtensions = new THashSet<>();
+  @NotNull private final Map<String, EventStream<Boolean>> serviceExtensions = new THashMap<>();
 
-  private final EventDispatcher<FlutterIsolateListener> myIsolateEventDispatcher = EventDispatcher.create(FlutterIsolateListener.class);
+  private final EventStream<IsolateRef> flutterIsolateRefStream;
 
-  private IsolateRef flutterIsolateRef;
   private boolean isRunning;
 
   public PerfService(@NotNull FlutterDebugProcess debugProcess, @NotNull VmService vmService) {
     this.heapMonitor = new HeapMonitor(vmService, debugProcess);
     this.flutterFramesMonitor = new FlutterFramesMonitor(vmService);
+    flutterIsolateRefStream = new EventStream<>(null);
 
     vmService.addVmServiceListener(new VmServiceListenerAdapter() {
       @Override
@@ -76,17 +74,20 @@ public class PerfService {
             @Override
             public void received(Isolate isolate) {
               // Populate flutter isolate info.
-              if (flutterIsolateRef == null) {
+              if (flutterIsolateRefStream.getValue() == null) {
                 for (String extensionName : isolate.getExtensionRPCs()) {
                   if (extensionName.startsWith("ext.flutter.")) {
-                    flutterIsolateRef = isolateRef;
-                    myIsolateEventDispatcher.getMulticaster().handleFutterIsolateChanged(flutterIsolateRef);
+                    setFlutterIsolate(isolateRef);
                     break;
                   }
                 }
               }
 
-              serviceExtensions.addAll(isolate.getExtensionRPCs());
+              ApplicationManager.getApplication().invokeLater(() -> {
+                for (String extension : isolate.getExtensionRPCs()) {
+                  addServiceExtension(extension);
+                }
+              });
             }
 
             @Override
@@ -114,13 +115,13 @@ public class PerfService {
   }
 
   /**
-   * Return the current Flutter isolate.
+   * Returns a StreamSubscription providing the current Flutter isolate.
    * <p>
-   * This can be null occasionally during initial application startup and for a brief time when doing a full restart.
+   * The current value of the subscription can be null occasionally during initial application startup and for a brief time when doing a
+   * full restart.
    */
-  @Nullable
-  public IsolateRef getCurrentFlutterIsolate() {
-    return flutterIsolateRef;
+  public StreamSubscription<IsolateRef> getCurrentFlutterIsolate(Consumer<IsolateRef> onValue, boolean onUIThread) {
+    return flutterIsolateRefStream.listen(onValue, onUIThread);
   }
 
   /**
@@ -141,23 +142,47 @@ public class PerfService {
     isRunning = false;
   }
 
+  private void setFlutterIsolate(IsolateRef ref) {
+    synchronized (flutterIsolateRefStream) {
+      final IsolateRef existing = flutterIsolateRefStream.getValue();
+      if (existing == ref || (existing != null && ref != null && StringUtil.equals(existing.getId(), ref.getId()))) {
+        // Isolate didn't change.
+        return;
+      }
+      flutterIsolateRefStream.setValue(ref);
+    }
+  }
+
   @SuppressWarnings("EmptyMethod")
   private void onVmServiceReceived(String streamId, Event event) {
     // Check for the current Flutter isolate exiting.
+    final IsolateRef flutterIsolateRef = flutterIsolateRefStream.getValue();
     if (flutterIsolateRef != null) {
       if (event.getKind() == EventKind.IsolateExit && StringUtil.equals(event.getIsolate().getId(), flutterIsolateRef.getId())) {
-        flutterIsolateRef = null;
-        myIsolateEventDispatcher.getMulticaster().handleFutterIsolateChanged(flutterIsolateRef);
+        setFlutterIsolate(null);
+
+        Iterable<EventStream<Boolean>> existingExtensions;
+        synchronized (serviceExtensions) {
+          existingExtensions = new ArrayList<>(serviceExtensions.values());
+        }
+        for (EventStream<Boolean> serviceExtension : existingExtensions) {
+          // The next Flutter isolate to load might not support this service
+          // extension.
+          serviceExtension.setValue(false);
+        }
       }
     }
 
+    if (event.getKind() == EventKind.ServiceExtensionAdded) {
+      addServiceExtension(event.getExtensionRPC());
+    }
+
     // Check to see if there's a new Flutter isolate.
-    if (flutterIsolateRef == null) {
+    if (flutterIsolateRefStream.getValue() == null) {
       // Check for Flutter frame events.
       if (event.getKind() == EventKind.Extension && event.getExtensionKind().startsWith("Flutter.")) {
         // Flutter.FrameworkInitialization, Flutter.FirstFrame, Flutter.Frame
-        flutterIsolateRef = event.getIsolate();
-        myIsolateEventDispatcher.getMulticaster().handleFutterIsolateChanged(flutterIsolateRef);
+        setFlutterIsolate(event.getIsolate());
       }
 
       // Check for service extension registrations.
@@ -165,8 +190,7 @@ public class PerfService {
         final String extensionName = event.getExtensionRPC();
 
         if (extensionName.startsWith("ext.flutter.")) {
-          flutterIsolateRef = event.getIsolate();
-          myIsolateEventDispatcher.getMulticaster().handleFutterIsolateChanged(flutterIsolateRef);
+          setFlutterIsolate(event.getIsolate());
         }
       }
     }
@@ -182,8 +206,20 @@ public class PerfService {
 
       heapMonitor.handleGCEvent(isolateRef, newHeapSpace, oldHeapSpace);
     }
-    else if (StringUtil.equals(streamId, VmService.ISOLATE_STREAM_ID) && event.getKind() == EventKind.ServiceExtensionAdded) {
-      serviceExtensions.add(event.getExtensionRPC());
+  }
+
+  /**
+   * This method must only be called on the UI thread.
+   */
+  private void addServiceExtension(String name) {
+    synchronized (serviceExtensions) {
+      EventStream<Boolean> stream = serviceExtensions.get(name);
+      if (stream == null) {
+        serviceExtensions.put(name, new EventStream<>(true));
+      }
+      else if (stream.getValue() == false) {
+        stream.setValue(true);
+      }
     }
   }
 
@@ -216,15 +252,16 @@ public class PerfService {
     }
   }
 
-  public void addFlutterIsolateListener(@NotNull FlutterIsolateListener listener) {
-    myIsolateEventDispatcher.addListener(listener);
-  }
-
-  public void removeFlutterIsolateListener(@NotNull FlutterIsolateListener listener) {
-    myIsolateEventDispatcher.removeListener(listener);
-  }
-
-  public boolean hasServiceExtension(String name) {
-    return serviceExtensions.contains(name);
+  public @NotNull
+  StreamSubscription<Boolean> hasServiceExtension(String name, Consumer<Boolean> onData) {
+    EventStream<Boolean> stream;
+    synchronized (serviceExtensions) {
+      stream = serviceExtensions.get(name);
+      if (stream == null) {
+        stream = new EventStream<>(false);
+        serviceExtensions.put(name, stream);
+      }
+    }
+    return stream.listen(onData, true);
   }
 }

--- a/src/io/flutter/perf/PerfService.java
+++ b/src/io/flutter/perf/PerfService.java
@@ -40,7 +40,7 @@ public class PerfService {
   public PerfService(@NotNull FlutterDebugProcess debugProcess, @NotNull VmService vmService) {
     this.heapMonitor = new HeapMonitor(vmService, debugProcess);
     this.flutterFramesMonitor = new FlutterFramesMonitor(vmService);
-    flutterIsolateRefStream = new EventStream<>(null);
+    flutterIsolateRefStream = new EventStream<>();
 
     vmService.addVmServiceListener(new VmServiceListenerAdapter() {
       @Override

--- a/src/io/flutter/run/daemon/FlutterApp.java
+++ b/src/io/flutter/run/daemon/FlutterApp.java
@@ -31,6 +31,7 @@ import io.flutter.pub.PubRoot;
 import io.flutter.pub.PubRoots;
 import io.flutter.run.FlutterDebugProcess;
 import io.flutter.run.FlutterLaunchMode;
+import io.flutter.utils.StreamSubscription;
 import org.dartlang.vm.service.VmService;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -38,6 +39,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 
 /**
  * A running Flutter app.
@@ -361,8 +363,9 @@ public class FlutterApp {
     });
   }
 
-  public boolean hasServiceExtension(String name) {
-    return getPerfService().hasServiceExtension(name);
+  public @NotNull
+  StreamSubscription<Boolean> hasServiceExtension(String name, Consumer<Boolean> onData) {
+    return getPerfService().hasServiceExtension(name, onData);
   }
 
   public void setConsole(@Nullable ConsoleView console) {

--- a/src/io/flutter/utils/EventStream.java
+++ b/src/io/flutter/utils/EventStream.java
@@ -18,14 +18,14 @@ import java.util.function.Consumer;
 /**
  * Simple class for listening for a value that can be repeatedly updated.
  * <p>
- * The  benefit of this class instead of listening for events is you don't have
- * to worry about missing values posted to the stream before your code started
- * listening.
+ * The  benefit of using this class instead of listening for events is you
+ * don't have to worry about missing values posted to the stream before your
+ * code started listening which can lead to hard to find bugs.
+ *
  * The benefit of using this class over awaiting a Future is that the value can
  * update multiple times.
  * <p>
- * New values to the EventStream can be posted on any thread to listen can be
- * made from any thread.
+ * The value associated with the EventStream can be set on any thread.
  * <p>
  * The class is inspired by listen method on the Stream class in Dart.
  */
@@ -34,6 +34,10 @@ public class EventStream<T> {
   protected final HashSet<StreamSubscription<T>> subscriptions = new LinkedHashSet<>();
 
   private volatile T currentValue;
+
+  public EventStream() {
+    this(null);
+  }
 
   public EventStream(T initialValue) {
     currentValue = initialValue;

--- a/src/io/flutter/utils/EventStream.java
+++ b/src/io/flutter/utils/EventStream.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2018 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.utils;
+
+
+import com.intellij.openapi.application.ApplicationManager;
+
+import javax.swing.*;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.function.Consumer;
+
+/**
+ * Simple class for listening for a value that can be repeatedly updated.
+ * <p>
+ * The  benefit of this class instead of listening for events is you don't have
+ * to worry about missing values posted to the stream before your code started
+ * listening.
+ * The benefit of using this class over awaiting a Future is that the value can
+ * update multiple times.
+ * <p>
+ * New values to the EventStream can be posted on any thread to listen can be
+ * made from any thread.
+ * <p>
+ * The class is inspired by listen method on the Stream class in Dart.
+ */
+public class EventStream<T> {
+
+  protected final HashSet<StreamSubscription<T>> subscriptions = new LinkedHashSet<>();
+
+  private volatile T currentValue;
+
+  public EventStream(T initialValue) {
+    currentValue = initialValue;
+  }
+
+  public T getValue() {
+    return currentValue;
+  }
+
+  public void setValue(T value) {
+    final List<StreamSubscription<T>> regularSubscriptions = new ArrayList<>();
+    final List<StreamSubscription<T>> uiThreadSubscriptions = new ArrayList<>();
+    synchronized (subscriptions) {
+      currentValue = value;
+      for (StreamSubscription<T> subscription : subscriptions) {
+        if (subscription.onUIThread) {
+          uiThreadSubscriptions.add(subscription);
+        }
+        else {
+          regularSubscriptions.add(subscription);
+        }
+      }
+    }
+
+    for (StreamSubscription<T> subscription : regularSubscriptions) {
+      subscription.notify(value);
+    }
+    if (!uiThreadSubscriptions.isEmpty()) {
+      Runnable doRun = () -> {
+        for (StreamSubscription<T> subscription : uiThreadSubscriptions) {
+          subscription.notify(value);
+        }
+      };
+      if (ApplicationManager.getApplication() != null) {
+        ApplicationManager.getApplication().invokeLater(doRun);
+      }
+      else {
+        // This case existing to support unittesting.
+        SwingUtilities.invokeLater(doRun);
+      }
+    }
+  }
+
+  /**
+   * Listens for changes to the value tracked by the EventStream.
+   * onData is always called immediately with the current value specified
+   * by the EventStream.
+   *
+   * @param onData     is called every time the value associated with the EventStream changes.
+   * @param onUIThread specifies that callbacks are made on the UI thread.
+   * @return a StreamSubscription object that is used to cancel the subscription.
+   */
+  public StreamSubscription<T> listen(Consumer<T> onData, boolean onUIThread) {
+    final StreamSubscription<T> subscription = new StreamSubscription<>(onData, onUIThread, this);
+    final T cachedCurrentValue;
+    synchronized (subscriptions) {
+      cachedCurrentValue = currentValue;
+      subscriptions.add(subscription);
+    }
+
+    onData.accept(cachedCurrentValue);
+    return subscription;
+  }
+
+  protected void removeSubscription(StreamSubscription<T> subscription) {
+    synchronized (subscriptions) {
+      subscriptions.remove(subscription);
+    }
+  }
+}

--- a/src/io/flutter/utils/StreamSubscription.java
+++ b/src/io/flutter/utils/StreamSubscription.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.utils;
+
+import com.intellij.openapi.Disposable;
+
+import java.util.function.Consumer;
+
+public class StreamSubscription<T> implements Disposable {
+  private final Consumer<T> onData;
+
+  /**
+   * Whether the onData callback should only be executed on the UI thread.
+   */
+  protected final boolean onUIThread;
+  private EventStream<T> owner;
+  private volatile boolean disposed = false;
+
+  protected StreamSubscription(Consumer<T> onData, boolean onUIThread, EventStream<T> owner) {
+    this.onData = onData;
+    this.onUIThread = onUIThread;
+    this.owner = owner;
+  }
+
+  @Override
+  public void dispose() {
+    disposed = true;
+    if (owner != null) {
+      owner.removeSubscription(this);
+      owner = null;
+    }
+  }
+
+  protected void notify(T value) {
+    // There is a risk the call to dispose could have been interleaved
+    // with calls on a different thread adding values to the stream so we suppress
+    // calls to notify if the subscription has lready been closed so no events
+    // get through after the dispose method is called.
+    if (!disposed) {
+      onData.accept(value);
+    }
+  }
+}

--- a/src/io/flutter/view/InspectorPanel.java
+++ b/src/io/flutter/view/InspectorPanel.java
@@ -32,8 +32,10 @@ import io.flutter.run.daemon.FlutterApp;
 import io.flutter.utils.AsyncRateLimiter;
 import io.flutter.utils.AsyncUtils;
 import io.flutter.utils.ColorIconMaker;
+import io.flutter.utils.StreamSubscription;
 import org.apache.commons.lang.StringUtils;
 import org.dartlang.vm.service.element.InstanceRef;
+import org.dartlang.vm.service.element.IsolateRef;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -83,6 +85,7 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
   @NotNull
   private final FlutterApp flutterApp;
   @NotNull private final InspectorService inspectorService;
+  private final StreamSubscription<IsolateRef> flutterIsolateSubscription;
   private CompletableFuture<DiagnosticsNode> rootFuture;
 
   private static final DataKey<Tree> INSPECTOR_KEY = DataKey.create("Flutter.InspectorKey");
@@ -152,6 +155,12 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
     treeSplitter.setFirstComponent(rootsTreeScrollPane);
     treeSplitter.setSecondComponent(ScrollPaneFactory.createScrollPane(myPropertiesPanel));
     add(treeSplitter);
+
+    flutterIsolateSubscription = inspectorService.getApp().getPerfService().getCurrentFlutterIsolate((IsolateRef flutterIsolate) -> {
+      if (flutterIsolate == null) {
+        onIsolateStopped();
+      }
+    }, true);
   }
 
   static DiagnosticsNode getDiagnosticNode(TreeNode treeNode) {
@@ -481,6 +490,7 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
 
   @Override
   public void dispose() {
+    flutterIsolateSubscription.dispose();
     // TODO(jacobr): actually implement.
   }
 

--- a/testSrc/unit/io/flutter/utils/EventStreamTest.java
+++ b/testSrc/unit/io/flutter/utils/EventStreamTest.java
@@ -41,14 +41,14 @@ public class EventStreamTest {
     eventStream = new EventStream<>(42);
   }
 
-  void logValueListener(int value) {
+  void logValueListener(Integer value) {
     synchronized (logValueListenerLock) {
       if (onUiThread && !SwingUtilities.isEventDispatchThread()) {
         log("subscriber should be called on Swing thread");
         return;
       }
 
-      log(Integer.toString(value));
+      log("" + value);
 
       numEvents++;
       if (numEvents == expectedEvents) {
@@ -98,6 +98,19 @@ public class EventStreamTest {
     });
 
     checkLog("42", "100", "100", "100", "200", "200");
+  }
+
+  @Test
+  public void nullInitialValue() {
+    expectedEvents = 3;
+    SwingUtilities.invokeLater(() -> {
+      eventStream = new EventStream<>();
+      addLogValueListener(true);
+      eventStream.setValue(100);
+      eventStream.setValue(200);
+    });
+
+    checkLog("null", "100", "200");
   }
 
   @Test

--- a/testSrc/unit/io/flutter/utils/EventStreamTest.java
+++ b/testSrc/unit/io/flutter/utils/EventStreamTest.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2018 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.utils;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.swing.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+public class EventStreamTest {
+
+  private EventStream<Integer> eventStream;
+
+  private final List<String> logEntries = new ArrayList<>();
+  private CompletableFuture<Object> callbacksDone;
+
+  private volatile int expectedEvents;
+  private volatile int numEvents;
+  private boolean onUiThread;
+  private final Object logValueListenerLock = new Object();
+
+  @Before
+  public void setUp() {
+    numEvents = 0;
+
+    callbacksDone = new CompletableFuture<>();
+    eventStream = new EventStream<>(42);
+  }
+
+  void logValueListener(int value) {
+    synchronized (logValueListenerLock) {
+      if (onUiThread && !SwingUtilities.isEventDispatchThread()) {
+        log("subscriber should be called on Swing thread");
+        return;
+      }
+
+      log(Integer.toString(value));
+
+      numEvents++;
+      if (numEvents == expectedEvents) {
+        callbacksDone.complete(null);
+      }
+      else if (numEvents > expectedEvents) {
+        log("unexpected number of events fired");
+      }
+    }
+  }
+
+  StreamSubscription<Integer> addLogValueListener(boolean onUiThread) {
+    this.onUiThread = onUiThread;
+    return eventStream.listen(this::logValueListener, onUiThread);
+  }
+
+  @Test
+  public void valueSetBeforeStart() {
+    eventStream.setValue(100);
+    eventStream.setValue(200); // Only value that will show up.
+    expectedEvents = 1;
+    SwingUtilities.invokeLater(() -> {
+      addLogValueListener(true);
+    });
+    checkLog("200");
+  }
+
+  @Test
+  public void calledWithDefaultValue() {
+    expectedEvents = 1;
+    SwingUtilities.invokeLater(() -> {
+      addLogValueListener(true);
+    });
+    checkLog("42");
+  }
+
+  @Test
+  public void duplicateValues() {
+    expectedEvents = 6;
+    SwingUtilities.invokeLater(() -> {
+      addLogValueListener(true);
+      eventStream.setValue(100);
+      eventStream.setValue(100);
+      eventStream.setValue(100);
+      eventStream.setValue(200);
+      eventStream.setValue(200);
+    });
+
+    checkLog("42", "100", "100", "100", "200", "200");
+  }
+
+  @Test
+  public void ignoreValuesAfterDispose() {
+    expectedEvents = 5;
+    final StreamSubscription<Integer> listener = addLogValueListener(false);
+    eventStream.setValue(100);
+    eventStream.setValue(200);
+    eventStream.setValue(300);
+    listener.dispose();
+    eventStream.setValue(400); // Ignored.
+    eventStream.setValue(500); // Ignored.
+    eventStream.setValue(9);
+    // Subscribe back getting the current value (9).
+    addLogValueListener(false);
+
+    checkLog("42", "100", "200", "300", "9");
+  }
+
+  @Test
+  public void doubleDispose() {
+    expectedEvents = 6;
+    final StreamSubscription<Integer> listener = addLogValueListener(false);
+    final StreamSubscription<Integer> listener2 = addLogValueListener(false);
+    eventStream.setValue(100); // This event will be received by both listeners.
+    listener.dispose();
+    // A second dispose is harmless and doesn't crash anything.
+    listener.dispose();
+    eventStream.setValue(200);
+    eventStream.setValue(300);
+    checkLog("42", "42", "100", "100", "200", "300");
+  }
+
+  @Test
+  public void eventsFromOtherThread() {
+    expectedEvents = 6;
+    addLogValueListener(false);
+
+    final Timer timer = new Timer(15, null);
+    timer.setRepeats(true);
+    timer.addActionListener(new ActionListener() {
+      int count = 0;
+
+      @Override
+      public void actionPerformed(ActionEvent e) {
+        count++;
+        eventStream.setValue(count);
+        if (count == 5) {
+          timer.stop();
+        }
+      }
+    });
+    timer.start();
+
+    checkLog("42", "1", "2", "3", "4", "5");
+  }
+
+  @Test
+  public void eventsFromOtherThreadOnUiThread() {
+    expectedEvents = 6;
+    SwingUtilities.invokeLater(() -> {
+      addLogValueListener(true);
+
+      final Timer timer = new Timer(15, null);
+      timer.setRepeats(true);
+      timer.addActionListener(new ActionListener() {
+        int count = 0;
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+          count++;
+          eventStream.setValue(count);
+          if (count == 5) {
+            timer.stop();
+          }
+        }
+      });
+      timer.start();
+    });
+
+    checkLog("42", "1", "2", "3", "4", "5");
+  }
+
+  @Test
+  public void unsubscribeFromUiThread() {
+    expectedEvents = 6;
+    SwingUtilities.invokeLater(() -> {
+      addLogValueListener(true);
+
+      final StreamSubscription[] subscription = new StreamSubscription[]{null};
+      subscription[0] = eventStream.listen((Integer value) -> {
+        log("L2: " + value);
+        if (value == 3) {
+          log("L2: stopped");
+          subscription[0].dispose();
+        }
+      }, true);
+
+      final Timer timer = new Timer(15, null);
+      timer.setRepeats(true);
+      timer.addActionListener(new ActionListener() {
+        int count = 0;
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+          count++;
+          eventStream.setValue(count);
+          if (count == 5) {
+            timer.stop();
+          }
+        }
+      });
+      timer.start();
+    });
+
+    checkLog("42", "L2: 42", "1", "L2: 1", "2", "L2: 2", "3", "L2: 3", "L2: stopped", "4", "5");
+  }
+
+  private synchronized void log(String message) {
+    synchronized (logEntries) {
+      logEntries.add(message);
+    }
+  }
+
+  private synchronized List<String> getLogEntries() {
+    synchronized (logEntries) {
+      return ImmutableList.copyOf(logEntries);
+    }
+  }
+
+  private void reportFailure(Exception e) {
+    fail("Exception: " + e + "\nLog: " + getLogEntries().toString());
+  }
+
+  private void checkLog(String... expectedEntries) {
+    try {
+      callbacksDone.get();
+    }
+    catch (InterruptedException | ExecutionException e) {
+      e.printStackTrace();
+    }
+    assertThat("logEntries entries are different", getLogEntries(), is(ImmutableList.copyOf(expectedEntries)));
+    logEntries.clear();
+  }
+}

--- a/third_party/intellij-plugins-dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcessZ.java
+++ b/third_party/intellij-plugins-dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcessZ.java
@@ -301,7 +301,7 @@ public class DartVmServiceDebugProcessZ extends DartVmServiceDebugProcess {
 
         @Override
         public void onError(RPCError error) {
-          System.out.println("XXX got an error" + error);
+          LOG.error(error.toString());
         }
       });
     }

--- a/third_party/intellij-plugins-dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcessZ.java
+++ b/third_party/intellij-plugins-dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcessZ.java
@@ -32,7 +32,9 @@ import io.flutter.FlutterBundle;
 import io.flutter.run.FlutterLaunchMode;
 import org.dartlang.vm.service.VmService;
 import org.dartlang.vm.service.consumer.GetObjectConsumer;
+import org.dartlang.vm.service.consumer.VMConsumer;
 import org.dartlang.vm.service.element.*;
+import org.dartlang.vm.service.element.Event;
 import org.dartlang.vm.service.logging.Logging;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -267,6 +269,41 @@ public class DartVmServiceDebugProcessZ extends DartVmServiceDebugProcess {
     final FlutterLaunchMode launchMode = FlutterLaunchMode.getMode(executionEnvironment);
     if (launchMode.supportsDebugConnection()) {
       myVmServiceWrapper.handleDebuggerConnected();
+
+      // TODO(jacobr): the following code is a workaround for issues
+      // auto-resuming isolates paused at their creation while running in
+      // debug mode.
+      // The ideal fix would by to fix VMServiceWrapper so that it checks
+      // for already running isolates like we do here or to refactor where we
+      // create our VmServiceWrapper so we can listen for isolate creation soon
+      // enough that we never miss an isolate creation message.
+      vmService.getVM(new VMConsumer() {
+        @Override
+        public void received(VM vm) {
+          final ElementList<IsolateRef> isolates = vm.getIsolates();
+          // There is a risk the isolate we care about loaded before the call
+          // to handleDebuggerConnected was made and so
+          for (IsolateRef isolateRef : isolates) {
+            vmService.getIsolate(isolateRef.getId(), new VmServiceConsumers.GetIsolateConsumerWrapper() {
+              public void received(Isolate isolate) {
+                final Event event = isolate.getPauseEvent();
+                final EventKind eventKind = event.getKind();
+                if (eventKind == EventKind.PauseStart) {
+                  ApplicationManager.getApplication().invokeLater(() -> {
+                    // We are assuming it is safe to call handleIsolate multiple times.
+                    myVmServiceWrapper.handleIsolate(isolateRef, true);
+                  });
+                }
+              }
+            });
+          }
+        }
+
+        @Override
+        public void onError(RPCError error) {
+          System.out.println("XXX got an error" + error);
+        }
+      });
     }
 
     // We re-enable the remote debug flag so that the service wrapper will call our guessRemoteProjectRoot()


### PR DESCRIPTION
Also fix race condition determining what Flutter extensions are available resulting in 
inspector toolbar buttons typically being disabled.

Also add code to be a bit paranoid about ensuring all updates to PerfService occur on the UI thread.
We could optimize that code a bit and only switch to the UI thread when about to update fields.

fixes https://github.com/flutter/flutter-intellij/issues/2071