### PR TITLE
fix an issue with an ArrayIndexOutOfBoundsException at connect time

### DIFF
--- a/third_party/intellij-plugins-dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcessZ.java
+++ b/third_party/intellij-plugins-dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcessZ.java
@@ -221,7 +221,7 @@ public class DartVmServiceDebugProcessZ extends DartVmServiceDebugProcess {
         vmService = VmService.connect(url);
         vmOpenSourceLocationListener = VmOpenSourceLocationListener.connect(url);
       }
-      catch (IOException e) {
+      catch (IOException | RuntimeException e) {
         onConnectFailed("Failed to connect to the VM observatory service at: " + url + "\n"
                         + e.toString() + "\n" +
                         formatStackTraces(e));

--- a/third_party/intellij-plugins-dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/VmOpenSourceLocationListener.java
+++ b/third_party/intellij-plugins-dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/VmOpenSourceLocationListener.java
@@ -54,7 +54,7 @@ public class VmOpenSourceLocationListener {
     catch (URISyntaxException e) {
       throw new IOException("Invalid URL: " + url, e);
     }
-    String wsScheme = uri.getScheme();
+    final String wsScheme = uri.getScheme();
     if (!"ws".equals(wsScheme) && !"wss".equals(wsScheme)) {
       throw new IOException("Unsupported URL scheme: " + wsScheme);
     }


### PR DESCRIPTION
If an flutter app dies during the process of connecting to the debugger port, the underlying websocket library we're using can throw an ArrayIndexOutOfBoundsException; this gets surfaced to the user as a crash in the plugin.

Instead, we convert the runtime error to an IOException and report that (as a failure to connect to the app instance, rather than as a plugin crash). 