### PR TITLE
Fix flutter setup links

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ app SDK to help developers and designers build modern mobile apps for iOS and An
 ## Documentation
 
 - [flutter.io](https://flutter.io)
-- [Installing Flutter](https://flutter.io/setup/)
+- [Installing Flutter](https://flutter.io/docs/get-started/install)
 - [Getting Started with IntelliJ](https://flutter.io/intellij-ide/)
 
 ## Fast development
@@ -24,7 +24,7 @@ simulators, and hardware for iOS and Android.
 
 A brief summary of the [getting started guide](https://flutter.io/intellij-ide/):
 
-- install the [Flutter SDK](https://flutter.io/setup/)
+- install the [Flutter SDK](https://flutter.io/docs/get-started/install)
 - run `flutter doctor` from the command line to verify your installation
 - ensure you have a supported [IntelliJ development environment](https://www.jetbrains.com/idea/download), either:
   - IntelliJ 2017.3 or 2018.1, Community or Ultimate Edition, or

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -4,7 +4,7 @@ Manual tests to execute before plugin releases.
 
 ## Setup
 
-Pre-reqs: Run through the [flutter setup](https://flutter.io/setup/) and
+Pre-reqs: Run through the [flutter setup](https://flutter.io/docs/get-started/install) and
 [flutter getting started](https://flutter.io/getting-started/) guides.
 
 * Run `flutter upgrade` in a terminal to get the latest version prior to starting testing.
@@ -150,7 +150,7 @@ Verify installation and configuration in a fresh IDEA installation.
 
 * Follow the instructions to
   [simulate a fresh installation](https://github.com/flutter/flutter-intellij/wiki/Development#simulating-a-fresh-install).
-* (If not running in a "runtime workbench", [install the plugins](https://flutter.io/setup/#install-the-plugins).)
+* (If not running in a "runtime workbench", [install the plugins](https://flutter.io/docs/development/packages-and-plugins/using-packages).)
 * Open "Languages & Frameworks>Flutter" in Preferences and verify that there is
   no Flutter SDK set.
 * Set the Flutter SDK path to a valid SDK location.

--- a/src/io/flutter/actions/InstallSdkAction.java
+++ b/src/io/flutter/actions/InstallSdkAction.java
@@ -168,7 +168,7 @@ public class InstallSdkAction extends DumbAwareAction {
     @Override
     void perform() {
       FlutterInitializer.sendAnalyticsAction(ANALYTICS_KEY);
-      BrowserUtil.browse("https://flutter.io/setup/");
+      BrowserUtil.browse("https://flutter.io/docs/get-started/install");
     }
 
     @Override


### PR DESCRIPTION
Flutter setup page url is changed to "get-started".

Please review this below. Is it right?
https://github.com/flutter/flutter-intellij/compare/master...ChangJoo-Park:master#diff-5a61e9f9f0b3221e1b12f6e24cf94ed4R153
