### PR TITLE
Attach debugger button for IntelliJ

### DIFF
--- a/flutter-studio/src/io/flutter/actions/ConnectAndroidDebuggerAction.java
+++ b/flutter-studio/src/io/flutter/actions/ConnectAndroidDebuggerAction.java
@@ -5,158 +5,25 @@
  */
 package io.flutter.actions;
 
-import com.google.common.base.Joiner;
-import com.intellij.execution.Executor;
-import com.intellij.execution.ProgramRunnerUtil;
-import com.intellij.execution.RunnerAndConfigurationSettings;
-import com.intellij.execution.configurations.RunConfiguration;
-import com.intellij.execution.runners.ExecutionEnvironment;
-import com.intellij.execution.runners.ExecutionEnvironmentBuilder;
 import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.ui.DialogWrapper;
-import com.intellij.openapi.ui.Messages;
-import com.intellij.openapi.wm.ToolWindowId;
-import io.flutter.FlutterInitializer;
-import io.flutter.FlutterUtils;
-import io.flutter.run.FlutterLaunchMode;
-import io.flutter.run.SdkFields;
-import io.flutter.run.SdkRunConfig;
-import io.flutter.run.SdkAttachConfig;
 import io.flutter.sdk.FlutterSdkUtil;
 import org.jetbrains.android.actions.AndroidConnectDebuggerAction;
-import org.jetbrains.annotations.Nullable;
-
-import javax.swing.*;
-import java.util.ArrayList;
-import java.util.List;
 
 public class ConnectAndroidDebuggerAction extends AndroidConnectDebuggerAction {
-  @SuppressWarnings("FieldCanBeLocal")
-  private static String RUN_DEBUG_LINK = "https://flutter.io/using-ide/#running-and-debugging";
-
-  @Override
-  public void actionPerformed(AnActionEvent e) {
-    // NOTE: When making changes here, consider making similar changes to RunFlutterAction.
-    if (!FlutterUtils.isAndroidStudio()) {
-      super.actionPerformed(e);
-      return;
-    }
-    FlutterInitializer.sendAnalyticsAction(this);
-
-    RunnerAndConfigurationSettings settings = RunFlutterAction.getRunConfigSettings(e);
-    if (settings == null) {
-      showSelectConfigDialog();
-      return;
-    }
-
-    RunConfiguration configuration = settings.getConfiguration();
-    if (!(configuration instanceof SdkRunConfig)) {
-      Project project = e.getProject();
-      if (project == null || project.isDefault()) {
-        super.actionPerformed(e);
-        return;
-      }
-      if (!FlutterSdkUtil.hasFlutterModules(project)) {
-        super.actionPerformed(e);
-        return;
-      }
-      showSelectConfigDialog();
-      return;
-    }
-
-    SdkAttachConfig sdkRunConfig = new SdkAttachConfig((SdkRunConfig)configuration);
-    SdkFields fields = sdkRunConfig.getFields();
-    String additionalArgs = fields.getAdditionalArgs();
-
-    String flavorArg = null;
-    if (fields.getBuildFlavor() != null) {
-      flavorArg = "--flavor=" + fields.getBuildFlavor();
-    }
-
-    List<String> args = new ArrayList<>();
-    if (additionalArgs != null) {
-      args.add(additionalArgs);
-    }
-    if (flavorArg != null) {
-      args.add(flavorArg);
-    }
-    if (!args.isEmpty()) {
-      fields.setAdditionalArgs(Joiner.on(" ").join(args));
-    }
-
-    Executor executor = RunFlutterAction.getExecutor(ToolWindowId.DEBUG);
-    if (executor == null) {
-      return;
-    }
-
-    ExecutionEnvironmentBuilder builder = ExecutionEnvironmentBuilder.create(executor, sdkRunConfig);
-
-    ExecutionEnvironment env = builder.activeTarget().dataContext(e.getDataContext()).build();
-    FlutterLaunchMode.addToEnvironment(env, FlutterLaunchMode.DEBUG);
-
-    ProgramRunnerUtil.executeConfiguration(env, false, true);
-  }
 
   @Override
   public void update(AnActionEvent e) {
-    if (!FlutterUtils.isAndroidStudio()) {
-      super.update(e);
-      return;
-    }
     Project project = e.getProject();
     if (project == null || project.isDefault()) {
       super.update(e);
       return;
     }
-    if (!FlutterSdkUtil.hasFlutterModules(project)) {
-      super.update(e);
+    if (FlutterSdkUtil.hasFlutterModules(project)) {
+      // Hide this button in Flutter projects; defer to superclass for Android projects.
+      e.getPresentation().setVisible(false);
       return;
     }
-    boolean enabled;
-    RunnerAndConfigurationSettings settings = RunFlutterAction.getRunConfigSettings(e);
-    if (settings == null) {
-      enabled = false;
-    } else {
-      RunConfiguration configuration = settings.getConfiguration();
-      enabled = configuration instanceof SdkRunConfig;
-    }
-    e.getPresentation().setEnabled(enabled);
-  }
-
-  private static void showSelectConfigDialog() {
-    ApplicationManager.getApplication().invokeLater(() -> new SelectConfigDialog().show(), ModalityState.NON_MODAL);
-  }
-
-  private static class SelectConfigDialog extends DialogWrapper {
-    private JPanel myPanel;
-    private JTextPane myTextPane;
-
-    SelectConfigDialog() {
-      super(null, false, false);
-      setTitle("Run Configuration");
-      myPanel = new JPanel();
-      myTextPane = new JTextPane();
-      Messages.installHyperlinkSupport(myTextPane);
-      String selectConfig = "<html><body>" +
-                            "<p>The run configuration for the Flutter module must be selected." +
-                            "<p>Please change the run configuration to the one created when the<br>" +
-                            "module was created. See <a href=\"" +
-                            RUN_DEBUG_LINK +
-                            "\">the Flutter documentation</a> for more information.</body></html>";
-      myTextPane.setText(selectConfig);
-      myPanel.add(myTextPane);
-      init();
-      //noinspection ConstantConditions
-      getButton(getCancelAction()).setVisible(false);
-    }
-
-    @Nullable
-    @Override
-    protected JComponent createCenterPanel() {
-      return myPanel;
-    }
+    super.update(e);
   }
 }

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -606,9 +606,10 @@
     </action>
     <action id="AttachDebuggerAction"
             class="io.flutter.actions.AttachDebuggerAction"
-            text="Attach Debugger to Android Process"
-            description="Attach Debugger to Android Process"
+            text="Attach debugger to embedded Flutter process"
+            description="Attach debugger to a Flutter process embedded in an Android app"
             icon="AllIcons.Debugger.AttachToProcess">
+      <add-to-group group-id="ToolbarRunGroup" anchor="after" relative-to-action="RunnerActions"/>
     </action>
 
     <!-- run menu actions -->

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -604,6 +604,12 @@
       <add-to-group group-id="ToolbarRunGroup" anchor="after" relative-to-action="RunnerActions"/>
       <keyboard-shortcut keymap="$default" first-keystroke="ctrl BACK_SLASH"/>
     </action>
+    <action id="AttachDebuggerAction"
+            class="io.flutter.actions.AttachDebuggerAction"
+            text="Attach Debugger to Android Process"
+            description="Attach Debugger to Android Process"
+            icon="AllIcons.Debugger.AttachToProcess">
+    </action>
 
     <!-- run menu actions -->
     <group id="Flutter.MenuActions.Run">

--- a/resources/META-INF/plugin_template.xml
+++ b/resources/META-INF/plugin_template.xml
@@ -125,6 +125,12 @@
       <add-to-group group-id="ToolbarRunGroup" anchor="after" relative-to-action="RunnerActions"/>
       <keyboard-shortcut keymap="$default" first-keystroke="ctrl BACK_SLASH"/>
     </action>
+    <action id="AttachDebuggerAction"
+            class="io.flutter.actions.AttachDebuggerAction"
+            text="Attach Debugger to Android Process"
+            description="Attach Debugger to Android Process"
+            icon="AllIcons.Debugger.AttachToProcess">
+    </action>
 
     <!-- run menu actions -->
     <group id="Flutter.MenuActions.Run">

--- a/resources/META-INF/plugin_template.xml
+++ b/resources/META-INF/plugin_template.xml
@@ -127,9 +127,10 @@
     </action>
     <action id="AttachDebuggerAction"
             class="io.flutter.actions.AttachDebuggerAction"
-            text="Attach Debugger to Android Process"
-            description="Attach Debugger to Android Process"
+            text="Attach debugger to embedded Flutter process"
+            description="Attach debugger to a Flutter process embedded in an Android app"
             icon="AllIcons.Debugger.AttachToProcess">
+      <add-to-group group-id="ToolbarRunGroup" anchor="after" relative-to-action="RunnerActions"/>
     </action>
 
     <!-- run menu actions -->

--- a/resources/META-INF/studio-contribs.xml
+++ b/resources/META-INF/studio-contribs.xml
@@ -39,8 +39,8 @@
       <add-to-group group-id="WelcomeScreen.QuickStart.IDEA" anchor="after" relative-to-action="WelcomeScreen.CreateNewProject"/>
     </action>
 
-    <!-- Re-purpose the named toolbar button to work for Flutter modules. (It doesn't make much sense otherwise.) -->
-    <!-- This works changes both the toolbar and menu items, thanks to the overrides attribute. -->
+    <!-- Configure an override so the the base definition can be hidden in Flutter projects. -->
+    <!-- This changes both the toolbar and menu items, thanks to the overrides attribute. -->
     <action id="AndroidConnectDebuggerAction"
             overrides="true"
             class="io.flutter.actions.ConnectAndroidDebuggerAction"

--- a/resources/META-INF/studio-contribs_template.xml
+++ b/resources/META-INF/studio-contribs_template.xml
@@ -37,8 +37,8 @@
       <add-to-group group-id="WelcomeScreen.QuickStart.IDEA" anchor="after" relative-to-action="WelcomeScreen.CreateNewProject"/>
     </action>
 
-    <!-- Re-purpose the named toolbar button to work for Flutter modules. (It doesn't make much sense otherwise.) -->
-    <!-- This works changes both the toolbar and menu items, thanks to the overrides attribute. -->
+    <!-- Configure an override so the the base definition can be hidden in Flutter projects. -->
+    <!-- This changes both the toolbar and menu items, thanks to the overrides attribute. -->
     <action id="AndroidConnectDebuggerAction"
             overrides="true"
             class="io.flutter.actions.ConnectAndroidDebuggerAction"

--- a/src/io/flutter/actions/AttachDebuggerAction.java
+++ b/src/io/flutter/actions/AttachDebuggerAction.java
@@ -102,6 +102,7 @@ public class AttachDebuggerAction extends FlutterSdkAction {
       return;
     }
     if (!FlutterSdkUtil.hasFlutterModules(project)) {
+      // Hide this button in Android projects.
       e.getPresentation().setVisible(false);
       return;
     }

--- a/src/io/flutter/actions/AttachDebuggerAction.java
+++ b/src/io/flutter/actions/AttachDebuggerAction.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2018 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.actions;
+
+import com.google.common.base.Joiner;
+import com.intellij.execution.Executor;
+import com.intellij.execution.ProgramRunnerUtil;
+import com.intellij.execution.RunManagerEx;
+import com.intellij.execution.RunnerAndConfigurationSettings;
+import com.intellij.execution.configurations.RunConfiguration;
+import com.intellij.execution.runners.ExecutionEnvironment;
+import com.intellij.execution.runners.ExecutionEnvironmentBuilder;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ModalityState;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.DialogWrapper;
+import com.intellij.openapi.ui.Messages;
+import com.intellij.openapi.wm.ToolWindowId;
+import io.flutter.FlutterInitializer;
+import io.flutter.pub.PubRoot;
+import io.flutter.run.FlutterLaunchMode;
+import io.flutter.run.SdkAttachConfig;
+import io.flutter.run.SdkFields;
+import io.flutter.run.SdkRunConfig;
+import io.flutter.sdk.FlutterSdk;
+import io.flutter.sdk.FlutterSdkUtil;
+import java.util.ArrayList;
+import java.util.List;
+import javax.swing.JComponent;
+import javax.swing.JPanel;
+import javax.swing.JTextPane;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class AttachDebuggerAction extends FlutterSdkAction {
+  @SuppressWarnings("FieldCanBeLocal")
+  private static String RUN_DEBUG_LINK = "https://flutter.io/using-ide/#running-and-debugging";
+
+  @Override
+  public void startCommand(@NotNull Project project, @NotNull FlutterSdk sdk, @Nullable PubRoot root, @NotNull DataContext context) {
+    // NOTE: When making changes here, consider making similar changes to RunFlutterAction.
+    FlutterInitializer.sendAnalyticsAction(this);
+
+    RunnerAndConfigurationSettings settings = RunManagerEx.getInstanceEx(project).getSelectedConfiguration();
+    if (settings == null) {
+      showSelectConfigDialog();
+      return;
+    }
+
+    RunConfiguration configuration = settings.getConfiguration();
+    if (!(configuration instanceof SdkRunConfig)) {
+      if (project.isDefault() || !FlutterSdkUtil.hasFlutterModules(project)) {
+        return;
+      }
+      showSelectConfigDialog();
+      return;
+    }
+
+    SdkAttachConfig sdkRunConfig = new SdkAttachConfig((SdkRunConfig)configuration);
+    SdkFields fields = sdkRunConfig.getFields();
+    String additionalArgs = fields.getAdditionalArgs();
+
+    String flavorArg = null;
+    if (fields.getBuildFlavor() != null) {
+      flavorArg = "--flavor=" + fields.getBuildFlavor();
+    }
+
+    List<String> args = new ArrayList<>();
+    if (additionalArgs != null) {
+      args.add(additionalArgs);
+    }
+    if (flavorArg != null) {
+      args.add(flavorArg);
+    }
+    if (!args.isEmpty()) {
+      fields.setAdditionalArgs(Joiner.on(" ").join(args));
+    }
+
+    Executor executor = RunFlutterAction.getExecutor(ToolWindowId.DEBUG);
+    if (executor == null) {
+      return;
+    }
+
+    ExecutionEnvironmentBuilder builder = ExecutionEnvironmentBuilder.create(executor, sdkRunConfig);
+
+    ExecutionEnvironment env = builder.activeTarget().dataContext(context).build();
+    FlutterLaunchMode.addToEnvironment(env, FlutterLaunchMode.DEBUG);
+
+    ProgramRunnerUtil.executeConfiguration(env, false, true);
+  }
+
+  @Override
+  public void update(AnActionEvent e) {
+    Project project = e.getProject();
+    if (project == null || project.isDefault()) {
+      super.update(e);
+      return;
+    }
+    if (!FlutterSdkUtil.hasFlutterModules(project)) {
+      e.getPresentation().setVisible(false);
+      return;
+    }
+    boolean enabled;
+    RunnerAndConfigurationSettings settings = RunFlutterAction.getRunConfigSettings(e);
+    if (settings == null) {
+      enabled = false;
+    }
+    else {
+      RunConfiguration configuration = settings.getConfiguration();
+      enabled = configuration instanceof SdkRunConfig;
+    }
+    e.getPresentation().setEnabled(enabled);
+  }
+
+  private static void showSelectConfigDialog() {
+    ApplicationManager.getApplication().invokeLater(() -> new SelectConfigDialog().show(), ModalityState.NON_MODAL);
+  }
+
+  private static class SelectConfigDialog extends DialogWrapper {
+    private JPanel myPanel;
+    private JTextPane myTextPane;
+
+    SelectConfigDialog() {
+      super(null, false, false);
+      setTitle("Run Configuration");
+      myPanel = new JPanel();
+      myTextPane = new JTextPane();
+      Messages.installHyperlinkSupport(myTextPane);
+      String selectConfig = "<html><body>" +
+                            "<p>The run configuration for the Flutter module must be selected." +
+                            "<p>Please change the run configuration to the one created when the<br>" +
+                            "module was created. See <a href=\"" +
+                            RUN_DEBUG_LINK +
+                            "\">the Flutter documentation</a> for more information.</body></html>";
+      myTextPane.setText(selectConfig);
+      myPanel.add(myTextPane);
+      init();
+      //noinspection ConstantConditions
+      getButton(getCancelAction()).setVisible(false);
+    }
+
+    @Nullable
+    @Override
+    protected JComponent createCenterPanel() {
+      return myPanel;
+    }
+  }
+}

--- a/src/io/flutter/actions/FlutterCleanAction.java
+++ b/src/io/flutter/actions/FlutterCleanAction.java
@@ -5,6 +5,7 @@
  */
 package io.flutter.actions;
 
+import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.project.Project;
 import io.flutter.FlutterMessages;
 import io.flutter.pub.PubRoot;
@@ -14,7 +15,7 @@ import org.jetbrains.annotations.Nullable;
 
 public class FlutterCleanAction extends FlutterSdkAction {
   @Override
-  public void startCommand(@NotNull Project project, @NotNull FlutterSdk sdk, @Nullable PubRoot root) {
+  public void startCommand(@NotNull Project project, @NotNull FlutterSdk sdk, @Nullable PubRoot root, @NotNull DataContext context) {
     if (root == null) {
       FlutterMessages.showError("Cannot Find Pub Root",
                                 "Flutter clean can only be run within a directory with a pubspec.yaml file");

--- a/src/io/flutter/actions/FlutterDoctorAction.java
+++ b/src/io/flutter/actions/FlutterDoctorAction.java
@@ -8,6 +8,7 @@ package io.flutter.actions;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configurations.GeneralCommandLine;
 import com.intellij.execution.process.OSProcessHandler;
+import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.io.FileUtil;
@@ -23,9 +24,13 @@ public class FlutterDoctorAction extends FlutterSdkAction {
 
   private static final Logger LOG = Logger.getInstance(FlutterDoctorAction.class);
 
-  @Override
   public void startCommand(@NotNull Project project, @NotNull FlutterSdk sdk, @Nullable PubRoot root) {
     sdk.flutterDoctor().startInConsole(project);
+  }
+
+  @Override
+  public void startCommand(@NotNull Project project, @NotNull FlutterSdk sdk, @Nullable PubRoot root, @NotNull DataContext context) {
+    startCommand(project, sdk, root);
   }
 
   @Override

--- a/src/io/flutter/actions/FlutterPackagesGetAction.java
+++ b/src/io/flutter/actions/FlutterPackagesGetAction.java
@@ -5,6 +5,7 @@
  */
 package io.flutter.actions;
 
+import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.project.Project;
 import io.flutter.FlutterMessages;
 import io.flutter.pub.PubRoot;
@@ -15,7 +16,7 @@ import org.jetbrains.annotations.Nullable;
 public class FlutterPackagesGetAction extends FlutterSdkAction {
 
   @Override
-  public void startCommand(@NotNull Project project, @NotNull FlutterSdk sdk, @Nullable PubRoot root) {
+  public void startCommand(@NotNull Project project, @NotNull FlutterSdk sdk, @Nullable PubRoot root, @NotNull DataContext context) {
     if (root == null) {
       FlutterMessages.showError("Cannot Find Pub Root",
         "Flutter packages get can only be run within a directory with a pubspec.yaml file");

--- a/src/io/flutter/actions/FlutterPackagesUpgradeAction.java
+++ b/src/io/flutter/actions/FlutterPackagesUpgradeAction.java
@@ -6,6 +6,7 @@
 package io.flutter.actions;
 
 
+import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.project.Project;
 import io.flutter.FlutterMessages;
 import io.flutter.pub.PubRoot;
@@ -16,7 +17,7 @@ import org.jetbrains.annotations.Nullable;
 public class FlutterPackagesUpgradeAction extends FlutterSdkAction {
 
   @Override
-  public void startCommand(@NotNull Project project, @NotNull FlutterSdk sdk, @Nullable PubRoot root) {
+  public void startCommand(@NotNull Project project, @NotNull FlutterSdk sdk, @Nullable PubRoot root, @NotNull DataContext context) {
     if (root == null) {
       FlutterMessages.showError("Cannot Find Pub Root",
                                 "Flutter packages upgrade can only be run within a directory with a pubspec.yaml file");

--- a/src/io/flutter/actions/FlutterSdkAction.java
+++ b/src/io/flutter/actions/FlutterSdkAction.java
@@ -6,6 +6,7 @@
 package io.flutter.actions;
 
 import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.project.DumbAwareAction;
@@ -51,10 +52,13 @@ public abstract class FlutterSdkAction extends DumbAwareAction {
 
     FlutterInitializer.sendAnalyticsAction(this);
     FileDocumentManager.getInstance().saveAllDocuments();
-    startCommand(project, sdk, PubRoot.forEventWithRefresh(event));
+    startCommand(project, sdk, PubRoot.forEventWithRefresh(event), event.getDataContext());
   }
 
-  public abstract void startCommand(@NotNull Project project, @NotNull FlutterSdk sdk, @Nullable PubRoot root);
+  public abstract void startCommand(@NotNull Project project,
+                                    @NotNull FlutterSdk sdk,
+                                    @Nullable PubRoot root,
+                                    @NotNull DataContext context);
 
   /**
    * Implemented by actions which are used in the Bazel context ({@link #enableActionInBazelContext()} returns true), by default this method

--- a/src/io/flutter/actions/FlutterUpgradeAction.java
+++ b/src/io/flutter/actions/FlutterUpgradeAction.java
@@ -5,6 +5,7 @@
  */
 package io.flutter.actions;
 
+import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.project.Project;
 import io.flutter.pub.PubRoot;
 import io.flutter.sdk.FlutterSdk;
@@ -13,7 +14,7 @@ import org.jetbrains.annotations.Nullable;
 
 public class FlutterUpgradeAction extends FlutterSdkAction {
   @Override
-  public void startCommand(@NotNull Project project, @NotNull FlutterSdk sdk, @Nullable PubRoot root) {
+  public void startCommand(@NotNull Project project, @NotNull FlutterSdk sdk, @Nullable PubRoot root, @NotNull DataContext context) {
     sdk.flutterUpgrade().startInConsole(project);
   }
 }


### PR DESCRIPTION
@pq @devoncarew 

- Add the attach button to the toolbar in IntelliJ (and AS). (We promised to do this.)
- Change the AS-specific action class to hide the Android attach button in Flutter projects.
- Change the name of the button to `Attach debugger to embedded Flutter process`
- API change: add DataContext parameter

/cc @matthew-carroll 