### PR TITLE
use the normal intellij background color

### DIFF
--- a/src/io/flutter/inspector/InspectorTree.java
+++ b/src/io/flutter/inspector/InspectorTree.java
@@ -93,9 +93,6 @@ public class InspectorTree extends Tree implements DataProvider, Disposable {
     super(treemodel);
     setUI(new InspectorTreeUI());
     final BasicTreeUI ui = (BasicTreeUI)getUI();
-    if (!legacyMode) {
-      setBackground(VERY_LIGHT_GREY);
-    }
     this.detailsSubtree = detailsSubtree;
 
     setRootVisible(rootVisible);

--- a/src/io/flutter/inspector/InspectorTree.java
+++ b/src/io/flutter/inspector/InspectorTree.java
@@ -93,12 +93,17 @@ public class InspectorTree extends Tree implements DataProvider, Disposable {
     super(treemodel);
     setUI(new InspectorTreeUI());
     final BasicTreeUI ui = (BasicTreeUI)getUI();
+    // TODO: Consider making changing the background a user preference, in order to do user testing.
+    if (!detailsSubtree && !legacyMode) {
+      setBackground(VERY_LIGHT_GREY);
+    }
     this.detailsSubtree = detailsSubtree;
 
     setRootVisible(rootVisible);
     getSelectionModel().setSelectionMode(TreeSelectionModel.SINGLE_TREE_SELECTION);
     registerShortcuts();
     if (detailsSubtree) {
+      // TODO(devoncarew): This empty text is not showing up for the details area, even when there are no detail nodes.
       getEmptyText().setText(treeName + " subtree of the selected " + parentTreeName);
     }
     else {

--- a/src/io/flutter/view/InspectorPanel.java
+++ b/src/io/flutter/view/InspectorPanel.java
@@ -74,14 +74,13 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
   private static final Logger LOG = Logger.getInstance(InspectorPanel.class);
   protected final boolean detailsSubtree;
   protected final boolean isSummaryTree;
-  @Nullable
   /**
    * Parent InspectorPanel if this is a details subtree
    */
-  protected final InspectorPanel parentTree;
+  @Nullable protected final InspectorPanel parentTree;
   protected final InspectorPanel subtreePanel;
   final CustomIconMaker iconMaker = new CustomIconMaker();
-  @NotNull final Splitter treeSplitter;
+  final Splitter treeSplitter;
   final Icon defaultIcon;
   final JBScrollPane treeScrollPane;
   private final InspectorTree myRootsTree;
@@ -220,9 +219,6 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
 
     treeScrollPane = (JBScrollPane)ScrollPaneFactory.createScrollPane(myRootsTree);
     treeScrollPane.setAutoscrolls(false);
-    // Add padding on the bottom so users can select an item even if a horizontal scroll bar is visible
-    // (and overlaying the bottom part of the scrollable area).
-    treeScrollPane.setViewportBorder(BorderFactory.createEmptyBorder(0, 0, JBUI.scale(14), 0));
 
     scrollAnimator = new TreeScrollAnimator(myRootsTree, treeScrollPane);
     shouldAutoHorizontalScroll.listen(scrollAnimator::setAutoHorizontalScroll, true);
@@ -251,11 +247,11 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
       }
       else {
         myPropertiesPanel = null; /// This InspectorPanel doesn't have its own property panel.
-        final JBRunnerTabs tabs = new JBRunnerTabs(flutterView.getProject(), ActionManager.getInstance(), null, this);
-        tabs.addTab(new TabInfo(subtreePanel)
-                      .append("Details", SimpleTextAttributes.REGULAR_ATTRIBUTES));
+        //final JBRunnerTabs tabs = new JBRunnerTabs(flutterView.getProject(), ActionManager.getInstance(), null, this);
+        //tabs.addTab(new TabInfo(subtreePanel)
+        //              .append("Details", SimpleTextAttributes.REGULAR_ATTRIBUTES));
 
-        treeSplitter.setSecondComponent(tabs.getComponent());
+        treeSplitter.setSecondComponent(subtreePanel);
       }
 
       Disposer.register(this, treeSplitter::dispose);

--- a/src/io/flutter/view/InspectorPanel.java
+++ b/src/io/flutter/view/InspectorPanel.java
@@ -225,7 +225,7 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
     myRootsTree.setScrollAnimator(scrollAnimator);
 
     if (!detailsSubtree) {
-      treeSplitter = new Splitter(detailsSubtree);
+      treeSplitter = new Splitter(false);
       treeSplitter.setProportion(flutterView.getState().getSplitterProportion());
       flutterView.getState().addListener(e -> {
         final float newProportion = flutterView.getState().getSplitterProportion();
@@ -247,10 +247,6 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
       }
       else {
         myPropertiesPanel = null; /// This InspectorPanel doesn't have its own property panel.
-        //final JBRunnerTabs tabs = new JBRunnerTabs(flutterView.getProject(), ActionManager.getInstance(), null, this);
-        //tabs.addTab(new TabInfo(subtreePanel)
-        //              .append("Details", SimpleTextAttributes.REGULAR_ATTRIBUTES));
-
         treeSplitter.setSecondComponent(subtreePanel);
       }
 


### PR DESCRIPTION
- use the normal intellij background color for the inspector trees (otherwise we get a strange looking artifact with smaller panes that the scrollable area)
- remove the tab for "Details"
- remove a small overscroll area - I think visually this didn't pay for itself

<img width="380" alt="screen shot 2018-04-20 at 10 17 10 am" src="https://user-images.githubusercontent.com/1269969/39065063-778eba5e-4485-11e8-871d-f7c1e02ebc11.png">

