### PR TITLE
Fix flickering bug for BoolServiceExtensionCheckbox.

### DIFF
--- a/src/io/flutter/view/BoolServiceExtensionCheckbox.java
+++ b/src/io/flutter/view/BoolServiceExtensionCheckbox.java
@@ -33,15 +33,20 @@ public class BoolServiceExtensionCheckbox implements Disposable {
     currentValue = app.getVMServiceManager().getServiceExtensionState(extensionCommand);
     app.hasServiceExtension(extensionCommand, checkbox::setEnabled, this);
 
-    checkbox.addChangeListener((l) -> {
+    checkbox.addActionListener((l) -> {
       final boolean newValue = checkbox.isSelected();
-      currentValue.setValue(newValue);
-      if (app.isSessionActive()) {
-        app.callBooleanExtension(extensionCommand, newValue);
+      if (currentValue.setValue(newValue)) {
+        if (app.isSessionActive()) {
+          app.callBooleanExtension(extensionCommand, newValue);
+        }
       }
     });
 
-    currentValueSubscription = currentValue.listen(checkbox::setSelected, true);
+    currentValueSubscription = currentValue.listen((value) -> {
+      if (checkbox.isSelected() != value) {
+        checkbox.setSelected(value);
+      }
+    }, true);
   }
 
   JCheckBox getComponent() {


### PR DESCRIPTION
The main problem was addChangeListener was used to listen for checkbox
changes instead of addActionListener.
The problem with using addChangeListener is it fired on mouse-over
and programatic value changes as value changes triggered by user interaction which
is all we care about.

Added some defensive changes to EventStream as well to prevent possible race
conditions for cases of many repeated value changes.