### PR TITLE
Add level combo renderer

### DIFF
--- a/src/io/flutter/logging/FlutterLogFilterPanel.java
+++ b/src/io/flutter/logging/FlutterLogFilterPanel.java
@@ -6,6 +6,7 @@
 package io.flutter.logging;
 
 import com.intellij.ui.CollectionComboBoxModel;
+import com.intellij.ui.ColoredListCellRenderer;
 import com.intellij.ui.SearchTextField;
 import com.intellij.util.ui.UIUtil;
 import org.jetbrains.annotations.NotNull;
@@ -38,6 +39,16 @@ public class FlutterLogFilterPanel {
       .collect(Collectors.toList());
     logLevelComboBox.setModel(new CollectionComboBoxModel<>(logLevels));
     logLevelComboBox.addActionListener(event -> onFilterListener.onFilter(getCurrentFilterParam()));
+    logLevelComboBox.setRenderer(new ColoredListCellRenderer<String>() {
+      @Override
+      protected void customizeCellRenderer(@NotNull JList<? extends String> list,
+                                           String value,
+                                           int index,
+                                           boolean selected,
+                                           boolean hasFocus) {
+        append(value);
+      }
+    });
   }
 
   @NotNull


### PR DESCRIPTION
Improves default rendering by padding items.

Before:

![image](https://user-images.githubusercontent.com/67586/41604870-147386a4-7395-11e8-84a5-5604c3f825b7.png)

After:

![image](https://user-images.githubusercontent.com/67586/41604874-16896422-7395-11e8-8444-0912a204e3e9.png)

Also leaves the door open for styling.  (Possibly using the level colors?)

/cc @quangson91 @scheglov 
