### PR TITLE
Remove import from project type list

### DIFF
--- a/src/io/flutter/module/settings/ProjectType.java
+++ b/src/io/flutter/module/settings/ProjectType.java
@@ -27,6 +27,7 @@ public class ProjectType {
       // Remove MODULE type until add-to-app is complete.
       if (System.getProperty("flutter.experimental.modules", null) == null) {
         myList.remove(FlutterProjectType.MODULE);
+        myList.remove(FlutterProjectType.IMPORT);
       }
       mySelected = myList.get(0);
     }


### PR DESCRIPTION
@devoncarew @jwren 

The new 'Import Module' item should not appear in the Project type list for project creation.