### PR TITLE
handle reload errors

### DIFF
--- a/src/io/flutter/run/FlutterReloadManager.java
+++ b/src/io/flutter/run/FlutterReloadManager.java
@@ -243,6 +243,9 @@ public class FlutterReloadManager {
         else if (result.isRestartRecommended()) {
           showRunNotification(app, "Reloading…", RESTART_SUGGESTED_TEXT, false);
         }
+      }).exceptionally(throwable -> {
+        showRunNotification(app, "Hot Reload", throwable.getMessage(), true);
+        return null;
       });
     }
   }
@@ -254,6 +257,9 @@ public class FlutterReloadManager {
         if (!result.ok()) {
           showRunNotification(app, "Hot Restart", result.getMessage(), true);
         }
+      }).exceptionally(throwable -> {
+        showRunNotification(app, "Hot Restart", throwable.getMessage(), true);
+        return null;
       });
 
       final FlutterDevice device = DeviceService.getInstance(myProject).getSelectedDevice();


### PR DESCRIPTION
We're seeing lots of unhandled errors from daemon protocol commands (https://github.com/flutter/flutter-intellij/issues/2319). I can't tell if they are all from a certain command, or general errors in the protocol encoding. In any case, this PR adds better error handling for the reload/restart commands.