### PR TITLE
Details subtree review

### DIFF
--- a/src/io/flutter/inspector/DiagnosticsPathNode.java
+++ b/src/io/flutter/inspector/DiagnosticsPathNode.java
@@ -17,10 +17,10 @@ import java.util.ArrayList;
  * on the device.
  */
 public class DiagnosticsPathNode {
-  private final InspectorService inspectorService;
+  private final InspectorService.ObjectGroup inspectorService;
   private final JsonObject json;
 
-  public DiagnosticsPathNode(JsonObject json, InspectorService inspectorService) {
+  public DiagnosticsPathNode(JsonObject json, InspectorService.ObjectGroup inspectorService) {
     this.inspectorService = inspectorService;
     this.json = json;
   }
@@ -28,7 +28,7 @@ public class DiagnosticsPathNode {
   public DiagnosticsNode getNode() {
     // We are lazy about getting the diagnosticNode instanceRef so that no additional round trips using the observatory protocol
     // are yet triggered for the typical case where properties of a node are not inspected.
-    return new DiagnosticsNode(json.getAsJsonObject("node"), inspectorService);
+    return new DiagnosticsNode(json.getAsJsonObject("node"), inspectorService, false);
   }
 
   public ArrayList<DiagnosticsNode> getChildren() {
@@ -39,7 +39,7 @@ public class DiagnosticsPathNode {
     }
     final JsonArray childrenJson = childrenElement.getAsJsonArray();
     for (int i = 0; i < childrenJson.size(); ++i) {
-      children.add(new DiagnosticsNode(childrenJson.get(i).getAsJsonObject(), inspectorService));
+      children.add(new DiagnosticsNode(childrenJson.get(i).getAsJsonObject(), inspectorService, false));
     }
     return children;
   }

--- a/src/io/flutter/inspector/InspectorInstanceRef.java
+++ b/src/io/flutter/inspector/InspectorInstanceRef.java
@@ -7,7 +7,7 @@ package io.flutter.inspector;
 
 /**
  * Reference to a Dart object.
- *
+ * <p>
  * This class is similar to the Observatory protocol InstanceRef with the
  * difference that InspectorInstanceRef objects do not expire and all
  * instances of the same Dart object are guaranteed to have the same
@@ -23,9 +23,15 @@ public class InspectorInstanceRef {
   public boolean equals(Object other) {
     //noinspection SimplifiableIfStatement
     if (other instanceof InspectorInstanceRef) {
-      return ((InspectorInstanceRef)other).id.equals(id);
+      final InspectorInstanceRef otherRef = (InspectorInstanceRef)other;
+      return id == null ? otherRef.id == null : id.equals(otherRef.id);
     }
     return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return id != null ? id.hashCode() : 0;
   }
 
   @Override

--- a/src/io/flutter/inspector/InspectorInstanceRef.java
+++ b/src/io/flutter/inspector/InspectorInstanceRef.java
@@ -5,6 +5,8 @@
  */
 package io.flutter.inspector;
 
+import java.util.Objects;
+
 /**
  * Reference to a Dart object.
  * <p>
@@ -24,7 +26,7 @@ public class InspectorInstanceRef {
     //noinspection SimplifiableIfStatement
     if (other instanceof InspectorInstanceRef) {
       final InspectorInstanceRef otherRef = (InspectorInstanceRef)other;
-      return id == null ? otherRef.id == null : id.equals(otherRef.id);
+      return Objects.equals(id, otherRef.id);
     }
     return false;
   }

--- a/src/io/flutter/inspector/InspectorObjectGroupManager.java
+++ b/src/io/flutter/inspector/InspectorObjectGroupManager.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2018 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.inspector;
+
+import io.flutter.inspector.InspectorService.ObjectGroup;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Manager that simplifies preventing memory leaks when using the
+ * InspectorService.
+ * <p>
+ * This class is designed for the use case where you want to manage
+ * object references associated with the current displayed UI and object
+ * references associated with the candidate next frame of UI to display. Once
+ * the next frame is ready, you determine whether you want to display it and
+ * discard the current frame and promote the next frame to the the current
+ * frame if you want to display the next frame otherwise you discard the next
+ * frame.
+ * <p>
+ * To use this class load all data you want for the next frame by using
+ * the object group specified by getNext() and then if you decide to switch
+ * to display that frame, call promoteNext() otherwise call clearNext().
+ */
+public class InspectorObjectGroupManager {
+  private final InspectorService inspectorService;
+  private final String debugName;
+  private ObjectGroup current;
+  private ObjectGroup next;
+
+  private CompletableFuture<Void> pendingNextFuture;
+
+  public InspectorObjectGroupManager(InspectorService inspectorService, String debugName) {
+    this.inspectorService = inspectorService;
+    this.debugName = debugName;
+  }
+
+  public CompletableFuture<?> getPendingUpdateDone() {
+    if (pendingNextFuture != null) {
+      return pendingNextFuture;
+    }
+    if (next == null) {
+      // There is no pending update.
+      return CompletableFuture.completedFuture(null);
+    }
+
+    pendingNextFuture = new CompletableFuture<>();
+    return pendingNextFuture;
+  }
+
+  public ObjectGroup getCurrent() {
+    if (current == null) {
+      current = inspectorService.createObjectGroup(debugName);
+    }
+    return current;
+  }
+
+  public ObjectGroup getNext() {
+    if (next == null) {
+      next = inspectorService.createObjectGroup(debugName);
+    }
+    return next;
+  }
+
+  public void clear(boolean isolateStopped) {
+    if (isolateStopped) {
+      // The Dart VM will handle GCing the underlying memory.
+      current = null;
+      setNextNull();
+    }
+    else {
+      clearCurrent();
+      cancelNext();
+    }
+  }
+
+  public void promoteNext() {
+    clearCurrent();
+    current = next;
+    setNextNull();
+  }
+
+  private void clearCurrent() {
+    if (current != null) {
+      current.dispose();
+      current = null;
+    }
+  }
+
+  public void cancelNext() {
+    if (next != null) {
+      next.dispose();
+      setNextNull();
+    }
+  }
+
+  private void setNextNull() {
+    next = null;
+    if (pendingNextFuture != null) {
+      pendingNextFuture.complete(null);
+      pendingNextFuture = null;
+    }
+  }
+}

--- a/src/io/flutter/inspector/InspectorService.java
+++ b/src/io/flutter/inspector/InspectorService.java
@@ -21,6 +21,9 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.BiConsumer;
+import java.util.function.Supplier;
 
 /**
  * Manages all communication between inspector code running on the DartVM and
@@ -29,10 +32,6 @@ import java.util.concurrent.CompletableFuture;
 public class InspectorService implements Disposable {
   private static int nextGroupId = 0;
 
-  /**
-   * Group name to to manage keeping alive nodes in the tree referenced by the inspector.
-   */
-  private final String groupName;
   @NotNull private final FlutterApp app;
   @NotNull private final FlutterDebugProcess debugProcess;
   @NotNull private final VmService vmService;
@@ -41,9 +40,9 @@ public class InspectorService implements Disposable {
   @NotNull private final Set<String> supportedServiceMethods;
 
   // TODO(jacobr): remove this field as soon as
-  // `ext.flutter.debugCallWidgetInspectorService` has been in two revs of the
-  // Flutter Beta channel. The feature is expected to have landed in the
-  // Flutter dev chanel on March 22, 2018.
+  // `ext.flutter.inspector.*` has been in two revs of the Flutter Beta
+  // channel. The feature landed in the Flutter dev chanel on
+  // April 16, 2018.
   private final boolean isDaemonApiSupported;
 
   public static CompletableFuture<InspectorService> create(@NotNull FlutterApp app,
@@ -55,11 +54,12 @@ public class InspectorService implements Disposable {
       vmService,
       app.getPerfService()
     );
-    final CompletableFuture<Library> libraryFuture = inspectorLibrary.libraryRef.thenComposeAsync(inspectorLibrary::getLibrary);
+    final CompletableFuture<Library> libraryFuture =
+      inspectorLibrary.libraryRef.thenComposeAsync((library) -> inspectorLibrary.getLibrary(library, null));
     return libraryFuture.thenComposeAsync((Library library) -> {
       for (ClassRef classRef : library.getClasses()) {
         if ("WidgetInspectorService".equals(classRef.getName())) {
-          return inspectorLibrary.getClass(classRef).thenApplyAsync((ClassObj classObj) -> {
+          return inspectorLibrary.getClass(classRef, null).thenApplyAsync((ClassObj classObj) -> {
             final Set<String> functionNames = new HashSet<>();
             for (FuncRef funcRef : classObj.getFunctions()) {
               functionNames.add(funcRef.getName());
@@ -86,14 +86,12 @@ public class InspectorService implements Disposable {
     this.supportedServiceMethods = supportedServiceMethods;
 
     // TODO(jacobr): remove this field as soon as
-    // `ext.flutter.debugCallWidgetInspectorService` has been in two revs of the
-    // Flutter Beta channel. The feature is expected to have landed in the
-    // Flutter dev chanel on March 22, 2018.
+    // `ext.flutter.inspector.*` has been in two revs of the Flutter Beta
+    // channel. The feature landed in the Flutter dev chanel on
+    // April 16, 2018.
     this.isDaemonApiSupported = hasServiceMethod("initServiceExtensions");
 
     clients = new HashSet<>();
-    groupName = "intellij_inspector_" + nextGroupId;
-    nextGroupId++;
 
     vmService.addVmServiceListener(new VmServiceListenerAdapter() {
       @Override
@@ -110,315 +108,8 @@ public class InspectorService implements Disposable {
     vmService.streamListen(VmService.EXTENSION_STREAM_ID, VmServiceConsumers.EMPTY_SUCCESS_CONSUMER);
   }
 
-  @NotNull
-  public FlutterDebugProcess getDebugProcess() {
-    return debugProcess;
-  }
-
-  public FlutterApp getApp() {
-    return debugProcess.getApp();
-  }
-
-  public CompletableFuture<XSourcePosition> getPropertyLocation(InstanceRef instanceRef, String name) {
-    return getInstance(instanceRef).thenComposeAsync((Instance instance) -> getPropertyLocationHelper(instance.getClassRef(), name));
-  }
-
-  public CompletableFuture<XSourcePosition> getPropertyLocationHelper(ClassRef classRef, String name) {
-    return inspectorLibrary.getClass(classRef).thenComposeAsync((ClassObj clazz) -> {
-      for (FuncRef f : clazz.getFunctions()) {
-        // TODO(pq): check for private properties that match name.
-        if (f.getName().equals(name)) {
-          return inspectorLibrary.getFunc(f).thenComposeAsync((Func func) -> {
-            final SourceLocation location = func.getLocation();
-            return inspectorLibrary.getSourcePosition(debugProcess, location.getScript(), location.getTokenPos());
-          });
-        }
-      }
-      final ClassRef superClass = clazz.getSuperClass();
-      return superClass == null ? CompletableFuture.completedFuture(null) : getPropertyLocationHelper(superClass, name);
-    });
-  }
-
-  public CompletableFuture<DiagnosticsNode> getRoot(FlutterTreeType type) {
-    switch (type) {
-      case widget:
-        return getRootWidget();
-      case renderObject:
-        return getRootRenderObject();
-    }
-    throw new RuntimeException("Unexpected FlutterTreeType");
-  }
-
-  private EvalOnDartLibrary getInspectorLibrary() {
-    return inspectorLibrary;
-  }
-
-  public void addClient(InspectorServiceClient client) {
-    clients.add(client);
-  }
-
-  /**
-   * Invokes a static method on the WidgetInspectorService class passing in the specified
-   * arguments.
-   * <p>
-   * Intent is we could refactor how the API is invoked by only changing this call.
-   */
-  // TODO(jacobr): remove this method as soon as
-  // `ext.flutter.debugCallWidgetInspectorService` has been in two revs of the
-  // Flutter Beta channel. The feature is expected to have landed in the
-  // Flutter dev chanel on March 22, 2018.
-  CompletableFuture<InstanceRef> invokeServiceMethodObservatory(String methodName) {
-    return getInspectorLibrary().eval("WidgetInspectorService.instance." + methodName + "(\"" + groupName + "\")", null);
-  }
-
-  CompletableFuture<JsonElement> invokeServiceMethodDaemon(String methodName) {
-    return invokeServiceMethodDaemon(methodName, groupName);
-  }
-
-  CompletableFuture<JsonElement> invokeServiceMethodDaemon(String methodName, String objectGroup) {
-    final Map<String, Object> params = new HashMap<>();
-    params.put("objectGroup", objectGroup);
-    return invokeServiceMethodDaemon(methodName, params);
-  }
-
-  CompletableFuture<JsonElement> invokeServiceMethodDaemon(String methodName, String arg, String objectGroup) {
-    final Map<String, Object> params = new HashMap<>();
-    params.put("arg", arg);
-    params.put("objectGroup", objectGroup);
-    return invokeServiceMethodDaemon(methodName, params);
-  }
-
-  CompletableFuture<JsonElement> invokeServiceMethodDaemon(String methodName, List<String> args) {
-    final Map<String, Object> params = new HashMap<>();
-    for (int i = 0; i < args.size(); ++i) {
-      params.put("arg" + i, args.get(i));
-    }
-    return invokeServiceMethodDaemon(methodName, params);
-  }
-
-  CompletableFuture<JsonElement> invokeServiceMethodDaemon(String methodName, Map<String, Object> params) {
-    return getApp().callServiceExtension("ext.flutter.inspector." + methodName, params).thenApply((JsonObject json) -> {
-      if (json.has("errorMessage")) {
-        String message = json.get("errorMessage").getAsString();
-        throw new RuntimeException(methodName + " -- " + message);
-      }
-      return json.get("result");
-    });
-  }
-
-  CompletableFuture<JsonElement> invokeServiceMethodDaemon(String methodName, InspectorInstanceRef arg) {
-    if (arg == null || arg.getId() == null) {
-      return invokeServiceMethodDaemon(methodName, null, groupName);
-    }
-    return invokeServiceMethodDaemon(methodName, arg.getId(), groupName);
-  }
-
-  // TODO(jacobr): remove this method as soon as
-  // `ext.flutter.debugCallWidgetInspectorService` has been in two revs of the
-  // Flutter Beta channel. The feature is expected to have landed in the
-  // Flutter dev chanel on March 22, 2018.
-  CompletableFuture<InstanceRef> invokeServiceMethodObservatory(String methodName, InspectorInstanceRef arg) {
-    if (arg == null || arg.getId() == null) {
-      return getInspectorLibrary().eval("WidgetInspectorService.instance." + methodName + "(null, \"" + groupName + "\")", null);
-    }
-    return getInspectorLibrary()
-      .eval("WidgetInspectorService.instance." + methodName + "(\"" + arg.getId() + "\", \"" + groupName + "\")", null);
-  }
-
-  /**
-   * Call a service method passing in an observatory instance reference.
-   * <p>
-   * This call is useful when receiving an "inspect" event from the
-   * observatory and future use cases such as inspecting a Widget from the
-   * IntelliJ watch window.
-   * <p>
-   * This method will always need to use the observatory service as the input
-   * parameter is an Observatory InstanceRef..
-   */
-  CompletableFuture<InstanceRef> invokeServiceMethodOnRefObservatory(String methodName, InstanceRef arg) {
-    final HashMap<String, String> scope = new HashMap<>();
-    if (arg == null) {
-      return getInspectorLibrary().eval("WidgetInspectorService.instance." + methodName + "(null, \"" + groupName + "\")", scope);
-    }
-    scope.put("arg1", arg.getId());
-    return getInspectorLibrary().eval("WidgetInspectorService.instance." + methodName + "(arg1, \"" + groupName + "\")", scope);
-  }
-
-  public CompletableFuture<Void> setPubRootDirectories(List<String> rootDirectories) {
-    // TODO(jacobr): remove call to hasServiceMethod("setPubRootDirectories") after
-    // the `setPubRootDirectories` method has been in two revs of the Flutter Alpha
-    // channel. The feature is expected to have landed in the Flutter dev
-    // chanel on March 2, 2018.
-    if (!hasServiceMethod("setPubRootDirectories")) {
-      return CompletableFuture.completedFuture(null);
-    }
-
-    if (isDaemonApiSupported) {
-      return invokeServiceMethodDaemon("setPubRootDirectories", rootDirectories).thenApplyAsync((ignored) -> null);
-    }
-    else {
-      // TODO(jacobr): remove this call as soon as
-      // `ext.flutter.debugCallWidgetInspectorService` has been in two revs of the
-      // Flutter Beta channel. The feature is expected to have landed in the
-      // Flutter dev chanel on March 22, 2018.
-      final JsonArray jsonArray = new JsonArray();
-      for (String rootDirectory : rootDirectories) {
-        jsonArray.add(rootDirectory);
-      }
-      return getInspectorLibrary().eval(
-        "WidgetInspectorService.instance.setPubRootDirectories(" + new Gson().toJson(jsonArray) + ")", null)
-        .thenApplyAsync((instance) -> null);
-    }
-  }
-
-  // TODO(jacobr): remove this method as soon as
-  // `ext.flutter.debugCallWidgetInspectorService` has been in two revs of the
-  // Flutter Beta channel. The feature is expected to have landed in the
-  // Flutter dev chanel on March 22, 2018.
-  CompletableFuture<DiagnosticsNode> parseDiagnosticsNodeObservatory(CompletableFuture<InstanceRef> instanceRefFuture) {
-    return instanceRefFuture.thenComposeAsync(this::parseDiagnosticsNodeObservatory);
-  }
-
-  /**
-   * Returns a CompletableFuture with a Map of property names to Observatory
-   * InstanceRef objects. This method is shorthand for individually evaluating
-   * each of the getters specified by property names.
-   * <p>
-   * It would be nice if the Observatory protocol provided a built in method
-   * to get InstanceRef objects for a list of properties but this is
-   * sufficient although slightly less efficient. The Observatory protocol
-   * does provide fast access to all fields as part of an Instance object
-   * but that is inadequate as for many Flutter data objects that we want
-   * to display visually we care about properties that are not necessarily
-   * fields.
-   * <p>
-   * The future will immediately complete to null if the inspectorInstanceRef is null.
-   */
-  public CompletableFuture<Map<String, InstanceRef>> getDartObjectProperties(
-    InspectorInstanceRef inspectorInstanceRef, final String[] propertyNames) {
-    return toObservatoryInstanceRef(inspectorInstanceRef).thenComposeAsync((InstanceRef instanceRef) -> {
-      final StringBuilder sb = new StringBuilder();
-      final List<String> propertyAccessors = new ArrayList<>();
-      final String objectName = "that";
-      for (String propertyName : propertyNames) {
-        propertyAccessors.add(objectName + "." + propertyName);
-      }
-      sb.append("[");
-      sb.append(Joiner.on(',').join(propertyAccessors));
-      sb.append("]");
-      final Map<String, String> scope = new HashMap<>();
-      scope.put(objectName, instanceRef.getId());
-      return getInstance(inspectorLibrary.eval(sb.toString(), scope)).thenApplyAsync(
-        (Instance instance) -> {
-          // We now have an instance object that is a Dart array of all the
-          // property values. Convert it back to a map from property name to
-          // property values.
-
-          final Map<String, InstanceRef> properties = new HashMap<>();
-          final ElementList<InstanceRef> values = instance.getElements();
-          assert (values.size() == propertyNames.length);
-          for (int i = 0; i < propertyNames.length; ++i) {
-            properties.put(propertyNames[i], values.get(i));
-          }
-          return properties;
-        });
-    });
-  }
-
-  public CompletableFuture<InstanceRef> toObservatoryInstanceRef(InspectorInstanceRef inspectorInstanceRef) {
-    return invokeServiceMethodObservatory("toObject", inspectorInstanceRef);
-  }
-
-  private CompletableFuture<Instance> getInstance(InstanceRef instanceRef) {
-    return getInspectorLibrary().getInstance(instanceRef);
-  }
-
-  CompletableFuture<Instance> getInstance(CompletableFuture<InstanceRef> instanceRefFuture) {
-    return instanceRefFuture.thenComposeAsync(this::getInstance);
-  }
-
-  CompletableFuture<DiagnosticsNode> parseDiagnosticsNodeObservatory(InstanceRef instanceRef) {
-    return instanceRefToJson(instanceRef).thenApplyAsync(this::parseDiagnosticsNodeHelper);
-  }
-
-  CompletableFuture<DiagnosticsNode> parseDiagnosticsNodeDaemon(CompletableFuture<JsonElement> json) {
-    return json.thenApplyAsync(this::parseDiagnosticsNodeHelper);
-  }
-
-  DiagnosticsNode parseDiagnosticsNodeHelper(JsonElement jsonElement) {
-    return new DiagnosticsNode(jsonElement.getAsJsonObject(), this);
-  }
-
-  /**
-   * Requires that the InstanceRef is really referring to a String that is valid JSON.
-   */
-  CompletableFuture<JsonElement> instanceRefToJson(InstanceRef instanceRef) {
-    return getInspectorLibrary().getInstance(instanceRef).thenApplyAsync((Instance instance) -> {
-      final String json = instance.getValueAsString();
-      return new JsonParser().parse(json);
-    });
-  }
-
-  CompletableFuture<ArrayList<DiagnosticsNode>> parseDiagnosticsNodesObservatory(InstanceRef instanceRef) {
-    return instanceRefToJson(instanceRef).thenApplyAsync((JsonElement jsonElement) -> {
-      final JsonArray jsonArray = jsonElement.getAsJsonArray();
-      return parseDiagnosticsNodesHelper(jsonArray);
-    });
-  }
-
-  ArrayList<DiagnosticsNode> parseDiagnosticsNodesHelper(JsonArray jsonArray) {
-    final ArrayList<DiagnosticsNode> nodes = new ArrayList<>();
-    for (JsonElement element : jsonArray) {
-      nodes.add(new DiagnosticsNode(element.getAsJsonObject(), this));
-    }
-    return nodes;
-  }
-
-  /**
-   * Converts an inspector ref to value suitable for use by generic intellij
-   * debugging tools.
-   * <p>
-   * Warning: DartVmServiceValue references do not make any lifetime guarantees
-   * so code keeping them around for a long period of time must be prepared to
-   * handle reference expiration gracefully.
-   */
-  public CompletableFuture<DartVmServiceValue> toDartVmServiceValueForSourceLocation(InspectorInstanceRef inspectorInstanceRef) {
-    return invokeServiceMethodObservatory("toObjectForSourceLocation", inspectorInstanceRef).thenApplyAsync(
-      (InstanceRef instanceRef) -> {
-        //noinspection CodeBlock2Expr
-        return new DartVmServiceValue(debugProcess, inspectorLibrary.getIsolateId(), "inspectedObject", instanceRef, null, null, false);
-      });
-  }
-
-  CompletableFuture<ArrayList<DiagnosticsNode>> parseDiagnosticsNodesObservatory(CompletableFuture<InstanceRef> instanceRefFuture) {
-    return instanceRefFuture.thenComposeAsync(this::parseDiagnosticsNodesObservatory);
-  }
-
-  CompletableFuture<ArrayList<DiagnosticsNode>> parseDiagnosticsNodesDaemon(CompletableFuture<JsonElement> jsonFuture) {
-    return jsonFuture.thenApplyAsync((json) -> parseDiagnosticsNodesHelper(json.getAsJsonArray()));
-  }
-
-  CompletableFuture<ArrayList<DiagnosticsNode>> getChildren(InspectorInstanceRef instanceRef) {
-    return getListHelper(instanceRef, "getChildren");
-  }
-
-  CompletableFuture<ArrayList<DiagnosticsNode>> getProperties(InspectorInstanceRef instanceRef) {
-    return getListHelper(instanceRef, "getProperties");
-  }
-
-  /**
-   * If the widget tree is not ready, the application should wait for the next
-   * Flutter.Frame event before attempting to display the widget tree. If the
-   * application is ready, the next Flutter.Frame event may never come as no
-   * new frames will be triggered to draw unless something changes in the UI.
-   */
-  public CompletableFuture<Boolean> isWidgetTreeReady() {
-    if (isDaemonApiSupported) {
-      return invokeServiceMethodDaemon("isWidgetTreeReady").thenApplyAsync((JsonElement element) -> element.getAsBoolean() == true);
-    }
-    else {
-      return invokeServiceMethodObservatory("isWidgetTreeReady").thenApplyAsync((InstanceRef ref) -> "true".equals(ref.getValueAsString()));
-    }
+  public boolean isDetailsSummaryViewSupported() {
+    return hasServiceMethod("getSelectedSummaryWidget");
   }
 
   /**
@@ -429,106 +120,44 @@ public class InspectorService implements Disposable {
     return supportedServiceMethods.contains(methodName);
   }
 
-  private CompletableFuture<ArrayList<DiagnosticsNode>> getListHelper(
-    InspectorInstanceRef instanceRef, String methodName) {
-    if (isDaemonApiSupported) {
-      return parseDiagnosticsNodesDaemon(invokeServiceMethodDaemon(methodName, instanceRef));
-    }
-    else {
-      return parseDiagnosticsNodesObservatory(invokeServiceMethodObservatory(methodName, instanceRef));
-    }
+  @NotNull
+  public FlutterDebugProcess getDebugProcess() {
+    return debugProcess;
   }
 
-  public CompletableFuture<DiagnosticsNode> invokeServiceMethodReturningNode(String methodName) {
-    if (isDaemonApiSupported) {
-      return parseDiagnosticsNodeDaemon(invokeServiceMethodDaemon(methodName));
-    }
-    else {
-      return parseDiagnosticsNodeObservatory(invokeServiceMethodObservatory(methodName));
-    }
+  public FlutterApp getApp() {
+    return debugProcess.getApp();
   }
 
-  public CompletableFuture<DiagnosticsNode> invokeServiceMethodReturningNode(String methodName, InspectorInstanceRef ref) {
-    if (isDaemonApiSupported) {
-      return parseDiagnosticsNodeDaemon(invokeServiceMethodDaemon(methodName, ref));
-    }
-    else {
-      return parseDiagnosticsNodeObservatory(invokeServiceMethodObservatory(methodName, ref));
-    }
+  public ObjectGroup createObjectGroup(String debugName) {
+    return new ObjectGroup(debugName);
   }
 
-  public CompletableFuture<Void> invokeVoidServiceMethod(String methodName, InspectorInstanceRef ref) {
-    if (isDaemonApiSupported) {
-      return invokeServiceMethodDaemon(methodName, ref).thenApply((ignored) -> null);
-    }
-    else {
-      return invokeServiceMethodObservatory(methodName, ref).thenApply((ignored) -> null);
-    }
-  }
-
-  public CompletableFuture<DiagnosticsNode> getRootWidget() {
-    return invokeServiceMethodReturningNode("getRootWidget");
-  }
-
-  public CompletableFuture<DiagnosticsNode> getRootRenderObject() {
-    return invokeServiceMethodReturningNode("getRootRenderObject");
-  }
-
-  public CompletableFuture<ArrayList<DiagnosticsPathNode>> getParentChain(DiagnosticsNode target) {
-    if (isDaemonApiSupported) {
-      return parseDiagnosticsPathDaeomon(invokeServiceMethodDaemon("getParentChain", target.getValueRef()));
-    }
-    else {
-      return parseDiagnosticsPathObservatory(invokeServiceMethodObservatory("getParentChain", target.getValueRef()));
-    }
-  }
-
-  CompletableFuture<ArrayList<DiagnosticsPathNode>> parseDiagnosticsPathObservatory(CompletableFuture<InstanceRef> instanceRefFuture) {
-    return instanceRefFuture.thenComposeAsync(this::parseDiagnosticsPathObservatory);
-  }
-
-  private CompletableFuture<ArrayList<DiagnosticsPathNode>> parseDiagnosticsPathObservatory(InstanceRef pathRef) {
-    return instanceRefToJson(pathRef).thenApplyAsync(this::parseDiagnosticsPathHelper);
-  }
-
-  CompletableFuture<ArrayList<DiagnosticsPathNode>> parseDiagnosticsPathDaeomon(CompletableFuture<JsonElement> jsonFuture) {
-    return jsonFuture.thenApplyAsync(this::parseDiagnosticsPathHelper);
-  }
-
-  private ArrayList<DiagnosticsPathNode> parseDiagnosticsPathHelper(JsonElement jsonElement) {
-    final JsonArray jsonArray = jsonElement.getAsJsonArray();
-    final ArrayList<DiagnosticsPathNode> pathNodes = new ArrayList<>();
-    for (JsonElement element : jsonArray) {
-      pathNodes.add(new DiagnosticsPathNode(element.getAsJsonObject(), this));
-    }
-    return pathNodes;
-  }
-
-  public CompletableFuture<DiagnosticsNode> getSelection(DiagnosticsNode previousSelection, FlutterTreeType treeType) {
-    CompletableFuture<DiagnosticsNode> result = null;
-    final InspectorInstanceRef previousSelectionRef = previousSelection != null ? previousSelection.getDartDiagnosticRef() : null;
-
-    switch (treeType) {
-      case widget:
-        result = invokeServiceMethodReturningNode("getSelectedWidget", previousSelectionRef);
-        break;
-      case renderObject:
-        result = invokeServiceMethodReturningNode("getSelectedRenderObject", previousSelectionRef);
-        break;
-    }
-    return result.thenApplyAsync((DiagnosticsNode newSelection) -> {
-      if (newSelection.getDartDiagnosticRef().equals(previousSelectionRef)) {
-        return previousSelection;
-      }
-      else {
-        return newSelection;
-      }
-    });
+  private EvalOnDartLibrary getInspectorLibrary() {
+    return inspectorLibrary;
   }
 
   @Override
   public void dispose() {
     inspectorLibrary.dispose();
+  }
+
+  public void forceRefresh() {
+    for (InspectorServiceClient client : clients) {
+      client.onForceRefresh();
+    }
+  }
+
+  private void notifySelectionChanged() {
+    ApplicationManager.getApplication().invokeLater(() -> {
+      for (InspectorServiceClient client : clients) {
+        client.onInspectorSelectionChanged();
+      }
+    });
+  }
+
+  public void addClient(InspectorServiceClient client) {
+    clients.add(client);
   }
 
   private void onVmServiceReceived(String streamId, Event event) {
@@ -537,7 +166,10 @@ public class InspectorService implements Disposable {
         if (event.getKind() == EventKind.Inspect) {
           // Make sure the WidgetInspector on the device switches to show the inspected object
           // if the inspected object is a Widget or RenderObject.
-          setSelection(event.getInspectee(), true);
+
+          // We create a dummy object group as this particular operation
+          // doesn't actually require an object group.
+          createObjectGroup("dummy").setSelection(event.getInspectee(), true);
           // Update the UI in IntelliJ.
           notifySelectionChanged();
         }
@@ -557,7 +189,566 @@ public class InspectorService implements Disposable {
     }
   }
 
+  /**
+   * If the widget tree is not ready, the application should wait for the next
+   * Flutter.Frame event before attempting to display the widget tree. If the
+   * application is ready, the next Flutter.Frame event may never come as no
+   * new frames will be triggered to draw unless something changes in the UI.
+   */
+  public CompletableFuture<Boolean> isWidgetTreeReady() {
+    if (isDaemonApiSupported) {
+      return invokeServiceMethodDaemonNoGroup("isWidgetTreeReady", new HashMap<>())
+        .thenApplyAsync((JsonElement element) -> element.getAsBoolean() == true);
+    }
+    else {
+      return invokeServiceMethodObservatoryNoGroup("isWidgetTreeReady")
+        .thenApplyAsync((InstanceRef ref) -> "true".equals(ref.getValueAsString()));
+    }
+  }
+
+  CompletableFuture<JsonElement> invokeServiceMethodDaemonNoGroup(String methodName, List<String> args) {
+    final Map<String, Object> params = new HashMap<>();
+    for (int i = 0; i < args.size(); ++i) {
+      params.put("arg" + i, args.get(i));
+    }
+    return invokeServiceMethodDaemonNoGroup(methodName, params);
+  }
+
+
+  public CompletableFuture<Void> setPubRootDirectories(List<String> rootDirectories) {
+    // TODO(jacobr): remove call to hasServiceMethod("setPubRootDirectories") after
+    // the `setPubRootDirectories` method has been in two revs of the Flutter Alpha
+    // channel. The feature is expected to have landed in the Flutter dev
+    // chanel on March 2, 2018.
+    if (!hasServiceMethod("setPubRootDirectories")) {
+      return CompletableFuture.completedFuture(null);
+    }
+
+    if (isDaemonApiSupported) {
+      return invokeServiceMethodDaemonNoGroup("setPubRootDirectories", rootDirectories).thenApplyAsync((ignored) -> null);
+    }
+    else {
+      // TODO(jacobr): remove this call as soon as
+      // `ext.flutter.inspector.*` has been in two revs of the Flutter Beta
+      // channel. The feature landed in the Flutter dev chanel on
+      // April 16, 2018.
+      final JsonArray jsonArray = new JsonArray();
+      for (String rootDirectory : rootDirectories) {
+        jsonArray.add(rootDirectory);
+      }
+      return getInspectorLibrary().eval(
+        "WidgetInspectorService.instance.setPubRootDirectories(" + new Gson().toJson(jsonArray) + ")", null, null)
+        .thenApplyAsync((instance) -> null);
+    }
+  }
+
+  CompletableFuture<InstanceRef> invokeServiceMethodObservatoryNoGroup(String methodName) {
+    return getInspectorLibrary().eval("WidgetInspectorService.instance." + methodName + "()", null, null);
+  }
+
+  CompletableFuture<JsonElement> invokeServiceMethodDaemonNoGroup(String methodName, Map<String, Object> params) {
+    return getApp().callServiceExtension("ext.flutter.inspector." + methodName, params).thenApply((JsonObject json) -> {
+      if (json.has("errorMessage")) {
+        String message = json.get("errorMessage").getAsString();
+        throw new RuntimeException(methodName + " -- " + message);
+      }
+      return json.get("result");
+    });
+  }
+
+// TODO(jacobr): fix indent of this class before landing.
+/**
+ * Class managing a group of inspector objects that can be freed by
+ * a single call to dispose().
+ * After dispose is called, all pending requests made with the ObjectGroup
+ * will be skipped. This means that clients should not have to write any
+ * special logic to handle orphaned requests.
+ *
+ * safeWhenComplete is the recommended way to await futures returned by the
+ * ObjectGroup as with that method the callback will be skipped if the
+ * ObjectGroup is disposed making it easy to get the correct behavior of
+ * skipping orphaned requests. Otherwise, code needs to handle getting back
+ * futures that return null values for requests from disposed ObjectGroup
+ * objects.
+ */
+public class ObjectGroup implements Disposable {
+  /**
+   * Object group all objects in this arena are allocated with.
+   */
+  final String groupName;
+
+  volatile boolean disposed;
+  final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+
+  private ObjectGroup(String debugName) {
+    this.groupName = debugName + "_" + nextGroupId;
+    nextGroupId++;
+  }
+
+  /**
+   * Once an ObjecGroup has been disposed, all methods returning
+   * DiagnosticsNode objects will return a placeholder dummy node and all methods
+   * returning lists or maps will return empty lists and all other methods will
+   * return null. Generally code should not be written to never call methods on
+   * a disposed object group but
+   * sometimes due to chained futures that can be difficult and it is simpler
+   * to just return an empty result that will be ignored anyway that to
+   * attempt carefully cancel futures.
+   */
+  @Override
+  public void dispose() {
+    lock.writeLock().lock();
+    invokeVoidServiceMethod("disposeGroup", groupName);
+    disposed = true;
+    lock.writeLock().unlock();
+  }
+
+  private <T> CompletableFuture<T> nullIfDisposed(Supplier<CompletableFuture<T>> supplier) {
+    lock.readLock().lock();
+    if (disposed) {
+      lock.readLock().unlock();
+      return CompletableFuture.completedFuture(null);
+    }
+
+    try {
+      return supplier.get();
+    }
+    finally {
+      lock.readLock().unlock();
+    }
+  }
+
+  private <T> T nullValueIfDisposed(Supplier<T> supplier) {
+    lock.readLock().lock();
+    if (disposed) {
+      lock.readLock().unlock();
+      return null;
+    }
+
+    try {
+      return supplier.get();
+    }
+    finally {
+      lock.readLock().unlock();
+    }
+  }
+
+  private void skipIfDisposed(Runnable runnable) {
+    lock.readLock().lock();
+    if (disposed) {
+      return;
+    }
+
+    try {
+      runnable.run();
+    }
+    finally {
+      lock.readLock().unlock();
+    }
+  }
+
+  public CompletableFuture<XSourcePosition> getPropertyLocation(InstanceRef instanceRef, String name) {
+    return nullIfDisposed(() -> getInstance(instanceRef)
+      .thenComposeAsync((Instance instance) -> nullValueIfDisposed(() -> getPropertyLocationHelper(instance.getClassRef(), name))));
+  }
+
+  public CompletableFuture<XSourcePosition> getPropertyLocationHelper(ClassRef classRef, String name) {
+    return nullIfDisposed(() -> inspectorLibrary.getClass(classRef, this).thenComposeAsync((ClassObj clazz) -> {
+      return nullIfDisposed(() -> {
+        for (FuncRef f : clazz.getFunctions()) {
+          // TODO(pq): check for private properties that match name.
+          if (f.getName().equals(name)) {
+            return inspectorLibrary.getFunc(f, this).thenComposeAsync((Func func) -> nullIfDisposed(() -> {
+              final SourceLocation location = func.getLocation();
+              return inspectorLibrary.getSourcePosition(debugProcess, location.getScript(), location.getTokenPos(), this);
+            }));
+          }
+        }
+        final ClassRef superClass = clazz.getSuperClass();
+        return superClass == null ? CompletableFuture.completedFuture(null) : getPropertyLocationHelper(superClass, name);
+      });
+    }));
+  }
+
+  public CompletableFuture<DiagnosticsNode> getRoot(FlutterTreeType type) {
+    // There is no excuse to call this method on a disposed group.
+    assert (!disposed);
+    switch (type) {
+      case widget:
+        return getRootWidget();
+      case renderObject:
+        return getRootRenderObject();
+    }
+    throw new RuntimeException("Unexpected FlutterTreeType");
+  }
+
+  /**
+   * Invokes a static method on the WidgetInspectorService class passing in the specified
+   * arguments.
+   * <p>
+   * Intent is we could refactor how the API is invoked by only changing this call.
+   */
+  CompletableFuture<InstanceRef> invokeServiceMethodObservatory(String methodName) {
+    return nullIfDisposed(() -> invokeServiceMethodObservatory(methodName, groupName));
+  }
+
+  CompletableFuture<InstanceRef> invokeServiceMethodObservatory(String methodName, String arg1) {
+    return nullIfDisposed(
+      () -> getInspectorLibrary().eval("WidgetInspectorService.instance." + methodName + "(\"" + arg1 + "\")", null, this));
+  }
+
+  CompletableFuture<JsonElement> invokeServiceMethodDaemon(String methodName) {
+    return invokeServiceMethodDaemon(methodName, groupName);
+  }
+
+  CompletableFuture<JsonElement> invokeServiceMethodDaemon(String methodName, String objectGroup) {
+    final Map<String, Object> params = new HashMap<>();
+    params.put("objectGroup", objectGroup);
+    return invokeServiceMethodDaemon(methodName, params);
+  }
+
+  CompletableFuture<JsonElement> invokeServiceMethodDaemon(String methodName, String arg, String objectGroup) {
+    final Map<String, Object> params = new HashMap<>();
+    params.put("arg", arg);
+    params.put("objectGroup", objectGroup);
+    return invokeServiceMethodDaemon(methodName, params);
+  }
+
+  // All calls to invokeServiceMethodDaemon bottom out to this call.
+  CompletableFuture<JsonElement> invokeServiceMethodDaemon(String methodName, Map<String, Object> params) {
+    return getInspectorLibrary().addRequest(this, () -> getApp().callServiceExtension("ext.flutter.inspector." + methodName, params)
+      .thenApply((JsonObject json) -> nullValueIfDisposed(() -> {
+        if (json.has("errorMessage")) {
+          String message = json.get("errorMessage").getAsString();
+          throw new RuntimeException(methodName + " -- " + message);
+        }
+        return json.get("result");
+      })));
+  }
+
+  CompletableFuture<JsonElement> invokeServiceMethodDaemon(String methodName, InspectorInstanceRef arg) {
+    if (arg == null || arg.getId() == null) {
+      return invokeServiceMethodDaemon(methodName, null, groupName);
+    }
+    return invokeServiceMethodDaemon(methodName, arg.getId(), groupName);
+  }
+
+  CompletableFuture<InstanceRef> invokeServiceMethodObservatory(String methodName, InspectorInstanceRef arg) {
+    return nullIfDisposed(() -> {
+      if (arg == null || arg.getId() == null) {
+        return getInspectorLibrary().eval("WidgetInspectorService.instance." + methodName + "(null, \"" + groupName + "\")", null, this);
+      }
+      return getInspectorLibrary()
+        .eval("WidgetInspectorService.instance." + methodName + "(\"" + arg.getId() + "\", \"" + groupName + "\")", null, this);
+    });
+  }
+
+  /**
+   * Call a service method passing in an observatory instance reference.
+   * <p>
+   * This call is useful when receiving an "inspect" event from the
+   * observatory and future use cases such as inspecting a Widget from the
+   * IntelliJ watch window.
+   * <p>
+   * This method will always need to use the observatory service as the input
+   * parameter is an Observatory InstanceRef..
+   */
+  CompletableFuture<InstanceRef> invokeServiceMethodOnRefObservatory(String methodName, InstanceRef arg) {
+    return nullIfDisposed(() -> {
+      final HashMap<String, String> scope = new HashMap<>();
+      if (arg == null) {
+        return getInspectorLibrary().eval("WidgetInspectorService.instance." + methodName + "(null, \"" + groupName + "\")", scope, this);
+      }
+      scope.put("arg1", arg.getId());
+      return getInspectorLibrary().eval("WidgetInspectorService.instance." + methodName + "(arg1, \"" + groupName + "\")", scope, this);
+    });
+  }
+
+  CompletableFuture<DiagnosticsNode> parseDiagnosticsNodeObservatory(CompletableFuture<InstanceRef> instanceRefFuture) {
+    return nullIfDisposed(() -> instanceRefFuture.thenComposeAsync(this::parseDiagnosticsNodeObservatory));
+  }
+
+  /**
+   * Returns a CompletableFuture with a Map of property names to Observatory
+   * InstanceRef objects. This method is shorthand for individually evaluating
+   * each of the getters specified by property names.
+   * <p>
+   * It would be nice if the Observatory protocol provided a built in method
+   * to get InstanceRef objects for a list of properties but this is
+   * sufficient although slightly less efficient. The Observatory protocol
+   * does provide fast access to all fields as part of an Instance object
+   * but that is inadequate as for many Flutter data objects that we want
+   * to display visually we care about properties that are not necessarily
+   * fields.
+   * <p>
+   * The future will immediately complete to null if the inspectorInstanceRef is null.
+   */
+  public CompletableFuture<Map<String, InstanceRef>> getDartObjectProperties(
+    InspectorInstanceRef inspectorInstanceRef, final String[] propertyNames) {
+    return nullIfDisposed(
+      () -> toObservatoryInstanceRef(inspectorInstanceRef).thenComposeAsync((InstanceRef instanceRef) -> nullIfDisposed(() -> {
+        final StringBuilder sb = new StringBuilder();
+        final List<String> propertyAccessors = new ArrayList<>();
+        final String objectName = "that";
+        for (String propertyName : propertyNames) {
+          propertyAccessors.add(objectName + "." + propertyName);
+        }
+        sb.append("[");
+        sb.append(Joiner.on(',').join(propertyAccessors));
+        sb.append("]");
+        final Map<String, String> scope = new HashMap<>();
+        scope.put(objectName, instanceRef.getId());
+        return getInstance(inspectorLibrary.eval(sb.toString(), scope, this)).thenApplyAsync(
+          (Instance instance) -> nullValueIfDisposed(() -> {
+            // We now have an instance object that is a Dart array of all the
+            // property values. Convert it back to a map from property name to
+            // property values.
+
+            final Map<String, InstanceRef> properties = new HashMap<>();
+            final ElementList<InstanceRef> values = instance.getElements();
+            assert (values.size() == propertyNames.length);
+            for (int i = 0; i < propertyNames.length; ++i) {
+              properties.put(propertyNames[i], values.get(i));
+            }
+            return properties;
+          }));
+      })));
+  }
+
+  public CompletableFuture<InstanceRef> toObservatoryInstanceRef(InspectorInstanceRef inspectorInstanceRef) {
+    return nullIfDisposed(() -> invokeServiceMethodObservatory("toObject", inspectorInstanceRef));
+  }
+
+  private CompletableFuture<Instance> getInstance(InstanceRef instanceRef) {
+    return nullIfDisposed(() -> getInspectorLibrary().getInstance(instanceRef, this));
+  }
+
+  CompletableFuture<Instance> getInstance(CompletableFuture<InstanceRef> instanceRefFuture) {
+    return nullIfDisposed(() -> instanceRefFuture.thenComposeAsync(this::getInstance));
+  }
+
+  CompletableFuture<DiagnosticsNode> parseDiagnosticsNodeObservatory(InstanceRef instanceRef) {
+    return nullIfDisposed(() -> instanceRefToJson(instanceRef).thenApplyAsync(this::parseDiagnosticsNodeHelper));
+  }
+
+  CompletableFuture<DiagnosticsNode> parseDiagnosticsNodeDaemon(CompletableFuture<JsonElement> json) {
+    return nullIfDisposed(() -> json.thenApplyAsync(this::parseDiagnosticsNodeHelper));
+  }
+
+  DiagnosticsNode parseDiagnosticsNodeHelper(JsonElement jsonElement) {
+    return nullValueIfDisposed(() -> {
+      if (jsonElement == null || jsonElement.isJsonNull()) {
+        return null;
+      }
+      return new DiagnosticsNode(jsonElement.getAsJsonObject(), this, false);
+    });
+  }
+
+  /**
+   * Requires that the InstanceRef is really referring to a String that is valid JSON.
+   */
+  CompletableFuture<JsonElement> instanceRefToJson(InstanceRef instanceRef) {
+
+    return nullIfDisposed(() -> getInspectorLibrary().getInstance(instanceRef, this).thenApplyAsync((Instance instance) -> {
+      return nullValueIfDisposed(() -> {
+        final String json = instance.getValueAsString();
+        return new JsonParser().parse(json);
+      });
+    }));
+  }
+
+  CompletableFuture<ArrayList<DiagnosticsNode>> parseDiagnosticsNodesObservatory(InstanceRef instanceRef) {
+    return nullIfDisposed(() -> instanceRefToJson(instanceRef).thenApplyAsync((JsonElement jsonElement) -> {
+      return nullValueIfDisposed(() -> {
+        final JsonArray jsonArray = jsonElement != null ? jsonElement.getAsJsonArray() : null;
+        return parseDiagnosticsNodesHelper(jsonArray);
+      });
+    }));
+  }
+
+  ArrayList<DiagnosticsNode> parseDiagnosticsNodesHelper(JsonElement jsonObject) {
+    return parseDiagnosticsNodesHelper(jsonObject != null ? jsonObject.getAsJsonArray() : null);
+  }
+
+  ArrayList<DiagnosticsNode> parseDiagnosticsNodesHelper(JsonArray jsonArray) {
+    return nullValueIfDisposed(() -> {
+      if (jsonArray == null) {
+        return null;
+      }
+      final ArrayList<DiagnosticsNode> nodes = new ArrayList<>();
+      for (JsonElement element : jsonArray) {
+        nodes.add(new DiagnosticsNode(element.getAsJsonObject(), this, false));
+      }
+      return nodes;
+    });
+  }
+
+  /**
+   * Converts an inspector ref to value suitable for use by generic intellij
+   * debugging tools.
+   * <p>
+   * Warning: DartVmServiceValue references do not make any lifetime guarantees
+   * so code keeping them around for a long period of time must be prepared to
+   * handle reference expiration gracefully.
+   */
+  public CompletableFuture<DartVmServiceValue> toDartVmServiceValueForSourceLocation(InspectorInstanceRef inspectorInstanceRef) {
+    return invokeServiceMethodObservatory("toObjectForSourceLocation", inspectorInstanceRef).thenApplyAsync(
+      (InstanceRef instanceRef) -> nullValueIfDisposed(() -> {
+        //noinspection CodeBlock2Expr
+        return new DartVmServiceValue(debugProcess, inspectorLibrary.getIsolateId(), "inspectedObject", instanceRef, null, null, false);
+      }));
+  }
+
+  CompletableFuture<ArrayList<DiagnosticsNode>> parseDiagnosticsNodesObservatory(CompletableFuture<InstanceRef> instanceRefFuture) {
+    return nullIfDisposed(() -> instanceRefFuture.thenComposeAsync(this::parseDiagnosticsNodesObservatory));
+  }
+
+  CompletableFuture<ArrayList<DiagnosticsNode>> parseDiagnosticsNodesDaemon(CompletableFuture<JsonElement> jsonFuture) {
+    return nullIfDisposed(() -> jsonFuture.thenApplyAsync(this::parseDiagnosticsNodesHelper));
+  }
+
+  CompletableFuture<ArrayList<DiagnosticsNode>> getChildren(InspectorInstanceRef instanceRef, boolean summaryTree) {
+    if (isDetailsSummaryViewSupported()) {
+      return getListHelper(instanceRef, summaryTree ? "getChildrenSummaryTree" : "getChildrenDetailsSubtree");
+    }
+    else {
+      return getListHelper(instanceRef, "getChildren");
+    }
+  }
+
+  CompletableFuture<ArrayList<DiagnosticsNode>> getProperties(InspectorInstanceRef instanceRef) {
+    return getListHelper(instanceRef, "getProperties");
+  }
+
+  private CompletableFuture<ArrayList<DiagnosticsNode>> getListHelper(
+    InspectorInstanceRef instanceRef, String methodName) {
+    return nullIfDisposed(() -> {
+      if (isDaemonApiSupported) {
+        return parseDiagnosticsNodesDaemon(invokeServiceMethodDaemon(methodName, instanceRef));
+      }
+      else {
+        return parseDiagnosticsNodesObservatory(invokeServiceMethodObservatory(methodName, instanceRef));
+      }
+    });
+  }
+
+  public CompletableFuture<DiagnosticsNode> invokeServiceMethodReturningNode(String methodName) {
+    return nullIfDisposed(() -> {
+      if (isDaemonApiSupported) {
+        return parseDiagnosticsNodeDaemon(invokeServiceMethodDaemon(methodName));
+      }
+      else {
+        return parseDiagnosticsNodeObservatory(invokeServiceMethodObservatory(methodName));
+      }
+    });
+  }
+
+  public CompletableFuture<DiagnosticsNode> invokeServiceMethodReturningNode(String methodName, InspectorInstanceRef ref) {
+    return nullIfDisposed(() -> {
+      if (isDaemonApiSupported) {
+        return parseDiagnosticsNodeDaemon(invokeServiceMethodDaemon(methodName, ref));
+      }
+      else {
+        return parseDiagnosticsNodeObservatory(invokeServiceMethodObservatory(methodName, ref));
+      }
+    });
+  }
+
+  public CompletableFuture<Void> invokeVoidServiceMethod(String methodName, String arg1) {
+    return nullIfDisposed(() -> {
+      if (isDaemonApiSupported) {
+        return invokeServiceMethodDaemon(methodName, arg1).thenApply((ignored) -> null);
+      }
+      else {
+        return invokeServiceMethodObservatory(methodName, arg1).thenApply((ignored) -> null);
+      }
+    });
+  }
+
+  public CompletableFuture<Void> invokeVoidServiceMethod(String methodName, InspectorInstanceRef ref) {
+    return nullIfDisposed(() -> {
+      if (isDaemonApiSupported) {
+        return invokeServiceMethodDaemon(methodName, ref).thenApply((ignored) -> null);
+      }
+      else {
+        return invokeServiceMethodObservatory(methodName, ref).thenApply((ignored) -> null);
+      }
+    });
+  }
+
+  public CompletableFuture<DiagnosticsNode> getRootWidget() {
+    return invokeServiceMethodReturningNode(isDetailsSummaryViewSupported() ? "getRootWidgetSummaryTree" : "getRootWidget");
+  }
+
+  public CompletableFuture<DiagnosticsNode> getRootRenderObject() {
+    assert (!disposed);
+    return invokeServiceMethodReturningNode("getRootRenderObject");
+  }
+
+  public CompletableFuture<ArrayList<DiagnosticsPathNode>> getParentChain(DiagnosticsNode target) {
+    return nullIfDisposed(() -> {
+      if (isDaemonApiSupported) {
+        return parseDiagnosticsPathDaemon(invokeServiceMethodDaemon("getParentChain", target.getValueRef()));
+      }
+      else {
+        return parseDiagnosticsPathObservatory(invokeServiceMethodObservatory("getParentChain", target.getValueRef()));
+      }
+    });
+  }
+
+  CompletableFuture<ArrayList<DiagnosticsPathNode>> parseDiagnosticsPathObservatory(CompletableFuture<InstanceRef> instanceRefFuture) {
+    return nullIfDisposed(() -> instanceRefFuture.thenComposeAsync(this::parseDiagnosticsPathObservatory));
+  }
+
+  private CompletableFuture<ArrayList<DiagnosticsPathNode>> parseDiagnosticsPathObservatory(InstanceRef pathRef) {
+    return nullIfDisposed(() -> instanceRefToJson(pathRef).thenApplyAsync(this::parseDiagnosticsPathHelper));
+  }
+
+  CompletableFuture<ArrayList<DiagnosticsPathNode>> parseDiagnosticsPathDaemon(CompletableFuture<JsonElement> jsonFuture) {
+    return nullIfDisposed(() -> jsonFuture.thenApplyAsync(this::parseDiagnosticsPathHelper));
+  }
+
+  private ArrayList<DiagnosticsPathNode> parseDiagnosticsPathHelper(JsonElement jsonElement) {
+    return nullValueIfDisposed(() -> {
+      final JsonArray jsonArray = jsonElement.getAsJsonArray();
+      final ArrayList<DiagnosticsPathNode> pathNodes = new ArrayList<>();
+      for (JsonElement element : jsonArray) {
+        pathNodes.add(new DiagnosticsPathNode(element.getAsJsonObject(), this));
+      }
+      return pathNodes;
+    });
+  }
+
+  public CompletableFuture<DiagnosticsNode> getSelection(DiagnosticsNode previousSelection, FlutterTreeType treeType, boolean localOnly) {
+    // There is no reason to allow calling this method on a disposed group.
+    assert (!disposed);
+    return nullIfDisposed(() -> {
+      CompletableFuture<DiagnosticsNode> result = null;
+      final InspectorInstanceRef previousSelectionRef = previousSelection != null ? previousSelection.getDartDiagnosticRef() : null;
+
+      switch (treeType) {
+        case widget:
+          result = invokeServiceMethodReturningNode(localOnly ? "getSelectedSummaryWidget" : "getSelectedWidget", previousSelectionRef);
+          break;
+        case renderObject:
+          result = invokeServiceMethodReturningNode("getSelectedRenderObject", previousSelectionRef);
+          break;
+      }
+      return result.thenApplyAsync((DiagnosticsNode newSelection) -> nullValueIfDisposed(() -> {
+        if (newSelection != null && newSelection.getDartDiagnosticRef().equals(previousSelectionRef)) {
+          return previousSelection;
+        }
+        else {
+          return newSelection;
+        }
+      }));
+    });
+  }
+
   public void setSelection(InspectorInstanceRef selection, boolean uiAlreadyUpdated) {
+    if (disposed) {
+      return;
+    }
     if (isDaemonApiSupported) {
       handleSetSelectionDaemon(invokeServiceMethodDaemon("setSelectionById", selection), uiAlreadyUpdated);
     }
@@ -571,15 +762,17 @@ public class InspectorService implements Disposable {
    * instead of an InspectorInstanceRef.
    */
   public void setSelection(InstanceRef selection, boolean uiAlreadyUpdated) {
+    // There is no excuse for calling setSelection using a disposed ObjectGroup.
+    assert (!disposed);
     // This call requires the observatory protocol as an observatory InstanceRef is specified.
     handleSetSelectionObservatory(invokeServiceMethodOnRefObservatory("setSelection", selection), uiAlreadyUpdated);
   }
 
   private void handleSetSelectionObservatory(CompletableFuture<InstanceRef> setSelectionResult, boolean uiAlreadyUpdated) {
     // TODO(jacobr): we need to cancel if another inspect request comes in while we are trying this one.
-    setSelectionResult.thenAcceptAsync((InstanceRef instanceRef) -> {
+    skipIfDisposed(() -> setSelectionResult.thenAcceptAsync((InstanceRef instanceRef) -> skipIfDisposed(() -> {
       handleSetSelectionHelper("true".equals(instanceRef.getValueAsString()), uiAlreadyUpdated);
-    });
+    })));
   }
 
   private void handleSetSelectionHelper(boolean selectionChanged, boolean uiAlreadyUpdated) {
@@ -589,50 +782,79 @@ public class InspectorService implements Disposable {
   }
 
   private void handleSetSelectionDaemon(CompletableFuture<JsonElement> setSelectionResult, boolean uiAlreadyUpdated) {
-    // TODO(jacobr): we need to cancel if another inspect request comes in while we are trying this one.
-    setSelectionResult.thenAcceptAsync((JsonElement json) -> {
-      handleSetSelectionHelper(json.getAsBoolean(), uiAlreadyUpdated);
-    });
-  }
-
-  private void notifySelectionChanged() {
-    ApplicationManager.getApplication().invokeLater(() -> {
-      for (InspectorServiceClient client : clients) {
-        client.onInspectorSelectionChanged();
-      }
-    });
+    skipIfDisposed(() ->
+                     // TODO(jacobr): we need to cancel if another inspect request comes in while we are trying this one.
+                     setSelectionResult.thenAcceptAsync(
+                       (JsonElement json) -> skipIfDisposed(() -> handleSetSelectionHelper(json.getAsBoolean(), uiAlreadyUpdated)))
+    );
   }
 
   public CompletableFuture<Map<String, InstanceRef>> getEnumPropertyValues(InspectorInstanceRef ref) {
-    if (ref == null || ref.getId() == null) {
-      final CompletableFuture<Map<String, InstanceRef>> ret = new CompletableFuture<>();
-      ret.complete(new HashMap<>());
-      return ret;
-    }
-    return getInstance(toObservatoryInstanceRef(ref))
-      .thenComposeAsync((Instance instance) -> getInspectorLibrary().getClass(instance.getClassRef()).thenApplyAsync((ClassObj clazz) -> {
-        final Map<String, InstanceRef> properties = new LinkedHashMap<>();
-        for (FieldRef field : clazz.getFields()) {
-          final String name = field.getName();
-          if (name.startsWith("_")) {
-            // Needed to filter out _deleted_enum_sentinel synthetic property.
-            // If showing private enum values is useful we could special case
-            // just the _deleted_enum_sentinel property name.
-            continue;
-          }
-          if (name.equals("values")) {
-            // Need to filter out the synthetic "values" member.
-            // TODO(jacobr): detect that this properties return type is
-            // different and filter that way.
-            continue;
-          }
-          if (field.isConst() && field.isStatic()) {
-            properties.put(field.getName(), field.getDeclaredType());
-          }
-        }
-        return properties;
-      }));
+    return nullIfDisposed(() -> {
+      if (ref == null || ref.getId() == null) {
+        return CompletableFuture.completedFuture(null);
+      }
+      return getInstance(toObservatoryInstanceRef(ref))
+        .thenComposeAsync(
+          (Instance instance) -> nullIfDisposed(() -> getInspectorLibrary().getClass(instance.getClassRef(), this).thenApplyAsync(
+            (ClassObj clazz) -> nullValueIfDisposed(() -> {
+              final Map<String, InstanceRef> properties = new LinkedHashMap<>();
+              for (FieldRef field : clazz.getFields()) {
+                final String name = field.getName();
+                if (name.startsWith("_")) {
+                  // Needed to filter out _deleted_enum_sentinel synthetic property.
+                  // If showing private enum values is useful we could special case
+                  // just the _deleted_enum_sentinel property name.
+                  continue;
+                }
+                if (name.equals("values")) {
+                  // Need to filter out the synthetic "values" member.
+                  // TODO(jacobr): detect that this properties return type is
+                  // different and filter that way.
+                  continue;
+                }
+                if (field.isConst() && field.isStatic()) {
+                  properties.put(field.getName(), field.getDeclaredType());
+                }
+              }
+              return properties;
+            })
+          )));
+    });
   }
+
+  public CompletableFuture<DiagnosticsNode> getDetailsSubtree(DiagnosticsNode node) {
+    if (node == null) {
+      return CompletableFuture.completedFuture(null);
+    }
+    return nullIfDisposed(() -> invokeServiceMethodReturningNode("getDetailsSubtree", node.getDartDiagnosticRef()));
+  }
+
+  FlutterApp getApp() {
+    return InspectorService.this.getApp();
+  }
+
+  /**
+   * Await a Future invoking the callback on completion on the UI thread only if the
+   * rhis ObjectGroup is still alive when the Future completes.
+   */
+  public <T> void safeWhenComplete(CompletableFuture<T> future, BiConsumer<? super T, ? super Throwable> action) {
+    if (future == null) {
+      return;
+    }
+    future.whenCompleteAsync(
+      (T value, Throwable throwable) -> skipIfDisposed(() -> {
+        ApplicationManager.getApplication().invokeLater(() -> {
+          action.accept(value, throwable);
+        });
+      })
+    );
+  }
+
+  public boolean isDisposed() {
+    return disposed;
+  }
+}
 
   public enum FlutterTreeType {
     widget("Widget"),
@@ -650,5 +872,7 @@ public class InspectorService implements Disposable {
     void onInspectorSelectionChanged();
 
     void onFlutterFrame();
+
+    void onForceRefresh();
   }
 }

--- a/src/io/flutter/inspector/InspectorService.java
+++ b/src/io/flutter/inspector/InspectorService.java
@@ -286,13 +286,12 @@ public class ObjectGroup implements Disposable {
   }
 
   /**
-   * Once an ObjecGroup has been disposed, all methods returning
+   * Once an ObjectGroup has been disposed, all methods returning
    * DiagnosticsNode objects will return a placeholder dummy node and all methods
    * returning lists or maps will return empty lists and all other methods will
-   * return null. Generally code should not be written to never call methods on
-   * a disposed object group but
-   * sometimes due to chained futures that can be difficult and it is simpler
-   * to just return an empty result that will be ignored anyway that to
+   * return null. Generally code should never call methods on a disposed object
+   * group but sometimes due to chained futures that can be difficult to avoid
+   * and it is simpler return an empty result that will be ignored anyway than to
    * attempt carefully cancel futures.
    */
   @Override

--- a/src/io/flutter/inspector/JumpToSourceActionBase.java
+++ b/src/io/flutter/inspector/JumpToSourceActionBase.java
@@ -55,7 +55,7 @@ public abstract class JumpToSourceActionBase extends InspectorTreeActionBase {
       return;
     }
     // We have to get a DartVmServiceValue to compute the source position.
-    final InspectorService inspectorService = diagnosticsNode.getInspectorService();
+    final InspectorService.ObjectGroup inspectorService = diagnosticsNode.getInspectorService();
     final CompletableFuture<DartVmServiceValue> valueFuture =
       inspectorService.toDartVmServiceValueForSourceLocation(diagnosticsNode.getValueRef());
     AsyncUtils.whenCompleteUiThread(valueFuture, (DartVmServiceValue value, Throwable throwable) -> {

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.java
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.java
@@ -41,8 +41,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 
 public class FlutterSettingsConfigurable implements SearchableConfigurable {
-  public static final boolean WIDGET_FILTERING_ENABLED = false;
-
   private static final Logger LOG = Logger.getInstance(FlutterSettingsConfigurable.class);
 
   private static final String FLUTTER_SETTINGS_PAGE_NAME = FlutterBundle.message("flutter.title");

--- a/src/io/flutter/view/DiagnosticsTreeCellRenderer.java
+++ b/src/io/flutter/view/DiagnosticsTreeCellRenderer.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright 2018 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.view;
+
+import com.google.gson.JsonObject;
+import com.intellij.openapi.util.Pair;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.ui.JBColor;
+import com.intellij.ui.SimpleTextAttributes;
+import com.intellij.ui.speedSearch.SpeedSearchSupply;
+import com.intellij.util.ui.UIUtil;
+import io.flutter.editor.FlutterMaterialIcons;
+import io.flutter.inspector.DiagnosticLevel;
+import io.flutter.inspector.DiagnosticsNode;
+import io.flutter.utils.ColorIconMaker;
+import org.apache.commons.lang.StringUtils;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+import javax.swing.tree.DefaultMutableTreeNode;
+import java.awt.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static io.flutter.utils.JsonUtils.getIntMember;
+
+class DiagnosticsTreeCellRenderer extends InspectorColoredTreeCellRenderer {
+  // TODO(jacobr): enable this experiment once we make the link actually
+  // clickable.
+  private static final boolean SHOW_RENDER_OBJECT_PROPERTIES_AS_LINKS = false;
+
+  private final InspectorPanel panel;
+  /**
+   * Split text into two groups, word characters at the start of a string
+   * and all other characters. Skip an <code>-</code> or <code>#</code> between the
+   * two groups.
+   */
+  private final Pattern primaryDescriptionPattern = Pattern.compile("(\\w+)[-#]?(.*)");
+
+  private JTree tree;
+  private boolean selected;
+
+  final ColorIconMaker colorIconMaker = new ColorIconMaker();
+
+  // Yellow color scheme for showing selecting and matching nodes.
+  // TODO(jacobr): consider a scheme where the selected node is blue
+  // to be more consistent with regular IntelliJ selected node display.
+  // The main problem is in the regular scheme, selected but not focused
+  // nodes are grey which makes the correlation between the selection in
+  // the two views less obvious.
+  final JBColor HIGHLIGHT_COLOR = new JBColor(new Color(202, 191, 69), new Color(99, 101, 103));
+  final JBColor SHOW_MATCH_COLOR = new JBColor(new Color(225, 225, 0), new Color(90, 93, 96));
+  final JBColor LINKED_COLOR = new JBColor(new Color(255, 255, 220), new Color(70, 73, 76));
+
+  public DiagnosticsTreeCellRenderer(InspectorPanel panel) {
+    this.panel = panel;
+  }
+
+  public void customizeCellRenderer(
+    @NotNull final JTree tree,
+    final Object value,
+    final boolean selected,
+    final boolean expanded,
+    final boolean leaf,
+    final int row,
+    final boolean hasFocus
+  ) {
+    this.tree = tree;
+    this.selected = selected;
+
+    setOpaque(false);
+    setIconOpaque(false);
+    setTransparentIconBackground(true);
+
+    final Object userObject = ((DefaultMutableTreeNode)value).getUserObject();
+    if (userObject instanceof String) {
+      appendText((String)userObject, SimpleTextAttributes.GRAYED_ATTRIBUTES);
+      return;
+    }
+    if (!(userObject instanceof DiagnosticsNode)) return;
+    final DiagnosticsNode node = (DiagnosticsNode)userObject;
+
+    boolean highlight = selected;
+    boolean isLinkedChild = false;
+    // Highlight nodes that exist in both the details and summary tree to
+    // show how the trees are linked together.
+    if (!highlight) {
+      if (panel.detailsSubtree && panel.isCreatedByLocalProject(node)) {
+        isLinkedChild = panel.parentTree.hasDiagnosticsValue(node.getValueRef());
+      }
+      else {
+        if (panel.subtreePanel != null) {
+          isLinkedChild = panel.subtreePanel.hasDiagnosticsValue(node.getValueRef());
+        }
+      }
+    }
+    if (highlight) {
+      setOpaque(true);
+      setIconOpaque(false);
+      setTransparentIconBackground(true);
+      setBackground(HIGHLIGHT_COLOR);
+      // TODO(jacobr): consider using UIUtil.getTreeSelectionBackground());
+      // instead.
+    }
+    else if (isLinkedChild) {
+      setOpaque(true);
+      setIconOpaque(false);
+      setTransparentIconBackground(true);
+      setBackground(panel.currentShowNode == value ? SHOW_MATCH_COLOR : LINKED_COLOR);
+    }
+
+    final String name = node.getName();
+    SimpleTextAttributes textAttributes = InspectorPanel.textAttributesForLevel(node.getLevel());
+    if (node.isProperty()) {
+      // Display of inline properties.
+      final String propertyType = node.getPropertyType();
+      final JsonObject properties = node.getValuePropertiesJson();
+      if (panel.isCreatedByLocalProject(node)) {
+        textAttributes = textAttributes
+          .derive(SimpleTextAttributes.REGULAR_ITALIC_ATTRIBUTES.getStyle(), null, null, null);
+      }
+
+      if (StringUtils.isNotEmpty(name) && node.getShowName()) {
+        appendText(name + node.getSeparator() + " ", textAttributes);
+      }
+
+      String description = node.getDescription();
+      if (propertyType != null && properties != null) {
+        switch (propertyType) {
+          case "Color": {
+            final int alpha = getIntMember(properties, "alpha");
+            final int red = getIntMember(properties, "red");
+            final int green = getIntMember(properties, "green");
+            final int blue = getIntMember(properties, "blue");
+
+            if (alpha == 255) {
+              description = String.format("#%02x%02x%02x", red, green, blue);
+            }
+            else {
+              description = String.format("#%02x%02x%02x%02x", alpha, red, green, blue);
+            }
+
+            //noinspection UseJBColor
+            final Color color = new Color(red, green, blue, alpha);
+            this.addIcon(colorIconMaker.getCustomIcon(color));
+            this.setIconOpaque(false);
+            this.setTransparentIconBackground(true);
+            break;
+          }
+
+          case "IconData": {
+            final int codePoint = getIntMember(properties, "codePoint");
+            if (codePoint > 0) {
+              final Icon icon = FlutterMaterialIcons.getMaterialIconForHex(String.format("%1$04x", codePoint));
+              if (icon != null) {
+                this.addIcon(icon);
+                this.setIconOpaque(false);
+                this.setTransparentIconBackground(true);
+              }
+            }
+            break;
+          }
+        }
+      }
+
+      if (SHOW_RENDER_OBJECT_PROPERTIES_AS_LINKS && propertyType.equals("RenderObject")) {
+        textAttributes = textAttributes
+          .derive(SimpleTextAttributes.LINK_ATTRIBUTES.getStyle(), JBColor.blue, null, null);
+      }
+
+      // TODO(jacobr): custom display for units, iterables, and padding.
+      appendText(description, textAttributes);
+      if (node.getLevel().equals(DiagnosticLevel.fine) && node.hasDefaultValue()) {
+        appendText(" ", textAttributes);
+        this.addIcon(panel.defaultIcon);
+      }
+    }
+    else {
+      // Non property, regular node case.
+      if (StringUtils.isNotEmpty(name) && node.getShowName()) {
+        // color in name?
+        if (name.equals("child") || name.startsWith("child ")) {
+          appendText(name, SimpleTextAttributes.GRAYED_ATTRIBUTES);
+        }
+        else {
+          appendText(name, textAttributes);
+        }
+
+        if (node.getShowSeparator()) {
+          // Is this good?
+          appendText(node.getSeparator(), SimpleTextAttributes.GRAY_ATTRIBUTES);
+        }
+        else {
+          appendText(" ", SimpleTextAttributes.GRAY_ATTRIBUTES);
+        }
+      }
+
+      if (panel.isCreatedByLocalProject(node)) {
+        textAttributes = textAttributes.derive(SimpleTextAttributes.REGULAR_BOLD_ATTRIBUTES.getStyle(), null, null, null);
+      }
+
+      final String description = node.getDescription();
+      final Matcher match = primaryDescriptionPattern.matcher(description);
+      if (match.matches()) {
+        appendText(" ", SimpleTextAttributes.GRAY_ATTRIBUTES);
+        appendText(match.group(1), textAttributes);
+        appendText(" ", textAttributes);
+        appendText(match.group(2), SimpleTextAttributes.GRAYED_ATTRIBUTES);
+      }
+      else if (!node.getDescription().isEmpty()) {
+        appendText(" ", SimpleTextAttributes.GRAY_ATTRIBUTES);
+        appendText(node.getDescription(), textAttributes);
+      }
+
+      final Icon icon = node.getIcon();
+      if (icon != null) {
+        setIcon(icon);
+      }
+    }
+  }
+
+  private void appendText(@NotNull String text, @NotNull SimpleTextAttributes attributes) {
+    appendFragmentsForSpeedSearch(tree, text, attributes, selected, this);
+  }
+
+  // Generally duplicated from SpeedSearchUtil.appendFragmentsForSpeedSearch
+  public void appendFragmentsForSpeedSearch(@NotNull JComponent speedSearchEnabledComponent,
+                                            @NotNull String text,
+                                            @NotNull SimpleTextAttributes attributes,
+                                            boolean selected,
+                                            @NotNull MultiIconSimpleColoredComponent simpleColoredComponent) {
+    final SpeedSearchSupply speedSearch = SpeedSearchSupply.getSupply(speedSearchEnabledComponent);
+    if (speedSearch != null) {
+      final Iterable<TextRange> fragments = speedSearch.matchingFragments(text);
+      if (fragments != null) {
+        final Color fg = attributes.getFgColor();
+        final Color bg = selected ? UIUtil.getTreeSelectionBackground() : UIUtil.getTreeTextBackground();
+        final int style = attributes.getStyle();
+        final SimpleTextAttributes plain = new SimpleTextAttributes(style, fg);
+        final SimpleTextAttributes highlighted = new SimpleTextAttributes(bg, fg, null, style | SimpleTextAttributes.STYLE_SEARCH_MATCH);
+        appendColoredFragments(simpleColoredComponent, text, fragments, plain, highlighted);
+        return;
+      }
+    }
+    simpleColoredComponent.append(text, attributes);
+  }
+
+  public void appendColoredFragments(final MultiIconSimpleColoredComponent simpleColoredComponent,
+                                     final String text,
+                                     Iterable<TextRange> colored,
+                                     final SimpleTextAttributes plain, final SimpleTextAttributes highlighted) {
+    final List<Pair<String, Integer>> searchTerms = new ArrayList<>();
+    for (TextRange fragment : colored) {
+      searchTerms.add(Pair.create(fragment.substring(text), fragment.getStartOffset()));
+    }
+
+    int lastOffset = 0;
+    for (Pair<String, Integer> pair : searchTerms) {
+      if (pair.second > lastOffset) {
+        simpleColoredComponent.append(text.substring(lastOffset, pair.second), plain);
+      }
+
+      simpleColoredComponent.append(text.substring(pair.second, pair.second + pair.first.length()), highlighted);
+      lastOffset = pair.second + pair.first.length();
+    }
+
+    if (lastOffset < text.length()) {
+      simpleColoredComponent.append(text.substring(lastOffset), plain);
+    }
+  }
+}

--- a/src/io/flutter/view/InspectorPanel.java
+++ b/src/io/flutter/view/InspectorPanel.java
@@ -49,6 +49,7 @@ import java.awt.event.ComponentEvent;
 import java.awt.event.ComponentListener;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
+import java.lang.System;
 import java.util.*;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -282,13 +283,11 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
 
       @Override
       public void componentShown(ComponentEvent e) {
-        // We should start updating here
         determineSplitterOrientation();
       }
 
       @Override
       public void componentHidden(ComponentEvent e) {
-        // We should pause updating here.
       }
     });
 
@@ -616,7 +615,6 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
    * Show the details subtree starting with node subtreeRoot highlighting
    * node subtreeSelection.
    */
-
   public void showDetailSubtrees(DiagnosticsNode subtreeRoot, DiagnosticsNode subtreeSelection) {
     // TODO(jacobr): handle render objects subtree panel and other subtree panels here.
     assert (!legacyMode);
@@ -1505,7 +1503,7 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
       groups.getNext()
         .safeWhenComplete(diagnostic.getProperties(groups.getNext()), (ArrayList<DiagnosticsNode> properties, Throwable throwable) -> {
           if (throwable != null || propertiesIdentical(properties, currentProperties)) {
-            // Dispose the new group as it wasn't used
+            // Dispose the new group as it wasn't used.
             groups.cancelNext();
             return;
           }

--- a/src/io/flutter/view/InspectorPanel.java
+++ b/src/io/flutter/view/InspectorPanel.java
@@ -6,6 +6,7 @@
 package io.flutter.view;
 
 import com.google.common.base.Joiner;
+import com.intellij.execution.ui.layout.impl.JBRunnerTabs;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.actionSystem.*;
 import com.intellij.openapi.diagnostic.Logger;
@@ -14,26 +15,20 @@ import com.intellij.openapi.util.Computable;
 import com.intellij.openapi.util.Disposer;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.ui.*;
+import com.intellij.ui.components.JBScrollPane;
 import com.intellij.ui.dualView.TreeTableView;
-import com.intellij.ui.speedSearch.SpeedSearchUtil;
+import com.intellij.ui.tabs.TabInfo;
 import com.intellij.ui.treeStructure.Tree;
 import com.intellij.ui.treeStructure.treetable.ListTreeTableModelOnColumns;
 import com.intellij.util.ui.ColumnInfo;
 import com.intellij.util.ui.JBUI;
-import com.intellij.util.ui.UIUtil;
 import com.intellij.util.ui.tree.TreeUtil;
-import com.intellij.xdebugger.impl.ui.DebuggerUIUtil;
-import com.intellij.xdebugger.impl.ui.tree.nodes.XValueNodeImpl;
 import io.flutter.FlutterBundle;
 import io.flutter.editor.FlutterMaterialIcons;
 import io.flutter.inspector.*;
 import io.flutter.pub.PubRoot;
 import io.flutter.run.daemon.FlutterApp;
-import io.flutter.utils.AsyncRateLimiter;
-import io.flutter.utils.AsyncUtils;
-import io.flutter.utils.ColorIconMaker;
-import io.flutter.utils.StreamSubscription;
-import org.apache.commons.lang.StringUtils;
+import io.flutter.utils.*;
 import org.dartlang.vm.service.element.InstanceRef;
 import org.dartlang.vm.service.element.IsolateRef;
 import org.jetbrains.annotations.NotNull;
@@ -42,7 +37,7 @@ import org.jetbrains.annotations.Nullable;
 import javax.swing.*;
 import javax.swing.event.TreeExpansionEvent;
 import javax.swing.event.TreeExpansionListener;
-import javax.swing.plaf.basic.BasicTreeUI;
+import javax.swing.event.TreeSelectionEvent;
 import javax.swing.table.JTableHeader;
 import javax.swing.table.TableCellRenderer;
 import javax.swing.tree.DefaultMutableTreeNode;
@@ -50,23 +45,19 @@ import javax.swing.tree.DefaultTreeModel;
 import javax.swing.tree.TreeNode;
 import javax.swing.tree.TreePath;
 import java.awt.*;
+import java.awt.event.ComponentEvent;
+import java.awt.event.ComponentListener;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
-import java.util.ArrayList;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import static io.flutter.utils.AsyncUtils.whenCompleteUiThread;
 
 // TODO(devoncarew): Should we filter out the CheckedModeBanner node type?
 // TODO(devoncarew): Should we filter out the WidgetInspector node type?
 
 public class InspectorPanel extends JPanel implements Disposable, InspectorService.InspectorServiceClient {
 
-  // TODO(jacobr): use a lower frame rate when the panel is hidden.
   /**
    * Maximum frame rate to refresh the inspector panel at to avoid taxing the
    * physical device with too many requests to recompute properties and trees.
@@ -77,84 +68,231 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
    * for now mainly to minimize the risk of unintended consequences.
    */
   public static final double REFRESH_FRAMES_PER_SECOND = 5.0;
-
-  private final TreeDataProvider myRootsTree;
-  private final PropertiesPanel myPropertiesPanel;
+  // We have to define this because SimpleTextAttributes does not define a
+  // value for warnings.
+  private static final SimpleTextAttributes WARNING_ATTRIBUTES = new SimpleTextAttributes(SimpleTextAttributes.STYLE_PLAIN, JBColor.ORANGE);
+  private static final Logger LOG = Logger.getInstance(InspectorPanel.class);
+  protected final boolean detailsSubtree;
+  protected final boolean isSummaryTree;
+  @Nullable
+  /**
+   * Parent InspectorPanel if this is a details subtree
+   */
+  protected final InspectorPanel parentTree;
+  protected final InspectorPanel subtreePanel;
+  final CustomIconMaker iconMaker = new CustomIconMaker();
+  @NotNull final Splitter treeSplitter;
+  final Icon defaultIcon;
+  final JBScrollPane treeScrollPane;
+  private final InspectorTree myRootsTree;
+  @Nullable private final PropertiesPanel myPropertiesPanel;
   private final Computable<Boolean> isApplicable;
   private final InspectorService.FlutterTreeType treeType;
   @NotNull
   private final FlutterApp flutterApp;
   @NotNull private final InspectorService inspectorService;
   private final StreamSubscription<IsolateRef> flutterIsolateSubscription;
-  private CompletableFuture<DiagnosticsNode> rootFuture;
-
-  private static final DataKey<Tree> INSPECTOR_KEY = DataKey.create("Flutter.InspectorKey");
-
-  // We have to define this because SimpleTextAttributes does not define a
-  // value for warnings.
-  private static final SimpleTextAttributes WARNING_ATTRIBUTES = new SimpleTextAttributes(SimpleTextAttributes.STYLE_PLAIN, JBColor.ORANGE);
-
-  @NotNull
-  public FlutterApp getFlutterApp() {
-    return flutterApp;
-  }
-
-  private DefaultMutableTreeNode selectedNode;
-
-  private CompletableFuture<DiagnosticsNode> pendingSelectionFuture;
-  @SuppressWarnings("FieldMayBeFinal") private boolean myIsListening = false;
-  private boolean isActive = false;
-
+  private final TreeScrollAnimator scrollAnimator;
+  /**
+   * Mode with a tree view and a property table instead of a details tree and
+   * a summary tree.
+   */
+  private final boolean legacyMode;
   private final AsyncRateLimiter refreshRateLimiter;
 
-  private static final Logger LOG = Logger.getInstance(InspectorPanel.class);
+  /**
+   * Groups used to manage and cancel requests to load data to display directly
+   * in the tree.
+   */
+  private final InspectorObjectGroupManager treeGroups;
+
+  /**
+   * Groups used to manage and cancel requests to determine what the current
+   * selection is.
+   * <p>
+   * This group needs to be kept separate from treeGroups as the selection is
+   * shared more with the details subtree.
+   * TODO(jacobr): is there a way we can unify the selection and tree groups?
+   */
+  private final InspectorObjectGroupManager selectionGroups;
+
+  /**
+   * Node being highlighted due to the current hover.
+   */
+  protected DefaultMutableTreeNode currentShowNode;
+  boolean flutterAppFrameReady = false;
+  private boolean treeLoadStarted = false;
+  private DiagnosticsNode subtreeRoot;
+  private boolean programaticSelectionChangeInProgress = false;
+  private boolean programaticExpansionInProgress = false;
+
+  private DefaultMutableTreeNode selectedNode;
+  private DefaultMutableTreeNode lastExpanded;
+  private boolean isActive = false;
+  private Map<InspectorInstanceRef, DefaultMutableTreeNode> valueToTreeNode = new HashMap<>();
+
+  /**
+   * When visibleToUser is false we should dispose all allocated objects and
+   * not perform any actions.
+   */
+  private boolean visibleToUser = false;
 
   public InspectorPanel(FlutterView flutterView,
                         @NotNull FlutterApp flutterApp,
                         @NotNull InspectorService inspectorService,
-                        Computable<Boolean> isApplicable,
-                        InspectorService.FlutterTreeType treeType) {
+                        @NotNull Computable<Boolean> isApplicable,
+                        @NotNull InspectorService.FlutterTreeType treeType,
+                        boolean isSummaryTree,
+                        boolean legacyMode,
+                        @NotNull EventStream<Boolean> shouldAutoHorizontalScroll) {
+    this(flutterView, flutterApp, inspectorService, isApplicable, treeType, false, null, isSummaryTree, legacyMode,
+         shouldAutoHorizontalScroll);
+  }
+
+  private InspectorPanel(FlutterView flutterView,
+                         @NotNull FlutterApp flutterApp,
+                         @NotNull InspectorService inspectorService,
+                         @NotNull Computable<Boolean> isApplicable,
+                         @NotNull InspectorService.FlutterTreeType treeType,
+                         boolean detailsSubtree,
+                         @Nullable InspectorPanel parentTree,
+                         boolean isSummaryTree,
+                         boolean legacyMode,
+                         @NotNull EventStream<Boolean> shouldAutoHorizontalScroll) {
     super(new BorderLayout());
 
     this.treeType = treeType;
     this.flutterApp = flutterApp;
     this.inspectorService = inspectorService;
+    this.treeGroups = new InspectorObjectGroupManager(inspectorService, "tree");
+    this.selectionGroups = new InspectorObjectGroupManager(inspectorService, "selection");
     this.isApplicable = isApplicable;
+    this.detailsSubtree = detailsSubtree;
+    this.isSummaryTree = isSummaryTree;
+    this.parentTree = parentTree;
+    this.legacyMode = legacyMode;
+
+    this.defaultIcon = iconMaker.fromInfo("Default");
 
     refreshRateLimiter = new AsyncRateLimiter(REFRESH_FRAMES_PER_SECOND, this::refresh);
 
-    myRootsTree = new TreeDataProvider(new DefaultMutableTreeNode(null), treeType.displayName);
+    String parentTreeDisplayName = (parentTree != null) ? parentTree.treeType.displayName : null;
+
+    myRootsTree = new InspectorTree(
+      new DefaultMutableTreeNode(null),
+      treeType.displayName,
+      detailsSubtree,
+      parentTreeDisplayName,
+      treeType != InspectorService.FlutterTreeType.widget || (!isSummaryTree && !legacyMode),
+      legacyMode
+    );
+    // We want to reserve double clicking for navigation within the detail
+    // tree and in the future for editing values in the tree.
+    myRootsTree.setHorizontalAutoScrollingEnabled(false);
+    myRootsTree.setAutoscrolls(false);
+    myRootsTree.setToggleClickCount(0);
+
     myRootsTree.addTreeExpansionListener(new MyTreeExpansionListener());
-    myPropertiesPanel = new PropertiesPanel();
+    InspectorTreeMouseListener mouseListener = new InspectorTreeMouseListener(this, myRootsTree);
+    myRootsTree.addMouseListener(mouseListener);
+    myRootsTree.addMouseMotionListener(mouseListener);
+
+    if (isSummaryTree && !legacyMode) {
+      subtreePanel = new InspectorPanel(
+        flutterView,
+        flutterApp,
+        inspectorService,
+        isApplicable,
+        treeType,
+        true,
+        this,
+        false,
+        legacyMode,
+        shouldAutoHorizontalScroll
+      );
+    }
+    else {
+      subtreePanel = null;
+    }
 
     initTree(myRootsTree);
-    myRootsTree.getSelectionModel().addTreeSelectionListener(e -> selectionChanged());
+    myRootsTree.getSelectionModel().addTreeSelectionListener(this::selectionChanged);
 
-    final Splitter treeSplitter = new Splitter(true);
-    treeSplitter.setProportion(flutterView.getState().getSplitterProportion());
-    flutterView.getState().addListener(e -> {
-      final float newProportion = flutterView.getState().getSplitterProportion();
-      if (treeSplitter.getProportion() != newProportion) {
-        treeSplitter.setProportion(newProportion);
-      }
-    });
-    //noinspection Convert2Lambda
-    treeSplitter.addPropertyChangeListener("proportion", new PropertyChangeListener() {
-      @Override
-      public void propertyChange(PropertyChangeEvent evt) {
-        flutterView.getState().setSplitterProportion(treeSplitter.getProportion());
-      }
-    });
-
-    // TODO(jacobr): surely there is more we should be disposing.
-    Disposer.register(this, treeSplitter::dispose);
-    final JScrollPane rootsTreeScrollPane = ScrollPaneFactory.createScrollPane(myRootsTree);
+    treeScrollPane = (JBScrollPane)ScrollPaneFactory.createScrollPane(myRootsTree);
+    treeScrollPane.setAutoscrolls(false);
     // Add padding on the bottom so users can select an item even if a horizontal scroll bar is visible
     // (and overlaying the bottom part of the scrollable area).
-    rootsTreeScrollPane.setViewportBorder(BorderFactory.createEmptyBorder(0, 0, JBUI.scale(14), 0));
-    treeSplitter.setFirstComponent(rootsTreeScrollPane);
-    treeSplitter.setSecondComponent(ScrollPaneFactory.createScrollPane(myPropertiesPanel));
-    add(treeSplitter);
+    treeScrollPane.setViewportBorder(BorderFactory.createEmptyBorder(0, 0, JBUI.scale(14), 0));
+
+    scrollAnimator = new TreeScrollAnimator(myRootsTree, treeScrollPane);
+    shouldAutoHorizontalScroll.listen(scrollAnimator::setAutoHorizontalScroll, true);
+    myRootsTree.setScrollAnimator(scrollAnimator);
+
+    if (!detailsSubtree) {
+      treeSplitter = new Splitter(detailsSubtree);
+      treeSplitter.setProportion(flutterView.getState().getSplitterProportion());
+      flutterView.getState().addListener(e -> {
+        final float newProportion = flutterView.getState().getSplitterProportion();
+        if (treeSplitter.getProportion() != newProportion) {
+          treeSplitter.setProportion(newProportion);
+        }
+      });
+      //noinspection Convert2Lambda
+      treeSplitter.addPropertyChangeListener("proportion", new PropertyChangeListener() {
+        @Override
+        public void propertyChange(PropertyChangeEvent evt) {
+          flutterView.getState().setSplitterProportion(treeSplitter.getProportion());
+        }
+      });
+
+      if (subtreePanel == null) {
+        myPropertiesPanel = new PropertiesPanel(flutterApp, inspectorService);
+        treeSplitter.setSecondComponent(ScrollPaneFactory.createScrollPane(myPropertiesPanel));
+      }
+      else {
+        myPropertiesPanel = null; /// This InspectorPanel doesn't have its own property panel.
+        final JBRunnerTabs tabs = new JBRunnerTabs(flutterView.getProject(), ActionManager.getInstance(), null, this);
+        tabs.addTab(new TabInfo(subtreePanel)
+                      .append("Details", SimpleTextAttributes.REGULAR_ATTRIBUTES));
+
+        treeSplitter.setSecondComponent(tabs.getComponent());
+      }
+
+      Disposer.register(this, treeSplitter::dispose);
+      Disposer.register(this, scrollAnimator::dispose);
+      treeSplitter.setFirstComponent(treeScrollPane);
+      add(treeSplitter);
+    }
+    else {
+      treeSplitter = null;
+      myPropertiesPanel = null;
+      add(treeScrollPane);
+    }
+
+    this.addComponentListener(new ComponentListener() {
+      @Override
+      public void componentResized(ComponentEvent e) {
+        determineSplitterOrientation();
+      }
+
+      @Override
+      public void componentMoved(ComponentEvent e) {
+
+      }
+
+      @Override
+      public void componentShown(ComponentEvent e) {
+        // We should start updating here
+        determineSplitterOrientation();
+      }
+
+      @Override
+      public void componentHidden(ComponentEvent e) {
+        // We should pause updating here.
+      }
+    });
+
+    determineSplitterOrientation();
 
     flutterIsolateSubscription = inspectorService.getApp().getPerfService().getCurrentFlutterIsolate((IsolateRef flutterIsolate) -> {
       if (flutterIsolate == null) {
@@ -171,31 +309,204 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
     return userData instanceof DiagnosticsNode ? (DiagnosticsNode)userData : null;
   }
 
+  private static void expandAll(JTree tree, TreePath parent, boolean expandProperties) {
+    TreeNode node = (TreeNode)parent.getLastPathComponent();
+    if (node.getChildCount() >= 0) {
+      for (Enumeration e = node.children(); e.hasMoreElements(); ) {
+        DefaultMutableTreeNode n = (DefaultMutableTreeNode)e.nextElement();
+        if (n.getUserObject() instanceof DiagnosticsNode) {
+          final DiagnosticsNode diagonsticsNode = (DiagnosticsNode)n.getUserObject();
+          if (!diagonsticsNode.childrenReady() ||
+              (diagonsticsNode.isProperty() && !expandProperties)) {
+            continue;
+          }
+        }
+        expandAll(tree, parent.pathByAddingChild(n), expandProperties);
+      }
+    }
+    tree.expandPath(parent);
+  }
+
+  protected static SimpleTextAttributes textAttributesForLevel(DiagnosticLevel level) {
+    switch (level) {
+      case hidden:
+        return SimpleTextAttributes.GRAYED_ATTRIBUTES;
+      case fine:
+        return SimpleTextAttributes.REGULAR_ATTRIBUTES;
+      case warning:
+        return WARNING_ATTRIBUTES;
+      case error:
+        return SimpleTextAttributes.ERROR_ATTRIBUTES;
+      case debug:
+      case info:
+      default:
+        return SimpleTextAttributes.REGULAR_ATTRIBUTES;
+    }
+  }
+
+  @Nullable
+  public static Tree getTree(final DataContext e) {
+    return e.getData(InspectorTree.INSPECTOR_KEY);
+  }
+
+  @NotNull
+  public FlutterApp getFlutterApp() {
+    return flutterApp;
+  }
+
+  public InspectorService.FlutterTreeType getTreeType() {
+    return treeType;
+  }
+
+  public void setVisibleToUser(boolean visible) {
+    if (visibleToUser == visible) {
+      return;
+    }
+    visibleToUser = visible;
+
+    if (subtreePanel != null) {
+      subtreePanel.setVisibleToUser(visible);
+    }
+    if (visibleToUser) {
+      if (parentTree == null) {
+        maybeLoadUI();
+      }
+    }
+    else {
+      shutdownTree(false);
+    }
+  }
+
+  private void determineSplitterOrientation() {
+    if (treeSplitter == null) {
+      return;
+    }
+    final double aspectRatio = (double)getWidth() / (double)getHeight();
+    final boolean vertical = aspectRatio < 1.4;
+    if (vertical != treeSplitter.getOrientation()) {
+      treeSplitter.setOrientation(vertical);
+    }
+  }
+
+  protected boolean hasDiagnosticsValue(InspectorInstanceRef ref) {
+    return valueToTreeNode.containsKey(ref);
+  }
+
+  protected DiagnosticsNode findDiagnosticsValue(InspectorInstanceRef ref) {
+    return getDiagnosticNode(valueToTreeNode.get(ref));
+  }
+
+  protected void endShowNode() {
+    highlightShowNode((DefaultMutableTreeNode)null);
+  }
+
+  protected boolean highlightShowNode(InspectorInstanceRef ref) {
+    return highlightShowNode(valueToTreeNode.get(ref));
+  }
+
+  protected boolean highlightShowNode(DefaultMutableTreeNode node) {
+    if (node == null && parentTree != null) {
+      // If nothing is highlighted, highlight the node selected in the parent
+      // tree so user has context of where the node selected in the parent is
+      // in the details tree.
+      node = findMatchingTreeNode(parentTree.getSelectedDiagnostic());
+    }
+
+    getTreeModel().nodeChanged(currentShowNode);
+    getTreeModel().nodeChanged(node);
+    currentShowNode = node;
+    return true;
+  }
+
+  private DefaultMutableTreeNode findMatchingTreeNode(DiagnosticsNode node) {
+    if (node == null) {
+      return null;
+    }
+    return valueToTreeNode.get(node.getValueRef());
+  }
+
   private DefaultTreeModel getTreeModel() {
     return (DefaultTreeModel)myRootsTree.getModel();
   }
 
+  private CompletableFuture<?> getPendingUpdateDone() {
+    // Wait for the selection to be resolved followed by waiting for the tree
+    // to be computed.
+    final CompletableFuture<?> ret = new CompletableFuture<>();
+    AsyncUtils.whenCompleteUiThread(selectionGroups.getPendingUpdateDone(), (value, error) -> {
+      treeGroups.getPendingUpdateDone().whenCompleteAsync((value2, error2) -> {
+        ret.complete(null);
+      });
+    });
+    return ret;
+  }
+
   private CompletableFuture<?> refresh() {
+    if (!visibleToUser) {
+      // We will refresh again once we are visible.
+      // There is a risk a refresh got triggered before the view was visble.
+      return CompletableFuture.completedFuture(null);
+    }
+
     // TODO(jacobr): refresh the tree as well as just the properties.
-    return myPropertiesPanel.refresh();
+    if (myPropertiesPanel != null) {
+      myPropertiesPanel.refresh();
+    }
+    if (myPropertiesPanel != null) {
+      return CompletableFuture.allOf(getPendingUpdateDone(), myPropertiesPanel.getPendingUpdateDone());
+    }
+    else if (subtreePanel != null) {
+      return CompletableFuture.allOf(getPendingUpdateDone(), subtreePanel.getPendingUpdateDone());
+    }
+    else {
+      return getPendingUpdateDone();
+    }
+  }
+
+  public void shutdownTree(boolean isolateStopped) {
+    // It is critical we clear all data that is kept alive by inspector object
+    // references in this method as that stale data will trigger inspector
+    // exceptions.
+    programaticSelectionChangeInProgress = true;
+    treeGroups.clear(isolateStopped);
+    selectionGroups.clear(isolateStopped);
+
+    currentShowNode = null;
+    selectedNode = null;
+    lastExpanded = null;
+
+    selectedNode = null;
+    subtreeRoot = null;
+
+    getTreeModel().setRoot(new DefaultMutableTreeNode());
+    if (subtreePanel != null) {
+      subtreePanel.shutdownTree(isolateStopped);
+    }
+    if (myPropertiesPanel != null) {
+      myPropertiesPanel.shutdownTree(isolateStopped);
+    }
+    programaticSelectionChangeInProgress = false;
+    valueToTreeNode.clear();
   }
 
   public void onIsolateStopped() {
-    // Make sure we cleanup all references to objects from the stopped isolate as they are now obsolete.
-    if (rootFuture != null && !rootFuture.isDone()) {
-      rootFuture.cancel(true);
+    flutterAppFrameReady = false;
+    treeLoadStarted = false;
+    shutdownTree(true);
+  }
+
+  @Override
+  public void onForceRefresh() {
+    if (!visibleToUser) {
+      return;
     }
-    rootFuture = null;
-
-    if (pendingSelectionFuture != null && !pendingSelectionFuture.isDone()) {
-      pendingSelectionFuture.cancel(true);
+    if (!legacyMode) {
+      // We can't efficiently refresh the full tree in legacy mode.
+      recomputeTreeRoot(null, null, false);
     }
-    pendingSelectionFuture = null;
-
-    selectedNode = null;
-
-    getTreeModel().setRoot(new DefaultMutableTreeNode());
-    myPropertiesPanel.showProperties(null);
+    if (myPropertiesPanel != null) {
+      myPropertiesPanel.refresh();
+    }
   }
 
   public void onAppChanged() {
@@ -219,52 +530,218 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
     }
 
     isActive = true;
-    assert (getInspectorService() != null);
     getInspectorService().addClient(this);
     final ArrayList<String> rootDirectories = new ArrayList<>();
     for (PubRoot root : getFlutterApp().getPubRoots()) {
       rootDirectories.add(root.getRoot().getCanonicalPath());
     }
-    getInspectorService().setPubRootDirectories(rootDirectories);
+    inspectorService.setPubRootDirectories(rootDirectories);
 
-    getInspectorService().isWidgetTreeReady().thenAccept((Boolean ready) -> {
-      if (ready) {
-        recomputeTreeRoot();
-      }
-    });
+    maybeLoadUI();
+  }
+
+  void maybeLoadUI() {
+    if (!visibleToUser || !isActive) {
+      return;
+    }
+
+    if (flutterAppFrameReady) {
+      // We need to start by quering the inspector service to find out the
+      // current state of the UI.
+      updateSelectionFromService();
+    }
+    else {
+      AsyncUtils.whenCompleteUiThread(inspectorService.isWidgetTreeReady(), (Boolean ready, Throwable throwable) -> {
+        if (throwable != null) {
+          return;
+        }
+        flutterAppFrameReady = ready;
+        if (isActive && ready) {
+          maybeLoadUI();
+        }
+      });
+    }
   }
 
   private DefaultMutableTreeNode getRootNode() {
     return (DefaultMutableTreeNode)getTreeModel().getRoot();
   }
 
-  private CompletableFuture<DiagnosticsNode> recomputeTreeRoot() {
-    if (rootFuture != null && !rootFuture.isDone()) {
-      return rootFuture;
-    }
-    rootFuture = Objects.requireNonNull(getInspectorService()).getRoot(treeType);
-
-    whenCompleteUiThread(rootFuture, (final DiagnosticsNode n, Throwable error) -> {
+  private void recomputeTreeRoot(DiagnosticsNode newSelection,
+                                 DiagnosticsNode detailsSelection,
+                                 boolean setSubtreeRoot) {
+    treeGroups.cancelNext();
+    treeGroups.getNext().safeWhenComplete(detailsSubtree
+                                          ? treeGroups.getNext().getDetailsSubtree(subtreeRoot)
+                                          : treeGroups.getNext().getRoot(treeType), (final DiagnosticsNode n, Throwable error) -> {
       if (error != null) {
+        LOG.error(error.toString());
+        treeGroups.cancelNext();
         return;
       }
-      final DefaultMutableTreeNode rootNode = new DefaultMutableTreeNode(n);
-      // TODO(jacobr): be more judicious about nuking the whole tree.
-      setupTreeNode(rootNode, n);
-      maybeLoadChildren(rootNode);
-      getTreeModel().setRoot(rootNode);
+      // TODO(jacobr): as a performance optimization we should check if the
+      // new tree is identical to the existing tree in which case we should
+      // dispose the new tree and keep the old tree.
+      treeGroups.promoteNext();
+      clearValueToTreeNodeMapping();
+      if (n != null) {
+        final DefaultMutableTreeNode rootNode = new DefaultMutableTreeNode(n);
+        getTreeModel().setRoot(rootNode);
+        setupTreeNode(rootNode, n, true);
+
+        // Legacy case. We got the root node but no children are loaded yet.
+        // When the root node is hidden, we will never show anything unless we
+        // load the children.
+        if (n.hasChildren() && !n.childrenReady()) {
+          maybeLoadChildren(rootNode);
+        }
+      }
+      else {
+        getTreeModel().setRoot(null);
+      }
+      refreshSelection(newSelection, detailsSelection, setSubtreeRoot);
     });
-    return rootFuture;
   }
 
-  void setupTreeNode(DefaultMutableTreeNode node, DiagnosticsNode diagnosticsNode) {
+  private void clearValueToTreeNodeMapping() {
+    if (parentTree != null) {
+      for (InspectorInstanceRef v : valueToTreeNode.keySet()) {
+        parentTree.maybeUpdateValueUI(v);
+      }
+    }
+    valueToTreeNode.clear();
+  }
+
+  /**
+   * Show the details subtree starting with node subtreeRoot highlighting
+   * node subtreeSelection.
+   */
+
+  public void showDetailSubtrees(DiagnosticsNode subtreeRoot, DiagnosticsNode subtreeSelection) {
+    // TODO(jacobr): handle render objects subtree panel and other subtree panels here.
+    assert (!legacyMode);
+
+    this.subtreeRoot = subtreeRoot;
+    myRootsTree.setHighlightedRoot(getSubtreeRootNode());
+    if (subtreePanel != null) {
+      subtreePanel.setSubtreeRoot(subtreeRoot, subtreeSelection);
+    }
+  }
+
+  public InspectorInstanceRef getSubtreeRootValue() {
+    return subtreeRoot != null ? subtreeRoot.getValueRef() : null;
+  }
+
+  public void setSubtreeRoot(DiagnosticsNode node, DiagnosticsNode selection) {
+    assert (detailsSubtree);
+    if (selection == null) {
+      selection = node;
+    }
+    if (node != null && node.equals(subtreeRoot)) {
+      //  Select the new node in the existing subtree.
+      applyNewSelection(selection, null, false);
+      return;
+    }
+    subtreeRoot = node;
+    if (node == null) {
+      // Passing in a null node indicates we should clear the subtree and free any memory allocated.
+      shutdownTree(false);
+      return;
+    }
+
+    // Clear now to eliminate frame of highlighted nodes flicker.
+    clearValueToTreeNodeMapping();
+    recomputeTreeRoot(selection, null, false);
+  }
+
+  DefaultMutableTreeNode getSubtreeRootNode() {
+    if (subtreeRoot == null) {
+      return null;
+    }
+    return valueToTreeNode.get(subtreeRoot.getValueRef());
+  }
+
+  private void refreshSelection(DiagnosticsNode newSelection, DiagnosticsNode detailsSelection, boolean setSubtreeRoot) {
+    if (newSelection == null) {
+      newSelection = getSelectedDiagnostic();
+    }
+    setSelectedNode(findMatchingTreeNode(newSelection));
+    syncSelectionHelper(setSubtreeRoot, detailsSelection);
+
+    if (subtreePanel != null) {
+      if ((subtreeRoot != null && getSubtreeRootNode() == null)) {
+        subtreeRoot = newSelection;
+        subtreePanel.setSubtreeRoot(newSelection, detailsSelection);
+      }
+    }
+    if (!legacyMode) {
+      myRootsTree.setHighlightedRoot(getSubtreeRootNode());
+    }
+
+    syncTreeSelection();
+  }
+
+  private void syncTreeSelection() {
+    programaticSelectionChangeInProgress = true;
+    final TreePath path = selectedNode != null ? new TreePath(selectedNode.getPath()) : null;
+    myRootsTree.setSelectionPath(path);
+    programaticSelectionChangeInProgress = false;
+    myRootsTree.expandPath(path);
+    animateTo(selectedNode);
+  }
+
+  private void selectAndShowNode(DiagnosticsNode node) {
+    if (node == null) {
+      return;
+    }
+    selectAndShowNode(node.getValueRef());
+  }
+
+  private void selectAndShowNode(InspectorInstanceRef ref) {
+    DefaultMutableTreeNode node = valueToTreeNode.get(ref);
+    if (node == null) {
+      return;
+    }
+    setSelectedNode(node);
+    syncTreeSelection();
+  }
+
+  private TreePath getTreePath(DiagnosticsNode node) {
+    if (node == null) {
+      return null;
+    }
+    final DefaultMutableTreeNode treeNode = valueToTreeNode.get(node.getValueRef());
+    if (treeNode == null) {
+      return null;
+    }
+    return new TreePath(treeNode.getPath());
+  }
+
+  protected void maybeUpdateValueUI(InspectorInstanceRef valueRef) {
+    DefaultMutableTreeNode node = valueToTreeNode.get(valueRef);
+    if (node == null) {
+      // The value isn't shown in the parent tree. Nothing to do.
+      return;
+    }
+    getTreeModel().nodeChanged(node);
+  }
+
+  void setupTreeNode(DefaultMutableTreeNode node, DiagnosticsNode diagnosticsNode, boolean expandChildren) {
     node.setUserObject(diagnosticsNode);
     node.setAllowsChildren(diagnosticsNode.hasChildren());
-    if (diagnosticsNode.hasChildren()) {
-      if (diagnosticsNode.childrenReady()) {
+    final InspectorInstanceRef valueRef = diagnosticsNode.getValueRef();
+    // Properties do not have unique values so should not go in the valueToTreeNode map.
+    if (valueRef.getId() != null && !diagnosticsNode.isProperty()) {
+      valueToTreeNode.put(valueRef, node);
+    }
+    if (parentTree != null) {
+      parentTree.maybeUpdateValueUI(valueRef);
+    }
+    if (diagnosticsNode.hasChildren() || !diagnosticsNode.getInlineProperties().isEmpty()) {
+      if (diagnosticsNode.childrenReady() || !diagnosticsNode.hasChildren()) {
         final CompletableFuture<ArrayList<DiagnosticsNode>> childrenFuture = diagnosticsNode.getChildren();
         assert (childrenFuture.isDone());
-        setupChildren(node, childrenFuture.getNow(null));
+        setupChildren(diagnosticsNode, node, childrenFuture.getNow(null), expandChildren);
       }
       else {
         node.removeAllChildren();
@@ -273,13 +750,33 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
     }
   }
 
-  void setupChildren(DefaultMutableTreeNode treeNode, ArrayList<DiagnosticsNode> children) {
-    treeNode.removeAllChildren();
-    treeNode.setAllowsChildren(!children.isEmpty());
+  void setupChildren(DiagnosticsNode parent, DefaultMutableTreeNode treeNode, ArrayList<DiagnosticsNode> children, boolean expandChildren) {
+    final DefaultTreeModel model = getTreeModel();
+    if (treeNode.getChildCount() > 0) {
+      // Only case supported is this is the loading node.
+      assert (treeNode.getChildCount() == 1);
+      model.removeNodeFromParent((DefaultMutableTreeNode)treeNode.getFirstChild());
+    }
+    final ArrayList<DiagnosticsNode> inlineProperties = parent.getInlineProperties();
+    treeNode.setAllowsChildren(!children.isEmpty() || !inlineProperties.isEmpty());
+
+    if (inlineProperties != null) {
+      for (DiagnosticsNode property : inlineProperties) {
+        final DefaultMutableTreeNode childTreeNode = new DefaultMutableTreeNode();
+        setupTreeNode(childTreeNode, property, false);
+        childTreeNode.setAllowsChildren(childTreeNode.getChildCount() > 0);
+        model.insertNodeInto(childTreeNode, treeNode, treeNode.getChildCount());
+      }
+    }
     for (DiagnosticsNode child : children) {
       final DefaultMutableTreeNode childTreeNode = new DefaultMutableTreeNode();
-      setupTreeNode(childTreeNode, child);
-      treeNode.add(childTreeNode);
+      setupTreeNode(childTreeNode, child, false);
+      model.insertNodeInto(childTreeNode, treeNode, treeNode.getChildCount());
+    }
+    if (expandChildren) {
+      programaticExpansionInProgress = true;
+      expandAll(myRootsTree, new TreePath(treeNode.getPath()), false);
+      programaticExpansionInProgress = false;
     }
   }
 
@@ -288,28 +785,36 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
       return;
     }
     final DiagnosticsNode diagnosticsNode = (DiagnosticsNode)node.getUserObject();
-    if (diagnosticsNode.hasChildren()) {
-      if (placeholderChildren(node)) {
-        whenCompleteUiThread(diagnosticsNode.getChildren(), (ArrayList<DiagnosticsNode> children, Throwable throwable) -> {
+    if (diagnosticsNode.hasChildren() || !diagnosticsNode.getInlineProperties().isEmpty()) {
+      if (hasPlaceholderChildren(node)) {
+        diagnosticsNode.safeWhenComplete(diagnosticsNode.getChildren(), (ArrayList<DiagnosticsNode> children, Throwable throwable) -> {
           if (throwable != null) {
-            // Display that children failed to load.
+            // TODO(jacobr): Display that children failed to load.
             return;
           }
           if (node.getUserObject() != diagnosticsNode) {
             // Node changed, this data is stale.
             return;
           }
-          setupChildren(node, children);
-          getTreeModel().nodeStructureChanged(node);
+          setupChildren(diagnosticsNode, node, children, true);
+          if (node == selectedNode || node == lastExpanded) {
+            animateTo(node);
+          }
         });
       }
     }
   }
 
   public void onFlutterFrame() {
-    if (rootFuture == null) {
+    flutterAppFrameReady = true;
+    if (!visibleToUser) {
+      return;
+    }
+
+    if (!treeLoadStarted) {
+      treeLoadStarted = true;
       // This was the first frame.
-      recomputeTreeRoot();
+      maybeLoadUI();
     }
     refreshRateLimiter.scheduleRequest();
   }
@@ -326,90 +831,178 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
   }
 
   public void onInspectorSelectionChanged() {
-    if (pendingSelectionFuture != null) {
-      // Pending selection changed is obsolete.
-      if (!pendingSelectionFuture.isDone()) {
-        pendingSelectionFuture.cancel(true);
-        pendingSelectionFuture = null;
-      }
+    if (!visibleToUser) {
+      // Don't do anything. We will update the view once it is visible again.
+      return;
     }
-    pendingSelectionFuture = Objects.requireNonNull(getInspectorService()).getSelection(getSelectedDiagnostic(), treeType);
-    whenCompleteUiThread(pendingSelectionFuture, (DiagnosticsNode newSelection, Throwable error) -> {
-      pendingSelectionFuture = null;
+    if (detailsSubtree) {
+      // Wait for the master to update.
+      return;
+    }
+    updateSelectionFromService();
+  }
+
+  public void updateSelectionFromService() {
+    treeLoadStarted = true;
+    selectionGroups.cancelNext();
+
+    final CompletableFuture<DiagnosticsNode> pendingSelectionFuture =
+      selectionGroups.getNext().getSelection(getSelectedDiagnostic(), treeType, isSummaryTree);
+
+    CompletableFuture<?> allPending;
+    final CompletableFuture<DiagnosticsNode> pendingDetailsFuture =
+      isSummaryTree ? selectionGroups.getNext().getSelection(getSelectedDiagnostic(), treeType, false) : null;
+
+    CompletableFuture<?> selectionsReady =
+      isSummaryTree ? CompletableFuture.allOf(pendingDetailsFuture, pendingSelectionFuture) : pendingSelectionFuture;
+    selectionGroups.getNext().safeWhenComplete(selectionsReady, (ignored, error) -> {
       if (error != null) {
         LOG.error(error);
+        selectionGroups.cancelNext();
         return;
       }
-      if (newSelection != getSelectedDiagnostic()) {
+
+      selectionGroups.promoteNext();
+
+      final DiagnosticsNode newSelection = pendingSelectionFuture.getNow(null);
+
+      if (!legacyMode) {
+        DiagnosticsNode detailsSelection = null;
+        if (pendingDetailsFuture != null) {
+          detailsSelection = pendingDetailsFuture.getNow(null);
+        }
+        subtreeRoot = newSelection;
+
+        applyNewSelection(newSelection, detailsSelection, true);
+      }
+      else {
+        // Legacy case. TODO(jacobr): deprecate and remove this code.
+        // This case only exists for the RenderObject tree which we haven't updated yet to use the new UI style.
+        // TODO(jacobr): delete it.
         if (newSelection == null) {
-          myRootsTree.clearSelection();
+          recomputeTreeRoot(null, null, false);
           return;
         }
-        whenCompleteUiThread(getInspectorService().getParentChain(newSelection), (ArrayList<DiagnosticsPathNode> path, Throwable ex) -> {
-          if (ex != null) {
-            LOG.error(ex);
-            return;
-          }
-          DefaultMutableTreeNode treeNode = getRootNode();
-          final DefaultTreeModel model = getTreeModel();
-          final DefaultMutableTreeNode[] treePath = new DefaultMutableTreeNode[path.size()];
-          for (int i = 0; i < path.size(); ++i) {
-            treePath[i] = treeNode;
-            final DiagnosticsPathNode pathNode = path.get(i);
-            final DiagnosticsNode pathDiagnosticNode = pathNode.getNode();
-            final ArrayList<DiagnosticsNode> newChildren = pathNode.getChildren();
-            final DiagnosticsNode existingNode = getDiagnosticNode(treeNode);
-            if (!identicalDiagnosticsNodes(pathDiagnosticNode, existingNode)) {
-              treeNode.setUserObject(pathDiagnosticNode);
+        // TODO(jacobr): switch to using current and next groups in this case
+        // as well to avoid memory leaks.
+        treeGroups.getCurrent()
+          .safeWhenComplete(treeGroups.getCurrent().getParentChain(newSelection), (ArrayList<DiagnosticsPathNode> path, Throwable ex) -> {
+            if (ex != null) {
+              LOG.error(ex);
+              return;
             }
-            treeNode.setAllowsChildren(!newChildren.isEmpty());
-            for (int j = 0; j < newChildren.size(); ++j) {
-              final DiagnosticsNode newChild = newChildren.get(j);
-              if (j >= treeNode.getChildCount() || !identicalDiagnosticsNodes(newChild, getDiagnosticNode(treeNode.getChildAt(j)))) {
-                final DefaultMutableTreeNode child;
-                if (j >= treeNode.getChildCount()) {
-                  child = new DefaultMutableTreeNode();
-                  treeNode.add(child);
-                }
-                else {
-                  child = (DefaultMutableTreeNode)treeNode.getChildAt(j);
-                }
-                if (j != pathNode.getChildIndex()) {
-                  setupTreeNode(child, newChild);
-                  model.reload(child);
-                }
-                else {
-                  child.setUserObject(newChild);
-                  child.setAllowsChildren(newChild.hasChildren());
-                  child.removeAllChildren();
-                }
-
-                // TODO(jacobr): we are likely calling the wrong node structure changed APIs.
-                // For example, we should be getting these change notifications for free if we
-                // switched to call methods on the model object directly to manipulate the tree.
-                model.nodeChanged(child);
-                model.nodeStructureChanged(child);
+            DefaultMutableTreeNode treeNode = getRootNode();
+            final DefaultTreeModel model = getTreeModel();
+            final DefaultMutableTreeNode[] treePath = new DefaultMutableTreeNode[path.size()];
+            for (int i = 0; i < path.size(); ++i) {
+              treePath[i] = treeNode;
+              final DiagnosticsPathNode pathNode = path.get(i);
+              final DiagnosticsNode pathDiagnosticNode = pathNode.getNode();
+              final ArrayList<DiagnosticsNode> newChildren = pathNode.getChildren();
+              final DiagnosticsNode existingNode = getDiagnosticNode(treeNode);
+              if (!identicalDiagnosticsNodes(pathDiagnosticNode, existingNode)) {
+                treeNode.setUserObject(pathDiagnosticNode);
               }
-              model.reload(treeNode);
+              treeNode.setAllowsChildren(!newChildren.isEmpty());
+              for (int j = 0; j < newChildren.size(); ++j) {
+                final DiagnosticsNode newChild = newChildren.get(j);
+                if (j >= treeNode.getChildCount() || !identicalDiagnosticsNodes(newChild, getDiagnosticNode(treeNode.getChildAt(j)))) {
+                  final DefaultMutableTreeNode child;
+                  if (j >= treeNode.getChildCount()) {
+                    child = new DefaultMutableTreeNode();
+                    treeNode.add(child);
+                  }
+                  else {
+                    child = (DefaultMutableTreeNode)treeNode.getChildAt(j);
+                  }
+                  if (j != pathNode.getChildIndex()) {
+                    setupTreeNode(child, newChild, false);
+                    model.reload(child);
+                  }
+                  else {
+                    child.setUserObject(newChild);
+                    child.setAllowsChildren(newChild.hasChildren());
+                    child.removeAllChildren();
+                  }
+
+                  // TODO(jacobr): we are likely calling the wrong node structure changed APIs.
+                  // For example, we should be getting these change notifications for free if we
+                  // switched to call methods on the model object directly to manipulate the tree.
+                  model.nodeChanged(child);
+                  model.nodeStructureChanged(child);
+                }
+                model.reload(treeNode);
+              }
+              if (i != path.size() - 1) {
+                treeNode = (DefaultMutableTreeNode)treeNode.getChildAt(pathNode.getChildIndex());
+              }
             }
-            if (i != path.size() - 1) {
-              treeNode = (DefaultMutableTreeNode)treeNode.getChildAt(pathNode.getChildIndex());
-            }
-          }
-          final TreePath selectionPath = new TreePath(treePath);
-          myRootsTree.setSelectionPath(selectionPath);
-          myRootsTree.scrollPathToVisible(selectionPath);
-        });
+            // TODO(jacobr): review and simplify this.
+            final TreePath selectionPath = new TreePath(treePath);
+            myRootsTree.setSelectionPath(selectionPath);
+            animateTo(treePath[treePath.length - 1]);
+          });
       }
     });
   }
 
-  private DiagnosticsNode getSelectedDiagnostic() {
-    if (selectedNode == null) {
-      return null;
+  protected void applyNewSelection(DiagnosticsNode newSelection,
+                                   DiagnosticsNode detailsSelection,
+                                   boolean setSubtreeRoot) {
+    final DefaultMutableTreeNode nodeInTree = findMatchingTreeNode(newSelection);
+
+    if (nodeInTree == null) {
+      // The tree has probably changed since we last updated. Do a full refresh
+      // so that the tree includes the new node we care about.
+      recomputeTreeRoot(newSelection, detailsSelection, setSubtreeRoot);
     }
-    final Object userObject = selectedNode.getUserObject();
-    return (userObject instanceof DiagnosticsNode) ? (DiagnosticsNode)userObject : null;
+
+    refreshSelection(newSelection, detailsSelection, setSubtreeRoot);
+  }
+
+  private DiagnosticsNode getSelectedDiagnostic() {
+    return getDiagnosticNode(selectedNode);
+  }
+
+  private void animateTo(DefaultMutableTreeNode node) {
+    if (node == null) {
+      return;
+    }
+    final List<TreePath> targets = new ArrayList<>();
+    final TreePath target = new TreePath(node.getPath());
+    targets.add(target);
+
+    // Backtrack to the the first non-property parent so that all properties
+    // for the node are visible if one property is animated to. This is helpful
+    // as typically users want to view the properties of a node as a chunk.
+    for (int i = target.getPathCount() - 1; i >= 0; i--) {
+      node = (DefaultMutableTreeNode)target.getPathComponent(i);
+      final Object userObject = node.getUserObject();
+      if (userObject instanceof DiagnosticsNode && !((DiagnosticsNode)userObject).isProperty()) {
+        break;
+      }
+    }
+    // Make sure we scroll so that immediate un-expanded children
+    // are also in view. There is no risk in including these children as
+    // the amount of space they take up is bounded. This also ensures that if
+    // a node is selected, its properties will also be selected as by
+    // convention properties are the first children of a node and properties
+    // typically do not have children and are never expanded by default.
+    for (int i = 0; i < node.getChildCount(); ++i) {
+      final DefaultMutableTreeNode child = (DefaultMutableTreeNode)node.getChildAt(i);
+      final DiagnosticsNode diagnosticsNode = TreeUtils.maybeGetDiagnostic(child);
+      final TreePath childPath = new TreePath(child.getPath());
+      targets.add(childPath);
+      if (!child.isLeaf() && myRootsTree.isExpanded(childPath)) {
+        // Stop if we get to expanded children as they might be too large
+        // to try to scroll into view.
+        break;
+      }
+      if (diagnosticsNode != null && !diagnosticsNode.isProperty()) {
+        break;
+      }
+    }
+    scrollAnimator.animateTo(targets);
   }
 
   private void maybePopulateChildren(DefaultMutableTreeNode treeNode) {
@@ -417,50 +1010,135 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
     if (userObject instanceof DiagnosticsNode) {
       final DiagnosticsNode diagnostic = (DiagnosticsNode)userObject;
       if (diagnostic.hasChildren() && treeNode.getChildCount() == 0) {
-        final CompletableFuture<ArrayList<DiagnosticsNode>> childrenFuture = diagnostic.getChildren();
-        whenCompleteUiThread(childrenFuture, (ArrayList<DiagnosticsNode> children, Throwable throwable) -> {
+        diagnostic.safeWhenComplete(diagnostic.getChildren(), (ArrayList<DiagnosticsNode> children, Throwable throwable) -> {
           if (throwable != null) {
-            // TODO(jacobr): show an error in the UI that we could not load children.
+            LOG.error(throwable);
             return;
           }
           if (treeNode.getChildCount() == 0) {
-            setupChildren(treeNode, children);
+            setupChildren(diagnostic, treeNode, children, true);
           }
           getTreeModel().nodeStructureChanged(treeNode);
-          // TODO(jacobr): do we need to do anything else to mark the tree as dirty?
+          if (treeNode == selectedNode) {
+            myRootsTree.expandPath(new TreePath(treeNode.getPath()));
+          }
         });
       }
     }
   }
 
-  private void selectionChanged() {
+  private void setSelectedNode(DefaultMutableTreeNode newSelection) {
+    if (newSelection == selectedNode) {
+      return;
+    }
+    if (selectedNode != null) {
+      if (!detailsSubtree) {
+        getTreeModel().nodeChanged(selectedNode.getParent());
+      }
+    }
+    selectedNode = newSelection;
+    animateTo(selectedNode);
+
+    lastExpanded = null; // New selected node takes prescidence.
+    endShowNode();
+    if (subtreePanel != null) {
+      subtreePanel.endShowNode();
+    }
+    else if (parentTree != null) {
+      parentTree.endShowNode();
+    }
+  }
+
+  private void selectionChanged(TreeSelectionEvent event) {
+    if (visibleToUser == false) {
+      return;
+    }
+
     final DefaultMutableTreeNode[] selectedNodes = myRootsTree.getSelectedNodes(DefaultMutableTreeNode.class, null);
     for (DefaultMutableTreeNode node : selectedNodes) {
       maybePopulateChildren(node);
     }
-
+    if (programaticSelectionChangeInProgress) {
+      return;
+    }
     if (selectedNodes.length > 0) {
-      selectedNode = selectedNodes[0];
-      final Object userObject = selectedNodes[0].getUserObject();
-      if (userObject instanceof DiagnosticsNode) {
-        final DiagnosticsNode diagnostic = (DiagnosticsNode)userObject;
-        if (isCreatedByLocalProject(diagnostic)) {
-          diagnostic.getCreationLocation().getXSourcePosition().createNavigatable(getFlutterApp().getProject())
-            .navigate(false);
+      assert (selectedNodes.length == 1);
+      setSelectedNode(selectedNodes[0]);
+
+      final DiagnosticsNode selectedDiagnostic = getSelectedDiagnostic();
+      // Don't reroot if the selected value is already visible in the details tree.
+      final boolean maybeReroot = isSummaryTree && subtreePanel != null && selectedDiagnostic != null &&
+                                  !subtreePanel.hasDiagnosticsValue(selectedDiagnostic.getValueRef());
+      syncSelectionHelper(maybeReroot, null);
+      if (maybeReroot == false) {
+        if (isSummaryTree && subtreePanel != null) {
+          subtreePanel.selectAndShowNode(selectedDiagnostic);
         }
-        myPropertiesPanel.showProperties(diagnostic);
-        if (getInspectorService() != null) {
-          getInspectorService().setSelection(diagnostic.getValueRef(), false);
+        else if (parentTree != null) {
+          parentTree.selectAndShowNode(firstAncestorInParentTree(selectedNode));
         }
       }
     }
   }
 
-  private void initTree(final Tree tree) {
-    tree.setCellRenderer(new DiagnosticsTreeCellRenderer());
-    tree.setShowsRootHandles(true);
-    UIUtil.setLineStyleAngled(tree);
+  DiagnosticsNode firstAncestorInParentTree(DefaultMutableTreeNode node) {
+    if (parentTree == null) {
+      return getDiagnosticNode(node);
+    }
+    while (node != null) {
+      DiagnosticsNode diagnostic = getDiagnosticNode(node);
+      if (diagnostic != null && parentTree.hasDiagnosticsValue(diagnostic.getValueRef())) {
+        return parentTree.findDiagnosticsValue(diagnostic.getValueRef());
+      }
+      node = (DefaultMutableTreeNode)node.getParent();
+    }
+    return null;
+  }
 
+  private void syncSelectionHelper(boolean maybeRerootSubtree, DiagnosticsNode detailsSelection) {
+    if (!detailsSubtree && selectedNode != null) {
+      getTreeModel().nodeChanged(selectedNode.getParent());
+    }
+    final DiagnosticsNode diagnostic = getSelectedDiagnostic();
+    if (diagnostic != null) {
+      if (isCreatedByLocalProject(diagnostic)) {
+        diagnostic.getCreationLocation().getXSourcePosition().createNavigatable(getFlutterApp().getProject())
+          .navigate(false);
+      }
+    }
+    if (myPropertiesPanel != null) {
+      myPropertiesPanel.showProperties(diagnostic);
+    }
+    if (detailsSubtree || subtreePanel == null) {
+      if (diagnostic != null) {
+        DiagnosticsNode toSelect = diagnostic;
+        if (diagnostic.isProperty()) {
+          // Set the selection to the parent of the property not the property as what we
+          // should display on device is the selected widget not the selected property
+          // of the widget.
+          final TreePath path = new TreePath(selectedNode.getPath());
+          // TODO(jacobr): even though it isn't currently an issue, we should
+          // search for the first non-diagnostic node parent instead of just
+          // assuming the first parent is a regular node.
+          toSelect = getDiagnosticNode((DefaultMutableTreeNode)path.getPathComponent(path.getPathCount() - 2));
+        }
+        toSelect.getInspectorService().setSelection(toSelect.getValueRef(), true);
+      }
+    }
+
+    if (maybeRerootSubtree) {
+      showDetailSubtrees(diagnostic, detailsSelection);
+    }
+    else if (diagnostic != null) {
+      // We can't rely on the details tree to update the selection on the server in this case.
+      DiagnosticsNode selection = detailsSelection != null ? detailsSelection : diagnostic;
+      selection.getInspectorService().setSelection(selection.getValueRef(), true);
+    }
+  }
+
+  private void initTree(final Tree tree) {
+    tree.setCellRenderer(new DiagnosticsTreeCellRenderer(this));
+    tree.setShowsRootHandles(true);
     TreeUtil.installActions(tree);
 
     PopupHandler.installUnknownPopupHandler(tree, createTreePopupActions(), ActionManager.getInstance());
@@ -492,52 +1170,44 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
   public void dispose() {
     flutterIsolateSubscription.dispose();
     // TODO(jacobr): actually implement.
+    final InspectorService service = getInspectorService();
+    if (service != null) {
+      shutdownTree(false);
+    }
+    // TODO(jacobr): verify subpanels are disposed as well.
   }
 
-  private static class TreeDataProvider extends Tree implements DataProvider, Disposable {
-    private TreeDataProvider(final DefaultMutableTreeNode treemodel, String treeName) {
-      super(treemodel);
-
-      setRootVisible(false);
-      registerShortcuts();
-      getEmptyText().setText(treeName + " tree for the running app");
-
-      // Decrease indent, scaled for different display types.
-      final BasicTreeUI ui = (BasicTreeUI)getUI();
-      ui.setRightChildIndent(JBUI.scale(4));
+  boolean isCreatedByLocalProject(DiagnosticsNode node) {
+    if (node.isCreatedByLocalProject()) {
+      return true;
     }
-
-    void registerShortcuts() {
-      DebuggerUIUtil.registerActionOnComponent(InspectorActions.JUMP_TO_TYPE_SOURCE, this, this);
+    // TODO(jacobr): remove the following code once the
+    // `setPubRootDirectories` method has been in two revs of the Flutter Alpha
+    // channel. The feature is expected to have landed in the Flutter dev
+    // chanel on March 2, 2018.
+    final InspectorSourceLocation location = node.getCreationLocation();
+    if (location == null) {
+      return false;
     }
-
-    @SuppressWarnings("EmptyMethod")
-    @Override
-    protected void paintComponent(final Graphics g) {
-      // TOOD(jacobr): actually perform some custom painting.
-      // For example, we should consider custom painting to display offstage objects differently.
-      super.paintComponent(g);
+    final VirtualFile file = location.getFile();
+    if (file == null) {
+      return false;
     }
-
-    @Override
-    public void dispose() {
-      // TODO(jacobr): do we have anything to dispose?
-    }
-
-    @Nullable
-    @Override
-    public Object getData(String dataId) {
-      if (INSPECTOR_KEY.is(dataId)) {
-        return this;
-      }
-      if (PlatformDataKeys.PREDEFINED_TEXT.is(dataId)) {
-        final XValueNodeImpl[] selectedNodes = getSelectedNodes(XValueNodeImpl.class, null);
-        if (selectedNodes.length == 1 && selectedNodes[0].getFullValueEvaluator() == null) {
-          return DebuggerUIUtil.getNodeRawValue(selectedNodes[0]);
+    final String filePath = file.getCanonicalPath();
+    if (filePath != null) {
+      for (PubRoot root : getFlutterApp().getPubRoots()) {
+        final String canonicalPath = root.getRoot().getCanonicalPath();
+        if (canonicalPath != null && filePath.startsWith(canonicalPath)) {
+          return true;
         }
       }
-      return null;
     }
+    return false;
+  }
+
+  boolean hasPlaceholderChildren(DefaultMutableTreeNode node) {
+    return node.getChildCount() == 0 ||
+           (node.getChildCount() == 1 && ((DefaultMutableTreeNode)node.getFirstChild()).getUserObject() instanceof String);
   }
 
   static class PropertyNameColumnInfo extends ColumnInfo<DefaultMutableTreeNode, DiagnosticsNode> {
@@ -579,177 +1249,6 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
     }
   }
 
-  private static class PropertiesPanel extends TreeTableView implements DataProvider {
-    /**
-     * Diagnostic we are displaying properties for.
-     */
-    private DiagnosticsNode diagnostic;
-
-    /**
-     * Current properties being displayed.
-     */
-    private ArrayList<DiagnosticsNode> currentProperties;
-
-    PropertiesPanel() {
-      super(new ListTreeTableModelOnColumns(
-        new DefaultMutableTreeNode(),
-        new ColumnInfo[]{
-          new PropertyNameColumnInfo("Property"),
-          new PropertyValueColumnInfo("Value")
-        }
-      ));
-      setRootVisible(false);
-
-      setStriped(true);
-      setRowHeight(getRowHeight() + JBUI.scale(4));
-
-      final JTableHeader tableHeader = getTableHeader();
-      tableHeader.setPreferredSize(new Dimension(0, getRowHeight()));
-
-      getColumnModel().getColumn(0).setPreferredWidth(120);
-      getColumnModel().getColumn(1).setPreferredWidth(200);
-    }
-
-    private ActionGroup createTreePopupActions() {
-      final DefaultActionGroup group = new DefaultActionGroup();
-      final ActionManager actionManager = ActionManager.getInstance();
-      group.add(actionManager.getAction(InspectorActions.JUMP_TO_SOURCE));
-      // TODO(pq): implement
-      //group.add(new JumpToPropertyDeclarationAction());
-      return group;
-    }
-
-    ListTreeTableModelOnColumns getTreeModel() {
-      return (ListTreeTableModelOnColumns)getTableModel();
-    }
-
-    public void showProperties(DiagnosticsNode diagnostic) {
-      this.diagnostic = diagnostic;
-
-      if (diagnostic == null) {
-        getEmptyText().setText(FlutterBundle.message("app.inspector.nothing_to_show"));
-        getTreeModel().setRoot(new DefaultMutableTreeNode());
-        return;
-      }
-      getEmptyText().setText(FlutterBundle.message("app.inspector.loading_properties"));
-      whenCompleteUiThread(diagnostic.getProperties(), (ArrayList<DiagnosticsNode> properties, Throwable throwable) -> {
-        if (throwable != null) {
-          getTreeModel().setRoot(new DefaultMutableTreeNode());
-          getEmptyText().setText(FlutterBundle.message("app.inspector.error_loading_properties"));
-          LOG.error(throwable);
-          return;
-        }
-        showPropertiesHelper(properties);
-        PopupHandler.installUnknownPopupHandler(this, createTreePopupActions(), ActionManager.getInstance());
-      });
-    }
-
-    private void showPropertiesHelper(ArrayList<DiagnosticsNode> properties) {
-      currentProperties = properties;
-      if (properties.size() == 0) {
-        getTreeModel().setRoot(new DefaultMutableTreeNode());
-        getEmptyText().setText(FlutterBundle.message("app.inspector.no_properties"));
-        return;
-      }
-      whenCompleteUiThread(loadPropertyMetadata(properties), (Void ignored, Throwable errorGettingInstances) -> {
-        if (errorGettingInstances != null) {
-          // TODO(jacobr): show error message explaining properties could not
-          // be loaded.
-          getTreeModel().setRoot(new DefaultMutableTreeNode());
-          LOG.error(errorGettingInstances);
-          getEmptyText().setText(FlutterBundle.message("app.inspector.error_loading_property_details"));
-          return;
-        }
-        setModelFromProperties(properties);
-      });
-    }
-
-    private void setModelFromProperties(ArrayList<DiagnosticsNode> properties) {
-      final ListTreeTableModelOnColumns model = getTreeModel();
-      final DefaultMutableTreeNode root = new DefaultMutableTreeNode();
-      for (DiagnosticsNode property : properties) {
-        if (property.getLevel() != DiagnosticLevel.hidden) {
-          root.add(new DefaultMutableTreeNode(property));
-        }
-      }
-      getEmptyText().setText(FlutterBundle.message("app.inspector.all_properties_hidden"));
-      model.setRoot(root);
-    }
-
-    private CompletableFuture<Void> loadPropertyMetadata(ArrayList<DiagnosticsNode> properties) {
-      // Preload all information we need about each property before instantiating
-      // the UI so that the property display UI does not have to deal with values
-      // that are not yet available. As the number of properties is small this is
-      // a reasonable tradeoff.
-      final CompletableFuture[] futures = new CompletableFuture[properties.size()];
-      int i = 0;
-      for (DiagnosticsNode property : properties) {
-        futures[i] = property.getValueProperties();
-        ++i;
-      }
-      return CompletableFuture.allOf(futures);
-    }
-
-    private CompletableFuture<?> refresh() {
-      if (diagnostic == null) {
-        final CompletableFuture<Void> refreshComplete = new CompletableFuture<>();
-        refreshComplete.complete(null);
-        return refreshComplete;
-      }
-      final CompletableFuture<ArrayList<DiagnosticsNode>> propertiesFuture = diagnostic.getProperties();
-      whenCompleteUiThread(propertiesFuture, (ArrayList<DiagnosticsNode> properties, Throwable throwable) -> {
-        if (throwable != null) {
-          return;
-        }
-        if (propertiesIdentical(properties, currentProperties)) {
-          return;
-        }
-        showPropertiesHelper(properties);
-      });
-      return propertiesFuture;
-    }
-
-    private boolean propertiesIdentical(ArrayList<DiagnosticsNode> a, ArrayList<DiagnosticsNode> b) {
-      if (a == b) {
-        return true;
-      }
-      if (a == null || b == null) {
-        return false;
-      }
-      if (a.size() != b.size()) {
-        return false;
-      }
-      for (int i = 0; i < a.size(); ++i) {
-        if (!a.get(i).identicalDisplay(b.get(i))) {
-          return false;
-        }
-      }
-      return true;
-    }
-
-    @Nullable
-    @Override
-    public Object getData(String dataId) {
-      return INSPECTOR_KEY.is(dataId) ? getTree() : null;
-    }
-  }
-
-  private static SimpleTextAttributes textAttributesForLevel(DiagnosticLevel level) {
-    switch (level) {
-      case hidden:
-      case fine:
-        return SimpleTextAttributes.GRAYED_ATTRIBUTES;
-      case warning:
-        return WARNING_ATTRIBUTES;
-      case error:
-        return SimpleTextAttributes.ERROR_ATTRIBUTES;
-      case debug:
-      case info:
-      default:
-        return SimpleTextAttributes.REGULAR_ATTRIBUTES;
-    }
-  }
-
   private static class PropertyNameRenderer extends ColoredTableCellRenderer {
     @Override
     protected void customizeCellRenderer(JTable table, @Nullable Object value, boolean selected, boolean hasFocus, int row, int column) {
@@ -762,13 +1261,14 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
       }
       // Present user defined properties in BOLD.
       final SimpleTextAttributes attributes =
-        node.hasCreationLocation() ? SimpleTextAttributes.REGULAR_BOLD_ATTRIBUTES : SimpleTextAttributes.REGULAR_ATTRIBUTES;
+        node.hasCreationLocation() ? SimpleTextAttributes.REGULAR_ITALIC_ATTRIBUTES : SimpleTextAttributes.REGULAR_ATTRIBUTES;
       append(node.getName(), attributes);
 
       // Set property description in tooltip.
       // TODO (pq):
       //  * consider tooltips for values
       //  * consider rich navigation hovers (w/ styling and navigable docs)
+
       final CompletableFuture<String> propertyDoc = node.getPropertyDoc();
       final String doc = propertyDoc.getNow(null);
       if (doc != null) {
@@ -777,7 +1277,8 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
       else {
         // Make sure we see nothing stale while we wait.
         setToolTipText(null);
-        AsyncUtils.whenCompleteUiThread(propertyDoc, (String tooltip, Throwable th) -> {
+        node.safeWhenComplete(propertyDoc, (String tooltip, Throwable th) -> {
+          // TODO(jacobr): make sure we still care about seeing this tooltip.
           if (th != null) {
             LOG.error(th);
           }
@@ -871,132 +1372,197 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
     }
   }
 
-  private class DiagnosticsTreeCellRenderer extends ColoredTreeCellRenderer {
+  private class PropertiesPanel extends TreeTableView implements DataProvider {
+    private final InspectorObjectGroupManager groups;
+    private final FlutterApp flutterApp;
     /**
-     * Split text into two groups, word characters at the start of a string
-     * and all other characters. Skip an <code>-</code> or <code>#</code> between the
-     * two groups.
+     * Diagnostic we are displaying properties for.
      */
-    private final Pattern primaryDescriptionPattern = Pattern.compile("(\\w+)[-#]?(.*)");
+    private DiagnosticsNode diagnostic;
+    /**
+     * Current properties being displayed.
+     */
+    private ArrayList<DiagnosticsNode> currentProperties;
 
-    private JTree tree;
-    private boolean selected;
+    PropertiesPanel(FlutterApp flutterApp, InspectorService inspectorService) {
+      super(new ListTreeTableModelOnColumns(
+        new DefaultMutableTreeNode(),
+        new ColumnInfo[]{
+          new PropertyNameColumnInfo("Property"),
+          new PropertyValueColumnInfo("Value")
+        }
+      ));
+      this.flutterApp = flutterApp;
+      this.groups = new InspectorObjectGroupManager(inspectorService, "panel");
+      setRootVisible(false);
 
-    public void customizeCellRenderer(
-      @NotNull final JTree tree,
-      final Object value,
-      final boolean selected,
-      final boolean expanded,
-      final boolean leaf,
-      final int row,
-      final boolean hasFocus
-    ) {
+      setStriped(true);
+      setRowHeight(getRowHeight() + JBUI.scale(4));
 
-      this.tree = tree;
-      this.selected = selected;
+      final JTableHeader tableHeader = getTableHeader();
+      tableHeader.setPreferredSize(new Dimension(0, getRowHeight()));
 
-      final Object userObject = ((DefaultMutableTreeNode)value).getUserObject();
-      if (userObject instanceof String) {
-        appendText((String)userObject, SimpleTextAttributes.GRAYED_ATTRIBUTES);
+      getColumnModel().getColumn(0).setPreferredWidth(120);
+      getColumnModel().getColumn(1).setPreferredWidth(200);
+    }
+
+    private ActionGroup createTreePopupActions() {
+      final DefaultActionGroup group = new DefaultActionGroup();
+      final ActionManager actionManager = ActionManager.getInstance();
+      group.add(actionManager.getAction(InspectorActions.JUMP_TO_SOURCE));
+      // TODO(pq): implement
+      //group.add(new JumpToPropertyDeclarationAction());
+      return group;
+    }
+
+    ListTreeTableModelOnColumns getTreeModel() {
+      return (ListTreeTableModelOnColumns)getTableModel();
+    }
+
+    public void showProperties(DiagnosticsNode diagnostic) {
+      this.diagnostic = diagnostic;
+      if (diagnostic == null || diagnostic.getInspectorService().isDisposed()) {
+        shutdownTree(false);
         return;
       }
-      if (!(userObject instanceof DiagnosticsNode)) return;
-      final DiagnosticsNode node = (DiagnosticsNode)userObject;
-      final String name = node.getName();
-      SimpleTextAttributes textAttributes = textAttributesForLevel(node.getLevel());
-      if (StringUtils.isNotEmpty(name) && node.getShowName()) {
-        // color in name?
-        if (name.equals("child") || name.startsWith("child ")) {
-          appendText(name, SimpleTextAttributes.GRAYED_ATTRIBUTES);
-        }
-        else {
-          appendText(name, textAttributes);
-        }
-
-        if (node.getShowSeparator()) {
-          // Is this good?
-          appendText(node.getSeparator(), SimpleTextAttributes.GRAY_ATTRIBUTES);
-        }
-        appendText(" ", SimpleTextAttributes.GRAY_ATTRIBUTES);
-      }
-
-      if (isCreatedByLocalProject(node)) {
-        textAttributes = textAttributes.derive(SimpleTextAttributes.REGULAR_BOLD_ATTRIBUTES.getStyle(), null, null, null);
-      }
-
-      // TODO(jacobr): custom display for units, colors, iterables, and icons.
-      final String description = node.getDescription();
-      final Matcher match = primaryDescriptionPattern.matcher(description);
-      if (match.matches()) {
-        appendText(match.group(1), textAttributes);
-        appendText(" ", textAttributes);
-        appendText(match.group(2), SimpleTextAttributes.GRAYED_ATTRIBUTES);
-      }
-      else {
-        appendText(node.getDescription(), textAttributes);
-      }
-
-      if (node.hasTooltip()) {
-        setToolTipText(node.getTooltip());
-      }
-
-      final Icon icon = node.getIcon();
-      if (icon != null) {
-        setIcon(icon);
-      }
+      getEmptyText().setText(FlutterBundle.message("app.inspector.loading_properties"));
+      groups.cancelNext();
+      groups.getNext()
+        .safeWhenComplete(diagnostic.getProperties(groups.getNext()), (ArrayList<DiagnosticsNode> properties, Throwable throwable) -> {
+          if (throwable != null) {
+            getTreeModel().setRoot(new DefaultMutableTreeNode());
+            getEmptyText().setText(FlutterBundle.message("app.inspector.error_loading_properties"));
+            LOG.error(throwable);
+            groups.cancelNext();
+            return;
+          }
+          showPropertiesHelper(properties);
+          PopupHandler.installUnknownPopupHandler(this, createTreePopupActions(), ActionManager.getInstance());
+        });
     }
 
-    private void appendText(@NotNull String text, @NotNull SimpleTextAttributes attributes) {
-      SpeedSearchUtil.appendFragmentsForSpeedSearch(tree, text, attributes, selected, this);
+    private void showPropertiesHelper(ArrayList<DiagnosticsNode> properties) {
+      currentProperties = properties;
+      if (properties.size() == 0) {
+        getTreeModel().setRoot(new DefaultMutableTreeNode());
+        getEmptyText().setText(FlutterBundle.message("app.inspector.no_properties"));
+        groups.promoteNext();
+        return;
+      }
+      groups.getNext().safeWhenComplete(loadPropertyMetadata(properties), (Void ignored, Throwable errorGettingInstances) -> {
+        if (errorGettingInstances != null) {
+          // TODO(jacobr): show error message explaining properties could not
+          // be loaded.
+          getTreeModel().setRoot(new DefaultMutableTreeNode());
+          LOG.error(errorGettingInstances);
+          getEmptyText().setText(FlutterBundle.message("app.inspector.error_loading_property_details"));
+          groups.cancelNext();
+          return;
+        }
+        groups.promoteNext();
+        setModelFromProperties(properties);
+      });
     }
-  }
 
-  boolean isCreatedByLocalProject(DiagnosticsNode node) {
-    if (node.isCreatedByLocalProject()) {
+    private void setModelFromProperties(ArrayList<DiagnosticsNode> properties) {
+      final ListTreeTableModelOnColumns model = getTreeModel();
+      final DefaultMutableTreeNode root = new DefaultMutableTreeNode();
+      for (DiagnosticsNode property : properties) {
+        if (property.getLevel() != DiagnosticLevel.hidden) {
+          root.add(new DefaultMutableTreeNode(property));
+        }
+      }
+      getEmptyText().setText(FlutterBundle.message("app.inspector.all_properties_hidden"));
+      model.setRoot(root);
+    }
+
+    private CompletableFuture<Void> loadPropertyMetadata(ArrayList<DiagnosticsNode> properties) {
+      // Preload all information we need about each property before instantiating
+      // the UI so that the property display UI does not have to deal with values
+      // that are not yet available. As the number of properties is small this is
+      // a reasonable tradeoff.
+      final CompletableFuture[] futures = new CompletableFuture[properties.size()];
+      int i = 0;
+      for (DiagnosticsNode property : properties) {
+        futures[i] = property.getValueProperties();
+        ++i;
+      }
+      return CompletableFuture.allOf(futures);
+    }
+
+    private void refresh() {
+      if (diagnostic == null) {
+        return;
+      }
+      // We don't know whether we will switch to the new group or keep the current group
+      // until we have tested whether the properties are identical.
+
+      groups.cancelNext(); // Cancel any existing pending next state.
+      if (diagnostic.getInspectorService().isDisposed()) {
+        // We are getting properties for a stale object. Wait until the next frame when we will have new properties.
+        return;
+      }
+      groups.getNext()
+        .safeWhenComplete(diagnostic.getProperties(groups.getNext()), (ArrayList<DiagnosticsNode> properties, Throwable throwable) -> {
+          if (throwable != null || propertiesIdentical(properties, currentProperties)) {
+            // Dispose the new group as it wasn't used
+            groups.cancelNext();
+            return;
+          }
+          showPropertiesHelper(properties);
+        });
+    }
+
+    private boolean propertiesIdentical(ArrayList<DiagnosticsNode> a, ArrayList<DiagnosticsNode> b) {
+      if (a == b) {
+        return true;
+      }
+      if (a == null || b == null) {
+        return false;
+      }
+      if (a.size() != b.size()) {
+        return false;
+      }
+      for (int i = 0; i < a.size(); ++i) {
+        if (!a.get(i).identicalDisplay(b.get(i))) {
+          return false;
+        }
+      }
       return true;
     }
-    // TODO(jacobr): remove the following code once the
-    // `setPubRootDirectories` method has been in two revs of the Flutter Alpha
-    // channel. The feature is expected to have landed in the Flutter dev
-    // chanel on March 2, 2018.
-    final InspectorSourceLocation location = node.getCreationLocation();
-    if (location == null) {
-      return false;
-    }
-    final VirtualFile file = location.getFile();
-    if (file == null) {
-      return false;
-    }
-    final String filePath = file.getCanonicalPath();
-    if (filePath != null) {
-      for (PubRoot root : getFlutterApp().getPubRoots()) {
-        final String canonicalPath = root.getRoot().getCanonicalPath();
-        if (canonicalPath != null && filePath.startsWith(canonicalPath)) {
-          return true;
-        }
-      }
-    }
-    return false;
-  }
 
-  boolean placeholderChildren(DefaultMutableTreeNode node) {
-    return node.getChildCount() == 0 ||
-           (node.getChildCount() == 1 && ((DefaultMutableTreeNode)node.getFirstChild()).getUserObject() instanceof String);
+    @Nullable
+    @Override
+    public Object getData(String dataId) {
+      return InspectorTree.INSPECTOR_KEY.is(dataId) ? getTree() : null;
+    }
+
+    public void shutdownTree(boolean isolateStopped) {
+      diagnostic = null;
+      getEmptyText().setText(FlutterBundle.message("app.inspector.nothing_to_show"));
+      getTreeModel().setRoot(new DefaultMutableTreeNode());
+      groups.clear(isolateStopped);
+    }
+
+    public CompletableFuture<?> getPendingUpdateDone() {
+      return groups.getPendingUpdateDone();
+    }
   }
 
   private class MyTreeExpansionListener implements TreeExpansionListener {
     @Override
     public void treeExpanded(TreeExpansionEvent event) {
-      maybeLoadChildren((DefaultMutableTreeNode)event.getPath().getLastPathComponent());
+      final DefaultMutableTreeNode treeNode = (DefaultMutableTreeNode)event.getPath().getLastPathComponent();
+      maybeLoadChildren(treeNode);
+
+      if (!programaticExpansionInProgress) {
+        lastExpanded = treeNode;
+        animateTo(treeNode);
+      }
     }
 
     @Override
     public void treeCollapsed(TreeExpansionEvent event) {
     }
-  }
-
-  @Nullable
-  public static Tree getTree(final DataContext e) {
-    return e.getData(INSPECTOR_KEY);
   }
 }

--- a/src/io/flutter/view/InspectorTreeMouseListener.java
+++ b/src/io/flutter/view/InspectorTreeMouseListener.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2018 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.view;
+
+import com.google.common.base.Joiner;
+import com.intellij.openapi.diagnostic.Logger;
+import io.flutter.inspector.DiagnosticsNode;
+import io.flutter.inspector.TreeUtils;
+
+import javax.swing.*;
+import javax.swing.tree.DefaultMutableTreeNode;
+import javax.swing.tree.TreeCellRenderer;
+import javax.swing.tree.TreePath;
+import java.awt.*;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Listener that handles mouse interaction for the Inspector tree.
+ *
+ * Handles displaying tooltips, notifying the InspectorPanel of what node is
+ * being highlighted, and custom double click selection behavior.
+ */
+class InspectorTreeMouseListener extends MouseAdapter {
+  private InspectorPanel panel;
+  private final JTree tree;
+  private DefaultMutableTreeNode lastHover;
+
+  private static final Logger LOG = Logger.getInstance(InspectorTreeMouseListener.class);
+
+  InspectorTreeMouseListener(InspectorPanel panel, JTree tree) {
+    this.panel = panel;
+    this.tree = tree;
+  }
+
+  @Override
+  public void mouseExited(MouseEvent e) {
+    clearTooltip();
+    endShowNode();
+  }
+
+  @Override
+  public void mouseClicked(MouseEvent event) {
+    final DefaultMutableTreeNode node = getClosestTreeNode(event);
+    /// TODO(jacobr): support clicking on a property.
+    // It would be reasonable for that to trigger selecting the parent of the
+    // property.
+    final DiagnosticsNode diagnostic = TreeUtils.maybeGetDiagnostic(node);
+    if (diagnostic != null && !diagnostic.isProperty()) {
+      // A double click triggers forcing changing the subtree root.
+      if (event.getClickCount() == 2) {
+        if (panel.isSummaryTree) {
+          panel.applyNewSelection(diagnostic, diagnostic, true);
+        }
+        else if (panel.parentTree != null) {
+          panel.parentTree.applyNewSelection(
+            panel.firstAncestorInParentTree(node), diagnostic, true);
+        }
+      }
+    }
+    event.consume();
+  }
+
+  private void clearTooltip() {
+    final DiagnosticsTreeCellRenderer r = (DiagnosticsTreeCellRenderer)tree.getCellRenderer();
+    r.setToolTipText(null);
+    lastHover = null;
+  }
+
+  @Override
+  public void mouseMoved(MouseEvent event) {
+    calculateTooltip(event);
+    final DefaultMutableTreeNode treeNode = getTreeNode(event);
+    final DiagnosticsNode node = TreeUtils.maybeGetDiagnostic(treeNode);
+    if (node != null && !node.isProperty()) {
+      if (panel.detailsSubtree && panel.isCreatedByLocalProject(node)) {
+        panel.parentTree.highlightShowNode(node.getValueRef());
+      }
+      else if (panel.subtreePanel != null) {
+        panel.subtreePanel.highlightShowNode(node.getValueRef());
+      }
+      panel.highlightShowNode(treeNode);
+      return;
+    }
+  }
+
+  private void endShowNode() {
+    if (panel.detailsSubtree) {
+      panel.parentTree.endShowNode();
+    }
+    else if (panel.subtreePanel != null) {
+      panel.subtreePanel.endShowNode();
+    }
+    panel.endShowNode();
+  }
+
+  private void calculateTooltip(MouseEvent event) {
+    final Point p = event.getPoint();
+    final int row = tree.getClosestRowForLocation(p.x, p.y);
+
+    final TreeCellRenderer r = tree.getCellRenderer();
+    if (r == null) {
+      return;
+    }
+    if (row == -1) {
+      clearTooltip();
+      return;
+    }
+    final TreePath path = tree.getPathForRow(row);
+    final DefaultMutableTreeNode node = (DefaultMutableTreeNode)path.getLastPathComponent();
+    lastHover = node;
+    final Component rComponent = r.getTreeCellRendererComponent(tree, node, tree.isRowSelected(row), tree.isExpanded(row),
+                                                                tree.getModel().isLeaf(node), row, true);
+    final Rectangle pathBounds = tree.getPathBounds(path);
+    if (pathBounds == null) {
+      // Something went wrong and thepath isn't really visible.
+      return;
+    }
+    p.translate(-pathBounds.x, -pathBounds.y);
+    if (rComponent == null) {
+      clearTooltip();
+      return;
+    }
+
+    String tooltip = null;
+    final DiagnosticsTreeCellRenderer renderer = (DiagnosticsTreeCellRenderer)rComponent;
+    final DiagnosticsNode diagnostic = TreeUtils.maybeGetDiagnostic(node);
+    if (diagnostic != null) {
+      if (diagnostic.hasTooltip()) {
+        tooltip = diagnostic.getTooltip();
+      }
+      final Icon icon = renderer.getIconAt(p.x);
+      if (icon != null) {
+        if (icon == panel.defaultIcon) {
+          tooltip = "default value";
+        }
+      }
+      else {
+        if (diagnostic.getShowName()) {
+          final int fragmentIndex = renderer.findFragmentAt(p.x);
+          if (fragmentIndex == 0) {
+            // The name fragment is being hovered over.
+            // Set property description in tooltip.
+            // TODO (pq):
+            //  * consider tooltips for values
+            //  * consider rich navigation hovers (w/ styling and navigable docs)
+            final CompletableFuture<String> propertyDoc = diagnostic.getPropertyDoc();
+            final String doc = propertyDoc.getNow(null);
+            if (doc != null) {
+              tooltip = doc;
+            }
+            else {
+              tooltip = "Loading dart docs...";
+              diagnostic.getInspectorService().safeWhenComplete(propertyDoc, (String tip, Throwable th) -> {
+                if (th != null) {
+                  LOG.error(th);
+                }
+                if (lastHover == node) {
+                  // We are still hovering of the same node so show the user the tooltip.
+                  renderer.setToolTipText(tip);
+                }
+              });
+            }
+          }
+          else {
+            if (diagnostic.isEnumProperty()) {
+              // We can display a better tooltip as we have access to introspection
+              // via the observatory service.
+              diagnostic.getInspectorService().safeWhenComplete(diagnostic.getValueProperties(), (properties, th) -> {
+                if (properties == null || lastHover != node) {
+                  return;
+                }
+                renderer.setToolTipText("Allowed values:\n" + Joiner.on('\n').join(properties.keySet()));
+              });
+            }
+            else {
+              renderer.setToolTipText(diagnostic.getTooltip());
+            }
+          }
+        }
+      }
+    }
+    renderer.setToolTipText(tooltip);
+  }
+
+  /**
+   * Match IntelliJ's fuzzier standards for what it takes to select a node.
+   */
+  private DefaultMutableTreeNode getClosestTreeNode(MouseEvent event) {
+
+    final Point p = event.getPoint();
+    final int row = tree.getClosestRowForLocation(p.x, p.y);
+
+    final TreeCellRenderer r = tree.getCellRenderer();
+    if (row == -1 || r == null) {
+      return null;
+    }
+    final TreePath path = tree.getPathForRow(row);
+    return (DefaultMutableTreeNode)path.getLastPathComponent();
+  }
+
+  /**
+   * Requires the mouse to actually be over a tree node.
+   */
+  private DefaultMutableTreeNode getTreeNode(MouseEvent event) {
+    final Point p = event.getPoint();
+    final int row = tree.getRowForLocation(p.x, p.y);
+    final TreeCellRenderer r = tree.getCellRenderer();
+    if (row == -1 || r == null) {
+      return null;
+    }
+    final TreePath path = tree.getPathForRow(row);
+    return (DefaultMutableTreeNode)path.getLastPathComponent();
+  }
+}

--- a/src/io/flutter/view/InspectorTreeMouseListener.java
+++ b/src/io/flutter/view/InspectorTreeMouseListener.java
@@ -117,7 +117,7 @@ class InspectorTreeMouseListener extends MouseAdapter {
                                                                 tree.getModel().isLeaf(node), row, true);
     final Rectangle pathBounds = tree.getPathBounds(path);
     if (pathBounds == null) {
-      // Something went wrong and thepath isn't really visible.
+      // Something went wrong and the path isn't really visible.
       return;
     }
     p.translate(-pathBounds.x, -pathBounds.y);

--- a/testSrc/unit/io/flutter/inspector/FlutterWidgetTest.java
+++ b/testSrc/unit/io/flutter/inspector/FlutterWidgetTest.java
@@ -158,7 +158,7 @@ public class FlutterWidgetTest {
     private final String description;
 
     public FakeNode(String description) {
-      super(null, null);
+      super(null, null, false);
       this.description = description;
     }
 


### PR DESCRIPTION
My apologies on the size of this commit. The changes to InspectorPanel escalated to the point where the diff is not very readable at points.
To test locally, patch https://github.com/flutter/flutter/pull/16638 into your flutter build.
If you don't do that, everything will work and you will see the custom tree line drawing but you won't see a details-summary view.

TLDR for InspectorService is all methods that were on InspectorService are now on the InspectorService.ObjectGroup class so that lifecycles of object references can be managed and there are now tons of checks to make sure we stop chaining futures as soon as the ObjectGroup is disposed. 
The code should now never leak memory on the device instead of leaking all the objects referenced by the inspector. This is important as the inspector is now referencing a ton more objects.

Changes:
Detail summary tree (when --track-widget-creation is set).
Animated auto-horizontal scroll.
Animated scroll to selected tree node.
Proper memory management of object lifecycles so we don't cause the device to leak a ton of memory.
The concept of an ObjectGroup which existed in the protocol but wasn't really exposed on the IntelliJ is used extensively to achieve that goal. 

Custom tree view rendering with lines between parents and children including dashed lines for offstage children.
Display of all properties inline in the tree view with the same tooltips and custom rendering as for the table view.
We are now aggressive at shutting down the inspector tree when you tab away from it rebuilding the tree from scratch when you tab back. This means we no longer pay the cost for the render tree when users rarely ever tab to it.
Fixes for out of order execution bugs that are now an issue given we are disposing object groups.

Lots of extra checks to make sure we dump the value of a future returned if the object group is disposed.

Extra menu item to trigger a UI refresh and an extra menu item to turn off the auto horizontal scrolling.