### PR TITLE
correct get selected log for row filter

### DIFF
--- a/src/io/flutter/logging/FlutterLogTree.java
+++ b/src/io/flutter/logging/FlutterLogTree.java
@@ -554,27 +554,25 @@ public class FlutterLogTree extends TreeTable {
     });
   }
 
-  @Nullable
+  @NotNull
   private String getSelectedLog() {
     final int[] rows = getSelectedRows();
-    final TreePath[] paths = getTree().getSelectionPaths();
-    if (paths == null) {
-      return null;
-    }
-    final StringBuilder sb = new StringBuilder();
-    for (final TreePath path : paths) {
+    final StringBuilder logBuilder = new StringBuilder();
+    for (int row : rows) {
+      final int realRow = convertRowIndexToModel(row);
+      final TreePath path = getTree().getPathForRow(realRow);
       final Object pathComponent = path.getLastPathComponent();
       if (pathComponent instanceof FlutterLogTree.FlutterEventNode) {
-        ((FlutterLogTree.FlutterEventNode)pathComponent).describeTo(sb);
+        ((FlutterLogTree.FlutterEventNode)pathComponent).describeTo(logBuilder);
       }
     }
-    return sb.toString();
+    return logBuilder.toString();
   }
 
   public void sendSelectedLogsToClipboard() {
     ApplicationManager.getApplication().invokeLater(() -> {
       final String log = getSelectedLog();
-      if (log != null) {
+      if (StringUtils.isNotEmpty(log)) {
         final Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
         final StringSelection selection = new StringSelection(log);
         clipboard.setContents(selection, selection);


### PR DESCRIPTION
###  correct get selected log for row filter
Reason: after apply row filter, the selected path will not correct. (because, some row is hidden by row-filter).

Screenshot:
**Before fix:**
<img width="1115" alt="screen shot 2018-09-09 at 10 06 05 am" src="https://user-images.githubusercontent.com/6185205/45260728-ee98b480-b418-11e8-89b6-dcfb1b8ecd0b.png">

**After fixed:**
<img width="1287" alt="screen shot 2018-09-09 at 10 08 33 am" src="https://user-images.githubusercontent.com/6185205/45260730-f35d6880-b418-11e8-88ec-c4a13e04a357.png">

// cc @pq, @devoncarew  for review.
Thanks!