### PR TITLE
remove unnecessary volatile keyword

### DIFF
--- a/src/io/flutter/logging/FlutterLogTree.java
+++ b/src/io/flutter/logging/FlutterLogTree.java
@@ -301,7 +301,7 @@ public class FlutterLogTree extends TreeTable {
     private final FlutterLog log;
     @NotNull
     private final Alarm uiThreadAlarm;
-    volatile boolean autoScrollToEnd;
+    boolean autoScrollToEnd;
     // Cached for hide and restore (because *sigh* Swing).
     private List<TableColumn> tableColumns;
     private JScrollPane scrollPane;


### PR DESCRIPTION
as for suggestions of @jacob314, I removed `volatile` as it unnecessary.
Ref: https://github.com/flutter/flutter-intellij/commit/6c968f95ac54511d9deffdb244733d9946065941#r29766875

// @jacob314 please take a look!