### PR TITLE
Log Tree popup (and clear entry action)

### DIFF
--- a/src/io/flutter/logging/FlutterLogView.java
+++ b/src/io/flutter/logging/FlutterLogView.java
@@ -40,7 +40,6 @@ import javax.swing.table.AbstractTableModel;
 import javax.swing.table.TableCellRenderer;
 import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.MutableTreeNode;
-import javax.swing.tree.TreePath;
 import java.awt.*;
 import java.awt.event.MouseEvent;
 import java.text.SimpleDateFormat;
@@ -61,33 +60,6 @@ public class FlutterLogView extends JPanel implements ConsoleView, DataProvider,
       ApplicationManager.getApplication().invokeLater(() -> {
         model.getRoot().removeAllChildren();
         model.update();
-      });
-    }
-
-    @Override
-    public void update(AnActionEvent e) {
-      e.getPresentation().setEnabled(model.getRoot().getChildCount() > 0);
-    }
-  }
-
-  private class ClearEntryAction extends AnAction {
-    ClearEntryAction() {
-      super("Clear", "Clear the selected entries", AllIcons.Actions.Delete);
-    }
-
-    @Override
-    public void actionPerformed(AnActionEvent e) {
-      ApplicationManager.getApplication().invokeLater(() -> {
-        final int[] rows = treeTable.getSelectedRows();
-        final LogRootTreeNode root = model.getRoot();
-        final TreePath[] paths = treeTable.getTree().getSelectionPaths();
-        if (paths != null) {
-          for (final TreePath path : paths) {
-            final DefaultMutableTreeNode node = (DefaultMutableTreeNode)(path.getLastPathComponent());
-            model.removeNodeFromParent(node);
-          }
-          model.update();
-        }
       });
     }
 
@@ -199,8 +171,6 @@ public class FlutterLogView extends JPanel implements ConsoleView, DataProvider,
       @Override
       public AnAction[] getChildren(@Nullable AnActionEvent e) {
         return new AnAction[]{
-          new ClearEntryAction(),
-          new Separator(),
           new ClearLogAction()
         };
       }


### PR DESCRIPTION
Adds a popup menu to the logging tree.

Implements a clear entry action.

![image](https://user-images.githubusercontent.com/67586/40443177-588e9e12-5e7a-11e8-8792-2a7e33c03102.png)

(FWIW: on the fence about Clear vs. Cut vs. Delete.  "Clear all" is implemented in the default console view.)

A few more to come (`Copy` to clipboard probably up next).

/cc @devoncarew 
