### PR TITLE
Update for Canary 10

### DIFF
--- a/flutter-studio/src/io/flutter/module/FlutterDescriptionProvider.java
+++ b/flutter-studio/src/io/flutter/module/FlutterDescriptionProvider.java
@@ -7,7 +7,7 @@ package io.flutter.module;
 
 import com.android.tools.idea.npw.module.ModuleDescriptionProvider;
 import com.android.tools.idea.npw.module.ModuleGalleryEntry;
-import com.android.tools.idea.npw.module.NewModuleModel;
+import com.android.tools.idea.npw.model.NewModuleModel;
 import com.android.tools.idea.observable.core.OptionalValueProperty;
 import com.android.tools.idea.wizard.model.SkippableWizardStep;
 import icons.FlutterIcons;

--- a/flutter-studio/src/io/flutter/project/FlutterProjectStep.java
+++ b/flutter-studio/src/io/flutter/project/FlutterProjectStep.java
@@ -152,7 +152,8 @@ public class FlutterProjectStep extends SkippableWizardStep<FlutterProjectModel>
     myInstallActionLink.setText(myInstallSdkAction.getLinkText());
 
     //noinspection unchecked
-    myInstallActionLink.setListener((label, linkUrl) -> myInstallSdkAction.actionPerformed(null), null);
+    myInstallActionLink.setListener((label, linkUrl) ->
+                                      myInstallSdkAction.actionPerformed(null), null);
 
     myProgressText.setFont(UIUtil.getLabelFont(UIUtil.FontSize.NORMAL).deriveFont(Font.ITALIC));
 

--- a/product-matrix.json
+++ b/product-matrix.json
@@ -7,8 +7,7 @@
       "ideaVersion": "173.4670197",
       "dartPluginVersion": "181.4203.498",
       "sinceBuild": "173.0",
-      "untilBuild": "173.*",
-      "filesToSkip": ["src/io/flutter/editor/FlutterCompletionContributor.java"]
+      "untilBuild": "173.*"
     },
     {
       "name": "IntelliJ",
@@ -17,8 +16,7 @@
       "ideaVersion": "181.4705630",
       "dartPluginVersion": "181.4203.498",
       "sinceBuild": "181.0",
-      "untilBuild": "181.*",
-      "filesToSkip": ["src/io/flutter/editor/FlutterCompletionContributor.java"]
+      "untilBuild": "181.*"
     },
     {
       "name": "IntelliJ",

--- a/product-matrix.json
+++ b/product-matrix.json
@@ -7,7 +7,8 @@
       "ideaVersion": "173.4670197",
       "dartPluginVersion": "181.4203.498",
       "sinceBuild": "173.0",
-      "untilBuild": "173.*"
+      "untilBuild": "173.*",
+      "filesToSkip": ["src/io/flutter/editor/FlutterCompletionContributor.java"]
     },
     {
       "name": "IntelliJ",
@@ -16,7 +17,8 @@
       "ideaVersion": "181.4705630",
       "dartPluginVersion": "181.4203.498",
       "sinceBuild": "181.0",
-      "untilBuild": "181.*"
+      "untilBuild": "181.*",
+      "filesToSkip": ["src/io/flutter/editor/FlutterCompletionContributor.java"]
     },
     {
       "name": "IntelliJ",

--- a/product-matrix.json
+++ b/product-matrix.json
@@ -5,16 +5,17 @@
       "version": "3.1",
       "ideaProduct": "android-studio",
       "ideaVersion": "173.4670197",
-      "dartPluginVersion": "173.4700",
+      "dartPluginVersion": "181.4203.498",
       "sinceBuild": "173.0",
-      "untilBuild": "173.*"
+      "untilBuild": "173.*",
+      "filesToSkip": ["src/io/flutter/editor/FlutterCompletionContributor.java"]
     },
     {
       "name": "IntelliJ",
       "version": "3.2",
       "ideaProduct": "android-studio",
       "ideaVersion": "181.4705630",
-      "dartPluginVersion": "181.2784.29",
+      "dartPluginVersion": "181.4203.498",
       "sinceBuild": "181.0",
       "untilBuild": "181.*",
       "filesToSkip": ["src/io/flutter/editor/FlutterCompletionContributor.java"]

--- a/product-matrix.json
+++ b/product-matrix.json
@@ -13,10 +13,11 @@
       "name": "IntelliJ",
       "version": "3.2",
       "ideaProduct": "android-studio",
-      "ideaVersion": "173.4688006",
-      "dartPluginVersion": "173.4700",
-      "sinceBuild": "173.0",
-      "untilBuild": "173.*"
+      "ideaVersion": "181.4705630",
+      "dartPluginVersion": "181.2784.29",
+      "sinceBuild": "181.0",
+      "untilBuild": "181.*",
+      "filesToSkip": ["src/io/flutter/editor/FlutterCompletionContributor.java"]
     },
     {
       "name": "IntelliJ",

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -38,10 +38,10 @@ else
   # Run some validations on the repo code.
   ./bin/plugin lint
 
-  # Run the build.
-  ./bin/plugin build --only-version=$IDEA_VERSION
-fi
-
 if [ "$IDEA_VERSION" = "3.1" ] ; then
   sed -i '' 's/npw\.model\.NewModuleModel/npw.module.NewModuleModel/' flutter-studio/src/io/flutter/module/FlutterDescriptionProvider.java
+fi
+
+  # Run the build.
+  ./bin/plugin build --only-version=$IDEA_VERSION
 fi

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -41,3 +41,7 @@ else
   # Run the build.
   ./bin/plugin build --only-version=$IDEA_VERSION
 fi
+
+if [ "$IDEA_VERSION" = "3.1" ] ; then
+  sed -i '' 's/npw\.model\.NewModuleModel/npw.module.NewModuleModel/' flutter-studio/src/io/flutter/module/FlutterDescriptionProvider.java
+fi

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -39,6 +39,8 @@ else
   ./bin/plugin lint
 
 if [ "$IDEA_VERSION" = "3.1" ] ; then
+  # The 3.1 sources have a class defined in a different package than 3.2 and later.
+  # Here we adjust the import statement for that change.
   sed -i 's/npw\.model\.NewModuleModel/npw.module.NewModuleModel/' flutter-studio/src/io/flutter/module/FlutterDescriptionProvider.java
 fi
 

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -39,7 +39,7 @@ else
   ./bin/plugin lint
 
 if [ "$IDEA_VERSION" = "3.1" ] ; then
-  sed -i '' 's/npw\.model\.NewModuleModel/npw.module.NewModuleModel/' flutter-studio/src/io/flutter/module/FlutterDescriptionProvider.java
+  sed -i '' -e 's/npw\.model\.NewModuleModel/npw.module.NewModuleModel/' flutter-studio/src/io/flutter/module/FlutterDescriptionProvider.java
 fi
 
   # Run the build.

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -39,7 +39,7 @@ else
   ./bin/plugin lint
 
 if [ "$IDEA_VERSION" = "3.1" ] ; then
-  sed -i '' -e 's/npw\.model\.NewModuleModel/npw.module.NewModuleModel/' flutter-studio/src/io/flutter/module/FlutterDescriptionProvider.java
+  sed -i s/npw\.model\.NewModuleModel/npw.module.NewModuleModel/' flutter-studio/src/io/flutter/module/FlutterDescriptionProvider.java
 fi
 
   # Run the build.

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -39,7 +39,7 @@ else
   ./bin/plugin lint
 
 if [ "$IDEA_VERSION" = "3.1" ] ; then
-  sed -i s/npw\.model\.NewModuleModel/npw.module.NewModuleModel/' flutter-studio/src/io/flutter/module/FlutterDescriptionProvider.java
+  sed -i 's/npw\.model\.NewModuleModel/npw.module.NewModuleModel/' flutter-studio/src/io/flutter/module/FlutterDescriptionProvider.java
 fi
 
   # Run the build.


### PR DESCRIPTION
@pq @devoncarew 

Update the sources (and travis) to build all supported platforms (assuming 3.0 is no longer supported).

If you want to try this at home, be aware that the sed command on MacOS is different from linux. You need to give an empty value to the in-place option:
```bash
sed -i '' 's/npw\.model\.NewModuleModel/npw.module.NewModuleModel/' flutter-studio/src/io/flutter/module/FlutterDescriptionProvider.java
```
I chose to edit the file in-place because we do a fresh check-out for each build.

An exception is thrown during project creation in Android Studio 3.2 but since that also happens when creating plain Android projects I'm ignoring it.