### PR TITLE
Fix console external file links w/ leading spaces

### DIFF
--- a/src/io/flutter/console/FlutterConsoleFilter.java
+++ b/src/io/flutter/console/FlutterConsoleFilter.java
@@ -109,8 +109,8 @@ public class FlutterConsoleFilter implements Filter {
     // Check for, e.g.,
     //   * "Launching lib/main.dart"
     //   * "open ios/Runner.xcworkspace"
-    if (line.startsWith("Launching ") || (line.startsWith("open "))) {
-      final String[] parts = line.split(" ");
+    if (pathPart.startsWith("Launching ") || pathPart.startsWith("open ")) {
+      final String[] parts = pathPart.split(" ");
       if (parts.length > 1) {
         pathPart = parts[1];
       }


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/67586/41746362-e2237814-755e-11e8-929f-e8b715156b93.png)

After:

![image](https://user-images.githubusercontent.com/67586/41746368-ec5512ca-755e-11e8-8429-972321191928.png)

/cc @scheglov @stevemessick 