### PR TITLE
Not ready for Canary 12

### DIFF
--- a/product-matrix.json
+++ b/product-matrix.json
@@ -16,7 +16,7 @@
       "ideaProduct": "android-studio",
       "ideaVersion": "181.4729833",
       "dartPluginVersion": "181.4203.498",
-      "sinceBuild": "181.0",
+      "sinceBuild": "181.4445",
       "untilBuild": "181.*"
     }
   ]


### PR DESCRIPTION
I don't think we're ready to "officially" support Android Studio 3.2 Canary releases yet. We can discuss it, but please try creating a new project first.

@devoncarew @pq 