### PR TITLE
support regex filter in log view

### DIFF
--- a/src/io/flutter/logging/FlutterLogTree.java
+++ b/src/io/flutter/logging/FlutterLogTree.java
@@ -266,12 +266,20 @@ public class FlutterLogTree extends TreeTable {
 
 
   public static class ContainsTextFilter implements EntryFilter {
+    @Nullable
     private final String text;
+    private final boolean isEnableRegex;
 
-    public ContainsTextFilter(String text) {
-      this.text = text;
+    public ContainsTextFilter(@Nullable String text) {
+      this(text, false);
     }
 
+    public ContainsTextFilter(@Nullable String text, boolean isEnableRegex) {
+      this.text = text;
+      this.isEnableRegex = isEnableRegex;
+    }
+
+    @Nullable
     public String getText() {
       return text;
     }
@@ -281,27 +289,32 @@ public class FlutterLogTree extends TreeTable {
       if (text == null) {
         return true;
       }
-
-      if (entry.getMessage().contains(text)) {
+      if (acceptByCheckingRegexOption(entry.getMessage(), text)) {
         return true;
       }
+      return acceptByCheckingRegexOption(entry.getCategory(), text);
+    }
 
-      //noinspection RedundantIfStatement
-      if (entry.getCategory().contains(text)) {
-        return true;
+    private boolean acceptByCheckingRegexOption(@NotNull String message, @NotNull String text) {
+      final String standardString = message.replaceAll("\n", "");
+      if (isEnableRegex) {
+        return standardString.matches(".*" + text + ".*");
       }
-
-      return false;
+      return standardString.contains(text);
     }
 
     @Override
-    public boolean equals(Object obj) {
-      return obj instanceof ContainsTextFilter && ((ContainsTextFilter)obj).text.equals(this.text);
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      final ContainsTextFilter filter = (ContainsTextFilter)o;
+      return isEnableRegex == filter.isEnableRegex &&
+             Objects.equals(text, filter.text);
     }
 
     @Override
     public int hashCode() {
-      return 13 ^ Objects.hashCode(text);
+      return 13 ^ Objects.hashCode(text) ^ Objects.hashCode(isEnableRegex);
     }
   }
 

--- a/src/io/flutter/logging/FlutterLogView.java
+++ b/src/io/flutter/logging/FlutterLogView.java
@@ -46,8 +46,12 @@ public class FlutterLogView extends JPanel implements ConsoleView, DataProvider,
   private class FilterToolbarAction extends AnAction implements CustomComponentAction /*, RightAlignedToolbarAction */ {
     private final JPanel myComponent;
     private final SearchTextField myField;
+    private final JCheckBox chbEnableRegex;
 
     public FilterToolbarAction() {
+      chbEnableRegex = new JCheckBox("Regex");
+      chbEnableRegex.setHorizontalTextPosition(SwingConstants.LEFT);
+      chbEnableRegex.addItemListener(e -> doFilter());
       myField = new SearchTextField(true) {
         @Override
         protected boolean preprocessEventForTextField(KeyEvent e) {
@@ -100,6 +104,7 @@ public class FlutterLogView extends JPanel implements ConsoleView, DataProvider,
       //  myComponent.add(label);
       //}
       myComponent.add(myField);
+      myComponent.add(chbEnableRegex);
     }
 
     @Override
@@ -108,9 +113,9 @@ public class FlutterLogView extends JPanel implements ConsoleView, DataProvider,
     }
 
     private void doFilter() {
-      // TODO(pq): support regexp matching (and add a mode toggle).
       final String text = getText();
-      final FlutterLogTree.EntryFilter filter = StringUtils.isEmpty(text) ? null : new FlutterLogTree.ContainsTextFilter(text);
+      final FlutterLogTree.EntryFilter filter =
+        StringUtils.isEmpty(text) ? null : new FlutterLogTree.ContainsTextFilter(text, chbEnableRegex.isSelected());
       ApplicationManager.getApplication().invokeLater(() -> logTree.setFilter(filter));
     }
 

--- a/testSrc/unit/io/flutter/logging/FlutterLogTreeTest.java
+++ b/testSrc/unit/io/flutter/logging/FlutterLogTreeTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2018 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.logging;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class FlutterLogTreeTest {
+
+  @Test
+  public void testMustAcceptIfFilterIsNull() {
+    final FlutterLogTree.ContainsTextFilter filterNormal = new FlutterLogTree.ContainsTextFilter(null);
+    final FlutterLogTree.ContainsTextFilter filterRegex = new FlutterLogTree.ContainsTextFilter(null, true);
+    final FlutterLogEntry entry = new FlutterLogEntry(0, "", "");
+    assertTrue(filterNormal.accept(entry));
+    assertTrue(filterRegex.accept(entry));
+  }
+
+  @Test
+  public void testAcceptInRegex() {
+    final FlutterLogTree.ContainsTextFilter filterRegex = new FlutterLogTree.ContainsTextFilter(".*hello.*", true);
+    final FlutterLogEntry entryMatchWithRegexByMessage = new FlutterLogEntry(0, "random", "log hello message");
+    final FlutterLogEntry entryMatchWithRegexByMessageWithBreakLine = new FlutterLogEntry(0, "random", "log hello message\nnewline\n");
+    final FlutterLogEntry entryMatchWithRegexByCategory = new FlutterLogEntry(0, "hello", "log random message");
+    final FlutterLogEntry entryNotMatchWithRegex = new FlutterLogEntry(0, "random", "log random message");
+    assertTrue(filterRegex.accept(entryMatchWithRegexByMessage));
+    assertTrue(filterRegex.accept(entryMatchWithRegexByMessageWithBreakLine));
+    assertTrue(filterRegex.accept(entryMatchWithRegexByCategory));
+    assertFalse(filterRegex.accept(entryNotMatchWithRegex));
+  }
+
+  @Test
+  public void testAcceptInNormalMode() {
+    final FlutterLogTree.ContainsTextFilter filterRegex = new FlutterLogTree.ContainsTextFilter("hello", true);
+    final FlutterLogEntry entryMatchByMessage = new FlutterLogEntry(0, "random", "log hello message");
+    final FlutterLogEntry entryMatchByCategory = new FlutterLogEntry(0, "hello", "log random message");
+    final FlutterLogEntry entryNotMatch = new FlutterLogEntry(0, "random", "log random message");
+
+    assertTrue(filterRegex.accept(entryMatchByMessage));
+    assertTrue(filterRegex.accept(entryMatchByCategory));
+    assertFalse(filterRegex.accept(entryNotMatch));
+  }
+}


### PR DESCRIPTION
Ref: https://github.com/flutter/flutter-intellij/issues/2200

Implement support filter by regex in the log view.

Notes:
If user enable `regex` => we will automatically added `.*` before/after the filter text.

Example:
User input: `hello`
=> The actual text filter in mode regex is `.*hello.*`