### PR TITLE
apply other attributes for log color from setting page

### DIFF
--- a/src/io/flutter/logging/FlutterLogTree.java
+++ b/src/io/flutter/logging/FlutterLogTree.java
@@ -61,7 +61,11 @@ public class FlutterLogTree extends TreeTable {
       }
 
       void appendStyled(FlutterLogEntry entry, String text) {
-        append(text, entryModel.style(entry, STYLE_PLAIN));
+        final SimpleTextAttributes style = entryModel.style(entry, STYLE_PLAIN);
+        if (style.getBgColor() != null) {
+          setBackground(style.getBgColor());
+        }
+        append(text, style);
       }
 
 

--- a/src/io/flutter/logging/FlutterLogView.java
+++ b/src/io/flutter/logging/FlutterLogView.java
@@ -20,6 +20,8 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.colors.EditorColorsManager;
 import com.intellij.openapi.editor.colors.EditorColorsScheme;
 import com.intellij.openapi.editor.colors.TextAttributesKey;
+import com.intellij.openapi.editor.markup.EffectType;
+import com.intellij.openapi.editor.markup.TextAttributes;
 import com.intellij.openapi.ui.SimpleToolWindowPanel;
 import com.intellij.ui.ColoredTableCellRenderer;
 import com.intellij.ui.PopupHandler;
@@ -47,6 +49,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import static com.intellij.openapi.editor.markup.EffectType.*;
 import static io.flutter.logging.FlutterLogConstants.LogColumns.*;
 
 public class FlutterLogView extends JPanel implements ConsoleView, DataProvider, FlutterLog.Listener {
@@ -55,6 +58,8 @@ public class FlutterLogView extends JPanel implements ConsoleView, DataProvider,
 
   @NotNull
   private static final Map<FlutterLog.Level, TextAttributesKey> LOG_LEVEL_TEXT_ATTRIBUTES_KEY_MAP;
+  @NotNull
+  private static final Map<EffectType, Integer> EFFECT_TYPE_TEXT_STYLE_MAP;
   @NotNull
   private static final SimpleTextAttributes REGULAR_ATTRIBUTES = SimpleTextAttributes.GRAY_ATTRIBUTES;
 
@@ -69,8 +74,19 @@ public class FlutterLogView extends JPanel implements ConsoleView, DataProvider,
     LOG_LEVEL_TEXT_ATTRIBUTES_KEY_MAP.put(Level.WARNING, FlutterLogConstants.WARNING_OUTPUT_KEY);
     LOG_LEVEL_TEXT_ATTRIBUTES_KEY_MAP.put(Level.SEVERE, FlutterLogConstants.SEVERE_OUTPUT_KEY);
     LOG_LEVEL_TEXT_ATTRIBUTES_KEY_MAP.put(Level.SHOUT, FlutterLogConstants.SHOUT_OUTPUT_KEY);
-  }
 
+    EFFECT_TYPE_TEXT_STYLE_MAP = new HashMap<>();
+    EFFECT_TYPE_TEXT_STYLE_MAP.put(LINE_UNDERSCORE, SimpleTextAttributes.STYLE_UNDERLINE);
+    EFFECT_TYPE_TEXT_STYLE_MAP.put(WAVE_UNDERSCORE, SimpleTextAttributes.STYLE_UNDERLINE | SimpleTextAttributes.STYLE_WAVED);
+    EFFECT_TYPE_TEXT_STYLE_MAP.put(BOLD_LINE_UNDERSCORE, SimpleTextAttributes.STYLE_UNDERLINE | SimpleTextAttributes.STYLE_BOLD);
+    EFFECT_TYPE_TEXT_STYLE_MAP.put(STRIKEOUT, SimpleTextAttributes.STYLE_STRIKEOUT);
+    EFFECT_TYPE_TEXT_STYLE_MAP.put(BOLD_DOTTED_LINE, SimpleTextAttributes.STYLE_BOLD_DOTTED_LINE);
+    EFFECT_TYPE_TEXT_STYLE_MAP.put(SEARCH_MATCH, SimpleTextAttributes.STYLE_SEARCH_MATCH);
+
+    // TODO(quangson91): Figureout how to mapping style for those setting.
+    EFFECT_TYPE_TEXT_STYLE_MAP.put(BOXED, null);
+    EFFECT_TYPE_TEXT_STYLE_MAP.put(ROUNDED_BOX, null);
+  }
 
   @NotNull
   private final Map<Level, SimpleTextAttributes> textAttributesByLogLevelCache = new ConcurrentHashMap<>();
@@ -82,9 +98,7 @@ public class FlutterLogView extends JPanel implements ConsoleView, DataProvider,
     public SimpleTextAttributes style(@Nullable FlutterLogEntry entry, int attributes) {
       if (showColors && entry != null) {
         final FlutterLog.Level level = FlutterLog.Level.forValue(entry.getLevel());
-        if (level != null) {
-          return getTextAttributesByLogLevel(level);
-        }
+        return getTextAttributesByLogLevel(level);
       }
       return SimpleTextAttributes.REGULAR_ATTRIBUTES;
     }
@@ -484,9 +498,24 @@ public class FlutterLogView extends JPanel implements ConsoleView, DataProvider,
     for (Level level : FlutterLog.Level.values()) {
       try {
         final TextAttributesKey key = LOG_LEVEL_TEXT_ATTRIBUTES_KEY_MAP.get(level);
-        final Color color = globalEditorColorsScheme.getAttributes(key).getForegroundColor();
+        final TextAttributes attributes = globalEditorColorsScheme.getAttributes(key);
+        int fontType = attributes.getFontType();
+        final Color effectColor = attributes.getEffectColor();
+        final Integer textStyle = EFFECT_TYPE_TEXT_STYLE_MAP.get(attributes.getEffectType());
+        // TextStyle can be exist even we unchecked in setting page.
+        // only effectColor null when we uncheck setting effect in setting page.
+        // So, we have to check both effectColor & textStyle not null.
+        if (effectColor != null && textStyle != null) {
+          fontType = fontType | textStyle;
+        }
 
-        final SimpleTextAttributes textAttributes = new SimpleTextAttributes(SimpleTextAttributes.STYLE_PLAIN, color);
+        final SimpleTextAttributes textAttributes = new SimpleTextAttributes(
+          attributes.getBackgroundColor(),
+          attributes.getForegroundColor(),
+          effectColor,
+          fontType
+        );
+
         textAttributesByLogLevelCache.put(level, textAttributes);
       }
       catch (Exception e) {

--- a/src/io/flutter/logging/FlutterLogView.java
+++ b/src/io/flutter/logging/FlutterLogView.java
@@ -83,7 +83,7 @@ public class FlutterLogView extends JPanel implements ConsoleView, DataProvider,
     EFFECT_TYPE_TEXT_STYLE_MAP.put(BOLD_DOTTED_LINE, SimpleTextAttributes.STYLE_BOLD_DOTTED_LINE);
     EFFECT_TYPE_TEXT_STYLE_MAP.put(SEARCH_MATCH, SimpleTextAttributes.STYLE_SEARCH_MATCH);
 
-    // TODO(quangson91): Figureout how to mapping style for those setting.
+    // TODO(quangson91): Figure out how to map style for these settings.
     EFFECT_TYPE_TEXT_STYLE_MAP.put(BOXED, null);
     EFFECT_TYPE_TEXT_STYLE_MAP.put(ROUNDED_BOX, null);
   }
@@ -502,9 +502,9 @@ public class FlutterLogView extends JPanel implements ConsoleView, DataProvider,
         int fontType = attributes.getFontType();
         final Color effectColor = attributes.getEffectColor();
         final Integer textStyle = EFFECT_TYPE_TEXT_STYLE_MAP.get(attributes.getEffectType());
-        // TextStyle can be exist even we unchecked in setting page.
-        // only effectColor null when we uncheck setting effect in setting page.
-        // So, we have to check both effectColor & textStyle not null.
+        // TextStyle can exist even when unchecked in settings page.
+        // only effectColor is null when setting effect is unchecked in setting page.
+        // So, we have to check that both effectColor & textStyle are not null.
         if (effectColor != null && textStyle != null) {
           fontType = fontType | textStyle;
         }


### PR DESCRIPTION
Issue: https://github.com/flutter/flutter-intellij/issues/2431
+ apply other attributes for log color from setting page

Notes: some attributes are not working.

// cc @pq for review.
**Screenshots.**

# Setting text bold/italic/background - 🆗
<img width="752" alt="1" src="https://user-images.githubusercontent.com/6185205/42120922-13956e66-7c4e-11e8-883c-5abf0c46cbd9.png">
<img width="464" alt="1 1" src="https://user-images.githubusercontent.com/6185205/42120923-13eeec84-7c4e-11e8-8925-1979f6cdf0c2.png">

# Dotted line - 🆗 
<img width="243" alt="5" src="https://user-images.githubusercontent.com/6185205/42120980-f7b15b46-7c4e-11e8-8f37-9d7d5b75d521.png">
<img width="450" alt="5 1" src="https://user-images.githubusercontent.com/6185205/42120981-f802ad5c-7c4e-11e8-9a72-b37f3c604497.png">

# Underwaved - 🆗 
<img width="223" alt="7" src="https://user-images.githubusercontent.com/6185205/42120991-2a979336-7c4f-11e8-9399-f0a7134e945e.png">
<img width="350" alt="7 1" src="https://user-images.githubusercontent.com/6185205/42120992-2ae7cb08-7c4f-11e8-9ab3-7616e7423212.png">

----------

# Underscored - Only underscore, color effect doesn't work.
<img width="243" alt="2" src="https://user-images.githubusercontent.com/6185205/42120941-52beac42-7c4e-11e8-89a5-9ed3a6dd7322.png">
<img width="427" alt="2 2" src="https://user-images.githubusercontent.com/6185205/42120942-530fc4ce-7c4e-11e8-89c7-97717dd5fc69.png">

# Strikeout - Only strikeout, color effect doesn't work.

<img width="223" alt="4" src="https://user-images.githubusercontent.com/6185205/42120970-dfe59b80-7c4e-11e8-8beb-3624ed046935.png">
<img width="441" alt="4 1" src="https://user-images.githubusercontent.com/6185205/42120971-e02b588c-7c4e-11e8-85a8-0abbfcd46645.png">

# Bold underscored - bold + underscored, color effect doesn't work.
<img width="239" alt="6" src="https://user-images.githubusercontent.com/6185205/42120985-1470b024-7c4f-11e8-81db-85b21f8cf5c8.png">
<img width="314" alt="6 1" src="https://user-images.githubusercontent.com/6185205/42120986-1560026e-7c4f-11e8-85b5-59b021b8aba5.png">

----------

# Bordered - Could not figureout text style for this setting.

