### PR TITLE
fix a StringIndexOutOfBoundsException

### DIFF
--- a/src/io/flutter/console/FlutterConsoleFilter.java
+++ b/src/io/flutter/console/FlutterConsoleFilter.java
@@ -120,7 +120,7 @@ public class FlutterConsoleFilter implements Filter {
     final String[] parts = pathPart.split(" ");
     for (String part : parts) {
       // "(lib/main.dart:49)"
-      if (part.startsWith("(") && pathPart.endsWith(")")) {
+      if (part.startsWith("(") && part.endsWith(")")) {
         part = part.substring(1, part.length() - 1);
         final String[] split = part.split(":");
         if (split.length == 2) {


### PR DESCRIPTION
- fix a StringIndexOutOfBoundsException

```
Caused by: java.lang.StringIndexOutOfBoundsException: String index out of range: -1
	at java.lang.String.substring(String.java:1967)
	at io.flutter.console.FlutterConsoleFilter.applyFilter(FlutterConsoleFilter.java:124)
	at com.intellij.execution.filters.CompositeFilter.applyFilter(CompositeFilter.java:75)
	... 22 more
```
