### PR TITLE
Set version constraint to 2018.1 after any Android Studio canary build

### DIFF
--- a/product-matrix.json
+++ b/product-matrix.json
@@ -16,7 +16,7 @@
       "ideaProduct": "ideaIC",
       "ideaVersion": "181.4203.400",
       "dartPluginVersion": "181.4203.498",
-      "sinceBuild": "181.0",
+      "sinceBuild": "181.4445",
       "untilBuild": "181.*"
     }
   ]


### PR DESCRIPTION
@pq @devoncarew 

This creates a locally-built plugin that will install into IJ 2018.1 but not AS Canary 12.