### PR TITLE
Add InheritedWidget and Stateful Widget with Animation live templates

### DIFF
--- a/resources/liveTemplates/flutter_miscellaneous.xml
+++ b/resources/liveTemplates/flutter_miscellaneous.xml
@@ -11,4 +11,17 @@
       <option name="DART_TOPLEVEL" value="true" />
     </context>
   </template>
+  <template name="inh" value="class $NAME$ extends InheritedWidget {&#10;  const $NAME$({&#10;    Key key,&#10;    @required Widget child,&#10;  }) : assert(child != null),&#10;       super(key: key, child: child);&#10;&#10;  static $NAME$ of(BuildContext context) {&#10;    return context.inheritFromWidgetOfExactType($NAME$) as $NAME$;&#10;  }&#10;&#10;  @override&#10;  bool updateShouldNotify($NAME$ old) {&#10;    return $SHOULD_NOTIFY$;&#10;  }&#10;}" description="New Inherited widget" toReformat="true" toShortenFQNames="true">
+    <variable name="NAME" expression="" defaultValue="" alwaysStopAt="true" />
+    <variable name="SHOULD_NOTIFY" expression="" defaultValue="" alwaysStopAt="true" />
+    <context>
+      <option name="DART_TOPLEVEL" value="true" />
+    </context>
+  </template>
+  <template name="stanim" value="class $NAME$ extends StatefulWidget {&#10;  @override&#10;  _$NAME$State createState() =&gt; _$NAME$State();&#10;}&#10;&#10;class _$NAME$State extends State&lt;$NAME$&gt; with SingleTickerProviderStateMixin {&#10;  AnimationController _controller;&#10;&#10;  @override&#10;  void initState() {&#10;    _controller = AnimationController(vsync: this);&#10;    super.initState();&#10;  }&#10;&#10;  @override&#10;  void dispose() {&#10;    _controller.dispose();&#10;    super.dispose();&#10;  }&#10;  &#10;  @override&#10;  Widget build(BuildContext context) {&#10;    return Container($END$);&#10;  }&#10;}&#10;" description="New Stateful widget with AnimationController" toReformat="false" toShortenFQNames="true">
+    <variable name="NAME" expression="" defaultValue="" alwaysStopAt="true" />
+    <context>
+      <option name="DART_TOPLEVEL" value="true" />
+    </context>
+  </template>
 </templateSet>


### PR DESCRIPTION
Howdy, y'all! I've been doing more and more animations, and thought the `stanim` snippet from VSCode was pretty cool. Same kinda thing with InheritedWidgets...

I've added two new live templates to quickly stub out the boilerplate for these classes.

They will produce the following code.

### stanim

```dart
class Anim extends StatefulWidget {
  @override
  _AnimState createState() => _AnimState();
}

class _AnimState extends State<Anim> with SingleTickerProviderStateMixin {
  AnimationController _controller;

  @override
  void initState() {
    _controller = AnimationController(vsync: this);
    super.initState();
  }

  @override
  void dispose() {
    _controller.dispose();
    super.dispose();
  }
  
  @override
  Widget build(BuildContext context) {
    return Container();
  }
}
```

### inh

```dart
class Inher extends InheritedWidget {
  const Inher({
    Key key,
    @required Widget child,
  })
      : assert(child != null),
        super(key: key, child: child);

  static Inher of(BuildContext context) {
    return context.inheritFromWidgetOfExactType(Inher) as Inher;
  }

  @override
  bool updateShouldNotify(Inher old) {
    return /* CURSOR WILL BE PLACED HERE AFTER NAMING THE WIDGET SO YOU CAN WRITE THE FUNCTIONALITY */;
  }
}
```

### Example in action


![new_templates](https://user-images.githubusercontent.com/126604/42125016-d27eda54-7c6e-11e8-98b7-2dc31c11b0f3.gif)
