### PR TITLE
build against android studio 3.2 canary 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,5 @@ script: ./tool/travis.sh
 # Testing product matrix; the values are generated from product-matrix.json.
 env:
   - DART_BOT=true
-  - IDEA_VERSION=3.1
-  - IDEA_VERSION=3.2
+  - IDEA_VERSION=2017.3
   - IDEA_VERSION=2018.1

--- a/product-matrix.json
+++ b/product-matrix.json
@@ -2,32 +2,23 @@
   "list": [
     {
       "name": "IntelliJ",
-      "version": "3.1",
+      "version": "2017.3",
       "ideaProduct": "android-studio",
-      "ideaVersion": "173.4670197",
-      "dartPluginVersion": "181.4203.498",
+      "ideaVersion": "173.4697961",
+      "dartPluginVersion": "173.4700",
       "sinceBuild": "173.0",
       "untilBuild": "173.*",
       "filesToSkip": ["src/io/flutter/editor/FlutterCompletionContributor.java"]
     },
     {
       "name": "IntelliJ",
-      "version": "3.2",
+      "version": "2018.1",
       "ideaProduct": "android-studio",
-      "ideaVersion": "181.4705630",
-      "dartPluginVersion": "181.4203.498",
+      "ideaVersion": "181.4720098",
+      "dartPluginVersion": "181.3007.17",
       "sinceBuild": "181.0",
       "untilBuild": "181.*",
       "filesToSkip": ["src/io/flutter/editor/FlutterCompletionContributor.java"]
-    },
-    {
-      "name": "IntelliJ",
-      "version": "2018.1",
-      "ideaProduct": "ideaIC",
-      "ideaVersion": "181.4203.400",
-      "dartPluginVersion": "181.4203.498",
-      "sinceBuild": "181.0",
-      "untilBuild": "181.*"
     }
   ]
 }

--- a/product-matrix.json
+++ b/product-matrix.json
@@ -13,12 +13,11 @@
     {
       "name": "IntelliJ",
       "version": "2018.1",
-      "ideaProduct": "android-studio",
-      "ideaVersion": "181.4720098",
-      "dartPluginVersion": "181.3007.17",
+      "ideaProduct": "ideaIC",
+      "ideaVersion": "181.4203.400",
+      "dartPluginVersion": "181.4203.498",
       "sinceBuild": "181.0",
-      "untilBuild": "181.*",
-      "filesToSkip": ["src/io/flutter/editor/FlutterCompletionContributor.java"]
+      "untilBuild": "181.*"
     }
   ]
 }

--- a/tool/plugin/test/plugin_test.dart
+++ b/tool/plugin/test/plugin_test.dart
@@ -30,7 +30,7 @@ void main() {
         var specs = (runner.commands['build'] as ProductCommand).specs;
         expect(specs, isNotNull);
         expect(specs.map((spec) => spec.ideaProduct),
-            orderedEquals(['android-studio', 'android-studio']));
+            orderedEquals(['android-studio', 'ideaIC']));
       });
     });
     test('test', () async {
@@ -39,7 +39,7 @@ void main() {
         var specs = (runner.commands['test'] as ProductCommand).specs;
         expect(specs, isNotNull);
         expect(specs.map((spec) => spec.ideaProduct),
-            orderedEquals(['android-studio', 'android-studio']));
+            orderedEquals(['android-studio', 'ideaIC']));
       });
     });
     test('deploy', () async {
@@ -48,7 +48,7 @@ void main() {
         var specs = (runner.commands['deploy'] as ProductCommand).specs;
         expect(specs, isNotNull);
         expect(specs.map((spec) => spec.ideaProduct),
-            orderedEquals(['android-studio', 'android-studio']));
+            orderedEquals(['android-studio', 'ideaIC']));
       });
     });
   });

--- a/tool/plugin/test/plugin_test.dart
+++ b/tool/plugin/test/plugin_test.dart
@@ -30,7 +30,7 @@ void main() {
         var specs = (runner.commands['build'] as ProductCommand).specs;
         expect(specs, isNotNull);
         expect(specs.map((spec) => spec.ideaProduct),
-            orderedEquals(['android-studio', 'android-studio', 'ideaIC']));
+            orderedEquals(['android-studio', 'android-studio']));
       });
     });
     test('test', () async {
@@ -39,7 +39,7 @@ void main() {
         var specs = (runner.commands['test'] as ProductCommand).specs;
         expect(specs, isNotNull);
         expect(specs.map((spec) => spec.ideaProduct),
-            orderedEquals(['android-studio', 'android-studio', 'ideaIC']));
+            orderedEquals(['android-studio', 'android-studio']));
       });
     });
     test('deploy', () async {
@@ -48,7 +48,7 @@ void main() {
         var specs = (runner.commands['deploy'] as ProductCommand).specs;
         expect(specs, isNotNull);
         expect(specs.map((spec) => spec.ideaProduct),
-            orderedEquals(['android-studio', 'android-studio', 'ideaIC']));
+            orderedEquals(['android-studio', 'android-studio']));
       });
     });
   });
@@ -119,8 +119,7 @@ void main() {
       expect(
           cmd.paths.map((p) => p.substring(p.indexOf('releases'))),
           orderedEquals([
-            'releases/release_19/3.1/flutter-intellij.zip',
-            'releases/release_19/3.2/flutter-intellij.zip',
+            'releases/release_19/2017.3/flutter-intellij.zip',
             'releases/release_19/2018.1/flutter-intellij.zip',
           ]));
     });

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -38,12 +38,6 @@ else
   # Run some validations on the repo code.
   ./bin/plugin lint
 
-if [ "$IDEA_VERSION" = "3.1" ] ; then
-  # The 3.1 sources have a class defined in a different package than 3.2 and later.
-  # Here we adjust the import statement for that change.
-  sed -i 's/npw\.model\.NewModuleModel/npw.module.NewModuleModel/' flutter-studio/src/io/flutter/module/FlutterDescriptionProvider.java
-fi
-
   # Run the build.
   ./bin/plugin build --only-version=$IDEA_VERSION
 fi


### PR DESCRIPTION
build against android studio 3.2 canary 11:

- move the 3.1 import re-writing logic to dart code (from the shell script) - this let's the local build progress
- just build two products (down from three); we were building two products compatible with 2018.1
- update to the latest version of AS and the dart plugin versions they resolve against

We don't compile against the version of the Dart plugin that resolves in AS 3.2; we'll need to backport Dat plugin changes to that version, or add back in some reflection code to the Flutter plugin.

@stevemessick @alexander-doroshko 