### PR TITLE
check for project dispose in save actions

### DIFF
--- a/src/io/flutter/editor/FlutterSaveActionsManager.java
+++ b/src/io/flutter/editor/FlutterSaveActionsManager.java
@@ -126,6 +126,10 @@ public class FlutterSaveActionsManager {
       ApplicationManager.getApplication().invokeLater(() -> new WriteCommandAction.Simple(myProject) {
         @Override
         protected void run() {
+          if (myProject.isDisposed()) {
+            return;
+          }
+
           AssistUtils.applySourceEdits(myProject, file, document, fileEdit.getEdits(), Collections.emptySet());
 
           // Committing a document here is required in order to guarantee that DartPostFormatProcessor.processText() is called afterwards.
@@ -155,6 +159,10 @@ public class FlutterSaveActionsManager {
     ApplicationManager.getApplication().invokeLater(() -> new WriteCommandAction.Simple(myProject) {
       @Override
       protected void run() {
+        if (myProject.isDisposed()) {
+          return;
+        }
+
         boolean didFormat = false;
 
         final List<SourceEdit> edits = formatResult.getEdits();
@@ -177,4 +185,3 @@ public class FlutterSaveActionsManager {
     return CodeStyleSettingsManager.getSettings(project).getCommonSettings(DartLanguage.INSTANCE).RIGHT_MARGIN;
   }
 }
-


### PR DESCRIPTION
- check for project dispose in save actions

There's some latency between when a save action is invoked and when its applied; check for project dispose during the process.

```
Project Project (Disposed) untitled_foo_123 already disposed
java.lang.Throwable: Project Project (Disposed) untitled_foo_123 already disposed
	at com.intellij.openapi.diagnostic.Logger.error(Logger.java:123)
	at com.intellij.openapi.command.impl.CoreCommandProcessor.executeCommand(CoreCommandProcessor.java:118)
	at com.intellij.openapi.command.impl.CoreCommandProcessor.executeCommand(CoreCommandProcessor.java:105)
	at com.intellij.openapi.command.WriteCommandAction.doExecuteCommand(WriteCommandAction.java:216)
	at com.intellij.openapi.command.WriteCommandAction.performWriteCommandAction(WriteCommandAction.java:172)
	at com.intellij.openapi.command.WriteCommandAction.execute(WriteCommandAction.java:155)
	at io.flutter.editor.FlutterSaveActionsManager.lambda$performFormat$1(FlutterSaveActionsManager.java:173)
	at com.intellij.openapi.application.TransactionGuardImpl$2.run(TransactionGuardImpl.java:315)
	at com.intellij.openapi.application.impl.LaterInvocator$FlushQueue.doRun$$$capture(LaterInvocator.java:447)
```