### PR TITLE
Fix launch state caching.

### DIFF
--- a/src/io/flutter/run/LaunchState.java
+++ b/src/io/flutter/run/LaunchState.java
@@ -107,8 +107,6 @@ public class LaunchState extends CommandLineState {
     final Project project = getEnvironment().getProject();
     final FlutterDevice device = DeviceService.getInstance(project).getSelectedDevice();
     final FlutterApp app = callback.createApp(device);
-    // Cache for use in console configuration.
-    FlutterApp.addToEnvironment(env, app);
 
     if (device == null) {
       Messages.showDialog(
@@ -119,6 +117,9 @@ public class LaunchState extends CommandLineState {
 
       return null;
     }
+
+    // Cache for use in console configuration.
+    FlutterApp.addToEnvironment(env, app);
 
     // Remember the run configuration that started this process.
     app.getProcessHandler().putUserData(FLUTTER_RUN_CONFIG_KEY, runConfig);


### PR DESCRIPTION
Trying to cache before the null device check was leading to failed assertions (and no useful dialog) on run attempts w/ no active device.


The offending change landed right after `M24` so no need to patch.

/cc @devoncarew 
