### PR TITLE
fix an issue where reload on save would stop working

### DIFF
--- a/src/io/flutter/run/daemon/FlutterApp.java
+++ b/src/io/flutter/run/daemon/FlutterApp.java
@@ -440,7 +440,7 @@ public class FlutterApp {
 
     // Do the rest in the background to avoid freezing the Swing dispatch thread.
     AppExecutorUtil.getAppExecutorService().submit(() -> {
-      // Try to shut down gracefully. (Need to wait for a response.)
+      // Try to shut down gracefully (need to wait for a response).
       final Future stopDone = myDaemonApi.stopApp(appId);
       final Stopwatch watch = Stopwatch.createStarted();
       while (watch.elapsed(TimeUnit.SECONDS) < 10 && getState() == State.TERMINATING) {
@@ -459,6 +459,7 @@ public class FlutterApp {
 
       // If it didn't work, shut down abruptly.
       myProcessHandler.destroyProcess();
+      myDaemonApi.cancelPending();
       done.run();
     });
     return done;


### PR DESCRIPTION
- fix an issue where reload on save would stop working

If a reload-in-save was occurring when an app shut down, the bit that indicated that we were in a reload on save wouldn't get cleared. We now properly pass the exception back through the reload result Future (by terminating all outstanding daemon calls), allowing the reload bit to be cleared.