### PR TITLE
fix the label for the performance view

### DIFF
--- a/src/io/flutter/run/FlutterLaunchMode.java
+++ b/src/io/flutter/run/FlutterLaunchMode.java
@@ -55,4 +55,9 @@ public enum FlutterLaunchMode {
   public boolean isProfiling() {
     return this == PROFILE;
   }
+
+  @Override
+  public String toString() {
+    return myCliCommand;
+  }
 }

--- a/src/io/flutter/view/InspectorPerfTab.java
+++ b/src/io/flutter/view/InspectorPerfTab.java
@@ -27,7 +27,7 @@ public class InspectorPerfTab extends JPanel implements InspectorTabPanel {
     add(Box.createVerticalStrut(6));
 
     Box labelBox = Box.createHorizontalBox();
-    labelBox.add(new JLabel("Running in debug mode"));
+    labelBox.add(new JLabel("Running in " + app.getLaunchMode() + " mode"));
     labelBox.add(Box.createHorizontalGlue());
     labelBox.setBorder(JBUI.Borders.empty(3, 10));
     add(labelBox);


### PR DESCRIPTION
This had always been showing as 'debug' mode, even for profile runs.