### PR TITLE
some improvements to how we pass --profile and --release info to launches

### DIFF
--- a/src/io/flutter/actions/RunFlutterAction.java
+++ b/src/io/flutter/actions/RunFlutterAction.java
@@ -62,19 +62,18 @@ public abstract class RunFlutterAction extends AnAction {
     final SdkRunConfig sdkRunConfig = (SdkRunConfig)configuration.clone();
     final SdkFields fields = sdkRunConfig.getFields();
     final String additionalArgs = fields.getAdditionalArgs();
-    final String runArg = "--" + myLaunchMode.getCliCommand();
-    String flavorArg = "";
+
+    String flavorArg = null;
     if (fields.getBuildFlavor() != null) {
-      flavorArg = " --flavor=" + fields.getBuildFlavor();
+      flavorArg = "--flavor=" + fields.getBuildFlavor();
     }
 
-    if (additionalArgs == null) {
-      fields.setAdditionalArgs(runArg + flavorArg);
-    }
-    else {
-      if (!additionalArgs.contains(runArg)) {
-        fields.setAdditionalArgs(additionalArgs + flavorArg + " " + runArg);
-      }
+    if (additionalArgs != null && flavorArg != null) {
+      fields.setAdditionalArgs(additionalArgs + " " + flavorArg);
+    } else if (flavorArg != null) {
+      fields.setAdditionalArgs(flavorArg);
+    } else if (additionalArgs != null) {
+      fields.setAdditionalArgs(additionalArgs);
     }
 
     final Executor executor = getExecutor(myExecutorId);
@@ -83,9 +82,9 @@ public abstract class RunFlutterAction extends AnAction {
     }
 
     final ExecutionEnvironmentBuilder builder = ExecutionEnvironmentBuilder.create(executor, sdkRunConfig);
-    final ExecutionEnvironment env = builder.activeTarget().dataContext(e.getDataContext()).build();
 
-    env.putUserData(FlutterLaunchMode.LAUNCH_MODE_KEY, myLaunchMode);
+    final ExecutionEnvironment env = builder.activeTarget().dataContext(e.getDataContext()).build();
+    FlutterLaunchMode.addToEnvironment(env, myLaunchMode);
 
     ProgramRunnerUtil.executeConfiguration(env, false, true);
   }

--- a/src/io/flutter/actions/RunFlutterAction.java
+++ b/src/io/flutter/actions/RunFlutterAction.java
@@ -5,6 +5,7 @@
  */
 package io.flutter.actions;
 
+import com.google.common.base.Joiner;
 import com.intellij.execution.Executor;
 import com.intellij.execution.ProgramRunnerUtil;
 import com.intellij.execution.RunManagerEx;
@@ -25,6 +26,8 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
+import java.util.ArrayList;
+import java.util.List;
 
 public abstract class RunFlutterAction extends AnAction {
   private final @NotNull String myDetailedTextKey;
@@ -68,12 +71,15 @@ public abstract class RunFlutterAction extends AnAction {
       flavorArg = "--flavor=" + fields.getBuildFlavor();
     }
 
-    if (additionalArgs != null && flavorArg != null) {
-      fields.setAdditionalArgs(additionalArgs + " " + flavorArg);
-    } else if (flavorArg != null) {
-      fields.setAdditionalArgs(flavorArg);
-    } else if (additionalArgs != null) {
-      fields.setAdditionalArgs(additionalArgs);
+    final List<String> args = new ArrayList<>();
+    if (additionalArgs != null) {
+      args.add(additionalArgs);
+    }
+    if (flavorArg != null) {
+      args.add(flavorArg);
+    }
+    if (!args.isEmpty()) {
+      fields.setAdditionalArgs(Joiner.on(" ").join(args));
     }
 
     final Executor executor = getExecutor(myExecutorId);

--- a/src/io/flutter/run/FlutterLaunchMode.java
+++ b/src/io/flutter/run/FlutterLaunchMode.java
@@ -26,7 +26,7 @@ public enum FlutterLaunchMode {
   }
 
   @NotNull
-  public static FlutterLaunchMode getFromEnvironment(@NotNull ExecutionEnvironment env) {
+  public static FlutterLaunchMode fromEnv(@NotNull ExecutionEnvironment env) {
     final FlutterLaunchMode launchMode = env.getUserData(FlutterLaunchMode.LAUNCH_MODE_KEY);
     return launchMode == null ? DEBUG : launchMode;
   }

--- a/src/io/flutter/run/FlutterLaunchMode.java
+++ b/src/io/flutter/run/FlutterLaunchMode.java
@@ -10,8 +10,7 @@ import com.intellij.openapi.util.Key;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * The Flutter launch mode. This corresponds to the flutter run modes: --debug,
- * --profile, and --release.
+ * The Flutter launch mode. This corresponds to the flutter run modes: --debug, --profile, and --release.
  */
 public enum FlutterLaunchMode {
   DEBUG("debug"),
@@ -20,10 +19,14 @@ public enum FlutterLaunchMode {
 
   RELEASE("release");
 
-  public static final Key<FlutterLaunchMode> LAUNCH_MODE_KEY = Key.create("FlutterLaunchMode");
+  private static final Key<FlutterLaunchMode> LAUNCH_MODE_KEY = Key.create("FlutterLaunchMode");
+
+  public static void addToEnvironment(ExecutionEnvironment env, FlutterLaunchMode mode) {
+    env.putUserData(FlutterLaunchMode.LAUNCH_MODE_KEY, mode);
+  }
 
   @NotNull
-  public static FlutterLaunchMode getMode(@NotNull ExecutionEnvironment env) {
+  public static FlutterLaunchMode getFromEnvironment(@NotNull ExecutionEnvironment env) {
     final FlutterLaunchMode launchMode = env.getUserData(FlutterLaunchMode.LAUNCH_MODE_KEY);
     return launchMode == null ? DEBUG : launchMode;
   }

--- a/src/io/flutter/run/LaunchState.java
+++ b/src/io/flutter/run/LaunchState.java
@@ -124,7 +124,7 @@ public class LaunchState extends CommandLineState {
       }
     }
 
-    final FlutterLaunchMode launchMode = FlutterLaunchMode.getFromEnvironment(env);
+    final FlutterLaunchMode launchMode = FlutterLaunchMode.fromEnv(env);
     if (launchMode.supportsDebugConnection()) {
       return createDebugSession(env, app, result).getRunContentDescriptor();
     }
@@ -347,7 +347,7 @@ public class LaunchState extends CommandLineState {
               }
               return launchState.launch(env);
             }
-            final FlutterLaunchMode launchMode = FlutterLaunchMode.getFromEnvironment(env);
+            final FlutterLaunchMode launchMode = FlutterLaunchMode.fromEnv(env);
             if (launchMode.supportsReload() && app.isStarted()) {
               // Map a re-run action to a flutter full restart.
               FileDocumentManager.getInstance().saveAllDocuments();

--- a/src/io/flutter/run/LaunchState.java
+++ b/src/io/flutter/run/LaunchState.java
@@ -84,6 +84,11 @@ public class LaunchState extends CommandLineState {
   private RunContentDescriptor launch(@NotNull ExecutionEnvironment env) throws ExecutionException {
     FileDocumentManager.getInstance().saveAllDocuments();
 
+    // Set our FlutterLaunchMode up in the ExecutionEnvironment.
+    if (RunMode.fromEnv(env).isProfiling()) {
+      FlutterLaunchMode.addToEnvironment(env, FlutterLaunchMode.PROFILE);
+    }
+
     final Project project = getEnvironment().getProject();
     final FlutterDevice device = DeviceService.getInstance(project).getSelectedDevice();
     final FlutterApp app = callback.createApp(device);
@@ -119,7 +124,7 @@ public class LaunchState extends CommandLineState {
       }
     }
 
-    final FlutterLaunchMode launchMode = FlutterLaunchMode.getMode(env);
+    final FlutterLaunchMode launchMode = FlutterLaunchMode.getFromEnvironment(env);
     if (launchMode.supportsDebugConnection()) {
       return createDebugSession(env, app, result).getRunContentDescriptor();
     }
@@ -342,7 +347,7 @@ public class LaunchState extends CommandLineState {
               }
               return launchState.launch(env);
             }
-            final FlutterLaunchMode launchMode = FlutterLaunchMode.getMode(env);
+            final FlutterLaunchMode launchMode = FlutterLaunchMode.getFromEnvironment(env);
             if (launchMode.supportsReload() && app.isStarted()) {
               // Map a re-run action to a flutter full restart.
               FileDocumentManager.getInstance().saveAllDocuments();

--- a/src/io/flutter/run/SdkFields.java
+++ b/src/io/flutter/run/SdkFields.java
@@ -108,8 +108,10 @@ public class SdkFields {
    * Create a command to run 'flutter run --machine'.
    */
   public GeneralCommandLine createFlutterSdkRunCommand(@NotNull Project project,
-                                                       @Nullable FlutterDevice device,
-                                                       @NotNull RunMode mode) throws ExecutionException {
+                                                       @NotNull RunMode runMode,
+                                                       @NotNull FlutterLaunchMode flutterLaunchMode,
+                                                       @Nullable FlutterDevice device
+  ) throws ExecutionException {
     final MainFile main = MainFile.verify(filePath, project).get();
 
     final FlutterSdk flutterSdk = FlutterSdk.getFlutterSdk(project);
@@ -126,7 +128,7 @@ public class SdkFields {
     if (buildFlavor != null) {
       args = ArrayUtil.append(args, "--flavor=" + buildFlavor);
     }
-    final FlutterCommand command = flutterSdk.flutterRun(root, main.getFile(), device, mode, args);
+    final FlutterCommand command = flutterSdk.flutterRun(root, main.getFile(), device, runMode, flutterLaunchMode, args);
     return command.createGeneralCommandLine(project);
   }
 

--- a/src/io/flutter/run/SdkRunConfig.java
+++ b/src/io/flutter/run/SdkRunConfig.java
@@ -223,11 +223,11 @@ public class SdkRunConfig extends LocatableConfigurationBase
   }
 
   @Override
-  public GeneralCommandLine getCommand(ExecutionEnvironment env, FlutterDevice device) throws ExecutionException {
+  public GeneralCommandLine getCommand(@NotNull ExecutionEnvironment env, @Nullable FlutterDevice device) throws ExecutionException {
     final SdkFields launchFields = fields.copy();
     final Project project = env.getProject();
     final RunMode mode = RunMode.fromEnv(env);
-    return fields.createFlutterSdkRunCommand(project, device, mode);
+    return fields.createFlutterSdkRunCommand(project, mode, FlutterLaunchMode.getFromEnvironment(env), device);
   }
 
   @Nullable

--- a/src/io/flutter/run/SdkRunConfig.java
+++ b/src/io/flutter/run/SdkRunConfig.java
@@ -227,7 +227,7 @@ public class SdkRunConfig extends LocatableConfigurationBase
     final SdkFields launchFields = fields.copy();
     final Project project = env.getProject();
     final RunMode mode = RunMode.fromEnv(env);
-    return fields.createFlutterSdkRunCommand(project, mode, FlutterLaunchMode.getFromEnvironment(env), device);
+    return fields.createFlutterSdkRunCommand(project, mode, FlutterLaunchMode.fromEnv(env), device);
   }
 
   @Nullable

--- a/src/io/flutter/run/daemon/FlutterApp.java
+++ b/src/io/flutter/run/daemon/FlutterApp.java
@@ -474,7 +474,7 @@ public class FlutterApp {
   }
 
   public FlutterLaunchMode getLaunchMode() {
-    return FlutterLaunchMode.getFromEnvironment(myExecutionEnvironment);
+    return FlutterLaunchMode.fromEnv(myExecutionEnvironment);
   }
 
   public boolean isSessionActive() {

--- a/src/io/flutter/run/daemon/FlutterApp.java
+++ b/src/io/flutter/run/daemon/FlutterApp.java
@@ -474,7 +474,7 @@ public class FlutterApp {
   }
 
   public FlutterLaunchMode getLaunchMode() {
-    return FlutterLaunchMode.getMode(myExecutionEnvironment);
+    return FlutterLaunchMode.getFromEnvironment(myExecutionEnvironment);
   }
 
   public boolean isSessionActive() {

--- a/src/io/flutter/sdk/FlutterSdk.java
+++ b/src/io/flutter/sdk/FlutterSdk.java
@@ -24,6 +24,7 @@ import com.intellij.util.ui.EdtInvocationManager;
 import com.jetbrains.lang.dart.sdk.DartSdk;
 import io.flutter.dart.DartPlugin;
 import io.flutter.pub.PubRoot;
+import io.flutter.run.FlutterLaunchMode;
 import io.flutter.run.daemon.FlutterDevice;
 import io.flutter.run.daemon.RunMode;
 import io.flutter.settings.FlutterSettings;
@@ -178,8 +179,8 @@ public class FlutterSdk {
     return new FlutterCommand(this, getHome(), FlutterCommand.Type.CONFIG, additionalArgs);
   }
 
-  public FlutterCommand flutterRun(@NotNull PubRoot root, @NotNull VirtualFile main,
-                                   @Nullable FlutterDevice device, @NotNull RunMode mode, String... additionalArgs) {
+  public FlutterCommand flutterRun(@NotNull PubRoot root, @NotNull VirtualFile main, @Nullable FlutterDevice device,
+                                   @NotNull RunMode mode, @NotNull FlutterLaunchMode flutterLaunchMode, String... additionalArgs) {
     final List<String> args = new ArrayList<>();
     args.add("--machine");
     if (FlutterSettings.getInstance().isVerboseLogging()) {
@@ -193,19 +194,26 @@ public class FlutterSdk {
       args.add("--no-preview-dart-2");
     }
 
-    if (!FlutterSettings.getInstance().isDisablePreviewDart2() && FlutterSettings.getInstance().isTrackWidgetCreation()) {
-      args.add("--track-widget-creation");
+    if (flutterLaunchMode == FlutterLaunchMode.DEBUG) {
+      if (!FlutterSettings.getInstance().isDisablePreviewDart2() && FlutterSettings.getInstance().isTrackWidgetCreation()) {
+        args.add("--track-widget-creation");
+      }
     }
 
     if (device != null) {
       args.add("--device-id=" + device.deviceId());
     }
+
     if (mode == RunMode.DEBUG) {
       args.add("--start-paused");
     }
-    if (mode == RunMode.PROFILE) {
+
+    if (flutterLaunchMode == FlutterLaunchMode.PROFILE) {
       args.add("--profile");
+    } else if (flutterLaunchMode == FlutterLaunchMode.RELEASE) {
+      args.add("--release");
     }
+
     args.addAll(asList(additionalArgs));
 
     // Make the path to main relative (to make the command line prettier).

--- a/third_party/intellij-plugins-dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcessZ.java
+++ b/third_party/intellij-plugins-dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcessZ.java
@@ -268,7 +268,7 @@ public class DartVmServiceDebugProcessZ extends DartVmServiceDebugProcess {
     // stderr streams (this would duplicate what we get over daemon logging).
     remoteDebug = false;
 
-    final FlutterLaunchMode launchMode = FlutterLaunchMode.getFromEnvironment(executionEnvironment);
+    final FlutterLaunchMode launchMode = FlutterLaunchMode.fromEnv(executionEnvironment);
     if (launchMode.supportsDebugConnection()) {
       myVmServiceWrapper.handleDebuggerConnected();
 

--- a/third_party/intellij-plugins-dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcessZ.java
+++ b/third_party/intellij-plugins-dart/src/com/jetbrains/lang/dart/ide/runner/server/vmService/DartVmServiceDebugProcessZ.java
@@ -268,7 +268,7 @@ public class DartVmServiceDebugProcessZ extends DartVmServiceDebugProcess {
     // stderr streams (this would duplicate what we get over daemon logging).
     remoteDebug = false;
 
-    final FlutterLaunchMode launchMode = FlutterLaunchMode.getMode(executionEnvironment);
+    final FlutterLaunchMode launchMode = FlutterLaunchMode.getFromEnvironment(executionEnvironment);
     if (launchMode.supportsDebugConnection()) {
       myVmServiceWrapper.handleDebuggerConnected();
 


### PR DESCRIPTION
some improvements to how we pass --profile and --release info to launches:
- no longer piggy-back on the  `additionalArgs` field
- instead, make sure the `FlutterLaunchMode` field is properly populated on the ExecutionEnvironment
- use that info when creating the params to `flutter run`
- and - now that that info is properly populated - don't pass in flags like `--track-widget-creation` when not run in `--debug` launches