### PR TITLE
Launch a simulator device if none is running (#2234)

### DIFF
--- a/src/io/flutter/actions/OpenSimulatorAction.java
+++ b/src/io/flutter/actions/OpenSimulatorAction.java
@@ -5,15 +5,10 @@
  */
 package io.flutter.actions;
 
-import com.intellij.execution.ExecutionException;
-import com.intellij.execution.configurations.GeneralCommandLine;
-import com.intellij.execution.process.OSProcessHandler;
-import com.intellij.execution.process.ProcessAdapter;
-import com.intellij.execution.process.ProcessEvent;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
-import io.flutter.FlutterBundle;
 import io.flutter.FlutterMessages;
+import io.flutter.sdk.XcodeUtils;
 
 @SuppressWarnings("ComponentNotRegistered")
 public class OpenSimulatorAction extends AnAction {
@@ -32,24 +27,15 @@ public class OpenSimulatorAction extends AnAction {
 
   @Override
   public void actionPerformed(AnActionEvent event) {
-    try {
-      final GeneralCommandLine cmd = new GeneralCommandLine().withExePath("open").withParameters("-a", "Simulator.app");
-      final OSProcessHandler handler = new OSProcessHandler(cmd);
-      handler.addProcessListener(new ProcessAdapter() {
-        @Override
-        public void processTerminated(final ProcessEvent event) {
-          if (event.getExitCode() != 0) {
-            final String msg = event.getText() != null ? event.getText() : "Process error - exit code: (" + event.getExitCode() + ")";
-            FlutterMessages.showError("Error Opening Simulator", msg);
-          }
-        }
-      });
-      handler.startNotify();
-    }
-    catch (ExecutionException e) {
-      FlutterMessages.showError(
-        "Error Opening Simulator",
-        FlutterBundle.message("flutter.command.exception.message", e.getMessage()));
-    }
+      // Check to see if the simulator is already running.
+      // If it is, and we're here, that means there are no booted devices.
+      if (XcodeUtils.isSimulatorRunning()) {
+        FlutterMessages.showDialog(event.getProject(),
+                                   "It looks like you have the Simulator app open but no booted devices;\n"
+                                   +"in the simulator, boot a device from the \"Hardware\" menu before running.", "No Booted Devices", new String[]{"OK"}, 0);
+        return;
+      }
+
+      XcodeUtils.startSimulator();
   }
 }

--- a/src/io/flutter/actions/OpenSimulatorAction.java
+++ b/src/io/flutter/actions/OpenSimulatorAction.java
@@ -31,7 +31,7 @@ public class OpenSimulatorAction extends AnAction {
     // If it is, and we're here, that means there are no booted devices.
     if (XcodeUtils.isSimulatorRunning()) {
       FlutterMessages.showDialog(event.getProject(),
-                                 "It looks like you have the Simulator app open but no booted devices;\n"
+                                 "It looks like you have the Simulator app open but no running devices;\n"
                                  + "in the Simulator, start a device from the \"Hardware\" menu before running.",
                                  "No Running Simulator Devices", new String[]{"OK"}, 0);
     } else {

--- a/src/io/flutter/actions/OpenSimulatorAction.java
+++ b/src/io/flutter/actions/OpenSimulatorAction.java
@@ -7,7 +7,6 @@ package io.flutter.actions;
 
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
-import io.flutter.FlutterMessages;
 import io.flutter.sdk.XcodeUtils;
 
 @SuppressWarnings("ComponentNotRegistered")
@@ -28,14 +27,15 @@ public class OpenSimulatorAction extends AnAction {
   @Override
   public void actionPerformed(AnActionEvent event) {
     // Check to see if the simulator is already running.
-    // If it is, and we're here, that means there are no booted devices.
+    // If it is, and we're here, that means there are no running devices and we want
+    // to issue an extra call to start (w/ `-n`) to load a new simulator.
     if (XcodeUtils.isSimulatorRunning()) {
-      FlutterMessages.showDialog(event.getProject(),
-                                 "It looks like you have the Simulator app open but no running devices;\n"
-                                 + "in the Simulator, start a device from the \"Hardware\" menu before running.",
-                                 "No Running Simulator Devices", new String[]{"OK"}, 0);
-    } else {
-      XcodeUtils.startSimulator();
+      if (XcodeUtils.openSimulator("-n") != 0) {
+        // No point in trying if we errored.
+        return;
+      }
     }
+
+    XcodeUtils.openSimulator();
   }
 }

--- a/src/io/flutter/actions/OpenSimulatorAction.java
+++ b/src/io/flutter/actions/OpenSimulatorAction.java
@@ -27,15 +27,15 @@ public class OpenSimulatorAction extends AnAction {
 
   @Override
   public void actionPerformed(AnActionEvent event) {
-      // Check to see if the simulator is already running.
-      // If it is, and we're here, that means there are no booted devices.
-      if (XcodeUtils.isSimulatorRunning()) {
-        FlutterMessages.showDialog(event.getProject(),
-                                   "It looks like you have the Simulator app open but no booted devices;\n"
-                                   +"in the simulator, boot a device from the \"Hardware\" menu before running.", "No Booted Devices", new String[]{"OK"}, 0);
-        return;
-      }
-
+    // Check to see if the simulator is already running.
+    // If it is, and we're here, that means there are no booted devices.
+    if (XcodeUtils.isSimulatorRunning()) {
+      FlutterMessages.showDialog(event.getProject(),
+                                 "It looks like you have the Simulator app open but no booted devices;\n"
+                                 + "in the Simulator, start a device from the \"Hardware\" menu before running.",
+                                 "No Running Simulator Devices", new String[]{"OK"}, 0);
+    } else {
       XcodeUtils.startSimulator();
+    }
   }
 }

--- a/src/io/flutter/sdk/XcodeUtils.java
+++ b/src/io/flutter/sdk/XcodeUtils.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2018 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.sdk;
+
+import com.intellij.execution.ExecutionException;
+import com.intellij.execution.configurations.GeneralCommandLine;
+import com.intellij.execution.process.*;
+import io.flutter.FlutterBundle;
+import io.flutter.FlutterMessages;
+import org.jetbrains.annotations.NotNull;
+
+public class XcodeUtils {
+
+  public static boolean isSimulatorRunning() {
+    final ProcessInfo[] processInfos = OSProcessUtil.getProcessList();
+    for (ProcessInfo info : processInfos) {
+      if (info.getExecutableName().equals("Simulator")) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  public static void startSimulator() {
+    try {
+      final GeneralCommandLine cmd = new GeneralCommandLine().withExePath("open").withParameters("-a", "Simulator.app");
+      final OSProcessHandler handler = new OSProcessHandler(cmd);
+      handler.addProcessListener(new ProcessAdapter() {
+        @Override
+        public void processTerminated(@NotNull final ProcessEvent event) {
+          if (event.getExitCode() != 0) {
+            final String msg = event.getText() != null ? event.getText() : "Process error - exit code: (" + event.getExitCode() + ")";
+            FlutterMessages.showError("Error Opening Simulator", msg);
+          }
+        }
+      });
+      handler.startNotify();
+    }
+    catch (ExecutionException e) {
+      FlutterMessages.showError(
+        "Error Opening Simulator",
+        FlutterBundle.message("flutter.command.exception.message", e.getMessage()));
+    }
+  }
+}


### PR DESCRIPTION
Updated to do a pre-run with `-n` as suggested by @DanTup 👍 


---

No longer relevant:

> Displays a message when the Xcode simulator is running but there are no booted devices.
> 
> 
> ![image](https://user-images.githubusercontent.com/67586/39842320-dbbc3974-539a-11e8-81cf-d135b990f5ff.png)
> 
> (**EDIT:** updated w/ word-smithed final text.)

See: #2234

@devoncarew 