### PR TITLE
Make highlight nodes shown in both trees optional.

### DIFF
--- a/src/io/flutter/view/DiagnosticsTreeCellRenderer.java
+++ b/src/io/flutter/view/DiagnosticsTreeCellRenderer.java
@@ -89,7 +89,7 @@ class DiagnosticsTreeCellRenderer extends InspectorColoredTreeCellRenderer {
     boolean isLinkedChild = false;
     // Highlight nodes that exist in both the details and summary tree to
     // show how the trees are linked together.
-    if (!highlight) {
+    if (!highlight && panel.isHighlightNodesShownInBothTrees()) {
       if (panel.detailsSubtree && panel.isCreatedByLocalProject(node)) {
         isLinkedChild = panel.parentTree.hasDiagnosticsValue(node.getValueRef());
       }
@@ -107,7 +107,7 @@ class DiagnosticsTreeCellRenderer extends InspectorColoredTreeCellRenderer {
       // TODO(jacobr): consider using UIUtil.getTreeSelectionBackground());
       // instead.
     }
-    else if (isLinkedChild) {
+    else if (isLinkedChild || panel.currentShowNode == value) {
       setOpaque(true);
       setIconOpaque(false);
       setTransparentIconBackground(true);

--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -86,6 +86,8 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
   public static final String PERFORMANCE_TAB_LABEL = "Performance";
 
   protected final EventStream<Boolean> shouldAutoHorizontalScroll = new EventStream<>(FlutterViewState.AUTO_SCROLL_DEFAULT);
+  protected final EventStream<Boolean> highlightNodesShownInBothTrees = new EventStream<>(FlutterViewState.HIGHLIGHT_NODES_SHOWN_IN_BOTH_TREES_DEFAULT);
+
 
   @NotNull
   private final FlutterViewState state = new FlutterViewState();
@@ -101,6 +103,7 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
     myProject = project;
 
     shouldAutoHorizontalScroll.listen(state::setShouldAutoScroll);
+    highlightNodesShownInBothTrees.listen(state::setHighlightNodesShownInBothTrees);
   }
 
   @Override
@@ -124,6 +127,7 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
     this.state.copyFrom(state);
 
     shouldAutoHorizontalScroll.setValue(this.state.getShouldAutoScroll());
+    highlightNodesShownInBothTrees.setValue(this.state.getHighlightNodesShownInBothTrees());
   }
 
   void initToolWindow(ToolWindow window) {
@@ -285,7 +289,8 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
       // TODO(jacobr): support the summary tree view for the RenderObject
       // tree instead of forcing the legacy view for the RenderObject tree.
       treeType != InspectorService.FlutterTreeType.widget || !inspectorService.isDetailsSummaryViewSupported(),
-      shouldAutoHorizontalScroll
+      shouldAutoHorizontalScroll,
+      highlightNodesShownInBothTrees
     );
     final TabInfo tabInfo = new TabInfo(inspectorPanel)
       .append(displayName, SimpleTextAttributes.REGULAR_ATTRIBUTES);
@@ -835,6 +840,12 @@ class AutoHorizontalScrollAction extends FlutterViewLocalToggleableAction {
   }
 }
 
+class HighlightNodesShownInBothTrees extends FlutterViewLocalToggleableAction {
+  HighlightNodesShownInBothTrees(@NotNull FlutterApp app, EventStream<Boolean> value) {
+    super(app, "Highlight nodes displayed in both trees", value);
+  }
+}
+
 class ShowPaintBaselinesAction extends FlutterViewToggleableAction {
   ShowPaintBaselinesAction(@NotNull FlutterApp app) {
     super(app, "Show Paint Baselines");
@@ -916,6 +927,8 @@ class OverflowAction extends AnAction implements RightAlignedToolbarAction {
     group.add(view.registerAction(new HideSlowBannerAction(app)));
     group.addSeparator();
     group.add(view.registerAction(new AutoHorizontalScrollAction(app, view.shouldAutoHorizontalScroll)));
+    group.add(view.registerAction(new HighlightNodesShownInBothTrees(app, view.highlightNodesShownInBothTrees)));
+
     return group;
   }
 }

--- a/src/io/flutter/view/FlutterViewState.java
+++ b/src/io/flutter/view/FlutterViewState.java
@@ -16,6 +16,7 @@ import javax.swing.event.ChangeListener;
  */
 public class FlutterViewState {
   public static final boolean AUTO_SCROLL_DEFAULT = false;
+  public static final boolean HIGHLIGHT_NODES_SHOWN_IN_BOTH_TREES_DEFAULT = false;
 
   private final EventDispatcher<ChangeListener> dispatcher = EventDispatcher.create(ChangeListener.class);
 
@@ -24,6 +25,9 @@ public class FlutterViewState {
 
   @Attribute(value = "should-auto-scroll")
   public boolean shouldAutoScroll = AUTO_SCROLL_DEFAULT;
+
+  @Attribute(value = "highlight-nodes-shown-in-both-trees")
+  public boolean highlightNodesShownInBothTrees = HIGHLIGHT_NODES_SHOWN_IN_BOTH_TREES_DEFAULT;
 
   public FlutterViewState() {
   }
@@ -56,5 +60,14 @@ public class FlutterViewState {
 
   void copyFrom(FlutterViewState other) {
     splitterProportion = other.splitterProportion;
+  }
+
+  public void setHighlightNodesShownInBothTrees(Boolean value) {
+    highlightNodesShownInBothTrees = value;
+    dispatcher.getMulticaster().stateChanged(new ChangeEvent(this));
+  }
+
+  public boolean getHighlightNodesShownInBothTrees() {
+    return highlightNodesShownInBothTrees;
   }
 }

--- a/src/io/flutter/view/InspectorPanel.java
+++ b/src/io/flutter/view/InspectorPanel.java
@@ -129,6 +129,7 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
    * not perform any actions.
    */
   private boolean visibleToUser = false;
+  private boolean highlightNodesShownInBothTrees = false;
 
   public InspectorPanel(FlutterView flutterView,
                         @NotNull FlutterApp flutterApp,
@@ -137,9 +138,11 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
                         @NotNull InspectorService.FlutterTreeType treeType,
                         boolean isSummaryTree,
                         boolean legacyMode,
-                        @NotNull EventStream<Boolean> shouldAutoHorizontalScroll) {
+                        @NotNull EventStream<Boolean> shouldAutoHorizontalScroll,
+                        @NotNull EventStream<Boolean> highlightNodesShownInBothTrees
+                        ) {
     this(flutterView, flutterApp, inspectorService, isApplicable, treeType, false, null, isSummaryTree, legacyMode,
-         shouldAutoHorizontalScroll);
+         shouldAutoHorizontalScroll, highlightNodesShownInBothTrees);
   }
 
   private InspectorPanel(FlutterView flutterView,
@@ -151,7 +154,8 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
                          @Nullable InspectorPanel parentTree,
                          boolean isSummaryTree,
                          boolean legacyMode,
-                         @NotNull EventStream<Boolean> shouldAutoHorizontalScroll) {
+                         @NotNull EventStream<Boolean> shouldAutoHorizontalScroll,
+                         @NotNull EventStream<Boolean> highlightNodesShownInBothTrees) {
     super(new BorderLayout());
 
     this.treeType = treeType;
@@ -201,7 +205,8 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
         this,
         false,
         legacyMode,
-        shouldAutoHorizontalScroll
+        shouldAutoHorizontalScroll,
+        highlightNodesShownInBothTrees
       );
     }
     else {
@@ -216,6 +221,7 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
 
     scrollAnimator = new TreeScrollAnimator(myRootsTree, treeScrollPane);
     shouldAutoHorizontalScroll.listen(scrollAnimator::setAutoHorizontalScroll, true);
+    highlightNodesShownInBothTrees.listen(this::setHighlightNodesShownInBothTrees, true);
     myRootsTree.setScrollAnimator(scrollAnimator);
 
     if (!detailsSubtree) {
@@ -283,6 +289,17 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
         onIsolateStopped();
       }
     }, true);
+  }
+
+  public boolean isHighlightNodesShownInBothTrees() {
+    return highlightNodesShownInBothTrees;
+  }
+
+  private void setHighlightNodesShownInBothTrees(boolean value) {
+    if (highlightNodesShownInBothTrees != value) {
+      highlightNodesShownInBothTrees = value;
+      myRootsTree.repaint();
+    }
   }
 
   static DiagnosticsNode getDiagnosticNode(TreeNode treeNode) {


### PR DESCRIPTION
The highlighting of nodes shown in both trees doesn't currently provide much value.
It is now behind an option which is unchecked by default.

Maybe I should just give up and remove it completely but I think there is a good feature hiding in this highlighting. My next step is to only highlight nodes that are actually scrolled into view in the details tree. I suspect it will become much more valuable in that case but I may just be overly attached to the highlighting.

Highlighting off looks much less busy.
![image](https://user-images.githubusercontent.com/1226812/39164110-a445e432-4732-11e8-9dce-7bb39b947937.png)
