### PR TITLE
drop support for 2017.3 (and AS 3.1)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ script: ./tool/travis.sh
 # Testing product matrix; the values are generated from product-matrix.json.
 env:
   - DART_BOT=true
-  - IDEA_VERSION=2017.3
   - IDEA_VERSION=2018.1
   - IDEA_VERSION=2018.2.1
   - IDEA_VERSION=2018.2.4

--- a/product-matrix.json
+++ b/product-matrix.json
@@ -1,20 +1,7 @@
 {
   "list": [
     {
-      "comments": "AS 3.1 and IntelliJ 2017.3",
-      "name": "IntelliJ",
-      "version": "2017.3",
-      "ideaProduct": "android-studio",
-      "ideaVersion": "173.4720617",
-      "dartPluginVersion": "173.4700",
-      "sinceBuild": "173.0",
-      "untilBuild": "173.*",
-      "filesToSkip": [
-        "flutter-studio/src/io/flutter/profiler"
-      ]
-    },
-    {
-      "comments": "AS 3.2 Beta and IntelliJ 2018.1",
+      "comments": "AS 3.2 and IntelliJ 2018.1",
       "name": "IntelliJ",
       "version": "2018.1",
       "ideaProduct": "android-studio",

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -11,7 +11,7 @@
 
   <category>Custom Languages</category>
   
-  <idea-version since-build="173.0" until-build="183.*"/>
+  <idea-version since-build="181.0" until-build="183.*"/>
 
   <depends>Dart</depends>
 

--- a/tool/plugin/test/plugin_test.dart
+++ b/tool/plugin/test/plugin_test.dart
@@ -33,9 +33,8 @@ void main() {
         var specs = (runner.commands['build'] as ProductCommand).specs;
         expect(specs, isNotNull);
         expect(
-            specs.map((spec) => spec.ideaProduct),
+            specs.map((spec) => spec.ideaProduct).toList(),
             orderedEquals([
-              'android-studio',
               'android-studio',
               'android-studio',
               'ideaIU',
@@ -50,9 +49,8 @@ void main() {
         var specs = (runner.commands['test'] as ProductCommand).specs;
         expect(specs, isNotNull);
         expect(
-            specs.map((spec) => spec.ideaProduct),
+            specs.map((spec) => spec.ideaProduct).toList(),
             orderedEquals([
-              'android-studio',
               'android-studio',
               'android-studio',
               'ideaIU',
@@ -67,9 +65,8 @@ void main() {
         var specs = (runner.commands['deploy'] as ProductCommand).specs;
         expect(specs, isNotNull);
         expect(
-            specs.map((spec) => spec.ideaProduct),
+            specs.map((spec) => spec.ideaProduct).toList(),
             orderedEquals([
-              'android-studio',
               'android-studio',
               'android-studio',
               'ideaIU',
@@ -150,7 +147,6 @@ void main() {
       expect(
           cmd.paths.map((p) => p.substring(p.indexOf('releases'))),
           orderedEquals([
-            'releases/release_19/2017.3/flutter-intellij.zip',
             'releases/release_19/2018.1/flutter-intellij.zip',
             'releases/release_19/2018.2.1/flutter-intellij.zip',
             'releases/release_19/2018.2.4/flutter-intellij.zip',


### PR DESCRIPTION
- drop support for 2017.3 (and AS 3.1)

I believe it's ok to drop support for these two platforms now.

@jwren @stevemessick @DaveShuckerow 