### PR TITLE
support hyperlinks in flutter console log

### DIFF
--- a/src/io/flutter/logging/FlutterLogTree.java
+++ b/src/io/flutter/logging/FlutterLogTree.java
@@ -133,18 +133,24 @@ public class FlutterLogTree extends TreeTable {
       @NotNull
       private final FlutterApp app;
       @NotNull
-      private final List<Filter> linkFilters;
+      private final Filter[] filters;
 
       MessageCellRenderer(@NotNull FlutterApp app) {
         this.app = app;
-        linkFilters = new ArrayList<>();
+        filters = createMessageFilters().toArray(new Filter[0]);
+      }
+
+      @NotNull
+      private List<Filter> createMessageFilters() {
+        final List<Filter> filters = new ArrayList<>();
         if (app.getModule() != null) {
-          linkFilters.add(new FlutterConsoleFilter(app.getModule()));
+          filters.add(new FlutterConsoleFilter(app.getModule()));
         }
-        linkFilters.addAll(Arrays.asList(
+        filters.addAll(Arrays.asList(
           new DartConsoleFilter(app.getProject(), app.getProject().getBaseDir()),
           new UrlFilter()
         ));
+        return filters;
       }
 
       @Override
@@ -156,7 +162,7 @@ public class FlutterLogTree extends TreeTable {
           return;
         }
         final List<Filter.ResultItem> resultItems = new ArrayList<>();
-        for (Filter filter : linkFilters) {
+        for (Filter filter : filters) {
           final Filter.Result result = filter.applyFilter(message, message.length());
           if (result == null) {
             continue;

--- a/src/io/flutter/logging/FlutterLogTree.java
+++ b/src/io/flutter/logging/FlutterLogTree.java
@@ -21,6 +21,7 @@ import com.intellij.util.ui.ColumnInfo;
 import com.jetbrains.lang.dart.ide.runner.DartConsoleFilter;
 import io.flutter.console.FlutterConsoleFilter;
 import io.flutter.run.daemon.FlutterApp;
+import org.apache.commons.lang.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -151,12 +152,18 @@ public class FlutterLogTree extends TreeTable {
         // TODO(pq): SpeedSearchUtil.applySpeedSearchHighlighting
         // TODO(pq): setTooltipText
         final String message = entry.getMessage();
-        final List<Filter.ResultItem> resultItems = linkFilters.stream()
-          .map(filter -> filter.applyFilter(message, message.length()))
-          .filter(Objects::nonNull)
-          .flatMap(result -> result.getResultItems().stream())
-          .sorted(Comparator.comparingInt(Filter.ResultItem::getHighlightStartOffset))
-          .collect(Collectors.toList());
+        if (StringUtils.isEmpty(message)) {
+          return;
+        }
+        final List<Filter.ResultItem> resultItems = new ArrayList<>();
+        for (Filter filter : linkFilters) {
+          final Filter.Result result = filter.applyFilter(message, message.length());
+          if (result == null) {
+            continue;
+          }
+          resultItems.addAll(result.getResultItems());
+        }
+        resultItems.sort(Comparator.comparingInt(Filter.ResultItem::getHighlightStartOffset));
 
         int cursor = 0;
         for (Filter.ResultItem item : resultItems) {


### PR DESCRIPTION
Issue: https://github.com/flutter/flutter-intellij/issues/2402
+ support hyperlinks in flutter console log

Use `DartConsoleFilter` & `UrlFilter` to support hyper link stacktrace & url in log console.

Notes: stack trace can clickable, but `url` can't click to open in the browser.

Screenshot:
![hyperlink_flutter_log](https://user-images.githubusercontent.com/6185205/42125986-a52b148c-7caa-11e8-9017-d9e62cc1fe5c.gif)

// cc @pq please take a look in next week :)
