### PR TITLE
Improve search for emulator tool.

### DIFF
--- a/src/io/flutter/android/AndroidSdk.java
+++ b/src/io/flutter/android/AndroidSdk.java
@@ -23,6 +23,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Arrays;
 
 /**
  * A wrapper around an Android SDK on disk.

--- a/src/io/flutter/android/AndroidSdk.java
+++ b/src/io/flutter/android/AndroidSdk.java
@@ -60,8 +60,12 @@ public class AndroidSdk {
 
   @Nullable
   public VirtualFile getEmulatorToolExecutable() {
-    // Look for $ANDROID_HOME/tools/emulator.
-    return home.findFileByRelativePath("tools/" + (SystemInfo.isWindows ? "emulator.exe" : "emulator"));
+    final List<String> searchDirs = Arrays.asList("emulator", "tools");
+
+    for (String dir : searchDirs){
+      // Look for $ANDROID_HOME/{dir}/emulator.
+      return home.findFileByRelativePath(dir + "/" + (SystemInfo.isWindows ? "emulator.exe" : "emulator"));
+    }
   }
 
   @NotNull


### PR DESCRIPTION
Gives priority to the emulator tool found in $ANDROID_HOME/emulator/emulator (if it exists) when selecting the emulator tool. Fixes #2351 