### PR TITLE
One parser per logger.

### DIFF
--- a/src/io/flutter/logging/FlutterLog.java
+++ b/src/io/flutter/logging/FlutterLog.java
@@ -27,14 +27,15 @@ public class FlutterLog {
 
   public static final String LOGGING_STREAM_ID = "_Logging";
 
-  private final List<Listener> listeners = new ArrayList<>();
-
   public static boolean isLoggingEnabled() {
     return FlutterSettings.getInstance().useFlutterLogView();
   }
 
+  private final List<Listener> listeners = new ArrayList<>();
+  private final FlutterLogEntryParser logEntryParser = new FlutterLogEntryParser();
+
   public void addConsoleEntry(@NotNull String text, @NotNull ConsoleViewContentType contentType) {
-    onEntry(FlutterLogEntryParser.parseConsoleEvent(text, contentType));
+    onEntry(logEntryParser.parseConsoleEvent(text, contentType));
   }
 
   public void addListener(@NotNull Listener listener, @Nullable Disposable parent) {
@@ -61,7 +62,7 @@ public class FlutterLog {
     processHandler.addProcessListener(new ProcessAdapter() {
       @Override
       public void onTextAvailable(@NotNull ProcessEvent event, @NotNull Key outputType) {
-        onEntry(FlutterLogEntryParser.parseDaemonEvent(event, outputType));
+        onEntry(logEntryParser.parseDaemonEvent(event, outputType));
       }
     }, parent);
   }
@@ -90,7 +91,7 @@ public class FlutterLog {
   }
 
   private void onVmServiceReceived(String id, Event event) {
-    onEntry(FlutterLogEntryParser.parse(id, event));
+    onEntry(logEntryParser.parse(id, event));
   }
 
   @SuppressWarnings("EmptyMethod")

--- a/src/io/flutter/logging/FlutterLogEntryParser.java
+++ b/src/io/flutter/logging/FlutterLogEntryParser.java
@@ -28,8 +28,7 @@ public class FlutterLogEntryParser {
   private static final NumberFormat nf = new DecimalFormat();
   private static final NumberFormat df1 = new DecimalFormat();
 
-  // TODO(pq): w/ state, we should now make the parser not static.
-  private static final StdoutJsonParser stdoutParser = new StdoutJsonParser();
+  private final StdoutJsonParser stdoutParser = new StdoutJsonParser();
 
   static {
     df1.setMinimumFractionDigits(1);
@@ -42,7 +41,7 @@ public class FlutterLogEntryParser {
   public static final String STDIO_STDOUT_CATEGORY = "stdout";
 
   @Nullable
-  public static FlutterLogEntry parse(@Nullable String id, @Nullable Event event) {
+  public FlutterLogEntry parse(@Nullable String id, @Nullable Event event) {
     if (id != null && event != null) {
       switch (id) {
         case LOGGING_STREAM_ID:
@@ -56,7 +55,7 @@ public class FlutterLogEntryParser {
   }
 
   @Nullable
-  static FlutterLogEntry parseDaemonEvent(@NotNull ProcessEvent event, @Nullable Key outputType) {
+  FlutterLogEntry parseDaemonEvent(@NotNull ProcessEvent event, @Nullable Key outputType) {
     // TODO(pq): process outputType
     final String text = event.getText();
     if (text.isEmpty()) return null;
@@ -66,11 +65,12 @@ public class FlutterLogEntryParser {
 
   @VisibleForTesting
   @Nullable
-  public static FlutterLogEntry parseDaemonEvent(@NotNull String eventText) {
+  public FlutterLogEntry parseDaemonEvent(@NotNull String eventText) {
     // TODO(pq): restructure parsing to ensure DaemonEvent messages are only parsed once
     // (with daemon JSON going into one stream and regular log messages going elsewhere)
     stdoutParser.appendOutput(eventText);
     for (String line : stdoutParser.getAvailableLines()) {
+      //noinspection StatementWithEmptyBody
       if (DaemonApi.parseAndValidateDaemonEvent(line.trim()) != null) {
         // Skip.
       }
@@ -129,7 +129,7 @@ public class FlutterLogEntryParser {
     }
   }
 
-  public static FlutterLogEntry parseConsoleEvent(String text, ConsoleViewContentType type) {
+  public FlutterLogEntry parseConsoleEvent(String text, ConsoleViewContentType type) {
     if (type == ConsoleViewContentType.NORMAL_OUTPUT) {
       return parseDaemonEvent(text);
     }


### PR DESCRIPTION
Follow-up from https://github.com/flutter/flutter-intellij/pull/2257#discussion_r189962211.

Stores a parser in each logger.

There's a larger refactoring we could consider that gets rid of the duplicated JSON parsing but that will take some doing.  Note that the `DaemonConsoleView` currently duplicates this parsing as well so at least this is no worse than if that option is toggled... 🙁 

Happy to chat about a bigger refactoring but this will at least solve the immediate problem in case there are multiple apps and event streams.


/cc @devoncarew 