### PR TITLE
misc logging fixes

### DIFF
--- a/src/io/flutter/logging/FlutterLog.java
+++ b/src/io/flutter/logging/FlutterLog.java
@@ -174,7 +174,8 @@ public class FlutterLog {
     });
 
     vmService.streamListen(LOGGING_STREAM_ID, VmServiceConsumers.EMPTY_SUCCESS_CONSUMER);
-    // TODO(pq): listen for GC and frame events (Flutter.FrameworkInitialization, Flutter.FirstFrame, Flutter.Frame, etc).
+    vmService.streamListen(VmService.GC_STREAM_ID, VmServiceConsumers.EMPTY_SUCCESS_CONSUMER);
+    // TODO(pq): listen for frame events (Flutter.FrameworkInitialization, Flutter.FirstFrame, Flutter.Frame, etc).
   }
 
   private void onVmServiceReceived(String id, Event event) {

--- a/src/io/flutter/logging/FlutterLogEntryParser.java
+++ b/src/io/flutter/logging/FlutterLogEntryParser.java
@@ -57,7 +57,7 @@ public class FlutterLogEntryParser {
   private final StdoutJsonParser stdoutParser = new StdoutJsonParser();
 
   private static FlutterLogEntry parseLoggingEvent(@NotNull Event event) {
-    // TODO(pq): parse more robustly; consider more properties (level, error, stackTrace)
+    // TODO(pq): parse more robustly; consider more properties (error, stackTrace)
     final JsonObject json = event.getJson();
     final JsonObject logRecord = json.get("logRecord").getAsJsonObject();
     final Instance message = new Instance(logRecord.getAsJsonObject().get("message").getAsJsonObject());
@@ -83,7 +83,11 @@ public class FlutterLogEntryParser {
 
     // TODO: If message.getValueAsStringIsTruncated() is true, we'll need to retrieve the full string
     // value and update this entry after creation.
-    return new FlutterLogEntry(timestamp(event), category, level, message.getValueAsString());
+    String messageStr = message.getValueAsString();
+    if (message.getValueAsStringIsTruncated()) {
+      messageStr += "...";
+    }
+    return new FlutterLogEntry(timestamp(event), category, level, messageStr);
   }
 
   @NotNull

--- a/src/io/flutter/logging/FlutterLogTree.java
+++ b/src/io/flutter/logging/FlutterLogTree.java
@@ -45,8 +45,8 @@ import java.awt.event.ActionEvent;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.text.SimpleDateFormat;
-import java.util.List;
 import java.util.*;
+import java.util.List;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
@@ -555,7 +555,7 @@ public class FlutterLogTree extends TreeTable {
   }
 
   public interface EventCountListener extends EventListener {
-    void updated(int filtered, int total);
+    void updated(int total, int filtered);
   }
 
   private final EventDispatcher<EventCountListener> countDispatcher = EventDispatcher.create(EventCountListener.class);
@@ -591,7 +591,7 @@ public class FlutterLogTree extends TreeTable {
         }
       }
     });
-    model.setUpdateCallback(this::updateCounter);
+    rowSorter.addRowSorterListener(e -> updateCounter());
   }
 
   @NotNull
@@ -700,7 +700,7 @@ public class FlutterLogTree extends TreeTable {
   private void updateCounter() {
     final int total = rowSorter.getModelRowCount();
     final int filtered = total - rowSorter.getViewRowCount();
-    countDispatcher.getMulticaster().updated(filtered, total);
+    countDispatcher.getMulticaster().updated(total, filtered);
   }
 
   public void clearEntries() {

--- a/src/io/flutter/logging/FlutterLogView.java
+++ b/src/io/flutter/logging/FlutterLogView.java
@@ -438,12 +438,13 @@ public class FlutterLogView extends JPanel implements ConsoleView, DataProvider,
     }
 
     @Override
-    public void updated(int filtered, int total) {
+    public void updated(int total, int filtered) {
       if (label != null && label.isVisible()) {
+        final int visibleCount = total - filtered;
 
         final StringBuilder sb = new StringBuilder();
-        sb.append(total).append(" event");
-        if (total != 1) {
+        sb.append(visibleCount).append(" event");
+        if (visibleCount != 1) {
           sb.append("s");
         }
         if (filtered > 0) {
@@ -453,14 +454,6 @@ public class FlutterLogView extends JPanel implements ConsoleView, DataProvider,
         label.setText(sb.toString());
         SwingUtilities.invokeLater(panel::repaint);
       }
-    }
-
-    @NotNull
-    private String countString(int count) {
-      if (count > 1000) {
-        return "1000+";
-      }
-      return Integer.toString(count);
     }
   }
 


### PR DESCRIPTION
- fix receiving GC events
- display `...` on message events where the text from the VM is truncated
- fix the filtering text label - if would often lag behind the actual contents, and erroneously show that items were filtered
- change the filtered count to display the number of visible items w/ some info about the number that aren't displayed  - `100 items (3 filtered)` (a switch from showing the total log count)

@pq