### PR TITLE
handle nulls from the service protocol

### DIFF
--- a/src/io/flutter/run/ObservatoryFile.java
+++ b/src/io/flutter/run/ObservatoryFile.java
@@ -11,9 +11,9 @@ import com.intellij.util.PathUtil;
 import com.intellij.xdebugger.XDebuggerUtil;
 import com.intellij.xdebugger.XSourcePosition;
 import com.jetbrains.lang.dart.DartFileType;
-import io.flutter.server.vmService.DartVmServiceDebugProcess;
 import gnu.trove.THashMap;
 import gnu.trove.TIntObjectHashMap;
+import io.flutter.server.vmService.DartVmServiceDebugProcess;
 import org.dartlang.vm.service.element.Script;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -102,11 +102,16 @@ class ObservatoryFile {
     return result;
   }
 
+  @Nullable
   private static LightVirtualFile createSnapshot(@NotNull Script script) {
     // LightVirtualFiles have no parent directory, so just use the filename.
-    // TODO(skybrian) maybe add more of the path anyway, for display?
     final String filename = PathUtil.getFileName(script.getUri());
-    final LightVirtualFile snapshot = new LightVirtualFile(filename, DartFileType.INSTANCE, script.getSource());
+    final String scriptSource = script.getSource();
+    if (scriptSource == null) {
+      return null;
+    }
+
+    final LightVirtualFile snapshot = new LightVirtualFile(filename, DartFileType.INSTANCE, scriptSource);
     snapshot.setWritable(false);
     return snapshot;
   }
@@ -151,6 +156,10 @@ class ObservatoryFile {
 
       final ObservatoryFile downloaded = new ObservatoryFile(script, wantSnapshot);
       this.versions.put(scriptId, downloaded);
+
+      if (wantSnapshot && !downloaded.hasSnapshot()) {
+        return null;
+      }
       return downloaded;
     }
   }

--- a/src/io/flutter/server/vmService/VMServiceManager.java
+++ b/src/io/flutter/server/vmService/VMServiceManager.java
@@ -71,10 +71,12 @@ public class VMServiceManager implements FlutterApp.FlutterAppListener {
             public void received(Isolate isolate) {
               // Populate flutter isolate info.
               if (flutterIsolateRefStream.getValue() == null) {
-                for (String extensionName : isolate.getExtensionRPCs()) {
-                  if (extensionName.startsWith("ext.flutter.")) {
-                    setFlutterIsolate(isolateRef);
-                    break;
+                if (isolate.getExtensionRPCs() != null) {
+                  for (String extensionName : isolate.getExtensionRPCs()) {
+                    if (extensionName.startsWith("ext.flutter.")) {
+                      setFlutterIsolate(isolateRef);
+                      break;
+                    }
                   }
                 }
               }
@@ -96,8 +98,10 @@ public class VMServiceManager implements FlutterApp.FlutterAppListener {
 
   public void addRegisteredExtensionRPCs(Isolate isolate) {
     ApplicationManager.getApplication().invokeLater(() -> {
-      for (String extension : isolate.getExtensionRPCs()) {
-        addServiceExtension(extension);
+      if (isolate.getExtensionRPCs() != null) {
+        for (String extension : isolate.getExtensionRPCs()) {
+          addServiceExtension(extension);
+        }
       }
     });
   }

--- a/src/io/flutter/server/vmService/frame/DartVmServiceStackFrame.java
+++ b/src/io/flutter/server/vmService/frame/DartVmServiceStackFrame.java
@@ -127,7 +127,15 @@ public class DartVmServiceStackFrame extends XStackFrame {
       return;
     }
 
-    myDebugProcess.getVmServiceWrapper().getObject(myIsolateId, thisVar.getValue().getClassRef().getId(), new GetObjectConsumer() {
+    final Object thisVarValue = thisVar.getValue();
+    if (!(thisVarValue instanceof InstanceRef)) {
+      addVars(node, vars);
+      return;
+    }
+
+    // InstanceRef
+    final ClassRef classRef = ((InstanceRef)thisVarValue).getClassRef();
+    myDebugProcess.getVmServiceWrapper().getObject(myIsolateId, classRef.getId(), new GetObjectConsumer() {
       @Override
       public void received(Obj classObj) {
         final SmartList<FieldRef> staticFields = new SmartList<>();
@@ -162,13 +170,14 @@ public class DartVmServiceStackFrame extends XStackFrame {
     final XValueChildrenList childrenList = new XValueChildrenList(vars.size());
 
     for (BoundVariable var : vars) {
-      final InstanceRef value = var.getValue();
-      if (value != null) {
+      final Object value = var.getValue();
+      if (value instanceof InstanceRef) {
+        final InstanceRef instanceRef = (InstanceRef)value;
         final DartVmServiceValue.LocalVarSourceLocation varLocation =
           "this".equals(var.getName())
           ? null
           : new DartVmServiceValue.LocalVarSourceLocation(myVmFrame.getLocation().getScript(), var.getDeclarationTokenPos());
-        childrenList.add(new DartVmServiceValue(myDebugProcess, myIsolateId, var.getName(), value, varLocation, null, false));
+        childrenList.add(new DartVmServiceValue(myDebugProcess, myIsolateId, var.getName(), instanceRef, varLocation, null, false));
       }
     }
 

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/VmService.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/VmService.java
@@ -77,7 +77,7 @@ public class VmService extends VmServiceBase {
   /**
    * The minor version number of the protocol supported by this client.
    */
-  public static final int versionMinor = 8;
+  public static final int versionMinor = 9;
 
   /**
    * The [addBreakpoint] RPC is used to add a breakpoint at a specific line of some script.
@@ -365,6 +365,30 @@ public class VmService extends VmServiceBase {
   public void getVersion(VersionConsumer consumer) {
     JsonObject params = new JsonObject();
     request("getVersion", params, consumer);
+  }
+
+  /**
+   * The [invoke] RPC is used to perform regular method invocation on some receiver, as if by
+   * dart:mirror's ObjectMirror.invoke. Note this does not provide a way to perform getter, setter
+   * or constructor invocation.
+   */
+  public void invoke(String isolateId, String targetId, String selector, List<String> argumentIds, InvokeConsumer consumer) {
+    JsonObject params = new JsonObject();
+    params.addProperty("isolateId", isolateId);
+    params.addProperty("targetId", targetId);
+    params.addProperty("selector", selector);
+    params.add("argumentIds", convertIterableToJsonArray(argumentIds));
+    request("invoke", params, consumer);
+  }
+
+  /**
+   * The [kill] RPC is used to kill an isolate as if by dart:isolate's
+   * <code>Isolate.kill(IMMEDIATE)</code>Isolate.kill(IMMEDIATE).
+   */
+  public void kill(String isolateId, SuccessConsumer consumer) {
+    JsonObject params = new JsonObject();
+    params.addProperty("isolateId", isolateId);
+    request("kill", params, consumer);
   }
 
   /**
@@ -678,6 +702,24 @@ public class VmService extends VmServiceBase {
       }
       if (responseType.equals("TypeArguments")) {
         ((GetObjectConsumer) consumer).received(new TypeArguments(json));
+        return;
+      }
+    }
+    if (consumer instanceof InvokeConsumer) {
+      if (responseType.equals("@Error")) {
+        ((InvokeConsumer) consumer).received(new ErrorRef(json));
+        return;
+      }
+      if (responseType.equals("@Instance")) {
+        ((InvokeConsumer) consumer).received(new InstanceRef(json));
+        return;
+      }
+      if (responseType.equals("@Null")) {
+        ((InvokeConsumer) consumer).received(new NullRef(json));
+        return;
+      }
+      if (responseType.equals("Sentinel")) {
+        ((InvokeConsumer) consumer).received(new Sentinel(json));
         return;
       }
     }

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/consumer/InvokeConsumer.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/consumer/InvokeConsumer.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2015, the Dart project authors.
+ *
+ * Licensed under the Eclipse Public License v1.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.dartlang.vm.service.consumer;
+
+// This is a generated file.
+
+import org.dartlang.vm.service.element.ErrorRef;
+import org.dartlang.vm.service.element.InstanceRef;
+import org.dartlang.vm.service.element.Sentinel;
+
+@SuppressWarnings({"WeakerAccess", "unused", "UnnecessaryInterfaceModifier"})
+public interface InvokeConsumer extends Consumer {
+
+  public void received(ErrorRef response);
+
+  public void received(InstanceRef response);
+
+  public void received(Sentinel response);
+}

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/element/BoundVariable.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/element/BoundVariable.java
@@ -15,7 +15,6 @@ package org.dartlang.vm.service.element;
 
 // This is a generated file.
 
-import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
 /**
@@ -55,14 +54,16 @@ public class BoundVariable extends Element {
   }
 
   /**
-   * @return one of <code>InstanceRef</code> or <code>Sentinel</code>
+   * @return one of <code>InstanceRef</code>, <code>TypeArgumentsRef</code> or
+   * <code>Sentinel</code>
    */
-  public InstanceRef getValue() {
-    JsonElement elem = json.get("value");
-    if (!elem.isJsonObject()) return null;
-    JsonObject child = elem.getAsJsonObject();
-    String type = child.get("type").getAsString();
-    if ("Sentinel".equals(type)) return null;
-    return new InstanceRef(child);
+  public Object getValue() {
+    JsonObject elem = (JsonObject)json.get("value");
+    if (elem == null) return null;
+
+    if (elem.get("type").getAsString().equals("@Instance")) return new InstanceRef(elem);
+    if (elem.get("type").getAsString().equals("@TypeArguments")) return new TypeArgumentsRef(elem);
+    if (elem.get("type").getAsString().equals("Sentinel")) return new Sentinel(elem);
+    return null;
   }
 }

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/element/Breakpoint.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/element/Breakpoint.java
@@ -37,6 +37,8 @@ public class Breakpoint extends Obj {
   /**
    * Is this a breakpoint that was added synthetically as part of a step OverAsyncSuspension resume
    * command?
+   *
+   * Can return <code>null</code>.
    */
   public boolean getIsSyntheticAsyncContinuation() {
     return json.get("isSyntheticAsyncContinuation") == null ? false : json.get("isSyntheticAsyncContinuation").getAsBoolean();

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/element/ClassObj.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/element/ClassObj.java
@@ -30,6 +30,8 @@ public class ClassObj extends Obj {
 
   /**
    * The error which occurred during class finalization, if it exists.
+   *
+   * Can return <code>null</code>.
    */
   public ErrorRef getError() {
     return json.get("error") == null ? null : new ErrorRef((JsonObject) json.get("error"));
@@ -83,6 +85,8 @@ public class ClassObj extends Obj {
 
   /**
    * The location of this class in the source code.
+   *
+   * Can return <code>null</code>.
    */
   public SourceLocation getLocation() {
     return json.get("location") == null ? null : new SourceLocation((JsonObject) json.get("location"));
@@ -92,6 +96,8 @@ public class ClassObj extends Obj {
    * The mixin type for this class, if any.
    *
    * The value will be of the kind: Type.
+   *
+   * Can return <code>null</code>.
    */
   public InstanceRef getMixin() {
     return json.get("mixin") == null ? null : new InstanceRef((JsonObject) json.get("mixin"));
@@ -118,6 +124,8 @@ public class ClassObj extends Obj {
 
   /**
    * The superclass of this class, if any.
+   *
+   * Can return <code>null</code>.
    */
   public ClassRef getSuperClass() {
     return json.get("super") == null ? null : new ClassRef((JsonObject) json.get("super"));
@@ -127,6 +135,8 @@ public class ClassObj extends Obj {
    * The supertype for this class, if any.
    *
    * The value will be of the kind: Type.
+   *
+   * Can return <code>null</code>.
    */
   public InstanceRef getSuperType() {
     return json.get("superType") == null ? null : new InstanceRef((JsonObject) json.get("superType"));

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/element/Context.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/element/Context.java
@@ -37,6 +37,8 @@ public class Context extends Obj {
 
   /**
    * The enclosing context for this context.
+   *
+   * Can return <code>null</code>.
    */
   public Context getParent() {
     return json.get("parent") == null ? null : new Context((JsonObject) json.get("parent"));

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/element/ErrorObj.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/element/ErrorObj.java
@@ -30,6 +30,8 @@ public class ErrorObj extends Obj {
 
   /**
    * If this error is due to an unhandled exception, this is the exception thrown.
+   *
+   * Can return <code>null</code>.
    */
   public InstanceRef getException() {
     return json.get("exception") == null ? null : new InstanceRef((JsonObject) json.get("exception"));
@@ -56,6 +58,8 @@ public class ErrorObj extends Obj {
 
   /**
    * If this error is due to an unhandled exception, this is the stacktrace object.
+   *
+   * Can return <code>null</code>.
    */
   public InstanceRef getStacktrace() {
     return json.get("stacktrace") == null ? null : new InstanceRef((JsonObject) json.get("stacktrace"));

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/element/Event.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/element/Event.java
@@ -35,9 +35,11 @@ public class Event extends Response {
    *
    * This is provided for the event kinds:
    *  - ServiceRegistered
+   *
+   * Can return <code>null</code>.
    */
   public String getAlias() {
-    return json.get("alias").getAsString();
+    return json.get("alias") == null ? null : json.get("alias").getAsString();
   }
 
   /**
@@ -46,6 +48,8 @@ public class Event extends Response {
    * This is provided for the event kinds:
    *  - PauseBreakpoint
    *  - PauseInterrupted
+   *
+   * Can return <code>null</code>.
    */
   public boolean getAtAsyncSuspension() {
     return json.get("atAsyncSuspension") == null ? false : json.get("atAsyncSuspension").getAsBoolean();
@@ -59,6 +63,8 @@ public class Event extends Response {
    *  - BreakpointAdded
    *  - BreakpointRemoved
    *  - BreakpointResolved
+   *
+   * Can return <code>null</code>.
    */
   public Breakpoint getBreakpoint() {
     return json.get("breakpoint") == null ? null : new Breakpoint((JsonObject) json.get("breakpoint"));
@@ -68,13 +74,17 @@ public class Event extends Response {
    * An array of bytes, encoded as a base64 string.
    *
    * This is provided for the WriteEvent event.
+   *
+   * Can return <code>null</code>.
    */
   public String getBytes() {
-    return json.get("bytes").getAsString();
+    return json.get("bytes") == null ? null : json.get("bytes").getAsString();
   }
 
   /**
    * The exception associated with this event, if this is a PauseException event.
+   *
+   * Can return <code>null</code>.
    */
   public InstanceRef getException() {
     return json.get("exception") == null ? null : new InstanceRef((JsonObject) json.get("exception"));
@@ -84,6 +94,8 @@ public class Event extends Response {
    * The extension event data.
    *
    * This is provided for the Extension event.
+   *
+   * Can return <code>null</code>.
    */
   public ExtensionData getExtensionData() {
     return json.get("extensionData") == null ? null : new ExtensionData((JsonObject) json.get("extensionData"));
@@ -93,24 +105,30 @@ public class Event extends Response {
    * The extension event kind.
    *
    * This is provided for the Extension event.
+   *
+   * Can return <code>null</code>.
    */
   public String getExtensionKind() {
-    return json.get("extensionKind").getAsString();
+    return json.get("extensionKind") == null ? null : json.get("extensionKind").getAsString();
   }
 
   /**
    * The RPC name of the extension that was added.
    *
    * This is provided for the ServiceExtensionAdded event.
+   *
+   * Can return <code>null</code>.
    */
   public String getExtensionRPC() {
-    return json.get("extensionRPC").getAsString();
+    return json.get("extensionRPC") == null ? null : json.get("extensionRPC").getAsString();
   }
 
   /**
    * The argument passed to dart:developer.inspect.
    *
    * This is provided for the Inspect event.
+   *
+   * Can return <code>null</code>.
    */
   public InstanceRef getInspectee() {
     return json.get("inspectee") == null ? null : new InstanceRef((JsonObject) json.get("inspectee"));
@@ -121,6 +139,8 @@ public class Event extends Response {
    *
    * This is provided for all event kinds except for:
    *  - VMUpdate
+   *
+   * Can return <code>null</code>.
    */
   public IsolateRef getIsolate() {
     return json.get("isolate") == null ? null : new IsolateRef((JsonObject) json.get("isolate"));
@@ -144,9 +164,11 @@ public class Event extends Response {
    * This is provided for the event kinds:
    *  - ServiceRegistered
    *  - ServiceUnregistered
+   *
+   * Can return <code>null</code>.
    */
   public String getMethod() {
-    return json.get("method").getAsString();
+    return json.get("method") == null ? null : json.get("method").getAsString();
   }
 
   /**
@@ -160,6 +182,8 @@ public class Event extends Response {
    *
    * This is provided for the event kinds:
    *  - PauseBreakpoint
+   *
+   * Can return <code>null</code>.
    */
   public ElementList<Breakpoint> getPauseBreakpoints() {
     if (json.get("pauseBreakpoints") == null) return null;
@@ -178,24 +202,30 @@ public class Event extends Response {
    * This is provided for the event kinds:
    *  - ServiceRegistered
    *  - ServiceUnregistered
+   *
+   * Can return <code>null</code>.
    */
   public String getService() {
-    return json.get("service").getAsString();
+    return json.get("service") == null ? null : json.get("service").getAsString();
   }
 
   /**
    * The status (success or failure) related to the event. This is provided for the event kinds:
    *  - IsolateReloaded
    *  - IsolateSpawn
+   *
+   * Can return <code>null</code>.
    */
   public String getStatus() {
-    return json.get("status").getAsString();
+    return json.get("status") == null ? null : json.get("status").getAsString();
   }
 
   /**
    * An array of TimelineEvents
    *
    * This is provided for the TimelineEvents event.
+   *
+   * Can return <code>null</code>.
    */
   public ElementList<TimelineEvent> getTimelineEvents() {
     if (json.get("timelineEvents") == null) return null;
@@ -230,6 +260,8 @@ public class Event extends Response {
    *
    * For the Resume event, the top frame is provided at all times except for the initial resume
    * event that is delivered when an isolate begins execution.
+   *
+   * Can return <code>null</code>.
    */
   public Frame getTopFrame() {
     return json.get("topFrame") == null ? null : new Frame((JsonObject) json.get("topFrame"));
@@ -240,6 +272,8 @@ public class Event extends Response {
    *
    * This is provided for the event kind:
    *  - VMUpdate
+   *
+   * Can return <code>null</code>.
    */
   public VMRef getVm() {
     return json.get("vm") == null ? null : new VMRef((JsonObject) json.get("vm"));

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/element/Field.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/element/Field.java
@@ -38,6 +38,8 @@ public class Field extends Obj {
 
   /**
    * The location of this field in the source code.
+   *
+   * Can return <code>null</code>.
    */
   public SourceLocation getLocation() {
     return json.get("location") == null ? null : new SourceLocation((JsonObject) json.get("location"));
@@ -59,6 +61,8 @@ public class Field extends Obj {
 
   /**
    * The value of this field, if the field is static.
+   *
+   * Can return <code>null</code>.
    */
   public InstanceRef getStaticValue() {
     return json.get("staticValue") == null ? null : new InstanceRef((JsonObject) json.get("staticValue"));

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/element/Flag.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/element/Flag.java
@@ -52,8 +52,10 @@ public class Flag extends Element {
    * The value of this flag as a string.
    *
    * If this property is absent, then the value of the flag was NULL.
+   *
+   * Can return <code>null</code>.
    */
   public String getValueAsString() {
-    return json.get("valueAsString").getAsString();
+    return json.get("valueAsString") == null ? null : json.get("valueAsString").getAsString();
   }
 }

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/element/Frame.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/element/Frame.java
@@ -26,10 +26,16 @@ public class Frame extends Response {
     super(json);
   }
 
+  /**
+   * Can return <code>null</code>.
+   */
   public CodeRef getCode() {
     return json.get("code") == null ? null : new CodeRef((JsonObject) json.get("code"));
   }
 
+  /**
+   * Can return <code>null</code>.
+   */
   public FuncRef getFunction() {
     return json.get("function") == null ? null : new FuncRef((JsonObject) json.get("function"));
   }
@@ -38,6 +44,9 @@ public class Frame extends Response {
     return json.get("index") == null ? -1 : json.get("index").getAsInt();
   }
 
+  /**
+   * Can return <code>null</code>.
+   */
   public FrameKind getKind() {
     if (json.get("kind") == null) return null;
     
@@ -49,10 +58,16 @@ public class Frame extends Response {
     }
   }
 
+  /**
+   * Can return <code>null</code>.
+   */
   public SourceLocation getLocation() {
     return json.get("location") == null ? null : new SourceLocation((JsonObject) json.get("location"));
   }
 
+  /**
+   * Can return <code>null</code>.
+   */
   public ElementList<BoundVariable> getVars() {
     if (json.get("vars") == null) return null;
     

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/element/Func.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/element/Func.java
@@ -29,6 +29,8 @@ public class Func extends Obj {
 
   /**
    * The compiled code associated with this function.
+   *
+   * Can return <code>null</code>.
    */
   public CodeRef getCode() {
     return json.get("code") == null ? null : new CodeRef((JsonObject) json.get("code"));
@@ -36,6 +38,8 @@ public class Func extends Obj {
 
   /**
    * The location of this function in the source code.
+   *
+   * Can return <code>null</code>.
    */
   public SourceLocation getLocation() {
     return json.get("location") == null ? null : new SourceLocation((JsonObject) json.get("location"));

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/element/Instance.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/element/Instance.java
@@ -34,6 +34,8 @@ public class Instance extends Obj {
    *
    * Provided for instance kinds:
    *  - Map
+   *
+   * Can return <code>null</code>.
    */
   public ElementList<MapAssociation> getAssociations() {
     if (json.get("associations") == null) return null;
@@ -54,6 +56,8 @@ public class Instance extends Obj {
    * Provided for instance kinds:
    *  - BoundedType
    *  - TypeParameter
+   *
+   * Can return <code>null</code>.
    */
   public InstanceRef getBound() {
     return json.get("bound") == null ? null : new InstanceRef((JsonObject) json.get("bound"));
@@ -79,9 +83,11 @@ public class Instance extends Obj {
    *  - Int32x4List
    *  - Float32x4List
    *  - Float64x2List
+   *
+   * Can return <code>null</code>.
    */
   public String getBytes() {
-    return json.get("bytes").getAsString();
+    return json.get("bytes") == null ? null : json.get("bytes").getAsString();
   }
 
   /**
@@ -96,6 +102,8 @@ public class Instance extends Obj {
    *
    * Provided for instance kinds:
    *  - Closure
+   *
+   * Can return <code>null</code>.
    */
   public ContextRef getClosureContext() {
     return json.get("closureContext") == null ? null : new ContextRef((JsonObject) json.get("closureContext"));
@@ -106,6 +114,8 @@ public class Instance extends Obj {
    *
    * Provided for instance kinds:
    *  - Closure
+   *
+   * Can return <code>null</code>.
    */
   public FuncRef getClosureFunction() {
     return json.get("closureFunction") == null ? null : new FuncRef((JsonObject) json.get("closureFunction"));
@@ -133,6 +143,8 @@ public class Instance extends Obj {
    *  - Int32x4List
    *  - Float32x4List
    *  - Float64x2List
+   *
+   * Can return <code>null</code>.
    */
   public int getCount() {
     return json.get("count") == null ? -1 : json.get("count").getAsInt();
@@ -145,6 +157,8 @@ public class Instance extends Obj {
    *  - List
    *
    * @return one of <code>ElementList<InstanceRef></code> or <code>ElementList<Sentinel></code>
+   *
+   * Can return <code>null</code>.
    */
   public ElementList<InstanceRef> getElements() {
     if (json.get("elements") == null) return null;
@@ -159,6 +173,8 @@ public class Instance extends Obj {
 
   /**
    * The fields of this Instance.
+   *
+   * Can return <code>null</code>.
    */
   public ElementList<BoundField> getFields() {
     if (json.get("fields") == null) return null;
@@ -176,6 +192,8 @@ public class Instance extends Obj {
    *
    * Provided for instance kinds:
    *  - RegExp
+   *
+   * Can return <code>null</code>.
    */
   public boolean getIsCaseSensitive() {
     return json.get("isCaseSensitive") == null ? false : json.get("isCaseSensitive").getAsBoolean();
@@ -186,6 +204,8 @@ public class Instance extends Obj {
    *
    * Provided for instance kinds:
    *  - RegExp
+   *
+   * Can return <code>null</code>.
    */
   public boolean getIsMultiLine() {
     return json.get("isMultiLine") == null ? false : json.get("isMultiLine").getAsBoolean();
@@ -225,6 +245,8 @@ public class Instance extends Obj {
    *  - Int32x4List
    *  - Float32x4List
    *  - Float64x2List
+   *
+   * Can return <code>null</code>.
    */
   public int getLength() {
     return json.get("length") == null ? -1 : json.get("length").getAsInt();
@@ -235,6 +257,8 @@ public class Instance extends Obj {
    *
    * Provided for instance kinds:
    *  - MirrorReference
+   *
+   * Can return <code>null</code>.
    */
   public InstanceRef getMirrorReferent() {
     return json.get("mirrorReferent") == null ? null : new InstanceRef((JsonObject) json.get("mirrorReferent"));
@@ -245,9 +269,11 @@ public class Instance extends Obj {
    *
    * Provided for instance kinds:
    *  - Type
+   *
+   * Can return <code>null</code>.
    */
   public String getName() {
-    return json.get("name").getAsString();
+    return json.get("name") == null ? null : json.get("name").getAsString();
   }
 
   /**
@@ -272,6 +298,8 @@ public class Instance extends Obj {
    *  - Int32x4List
    *  - Float32x4List
    *  - Float64x2List
+   *
+   * Can return <code>null</code>.
    */
   public int getOffset() {
     return json.get("offset") == null ? -1 : json.get("offset").getAsInt();
@@ -282,6 +310,8 @@ public class Instance extends Obj {
    *
    * Provided for instance kinds:
    *  - TypeParameter
+   *
+   * Can return <code>null</code>.
    */
   public int getParameterIndex() {
     return json.get("parameterIndex") == null ? -1 : json.get("parameterIndex").getAsInt();
@@ -292,6 +322,8 @@ public class Instance extends Obj {
    *
    * Provided for instance kinds:
    *  - TypeParameter
+   *
+   * Can return <code>null</code>.
    */
   public ClassRef getParameterizedClass() {
     return json.get("parameterizedClass") == null ? null : new ClassRef((JsonObject) json.get("parameterizedClass"));
@@ -302,9 +334,11 @@ public class Instance extends Obj {
    *
    * Provided for instance kinds:
    *  - RegExp
+   *
+   * Can return <code>null</code>.
    */
   public String getPattern() {
-    return json.get("pattern").getAsString();
+    return json.get("pattern") == null ? null : json.get("pattern").getAsString();
   }
 
   /**
@@ -312,6 +346,8 @@ public class Instance extends Obj {
    *
    * Provided for instance kinds:
    *  - WeakProperty
+   *
+   * Can return <code>null</code>.
    */
   public InstanceRef getPropertyKey() {
     return json.get("propertyKey") == null ? null : new InstanceRef((JsonObject) json.get("propertyKey"));
@@ -322,6 +358,8 @@ public class Instance extends Obj {
    *
    * Provided for instance kinds:
    *  - WeakProperty
+   *
+   * Can return <code>null</code>.
    */
   public InstanceRef getPropertyValue() {
     return json.get("propertyValue") == null ? null : new InstanceRef((JsonObject) json.get("propertyValue"));
@@ -335,6 +373,8 @@ public class Instance extends Obj {
    * Provided for instance kinds:
    *  - BoundedType
    *  - TypeRef
+   *
+   * Can return <code>null</code>.
    */
   public InstanceRef getTargetType() {
     return json.get("targetType") == null ? null : new InstanceRef((JsonObject) json.get("targetType"));
@@ -345,6 +385,8 @@ public class Instance extends Obj {
    *
    * Provided for instance kinds:
    *  - Type
+   *
+   * Can return <code>null</code>.
    */
   public TypeArgumentsRef getTypeArguments() {
     return json.get("typeArguments") == null ? null : new TypeArgumentsRef((JsonObject) json.get("typeArguments"));
@@ -355,6 +397,8 @@ public class Instance extends Obj {
    *
    * Provided for instance kinds:
    *  - Type
+   *
+   * Can return <code>null</code>.
    */
   public ClassRef getTypeClass() {
     return json.get("typeClass") == null ? null : new ClassRef((JsonObject) json.get("typeClass"));
@@ -368,9 +412,11 @@ public class Instance extends Obj {
    *  - Double (suitable for passing to Double.parse())
    *  - Int (suitable for passing to int.parse())
    *  - String (value may be truncated)
+   *
+   * Can return <code>null</code>.
    */
   public String getValueAsString() {
-    return json.get("valueAsString").getAsString();
+    return json.get("valueAsString") == null ? null : json.get("valueAsString").getAsString();
   }
 
   /**
@@ -378,6 +424,8 @@ public class Instance extends Obj {
    * the value 'true'.
    *
    * New code should use 'length' and 'count' instead.
+   *
+   * Can return <code>null</code>.
    */
   public boolean getValueAsStringIsTruncated() {
     JsonElement elem = json.get("valueAsStringIsTruncated");

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/element/InstanceRef.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/element/InstanceRef.java
@@ -69,6 +69,8 @@ public class InstanceRef extends ObjRef {
    *  - Int32x4List
    *  - Float32x4List
    *  - Float64x2List
+   *
+   * Can return <code>null</code>.
    */
   public int getLength() {
     return json.get("length") == null ? -1 : json.get("length").getAsInt();
@@ -79,9 +81,11 @@ public class InstanceRef extends ObjRef {
    *
    * Provided for instance kinds:
    *  - Type
+   *
+   * Can return <code>null</code>.
    */
   public String getName() {
-    return json.get("name").getAsString();
+    return json.get("name") == null ? null : json.get("name").getAsString();
   }
 
   /**
@@ -89,6 +93,8 @@ public class InstanceRef extends ObjRef {
    *
    * Provided for instance kinds:
    *  - TypeParameter
+   *
+   * Can return <code>null</code>.
    */
   public ClassRef getParameterizedClass() {
     return json.get("parameterizedClass") == null ? null : new ClassRef((JsonObject) json.get("parameterizedClass"));
@@ -101,6 +107,8 @@ public class InstanceRef extends ObjRef {
    *
    * Provided for instance kinds:
    *  - RegExp
+   *
+   * Can return <code>null</code>.
    */
   public InstanceRef getPattern() {
     return json.get("pattern") == null ? null : new InstanceRef((JsonObject) json.get("pattern"));
@@ -111,6 +119,8 @@ public class InstanceRef extends ObjRef {
    *
    * Provided for instance kinds:
    *  - Type
+   *
+   * Can return <code>null</code>.
    */
   public ClassRef getTypeClass() {
     return json.get("typeClass") == null ? null : new ClassRef((JsonObject) json.get("typeClass"));
@@ -129,9 +139,11 @@ public class InstanceRef extends ObjRef {
    *  - Float64x2
    *  - Int32x4
    *  - StackTrace
+   *
+   * Can return <code>null</code>.
    */
   public String getValueAsString() {
-    return json.get("valueAsString").getAsString();
+    return json.get("valueAsString") == null ? null : json.get("valueAsString").getAsString();
   }
 
   /**
@@ -139,6 +151,8 @@ public class InstanceRef extends ObjRef {
    * the value 'true'.
    *
    * New code should use 'length' and 'count' instead.
+   *
+   * Can return <code>null</code>.
    */
   public boolean getValueAsStringIsTruncated() {
     JsonElement elem = json.get("valueAsStringIsTruncated");

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/element/Isolate.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/element/Isolate.java
@@ -44,6 +44,8 @@ public class Isolate extends Response {
 
   /**
    * The error that is causing this isolate to exit, if applicable.
+   *
+   * Can return <code>null</code>.
    */
   public ErrorObj getError() {
     return json.get("error") == null ? null : new ErrorObj((JsonObject) json.get("error"));
@@ -63,9 +65,11 @@ public class Isolate extends Response {
 
   /**
    * The list of service extension RPCs that are registered for this isolate, if any.
+   *
+   * Can return <code>null</code>.
    */
   public List<String> getExtensionRPCs() {
-    return getListString("extensionRPCs");
+    return json.get("extensionRPCs") == null ? null : getListString("extensionRPCs");
   }
 
   /**
@@ -129,6 +133,8 @@ public class Isolate extends Response {
    * The root library for this isolate.
    *
    * Guaranteed to be initialized when the IsolateRunnable event fires.
+   *
+   * Can return <code>null</code>.
    */
   public LibraryRef getRootLib() {
     return json.get("rootLib") == null ? null : new LibraryRef((JsonObject) json.get("rootLib"));

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/element/Message.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/element/Message.java
@@ -30,6 +30,8 @@ public class Message extends Response {
 
   /**
    * A reference to the function that will be invoked to handle this message.
+   *
+   * Can return <code>null</code>.
    */
   public FuncRef getHandler() {
     return json.get("handler") == null ? null : new FuncRef((JsonObject) json.get("handler"));
@@ -45,6 +47,8 @@ public class Message extends Response {
 
   /**
    * The source location of handler.
+   *
+   * Can return <code>null</code>.
    */
   public SourceLocation getLocation() {
     return json.get("location") == null ? null : new SourceLocation((JsonObject) json.get("location"));

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/element/Obj.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/element/Obj.java
@@ -34,6 +34,8 @@ public class Obj extends Response {
    *
    * Moving an Object into or out of the heap is considered a backwards compatible change for types
    * other than Instance.
+   *
+   * Can return <code>null</code>.
    */
   public ClassRef getClassRef() {
     return json.get("class") == null ? null : new ClassRef((JsonObject) json.get("class"));
@@ -55,6 +57,8 @@ public class Obj extends Response {
    *
    * Note that the size can be zero for some objects. In the current VM implementation, this occurs
    * for small integers, which are stored entirely within their object pointers.
+   *
+   * Can return <code>null</code>.
    */
   public int getSize() {
     return json.get("size") == null ? -1 : json.get("size").getAsInt();

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/element/Script.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/element/Script.java
@@ -36,11 +36,12 @@ public class Script extends Obj {
   }
 
   /**
-   * The source code for this script. For certain built-in scripts, this may be reconstructed
-   * without source comments.
+   * The source code for this script. This can be null for certain built-in scripts.
+   *
+   * Can return <code>null</code>.
    */
   public String getSource() {
-    return json.get("source").getAsString();
+    return json.get("source") == null ? null : json.get("source").getAsString();
   }
 
   /**

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/element/SourceLocation.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/element/SourceLocation.java
@@ -29,6 +29,8 @@ public class SourceLocation extends Response {
 
   /**
    * The last token of the location if this is a range.
+   *
+   * Can return <code>null</code>.
    */
   public int getEndTokenPos() {
     return json.get("endTokenPos") == null ? -1 : json.get("endTokenPos").getAsInt();

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/element/SourceReportRange.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/element/SourceReportRange.java
@@ -39,6 +39,8 @@ public class SourceReportRange extends Element {
   /**
    * Code coverage information for this range.  Provided only when the Coverage report has been
    * requested and the range has been compiled.
+   *
+   * Can return <code>null</code>.
    */
   public SourceReportCoverage getCoverage() {
     return json.get("coverage") == null ? null : new SourceReportCoverage((JsonObject) json.get("coverage"));
@@ -54,6 +56,8 @@ public class SourceReportRange extends Element {
   /**
    * The error while attempting to compile this range, if this report was generated with
    * forceCompile=true.
+   *
+   * Can return <code>null</code>.
    */
   public ErrorRef getError() {
     return json.get("error") == null ? null : new ErrorRef((JsonObject) json.get("error"));
@@ -63,6 +67,8 @@ public class SourceReportRange extends Element {
    * Possible breakpoint information for this range, represented as a sorted list of token
    * positions.  Provided only when the when the PossibleBreakpoint report has been requested and
    * the range has been compiled.
+   *
+   * Can return <code>null</code>.
    */
   public List<Integer> getPossibleBreakpoints() {
     return getListInt("possibleBreakpoints");

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/element/Stack.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/element/Stack.java
@@ -25,6 +25,9 @@ public class Stack extends Response {
     super(json);
   }
 
+  /**
+   * Can return <code>null</code>.
+   */
   public ElementList<Frame> getAsyncCausalFrames() {
     if (json.get("asyncCausalFrames") == null) return null;
     
@@ -36,6 +39,9 @@ public class Stack extends Response {
     };
   }
 
+  /**
+   * Can return <code>null</code>.
+   */
   public ElementList<Frame> getAwaiterFrames() {
     if (json.get("awaiterFrames") == null) return null;
     

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/element/UnresolvedSourceLocation.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/element/UnresolvedSourceLocation.java
@@ -32,6 +32,8 @@ public class UnresolvedSourceLocation extends Response {
   /**
    * An approximate column number for the source location. This may change when the location is
    * resolved.
+   *
+   * Can return <code>null</code>.
    */
   public int getColumn() {
     return json.get("column") == null ? -1 : json.get("column").getAsInt();
@@ -40,6 +42,8 @@ public class UnresolvedSourceLocation extends Response {
   /**
    * An approximate line number for the source location. This may change when the location is
    * resolved.
+   *
+   * Can return <code>null</code>.
    */
   public int getLine() {
     return json.get("line") == null ? -1 : json.get("line").getAsInt();
@@ -47,6 +51,8 @@ public class UnresolvedSourceLocation extends Response {
 
   /**
    * The script containing the source location if the script has been loaded.
+   *
+   * Can return <code>null</code>.
    */
   public ScriptRef getScript() {
     return json.get("script") == null ? null : new ScriptRef((JsonObject) json.get("script"));
@@ -54,14 +60,18 @@ public class UnresolvedSourceLocation extends Response {
 
   /**
    * The uri of the script containing the source location if the script has yet to be loaded.
+   *
+   * Can return <code>null</code>.
    */
   public String getScriptUri() {
-    return json.get("scriptUri").getAsString();
+    return json.get("scriptUri") == null ? null : json.get("scriptUri").getAsString();
   }
 
   /**
    * An approximate token position for the source location. This may change when the location is
    * resolved.
+   *
+   * Can return <code>null</code>.
    */
   public int getTokenPos() {
     return json.get("tokenPos") == null ? -1 : json.get("tokenPos").getAsInt();


### PR DESCRIPTION
- commit the latest version of the service protocol library (this version returns nulls for some fields, and documents which ones)
- update to some signature changes from the new library version
- be tolerant of nulls from Isolate.extensionRPCs
(fix https://github.com/dart-lang/vm_service_drivers/issues/185)
- handle cases where `Script.source` is null (this is new behavior in the VM, and happens for some `dart:` sources); fix https://github.com/flutter/flutter-intellij/issues/2617

The bulk of these changes are from the auto-generated protocol library.

@jacob314 @stevemessick 