### PR TITLE
Add a setting to control syncing Android libraries

### DIFF
--- a/flutter-studio/src/io/flutter/FlutterStudioStartupActivity.java
+++ b/flutter-studio/src/io/flutter/FlutterStudioStartupActivity.java
@@ -14,6 +14,7 @@ import io.flutter.actions.FlutterShowStructureSettingsAction;
 import io.flutter.actions.OpenAndroidModule;
 import io.flutter.android.AndroidModuleLibraryManager;
 import io.flutter.project.FlutterProjectCreator;
+import io.flutter.settings.FlutterSettings;
 import io.flutter.utils.FlutterModuleUtils;
 import org.jetbrains.annotations.NotNull;
 
@@ -45,7 +46,8 @@ public class FlutterStudioStartupActivity implements StartupActivity {
     // TODO(messick) Delete once 3.0.x has 0 7DA's.
     FlutterProjectCreator.disableUserConfig(project);
     // Monitor Android dependencies.
-    if (System.getProperty("flutter.android.library.sync", null) != null) {
+    if (FlutterSettings.getInstance().isSyncingAndroidLibraries() ||
+        System.getProperty("flutter.android.library.sync", null) != null) {
       // TODO(messick): Remove the flag once this sync mechanism is stable.
       AndroidModuleLibraryManager.startWatching(project);
     }

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.form
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.form
@@ -14,9 +14,6 @@
           <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
-        <clientProperties>
-          <BorderFactoryClass class="java.lang.String" value="com.intellij.ui.IdeBorderFactory$PlainSmallWithIndent"/>
-        </clientProperties>
         <border type="etched" title="SDK"/>
         <children>
           <component id="a59e7" class="javax.swing.JLabel">
@@ -60,9 +57,6 @@
           <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
-        <clientProperties>
-          <BorderFactoryClass class="java.lang.String" value="com.intellij.ui.IdeBorderFactory$PlainSmallWithIndent"/>
-        </clientProperties>
         <border type="etched" title="General"/>
         <children>
           <component id="6304a" class="javax.swing.JCheckBox" binding="myReportUsageInformationCheckBox">
@@ -114,15 +108,12 @@
           </component>
         </children>
       </grid>
-      <grid id="23e52" layout-manager="GridLayoutManager" row-count="3" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="23e52" layout-manager="GridLayoutManager" row-count="4" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
-        <clientProperties>
-          <BorderFactoryClass class="java.lang.String" value="com.intellij.ui.IdeBorderFactory$PlainSmallWithIndent"/>
-        </clientProperties>
         <border type="etched" title="Experiments"/>
         <children>
           <component id="42d6c" class="javax.swing.JLabel">
@@ -149,6 +140,15 @@
               <text value="Replace the Run and Debug console output with an experimental Flutter Logging view"/>
             </properties>
           </component>
+          <component id="33088" class="javax.swing.JCheckBox" binding="mySyncAndroidLibrariesCheckBox">
+            <constraints>
+              <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Show Android libraries; for working with Java/Kotlin (requires reopening projects)"/>
+              <toolTipText value="Requires a Gradle build"/>
+            </properties>
+          </component>
         </children>
       </grid>
       <grid id="919ec" layout-manager="GridLayoutManager" row-count="3" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
@@ -157,9 +157,6 @@
           <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
-        <clientProperties>
-          <BorderFactoryClass class="java.lang.String" value="com.intellij.ui.IdeBorderFactory$PlainSmallWithIndent"/>
-        </clientProperties>
         <border type="etched" title="App Execution"/>
         <children>
           <component id="356a" class="javax.swing.JCheckBox" binding="myOpenInspectorOnAppLaunchCheckBox">

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.java
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.java
@@ -25,6 +25,7 @@ import com.intellij.ui.components.JBLabel;
 import io.flutter.FlutterBundle;
 import io.flutter.FlutterConstants;
 import io.flutter.FlutterInitializer;
+import io.flutter.FlutterUtils;
 import io.flutter.settings.FlutterSettings;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
@@ -58,6 +59,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
   private JCheckBox myShowHeapDisplayCheckBox;
   private JCheckBox myTrackWidgetCreationCheckBox;
   private JCheckBox myUseLogViewCheckBox;
+  private JCheckBox mySyncAndroidLibrariesCheckBox;
   private final @NotNull Project myProject;
 
   FlutterSettingsConfigurable(@NotNull Project project) {
@@ -74,6 +76,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
 
     final JTextComponent sdkEditor = (JTextComponent)mySdkCombo.getComboBox().getEditor().getEditorComponent();
     sdkEditor.getDocument().addDocumentListener(new DocumentAdapter() {
+      @Override
       protected void textChanged(final DocumentEvent e) {
         updateVersionText();
       }
@@ -84,6 +87,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
                                        TextComponentAccessor.STRING_COMBOBOX_WHOLE_TEXT);
 
     myPrivacyPolicy.addMouseListener(new MouseAdapter() {
+      @Override
       public void mouseClicked(MouseEvent e) {
         try {
           BrowserLauncher.getInstance().browse(new URI(FlutterBundle.message("flutter.analytics.privacyUrl")));
@@ -96,6 +100,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     //noinspection Convert2Lambda
     myFormatCodeOnSaveCheckBox
       .addChangeListener((e) -> myOrganizeImportsOnSaveCheckBox.setEnabled(myFormatCodeOnSaveCheckBox.isSelected()));
+    mySyncAndroidLibrariesCheckBox.setVisible(FlutterUtils.isAndroidStudio());
   }
 
   private void createUIComponents() {
@@ -167,6 +172,9 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     if (settings.isVerboseLogging() != myEnableVerboseLoggingCheckBox.isSelected()) {
       return true;
     }
+    if (settings.isSyncingAndroidLibraries() != mySyncAndroidLibrariesCheckBox.isSelected()) {
+      return true;
+    }
 
     return false;
   }
@@ -197,6 +205,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     settings.setOpenInspectorOnAppLaunch(myOpenInspectorOnAppLaunchCheckBox.isSelected());
     settings.setTrackWidgetCreation(myTrackWidgetCreationCheckBox.isSelected());
     settings.setVerboseLogging(myEnableVerboseLoggingCheckBox.isSelected());
+    settings.setSyncingAndroidLibraries(mySyncAndroidLibrariesCheckBox.isSelected());
 
     reset(); // because we rely on remembering initial state
   }
@@ -224,6 +233,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     myOpenInspectorOnAppLaunchCheckBox.setSelected(settings.isOpenInspectorOnAppLaunch());
     myTrackWidgetCreationCheckBox.setSelected(settings.isTrackWidgetCreation());
     myEnableVerboseLoggingCheckBox.setSelected(settings.isVerboseLogging());
+    mySyncAndroidLibrariesCheckBox.setSelected(settings.isSyncingAndroidLibraries());
 
     myOrganizeImportsOnSaveCheckBox.setEnabled(myFormatCodeOnSaveCheckBox.isSelected());
   }

--- a/src/io/flutter/settings/FlutterSettings.java
+++ b/src/io/flutter/settings/FlutterSettings.java
@@ -24,6 +24,7 @@ public class FlutterSettings {
   private static final String organizeImportsOnSaveKey = "io.flutter.organizeImportsOnSave";
   private static final String showOnlyWidgetsKey = "io.flutter.showOnlyWidgets";
   private static final String showPreviewAreaKey = "io.flutter.showPreviewArea";
+  private static final String syncAndroidLibrariesKey = "io.flutter.syncAndroidLibraries";
   private static final String trackWidgetCreationKey = "io.flutter.trackWidgetCreation";
   private static final String useFlutterLogView = "io.flutter.useLogView";
 
@@ -136,6 +137,16 @@ public class FlutterSettings {
 
   public void setShowPreviewArea(boolean value) {
     getPropertiesComponent().setValue(showPreviewAreaKey, value, false);
+
+    fireEvent();
+  }
+
+  public boolean isSyncingAndroidLibraries() {
+    return getPropertiesComponent().getBoolean(syncAndroidLibrariesKey, false);
+  }
+
+  public void setSyncingAndroidLibraries(boolean value) {
+    getPropertiesComponent().setValue(syncAndroidLibrariesKey, value, false);
 
     fireEvent();
   }


### PR DESCRIPTION
@devoncarew @pq 

The ability to automatically define an external library containing Android dependencies has been available behind a dev-only flag for a couple weeks. This PR adds a line to the Settings/Preferences panel to enable or disable it, but only for Android Studio.

I'm not sure whether this should go into the next release or not, so we should discuss that before merging.

No idea why BorderFactoryClass got removed from the form...