### PR TITLE
Revert save files before command

### DIFF
--- a/src/io/flutter/sdk/FlutterCommand.java
+++ b/src/io/flutter/sdk/FlutterCommand.java
@@ -203,7 +203,6 @@ public class FlutterCommand {
       return new FlutterCommandStartResult(FlutterCommandStartResultStatus.ANOTHER_RUNNING);
     }
 
-    FileDocumentManager.getInstance().saveAllDocuments();
     if (isPubRelatedCommand()) {
       DartPlugin.setPubActionInProgress(true);
     }


### PR DESCRIPTION
@pq @devoncarew 

Turns out saving files before running a Flutter command is more complicated than I thought.

Need to revert that change and push another build.