### PR TITLE
Use read context to init debugger

### DIFF
--- a/src/io/flutter/server/vmService/VmServiceWrapper.java
+++ b/src/io/flutter/server/vmService/VmServiceWrapper.java
@@ -242,8 +242,10 @@ public class VmServiceWrapper implements Disposable {
     // Just to make sure that the main isolate is not handled twice, both from handleDebuggerConnected() and DartVmServiceListener.received(PauseStart)
     if (newIsolate) {
       XDebugSessionImpl session = (XDebugSessionImpl)myDebugProcess.getSession();
-      session.reset();
-      session.initBreakpoints();
+      ApplicationManager.getApplication().runReadAction(() -> {
+        session.reset();
+        session.initBreakpoints();
+      });
       addRequest(() -> myVmService.setExceptionPauseMode(isolateRef.getId(),
                                                          myDebugProcess.getBreakOnExceptionMode(),
                                                          new VmServiceConsumers.SuccessConsumerWrapper() {


### PR DESCRIPTION
@pq @devoncarew 

Fixes #2693 

As the comment at the top of this code block says, there are two paths to this code. One of them already has a read context. The other didn't.