### PR TITLE
Update the action label depending on selection

### DIFF
--- a/flutter-intellij-community.iml
+++ b/flutter-intellij-community.iml
@@ -44,5 +44,6 @@
     <orderEntry type="library" name="snakeyaml" level="project" />
     <orderEntry type="library" name="Dart SDK" level="project" />
     <orderEntry type="library" name="Dart Packages" level="project" />
+    <orderEntry type="library" name="jsr305" level="project" />
   </component>
 </module>

--- a/flutter-intellij-community.iml
+++ b/flutter-intellij-community.iml
@@ -44,6 +44,5 @@
     <orderEntry type="library" name="snakeyaml" level="project" />
     <orderEntry type="library" name="Dart SDK" level="project" />
     <orderEntry type="library" name="Dart Packages" level="project" />
-    <orderEntry type="library" name="jsr305" level="project" />
   </component>
 </module>

--- a/flutter-intellij.iml
+++ b/flutter-intellij.iml
@@ -58,6 +58,5 @@
     </orderEntry>
     <orderEntry type="library" name="Dart SDK" level="project" />
     <orderEntry type="library" name="Dart Packages" level="project" />
-    <orderEntry type="library" name="jsr305" level="project" />
   </component>
 </module>

--- a/flutter-intellij.iml
+++ b/flutter-intellij.iml
@@ -58,5 +58,6 @@
     </orderEntry>
     <orderEntry type="library" name="Dart SDK" level="project" />
     <orderEntry type="library" name="Dart Packages" level="project" />
+    <orderEntry type="library" name="jsr305" level="project" />
   </component>
 </module>

--- a/src/io/flutter/FlutterBundle.properties
+++ b/src/io/flutter/FlutterBundle.properties
@@ -162,3 +162,8 @@ old.android.studio.message=Your path contains Android Studio 2.x,\n\
   which does not support Flutter.\n\n\
   You can change it using the flutter command-line tool via:\n\
   flutter\u00a0config\u00a0--android-studio-dir\u00a0{0}path{0}to{0}Android\u00a0Studio\u00a03.x
+
+flutter.androidstudio.open.module.text=Open Android module in Android Studio
+flutter.androidstudio.open.module.description=Open Android Studio in a new window to edit the top-level Android project
+flutter.androidstudio.open.file.text=Open for Editing in Android Studio
+flutter.androidstudio.open.file.description=Open Android Studio in a new window to edit this file

--- a/src/io/flutter/actions/OpenInAndroidStudioAction.java
+++ b/src/io/flutter/actions/OpenInAndroidStudioAction.java
@@ -30,13 +30,14 @@ import java.io.File;
 
 public class OpenInAndroidStudioAction extends AnAction {
 
+  private static final String LABEL_FILE = FlutterBundle.message("flutter.androidstudio.open.file.text");
+  private static final String DESCR_FILE = FlutterBundle.message("flutter.androidstudio.open.file.description");
+  private static final String LABEL_MODULE = FlutterBundle.message("flutter.androidstudio.open.module.text");
+  private static final String DESCR_MODULE = FlutterBundle.message("flutter.androidstudio.open.module.description");
+
   @Override
   public void update(AnActionEvent event) {
-    final boolean enabled = findProjectFile(event) != null;
-
-    final Presentation presentation = event.getPresentation();
-    presentation.setEnabled(enabled);
-    presentation.setVisible(enabled);
+    updatePresentation(event, event.getPresentation());
   }
 
   @Override
@@ -56,6 +57,29 @@ public class OpenInAndroidStudioAction extends AnAction {
     final VirtualFile file = e.getData(CommonDataKeys.VIRTUAL_FILE);
     final String sourceFile = file == null ? null : file.isDirectory() ? null : file.getPath();
     openFileInStudio(projectFile, androidStudioPath, sourceFile);
+  }
+
+  private static void updatePresentation(AnActionEvent event, Presentation state) {
+    if (findProjectFile(event) == null) {
+      state.setVisible(false);
+    }
+    else {
+      VirtualFile file = event.getData(CommonDataKeys.VIRTUAL_FILE);
+      String label, descr;
+      if (file != null && !file.isDirectory()) {
+        // The file will be opened in an editor in the new IDE window.
+        label = LABEL_FILE;
+        descr = DESCR_FILE;
+      }
+      else {
+        // The new IDE window will be opened on the Android module but there is no file selected for editing.
+        label = LABEL_MODULE;
+        descr = DESCR_MODULE;
+      }
+      state.setVisible(true);
+      state.setText(label);
+      state.setDescription(descr);
+    }
   }
 
   protected static boolean isProjectFileName(String name) {

--- a/src/io/flutter/editor/NativeEditorNotificationProvider.java
+++ b/src/io/flutter/editor/NativeEditorNotificationProvider.java
@@ -60,6 +60,9 @@ public class NativeEditorNotificationProvider extends EditorNotifications.Provid
   }
 
   private static String getActionName(VirtualFile root) {
+    if (root == null) {
+      return null;
+    }
     if (root.getName().equals("android")) {
       return "flutter.androidstudio.open";
     }

--- a/src/io/flutter/editor/NativeEditorNotificationProvider.java
+++ b/src/io/flutter/editor/NativeEditorNotificationProvider.java
@@ -15,7 +15,6 @@ import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.ui.EditorNotificationPanel;
 import com.intellij.ui.EditorNotifications;
-import com.intellij.ui.HyperlinkLabel;
 import icons.FlutterIcons;
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
@@ -42,29 +41,38 @@ public class NativeEditorNotificationProvider extends EditorNotifications.Provid
     if (!file.isInLocalFileSystem()) {
       return null;
     }
-    final VirtualFile root = findRootDir(file);
+    return createPanelForFile(file, findRootDir(file, myProject.getBaseDir()));
+  }
+
+  private EditorNotificationPanel createPanelForFile(VirtualFile file, VirtualFile root) {
     if (root == null) {
       return null;
     }
+    return createPanelForAction(file, root, getActionName(root));
+  }
 
-    final String actionName;
-    if (root.getName().equals("android")) {
-      actionName = "flutter.androidstudio.open";
-    }
-    else if (root.getName().equals("ios")) {
-      actionName = "flutter.xcode.open";
-    }
-    else {
+  private EditorNotificationPanel createPanelForAction(VirtualFile file, VirtualFile root, String actionName) {
+    if (actionName == null) {
       return null;
     }
-
     NativeEditorActionsPanel panel = new NativeEditorActionsPanel(file, root, actionName);
     return panel.isValidForFile() ? panel : null;
   }
 
-  private VirtualFile findRootDir(@NotNull VirtualFile file) {
+  private static String getActionName(VirtualFile root) {
+    if (root.getName().equals("android")) {
+      return "flutter.androidstudio.open";
+    }
+    else if (root.getName().equals("ios")) {
+      return "flutter.xcode.open";
+    }
+    else {
+      return null;
+    }
+  }
+
+  private static VirtualFile findRootDir(@NotNull VirtualFile file, VirtualFile projectDir) {
     // Return the top-most parent of file that is a child of the project directory.
-    final VirtualFile projectDir = myProject.getBaseDir();
     VirtualFile parent = file.getParent();
     if (projectDir.equals(parent)) {
       return null;
@@ -84,6 +92,7 @@ public class NativeEditorNotificationProvider extends EditorNotifications.Provid
     final VirtualFile myFile;
     final VirtualFile myRoot;
     final AnAction myAction;
+    final boolean isVisible;
 
     NativeEditorActionsPanel(VirtualFile file, VirtualFile root, String actionName) {
       super(EditorColors.GUTTER_BACKGROUND);
@@ -94,17 +103,15 @@ public class NativeEditorNotificationProvider extends EditorNotifications.Provid
       icon(FlutterIcons.Flutter);
       text("Flutter commands");
 
-      final Presentation present = myAction.getTemplatePresentation();
-      final HyperlinkLabel label = createActionLabel(present.getText(), this::performAction);
-      label.setToolTipText(present.getDescription());
+      // Ensure this project is a Flutter project by updating the menu action. It will only be visible for Flutter projects.
+      myAction.update(AnActionEvent.createFromDataContext(ActionPlaces.EDITOR_TOOLBAR, myAction.getTemplatePresentation(), makeContext()));
+      isVisible = myAction.getTemplatePresentation().isVisible();
+      createActionLabel(myAction.getTemplatePresentation().getText(), this::performAction)
+        .setToolTipText(myAction.getTemplatePresentation().getDescription());
     }
 
     private boolean isValidForFile() {
-      final DataContext context = makeContext();
-      final AnActionEvent event = AnActionEvent.createFromDataContext(ActionPlaces.EDITOR_TOOLBAR, null, context);
-      // Ensure this project is a Flutter project by updating the menu action. It will only be visible for Flutter projects.
-      myAction.update(event);
-      if (event.getPresentation().isVisible()) {
+      if (isVisible) {
         // The menu items are visible for certain elements outside the module directories.
         return FileUtil.isAncestor(myRoot.getPath(), myFile.getPath(), true);
       }
@@ -112,11 +119,9 @@ public class NativeEditorNotificationProvider extends EditorNotifications.Provid
     }
 
     private void performAction() {
-      final Presentation present = myAction.getTemplatePresentation();
-      final DataContext context = makeContext();
-      final AnActionEvent event = AnActionEvent.createFromDataContext(ActionPlaces.EDITOR_TOOLBAR, present, context);
       // Open Xcode or Android Studio. If already running AS then just open a new window.
-      myAction.actionPerformed(event);
+      myAction.actionPerformed(
+        AnActionEvent.createFromDataContext(ActionPlaces.EDITOR_TOOLBAR, myAction.getTemplatePresentation(), makeContext()));
     }
 
     private DataContext makeContext() {


### PR DESCRIPTION
Update the label (and hover-text description) of the action for "Open in Android Studio" based on whether a file is selected (or open for editing) or not. This implements the suggestion made by @mit-mit in #2216.

Also added the dep for jsr305. It is distributed with IJ/AS so we might as well use it.

@devoncarew 