### PR TITLE
remove uses of the singleForProject/singleForModule calls

### DIFF
--- a/flutter-studio/src/io/flutter/project/FlutterProjectCreator.java
+++ b/flutter-studio/src/io/flutter/project/FlutterProjectCreator.java
@@ -85,7 +85,7 @@ public class FlutterProjectCreator {
   }
 
   public static void disableUserConfig(Project project) {
-    if (FlutterModuleUtils.usesFlutter(project)) {
+    if (FlutterModuleUtils.declaresFlutter(project)) {
       for (Module module : ModuleManager.getInstance(project).getModules()) {
         final AndroidFacet facet = AndroidFacet.getInstance(module);
         if (facet == null) {

--- a/src/io/flutter/FlutterUtils.java
+++ b/src/io/flutter/FlutterUtils.java
@@ -93,7 +93,7 @@ public class FlutterUtils {
    */
   public static boolean isInFlutterProject(@NotNull PsiElement element) {
     final Module module = ModuleUtil.findModuleForPsiElement(element);
-    return module != null && FlutterModuleUtils.usesFlutter(module);
+    return module != null && FlutterModuleUtils.declaresFlutter(module);
   }
 
   public static boolean isInTestDir(@Nullable DartFile file) {

--- a/src/io/flutter/ProjectOpenActivity.java
+++ b/src/io/flutter/ProjectOpenActivity.java
@@ -17,6 +17,7 @@ import com.intellij.openapi.startup.StartupActivity;
 import com.intellij.openapi.ui.Messages;
 import icons.FlutterIcons;
 import io.flutter.pub.PubRoot;
+import io.flutter.pub.PubRoots;
 import io.flutter.sdk.FlutterSdk;
 import io.flutter.utils.FlutterModuleUtils;
 import org.jetbrains.annotations.NotNull;
@@ -27,99 +28,48 @@ import org.jetbrains.annotations.NotNull;
  * @see FlutterInitializer for actions that run later.
  */
 public class ProjectOpenActivity implements StartupActivity, DumbAware {
+  private static final Logger LOG = Logger.getInstance(ProjectOpenActivity.class);
+
   @Override
   public void runActivity(@NotNull Project project) {
-    if (!FlutterModuleUtils.usesFlutter(project)) {
-      // This method is called in twice when importing a project, because the project is reloaded.
-      // Don't do anything until the second time.
+    if (!FlutterModuleUtils.declaresFlutter(project)) {
       return;
     }
 
-    PubRoot root = PubRoot.singleForProjectWithRefresh(project);
-    if (root == null) {
-      return;
-    }
-
-    if (!downloadDependencies(project, root)) {
-      return;
-    }
-
-    root = root.refresh();
-    if (root != null && !root.hasUpToDatePackages()) {
-      Notifications.Bus.notify(new PackagesOutOfDateNotification(project));
-    }
-  }
-
-  /**
-   * Ensures that we can start the analysis server and it won't see bad imports.
-   * <p>
-   * We might need to download the Dart SDK or some packages.
-   * <p>
-   * Waits until download is complete. (On a slow network, this can take many seconds.)
-   * <p>
-   * Returns true if successful.
-   */
-  private boolean downloadDependencies(@NotNull Project project, @NotNull PubRoot root) {
     final FlutterSdk sdk = FlutterSdk.getIncomplete(project);
     if (sdk == null) {
-      // Can't do anything without a Flutter SDK.
-      return false;
+      // We can't do anything without a Flutter SDK.
+      return;
     }
 
-    if (root.getPackages() == null) {
-      // Get packages; as a side effect this will also download the Dart SDK if needed.
-      try {
-        final Process process = sdk.startPackagesGet(root, project);
-        if (process != null) {
-          process.waitFor();
-          return process.exitValue() == 0;
-        }
+    for (PubRoot pubRoot : PubRoots.forProject(project)) {
+      if (!pubRoot.hasUpToDatePackages()) {
+        Notifications.Bus.notify(new PackagesOutOfDateNotification(project, pubRoot));
       }
-      catch (InterruptedException e) {
-        FlutterMessages.showError("Error opening", e.getMessage());
-      }
-      return false;
-    } else if (sdk.getDartSdkPath() == null) {
-      // This can happen when opening an example project after "git clone flutter".
-      // We have a .packages file, but need to run a flutter command to download the Dart SDK.
-      final boolean ok = sdk.sync(project);
-      if (!ok) {
-        FlutterMessages.showError("Error opening project", "Failed to download Dart SDK for Flutter");
-      }
-      return ok;
-    } else {
-      return true; // Nothing to do.
     }
   }
 
   private static class PackagesOutOfDateNotification extends Notification {
+    @NotNull private final Project myProject;
+    @NotNull private final PubRoot myRoot;
 
-    @NotNull
-    private final Project myProject;
-
-    public PackagesOutOfDateNotification(@NotNull Project project) {
+    public PackagesOutOfDateNotification(@NotNull Project project, @NotNull PubRoot root) {
       super("Flutter Packages", FlutterIcons.Flutter, "Flutter packages get.",
             null, "The pubspec.yaml file has been modified since " +
                   "the last time 'flutter packages get' was run.",
             NotificationType.INFORMATION, null);
 
       myProject = project;
+      myRoot = root;
 
       addAction(new AnAction("Run 'flutter packages get'") {
         @Override
         public void actionPerformed(AnActionEvent event) {
-          // TODO(skybrian) analytics for the action? (The command is logged.)
           expire();
 
           final FlutterSdk sdk = FlutterSdk.getFlutterSdk(project);
           if (sdk == null) {
             Messages.showErrorDialog(project, "Flutter SDK not found", "Error");
-            return;
-          }
-
-          final PubRoot root = PubRoot.singleForProjectWithRefresh(project);
-          if (root == null) {
-            Messages.showErrorDialog("Pub root not found", "Error");
             return;
           }
 
@@ -130,6 +80,4 @@ public class ProjectOpenActivity implements StartupActivity, DumbAware {
       });
     }
   }
-
-  private static final Logger LOG = Logger.getInstance(ProjectOpenActivity.class);
 }

--- a/src/io/flutter/actions/FlutterToolsActionGroup.java
+++ b/src/io/flutter/actions/FlutterToolsActionGroup.java
@@ -13,13 +13,12 @@ import io.flutter.utils.FlutterModuleUtils;
 import org.jetbrains.annotations.Nullable;
 
 public class FlutterToolsActionGroup extends DefaultActionGroup {
-
   @Override
   public void update(@Nullable AnActionEvent e) {
     final Project project = e == null ? null : e.getProject();
     final Presentation presentation = e == null ? null : e.getPresentation();
     if (presentation != null) {
-      final boolean visible = project != null && FlutterModuleUtils.usesFlutter(project);
+      final boolean visible = project != null && FlutterModuleUtils.declaresFlutter(project);
       presentation.setEnabled(visible);
       presentation.setVisible(visible);
     }

--- a/src/io/flutter/inspections/FlutterDependencyInspection.java
+++ b/src/io/flutter/inspections/FlutterDependencyInspection.java
@@ -55,7 +55,7 @@ public class FlutterDependencyInspection extends LocalInspectionTool {
 
     // TODO(pq): consider validating package name here (`get` will fail if it's invalid).
 
-    if (root.getPackages() == null) {
+    if (root.getPackagesFile() == null) {
       return createProblemDescriptors(manager, psiFile, root, FlutterBundle.message("packages.get.never.done"));
     }
 

--- a/src/io/flutter/preview/RenderHelper.java
+++ b/src/io/flutter/preview/RenderHelper.java
@@ -39,7 +39,7 @@ public class RenderHelper {
   private String myTesterPath = null;
   private final RenderThread myRenderThread = new RenderThread();
 
-  private VirtualFile myPackages;
+  private VirtualFile myPackagesFile;
   private VirtualFile myFile;
   private FlutterOutline myFileOutline;
   private String myInstrumentedCode;
@@ -67,10 +67,10 @@ public class RenderHelper {
     myFileOutline = fileOutline;
     myInstrumentedCode = instrumentedCode;
 
-    myPackages = null;
+    myPackagesFile = null;
     final PubRoot pubRoot = PubRoot.forFile(file);
     if (pubRoot != null) {
-      myPackages = pubRoot.getPackages();
+      myPackagesFile = pubRoot.getPackagesFile();
     }
 
     myWidgetOutline = null;
@@ -144,7 +144,7 @@ public class RenderHelper {
   }
 
   private void scheduleRendering() {
-    if (myPackages == null || myInstrumentedCode == null || myWidgetOutline == null || myWidth == 0 || myHeight == 0) {
+    if (myPackagesFile == null || myInstrumentedCode == null || myWidgetOutline == null || myWidth == 0 || myHeight == 0) {
       return;
     }
 
@@ -156,7 +156,7 @@ public class RenderHelper {
     final String widgetClass = myWidgetOutline.getDartElement().getName();
     final String constructor = myWidgetOutline.getRenderConstructor();
     final RenderRequest request =
-      new RenderRequest(myTesterPath, myPackages, myFile, myInstrumentedCode,
+      new RenderRequest(myTesterPath, myPackagesFile, myFile, myInstrumentedCode,
                         myWidgetOutline, widgetClass, constructor,
                         myWidth, myHeight, myListener);
     myRenderThread.setRequest(request);

--- a/src/io/flutter/project/FlutterIconProvider.java
+++ b/src/io/flutter/project/FlutterIconProvider.java
@@ -33,7 +33,7 @@ public class FlutterIconProvider extends IconProvider {
   @Nullable
   public Icon getIcon(@NotNull final PsiElement element, @Iconable.IconFlags final int flags) {
     final Project project = element.getProject();
-    if (!FlutterModuleUtils.usesFlutter(project)) return null;
+    if (!FlutterModuleUtils.declaresFlutter(project)) return null;
 
     // Directories.
     if (element instanceof PsiDirectory) {

--- a/src/io/flutter/sdk/FlutterPluginsLibraryManager.java
+++ b/src/io/flutter/sdk/FlutterPluginsLibraryManager.java
@@ -24,6 +24,7 @@ import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.*;
 import com.jetbrains.lang.dart.util.DotPackagesFileUtil;
 import io.flutter.pub.PubRoot;
+import io.flutter.pub.PubRoots;
 import io.flutter.utils.FlutterModuleUtils;
 import org.jetbrains.annotations.NotNull;
 
@@ -98,12 +99,12 @@ public class FlutterPluginsLibraryManager {
   }
 
   private void updateFlutterPluginsImpl() {
-    final boolean usesFlutter = FlutterModuleUtils.usesFlutter(project);
+    final boolean declaresFlutter = FlutterModuleUtils.declaresFlutter(project);
 
     final LibraryTable projectLibraryTable = ProjectLibraryTable.getInstance(project);
     final Library existingLibrary = projectLibraryTable.getLibraryByName(FlutterPluginLibraryType.FLUTTER_PLUGINS_LIBRARY_NAME);
 
-    if (!usesFlutter) {
+    if (!declaresFlutter) {
       // If we have a Flutter library, remove it.
       if (existingLibrary != null) {
         WriteAction.compute(() -> {
@@ -130,7 +131,7 @@ public class FlutterPluginsLibraryManager {
                               return lib;
                             });
 
-    final Set<String> flutterPluginPaths = getFlutterPluginPaths(PubRoot.multipleForProject(project));
+    final Set<String> flutterPluginPaths = getFlutterPluginPaths(PubRoots.forProject(project));
     final Set<String> flutterPluginUrls = new HashSet<>();
     for (String path : flutterPluginPaths) {
       flutterPluginUrls.add(VfsUtilCore.pathToUrl(path));
@@ -161,7 +162,7 @@ public class FlutterPluginsLibraryManager {
     });
 
     for (final Module module : ModuleManager.getInstance(project).getModules()) {
-      if (FlutterModuleUtils.usesFlutter(module)) {
+      if (FlutterModuleUtils.declaresFlutter(module)) {
         addFlutterLibraryDependency(module, library);
       }
       else {
@@ -174,11 +175,11 @@ public class FlutterPluginsLibraryManager {
     final Set<String> paths = new HashSet<>();
 
     for (PubRoot pubRoot : roots) {
-      if (pubRoot.getPackages() == null) {
+      if (pubRoot.getPackagesFile() == null) {
         continue;
       }
 
-      final Map<String, String> map = DotPackagesFileUtil.getPackagesMap(pubRoot.getPackages());
+      final Map<String, String> map = DotPackagesFileUtil.getPackagesMap(pubRoot.getPackagesFile());
       if (map == null) {
         continue;
       }

--- a/src/io/flutter/sdk/FlutterSdkUtil.java
+++ b/src/io/flutter/sdk/FlutterSdkUtil.java
@@ -26,6 +26,7 @@ import com.jetbrains.lang.dart.sdk.DartSdkUpdateOption;
 import io.flutter.FlutterBundle;
 import io.flutter.dart.DartPlugin;
 import io.flutter.pub.PubRoot;
+import io.flutter.pub.PubRoots;
 import io.flutter.utils.FlutterModuleUtils;
 import io.flutter.utils.System;
 import org.jetbrains.annotations.NotNull;
@@ -246,24 +247,22 @@ public class FlutterSdkUtil {
    */
   @Nullable
   public static String guessFlutterSdkFromPackagesFile(@NotNull Module module) {
-    final PubRoot pubRoot = PubRoot.forModuleWithRefresh(module);
-    if (pubRoot == null) {
-      return null;
+    for (PubRoot pubRoot : PubRoots.forModule(module)) {
+      final VirtualFile packagesFile = pubRoot.getPackagesFile();
+      if (packagesFile == null) {
+        continue;
+      }
+
+      // parse it
+      try {
+        final String contents = new String(packagesFile.contentsToByteArray(true /* cache contents */));
+        return parseFlutterSdkPath(contents);
+      }
+      catch (IOException ignored) {
+      }
     }
 
-    final VirtualFile packagesFile = pubRoot.getPackages();
-    if (packagesFile == null) {
-      return null;
-    }
-
-    // parse it
-    try {
-      final String contents = new String(packagesFile.contentsToByteArray(true /* cache contents */));
-      return parseFlutterSdkPath(contents);
-    }
-    catch (IOException e) {
-      return null;
-    }
+    return null;
   }
 
   @VisibleForTesting


### PR DESCRIPTION
Some follow up to https://github.com/flutter/flutter-intellij/pull/2070 - remove uses of the singleForProject* calls. These would explicitly not handle the case of multiple flutter modules per project, or multiple pub roots per module. This removes the methods, and re-writes their previous call sites to handle multiple modules/pub roots.

Also, remove some older init code in `ProjectOpenActivity.java`.

@pq 
