### PR TITLE
add -Didea.is.internal=true flag so that the Swing UI inspector can be used to debug the plugin

### DIFF
--- a/.idea/runConfigurations/Flutter_Plugin.xml
+++ b/.idea/runConfigurations/Flutter_Plugin.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Flutter Plugin" type="#org.jetbrains.idea.devkit.run.PluginConfigurationType" factoryName="Plugin">
     <module name="flutter-intellij" />
-    <option name="VM_PARAMETERS" value="-Xmx512m -Xms256m -XX:MaxPermSize=250m -ea -Didea.fatal.error.notification=enabled" />
+    <option name="VM_PARAMETERS" value="-Xmx512m -Xms256m -XX:MaxPermSize=250m -ea -Didea.fatal.error.notification=enabled -Didea.is.internal=true " />
     <option name="PROGRAM_PARAMETERS" value="" />
     <predefined_log_file id="idea.log" enabled="true" />
     <method />


### PR DESCRIPTION
Adding this means we can use the Swing UI Inspector which is very handy.
Thanks @terrylucas  for pointing this out.
<img width="639" alt="screen shot 2018-10-02 at 6 13 00 pm" src="https://user-images.githubusercontent.com/1226812/46385075-dcecaa80-c66e-11e8-9fe4-9223839ec226.png">
