### PR TITLE
Ignore non-Dart files completely in setSelectedFile().

### DIFF
--- a/src/io/flutter/preview/PreviewView.java
+++ b/src/io/flutter/preview/PreviewView.java
@@ -774,9 +774,14 @@ public class PreviewView implements PersistentStateComponent<PreviewViewState>, 
       currentFilePath = null;
     }
 
+    // If not a Dart file, ignore it.
+    if (newFile != null && !FlutterUtils.isDartFile(newFile)) {
+      newFile = null;
+    }
+
     // Show the toolbar if the new file is a Dart file, or hide otherwise.
     if (windowPanel != null) {
-      if (newFile != null && FlutterUtils.isDartFile(newFile)) {
+      if (newFile != null) {
         windowPanel.setToolbar(windowToolbar.getComponent());
       }
       else if (windowPanel.isToolbarVisible()) {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter-intellij/issues/2330