### PR TITLE
remove older uses of reflection

### DIFF
--- a/src/io/flutter/server/vmService/VmServiceConsumers.java
+++ b/src/io/flutter/server/vmService/VmServiceConsumers.java
@@ -58,4 +58,23 @@ public class VmServiceConsumers {
 
     abstract public void noGoodResult();
   }
+
+  public static abstract class InvokeConsumerWrapper implements InvokeConsumer {
+    @Override
+    public final void received(ErrorRef response) {
+      noGoodResult();
+    }
+
+    @Override
+    public final void received(Sentinel response) {
+      noGoodResult();
+    }
+
+    @Override
+    public final void onError(RPCError error) {
+      noGoodResult();
+    }
+
+    abstract public void noGoodResult();
+  }
 }

--- a/src/io/flutter/server/vmService/VmServiceWrapper.java
+++ b/src/io/flutter/server/vmService/VmServiceWrapper.java
@@ -21,42 +21,17 @@ import io.flutter.server.vmService.frame.DartAsyncMarkerFrame;
 import io.flutter.server.vmService.frame.DartVmServiceEvaluator;
 import io.flutter.server.vmService.frame.DartVmServiceStackFrame;
 import io.flutter.server.vmService.frame.DartVmServiceValue;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.atomic.AtomicInteger;
 import org.dartlang.vm.service.VmService;
-import org.dartlang.vm.service.consumer.EvaluateConsumer;
-import org.dartlang.vm.service.consumer.EvaluateInFrameConsumer;
-import org.dartlang.vm.service.consumer.GetIsolateConsumer;
-import org.dartlang.vm.service.consumer.GetObjectConsumer;
-import org.dartlang.vm.service.consumer.StackConsumer;
-import org.dartlang.vm.service.consumer.SuccessConsumer;
-import org.dartlang.vm.service.consumer.VMConsumer;
-import org.dartlang.vm.service.element.Breakpoint;
-import org.dartlang.vm.service.element.ElementList;
-import org.dartlang.vm.service.element.ErrorRef;
-import org.dartlang.vm.service.element.Event;
-import org.dartlang.vm.service.element.EventKind;
-import org.dartlang.vm.service.element.ExceptionPauseMode;
-import org.dartlang.vm.service.element.Frame;
-import org.dartlang.vm.service.element.FrameKind;
-import org.dartlang.vm.service.element.InstanceRef;
-import org.dartlang.vm.service.element.Isolate;
-import org.dartlang.vm.service.element.IsolateRef;
-import org.dartlang.vm.service.element.Obj;
-import org.dartlang.vm.service.element.RPCError;
-import org.dartlang.vm.service.element.Script;
-import org.dartlang.vm.service.element.Sentinel;
+import org.dartlang.vm.service.consumer.*;
+import org.dartlang.vm.service.element.*;
 import org.dartlang.vm.service.element.Stack;
-import org.dartlang.vm.service.element.StepOption;
-import org.dartlang.vm.service.element.Success;
-import org.dartlang.vm.service.element.VM;
 import org.dartlang.vm.service.logging.Logging;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class VmServiceWrapper implements Disposable {
 
@@ -437,7 +412,7 @@ public class VmServiceWrapper implements Disposable {
         @Override
         public void onError(RPCError error) {
           myDebugProcess.getSession().getConsoleView()
-                        .print("Error from drop frame: " + error.getMessage() + "\n", ConsoleViewContentType.ERROR_OUTPUT);
+            .print("Error from drop frame: " + error.getMessage() + "\n", ConsoleViewContentType.ERROR_OUTPUT);
         }
 
         @Override
@@ -602,5 +577,11 @@ public class VmServiceWrapper implements Disposable {
         callback.errorOccurred(error.getMessage());
       }
     });
+  }
+
+  public void callToString(@NotNull final String isolateId,
+                           @NotNull final String targetId,
+                           @NotNull final InvokeConsumer callback) {
+    addRequest(() -> myVmService.invoke(isolateId, targetId, "toString", Collections.emptyList(), callback));
   }
 }

--- a/src/io/flutter/server/vmService/frame/DartVmServiceValue.java
+++ b/src/io/flutter/server/vmService/frame/DartVmServiceValue.java
@@ -285,30 +285,29 @@ public class DartVmServiceValue extends XNamedValue {
   }
 
   private void computeDefaultPresentation(@NotNull final XValueNode node) {
-    myDebugProcess.getVmServiceWrapper()
-      .evaluateInTargetContext(myIsolateId, myInstanceRef.getId(), "toString()", new VmServiceConsumers.EvaluateConsumerWrapper() {
-        @Override
-        public void received(final InstanceRef toStringInstanceRef) {
-          if (toStringInstanceRef.getKind() == InstanceKind.String) {
-            final String string = toStringInstanceRef.getValueAsString();
-            // default toString() implementation returns "Instance of 'ClassName'" - no interest to show
-            if (string.equals("Instance of '" + myInstanceRef.getClassRef().getName() + "'")) {
-              noGoodResult();
-            }
-            else {
-              node.setPresentation(getIcon(), myInstanceRef.getClassRef().getName(), string, true);
-            }
+    myDebugProcess.getVmServiceWrapper().callToString(myIsolateId, myInstanceRef.getId(), new VmServiceConsumers.InvokeConsumerWrapper() {
+      @Override
+      public void received(final InstanceRef toStringInstanceRef) {
+        if (toStringInstanceRef.getKind() == InstanceKind.String) {
+          final String string = toStringInstanceRef.getValueAsString();
+          // default toString() implementation returns "Instance of 'ClassName'" - no interest to show
+          if (string.equals("Instance of '" + myInstanceRef.getClassRef().getName() + "'")) {
+            noGoodResult();
           }
           else {
-            noGoodResult(); // unlikely possible
+            node.setPresentation(getIcon(), myInstanceRef.getClassRef().getName(), string, true);
           }
         }
-
-        @Override
-        public void noGoodResult() {
-          node.setPresentation(getIcon(), myInstanceRef.getClassRef().getName(), "", true);
+        else {
+          noGoodResult(); // unlikely possible
         }
-      });
+      }
+
+      @Override
+      public void noGoodResult() {
+        node.setPresentation(getIcon(), myInstanceRef.getClassRef().getName(), "", true);
+      }
+    });
   }
 
   @Override


### PR DESCRIPTION
- remove an older (and not needed, since consolidating the debugging library into the Flutter plugin) use of reflection for vmService.evaluate()
- switch from calling `evaluate` to get the toString() value of objects when debugging to `invoke`

@jacob314 