### PR TITLE
move the memory tab into its own tool window

### DIFF
--- a/resources/META-INF/studio-contribs.xml
+++ b/resources/META-INF/studio-contribs.xml
@@ -19,6 +19,12 @@
     <library.type implementation="io.flutter.android.AndroidModuleLibraryType"/>
     <projectService serviceInterface="io.flutter.android.AndroidModuleLibraryManager"
                     serviceImplementation="io.flutter.android.AndroidModuleLibraryManager"/>
+
+    <toolWindow id="Flutter Performance" anchor="bottom" icon="FlutterIcons.Flutter_13"
+                factoryClass="io.flutter.view.FlutterPerfViewFactory"/>
+    <projectService serviceInterface="io.flutter.view.FlutterPerfView"
+                    serviceImplementation="io.flutter.view.FlutterPerfView"
+                    overrides="false"/>
   </extensions>
 
   <actions>

--- a/resources/META-INF/studio-contribs_template.xml
+++ b/resources/META-INF/studio-contribs_template.xml
@@ -17,6 +17,12 @@
     <library.type implementation="io.flutter.android.AndroidModuleLibraryType"/>
     <projectService serviceInterface="io.flutter.android.AndroidModuleLibraryManager"
                     serviceImplementation="io.flutter.android.AndroidModuleLibraryManager"/>
+
+    <toolWindow id="Flutter Performance" anchor="bottom" icon="FlutterIcons.Flutter_13"
+                factoryClass="io.flutter.view.FlutterPerfViewFactory"/>
+    <projectService serviceInterface="io.flutter.view.FlutterPerfView"
+                    serviceImplementation="io.flutter.view.FlutterPerfView"
+                    overrides="false"/>
   </extensions>
 
   <actions>

--- a/src/io/flutter/FlutterInitializer.java
+++ b/src/io/flutter/FlutterInitializer.java
@@ -23,8 +23,8 @@ import com.intellij.openapi.startup.StartupActivity;
 import io.flutter.analytics.Analytics;
 import io.flutter.analytics.ToolWindowTracker;
 import io.flutter.android.IntelliJAndroidSdk;
-import io.flutter.perf.FlutterWidgetPerfManager;
 import io.flutter.editor.FlutterSaveActionsManager;
+import io.flutter.perf.FlutterWidgetPerfManager;
 import io.flutter.pub.PubRoot;
 import io.flutter.pub.PubRoots;
 import io.flutter.run.FlutterReloadManager;
@@ -33,6 +33,7 @@ import io.flutter.run.daemon.DeviceService;
 import io.flutter.sdk.FlutterPluginsLibraryManager;
 import io.flutter.settings.FlutterSettings;
 import io.flutter.utils.FlutterModuleUtils;
+import io.flutter.view.FlutterPerfViewFactory;
 import io.flutter.view.FlutterViewFactory;
 import org.jetbrains.annotations.NotNull;
 
@@ -75,6 +76,10 @@ public class FlutterInitializer implements StartupActivity {
 
     // Start watching for Flutter debug active events.
     FlutterViewFactory.init(project);
+
+    if (FlutterUtils.isAndroidStudio()) {
+      FlutterPerfViewFactory.init(project);
+    }
 
     // If the project declares a Flutter dependency, do some extra initialization.
     boolean hasFlutterModule = false;

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.form
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.form
@@ -114,7 +114,7 @@
           </component>
         </children>
       </grid>
-      <grid id="23e52" layout-manager="GridLayoutManager" row-count="5" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="23e52" layout-manager="GridLayoutManager" row-count="4" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -156,15 +156,6 @@
             <properties>
               <text value="Enable code completion, navigation, etc. for Java/Kotlin (requires restart to do Gradle build)"/>
               <toolTipText value="Provides advanced editing capabilities for Java and Kotlin code. Uses Gradle to find Android libraries then links them into the Flutter project."/>
-            </properties>
-          </component>
-          <component id="5fae0" class="javax.swing.JCheckBox" binding="myEnableMemoryProfilerCheckBox" default-binding="true">
-            <constraints>
-              <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <text value="Enable Memory Profiler"/>
-              <toolTipText value="Memory Profiling tab located inside of the Inspector view displays memory statistics."/>
             </properties>
           </component>
         </children>

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.java
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.java
@@ -169,16 +169,12 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
       return true;
     }
 
-    //noinspection RedundantIfStatement
     if (settings.isVerboseLogging() != myEnableVerboseLoggingCheckBox.isSelected()) {
       return true;
     }
 
+    //noinspection RedundantIfStatement
     if (settings.isSyncingAndroidLibraries() != mySyncAndroidLibrariesCheckBox.isSelected()) {
-      return true;
-    }
-
-    if (settings.isMemoryProfilerEnabled() != myEnableMemoryProfilerCheckBox.isSelected()) {
       return true;
     }
 
@@ -212,7 +208,6 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     settings.setTrackWidgetCreation(myTrackWidgetCreationCheckBox.isSelected());
     settings.setVerboseLogging(myEnableVerboseLoggingCheckBox.isSelected());
     settings.setSyncingAndroidLibraries(mySyncAndroidLibrariesCheckBox.isSelected());
-    settings.setMemoryProfilerEnabled(myEnableMemoryProfilerCheckBox.isSelected());
 
     reset(); // because we rely on remembering initial state
   }
@@ -241,7 +236,6 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     myTrackWidgetCreationCheckBox.setSelected(settings.isTrackWidgetCreation());
     myEnableVerboseLoggingCheckBox.setSelected(settings.isVerboseLogging());
     mySyncAndroidLibrariesCheckBox.setSelected(settings.isSyncingAndroidLibraries());
-    myEnableMemoryProfilerCheckBox.setSelected(settings.isMemoryProfilerEnabled());
 
     myOrganizeImportsOnSaveCheckBox.setEnabled(myFormatCodeOnSaveCheckBox.isSelected());
   }

--- a/src/io/flutter/settings/FlutterSettings.java
+++ b/src/io/flutter/settings/FlutterSettings.java
@@ -27,7 +27,6 @@ public class FlutterSettings {
   private static final String syncAndroidLibrariesKey = "io.flutter.syncAndroidLibraries";
   private static final String trackWidgetCreationKey = "io.flutter.trackWidgetCreation";
   private static final String useFlutterLogView = "io.flutter.useLogView";
-  private static final String memoryProfilerKey = "io.flutter.memoryProfiler";
 
   public static FlutterSettings getInstance() {
     return ServiceManager.getService(FlutterSettings.class);
@@ -189,16 +188,6 @@ public class FlutterSettings {
 
   public void setVerboseLogging(boolean value) {
     getPropertiesComponent().setValue(verboseLoggingKey, value, false);
-
-    fireEvent();
-  }
-
-  public boolean isMemoryProfilerEnabled() {
-    return getPropertiesComponent().getBoolean(memoryProfilerKey, false);
-  }
-
-  public void setMemoryProfilerEnabled(boolean value) {
-    getPropertiesComponent().setValue(memoryProfilerKey, value, false);
 
     fireEvent();
   }

--- a/src/io/flutter/view/FlutterPerfView.java
+++ b/src/io/flutter/view/FlutterPerfView.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2018 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.view;
+
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.SimpleToolWindowPanel;
+import com.intellij.openapi.util.Disposer;
+import com.intellij.openapi.wm.ToolWindow;
+import com.intellij.openapi.wm.ToolWindowManager;
+import com.intellij.openapi.wm.ex.ToolWindowManagerEx;
+import com.intellij.ui.components.JBLabel;
+import com.intellij.ui.content.Content;
+import com.intellij.ui.content.ContentManager;
+import com.intellij.util.ui.UIUtil;
+import icons.FlutterIcons;
+import io.flutter.run.daemon.FlutterApp;
+import io.flutter.run.daemon.FlutterDevice;
+import io.flutter.utils.VmServiceListenerAdapter;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+import java.awt.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class FlutterPerfView {
+  public static final String TOOL_WINDOW_ID = "Flutter Performance";
+
+  private static final Logger LOG = Logger.getInstance(FlutterPerfView.class);
+
+  @NotNull
+  private final Project myProject;
+
+  private final Map<FlutterApp, PerfViewAppState> perAppViewState = new HashMap<>();
+
+  public FlutterPerfView(@NotNull Project project) {
+    myProject = project;
+  }
+
+  void initToolWindow(ToolWindow window) {
+    if (window.isDisposed()) return;
+
+    updateForEmptyContent(window);
+  }
+
+  @NotNull
+  public Project getProject() {
+    return myProject;
+  }
+
+  private void updateForEmptyContent(ToolWindow toolWindow) {
+    // There's a possible race here where the tool window gets disposed while we're displaying contents.
+    if (toolWindow.isDisposed()) {
+      //noinspection UnnecessaryReturnStatement
+      return;
+    }
+  }
+
+  void debugActive(@NotNull FlutterViewMessages.FlutterDebugEvent event) {
+    final FlutterApp app = event.app;
+
+    final ToolWindowManager toolWindowManager = ToolWindowManager.getInstance(myProject);
+    if (!(toolWindowManager instanceof ToolWindowManagerEx)) {
+      return;
+    }
+
+    final ToolWindow toolWindow = toolWindowManager.getToolWindow(TOOL_WINDOW_ID);
+    if (toolWindow == null) {
+      return;
+    }
+
+    addPerformanceViewContent(app, toolWindow);
+
+    app.getVmService().addVmServiceListener(new VmServiceListenerAdapter() {
+      @Override
+      public void connectionOpened() {
+        onAppChanged(app);
+      }
+
+      @Override
+      public void connectionClosed() {
+        ApplicationManager.getApplication().invokeLater(() -> {
+          if (toolWindow.isDisposed()) return;
+          final ContentManager contentManager = toolWindow.getContentManager();
+          onAppChanged(app);
+          final PerfViewAppState state = perAppViewState.remove(app);
+          if (state != null) {
+            if (state.content != null) {
+              contentManager.removeContent(state.content, true);
+            }
+            if (state.disposable != null) {
+              state.disposable.dispose();
+            }
+          }
+          if (perAppViewState.isEmpty()) {
+            // No more applications are running.
+            updateForEmptyContent(toolWindow);
+          }
+        });
+      }
+    });
+
+    onAppChanged(app);
+  }
+
+  private void addPerformanceViewContent(FlutterApp app, ToolWindow toolWindow) {
+    final ContentManager contentManager = toolWindow.getContentManager();
+    final SimpleToolWindowPanel toolWindowPanel = new SimpleToolWindowPanel(true);
+
+    final List<FlutterDevice> existingDevices = new ArrayList<>();
+    for (FlutterApp otherApp : perAppViewState.keySet()) {
+      existingDevices.add(otherApp.device());
+    }
+
+    final JPanel panelContainer = new JPanel(new BorderLayout());
+    final Content content = contentManager.getFactory().createContent(null, app.device().getUniqueName(existingDevices), false);
+    content.setComponent(panelContainer);
+    content.putUserData(ToolWindow.SHOW_CONTENT_ICON, Boolean.TRUE);
+    content.setIcon(FlutterIcons.Phone);
+    contentManager.addContent(content);
+
+    final PerfViewAppState state = getOrCreateStateForApp(app);
+    assert (state.content == null);
+    state.content = content;
+
+    final boolean debugConnectionAvailable = app.getLaunchMode().supportsDebugConnection();
+    final boolean isInProfileMode = app.getMode().isProfiling() || app.getLaunchMode().isProfiling();
+
+    // If the inspector is available (non-release mode), then show it.
+    if (debugConnectionAvailable) {
+      state.disposable = Disposer.newDisposable();
+
+      final InspectorMemoryTab memoryTab = new InspectorMemoryTab(state.disposable, app);
+      panelContainer.add(memoryTab, BorderLayout.CENTER);
+
+      // If in profile mode, auto-open the performance tool window.
+      if (isInProfileMode) {
+        activateToolWindow();
+      }
+    }
+    else {
+      // Add a message about the inspector not being available in release mode.
+      final JBLabel label = new JBLabel("Profiling is not available in release mode", SwingConstants.CENTER);
+      label.setForeground(UIUtil.getLabelDisabledForeground());
+      panelContainer.add(label, BorderLayout.CENTER);
+    }
+  }
+
+  private void onAppChanged(FlutterApp app) {
+    if (myProject.isDisposed()) {
+      return;
+    }
+
+    final ToolWindow toolWindow = ToolWindowManager.getInstance(myProject).getToolWindow(TOOL_WINDOW_ID);
+    if (toolWindow == null) {
+      //noinspection UnnecessaryReturnStatement
+      return;
+    }
+  }
+
+  /**
+   * Activate the tool window.
+   */
+  private void activateToolWindow() {
+    final ToolWindowManager toolWindowManager = ToolWindowManager.getInstance(myProject);
+
+    final ToolWindow toolWindow = toolWindowManager.getToolWindow(TOOL_WINDOW_ID);
+    if (toolWindow.isVisible()) {
+      return;
+    }
+
+    toolWindow.show(null);
+  }
+
+  private PerfViewAppState getStateForApp(FlutterApp app) {
+    return perAppViewState.get(app);
+  }
+
+  private PerfViewAppState getOrCreateStateForApp(FlutterApp app) {
+    return perAppViewState.computeIfAbsent(app, k -> new PerfViewAppState());
+  }
+
+  private static class PerfViewAppState {
+    @Nullable Content content;
+
+    @Nullable Disposable disposable;
+  }
+}

--- a/src/io/flutter/view/FlutterPerfViewFactory.java
+++ b/src/io/flutter/view/FlutterPerfViewFactory.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.view;
+
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.project.DumbAware;
+import com.intellij.openapi.project.DumbService;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.wm.ToolWindow;
+import com.intellij.openapi.wm.ToolWindowFactory;
+import org.jetbrains.annotations.NotNull;
+
+public class FlutterPerfViewFactory implements ToolWindowFactory, DumbAware {
+  public static void init(@NotNull Project project) {
+    project.getMessageBus().connect().subscribe(
+      FlutterViewMessages.FLUTTER_DEBUG_TOPIC, (event) -> initPerfView(project, event)
+    );
+  }
+
+  private static void initPerfView(@NotNull Project project, FlutterViewMessages.FlutterDebugEvent event) {
+    ApplicationManager.getApplication().invokeLater(() -> {
+      final FlutterPerfView flutterPerfView = ServiceManager.getService(project, FlutterPerfView.class);
+      flutterPerfView.debugActive(event);
+    });
+  }
+
+  @Override
+  public void createToolWindowContent(@NotNull Project project, @NotNull ToolWindow toolWindow) {
+    //noinspection CodeBlock2Expr
+    DumbService.getInstance(project).runWhenSmart(() -> {
+      (ServiceManager.getService(project, FlutterPerfView.class)).initToolWindow(toolWindow);
+    });
+  }
+}

--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -230,11 +230,6 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
       }
 
       addPerformanceTab(runnerTabs, app, !hasInspectorService);
-
-      // Only show the Memory tab if the "Memory Profiler" experiment is enabled.
-      if (FlutterSettings.getInstance().isMemoryProfilerEnabled()) {
-        addMemoryTab(runnerTabs, app, !hasInspectorService);
-      }
     }
     else {
       // Add a message about the inspector not being available in release mode.
@@ -331,18 +326,6 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
     final InspectorPerfTab perfTab = new InspectorPerfTab(runnerTabs, app);
     final TabInfo tabInfo = new TabInfo(perfTab)
       .append(PERFORMANCE_TAB_LABEL, SimpleTextAttributes.REGULAR_ATTRIBUTES);
-    runnerTabs.addTab(tabInfo);
-    if (selectedTab) {
-      runnerTabs.select(tabInfo, false);
-    }
-  }
-
-  private void addMemoryTab(JBRunnerTabs runnerTabs,
-                            FlutterApp app,
-                            boolean selectedTab) {
-    final InspectorMemoryTab perfTab = new InspectorMemoryTab(runnerTabs, app);
-    final TabInfo tabInfo = new TabInfo(perfTab)
-      .append(MEMORY_TAB_LABEL, SimpleTextAttributes.REGULAR_ATTRIBUTES);
     runnerTabs.addTab(tabInfo);
     if (selectedTab) {
       runnerTabs.select(tabInfo, false);

--- a/src/io/flutter/view/InspectorMemoryTab.java
+++ b/src/io/flutter/view/InspectorMemoryTab.java
@@ -7,7 +7,9 @@ package io.flutter.view;
 
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.ui.JBColor;
 import com.intellij.ui.components.JBLabel;
+import com.intellij.util.ui.JBFont;
 import com.intellij.util.ui.JBUI;
 import io.flutter.run.FlutterLaunchMode;
 import io.flutter.run.daemon.FlutterApp;
@@ -26,26 +28,7 @@ public class InspectorMemoryTab extends JPanel implements InspectorTabPanel {
   InspectorMemoryTab(Disposable parentDisposable, @NotNull FlutterApp app) {
     this.app = app;
 
-    setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
-
-    add(Box.createVerticalStrut(6));
-
-    Box labelBox = Box.createHorizontalBox();
-    labelBox.add(new JLabel("Running in " + app.getLaunchMode() + " mode"));
-    labelBox.add(Box.createHorizontalGlue());
-    labelBox.setBorder(JBUI.Borders.empty(3, 10));
-    add(labelBox);
-
-
-    if (app.getLaunchMode() == FlutterLaunchMode.DEBUG) {
-      labelBox = Box.createHorizontalBox();
-      labelBox.add(new JBLabel("<html><body><p style='color:red'>Note: for best results, re-run in profile mode</p></body></html>"));
-      labelBox.add(Box.createHorizontalGlue());
-      labelBox.setBorder(JBUI.Borders.empty(3, 10));
-      add(labelBox);
-    }
-
-    add(Box.createVerticalStrut(6));
+    setLayout(new BorderLayout());
 
     // Dynamically load, instantiate the Flutter Profiler classes (only
     // available in Android Studio) then add the component to the the inspector
@@ -84,6 +67,20 @@ public class InspectorMemoryTab extends JPanel implements InspectorTabPanel {
       Component component =
         (Component)getComponentMethod.invoke(flutterStudioProfilersView_instance, (Object[])noArguments);
 
+      final JPanel labels = new JPanel(new BorderLayout(6, 0));
+      labels.setBorder(JBUI.Borders.empty(3, 10));
+      add(labels, BorderLayout.NORTH);
+
+      labels.add(
+        new JBLabel("Running in " + app.getLaunchMode() + " mode"),
+        BorderLayout.WEST);
+
+      if (app.getLaunchMode() == FlutterLaunchMode.DEBUG) {
+        final JBLabel label = new JBLabel("(note: for best results, re-run in profile mode)");
+        label.setForeground(JBColor.RED);
+        labels.add(label, BorderLayout.CENTER);
+      }
+
       add(component, BorderLayout.CENTER);
 
       // Start collecting immediately if memory profiling is enabled.
@@ -95,18 +92,11 @@ public class InspectorMemoryTab extends JPanel implements InspectorTabPanel {
       InvocationTargetException e) {
       LOG.warn("Problem loading Flutter Memory Profiler - " + e.getMessage());
 
-      labelBox = Box.createHorizontalBox();
-      JLabel warningLabel = new JLabel("Memory profiling is only available in Android Studio.");
-
-      // Bold the message.
-      Font font = warningLabel.getFont();
-      Font boldFont = new Font(font.getFontName(), Font.BOLD, font.getSize());
-      warningLabel.setFont(boldFont);
-
-      labelBox.add(warningLabel);
-      labelBox.add(Box.createHorizontalGlue());
-      labelBox.setBorder(JBUI.Borders.empty(3, 10));
-      add(labelBox);
+      final JLabel warningLabel = new JLabel(
+        "Memory profiling is only available in Android Studio.", null, SwingConstants.CENTER);
+      warningLabel.setFont(JBFont.create(warningLabel.getFont()).asBold());
+      warningLabel.setBorder(JBUI.Borders.empty(3, 10));
+      add(warningLabel, BorderLayout.CENTER);
     }
   }
 


### PR DESCRIPTION
- move the memory tab into its own tool window

This splits the memory tab out of the Inspector and moves it into its own tool window. It also makes it only available contributed in Android Studio; we can adjust that once the charting lib is available in IntelliJ. The functionality of the memory view should be unaffected.

The tool window is named `Flutter Performance`, but we can noodle on alternative names (once we ship it however we should stay consistent). Note that this work is not for the current (M30) release.

<img width="1389" alt="screen shot 2018-10-31 at 7 28 42 pm" src="https://user-images.githubusercontent.com/1269969/47866172-47525100-ddbb-11e8-9811-550603a9247a.png">
