### PR TITLE
Fix race condition when tool window is disposed.

### DIFF
--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -395,6 +395,11 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
   }
 
   private void displayEmptyContent(ToolWindow toolWindow) {
+    // There's a possible race here where the tool window gets disposed while we're displaying contents.
+    if (toolWindow.isDisposed()) {
+      return;
+    }
+
     // Display a 'No running applications' message.
     final ContentManager contentManager = toolWindow.getContentManager();
     final JPanel panel = new JPanel(new BorderLayout());


### PR DESCRIPTION
The reported issue is percolating up from the platform and *may* be fixed in the latest platform releases but this extra check should give us a little more security.


Fixes: #2103.

@scheglov @devoncarew 