### PR TITLE
[experimental] logging channel UI

### DIFF
--- a/src/io/flutter/logging/FlutterLogEntryParser.java
+++ b/src/io/flutter/logging/FlutterLogEntryParser.java
@@ -13,6 +13,7 @@ import com.intellij.execution.process.ProcessEvent;
 import com.intellij.execution.ui.ConsoleViewContentType;
 import com.intellij.openapi.util.Key;
 import io.flutter.perf.HeapMonitor;
+import io.flutter.run.FlutterDebugProcess;
 import io.flutter.run.daemon.DaemonApi;
 import io.flutter.utils.StdoutJsonParser;
 import org.dartlang.vm.service.VmService;
@@ -41,6 +42,16 @@ public class FlutterLogEntryParser {
   static {
     df1.setMinimumFractionDigits(1);
     df1.setMaximumFractionDigits(1);
+  }
+
+  private FlutterDebugProcess debugProcess;
+
+  public void setDebugProcess(FlutterDebugProcess debugProcess) {
+    this.debugProcess = debugProcess;
+  }
+
+  public FlutterDebugProcess getDebugProcess() {
+    return debugProcess;
   }
 
   private final StdoutJsonParser stdoutParser = new StdoutJsonParser();

--- a/src/io/flutter/logging/FlutterLogView.java
+++ b/src/io/flutter/logging/FlutterLogView.java
@@ -330,7 +330,8 @@ public class FlutterLogView extends JPanel implements ConsoleView, DataProvider,
       app.getFlutterLog().getLoggingChannels().thenAccept(channels -> ApplicationManager.getApplication().invokeAndWait(() -> {
         final ChannelPanel panel = new ChannelPanel(channels);
         final Rectangle visibleRect = logTree.getVisibleRect();
-        final Point topRight = new Point(logTree.getLocationOnScreen().x + visibleRect.width - 150 /* TODO: make dynamic */,
+        // TODO(pq): make width dynamic based on channel name length
+        final Point topRight = new Point(logTree.getLocationOnScreen().x + visibleRect.width - 150,
                                          logTree.getLocationOnScreen().y + visibleRect.y);
         JBPopupFactory.getInstance()
           .createComponentPopupBuilder(panel, panel)

--- a/src/io/flutter/logging/FlutterLogView.java
+++ b/src/io/flutter/logging/FlutterLogView.java
@@ -21,10 +21,13 @@ import com.intellij.openapi.editor.colors.TextAttributesKey;
 import com.intellij.openapi.editor.markup.EffectType;
 import com.intellij.openapi.editor.markup.TextAttributes;
 import com.intellij.openapi.ui.SimpleToolWindowPanel;
+import com.intellij.openapi.ui.popup.JBPopupFactory;
 import com.intellij.ui.ColoredTableCellRenderer;
 import com.intellij.ui.PopupHandler;
 import com.intellij.ui.ScrollPaneFactory;
 import com.intellij.ui.SimpleTextAttributes;
+import com.intellij.ui.awt.RelativePoint;
+import com.intellij.ui.components.JBCheckBox;
 import com.intellij.ui.components.JBLabel;
 import com.intellij.ui.content.Content;
 import com.intellij.ui.content.ContentFactory;
@@ -41,16 +44,21 @@ import javax.swing.event.ChangeListener;
 import javax.swing.table.TableCellRenderer;
 import javax.swing.table.TableColumn;
 import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
 import java.awt.event.MouseEvent;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
+import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static com.intellij.openapi.editor.markup.EffectType.*;
 import static io.flutter.logging.FlutterLogConstants.LogColumns.*;
 
 public class FlutterLogView extends JPanel implements ConsoleView, DataProvider, FlutterLog.Listener {
+
+  // Toggle to enable experimental logging channel UI.
+  public static final boolean ENABLE_LOGGING_CHANNELS = false;
+
   @NotNull
   private static final Logger LOG = Logger.getInstance(FlutterLogView.class);
 
@@ -140,7 +148,7 @@ public class FlutterLogView extends JPanel implements ConsoleView, DataProvider,
 
     @NotNull
     private DefaultActionGroup createPopupActionGroup() {
-      return new DefaultActionGroup(
+      final DefaultActionGroup actionGroup = new DefaultActionGroup(
         new ShowTimeStampsAction(),
         new ShowSequenceNumbersAction(),
         new ShowLevelAction(),
@@ -151,6 +159,10 @@ public class FlutterLogView extends JPanel implements ConsoleView, DataProvider,
         new Separator(),
         new ShowColorsAction()
       );
+      if (ENABLE_LOGGING_CHANNELS) {
+        actionGroup.addAll(Arrays.asList(new Separator(), new ConfigureChannelsAction()));
+      }
+      return actionGroup;
     }
   }
 
@@ -280,6 +292,56 @@ public class FlutterLogView extends JPanel implements ConsoleView, DataProvider,
       flutterLogPreferences.setShowColor(state);
       entryModel.showColors = state;
       logModel.update();
+    }
+  }
+
+  private class ChannelPanel extends JPanel {
+    class LoggerCheckBox extends JBCheckBox implements ActionListener {
+      @NotNull
+      private final LoggingChannel channel;
+
+      LoggerCheckBox(@NotNull LoggingChannel channel) {
+        super(channel.name);
+        this.channel = channel;
+        setToolTipText(channel.description);
+        setSelected(channel.enabled);
+        addActionListener(this);
+      }
+
+      @Override
+      public void actionPerformed(ActionEvent e) {
+        app.getFlutterLog().enable(channel, isSelected());
+      }
+    }
+
+    ChannelPanel(List<LoggingChannel> channels) {
+      setLayout(new GridLayout(0, 1));
+      channels.forEach(c -> add(new LoggerCheckBox(c)));
+    }
+  }
+
+  private class ConfigureChannelsAction extends AnAction {
+    ConfigureChannelsAction() {
+      super("Configure channels...");
+    }
+
+    @Override
+    public void actionPerformed(AnActionEvent e) {
+      app.getFlutterLog().getLoggingChannels().thenAccept(channels -> ApplicationManager.getApplication().invokeAndWait(() -> {
+        final ChannelPanel panel = new ChannelPanel(channels);
+        final Rectangle visibleRect = logTree.getVisibleRect();
+        final Point topRight = new Point(logTree.getLocationOnScreen().x + visibleRect.width - 150 /* TODO: make dynamic */,
+                                         logTree.getLocationOnScreen().y + visibleRect.y);
+        JBPopupFactory.getInstance()
+          .createComponentPopupBuilder(panel, panel)
+          .setTitle("Logging channels")
+          .setMovable(true)
+          .setRequestFocus(true)
+          .createPopup().show(RelativePoint.fromScreen(topRight));
+      })).exceptionally(throwable -> {
+        throwable.printStackTrace();
+        return null;
+      });
     }
   }
 

--- a/src/io/flutter/logging/LoggingChannel.java
+++ b/src/io/flutter/logging/LoggingChannel.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.logging;
+
+import com.google.gson.JsonObject;
+
+public class LoggingChannel {
+  final String name;
+  final String description;
+  final boolean enabled;
+
+  public LoggingChannel(String name, String description, boolean enabled) {
+    this.name = name;
+    this.description = description;
+    this.enabled = enabled;
+  }
+
+  public static LoggingChannel fromJson(String name, JsonObject properties) {
+    final String description = properties.getAsJsonPrimitive("description").getAsString();
+    final boolean enabled = properties.getAsJsonPrimitive("enabled").getAsBoolean();
+    return new LoggingChannel(name, description, enabled);
+  }
+}

--- a/src/io/flutter/run/daemon/FlutterApp.java
+++ b/src/io/flutter/run/daemon/FlutterApp.java
@@ -6,7 +6,6 @@
 package io.flutter.run.daemon;
 
 import com.google.common.base.Stopwatch;
-import com.google.common.collect.Lists;
 import com.google.gson.JsonObject;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.ExecutionManager;
@@ -23,7 +22,6 @@ import com.intellij.history.LocalHistory;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.project.ProjectManager;
 import com.intellij.openapi.util.Disposer;
 import com.intellij.openapi.util.Key;
 import com.intellij.openapi.util.text.StringUtil;
@@ -522,6 +520,7 @@ public class FlutterApp {
 
   public void setFlutterDebugProcess(FlutterDebugProcess flutterDebugProcess) {
     myFlutterDebugProcess = flutterDebugProcess;
+    myFlutterLog.setFlutterDebugProcess(flutterDebugProcess);
   }
 
   public FlutterDebugProcess getFlutterDebugProcess() {


### PR DESCRIPTION
Conditionally (if `ENABLE_LOGGING_CHANNELS` is toggled) contributes a simple UI for querying, enabling and disabling log channels as contributed by the [logs package](https://github.com/pq/logs).

![image](https://user-images.githubusercontent.com/67586/46222364-e12e6600-c304-11e8-8fec-1384d8d2dd50.png)


![image](https://user-images.githubusercontent.com/67586/46222369-e4c1ed00-c304-11e8-8737-4b4600c1330c.png)

/cc @devoncarew @jacob314 
