### PR TITLE
Revert "Disable evaluating expressions when not on a call frame due t…

### DIFF
--- a/src/io/flutter/server/vmService/DartVmServiceDebugProcess.java
+++ b/src/io/flutter/server/vmService/DartVmServiceDebugProcess.java
@@ -499,7 +499,7 @@ public class DartVmServiceDebugProcess extends XDebugProcess {
     if (frame != null) {
       return frame.getEvaluator();
     }
-    return null;
+    return new DartVmServiceEvaluator(this);
   }
 
   @NotNull


### PR DESCRIPTION
…o DartVM crashes. (#2436)"

This reverts commit ddd96076068fee3edca4132ce0e8c94b4164f977.