### PR TITLE
persist the track-widget-creation setting

### DIFF
--- a/src/io/flutter/settings/FlutterSettings.java
+++ b/src/io/flutter/settings/FlutterSettings.java
@@ -87,7 +87,7 @@ public class FlutterSettings {
   }
 
   public void setTrackWidgetCreation(boolean value) {
-    getPropertiesComponent().setValue(trackWidgetCreationKey, value);
+    getPropertiesComponent().setValue(trackWidgetCreationKey, value, true);
 
     fireEvent();
   }


### PR DESCRIPTION
- fix an issue where the setting for `--track-widget-creation` was not persisted

@jacob314 