### PR TITLE
add a 'performance' tab to the inspector

### DIFF
--- a/src/io/flutter/perf/HeapMonitor.java
+++ b/src/io/flutter/perf/HeapMonitor.java
@@ -125,6 +125,8 @@ public class HeapMonitor {
   @NotNull
   private final VmService vmService;
 
+  private boolean isPolling;
+
   public HeapMonitor(@NotNull VmService vmService, @NotNull FlutterDebugProcess debugProcess) {
     this.vmService = vmService;
   }
@@ -142,10 +144,23 @@ public class HeapMonitor {
   }
 
   void start() {
+    isPolling = true;
     pollingScheduler = executor.scheduleAtFixedRate(this::poll, 0, POLL_PERIOD_IN_MS, TimeUnit.MILLISECONDS);
   }
 
+  public void pausePolling() {
+    isPolling = false;
+  }
+
+  public void resumePolling() {
+    isPolling = true;
+  }
+
   private void poll() {
+    if (!isPolling) {
+      return;
+    }
+
     vmService.getVM(new VMConsumer() {
       @Override
       public void received(VM vm) {

--- a/src/io/flutter/perf/PerfService.java
+++ b/src/io/flutter/perf/PerfService.java
@@ -126,7 +126,7 @@ public class PerfService {
 
   /**
    * Return the current Flutter IsolateRef, if any.
-   *
+   * <p>
    * Note that this may not be immediately populated at app startup for Flutter apps; clients that wish to
    * be notified when the Flutter isolate is discovered should prefer the StreamSubscription varient of this
    * method (getCurrentFlutterIsolate()).
@@ -276,5 +276,17 @@ public class PerfService {
       }
     }
     return stream.listen(onData, true);
+  }
+
+  public void pausePolling() {
+    if (isRunning) {
+      heapMonitor.pausePolling();
+    }
+  }
+
+  public void resumePolling() {
+    if (isRunning) {
+      heapMonitor.resumePolling();
+    }
   }
 }

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.form
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.form
@@ -96,7 +96,7 @@
           </component>
         </children>
       </grid>
-      <grid id="23e52" layout-manager="GridLayoutManager" row-count="5" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="23e52" layout-manager="GridLayoutManager" row-count="4" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -117,7 +117,7 @@
           </component>
           <component id="8bd46" class="javax.swing.JCheckBox" binding="myOrganizeImportsOnSaveCheckBox" default-binding="true">
             <constraints>
-              <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="2" use-parent-layout="false"/>
+              <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="2" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text value="Organize imports on save"/>
@@ -126,7 +126,7 @@
           </component>
           <component id="a0dd8" class="javax.swing.JCheckBox" binding="myFormatCodeOnSaveCheckBox" default-binding="true">
             <constraints>
-              <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text value="Format code on save"/>
@@ -139,14 +139,6 @@
             </constraints>
             <properties>
               <text value="Show a live preview area in Flutter Outline"/>
-            </properties>
-          </component>
-          <component id="e5c7" class="javax.swing.JCheckBox" binding="myShowHeapDisplayCheckBox">
-            <constraints>
-              <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <text value="Display application memory usage in the Flutter Inspector"/>
             </properties>
           </component>
         </children>

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.java
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.java
@@ -156,10 +156,6 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
       return true;
     }
 
-    if (settings.isShowHeapDisplay() != myShowHeapDisplayCheckBox.isSelected()) {
-      return true;
-    }
-
     if (settings.isOpenInspectorOnAppLaunch() != myOpenInspectorOnAppLaunchCheckBox.isSelected()) {
       return true;
     }
@@ -198,7 +194,6 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     settings.setFormatCodeOnSave(myFormatCodeOnSaveCheckBox.isSelected());
     settings.setOrganizeImportsOnSaveKey(myOrganizeImportsOnSaveCheckBox.isSelected());
     settings.setShowPreviewArea(myShowPreviewAreaCheckBox.isSelected());
-    settings.setShowHeapDisplay(myShowHeapDisplayCheckBox.isSelected());
     settings.setOpenInspectorOnAppLaunch(myOpenInspectorOnAppLaunchCheckBox.isSelected());
     settings.setDart2ModeSettingOrdinal(myPreviewDart2Combo.getSelectedIndex());
     settings.setVerboseLogging(myEnableVerboseLoggingCheckBox.isSelected());
@@ -225,7 +220,6 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     myFormatCodeOnSaveCheckBox.setSelected(settings.isFormatCodeOnSave());
     myOrganizeImportsOnSaveCheckBox.setSelected(settings.isOrganizeImportsOnSaveKey());
     myShowPreviewAreaCheckBox.setSelected(settings.isShowPreviewArea());
-    myShowHeapDisplayCheckBox.setSelected(settings.isShowHeapDisplay());
     myOpenInspectorOnAppLaunchCheckBox.setSelected(settings.isOpenInspectorOnAppLaunch());
     myPreviewDart2Combo.setSelectedIndex(settings.getDart2ModeSetting().getOrdinal());
     myEnableVerboseLoggingCheckBox.setSelected(settings.isVerboseLogging());

--- a/src/io/flutter/settings/FlutterSettings.java
+++ b/src/io/flutter/settings/FlutterSettings.java
@@ -23,7 +23,6 @@ public class FlutterSettings {
   private static final String organizeImportsOnSaveKey = "io.flutter.organizeImportsOnSave";
   private static final String showOnlyWidgetsKey = "io.flutter.showOnlyWidgets";
   private static final String showPreviewAreaKey = "io.flutter.showPreviewArea";
-  private static final String showHeapDisplayKey = "io.flutter.showHeapDisplay";
 
   public enum Dart2ModeSettings {
     useSdkDefault(0),
@@ -86,9 +85,6 @@ public class FlutterSettings {
     }
     if (isShowPreviewArea()) {
       analytics.sendEvent("settings", afterLastPeriod(showPreviewAreaKey));
-    }
-    if (isShowHeapDisplay()) {
-      analytics.sendEvent("settings", afterLastPeriod(showHeapDisplayKey));
     }
   }
 
@@ -156,16 +152,6 @@ public class FlutterSettings {
 
   public void setShowPreviewArea(boolean value) {
     getPropertiesComponent().setValue(showPreviewAreaKey, value, false);
-
-    fireEvent();
-  }
-
-  public boolean isShowHeapDisplay() {
-    return getPropertiesComponent().getBoolean(showHeapDisplayKey, false);
-  }
-
-  public void setShowHeapDisplay(boolean value) {
-    getPropertiesComponent().setValue(showHeapDisplayKey, value, false);
 
     fireEvent();
   }

--- a/src/io/flutter/view/InspectorPanel.java
+++ b/src/io/flutter/view/InspectorPanel.java
@@ -53,11 +53,7 @@ import java.util.*;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
-// TODO(devoncarew): Should we filter out the CheckedModeBanner node type?
-// TODO(devoncarew): Should we filter out the WidgetInspector node type?
-
-public class InspectorPanel extends JPanel implements Disposable, InspectorService.InspectorServiceClient {
-
+public class InspectorPanel extends JPanel implements Disposable, InspectorService.InspectorServiceClient, InspectorTabPanel {
   /**
    * Maximum frame rate to refresh the inspector panel at to avoid taxing the
    * physical device with too many requests to recompute properties and trees.

--- a/src/io/flutter/view/InspectorPerfTab.java
+++ b/src/io/flutter/view/InspectorPerfTab.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.view;
+
+import com.intellij.openapi.Disposable;
+import com.intellij.util.ui.JBUI;
+import io.flutter.inspector.FPSDisplay;
+import io.flutter.inspector.HeapDisplay;
+import io.flutter.run.FlutterLaunchMode;
+import io.flutter.run.daemon.FlutterApp;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+import java.awt.*;
+
+public class InspectorPerfTab extends JPanel implements InspectorTabPanel {
+  private @NotNull FlutterApp app;
+
+  InspectorPerfTab(Disposable parentDisposable, @NotNull FlutterApp app) {
+    this.app = app;
+
+    setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
+
+    add(Box.createVerticalStrut(6));
+
+    Box labelBox = Box.createHorizontalBox();
+    labelBox.add(new JLabel("Running in debug mode"));
+    labelBox.add(Box.createHorizontalGlue());
+    labelBox.setBorder(JBUI.Borders.empty(3, 10));
+    add(labelBox);
+
+    if (app.getLaunchMode() == FlutterLaunchMode.DEBUG) {
+      labelBox = Box.createHorizontalBox();
+      labelBox.add(new JLabel("Note: for best results, re-run in profile mode"));
+      labelBox.add(Box.createHorizontalGlue());
+      labelBox.setBorder(JBUI.Borders.empty(3, 10));
+      add(labelBox);
+    }
+
+    add(Box.createVerticalStrut(6));
+
+    add(FPSDisplay.createJPanelView(parentDisposable, app), BorderLayout.NORTH);
+    add(Box.createVerticalStrut(16));
+    add(HeapDisplay.createJPanelView(parentDisposable, app), BorderLayout.SOUTH);
+    add(Box.createVerticalGlue());
+  }
+
+  @Override
+  public void setVisibleToUser(boolean visible) {
+    assert app.getPerfService() != null;
+
+    if (visible) {
+      app.getPerfService().resumePolling();
+    }
+    else {
+      app.getPerfService().pausePolling();
+    }
+  }
+}

--- a/src/io/flutter/view/InspectorTabPanel.java
+++ b/src/io/flutter/view/InspectorTabPanel.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2018 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.view;
+
+public interface InspectorTabPanel {
+  void setVisibleToUser(boolean visible);
+}


### PR DESCRIPTION
add a 'performance' tab to the inspector:
- add a performance tab to the inspector
- due to the number of tabs, move the toolbar to the line above the inspector tabs (otherwise we run out of horizontal space)
- in debug mode runs, have a warning in the tab about preferring to profile in profile mode
- in profile mode, show the regular inspector tabs as disabled, and have the performance tab selected by default (but keep the widgets/render/perf tab order the same)
- only poll for memory usage when the tab is active
- remove the user preference in the experimental section of the preferences UI
- fix https://github.com/flutter/flutter-intellij/issues/2016

<img width="423" alt="screen shot 2018-04-22 at 3 22 26 pm" src="https://user-images.githubusercontent.com/1269969/39100656-cb8e0142-4641-11e8-8174-074e7178ab0c.png">

@jacob314 @pq 