### PR TITLE
Default log coloring to on

### DIFF
--- a/src/io/flutter/logging/FlutterLogPreferences.java
+++ b/src/io/flutter/logging/FlutterLogPreferences.java
@@ -16,7 +16,7 @@ public class FlutterLogPreferences implements PersistentStateComponent<FlutterLo
   private boolean showSequenceNumbers = false;
   private boolean showLogLevel = true;
   private boolean showLogCategory = true;
-  private boolean showColor = false;
+  private boolean showColor = true;
 
   private int toolWindowLogLevel = FlutterLog.Level.CONFIG.value;
   private boolean toolWindowMatchCase = false;


### PR DESCRIPTION
Following up on this question from @quangson91:

> @pq, I have a question. Why don't we enable show color by default?
(For me, if the log levels like warning/shout => we should be coloring them. It is better for eyes to recognize).

I tend to agree.  Especially since, like logcat, we only color severe and shout out of the box:

![image](https://user-images.githubusercontent.com/67586/42330043-161f8c0c-8027-11e8-8d39-1da3307ec0dc.png)

Related to: #2457.


/cc @quangson91 @devoncarew 
