### PR TITLE
Handle the device being disconnected more gracefully.

### DIFF
--- a/src/io/flutter/server/vmService/frame/DartVmServiceEvaluator.java
+++ b/src/io/flutter/server/vmService/frame/DartVmServiceEvaluator.java
@@ -52,6 +52,10 @@ public class DartVmServiceEvaluator extends XDebuggerEvaluator {
     final List<VirtualFile> libraryFiles = new ArrayList<>();
     // Turn off pausing on exceptions as it is confusing to mouse over an expression
     // and to have that trigger pausing at an exception.
+    if (myDebugProcess == null || myDebugProcess.getVmServiceWrapper() == null) {
+      callback.errorOccurred("Device disconnected");
+      return;
+    }
     myDebugProcess.getVmServiceWrapper().setExceptionPauseMode(ExceptionPauseMode.None);
     final XEvaluationCallback wrappedCallback = new XEvaluationCallback() {
       @Override


### PR DESCRIPTION
Fix race condition that sometimes occurs when the app is restarted resulting an easily avoidable error in the IntelliJ console.