### PR TITLE
Auto-toggle offline mode if we’re obviously offline (#1923).

### DIFF
--- a/src/io/flutter/module/settings/FlutterCreateAdditionalSettingsFields.java
+++ b/src/io/flutter/module/settings/FlutterCreateAdditionalSettingsFields.java
@@ -103,7 +103,7 @@ public class FlutterCreateAdditionalSettingsFields {
       settingsStep.addSettingsComponent(new SettingsHelpForm().getComponent());
     }
 
-    settingsStep.addSettingsComponent(createParams.getComponent());
+    settingsStep.addSettingsComponent(createParams.setInitialValues().getComponent());
   }
 
   public FlutterCreateAdditionalSettings getAdditionalSettings() {

--- a/src/io/flutter/module/settings/FlutterCreateParams.form
+++ b/src/io/flutter/module/settings/FlutterCreateParams.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="io.flutter.module.settings.FlutterCreateParams">
-  <grid id="27dc6" binding="mainPanel" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="mainPanel" layout-manager="GridLayoutManager" row-count="2" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="500" height="400"/>
@@ -13,16 +13,37 @@
           <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
-      <component id="681d2" class="javax.swing.JCheckBox" binding="createProjectOfflineCheckBox" default-binding="true">
+      <component id="ef6df" class="javax.swing.JLabel" binding="infoLabel">
         <constraints>
-          <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
-          <actionCommand value="Create project offline"/>
-          <text value="Create project &amp;offline" noi18n="true"/>
-          <toolTipText value="Run the flutter create command in &quot;offline&quot; mode."/>
+          <horizontalAlignment value="4"/>
+          <icon value="general/information.png"/>
+          <text value=""/>
+          <toolTipText value="Off-line mode auto-selected."/>
         </properties>
       </component>
+      <grid id="d7bac" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+        <margin top="0" left="0" bottom="0" right="3"/>
+        <constraints>
+          <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+        <border type="none"/>
+        <children>
+          <component id="681d2" class="javax.swing.JCheckBox" binding="createProjectOfflineCheckBox" default-binding="true">
+            <constraints>
+              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="1" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <actionCommand value="Create project offline"/>
+              <text value="Create project &amp;offline" noi18n="true"/>
+              <toolTipText value="Run the flutter create command in &quot;offline&quot; mode."/>
+            </properties>
+          </component>
+        </children>
+      </grid>
     </children>
   </grid>
 </form>

--- a/src/io/flutter/module/settings/FlutterCreateParams.form
+++ b/src/io/flutter/module/settings/FlutterCreateParams.form
@@ -21,7 +21,7 @@
           <horizontalAlignment value="4"/>
           <icon value="general/information.png"/>
           <text value=""/>
-          <toolTipText value="Off-line mode auto-selected."/>
+          <toolTipText value="Offline mode auto-selected."/>
         </properties>
       </component>
       <grid id="d7bac" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">

--- a/src/io/flutter/module/settings/FlutterCreateParams.java
+++ b/src/io/flutter/module/settings/FlutterCreateParams.java
@@ -8,10 +8,21 @@ package io.flutter.module.settings;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
 
 public class FlutterCreateParams {
   private JCheckBox createProjectOfflineCheckBox;
   private JPanel mainPanel;
+  private JLabel infoLabel;
+
+  public FlutterCreateParams setInitialValues() {
+    final boolean autoSelectOffline = !isPubAvailable();
+    createProjectOfflineCheckBox.setSelected(autoSelectOffline);
+    infoLabel.setVisible(autoSelectOffline);
+    return this;
+  }
 
   @NotNull
   public JComponent getComponent() {
@@ -20,6 +31,18 @@ public class FlutterCreateParams {
 
   public boolean isOfflineSelected() {
     return createProjectOfflineCheckBox.isSelected();
+  }
+
+  private static boolean isPubAvailable() {
+    // Check to see if the pub site is accessible as an indicator for whether we're online
+    // and if we should expect pub commands to succeed.
+    try {
+      new Socket(InetAddress.getByName("pub.dartlang.org"), 80);
+      return true;
+    } catch (IOException ex) {
+      // Ignore.
+    }
+    return false;
   }
 
 }

--- a/src/io/flutter/module/settings/FlutterCreateParams.java
+++ b/src/io/flutter/module/settings/FlutterCreateParams.java
@@ -34,7 +34,7 @@ public class FlutterCreateParams {
   }
 
   private static boolean isPubAvailable() {
-    // Check to see if the pub site is accessible as an indicator for whether we're online
+    // Check to see if the pub site is accessible to indicate whether we're online
     // and if we should expect pub commands to succeed.
     try {
       new Socket(InetAddress.getByName("pub.dartlang.org"), 80);

--- a/src/io/flutter/module/settings/FlutterCreateParams.java
+++ b/src/io/flutter/module/settings/FlutterCreateParams.java
@@ -37,7 +37,7 @@ public class FlutterCreateParams {
     // Check to see if the pub site is accessible to indicate whether we're online
     // and if we should expect pub commands to succeed.
     try {
-      new Socket(InetAddress.getByName("pub.dartlang.org"), 80);
+      new Socket(InetAddress.getByName("pub.dartlang.org"), 80).close();
       return true;
     } catch (IOException ex) {
       // Ignore.


### PR DESCRIPTION
Checks to see if pub (the website) is reachable as a proxy for "are we online and should we expect flutter create online to work".  If it's not, it auto-toggles the offline option and adds a label decoration to make it hopefully not too subtle.

![image](https://user-images.githubusercontent.com/67586/38893022-df41e710-423d-11e8-9bdd-9f3ad5be9d1a.png)

with a tooltip:

![image](https://user-images.githubusercontent.com/67586/38893183-703908f2-423e-11e8-889a-9c675c45fb87.png)

Online defaults to:

![image](https://user-images.githubusercontent.com/67586/38893033-ecb7d242-423d-11e8-832f-5506dd6ef444.png)

See: #1923.

@scheglov @devoncarew 