### PR TITLE
change the default value for the 'only show widgets' toggle

### DIFF
--- a/src/io/flutter/settings/FlutterSettings.java
+++ b/src/io/flutter/settings/FlutterSettings.java
@@ -144,11 +144,11 @@ public class FlutterSettings {
   }
 
   public boolean isShowOnlyWidgets() {
-    return getPropertiesComponent().getBoolean(showOnlyWidgetsKey, true);
+    return getPropertiesComponent().getBoolean(showOnlyWidgetsKey, false);
   }
 
   public void setShowOnlyWidgets(boolean value) {
-    getPropertiesComponent().setValue(showOnlyWidgetsKey, value, true);
+    getPropertiesComponent().setValue(showOnlyWidgetsKey, value, false);
 
     fireEvent();
   }


### PR DESCRIPTION
- change the default value for the 'only show widgets' toggle (we now default to showing everything in the outline view)

<img width="117" alt="screen shot 2018-11-06 at 12 22 05 pm" src="https://user-images.githubusercontent.com/1269969/48091476-a6023b00-e1be-11e8-8c55-bbeb05be029d.png">

@scheglov 