### PR TITLE
Fix log filter background

### DIFF
--- a/src/io/flutter/logging/FlutterLogFilterPanel.form
+++ b/src/io/flutter/logging/FlutterLogFilterPanel.form
@@ -6,7 +6,6 @@
       <xy x="20" y="34" width="450" height="35"/>
     </constraints>
     <properties>
-      <background color="-1250068"/>
       <enabled value="true"/>
       <minimumSize width="450" height="35"/>
       <preferredSize width="450" height="35"/>


### PR DESCRIPTION
The hardcoded background color introduced in #2361 doesn't play nice w/ darcula:

![image](https://user-images.githubusercontent.com/67586/41305255-38b19740-6e27-11e8-9cc5-8c9fe7486a63.png)

These returns us to the default, which fixes it.

![image](https://user-images.githubusercontent.com/67586/41305298-5ed0f088-6e27-11e8-9292-b09f2cb496d3.png)

![image](https://user-images.githubusercontent.com/67586/41305308-67af483a-6e27-11e8-824d-bc8ceb73dc08.png)

/cc @stevemessick  @quangson91 





