### PR TITLE
Add a command bar to editors that can open in a native-code editor

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -301,6 +301,7 @@
 
     <editorNotificationProvider implementation="io.flutter.editor.FlutterPubspecNotificationProvider"/>
     <editorNotificationProvider implementation="io.flutter.inspections.SdkConfigurationNotificationProvider"/>
+    <editorNotificationProvider implementation="io.flutter.editor.NativeEditorNotificationProvider"/>
 
     <projectService serviceInterface="io.flutter.run.FlutterReloadManager"
                     serviceImplementation="io.flutter.run.FlutterReloadManager"

--- a/resources/META-INF/plugin_template.xml
+++ b/resources/META-INF/plugin_template.xml
@@ -230,6 +230,7 @@
 
     <editorNotificationProvider implementation="io.flutter.editor.FlutterPubspecNotificationProvider"/>
     <editorNotificationProvider implementation="io.flutter.inspections.SdkConfigurationNotificationProvider"/>
+    <editorNotificationProvider implementation="io.flutter.editor.NativeEditorNotificationProvider"/>
 
     <projectService serviceInterface="io.flutter.run.FlutterReloadManager"
                     serviceImplementation="io.flutter.run.FlutterReloadManager"

--- a/src/io/flutter/editor/NativeEditorNotificationProvider.java
+++ b/src/io/flutter/editor/NativeEditorNotificationProvider.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2018 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.editor;
+
+import com.intellij.openapi.actionSystem.*;
+import com.intellij.openapi.editor.colors.EditorColors;
+import com.intellij.openapi.fileEditor.FileEditor;
+import com.intellij.openapi.project.DumbAware;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Key;
+import com.intellij.openapi.util.io.FileUtil;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.ui.EditorNotificationPanel;
+import com.intellij.ui.EditorNotifications;
+import com.intellij.ui.HyperlinkLabel;
+import icons.FlutterIcons;
+import org.jetbrains.annotations.NonNls;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class NativeEditorNotificationProvider extends EditorNotifications.Provider<EditorNotificationPanel> implements DumbAware {
+  private static final Key<EditorNotificationPanel> KEY = Key.create("flutter.native.editor.notification");
+
+  private final Project myProject;
+
+  public NativeEditorNotificationProvider(@NotNull Project project) {
+    myProject = project;
+  }
+
+  @NotNull
+  @Override
+  public Key<EditorNotificationPanel> getKey() {
+    return KEY;
+  }
+
+  @Nullable
+  @Override
+  public EditorNotificationPanel createNotificationPanel(@NotNull VirtualFile file, @NotNull FileEditor fileEditor) {
+    if (!file.isInLocalFileSystem()) {
+      return null;
+    }
+    VirtualFile root = findRootDir(file);
+    if (root == null) {
+      return null;
+    }
+
+    String actionName;
+    if (root.getName().equals("android")) {
+      actionName = "flutter.androidstudio.open";
+    } else if (root.getName().equals("ios")) {
+      actionName = "flutter.xcode.open";
+    } else {
+      return null;
+    }
+
+    NativeEditorActionsPanel panel = new NativeEditorActionsPanel(file, root, actionName);
+    return panel.isValidForFile() ? panel : null;
+  }
+
+  private VirtualFile findRootDir(@NotNull VirtualFile file) {
+    // Return the top-most parent of file that is a child of the project directory.
+    VirtualFile projectDir = myProject.getBaseDir();
+    VirtualFile parent = file.getParent();
+    if (projectDir.equals(parent)) {
+      return null;
+    }
+    VirtualFile root = parent;
+    while (parent != null) {
+      parent = parent.getParent();
+      if (projectDir.equals(parent)) {
+        return root;
+      }
+      root = parent;
+    }
+    return null;
+  }
+
+  class NativeEditorActionsPanel extends EditorNotificationPanel {
+    final VirtualFile myFile;
+    final VirtualFile myRoot;
+    final AnAction myAction;
+
+    NativeEditorActionsPanel(VirtualFile file, VirtualFile root, String actionName) {
+      super(EditorColors.GUTTER_BACKGROUND);
+      myFile = file;
+      myRoot = root;
+      myAction = ActionManager.getInstance().getAction(actionName);
+
+      icon(FlutterIcons.Flutter);
+      text("Flutter commands");
+
+      Presentation present = myAction.getTemplatePresentation();
+      HyperlinkLabel label = createActionLabel(present.getText(), this::performAction);
+      label.setToolTipText(present.getDescription());
+    }
+
+    private boolean isValidForFile() {
+      DataContext context = makeContext();
+      AnActionEvent event = AnActionEvent.createFromDataContext(ActionPlaces.EDITOR_TOOLBAR, null, context);
+      // Ensure this project is a Flutter project by updating the menu action. It will only be visible for Flutter projects.
+      myAction.update(event);
+      if (event.getPresentation().isVisible()) {
+        // The menu items are visible for certain elements outside the module directories.
+        return FileUtil.isAncestor(myRoot.getPath(), myFile.getPath(), true);
+      }
+      return false;
+    }
+
+    private void performAction() {
+      Presentation present = myAction.getTemplatePresentation();
+      DataContext context = makeContext();
+      AnActionEvent event = AnActionEvent.createFromDataContext(ActionPlaces.EDITOR_TOOLBAR, present, context);
+      // Open Xcode or Android Studio. If already running AS then just open a new window.
+      myAction.actionPerformed(event);
+    }
+
+    private DataContext makeContext() {
+      return new DataContext() {
+        @Override
+        @Nullable
+        public Object getData(@NonNls String dataId) {
+          if (CommonDataKeys.VIRTUAL_FILE.is(dataId)) {
+            return myFile;
+          }
+          if (CommonDataKeys.PROJECT.is(dataId)) {
+            return myProject;
+          }
+          return null;
+        }
+      };
+    }
+  }
+}

--- a/src/io/flutter/editor/NativeEditorNotificationProvider.java
+++ b/src/io/flutter/editor/NativeEditorNotificationProvider.java
@@ -42,12 +42,12 @@ public class NativeEditorNotificationProvider extends EditorNotifications.Provid
     if (!file.isInLocalFileSystem()) {
       return null;
     }
-    VirtualFile root = findRootDir(file);
+    final VirtualFile root = findRootDir(file);
     if (root == null) {
       return null;
     }
 
-    String actionName;
+    final String actionName;
     if (root.getName().equals("android")) {
       actionName = "flutter.androidstudio.open";
     }
@@ -64,7 +64,7 @@ public class NativeEditorNotificationProvider extends EditorNotifications.Provid
 
   private VirtualFile findRootDir(@NotNull VirtualFile file) {
     // Return the top-most parent of file that is a child of the project directory.
-    VirtualFile projectDir = myProject.getBaseDir();
+    final VirtualFile projectDir = myProject.getBaseDir();
     VirtualFile parent = file.getParent();
     if (projectDir.equals(parent)) {
       return null;
@@ -94,14 +94,14 @@ public class NativeEditorNotificationProvider extends EditorNotifications.Provid
       icon(FlutterIcons.Flutter);
       text("Flutter commands");
 
-      Presentation present = myAction.getTemplatePresentation();
-      HyperlinkLabel label = createActionLabel(present.getText(), this::performAction);
+      final Presentation present = myAction.getTemplatePresentation();
+      final HyperlinkLabel label = createActionLabel(present.getText(), this::performAction);
       label.setToolTipText(present.getDescription());
     }
 
     private boolean isValidForFile() {
-      DataContext context = makeContext();
-      AnActionEvent event = AnActionEvent.createFromDataContext(ActionPlaces.EDITOR_TOOLBAR, null, context);
+      final DataContext context = makeContext();
+      final AnActionEvent event = AnActionEvent.createFromDataContext(ActionPlaces.EDITOR_TOOLBAR, null, context);
       // Ensure this project is a Flutter project by updating the menu action. It will only be visible for Flutter projects.
       myAction.update(event);
       if (event.getPresentation().isVisible()) {
@@ -112,9 +112,9 @@ public class NativeEditorNotificationProvider extends EditorNotifications.Provid
     }
 
     private void performAction() {
-      Presentation present = myAction.getTemplatePresentation();
-      DataContext context = makeContext();
-      AnActionEvent event = AnActionEvent.createFromDataContext(ActionPlaces.EDITOR_TOOLBAR, present, context);
+      final Presentation present = myAction.getTemplatePresentation();
+      final DataContext context = makeContext();
+      final AnActionEvent event = AnActionEvent.createFromDataContext(ActionPlaces.EDITOR_TOOLBAR, present, context);
       // Open Xcode or Android Studio. If already running AS then just open a new window.
       myAction.actionPerformed(event);
     }

--- a/src/io/flutter/editor/NativeEditorNotificationProvider.java
+++ b/src/io/flutter/editor/NativeEditorNotificationProvider.java
@@ -50,9 +50,11 @@ public class NativeEditorNotificationProvider extends EditorNotifications.Provid
     String actionName;
     if (root.getName().equals("android")) {
       actionName = "flutter.androidstudio.open";
-    } else if (root.getName().equals("ios")) {
+    }
+    else if (root.getName().equals("ios")) {
       actionName = "flutter.xcode.open";
-    } else {
+    }
+    else {
       return null;
     }
 

--- a/src/io/flutter/inspector/InspectorService.java
+++ b/src/io/flutter/inspector/InspectorService.java
@@ -9,6 +9,7 @@ import com.google.common.base.Joiner;
 import com.google.gson.*;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.util.SystemInfo;
 import com.intellij.xdebugger.XSourcePosition;
 import com.jetbrains.lang.dart.ide.runner.server.vmService.VmServiceConsumers;
 import com.jetbrains.lang.dart.ide.runner.server.vmService.frame.DartVmServiceValue;
@@ -118,7 +119,14 @@ public class InspectorService implements Disposable {
         }
         final ArrayList<String> rootDirectories = new ArrayList<>();
         for (PubRoot root : app.getPubRoots()) {
-          rootDirectories.add(root.getRoot().getCanonicalPath());
+          String path = root.getRoot().getCanonicalPath();
+          if (SystemInfo.isWindows) {
+            // TODO(jacobr): remove after https://github.com/flutter/flutter-intellij/issues/2217.
+            // The problem is setPubRootDirectories is currently expecting
+            // valid URIs as opposed to windows paths.
+            path = "file:///" + path;
+          }
+          rootDirectories.add(path);
         }
         setPubRootDirectories(rootDirectories);
       });

--- a/src/io/flutter/inspector/InspectorSourceLocation.java
+++ b/src/io/flutter/inspector/InspectorSourceLocation.java
@@ -7,6 +7,7 @@ package io.flutter.inspector;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
+import com.intellij.openapi.util.SystemInfo;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.xdebugger.XSourcePosition;
@@ -30,8 +31,13 @@ public class InspectorSourceLocation {
       return parent != null ? parent.getFile() : null;
     }
 
-    // We have to strip the file:// prefix from the Dart file path for compatibility.
-    final String filePrefix = "file://";
+    // We have to strip the file:// or file:/// prefix depending on the
+    // operating system to convert from paths stored as URIs to local operating
+    // system paths.
+    // TODO(jacobr): remove this workaround after the code in package:flutter
+    // is fixed to return operating system paths instead of URIs.
+    // https://github.com/flutter/flutter-intellij/issues/2217
+    final String filePrefix = SystemInfo.isWindows ? "file:///" : "file://";
     if (fileName.startsWith(filePrefix)) {
       fileName = fileName.substring(filePrefix.length());
     }

--- a/src/io/flutter/view/InspectorPanel.java
+++ b/src/io/flutter/view/InspectorPanel.java
@@ -21,6 +21,7 @@ import com.intellij.ui.treeStructure.treetable.ListTreeTableModelOnColumns;
 import com.intellij.util.ui.ColumnInfo;
 import com.intellij.util.ui.JBUI;
 import com.intellij.util.ui.tree.TreeUtil;
+import com.intellij.xdebugger.XSourcePosition;
 import io.flutter.FlutterBundle;
 import io.flutter.editor.FlutterMaterialIcons;
 import io.flutter.inspector.*;
@@ -1097,8 +1098,10 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
     final DiagnosticsNode diagnostic = getSelectedDiagnostic();
     if (diagnostic != null) {
       if (isCreatedByLocalProject(diagnostic)) {
-        diagnostic.getCreationLocation().getXSourcePosition().createNavigatable(getFlutterApp().getProject())
-          .navigate(false);
+        XSourcePosition position = diagnostic.getCreationLocation().getXSourcePosition();
+        if (position != null) {
+          position.createNavigatable(getFlutterApp().getProject()).navigate(false);
+        }
       }
     }
     if (myPropertiesPanel != null) {


### PR DESCRIPTION
Add "Flutter commands" at the top of an editor when it can be opened in a native code editor like Xcode or Android Studio. This reuses the menu actions to do all the heavy lifting, which is nice since the Android Studio version does not try (and fail) to re-launch itself.

It would be nice to make the just-opened file open for editing in the new window but I haven't figured out how to do that with either Xcode or IntelliJ yet. I'm pretty sure I can do it in the case where Android Studio opens a new Android Studio project, but I have less confidence when IntelliJ launches Android Studio or when either fires up Xcode.

@pq @devoncarew 