### PR TITLE
change the default for the open inspector setting

### DIFF
--- a/src/io/flutter/settings/FlutterSettings.java
+++ b/src/io/flutter/settings/FlutterSettings.java
@@ -151,11 +151,11 @@ public class FlutterSettings {
   }
 
   public boolean isOpenInspectorOnAppLaunch() {
-    return getPropertiesComponent().getBoolean(openInspectorOnAppLaunchKey, true);
+    return getPropertiesComponent().getBoolean(openInspectorOnAppLaunchKey, false);
   }
 
   public void setOpenInspectorOnAppLaunch(boolean value) {
-    getPropertiesComponent().setValue(openInspectorOnAppLaunchKey, value, true);
+    getPropertiesComponent().setValue(openInspectorOnAppLaunchKey, value, false);
 
     fireEvent();
   }


### PR DESCRIPTION
- change the default for the open inspector setting
- fix https://github.com/flutter/flutter-intellij/issues/2354

@jacob314, Tao opened an issue about this; I'm not sure what your thinking is here