### PR TITLE
Add "Track Widget Creation" checkbox to FlutterConfigurationEditorForm

### DIFF
--- a/src/io/flutter/sdk/FlutterSdk.java
+++ b/src/io/flutter/sdk/FlutterSdk.java
@@ -193,6 +193,10 @@ public class FlutterSdk {
       args.add("--no-preview-dart-2");
     }
 
+    if (!FlutterSettings.getInstance().isDisablePreviewDart2() && FlutterSettings.getInstance().isTrackWidgetCreation()) {
+      args.add("--track-widget-creation");
+    }
+
     if (device != null) {
       args.add("--device-id=" + device.deviceId());
     }

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.form
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.form
@@ -3,7 +3,7 @@
   <grid id="27dc6" binding="mainPanel" layout-manager="GridLayoutManager" row-count="6" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="574" height="671"/>
+      <xy x="20" y="20" width="802" height="671"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -143,7 +143,7 @@
           </component>
         </children>
       </grid>
-      <grid id="919ec" layout-manager="GridLayoutManager" row-count="3" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="919ec" layout-manager="GridLayoutManager" row-count="4" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -171,10 +171,10 @@
               <toolTipText value="On save, hot reload changes into running Flutter apps."/>
             </properties>
           </component>
-          <grid id="8dda3" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+          <grid id="8dda3" layout-manager="GridLayoutManager" row-count="2" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
             <margin top="0" left="0" bottom="0" right="0"/>
             <constraints>
-              <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+              <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties/>
             <border type="none"/>
@@ -189,7 +189,7 @@
               </component>
               <component id="f8034" class="javax.swing.JComboBox" binding="myPreviewDart2Combo">
                 <constraints>
-                  <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="2" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                  <grid row="0" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="2" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>
                 <properties>
                   <model>
@@ -197,6 +197,15 @@
                     <item value="Enable Dart 2"/>
                     <item value="Disable Dart 2"/>
                   </model>
+                </properties>
+              </component>
+              <component id="6d6f0" class="javax.swing.JCheckBox" binding="myTrackWidgetCreationCheckBox">
+                <constraints>
+                  <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text value="Run applications with --track-widget-creation"/>
+                  <toolTipText value="Allows the Flutter Inspector to track source locations where each widget was created. This is a slightly experimental feature required for advanced Flutter Inspector functionality."/>
                 </properties>
               </component>
             </children>

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.java
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.java
@@ -59,6 +59,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
   private JCheckBox myShowPreviewAreaCheckBox;
   private JCheckBox myShowHeapDisplayCheckBox;
   private JComboBox myPreviewDart2Combo;
+  private JCheckBox myTrackWidgetCreationCheckBox;
   private final @NotNull Project myProject;
 
   FlutterSettingsConfigurable(@NotNull Project project) {
@@ -95,11 +96,13 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     });
 
     //noinspection Convert2Lambda
-    myFormatCodeOnSaveCheckBox.addChangeListener(new ChangeListener() {
-      @Override
-      public void stateChanged(ChangeEvent e) {
-        myOrganizeImportsOnSaveCheckBox.setEnabled(myFormatCodeOnSaveCheckBox.isSelected());
-      }
+    myFormatCodeOnSaveCheckBox
+      .addChangeListener((e) -> myOrganizeImportsOnSaveCheckBox.setEnabled(myFormatCodeOnSaveCheckBox.isSelected()));
+
+    myPreviewDart2Combo.addActionListener((e) -> {
+      final boolean disableDart2 =
+        myPreviewDart2Combo.getSelectedIndex() == FlutterSettings.Dart2ModeSettings.disablePreviewDart2.getOrdinal();
+      myTrackWidgetCreationCheckBox.setEnabled(!disableDart2);
     });
   }
 
@@ -163,6 +166,9 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     if (settings.getDart2ModeSetting().getOrdinal() != myPreviewDart2Combo.getSelectedIndex()) {
       return true;
     }
+    if (settings.isTrackWidgetCreation() != myTrackWidgetCreationCheckBox.isSelected()) {
+      return true;
+    }
 
     //noinspection RedundantIfStatement
     if (settings.isVerboseLogging() != myEnableVerboseLoggingCheckBox.isSelected()) {
@@ -196,6 +202,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     settings.setShowPreviewArea(myShowPreviewAreaCheckBox.isSelected());
     settings.setOpenInspectorOnAppLaunch(myOpenInspectorOnAppLaunchCheckBox.isSelected());
     settings.setDart2ModeSettingOrdinal(myPreviewDart2Combo.getSelectedIndex());
+    settings.setTrackWidgetCreation(myTrackWidgetCreationCheckBox.isSelected());
     settings.setVerboseLogging(myEnableVerboseLoggingCheckBox.isSelected());
 
     reset(); // because we rely on remembering initial state
@@ -222,6 +229,8 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     myShowPreviewAreaCheckBox.setSelected(settings.isShowPreviewArea());
     myOpenInspectorOnAppLaunchCheckBox.setSelected(settings.isOpenInspectorOnAppLaunch());
     myPreviewDart2Combo.setSelectedIndex(settings.getDart2ModeSetting().getOrdinal());
+    myTrackWidgetCreationCheckBox.setSelected(settings.isTrackWidgetCreation());
+    myTrackWidgetCreationCheckBox.setEnabled(!settings.getDart2ModeSetting().equals(FlutterSettings.Dart2ModeSettings.disablePreviewDart2));
     myEnableVerboseLoggingCheckBox.setSelected(settings.isVerboseLogging());
 
     myOrganizeImportsOnSaveCheckBox.setEnabled(myFormatCodeOnSaveCheckBox.isSelected());

--- a/src/io/flutter/settings/FlutterSettings.java
+++ b/src/io/flutter/settings/FlutterSettings.java
@@ -23,6 +23,7 @@ public class FlutterSettings {
   private static final String organizeImportsOnSaveKey = "io.flutter.organizeImportsOnSave";
   private static final String showOnlyWidgetsKey = "io.flutter.showOnlyWidgets";
   private static final String showPreviewAreaKey = "io.flutter.showPreviewArea";
+  private static final String trackWidgetCreationKey = "io.flutter.trackWidgetCreation";
 
   public enum Dart2ModeSettings {
     useSdkDefault(0),
@@ -109,6 +110,17 @@ public class FlutterSettings {
   public boolean isReloadOnSave() {
     return getPropertiesComponent().getBoolean(reloadOnSaveKey, true);
   }
+
+  public boolean isTrackWidgetCreation() {
+    return getPropertiesComponent().getBoolean(trackWidgetCreationKey, false);
+  }
+
+  public void setTrackWidgetCreation(boolean value) {
+    getPropertiesComponent().setValue(trackWidgetCreationKey, value);
+
+    fireEvent();
+  }
+
 
   public void setReloadOnSave(boolean value) {
     getPropertiesComponent().setValue(reloadOnSaveKey, value, true);


### PR DESCRIPTION
and
"Default to Track Widget Creation (requires Dart 2.0)"
checkbox to FlutterSettingsConfigurable.
Logic is that if you create an new FlutterConfiguration you get the value
from FlutterSettings as the default.

By default both are off so users won't be forced into running the transform.
Next step is to warn users at the bottom of the inspector that it is more awesome if they check the option.

![image](https://user-images.githubusercontent.com/1226812/39161612-6de8b560-4726-11e8-99a8-b66034878c52.png)

![image](https://user-images.githubusercontent.com/1226812/39161639-8e1c39c4-4726-11e8-8a44-ff703338fa85.png)
