### PR TITLE
remove “module” project type

### DIFF
--- a/src/io/flutter/module/FlutterProjectType.java
+++ b/src/io/flutter/module/FlutterProjectType.java
@@ -10,8 +10,9 @@ import io.flutter.FlutterBundle;
 public enum FlutterProjectType {
   APP(FlutterBundle.message("flutter.module.create.settings.type.application"), "app"),
   PLUGIN(FlutterBundle.message("flutter.module.create.settings.type.plugin"), "plugin"),
-  PACKAGE(FlutterBundle.message("flutter.module.create.settings.type.package"), "package"),
-  MODULE(FlutterBundle.message("flutter.module.create.settings.type.module"), "module");
+  PACKAGE(FlutterBundle.message("flutter.module.create.settings.type.package"), "package");
+  // TODO(messick): re-introduce when add-to-app is fully supported.
+  //MODULE(FlutterBundle.message("flutter.module.create.settings.type.module"), "module");
 
   final public String title;
   final public String arg;

--- a/src/io/flutter/module/FlutterProjectType.java
+++ b/src/io/flutter/module/FlutterProjectType.java
@@ -10,9 +10,8 @@ import io.flutter.FlutterBundle;
 public enum FlutterProjectType {
   APP(FlutterBundle.message("flutter.module.create.settings.type.application"), "app"),
   PLUGIN(FlutterBundle.message("flutter.module.create.settings.type.plugin"), "plugin"),
-  PACKAGE(FlutterBundle.message("flutter.module.create.settings.type.package"), "package");
-  // TODO(messick): re-introduce when add-to-app is fully supported.
-  //MODULE(FlutterBundle.message("flutter.module.create.settings.type.module"), "module");
+  PACKAGE(FlutterBundle.message("flutter.module.create.settings.type.package"), "package"),
+  MODULE(FlutterBundle.message("flutter.module.create.settings.type.module"), "module");
 
   final public String title;
   final public String arg;

--- a/src/io/flutter/module/settings/ProjectType.java
+++ b/src/io/flutter/module/settings/ProjectType.java
@@ -6,22 +6,64 @@
 package io.flutter.module.settings;
 
 import com.intellij.openapi.ui.ComboBox;
-import com.intellij.ui.EnumComboBoxModel;
 import io.flutter.FlutterBundle;
 import io.flutter.module.FlutterProjectType;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
 import java.awt.event.ItemListener;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
 
 public class ProjectType {
+  // TODO(pq): replace w/ simple EnumComboBoxModel when add-to-app is complete and we no longer need to filter out MODULE types.
+  private static final class ProjectTypeComboBoxModel extends AbstractListModel<FlutterProjectType>
+    implements ComboBoxModel<FlutterProjectType> {
+    private final List<FlutterProjectType> myList = new ArrayList<>(EnumSet.allOf(FlutterProjectType.class));
+    private FlutterProjectType mySelected;
+
+    public ProjectTypeComboBoxModel() {
+      // Remove MODULE type until add-to-app is complete.
+      if (System.getProperty("flutter.experimental.modules", null) == null) {
+        myList.remove(FlutterProjectType.MODULE);
+      }
+      mySelected = myList.get(0);
+    }
+
+    @Override
+    public int getSize() {
+      return myList.size();
+    }
+
+    @Override
+    public FlutterProjectType getElementAt(int index) {
+      return myList.get(index);
+    }
+
+    @Override
+    public void setSelectedItem(Object item) {
+      setSelectedItem((FlutterProjectType)item);
+    }
+
+    @Override
+    public FlutterProjectType getSelectedItem() {
+      return mySelected;
+    }
+
+    public void setSelectedItem(FlutterProjectType item) {
+      mySelected = item;
+      fireContentsChanged(this, 0, getSize());
+    }
+  }
+
   private JPanel projectTypePanel;
   private ComboBox projectTypeCombo;
 
   private void createUIComponents() {
     projectTypeCombo = new ComboBox<>();
     //noinspection unchecked
-    projectTypeCombo.setModel(new EnumComboBoxModel<>(FlutterProjectType.class));
+    projectTypeCombo.setModel(new ProjectTypeComboBoxModel());
     projectTypeCombo.setToolTipText(FlutterBundle.message("flutter.module.create.settings.type.tip"));
   }
 
@@ -31,7 +73,7 @@ public class ProjectType {
   }
 
   public FlutterProjectType getType() {
-    return (FlutterProjectType) projectTypeCombo.getSelectedItem();
+    return (FlutterProjectType)projectTypeCombo.getSelectedItem();
   }
 
   public void addListener(ItemListener listener) {


### PR DESCRIPTION
To add back when add-top-app is more fully baked.

Note this was showing up in the project creation UI.

Before:

![image](https://user-images.githubusercontent.com/67586/43548988-45ebea66-9594-11e8-8328-00b2931538f0.png)


After:

![image](https://user-images.githubusercontent.com/67586/43552554-ca100e20-959f-11e8-9038-9b3c80ba78d9.png)


/cc @stevemessick 
