### PR TITLE
Build 3.3beta for M30 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,5 @@ script: ./tool/travis.sh
 env:
   - DART_BOT=true
   - IDEA_VERSION=2018.1
-  - IDEA_VERSION=2018.2.1
   - IDEA_VERSION=2018.2.4
   - IDEA_VERSION=2018.3

--- a/flutter-studio/src/io/flutter/android/AndroidModuleLibraryManager.java
+++ b/flutter-studio/src/io/flutter/android/AndroidModuleLibraryManager.java
@@ -12,15 +12,11 @@ import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.diagnostic.Logger;
-import com.intellij.openapi.module.Module;
-import com.intellij.openapi.module.ModuleManager;
 import com.intellij.openapi.project.DumbService;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.impl.ProjectImpl;
-import com.intellij.openapi.projectRoots.Sdk;
 import com.intellij.openapi.roots.ModuleRootEvent;
 import com.intellij.openapi.roots.ModuleRootListener;
-import com.intellij.openapi.roots.ModuleRootManager;
 import com.intellij.openapi.roots.OrderRootType;
 import com.intellij.openapi.roots.libraries.Library;
 import com.intellij.openapi.roots.libraries.LibraryTable;
@@ -31,7 +27,6 @@ import com.intellij.openapi.vfs.*;
 import com.intellij.util.containers.hash.HashSet;
 import io.flutter.sdk.AbstractLibraryManager;
 import io.flutter.sdk.FlutterSdkUtil;
-import org.jetbrains.android.sdk.AndroidSdkUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -63,28 +58,13 @@ public class AndroidModuleLibraryManager extends AbstractLibraryManager<AndroidM
   }
 
   private Void updateAndroidLibraryContent(@NotNull Project androidProject) {
-    ModuleManager mgr = ModuleManager.getInstance(androidProject);
-    Module module = null;
-    for (Module mod : mgr.getModules()) {
-      if (mod.getName().equals("android") || mod.getName().equals(".android")) {
-        module = mod;
-        break;
-      }
-    }
-    HashSet<String> urls = new HashSet<>();
-    if (module != null) {
-      AndroidSdkUtils.setupAndroidPlatformIfNecessary(module, true);
-      Sdk currentSdk = ModuleRootManager.getInstance(module).getSdk();
-      if (currentSdk != null){
-        urls.addAll(Arrays.asList(currentSdk.getRootProvider().getUrls(OrderRootType.CLASSES)));
-      }
-    }
     LibraryTable androidProjectLibraryTable = LibraryTablesRegistrar.getInstance().getLibraryTable(androidProject);
     Library[] androidProjectLibraries = androidProjectLibraryTable.getLibraries();
     if (androidProjectLibraries.length == 0) {
       LOG.warn("Gradle sync was incomplete -- no Android libraries found");
       return null;
     }
+    HashSet<String> urls = new HashSet<>();
     for (Library refLibrary : androidProjectLibraries) {
       urls.addAll(Arrays.asList(refLibrary.getRootProvider().getUrls(OrderRootType.CLASSES)));
     }

--- a/flutter-studio/src/io/flutter/module/FlutterModuleImporter.java
+++ b/flutter-studio/src/io/flutter/module/FlutterModuleImporter.java
@@ -59,15 +59,15 @@ public class FlutterModuleImporter {
     }
 
     String newPath = Paths.get(myRelativePath, "android", "include_flutter.groovy").normalize().toString();
-    if (!new File(newPath).exists()) {
+    if (!new File(moduleRoot.getParent().getPath(), newPath).exists()) {
       // For old modules
       newPath = Paths.get(myRelativePath, ".android", "include_flutter.groovy").normalize().toString();
-      if (!new File(newPath).exists()) {
+      if (!new File(moduleRoot.getParent().getPath(), newPath).exists()) {
         showHowToEditDialog();
         return;
       }
     }
-    myRelativePath = StringUtil.escapeSlashes(newPath);
+    myRelativePath = StringUtil.escapeBackSlashes(newPath);
     VirtualFile settingsFile = projectRoot.findChild("settings.gradle");
     if (settingsFile == null) {
       showHowToEditDialog();

--- a/flutter-studio/src/io/flutter/profiler/FlutterStudioMonitorStageView.java
+++ b/flutter-studio/src/io/flutter/profiler/FlutterStudioMonitorStageView.java
@@ -162,7 +162,7 @@ public class FlutterStudioMonitorStageView extends FlutterStageView<FlutterStudi
 
     Range allData = getTimeline().getDataRange();
 
-    legendComponentModel = new LegendComponentModel(100);
+    legendComponentModel = new LegendComponentModel(new Range(100.0, 100.0));
     timeGlobalRangeUs = new Range(0, 0);
 
     RangedContinuousSeries maxHeapRangedData = new RangedContinuousSeries("Max Heap", timeGlobalRangeUs, allData, memoryMax);

--- a/flutter-studio/src/io/flutter/project/FlutterProjectSystem.java
+++ b/flutter-studio/src/io/flutter/project/FlutterProjectSystem.java
@@ -126,9 +126,9 @@ public class FlutterProjectSystem implements AndroidProjectSystem {
     return false;
   }
 
-  @Nullable
+  @NotNull
   @SuppressWarnings("override")
   public LightResourceClassService getLightResourceClassService() {
-    return null;
+    return gradleProjectSystem.getLightResourceClassService();
   }
 }

--- a/product-matrix.json
+++ b/product-matrix.json
@@ -11,23 +11,13 @@
       "untilBuild": "181.*"
     },
     {
-      "comments": "AS 3.3 Canary and IntelliJ 2018.2",
-      "name": "IntelliJ",
-      "version": "2018.2.1",
-      "ideaProduct": "android-studio",
-      "ideaVersion": "182.4968538",
-      "dartPluginVersion": "182.3911.37",
-      "sinceBuild": "182.0",
-      "untilBuild": "182.3912"
-    },
-    {
-      "comments": "IntelliJ 2018.2.2",
+      "comments": "AS 3.3 Beta and IntelliJ 2018.2",
       "name": "IntelliJ",
       "version": "2018.2.4",
-      "ideaProduct": "ideaIU",
-      "ideaVersion": "2018.2.2",
-      "dartPluginVersion": "182.4129.13",
-      "sinceBuild": "182.4129",
+      "ideaProduct": "android-studio",
+      "ideaVersion": "182.5073496",
+      "dartPluginVersion": "182.4999",
+      "sinceBuild": "182.4505",
       "untilBuild": "182.*"
     },
     {

--- a/tool/plugin/lib/plugin.dart
+++ b/tool/plugin/lib/plugin.dart
@@ -532,38 +532,10 @@ class BuildCommand extends ProductCommand {
         }
       }
 
-      // TODO(devoncarew): Remove this when we no longer support AS 3.1.
-      File processedFile1, processedFile2, processedFile3;
-      String oldSource1, oldSource2, oldSource3, newSource;
-      if (spec.version == '2017.3') {
-        processedFile1 = new File(
-            'flutter-studio/src/io/flutter/module/FlutterDescriptionProvider.java');
-        log('Editing ${processedFile1.path}');
-        oldSource1 = processedFile1.readAsStringSync();
-        newSource = oldSource1;
-        newSource = newSource.replaceAll(
-          'import com.android.tools.idea.npw.model.NewModuleModel',
-          'import com.android.tools.idea.npw.module.NewModuleModel',
-        );
-        newSource = newSource.replaceAll(
-          'import java.awt.*',
-          'import javax.swing.*',
-        );
-        newSource = newSource.replaceAll('public Image', 'public Icon');
-        newSource =
-            newSource.replaceAll('IconUtil.toImage', ''); // Leaves parens
-        processedFile1.writeAsStringSync(newSource);
-        processedFile2 = new File(
-            'flutter-studio/src/io/flutter/project/ChoseProjectTypeStep.java');
-        log('Editing ${processedFile2.path}');
-        oldSource2 = processedFile2.readAsStringSync();
-        newSource = oldSource2;
-        newSource = newSource.replaceAll(
-            "import com.intellij.ui.components.JBScrollPane;",
-            "import com.intellij.ui.components.JBScrollPane;\nimport com.intellij.util.IconUtil;");
-        newSource = newSource.replaceAll(
-            'image.getIcon()', 'IconUtil.toImage(image.getIcon())');
-        processedFile2.writeAsStringSync(newSource);
+      // TODO: Remove this when we no longer support AS 3.2.
+      File processedFile3, processedFile4;
+      String oldSource3, oldSource4, newSource;
+      if (spec.version == '2018.1') {
         processedFile3 = new File(
             'flutter-studio/src/io/flutter/project/FlutterProjectSystem.java');
         oldSource3 = processedFile3.readAsStringSync();
@@ -571,33 +543,28 @@ class BuildCommand extends ProductCommand {
         newSource = newSource.replaceAll('.LightResourceClassService', '.*');
         newSource =
             newSource.replaceAll(' LightResourceClassService', ' Object');
+        newSource = newSource.replaceAll(
+            'gradleProjectSystem.getLightResourceClassService()', 'null');
         processedFile3.writeAsStringSync(newSource);
-      } else if (spec.version == '2018.1') {
-        processedFile3 = new File(
-            'flutter-studio/src/io/flutter/project/FlutterProjectSystem.java');
-        oldSource3 = processedFile3.readAsStringSync();
-        newSource = oldSource3;
-        newSource = newSource.replaceAll('.LightResourceClassService', '.*');
-        newSource =
-            newSource.replaceAll(' LightResourceClassService', ' Object');
-        processedFile3.writeAsStringSync(newSource);
+        processedFile4 = new File(
+            'flutter-studio/src/io/flutter/profiler/FlutterStudioMonitorStageView.java');
+        oldSource4 = processedFile4.readAsStringSync();
+        newSource = oldSource4;
+        newSource = newSource.replaceAll('new Range(100.0, 100.0)', '100');
+        processedFile4.writeAsStringSync(newSource);
       }
 
       try {
         result = await runner.javac2(spec);
       } finally {
-        // Restore 3.2 sources.
-        if (oldSource1 != null) {
-          log('Restoring ${processedFile1.path}');
-          processedFile1.writeAsStringSync(oldSource1);
-        }
-        if (oldSource2 != null) {
-          log('Reestoring ${processedFile2.path}');
-          processedFile2.writeAsStringSync(oldSource2);
-        }
+        // Restore sources.
         if (oldSource3 != null) {
           log('Reestoring ${processedFile3.path}');
           processedFile3.writeAsStringSync(oldSource3);
+        }
+        if (oldSource4 != null) {
+          log('Reestoring ${processedFile4.path}');
+          processedFile4.writeAsStringSync(oldSource4);
         }
 
         // Restore skipped files.

--- a/tool/plugin/test/plugin_test.dart
+++ b/tool/plugin/test/plugin_test.dart
@@ -37,7 +37,6 @@ void main() {
             orderedEquals([
               'android-studio',
               'android-studio',
-              'ideaIU',
               'ideaIU'
             ]));
       });
@@ -53,7 +52,6 @@ void main() {
             orderedEquals([
               'android-studio',
               'android-studio',
-              'ideaIU',
               'ideaIU'
             ]));
       });
@@ -69,7 +67,6 @@ void main() {
             orderedEquals([
               'android-studio',
               'android-studio',
-              'ideaIU',
               'ideaIU'
             ]));
       });
@@ -148,7 +145,6 @@ void main() {
           cmd.paths.map((p) => p.substring(p.indexOf('releases'))),
           orderedEquals([
             'releases/release_19/2018.1/flutter-intellij.zip',
-            'releases/release_19/2018.2.1/flutter-intellij.zip',
             'releases/release_19/2018.2.4/flutter-intellij.zip',
             'releases/release_19/2018.3/flutter-intellij.zip'
           ]));


### PR DESCRIPTION
Had to re-create this four day old PR because it was too out of date to manage.

@pq @devoncarew @terrylucas @jacob314 @keertip 

 - Update the plugin tool to build for AS 3.3 beta.
 - Patch sources to match API changes in FlutterProjectSystem and FlutterStudioMonitorStageView
 - Generate new build files
 - Delete dead code for building AS 3.1

After merging this PR you'll need to update your Android Studio dependency to use 3.3; the 3.2 version won't compile anymore unless using the plugin tool.

You won't be able to build using the plugin tool until the new Android Studio artifact is uploaded to the cloud. I'll do that next week, but if someone wants to do it sooner, the file name is android-studio-ide-182.5073496-linux.zip and can be downloaded from the Android Studio preview site.

@terrylucas I don't know if the change to FlutterStudioMonitorStageView is correct. If it isn't you'll need to update plugin.dart to match whatever it should be. See line 553.