### PR TITLE
add flutter log color setting page

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -671,6 +671,7 @@
 
     <projectStructureDetector implementation="io.flutter.project.FlutterProjectStructureDetector"/>
     <colorSettingsPage implementation="io.flutter.logging.FlutterLogColorPage"/>
+    <additionalTextAttributes scheme="Default" file="colorSchemes/FlutterLogColorSchemeDefault.xml"/>
   </extensions>
 
   <!-- Dart Plugin extensions -->

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -670,6 +670,7 @@
     <library.type implementation="io.flutter.sdk.FlutterPluginLibraryType"/>
 
     <projectStructureDetector implementation="io.flutter.project.FlutterProjectStructureDetector"/>
+    <colorSettingsPage implementation="io.flutter.logging.FlutterLogColorPage"/>
   </extensions>
 
   <!-- Dart Plugin extensions -->

--- a/resources/META-INF/plugin_template.xml
+++ b/resources/META-INF/plugin_template.xml
@@ -250,6 +250,7 @@
     <library.type implementation="io.flutter.sdk.FlutterPluginLibraryType"/>
 
     <projectStructureDetector implementation="io.flutter.project.FlutterProjectStructureDetector"/>
+    <colorSettingsPage implementation="io.flutter.logging.FlutterLogColorPage"/>
   </extensions>
 
   <!-- Dart Plugin extensions -->

--- a/resources/META-INF/plugin_template.xml
+++ b/resources/META-INF/plugin_template.xml
@@ -251,6 +251,7 @@
 
     <projectStructureDetector implementation="io.flutter.project.FlutterProjectStructureDetector"/>
     <colorSettingsPage implementation="io.flutter.logging.FlutterLogColorPage"/>
+    <additionalTextAttributes scheme="Default" file="colorSchemes/FlutterLogColorSchemeDefault.xml"/>
   </extensions>
 
   <!-- Dart Plugin extensions -->

--- a/resources/colorSchemes/FlutterLogColorSchemeDefault.xml
+++ b/resources/colorSchemes/FlutterLogColorSchemeDefault.xml
@@ -1,0 +1,63 @@
+<?xml version='1.0'?>
+<!--
+  ~ Copyright 2018 The Chromium Authors. All rights reserved.
+  ~ Use of this source code is governed by a BSD-style license that can be
+  ~ found in the LICENSE file.
+  -->
+
+<list>
+  <!--<option name="TEMPLATE_CONFIG_NAME">-->
+  <!--<value>-->
+  <!--<option name="FOREGROUND" value="008000"/>-->
+  <!--<option name="BACKGROUND" value="e3fcff"/>-->
+  <!--<option name="FONT_TYPE" value="1"/>-->
+  <!--</value>-->
+  <!--</option>-->
+
+  <option name="FLUTTER_LOG_NONE_OUTPUT">
+    <value>
+      <option name="FOREGROUND" value="#000000"/>
+    </value>
+  </option>
+  <option name="FLUTTER_LOG_FINEST_OUTPUT">
+    <value>
+      <option name="FOREGROUND" value="#000000"/>
+    </value>
+  </option>
+  <option name="FLUTTER_LOG_FINER_OUTPUT">
+    <value>
+      <option name="FOREGROUND" value="#000000"/>
+    </value>
+  </option>
+  <option name="FLUTTER_LOG_FINE_OUTPUT">
+    <value>
+      <option name="FOREGROUND" value="#000000"/>
+    </value>
+  </option>
+  <option name="FLUTTER_LOG_CONFIG_OUTPUT">
+    <value>
+      <option name="FOREGROUND" value="#000000"/>
+    </value>
+  </option>
+  <option name="FLUTTER_LOG_INFO_OUTPUT">
+    <value>
+      <option name="FOREGROUND" value="#000000"/>
+    </value>
+  </option>
+  <option name="FLUTTER_LOG_WARNING_OUTPUT">
+    <value>
+      <option name="FOREGROUND" value="#00007F"/>
+    </value>
+  </option>
+  <option name="FLUTTER_LOG_SEVERE_OUTPUT">
+    <value>
+      <option name="FOREGROUND" value="#7F0000"/>
+    </value>
+  </option>
+  <option name="FLUTTER_LOG_SHOUT_OUTPUT">
+    <value>
+      <option name="FOREGROUND" value="#7F0000"/>
+    </value>
+  </option>
+
+</list>

--- a/src/io/flutter/FlutterBundle.properties
+++ b/src/io/flutter/FlutterBundle.properties
@@ -167,3 +167,15 @@ flutter.androidstudio.open.module.text=Open Android module in Android Studio
 flutter.androidstudio.open.module.description=Open Android Studio in a new window to edit the top-level Android project
 flutter.androidstudio.open.file.text=Open for Editing in Android Studio
 flutter.androidstudio.open.file.description=Open Android Studio in a new window to edit this file
+
+# Flutter Log Color Page
+none.level.title=None
+finest.level.title=Finest
+finer.level.title=Finer
+fine.level.title=Fine
+config.level.title=Config
+info.level.title=Info
+warning.level.title=Warning
+severe.level.title=Severe
+shout.level.title=Shout
+# End Flutter Log Color Page

--- a/src/io/flutter/logging/FlutterLogColorPage.java
+++ b/src/io/flutter/logging/FlutterLogColorPage.java
@@ -20,6 +20,8 @@ import javax.swing.*;
 import java.util.HashMap;
 import java.util.Map;
 
+// TODO(quangson91): Figure out why color setting page display as alphabet
+// Ref: https://github.com/flutter/flutter-intellij/pull/2394#discussion_r196756990
 public final class FlutterLogColorPage implements ColorSettingsPage {
   @NotNull
   private static final Map<String, TextAttributesKey> ADDITIONAL_HIGHLIGHT_DESCRIPTORS = new HashMap<>();

--- a/src/io/flutter/logging/FlutterLogColorPage.java
+++ b/src/io/flutter/logging/FlutterLogColorPage.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2018 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.logging;
+
+import com.intellij.icons.AllIcons;
+import com.intellij.openapi.editor.colors.TextAttributesKey;
+import com.intellij.openapi.fileTypes.PlainSyntaxHighlighter;
+import com.intellij.openapi.fileTypes.SyntaxHighlighter;
+import com.intellij.openapi.options.colors.AttributesDescriptor;
+import com.intellij.openapi.options.colors.ColorDescriptor;
+import com.intellij.openapi.options.colors.ColorSettingsPage;
+import io.flutter.FlutterBundle;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+import java.util.HashMap;
+import java.util.Map;
+
+public final class FlutterLogColorPage implements ColorSettingsPage {
+  @NotNull
+  private static final Map<String, TextAttributesKey> ADDITIONAL_HIGHLIGHT_DESCRIPTORS = new HashMap<>();
+  @NotNull
+  private static final String DEMO_TEXT = "Flutter log:\n" +
+                                          "<none>02-02 18:52:57.132: NONE/FlutterIsCool: log message</none>\n" +
+                                          "<finest>02-02 18:52:57.132: FINEST/FlutterIsCool: log message</finest>\n" +
+                                          "<finer>02-02 18:52:57.132: FINER/FlutterIsCool: log message</finer>\n" +
+                                          "<fine>02-02 18:52:57.132: FINE/FlutterIsCool: log message</fine>\n" +
+                                          "<config>02-02 18:52:57.132: CONFIG/FlutterIsCool: log message</config>\n" +
+                                          "<info>02-02 18:52:57.132: INFO/FlutterIsCool: log message</info>\n" +
+                                          "<warning>02-02 18:52:57.132: WARNING/FlutterIsCool: log message</warning>\n" +
+                                          "<severe>02-02 18:52:57.132: SEVERE/FlutterIsCool: log message</severe>\n" +
+                                          "<shout>02-02 18:52:57.132: SHOUT/FlutterIsCool: log message</shout>";
+
+  static {
+    ADDITIONAL_HIGHLIGHT_DESCRIPTORS.put("none", FlutterLogConstants.NONE_OUTPUT_KEY);
+    ADDITIONAL_HIGHLIGHT_DESCRIPTORS.put("finest", FlutterLogConstants.FINEST_OUTPUT_KEY);
+    ADDITIONAL_HIGHLIGHT_DESCRIPTORS.put("finer", FlutterLogConstants.FINER_OUTPUT_KEY);
+    ADDITIONAL_HIGHLIGHT_DESCRIPTORS.put("fine", FlutterLogConstants.FINE_OUTPUT_KEY);
+    ADDITIONAL_HIGHLIGHT_DESCRIPTORS.put("config", FlutterLogConstants.CONFIG_OUTPUT_KEY);
+    ADDITIONAL_HIGHLIGHT_DESCRIPTORS.put("info", FlutterLogConstants.INFO_OUTPUT_KEY);
+    ADDITIONAL_HIGHLIGHT_DESCRIPTORS.put("warning", FlutterLogConstants.WARNING_OUTPUT_KEY);
+    ADDITIONAL_HIGHLIGHT_DESCRIPTORS.put("severe", FlutterLogConstants.SEVERE_OUTPUT_KEY);
+    ADDITIONAL_HIGHLIGHT_DESCRIPTORS.put("shout", FlutterLogConstants.SHOUT_OUTPUT_KEY);
+  }
+
+  @NotNull
+  private static final AttributesDescriptor[] ATTRIBUTES_DESCRIPTORS =
+    new AttributesDescriptor[]{
+      new AttributesDescriptor(FlutterBundle.message("none.level.title"), FlutterLogConstants.NONE_OUTPUT_KEY),
+      new AttributesDescriptor(FlutterBundle.message("finest.level.title"), FlutterLogConstants.FINEST_OUTPUT_KEY),
+      new AttributesDescriptor(FlutterBundle.message("finer.level.title"), FlutterLogConstants.FINER_OUTPUT_KEY),
+      new AttributesDescriptor(FlutterBundle.message("fine.level.title"), FlutterLogConstants.FINE_OUTPUT_KEY),
+      new AttributesDescriptor(FlutterBundle.message("config.level.title"), FlutterLogConstants.CONFIG_OUTPUT_KEY),
+      new AttributesDescriptor(FlutterBundle.message("info.level.title"), FlutterLogConstants.INFO_OUTPUT_KEY),
+      new AttributesDescriptor(FlutterBundle.message("warning.level.title"), FlutterLogConstants.WARNING_OUTPUT_KEY),
+      new AttributesDescriptor(FlutterBundle.message("severe.level.title"), FlutterLogConstants.SEVERE_OUTPUT_KEY),
+      new AttributesDescriptor(FlutterBundle.message("shout.level.title"), FlutterLogConstants.SHOUT_OUTPUT_KEY)};
+
+  @Override
+  @NotNull
+  public String getDisplayName() {
+    return "Flutter Log";
+  }
+
+  @Override
+  public Icon getIcon() {
+    return AllIcons.Debugger.Console_log;
+  }
+
+  @Override
+  @NotNull
+  public AttributesDescriptor[] getAttributeDescriptors() {
+    return ATTRIBUTES_DESCRIPTORS;
+  }
+
+  @Override
+  @NotNull
+  public ColorDescriptor[] getColorDescriptors() {
+    return ColorDescriptor.EMPTY_ARRAY;
+  }
+
+  @Override
+  @NotNull
+  public SyntaxHighlighter getHighlighter() {
+    return new PlainSyntaxHighlighter();
+  }
+
+  @Override
+  @NotNull
+  public String getDemoText() {
+    return DEMO_TEXT;
+  }
+
+  @Override
+  public Map<String, TextAttributesKey> getAdditionalHighlightingTagToDescriptorMap() {
+    return ADDITIONAL_HIGHLIGHT_DESCRIPTORS;
+  }
+}

--- a/src/io/flutter/logging/FlutterLogColorPage.java
+++ b/src/io/flutter/logging/FlutterLogColorPage.java
@@ -14,6 +14,7 @@ import com.intellij.openapi.options.colors.ColorDescriptor;
 import com.intellij.openapi.options.colors.ColorSettingsPage;
 import io.flutter.FlutterBundle;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 import java.util.HashMap;
@@ -66,8 +67,9 @@ public final class FlutterLogColorPage implements ColorSettingsPage {
   }
 
   @Override
+  @Nullable
   public Icon getIcon() {
-    return AllIcons.Debugger.Console_log;
+    return null;
   }
 
   @Override

--- a/src/io/flutter/logging/FlutterLogColorPage.java
+++ b/src/io/flutter/logging/FlutterLogColorPage.java
@@ -5,7 +5,6 @@
  */
 package io.flutter.logging;
 
-import com.intellij.icons.AllIcons;
 import com.intellij.openapi.editor.colors.TextAttributesKey;
 import com.intellij.openapi.fileTypes.PlainSyntaxHighlighter;
 import com.intellij.openapi.fileTypes.SyntaxHighlighter;

--- a/src/io/flutter/logging/FlutterLogConstants.java
+++ b/src/io/flutter/logging/FlutterLogConstants.java
@@ -18,32 +18,31 @@ public final class FlutterLogConstants {
 
   @NotNull
   public static final TextAttributesKey NONE_OUTPUT_KEY =
-    TextAttributesKey.createTextAttributesKey("LOGCAT_NONE_OUTPUT", ConsoleViewContentType.NORMAL_OUTPUT_KEY);
+    TextAttributesKey.createTextAttributesKey("FLUTTER_LOG_NONE_OUTPUT", ConsoleViewContentType.NORMAL_OUTPUT_KEY);
   @NotNull
   public static final TextAttributesKey FINEST_OUTPUT_KEY =
-    TextAttributesKey.createTextAttributesKey("LOGCAT_FINEST_OUTPUT", ConsoleViewContentType.NORMAL_OUTPUT_KEY);
+    TextAttributesKey.createTextAttributesKey("FLUTTER_LOG_FINEST_OUTPUT", ConsoleViewContentType.NORMAL_OUTPUT_KEY);
   @NotNull
   public static final TextAttributesKey FINER_OUTPUT_KEY =
-    TextAttributesKey.createTextAttributesKey("LOGCAT_FINER_OUTPUT", ConsoleViewContentType.NORMAL_OUTPUT_KEY);
+    TextAttributesKey.createTextAttributesKey("FLUTTER_LOG_FINER_OUTPUT", ConsoleViewContentType.NORMAL_OUTPUT_KEY);
   @NotNull
   public static final TextAttributesKey FINE_OUTPUT_KEY =
-    TextAttributesKey.createTextAttributesKey("LOGCAT_FINE_OUTPUT", ConsoleViewContentType.NORMAL_OUTPUT_KEY);
+    TextAttributesKey.createTextAttributesKey("FLUTTER_LOG_FINE_OUTPUT", ConsoleViewContentType.NORMAL_OUTPUT_KEY);
   @NotNull
   public static final TextAttributesKey CONFIG_OUTPUT_KEY =
-    TextAttributesKey.createTextAttributesKey("LOGCAT_CONFIG_OUTPUT", ConsoleViewContentType.NORMAL_OUTPUT_KEY);
+    TextAttributesKey.createTextAttributesKey("FLUTTER_LOG_CONFIG_OUTPUT", ConsoleViewContentType.NORMAL_OUTPUT_KEY);
   @NotNull
   public static final TextAttributesKey INFO_OUTPUT_KEY =
-    TextAttributesKey.createTextAttributesKey("LOGCAT_INFO_OUTPUT", ConsoleViewContentType.NORMAL_OUTPUT_KEY);
+    TextAttributesKey.createTextAttributesKey("FLUTTER_LOG_INFO_OUTPUT", ConsoleViewContentType.NORMAL_OUTPUT_KEY);
   @NotNull
   public static final TextAttributesKey WARNING_OUTPUT_KEY =
-    TextAttributesKey.createTextAttributesKey("LOGCAT_WARNING_OUTPUT", ConsoleViewContentType.NORMAL_OUTPUT_KEY);
+    TextAttributesKey.createTextAttributesKey("FLUTTER_LOG_WARNING_OUTPUT", ConsoleViewContentType.NORMAL_OUTPUT_KEY);
   @NotNull
   public static final TextAttributesKey SEVERE_OUTPUT_KEY =
-    TextAttributesKey.createTextAttributesKey("LOGCAT_SEVERE_OUTPUT", ConsoleViewContentType.NORMAL_OUTPUT_KEY);
+    TextAttributesKey.createTextAttributesKey("FLUTTER_LOG_SEVERE_OUTPUT", ConsoleViewContentType.NORMAL_OUTPUT_KEY);
   @NotNull
   public static final TextAttributesKey SHOUT_OUTPUT_KEY =
-    TextAttributesKey.createTextAttributesKey("LOGCAT_SHOUT_OUTPUT", ConsoleViewContentType.NORMAL_OUTPUT_KEY);
-
+    TextAttributesKey.createTextAttributesKey("FLUTTER_LOG_SHOUT_OUTPUT", ConsoleViewContentType.NORMAL_OUTPUT_KEY);
 
   @NotNull
   public static final Key NONE = new Key("none.level.title");

--- a/src/io/flutter/logging/FlutterLogConstants.java
+++ b/src/io/flutter/logging/FlutterLogConstants.java
@@ -36,13 +36,13 @@ public final class FlutterLogConstants {
     TextAttributesKey.createTextAttributesKey("FLUTTER_LOG_INFO_OUTPUT", ConsoleViewContentType.NORMAL_OUTPUT_KEY);
   @NotNull
   public static final TextAttributesKey WARNING_OUTPUT_KEY =
-    TextAttributesKey.createTextAttributesKey("FLUTTER_LOG_WARNING_OUTPUT", ConsoleViewContentType.NORMAL_OUTPUT_KEY);
+    TextAttributesKey.createTextAttributesKey("FLUTTER_LOG_WARNING_OUTPUT", ConsoleViewContentType.SYSTEM_OUTPUT_KEY);
   @NotNull
   public static final TextAttributesKey SEVERE_OUTPUT_KEY =
-    TextAttributesKey.createTextAttributesKey("FLUTTER_LOG_SEVERE_OUTPUT", ConsoleViewContentType.NORMAL_OUTPUT_KEY);
+    TextAttributesKey.createTextAttributesKey("FLUTTER_LOG_SEVERE_OUTPUT", ConsoleViewContentType.ERROR_OUTPUT_KEY);
   @NotNull
   public static final TextAttributesKey SHOUT_OUTPUT_KEY =
-    TextAttributesKey.createTextAttributesKey("FLUTTER_LOG_SHOUT_OUTPUT", ConsoleViewContentType.NORMAL_OUTPUT_KEY);
+    TextAttributesKey.createTextAttributesKey("FLUTTER_LOG_SHOUT_OUTPUT", ConsoleViewContentType.ERROR_OUTPUT_KEY);
 
   @NotNull
   public static final Key NONE = new Key("none.level.title");

--- a/src/io/flutter/logging/FlutterLogConstants.java
+++ b/src/io/flutter/logging/FlutterLogConstants.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2018 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.logging;
+
+import com.intellij.execution.ui.ConsoleViewContentType;
+import com.intellij.openapi.editor.colors.TextAttributesKey;
+import com.intellij.openapi.util.Key;
+import org.jetbrains.annotations.NotNull;
+
+import static com.intellij.execution.ui.ConsoleViewContentType.registerNewConsoleViewType;
+
+public final class FlutterLogConstants {
+  private FlutterLogConstants() {
+  }
+
+  @NotNull
+  public static final TextAttributesKey NONE_OUTPUT_KEY =
+    TextAttributesKey.createTextAttributesKey("LOGCAT_NONE_OUTPUT", ConsoleViewContentType.NORMAL_OUTPUT_KEY);
+  @NotNull
+  public static final TextAttributesKey FINEST_OUTPUT_KEY =
+    TextAttributesKey.createTextAttributesKey("LOGCAT_FINEST_OUTPUT", ConsoleViewContentType.NORMAL_OUTPUT_KEY);
+  @NotNull
+  public static final TextAttributesKey FINER_OUTPUT_KEY =
+    TextAttributesKey.createTextAttributesKey("LOGCAT_FINER_OUTPUT", ConsoleViewContentType.NORMAL_OUTPUT_KEY);
+  @NotNull
+  public static final TextAttributesKey FINE_OUTPUT_KEY =
+    TextAttributesKey.createTextAttributesKey("LOGCAT_FINE_OUTPUT", ConsoleViewContentType.NORMAL_OUTPUT_KEY);
+  @NotNull
+  public static final TextAttributesKey CONFIG_OUTPUT_KEY =
+    TextAttributesKey.createTextAttributesKey("LOGCAT_CONFIG_OUTPUT", ConsoleViewContentType.NORMAL_OUTPUT_KEY);
+  @NotNull
+  public static final TextAttributesKey INFO_OUTPUT_KEY =
+    TextAttributesKey.createTextAttributesKey("LOGCAT_INFO_OUTPUT", ConsoleViewContentType.NORMAL_OUTPUT_KEY);
+  @NotNull
+  public static final TextAttributesKey WARNING_OUTPUT_KEY =
+    TextAttributesKey.createTextAttributesKey("LOGCAT_WARNING_OUTPUT", ConsoleViewContentType.NORMAL_OUTPUT_KEY);
+  @NotNull
+  public static final TextAttributesKey SEVERE_OUTPUT_KEY =
+    TextAttributesKey.createTextAttributesKey("LOGCAT_SEVERE_OUTPUT", ConsoleViewContentType.NORMAL_OUTPUT_KEY);
+  @NotNull
+  public static final TextAttributesKey SHOUT_OUTPUT_KEY =
+    TextAttributesKey.createTextAttributesKey("LOGCAT_SHOUT_OUTPUT", ConsoleViewContentType.NORMAL_OUTPUT_KEY);
+
+
+  @NotNull
+  public static final Key NONE = new Key("none.level.title");
+  @NotNull
+  public static final Key FINEST = new Key("finest.level.title");
+  @NotNull
+  public static final Key FINER = new Key("finer.level.title");
+  @NotNull
+  public static final Key FINE = new Key("fine.level.title");
+  @NotNull
+  public static final Key CONFIG = new Key("config.level.title");
+  @NotNull
+  public static final Key INFO = new Key("info.level.title");
+  @NotNull
+  public static final Key WARNING = new Key("warning.level.title");
+  @NotNull
+  public static final Key SEVERE = new Key("severe.level.title");
+  @NotNull
+  public static final Key SHOUT = new Key("shout.level.title");
+
+  static {
+    registerNewConsoleViewType(NONE, new ConsoleViewContentType(NONE.toString(), NONE_OUTPUT_KEY));
+    registerNewConsoleViewType(FINEST, new ConsoleViewContentType(FINEST.toString(), FINEST_OUTPUT_KEY));
+    registerNewConsoleViewType(FINER, new ConsoleViewContentType(FINER.toString(), FINER_OUTPUT_KEY));
+    registerNewConsoleViewType(FINE, new ConsoleViewContentType(FINE.toString(), FINE_OUTPUT_KEY));
+    registerNewConsoleViewType(CONFIG, new ConsoleViewContentType(CONFIG.toString(), CONFIG_OUTPUT_KEY));
+    registerNewConsoleViewType(INFO, new ConsoleViewContentType(INFO.toString(), INFO_OUTPUT_KEY));
+    registerNewConsoleViewType(WARNING, new ConsoleViewContentType(WARNING.toString(), WARNING_OUTPUT_KEY));
+    registerNewConsoleViewType(SEVERE, new ConsoleViewContentType(SEVERE.toString(), SEVERE_OUTPUT_KEY));
+    registerNewConsoleViewType(SHOUT, new ConsoleViewContentType(SHOUT.toString(), SHOUT_OUTPUT_KEY));
+  }
+}

--- a/src/io/flutter/logging/FlutterLogView.java
+++ b/src/io/flutter/logging/FlutterLogView.java
@@ -45,6 +45,7 @@ public class FlutterLogView extends JPanel implements ConsoleView, DataProvider,
     public SimpleTextAttributes style(@Nullable FlutterLogEntry entry, int attributes) {
       if (showColors && entry != null) {
         final FlutterLog.Level level = FlutterLog.Level.forValue(entry.getLevel());
+        // TODO(quangson91): use color from FlutterLogColorPage
         if (level != null) {
           switch (level) {
             case FINER:


### PR DESCRIPTION
Issue: https://github.com/flutter/flutter-intellij/issues/2200

add flutter log color setting page

**TODO**

- [ ] update log color by getting setting from FlutterLogColorPage
- [x] setting default color for logging (by level)
- [ ] update sample log message
- [ ] Order log level in flutter log color setting page (without order alphabet - keep by log level ordering)
- [x] use command `./bin/plugin generate` to generate plugin.xml file


Screenshot
<img width="1021" alt="screen shot 2018-06-20 at 10 33 51 am" src="https://user-images.githubusercontent.com/6185205/41635896-7b6b35f6-7475-11e8-8e2e-5f3fc6029843.png">
