### PR TITLE
Add a BoolServiceExtensionCheckbox class to support toggleable checkboxes.

### DIFF
--- a/src/io/flutter/server/vmService/VMServiceManager.java
+++ b/src/io/flutter/server/vmService/VMServiceManager.java
@@ -30,6 +30,14 @@ public class VMServiceManager implements FlutterApp.FlutterAppListener {
   @NotNull private final FlutterFramesMonitor flutterFramesMonitor;
   @NotNull private final Map<String, EventStream<Boolean>> serviceExtensions = new THashMap<>();
 
+  // TODO(jacobr): on attach to a running Flutter isolate query the VM for the
+  // current state of each of the boolean service extensions we care about.
+  /**
+   * Boolean value applicable only for boolean service extensions indicating
+   * whether the service extension is enabled or disabled.
+   */
+  @NotNull private final Map<String, EventStream<Boolean>> serviceExtensionsState = new THashMap<>();
+
   private final EventStream<IsolateRef> flutterIsolateRefStream;
 
   private boolean isRunning;
@@ -271,15 +279,26 @@ public class VMServiceManager implements FlutterApp.FlutterAppListener {
 
   public @NotNull
   StreamSubscription<Boolean> hasServiceExtension(String name, Consumer<Boolean> onData) {
+    EventStream<Boolean> stream = getStream(name, serviceExtensions);
+    return stream.listen(onData, true);
+  }
+
+  public @NotNull
+  EventStream<Boolean> getServiceExtensionState(String name) {
+    return getStream(name, serviceExtensionsState);
+  }
+
+  @NotNull
+  private EventStream<Boolean> getStream(String name, Map<String, EventStream<Boolean>> streamMap) {
     EventStream<Boolean> stream;
-    synchronized (serviceExtensions) {
-      stream = serviceExtensions.get(name);
+    synchronized (streamMap) {
+      stream = streamMap.get(name);
       if (stream == null) {
         stream = new EventStream<>(false);
-        serviceExtensions.put(name, stream);
+        streamMap.put(name, stream);
       }
     }
-    return stream.listen(onData, true);
+    return stream;
   }
 
   /**

--- a/src/io/flutter/view/BoolServiceExtensionCheckbox.java
+++ b/src/io/flutter/view/BoolServiceExtensionCheckbox.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.view;
+
+import com.intellij.openapi.Disposable;
+import io.flutter.run.daemon.FlutterApp;
+import io.flutter.utils.EventStream;
+import io.flutter.utils.StreamSubscription;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+
+/**
+ * This class performs the same role as FlutterViewToggleableAction but
+ * renders the UI as a simple JCheckbox instead of as a DumbAwareAction
+ * enabling embedding UI to turn on and off the service extension
+ * in a JPanel.
+ */
+public class BoolServiceExtensionCheckbox implements Disposable {
+
+  private final EventStream<Boolean> currentValue;
+  private final JCheckBox checkbox;
+  private StreamSubscription<Boolean> currentValueSubscription;
+
+  BoolServiceExtensionCheckbox(FlutterApp app, @NotNull String extensionCommand, String label, String tooltip) {
+    checkbox = new JCheckBox(label);
+    checkbox.setHorizontalAlignment(JLabel.LEFT);
+    checkbox.setToolTipText(tooltip);
+    assert(app.getVMServiceManager() != null);
+    currentValue = app.getVMServiceManager().getServiceExtensionState(extensionCommand);
+    app.hasServiceExtension(extensionCommand, checkbox::setEnabled, this);
+
+    checkbox.addChangeListener((l) -> {
+      final boolean newValue = checkbox.isSelected();
+      currentValue.setValue(newValue);
+      if (app.isSessionActive()) {
+        app.callBooleanExtension(extensionCommand, newValue);
+      }
+    });
+
+    currentValueSubscription = currentValue.listen(checkbox::setSelected, true);
+  }
+
+  JCheckBox getComponent() {
+    return checkbox;
+  }
+
+  @Override
+  public void dispose() {
+    if (currentValueSubscription != null) {
+      currentValueSubscription.dispose();;
+      currentValueSubscription = null;
+    }
+  }
+}

--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -592,15 +592,17 @@ class DebugDrawAction extends FlutterViewToggleableAction {
 }
 
 class PerformanceOverlayAction extends FlutterViewToggleableAction {
+
+  public static final String SHOW_PERFORMANCE_OVERLAY = "ext.flutter.showPerformanceOverlay";
+
   PerformanceOverlayAction(@NotNull FlutterApp app) {
     super(app, "Toggle Performance Overlay", "Toggle Performance Overlay", AllIcons.Modules.Library);
-
     setExtensionCommand("ext.flutter.showPerformanceOverlay");
   }
 
   protected void perform(@Nullable AnActionEvent event) {
     if (app.isSessionActive()) {
-      app.callBooleanExtension("ext.flutter.showPerformanceOverlay", isSelected());
+      app.callBooleanExtension(SHOW_PERFORMANCE_OVERLAY, isSelected());
     }
   }
 
@@ -707,15 +709,18 @@ class TogglePlatformAction extends FlutterViewAction {
 }
 
 class RepaintRainbowAction extends FlutterViewToggleableAction {
-  RepaintRainbowAction(@NotNull FlutterApp app) {
-    super(app, "Enable Repaint Rainbow");
 
-    setExtensionCommand("ext.flutter.repaintRainbow");
+  public static final String SHOW_REPAINT_RAINBOW = "ext.flutter.repaintRainbow";
+
+  RepaintRainbowAction(@NotNull FlutterApp app) {
+    super(app, "Show Repaint Rainbow");
+
+    setExtensionCommand(SHOW_REPAINT_RAINBOW);
   }
 
   protected void perform(@Nullable AnActionEvent event) {
     if (app.isSessionActive()) {
-      app.callBooleanExtension("ext.flutter.repaintRainbow", isSelected());
+      app.callBooleanExtension(SHOW_REPAINT_RAINBOW, isSelected());
     }
   }
 

--- a/src/io/flutter/view/FlutterViewToggleableAction.java
+++ b/src/io/flutter/view/FlutterViewToggleableAction.java
@@ -11,6 +11,7 @@ import com.intellij.openapi.actionSystem.Presentation;
 import com.intellij.openapi.actionSystem.Toggleable;
 import com.intellij.openapi.application.ApplicationManager;
 import io.flutter.run.daemon.FlutterApp;
+import io.flutter.utils.EventStream;
 import io.flutter.utils.StreamSubscription;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -18,9 +19,10 @@ import org.jetbrains.annotations.Nullable;
 import javax.swing.*;
 
 abstract class FlutterViewToggleableAction extends FlutterViewAction implements Toggleable, Disposable {
-  private boolean selected = false;
   private String extensionCommand;
-  private StreamSubscription<Boolean> subscription;
+  private StreamSubscription<Boolean> serviceExtensionSubscription;
+  private EventStream<Boolean> currentValue;
+  private StreamSubscription<Boolean> currentValueSubscription;
 
   FlutterViewToggleableAction(@NotNull FlutterApp app, @Nullable String text) {
     super(app, text);
@@ -42,16 +44,23 @@ abstract class FlutterViewToggleableAction extends FlutterViewAction implements 
     presentation.putClientProperty("selected", selected);
 
     if (!app.isSessionActive()) {
-      if (subscription != null) {
-        subscription.dispose();
-        subscription = null;
-      }
+      disposeSubscriptions();
       e.getPresentation().setEnabled(false);
       return;
     }
 
-    if (subscription == null) {
-      subscription = app.hasServiceExtension(extensionCommand, (enabled) -> {
+    if (currentValueSubscription == null) {
+      assert(currentValue == null);
+      currentValue = app.getVMServiceManager().getServiceExtensionState(extensionCommand);
+      currentValueSubscription = currentValue.listen((isSelected) -> {
+        if (presentation.getClientProperty("selected") != isSelected) {
+          presentation.putClientProperty("selected", isSelected);
+        }
+      }, true);
+    }
+
+    if (serviceExtensionSubscription == null) {
+      serviceExtensionSubscription = app.hasServiceExtension(extensionCommand, (enabled) -> {
         e.getPresentation().setEnabled(app.isSessionActive() && enabled);
       });
     }
@@ -59,30 +68,38 @@ abstract class FlutterViewToggleableAction extends FlutterViewAction implements 
 
   @Override
   public void dispose() {
-    if (subscription != null) {
-      subscription.dispose();
-      subscription = null;
+    disposeSubscriptions();
+  }
+
+  void disposeSubscriptions() {
+    if (serviceExtensionSubscription != null) {
+      serviceExtensionSubscription.dispose();
+      serviceExtensionSubscription = null;
+    }
+    if (currentValueSubscription != null) {
+      currentValueSubscription.dispose();;
+      currentValueSubscription = null;
+      currentValue = null;
     }
   }
 
   @Override
   public void actionPerformed(AnActionEvent event) {
     this.setSelected(event, !isSelected());
-    final Presentation presentation = event.getPresentation();
-    presentation.putClientProperty("selected", isSelected());
-
     super.actionPerformed(event);
   }
 
   public boolean isSelected() {
-    return selected;
+    return currentValue != null ? currentValue.getValue() : false;
   }
 
   public void setSelected(@Nullable AnActionEvent event, boolean selected) {
-    this.selected = selected;
+    if (currentValue != null) {
+      currentValue.setValue(selected);
 
-    if (event != null) {
-      ApplicationManager.getApplication().invokeLater(() -> this.update(event));
+      if (event != null) {
+        ApplicationManager.getApplication().invokeLater(() -> this.update(event));
+      }
     }
   }
 }


### PR DESCRIPTION
The checkboxes behave like and share common underlying state with FlutterViewToggleableAction.
If there was a general adapter to display an Action like a checkbox I'd use that but this code is simple enough that the duplication probably isn't a big deal.

This class supports adding checkboxes for a few common actions inline in the Flutter perf panel.
Values are synced with the actions so if you change one value, the other shows up immediately with the new value in the UI.
<img width="449" alt="screen shot 2018-10-29 at 2 36 29 pm" src="https://user-images.githubusercontent.com/1226812/47682307-391cee80-db89-11e8-953d-68ed49696341.png">
