### PR TITLE
Clean up the quick fixes in build-17

### DIFF
--- a/flutter-studio/README.md
+++ b/flutter-studio/README.md
@@ -11,6 +11,9 @@ To set up a development environment using sources for Android Studio:
     - possibly skip running intellij-community/getPlugins.sh
 4. Checkout Dart plugin sources, branch 173.
 5. Build everything.
+    - Do a blaze pre-build:
+        - tools/base/bazel/bazel build //tools/adt/idea/android:artifacts
+        - This generates some required classes that are not checked in.
     - Do a blaze build from a terminal window. Allow 15+ min for this.
     - OR in IntelliJ: Build > Rebuild Project
     - Some Android Studio classes need to be generated.

--- a/flutter-studio/src/io/flutter/project/FlutterProjectSystem.java
+++ b/flutter-studio/src/io/flutter/project/FlutterProjectSystem.java
@@ -11,17 +11,22 @@ import com.android.tools.idea.projectsystem.AndroidProjectSystem;
 import com.android.tools.idea.projectsystem.ProjectSystemSyncManager;
 import com.android.tools.idea.projectsystem.gradle.GradleProjectSystem;
 import com.android.tools.idea.projectsystem.gradle.GradleProjectSystemProvider;
+import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiElementFinder;
+import com.intellij.util.ReflectionUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.nio.file.Path;
 import java.util.Collection;
 
 public class FlutterProjectSystem implements AndroidProjectSystem {
+  private static final Logger LOG = Logger.getInstance(FlutterProjectSystem.class);
   @NotNull final private GradleProjectSystem gradleProjectSystem;
 
   public FlutterProjectSystem(Project project) {
@@ -43,6 +48,7 @@ public class FlutterProjectSystem implements AndroidProjectSystem {
   @Override
   public void buildProject() {
     // flutter build ?
+    LOG.warn("FlutterProjectSystem.buildProject() called but not (properly) implemented.");
   }
 
   @Override
@@ -75,16 +81,31 @@ public class FlutterProjectSystem implements AndroidProjectSystem {
     return gradleProjectSystem.getSyncManager();
   }
 
+  @SuppressWarnings("override")
   @Nullable
   public GradleCoordinate getAvailableDependency(@NotNull GradleCoordinate coordinate, boolean includePreview) {
     return null;
   }
 
+  @SuppressWarnings("override")
   @NotNull
   public Collection<PsiElementFinder> getPsiElementFinders() {
-    return null;//gradleProjectSystem.getPsiElementFinders();
+    Method finders = ReflectionUtil.getMethod(gradleProjectSystem.getClass(), "getPsiElementFinders");
+    if (finders == null) {
+      // Not reached; method exists in c18 and not called in c<18.
+      throw new NullPointerException();
+    }
+    try {
+      //noinspection unchecked
+      return (Collection<PsiElementFinder>) finders.invoke(gradleProjectSystem);
+    }
+    catch (IllegalAccessException | InvocationTargetException e) {
+      LOG.error(e);
+      throw new IllegalArgumentException(e);
+    }
   }
 
+  @SuppressWarnings("override")
   public boolean getAugmentRClasses() {
     return false;
   }

--- a/flutter-studio/src/io/flutter/project/FlutterProjectSystem.java
+++ b/flutter-studio/src/io/flutter/project/FlutterProjectSystem.java
@@ -24,6 +24,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.file.Path;
 import java.util.Collection;
+import java.util.Collections;
 
 public class FlutterProjectSystem implements AndroidProjectSystem {
   private static final Logger LOG = Logger.getInstance(FlutterProjectSystem.class);
@@ -92,8 +93,8 @@ public class FlutterProjectSystem implements AndroidProjectSystem {
   public Collection<PsiElementFinder> getPsiElementFinders() {
     Method finders = ReflectionUtil.getMethod(gradleProjectSystem.getClass(), "getPsiElementFinders");
     if (finders == null) {
-      // Not reached; method exists in c18 and not called in c<18.
-      throw new NullPointerException();
+      LOG.error("No method found: GradleProjectSystem.getPsiElementFinders()");
+      return Collections.emptyList();
     }
     try {
       //noinspection unchecked

--- a/flutter-studio/testSrc/com/android/tools/idea/tests/gui/framework/fixture/newProjectWizard/NewFlutterModuleWizardFixture.java
+++ b/flutter-studio/testSrc/com/android/tools/idea/tests/gui/framework/fixture/newProjectWizard/NewFlutterModuleWizardFixture.java
@@ -18,19 +18,12 @@ import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
 
-//import static com.android.tools.idea.tests.gui.framework.GuiTests.findAndClickButtonWhenEnabled;
+import static com.android.tools.idea.tests.gui.framework.GuiTests.findAndClickButton;
 
 public class NewFlutterModuleWizardFixture extends AbstractWizardFixture<NewFlutterModuleWizardFixture> {
 
   private NewFlutterModuleWizardFixture(@NotNull Robot robot, @NotNull JDialog target) {
     super(NewFlutterModuleWizardFixture.class, robot, target);
-  }
-
-  @NotNull
-  public static NewFlutterModuleWizardFixture find(@NotNull IdeaFrameFixture fixture) {
-    Robot robot = fixture.robot();
-    JDialog dialog = GuiTests.waitUntilShowing(robot, Matchers.byTitle(JDialog.class, "Create New Module"));
-    return new NewFlutterModuleWizardFixture(robot, dialog);
   }
 
   public NewFlutterModuleWizardFixture chooseModuleType(@NotNull String activity) {
@@ -42,6 +35,7 @@ public class NewFlutterModuleWizardFixture extends AbstractWizardFixture<NewFlut
   @NotNull
   public FlutterProjectStepFixture<NewFlutterModuleWizardFixture> getFlutterProjectStep(@NotNull FlutterProjectType type) {
     String projectType;
+    //noinspection Duplicates
     switch (type) {
       case APP:
         projectType = "application";
@@ -65,12 +59,20 @@ public class NewFlutterModuleWizardFixture extends AbstractWizardFixture<NewFlut
     return new FlutterSettingsStepFixture<>(this, rootPane);
   }
 
+  @SuppressWarnings("UnusedReturnValue")
   @NotNull
   public NewFlutterModuleWizardFixture clickFinish() {
-    // Do not user superclass method. When the project/module wizard is run from the IDE (not the Welcome screen)
+    // Do not use superclass method. When the project/module wizard is run from the IDE (not the Welcome screen)
     // the dialog does not disappear within the time allotted by the superclass method.
-    //findAndClickButtonWhenEnabled(this, "Finish"); TODO(messick) Fix this quick hack.
+    findAndClickButton(this, "Finish");
     Wait.seconds(30).expecting("dialog to disappear").until(() -> !target().isShowing());
     return myself();
+  }
+
+  @NotNull
+  public static NewFlutterModuleWizardFixture find(@NotNull IdeaFrameFixture fixture) {
+    Robot robot = fixture.robot();
+    JDialog dialog = GuiTests.waitUntilShowing(robot, Matchers.byTitle(JDialog.class, "Create New Module"));
+    return new NewFlutterModuleWizardFixture(robot, dialog);
   }
 }

--- a/flutter-studio/testSrc/io/flutter/tests/gui/NewModuleTest.java
+++ b/flutter-studio/testSrc/io/flutter/tests/gui/NewModuleTest.java
@@ -19,6 +19,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.model.InitializationError;
+import org.junit.runners.model.RunnerBuilder;
 
 import java.io.IOException;
 
@@ -34,8 +35,8 @@ public class NewModuleTest {
    */
   public static class CustomRunner extends GuiTestSuiteRunner {
 
-    public CustomRunner(Class<?> testClass) throws InitializationError, IOException {
-      super(testClass, null); // TODO(mesick) Fix this quick hack.
+    public CustomRunner(Class<?> suiteClass, RunnerBuilder builder) throws InitializationError, IOException {
+      super(suiteClass, builder);
       System.setProperty("gui.tests.root.dir.path", "somewhere");
     }
 


### PR DESCRIPTION
@devoncarew Canary 18 introduces more API changes. This fixes all known issues for that, in a way that continues to work in 3.1.

Hopefully, the `@SuppressWarnings("override")` will let us easily find all those places that need annotations once 3.2 goes stable.