### PR TITLE
Reorder level and text filters

### DIFF
--- a/src/io/flutter/logging/FlutterLogFilterPanel.form
+++ b/src/io/flutter/logging/FlutterLogFilterPanel.form
@@ -14,7 +14,7 @@
     <children>
       <component id="20384" class="javax.swing.JCheckBox" binding="matchCaseCheckBox">
         <constraints>
-          <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Match case"/>
@@ -22,7 +22,7 @@
       </component>
       <component id="d9caf" class="javax.swing.JCheckBox" binding="regexCheckBox">
         <constraints>
-          <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="0" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Regex"/>
@@ -30,7 +30,7 @@
       </component>
       <component id="b7426" class="com.intellij.ui.SearchTextField" binding="textExpression" custom-create="true">
         <constraints>
-          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false">
+          <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false">
             <minimum-size width="50" height="-1"/>
             <preferred-size width="200" height="-1"/>
           </grid>
@@ -39,7 +39,7 @@
       </component>
       <component id="4ad5d" class="javax.swing.JComboBox" binding="logLevelComboBox">
         <constraints>
-          <grid row="0" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="0" indent="0" use-parent-layout="false">
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="0" indent="0" use-parent-layout="false">
             <minimum-size width="100" height="-1"/>
             <preferred-size width="100" height="-1"/>
             <maximum-size width="100" height="-1"/>

--- a/src/io/flutter/logging/FlutterLogFilterPanel.java
+++ b/src/io/flutter/logging/FlutterLogFilterPanel.java
@@ -23,7 +23,7 @@ public class FlutterLogFilterPanel {
   private JCheckBox matchCaseCheckBox;
   private JCheckBox regexCheckBox;
   private SearchTextField textExpression;
-  private JComboBox logLevelComboBox;
+  private JComboBox<String> logLevelComboBox;
   @NotNull
   private final OnFilterListener onFilterListener;
 
@@ -34,7 +34,7 @@ public class FlutterLogFilterPanel {
     matchCaseCheckBox.addItemListener(e -> onFilterListener.onFilter(getCurrentFilterParam()));
     regexCheckBox.addItemListener(e -> onFilterListener.onFilter(getCurrentFilterParam()));
     final List<String> logLevels = Arrays.stream(FlutterLog.Level.values())
-      .map(Enum::name)
+      .map(level -> " " + level.name())
       .collect(Collectors.toList());
     logLevelComboBox.setModel(new CollectionComboBoxModel<>(logLevels));
     logLevelComboBox.addActionListener(event -> onFilterListener.onFilter(getCurrentFilterParam()));

--- a/src/io/flutter/logging/FlutterLogFilterPanel.java
+++ b/src/io/flutter/logging/FlutterLogFilterPanel.java
@@ -34,7 +34,7 @@ public class FlutterLogFilterPanel {
     matchCaseCheckBox.addItemListener(e -> onFilterListener.onFilter(getCurrentFilterParam()));
     regexCheckBox.addItemListener(e -> onFilterListener.onFilter(getCurrentFilterParam()));
     final List<String> logLevels = Arrays.stream(FlutterLog.Level.values())
-      .map(level -> " " + level.name())
+      .map(Enum::name)
       .collect(Collectors.toList());
     logLevelComboBox.setModel(new CollectionComboBoxModel<>(logLevels));
     logLevelComboBox.addActionListener(event -> onFilterListener.onFilter(getCurrentFilterParam()));


### PR DESCRIPTION
Sort log level first.

![image](https://user-images.githubusercontent.com/67586/41577596-99dfcc60-7342-11e8-9cee-c9f0feb71453.png)

I *think* it looks a bit better and makes semantic sense... it's also consistent w/ logcat (for what that's worth).

/cc @quangson91 