### PR TITLE
Move attach-debug classes to main module

### DIFF
--- a/flutter-studio/src/io/flutter/actions/ConnectAndroidDebuggerAction.java
+++ b/flutter-studio/src/io/flutter/actions/ConnectAndroidDebuggerAction.java
@@ -24,7 +24,7 @@ import io.flutter.FlutterUtils;
 import io.flutter.run.FlutterLaunchMode;
 import io.flutter.run.SdkFields;
 import io.flutter.run.SdkRunConfig;
-import io.flutter.run.attach.SdkAttachConfig;
+import io.flutter.run.SdkAttachConfig;
 import io.flutter.sdk.FlutterSdkUtil;
 import org.jetbrains.android.actions.AndroidConnectDebuggerAction;
 import org.jetbrains.annotations.Nullable;

--- a/src/io/flutter/run/AttachState.java
+++ b/src/io/flutter/run/AttachState.java
@@ -1,9 +1,19 @@
 /*
- * Copyright 2018 The Chromium Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-package io.flutter.run.attach;
+package io.flutter.run;
 
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.ExecutionResult;

--- a/src/io/flutter/run/SdkAttachConfig.java
+++ b/src/io/flutter/run/SdkAttachConfig.java
@@ -1,9 +1,19 @@
 /*
- * Copyright 2018 The Chromium Authors. All rights reserved.
- * Use of this source code is governed by a BSD-style license that can be
- * found in the LICENSE file.
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-package io.flutter.run.attach;
+package io.flutter.run;
 
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.Executor;
@@ -27,7 +37,6 @@ import io.flutter.FlutterBundle;
 import io.flutter.console.FlutterConsoleFilter;
 import io.flutter.dart.DartPlugin;
 import io.flutter.pub.PubRoot;
-import io.flutter.run.*;
 import io.flutter.run.daemon.FlutterApp;
 import io.flutter.run.daemon.FlutterDevice;
 import io.flutter.run.daemon.RunMode;


### PR DESCRIPTION
@pq @jacob314 @devoncarew 

This is the first step toward making 'flutter attach' debugging available in IntelliJ.

The changes were all automatic; I just used the Refactor>Move function to move two classes out of the flutter-studio module.