### PR TITLE
Fix track-widget-creation on Windows.

### DIFF
--- a/src/io/flutter/inspector/InspectorService.java
+++ b/src/io/flutter/inspector/InspectorService.java
@@ -9,6 +9,7 @@ import com.google.common.base.Joiner;
 import com.google.gson.*;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.util.SystemInfo;
 import com.intellij.xdebugger.XSourcePosition;
 import com.jetbrains.lang.dart.ide.runner.server.vmService.VmServiceConsumers;
 import com.jetbrains.lang.dart.ide.runner.server.vmService.frame.DartVmServiceValue;
@@ -118,7 +119,14 @@ public class InspectorService implements Disposable {
         }
         final ArrayList<String> rootDirectories = new ArrayList<>();
         for (PubRoot root : app.getPubRoots()) {
-          rootDirectories.add(root.getRoot().getCanonicalPath());
+          String path = root.getRoot().getCanonicalPath();
+          if (SystemInfo.isWindows) {
+            // TODO(jacobr): remove after https://github.com/flutter/flutter-intellij/issues/2217.
+            // The problem is setPubRootDirectories is currently expecting
+            // valid URIs as opposed to windows paths.
+            path = "file:///" + path;
+          }
+          rootDirectories.add(path);
         }
         setPubRootDirectories(rootDirectories);
       });

--- a/src/io/flutter/inspector/InspectorSourceLocation.java
+++ b/src/io/flutter/inspector/InspectorSourceLocation.java
@@ -7,6 +7,7 @@ package io.flutter.inspector;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
+import com.intellij.openapi.util.SystemInfo;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.xdebugger.XSourcePosition;
@@ -30,8 +31,13 @@ public class InspectorSourceLocation {
       return parent != null ? parent.getFile() : null;
     }
 
-    // We have to strip the file:// prefix from the Dart file path for compatibility.
-    final String filePrefix = "file://";
+    // We have to strip the file:// or file:/// prefix depending on the
+    // operating to convert from paths stored as URIs to local file system
+    // paths.
+    // TODO(jacobr): remove this workaround after the code in package:flutter
+    // is fixed to return local file system paths instead of URIs.
+    // https://github.com/flutter/flutter-intellij/issues/2217
+    final String filePrefix = SystemInfo.isWindows ? "file:///" : "file://";
     if (fileName.startsWith(filePrefix)) {
       fileName = fileName.substring(filePrefix.length());
     }

--- a/src/io/flutter/inspector/InspectorSourceLocation.java
+++ b/src/io/flutter/inspector/InspectorSourceLocation.java
@@ -32,10 +32,10 @@ public class InspectorSourceLocation {
     }
 
     // We have to strip the file:// or file:/// prefix depending on the
-    // operating to convert from paths stored as URIs to local file system
-    // paths.
+    // operating system to convert from paths stored as URIs to local operating
+    // system paths.
     // TODO(jacobr): remove this workaround after the code in package:flutter
-    // is fixed to return local file system paths instead of URIs.
+    // is fixed to return operating system paths instead of URIs.
     // https://github.com/flutter/flutter-intellij/issues/2217
     final String filePrefix = SystemInfo.isWindows ? "file:///" : "file://";
     if (fileName.startsWith(filePrefix)) {

--- a/src/io/flutter/view/InspectorPanel.java
+++ b/src/io/flutter/view/InspectorPanel.java
@@ -21,6 +21,7 @@ import com.intellij.ui.treeStructure.treetable.ListTreeTableModelOnColumns;
 import com.intellij.util.ui.ColumnInfo;
 import com.intellij.util.ui.JBUI;
 import com.intellij.util.ui.tree.TreeUtil;
+import com.intellij.xdebugger.XSourcePosition;
 import io.flutter.FlutterBundle;
 import io.flutter.editor.FlutterMaterialIcons;
 import io.flutter.inspector.*;
@@ -1097,8 +1098,10 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
     final DiagnosticsNode diagnostic = getSelectedDiagnostic();
     if (diagnostic != null) {
       if (isCreatedByLocalProject(diagnostic)) {
-        diagnostic.getCreationLocation().getXSourcePosition().createNavigatable(getFlutterApp().getProject())
-          .navigate(false);
+        XSourcePosition position = diagnostic.getCreationLocation().getXSourcePosition();
+        if (position != null) {
+          position.createNavigatable(getFlutterApp().getProject()).navigate(false);
+        }
       }
     }
     if (myPropertiesPanel != null) {


### PR DESCRIPTION
https://github.com/flutter/flutter-intellij/issues/2205
There were two separate bugs in how we handled windows file paths. This isn't the ideal fix but fixes the issue without requiring a fix on the flutter engine side.