### PR TITLE
Support for log clear on restart/reload

### DIFF
--- a/src/io/flutter/logging/FlutterLogEntry.java
+++ b/src/io/flutter/logging/FlutterLogEntry.java
@@ -9,7 +9,15 @@ import com.intellij.openapi.util.text.StringUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import static io.flutter.logging.FlutterLogEntryParser.TOOLS_CATEGORY;
+
 public class FlutterLogEntry {
+
+  enum Kind {
+    RELOAD,
+    RESTART,
+    UNSPECIFIED
+  }
 
   public static final FlutterLog.Level UNDEFINED_LEVEL = FlutterLog.Level.INFO;
 
@@ -21,15 +29,36 @@ public class FlutterLogEntry {
   private final String message;
   private int sequenceNumber = -1;
 
+  @NotNull
+  private final Kind kind;
+
   public FlutterLogEntry(long timestamp, @NotNull String category, int level, @Nullable String message) {
     this.timestamp = timestamp;
     this.category = category;
     this.level = level;
     this.message = StringUtil.notNullize(message);
+    this.kind = parseKind(category, this.message);
+  }
+
+  private static Kind parseKind(@NotNull String category, @NotNull String message) {
+    if (category.equals(TOOLS_CATEGORY)) {
+      if (message.trim().equals("Performing hot reload...")) {
+        return Kind.RELOAD;
+      }
+      if (message.trim().equals("Performing hot restart...")) {
+        return Kind.RESTART;
+      }
+    }
+    return Kind.UNSPECIFIED;
   }
 
   public FlutterLogEntry(long timestamp, @NotNull String category, @Nullable String message) {
     this(timestamp, category, UNDEFINED_LEVEL.value, message);
+  }
+
+  @NotNull
+  public Kind getKind() {
+    return kind;
   }
 
   public long getTimestamp() {

--- a/src/io/flutter/logging/FlutterLogPreferences.java
+++ b/src/io/flutter/logging/FlutterLogPreferences.java
@@ -12,6 +12,8 @@ import org.jetbrains.annotations.NotNull;
 
 @State(name = "FlutterLogPreferences", storages = @Storage(StoragePathMacros.WORKSPACE_FILE))
 public class FlutterLogPreferences implements PersistentStateComponent<FlutterLogPreferences> {
+  private boolean clearOnReload = false;
+  private boolean clearOnRestart = true;
   private boolean showTimestamp = false;
   private boolean showSequenceNumbers = false;
   private boolean showLogLevel = true;
@@ -34,6 +36,22 @@ public class FlutterLogPreferences implements PersistentStateComponent<FlutterLo
   @Override
   public void loadState(@NotNull FlutterLogPreferences object) {
     XmlSerializerUtil.copyBean(object, this);
+  }
+
+  public void setClearOnReload(boolean clearOnReload) {
+    this.clearOnReload = clearOnReload;
+  }
+
+  public boolean isClearOnReload() {
+    return clearOnReload;
+  }
+
+  public void setClearOnRestart(boolean clearOnRestart) {
+    this.clearOnRestart = clearOnRestart;
+  }
+
+  public boolean isClearOnRestart() {
+    return clearOnRestart;
   }
 
   public boolean isShowTimestamp() {

--- a/src/io/flutter/logging/FlutterLogView.java
+++ b/src/io/flutter/logging/FlutterLogView.java
@@ -146,6 +146,9 @@ public class FlutterLogView extends JPanel implements ConsoleView, DataProvider,
         new ShowLevelAction(),
         new ShowCategoryAction(),
         new Separator(),
+        new ClearOnRestartAction(),
+        new ClearOnReloadAction(),
+        new Separator(),
         new ShowColorsAction()
       );
     }
@@ -224,6 +227,40 @@ public class FlutterLogView extends JPanel implements ConsoleView, DataProvider,
       flutterLogPreferences.setShowLogLevel(state);
       logModel.setShowLogLevels(state);
       logModel.update();
+    }
+  }
+
+  private class ClearOnReloadAction extends ToggleAction {
+
+    ClearOnReloadAction() {
+      super("Clear on reload");
+    }
+
+    @Override
+    public boolean isSelected(AnActionEvent e) {
+      return flutterLogPreferences.isClearOnReload();
+    }
+
+    @Override
+    public void setSelected(AnActionEvent e, boolean state) {
+      flutterLogPreferences.setClearOnReload(state);
+    }
+  }
+
+  private class ClearOnRestartAction extends ToggleAction {
+
+    ClearOnRestartAction() {
+      super("Clear on restart");
+    }
+
+    @Override
+    public boolean isSelected(AnActionEvent e) {
+      return flutterLogPreferences.isClearOnRestart();
+    }
+
+    @Override
+    public void setSelected(AnActionEvent e, boolean state) {
+      flutterLogPreferences.setClearOnRestart(state);
     }
   }
 


### PR DESCRIPTION
Clears log entries on restart / reload.

Configurable via the gear menu:

![image](https://user-images.githubusercontent.com/67586/45492324-d7abd800-b720-11e8-9310-08d9c68dde97.png)

Default is to clear on restart.


/cc @devoncarew @stevemessick 

FYI @quangson91 