### PR TITLE
Port ADT package name validation logic.

### DIFF
--- a/src/io/flutter/module/FlutterModuleBuilder.java
+++ b/src/io/flutter/module/FlutterModuleBuilder.java
@@ -35,6 +35,7 @@ import io.flutter.pub.PubRoot;
 import io.flutter.sdk.FlutterCreateAdditionalSettings;
 import io.flutter.sdk.FlutterSdk;
 import io.flutter.sdk.FlutterSdkUtil;
+import io.flutter.utils.AndroidUtils;
 import io.flutter.utils.FlutterModuleUtils;
 import org.apache.commons.lang.StringUtils;
 import org.jetbrains.annotations.NotNull;
@@ -136,10 +137,14 @@ public class FlutterModuleBuilder extends ModuleBuilder {
       return "Invalid package description: '" + description + "' - cannot contain the sequence ': '.";
     }
     final String org = settings.getOrg();
+    if (org == null) {
+      return null;
+    }
     if (StringUtils.endsWith(org, ".")) {
       return "Invalid organization name: '" + org + "' - cannot end in '.'.";
     }
-    return null;
+    // Invalid package names will cause issues down the line.
+    return AndroidUtils.validateAndroidPackageName(org);
   }
 
   private static void addAndroidModule(@NotNull Project project,

--- a/src/io/flutter/utils/AndroidUtils.java
+++ b/src/io/flutter/utils/AndroidUtils.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2018 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.utils;
+
+import com.intellij.lang.java.JavaParserDefinition;
+import com.intellij.lexer.Lexer;
+import com.intellij.pom.java.LanguageLevel;
+import com.intellij.psi.JavaTokenType;
+import com.intellij.psi.tree.java.IKeywordElementType;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+// based on: org.jetbrains.android.util.AndroidUtils
+public class AndroidUtils {
+
+  private static final Lexer JAVA_LEXER = JavaParserDefinition.createLexer(LanguageLevel.JDK_1_5);
+
+  /**
+   * Validates a potential package name and returns null if the package name is valid, and otherwise
+   * returns a description for why it is not valid.
+   * <p>
+   * Note that Android package names are more restrictive than general Java package names;
+   * we require at least two segments, limit the character set to [a-zA-Z0-9_] (Java allows any
+   * {@link Character#isLetter(char)} and require that each segment start with a letter (Java allows
+   * underscores at the beginning).
+   * <p>
+   * For details, see core/java/android/content/pm/PackageParser.java#validateName
+   *
+   * @param name the package name
+   * @return null if the package is valid as an Android package name, and otherwise a description for why not
+   */
+  @Nullable
+  public static String validateAndroidPackageName(@NotNull String name) {
+    if (name.isEmpty()) {
+      return "Package name is missing";
+    }
+
+    String packageManagerCheck = validateName(name, true);
+    if (packageManagerCheck != null) {
+      return packageManagerCheck;
+    }
+
+    // In addition, we have to check that none of the segments are Java identifiers, since
+    // that will lead to compilation errors, which the package manager doesn't need to worry about
+    // (the code wouldn't have compiled)
+    int index = 0;
+    while (true) {
+      int index1 = name.indexOf('.', index);
+      if (index1 < 0) {
+        index1 = name.length();
+      }
+      String error = isReservedKeyword(name.substring(index, index1));
+      if (error != null) return error;
+      if (index1 == name.length()) {
+        break;
+      }
+      index = index1 + 1;
+    }
+
+    return null;
+  }
+
+  @Nullable
+  public static String isReservedKeyword(@NotNull String string) {
+    Lexer lexer = JAVA_LEXER;
+    lexer.start(string);
+    if (lexer.getTokenType() != JavaTokenType.IDENTIFIER) {
+      if (lexer.getTokenType() instanceof IKeywordElementType) {
+        return "Package names cannot contain Java keywords like '" + string + "'";
+      }
+      if (string.isEmpty()) {
+        return "Package segments must be of non-zero length";
+      }
+      return string + " is not a valid identifier";
+    }
+    return null;
+  }
+
+  // This method is a copy of android.content.pm.PackageParser#validateName with the
+  // error messages tweaked
+  @Nullable
+  private static String validateName(String name, boolean requiresSeparator) {
+    final int N = name.length();
+    boolean hasSep = false;
+    boolean front = true;
+    for (int i = 0; i < N; i++) {
+      final char c = name.charAt(i);
+      if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')) {
+        front = false;
+        continue;
+      }
+      if ((c >= '0' && c <= '9') || c == '_') {
+        if (!front) {
+          continue;
+        }
+        else {
+          if (c == '_') {
+            return "The character '_' cannot be the first character in a package segment";
+          }
+          else {
+            return "A digit cannot be the first character in a package segment";
+          }
+        }
+      }
+      if (c == '.') {
+        hasSep = true;
+        front = true;
+        continue;
+      }
+      return "The character '" + c + "' is not allowed in Android application package names";
+    }
+    return hasSep || !requiresSeparator ? null : "The package must have at least one '.' separator";
+  }
+}


### PR DESCRIPTION
Further validation of android package names.

Bad package names spell trouble and are winnowed out in standard Android project creation.

Follow-up from #2468. 

/cc @stevemessick @devoncarew 