### PR TITLE
update the color icon provider, and fix some regressions due to opt. const

### DIFF
--- a/src/io/flutter/dart/DartSyntax.java
+++ b/src/io/flutter/dart/DartSyntax.java
@@ -40,6 +40,30 @@ public class DartSyntax {
     return null; // not found
   }
 
+  @Nullable
+  public static DartNewExpression findEnclosingNewExpression(@NotNull PsiElement elt) {
+    while (elt != null) {
+      if (elt instanceof DartNewExpression) {
+        return (DartNewExpression)elt;
+      }
+      elt = elt.getParent();
+    }
+    return null;
+  }
+
+  @Nullable
+  public static DartReferenceExpression findEnclosingReferenceExpression(@NotNull PsiElement elt) {
+    while (elt != null) {
+      if (elt instanceof DartReferenceExpression) {
+        if (!(elt.getParent() instanceof DartReferenceExpression)) {
+          return (DartReferenceExpression)elt;
+        }
+      }
+      elt = elt.getParent();
+    }
+    return null;
+  }
+
   /**
    * Gets an argument to a function call, provided that the expression has the given type.
    * <p>
@@ -112,5 +136,4 @@ public class DartSyntax {
     if (!(call.getFirstChild() instanceof DartReference)) return null;
     return call.getFirstChild().getText();
   }
-
 }

--- a/src/io/flutter/editor/FlutterEditorAnnotator.java
+++ b/src/io/flutter/editor/FlutterEditorAnnotator.java
@@ -8,10 +8,10 @@ package io.flutter.editor;
 import com.intellij.lang.annotation.Annotation;
 import com.intellij.lang.annotation.AnnotationHolder;
 import com.intellij.lang.annotation.Annotator;
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.psi.PsiElement;
 import com.intellij.util.ui.ColorIcon;
 import com.jetbrains.lang.dart.psi.DartArrayAccessExpression;
+import com.jetbrains.lang.dart.psi.DartCallExpression;
 import com.jetbrains.lang.dart.psi.DartNewExpression;
 import com.jetbrains.lang.dart.psi.DartReferenceExpression;
 import io.flutter.editor.FlutterColors.FlutterColor;
@@ -20,23 +20,15 @@ import org.jetbrains.annotations.NotNull;
 import javax.swing.*;
 import java.awt.*;
 
-import static io.flutter.utils.FlutterModuleUtils.isInFlutterModule;
-
 /**
  * Add Material icons and Flutter color icons to the editor's gutter.
  */
 public class FlutterEditorAnnotator implements Annotator {
-  private static final Logger LOG = Logger.getInstance(FlutterEditorAnnotator.class);
-
   @Override
   public void annotate(@NotNull PsiElement element, @NotNull AnnotationHolder holder) {
     if (holder.isBatchMode()) return;
 
     if (element instanceof DartReferenceExpression || element instanceof DartArrayAccessExpression) {
-      if (!isInFlutterModule(element)) {
-        return;
-      }
-
       final String text = element.getText();
 
       if (text.startsWith("Colors.")) {
@@ -45,7 +37,8 @@ public class FlutterEditorAnnotator implements Annotator {
         if (color != null) {
           if (!color.isPrimary()) {
             attachColorIcon(element, holder, color.getAWTColor());
-          } else {
+          }
+          else {
             // If we're a primary color access, and
             // - we're not followed by an array access (really referencing a more specific color)
             // - we're not followed by a shadeXXX access
@@ -53,7 +46,7 @@ public class FlutterEditorAnnotator implements Annotator {
             final boolean inShadeExpression =
               (element.getParent() instanceof DartReferenceExpression && element.getParent().getText().startsWith(text + ".shade"));
             if (!inShadeExpression && !inColorIndexExpression) {
-                attachColorIcon(element, holder, color.getAWTColor());
+              attachColorIcon(element, holder, color.getAWTColor());
             }
           }
         }
@@ -70,41 +63,75 @@ public class FlutterEditorAnnotator implements Annotator {
       // const IconData(0xe914)
       final String text = element.getText();
 
-      if (text.startsWith("const IconData(") && text.endsWith(")")) {
-        String val = text.substring("const IconData(".length());
-        val = val.substring(0, val.length() - 1);
-        final int index = val.indexOf(',');
-        if (index != -1) {
-          val = val.substring(0, index);
-        }
-        try {
-          final int value = val.startsWith("0x")
-                            ? Integer.parseInt(val.substring(2), 16)
-                            : Integer.parseInt(val);
-          final String hex = Integer.toHexString(value);
+      final String constIconDataText = "const IconData(";
+      final String constColorText = "const Color(";
+
+      if (text.startsWith(constIconDataText)) {
+        final Integer val = parseNumberFromCallParam(text, constIconDataText);
+        if (val != null) {
+          final String hex = Long.toHexString(val);
           final Icon icon = FlutterMaterialIcons.getMaterialIconForHex(hex);
           if (icon != null) {
             attachIcon(element, holder, icon);
           }
         }
-        catch (NumberFormatException ignored) {
-        }
       }
-      else if (text.startsWith("const Color(") && text.endsWith(")")) {
-        String val = text.substring("const Color(".length());
-        val = val.substring(0, val.length() - 1);
-        try {
-          final long value = val.startsWith("0x")
-                             ? Long.parseLong(val.substring(2), 16)
-                             : Long.parseLong(val);
+      else if (text.startsWith(constColorText)) {
+        final Integer val = parseNumberFromCallParam(text, constColorText);
+        if (val != null) {
+          final int value = val;
           //noinspection UseJBColor
           final Color color = new Color((int)(value >> 16) & 0xFF, (int)(value >> 8) & 0xFF, (int)value & 0xFF, (int)(value >> 24) & 0xFF);
           attachColorIcon(element, holder, color);
         }
-        catch (NumberFormatException ignored) {
+      }
+    }
+    else if (element instanceof DartCallExpression) {
+      // IconData(0xe914)
+      final String text = element.getText();
+
+      final String iconDataText = "IconData(";
+      final String colorText = "Color(";
+
+      if (text.startsWith(iconDataText)) {
+        final Integer val = parseNumberFromCallParam(text, iconDataText);
+        if (val != null) {
+          final String hex = Long.toHexString(val);
+          final Icon icon = FlutterMaterialIcons.getMaterialIconForHex(hex);
+          if (icon != null) {
+            attachIcon(element, holder, icon);
+          }
+        }
+      }
+      else if (text.startsWith(colorText)) {
+        final Integer val = parseNumberFromCallParam(text, colorText);
+        if (val != null) {
+          final int value = val;
+          //noinspection UseJBColor
+          final Color color = new Color((int)(value >> 16) & 0xFF, (int)(value >> 8) & 0xFF, (int)value & 0xFF, (int)(value >> 24) & 0xFF);
+          attachColorIcon(element, holder, color);
         }
       }
     }
+  }
+
+  private static Integer parseNumberFromCallParam(String callText, String prefix) {
+    if (callText.startsWith(prefix) && callText.endsWith(")")) {
+      String val = callText.substring(prefix.length(), callText.length() - 1);
+      final int index = val.indexOf(',');
+      if (index != -1) {
+        val = val.substring(0, index);
+      }
+      try {
+        return val.startsWith("0x")
+               ? Integer.parseUnsignedInt(val.substring(2), 16)
+               : Integer.parseUnsignedInt(val);
+      }
+      catch (NumberFormatException ignored) {
+      }
+    }
+
+    return null;
   }
 
   private static void attachColorIcon(final PsiElement element, AnnotationHolder holder, Color color) {

--- a/src/io/flutter/editor/FlutterEditorAnnotator.java
+++ b/src/io/flutter/editor/FlutterEditorAnnotator.java
@@ -87,6 +87,9 @@ public class FlutterEditorAnnotator implements Annotator {
       }
     }
     else if (element instanceof DartCallExpression) {
+      // Look for call expressions that are really new (constructor) expressions; The IntelliJ parser can't
+      // distinguish between call expressions, and call expressions that are really constructor calls.
+
       // IconData(0xe914)
       final String text = element.getText();
 
@@ -117,7 +120,7 @@ public class FlutterEditorAnnotator implements Annotator {
 
   private static Integer parseNumberFromCallParam(String callText, String prefix) {
     if (callText.startsWith(prefix) && callText.endsWith(")")) {
-      String val = callText.substring(prefix.length(), callText.length() - 1);
+      String val = callText.substring(prefix.length(), callText.length() - 1).trim();
       final int index = val.indexOf(',');
       if (index != -1) {
         val = val.substring(0, index);

--- a/testSrc/unit/io/flutter/bazel/WorkspaceTest.java
+++ b/testSrc/unit/io/flutter/bazel/WorkspaceTest.java
@@ -16,7 +16,6 @@ import org.junit.Test;
 import static org.junit.Assert.*;
 
 public class WorkspaceTest {
-
   @Rule
   public final ProjectFixture fixture = Testing.makeEmptyModule();
 

--- a/testSrc/unit/io/flutter/editor/FlutterEditorAnnotatorTest.java
+++ b/testSrc/unit/io/flutter/editor/FlutterEditorAnnotatorTest.java
@@ -107,6 +107,48 @@ public class FlutterEditorAnnotatorTest extends AbstractDartElementTest {
   }
 
   @Test
+  public void locatesConstColorArray() throws Exception {
+    run(() -> {
+      final PsiElement testIdentifier = setUpDartElement("main() { const [Color(0xFFE3F2FD)]; }", "Color", LeafPsiElement.class);
+      final DartCallExpression element = DartSyntax.findEnclosingFunctionCall(testIdentifier, "Color");
+      assert element != null;
+
+      final FlutterEditorAnnotator annotator = new FlutterEditorAnnotator();
+      final AnnotationSession annotationSession = new AnnotationSession(testIdentifier.getContainingFile());
+      final AnnotationHolderImpl annotationHolder = new AnnotationHolderImpl(annotationSession);
+
+      annotator.annotate(element, annotationHolder);
+
+      assertTrue(annotationHolder.hasAnnotations());
+      assertEquals(1, annotationHolder.size());
+
+      final Annotation annotation = annotationHolder.get(0);
+      assertEquals(HighlightSeverity.INFORMATION, annotation.getSeverity());
+    });
+  }
+
+  @Test
+  public void locatesConstColorWhitespace() throws Exception {
+    run(() -> {
+      final PsiElement testIdentifier = setUpDartElement("main() { const Color( 0xFFE3F2FD); }", "Color", LeafPsiElement.class);
+      final DartNewExpression element = DartSyntax.findEnclosingNewExpression(testIdentifier);
+      assert element != null;
+
+      final FlutterEditorAnnotator annotator = new FlutterEditorAnnotator();
+      final AnnotationSession annotationSession = new AnnotationSession(testIdentifier.getContainingFile());
+      final AnnotationHolderImpl annotationHolder = new AnnotationHolderImpl(annotationSession);
+
+      annotator.annotate(element, annotationHolder);
+
+      assertTrue(annotationHolder.hasAnnotations());
+      assertEquals(1, annotationHolder.size());
+
+      final Annotation annotation = annotationHolder.get(0);
+      assertEquals(HighlightSeverity.INFORMATION, annotation.getSeverity());
+    });
+  }
+
+  @Test
   public void locatesIconCtor() throws Exception {
     run(() -> {
       final PsiElement testIdentifier =

--- a/testSrc/unit/io/flutter/editor/FlutterEditorAnnotatorTest.java
+++ b/testSrc/unit/io/flutter/editor/FlutterEditorAnnotatorTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2018 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.editor;
+
+import com.intellij.codeInsight.daemon.impl.AnnotationHolderImpl;
+import com.intellij.lang.annotation.Annotation;
+import com.intellij.lang.annotation.AnnotationSession;
+import com.intellij.lang.annotation.HighlightSeverity;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.impl.source.tree.LeafPsiElement;
+import com.jetbrains.lang.dart.psi.DartCallExpression;
+import com.jetbrains.lang.dart.psi.DartNewExpression;
+import com.jetbrains.lang.dart.psi.DartReferenceExpression;
+import io.flutter.AbstractDartElementTest;
+import io.flutter.dart.DartSyntax;
+import org.junit.Test;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
+
+public class FlutterEditorAnnotatorTest extends AbstractDartElementTest {
+  @Test
+  public void locatesColorReference() throws Exception {
+    run(() -> {
+      final PsiElement testIdentifier = setUpDartElement("main() { Colors.blue; }", "Colors", LeafPsiElement.class);
+      final DartReferenceExpression element = DartSyntax.findEnclosingReferenceExpression(testIdentifier);
+      assert element != null;
+
+      final FlutterEditorAnnotator annotator = new FlutterEditorAnnotator();
+      final AnnotationSession annotationSession = new AnnotationSession(testIdentifier.getContainingFile());
+      final AnnotationHolderImpl annotationHolder = new AnnotationHolderImpl(annotationSession);
+
+      annotator.annotate(element, annotationHolder);
+
+      assertTrue(annotationHolder.hasAnnotations());
+      assertEquals(1, annotationHolder.size());
+
+      final Annotation annotation = annotationHolder.get(0);
+      assertEquals(HighlightSeverity.INFORMATION, annotation.getSeverity());
+    });
+  }
+
+  @Test
+  public void locatesIconReference() throws Exception {
+    run(() -> {
+      final PsiElement testIdentifier = setUpDartElement("main() { Icons.access_alarm; }", "Icons", LeafPsiElement.class);
+      final DartReferenceExpression element = DartSyntax.findEnclosingReferenceExpression(testIdentifier);
+      assert element != null;
+
+      final FlutterEditorAnnotator annotator = new FlutterEditorAnnotator();
+      final AnnotationSession annotationSession = new AnnotationSession(testIdentifier.getContainingFile());
+      final AnnotationHolderImpl annotationHolder = new AnnotationHolderImpl(annotationSession);
+
+      annotator.annotate(element, annotationHolder);
+
+      assertTrue(annotationHolder.hasAnnotations());
+      assertEquals(1, annotationHolder.size());
+
+      final Annotation annotation = annotationHolder.get(0);
+      assertEquals(HighlightSeverity.INFORMATION, annotation.getSeverity());
+    });
+  }
+
+  @Test
+  public void locatesColorCtor() throws Exception {
+    run(() -> {
+      final PsiElement testIdentifier = setUpDartElement("main() { Color(0xFFE3F2FD); }", "Color", LeafPsiElement.class);
+      final DartCallExpression element = DartSyntax.findEnclosingFunctionCall(testIdentifier, "Color");
+      assert element != null;
+
+      final FlutterEditorAnnotator annotator = new FlutterEditorAnnotator();
+      final AnnotationSession annotationSession = new AnnotationSession(testIdentifier.getContainingFile());
+      final AnnotationHolderImpl annotationHolder = new AnnotationHolderImpl(annotationSession);
+
+      annotator.annotate(element, annotationHolder);
+
+      assertTrue(annotationHolder.hasAnnotations());
+      assertEquals(1, annotationHolder.size());
+
+      final Annotation annotation = annotationHolder.get(0);
+      assertEquals(HighlightSeverity.INFORMATION, annotation.getSeverity());
+    });
+  }
+
+  @Test
+  public void locatesConstColorCtor() throws Exception {
+    run(() -> {
+      final PsiElement testIdentifier = setUpDartElement("main() { const Color(0xFFE3F2FD); }", "Color", LeafPsiElement.class);
+      final DartNewExpression element = DartSyntax.findEnclosingNewExpression(testIdentifier);
+      assert element != null;
+
+      final FlutterEditorAnnotator annotator = new FlutterEditorAnnotator();
+      final AnnotationSession annotationSession = new AnnotationSession(testIdentifier.getContainingFile());
+      final AnnotationHolderImpl annotationHolder = new AnnotationHolderImpl(annotationSession);
+
+      annotator.annotate(element, annotationHolder);
+
+      assertTrue(annotationHolder.hasAnnotations());
+      assertEquals(1, annotationHolder.size());
+
+      final Annotation annotation = annotationHolder.get(0);
+      assertEquals(HighlightSeverity.INFORMATION, annotation.getSeverity());
+    });
+  }
+
+  @Test
+  public void locatesIconCtor() throws Exception {
+    run(() -> {
+      final PsiElement testIdentifier =
+        setUpDartElement("main() { IconData(0xe190, fontFamily: 'MaterialIcons'); }", "IconData", LeafPsiElement.class);
+      final DartCallExpression element = DartSyntax.findEnclosingFunctionCall(testIdentifier, "IconData");
+      assert element != null;
+
+      final FlutterEditorAnnotator annotator = new FlutterEditorAnnotator();
+      final AnnotationSession annotationSession = new AnnotationSession(testIdentifier.getContainingFile());
+      final AnnotationHolderImpl annotationHolder = new AnnotationHolderImpl(annotationSession);
+
+      annotator.annotate(element, annotationHolder);
+
+      assertTrue(annotationHolder.hasAnnotations());
+      assertEquals(1, annotationHolder.size());
+
+      final Annotation annotation = annotationHolder.get(0);
+      assertEquals(HighlightSeverity.INFORMATION, annotation.getSeverity());
+    });
+  }
+
+  @Test
+  public void locatesConstIconCtor() throws Exception {
+    run(() -> {
+      final PsiElement testIdentifier =
+        setUpDartElement("main() { const IconData(0xe190, fontFamily: 'MaterialIcons'); }", "IconData", LeafPsiElement.class);
+      final DartNewExpression element = DartSyntax.findEnclosingNewExpression(testIdentifier);
+      assert element != null;
+
+      final FlutterEditorAnnotator annotator = new FlutterEditorAnnotator();
+      final AnnotationSession annotationSession = new AnnotationSession(testIdentifier.getContainingFile());
+      final AnnotationHolderImpl annotationHolder = new AnnotationHolderImpl(annotationSession);
+
+      annotator.annotate(element, annotationHolder);
+
+      assertTrue(annotationHolder.hasAnnotations());
+      assertEquals(1, annotationHolder.size());
+
+      final Annotation annotation = annotationHolder.get(0);
+      assertEquals(HighlightSeverity.INFORMATION, annotation.getSeverity());
+    });
+  }
+}

--- a/tool/colors/colors.dart
+++ b/tool/colors/colors.dart
@@ -17,6 +17,11 @@ import 'colors_main.dart';
 ///  * [Colors], which defines all of the standard material colors.
 class MaterialColor extends ColorSwatch<int> {
   /// Creates a color swatch with a variety of shades.
+  ///
+  /// The `primary` argument should be the 32 bit ARGB value of one of the
+  /// values in the swatch, as would be passed to the [new Color] constructor
+  /// for that same color, and as is exposed by [value]. (This is distinct from
+  /// the specific index of the color in the swatch.)
   const MaterialColor(int primary, Map<int, Color> swatch) : super(primary, swatch);
 
   /// The lightest shade.
@@ -61,7 +66,7 @@ class MaterialColor extends ColorSwatch<int> {
 /// See also:
 ///
 ///  * [Colors], which defines all of the standard material colors.
-///  * <https://material.io/guidelines/style/color.html#color-color-schemes>
+///  * <https://material.io/go/design-theming#color-color-schemes>
 class MaterialAccentColor extends ColorSwatch<int> {
   /// Creates a color swatch with a variety of shades appropriate for accent
   /// colors.
@@ -111,66 +116,66 @@ class MaterialAccentColor extends ColorSwatch<int> {
 /// Each [ColorSwatch] constant is a color and can used directly. For example:
 ///
 /// ```dart
-/// new Container(
+/// Container(
 ///   color: Colors.blue, // same as Colors.blue[500] or Colors.blue.shade500
 /// )
 /// ```
 ///
 /// ## Color palettes
 ///
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.pink.png)
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.pinkAccent.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.pink.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.pinkAccent.png)
 ///
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.red.png)
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.redAccent.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.red.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.redAccent.png)
 ///
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.deepOrange.png)
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.deepOrangeAccent.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.deepOrange.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.deepOrangeAccent.png)
 ///
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.orange.png)
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.orangeAccent.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.orange.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.orangeAccent.png)
 ///
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.amber.png)
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.amberAccent.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.amber.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.amberAccent.png)
 ///
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.yellow.png)
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.yellowAccent.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.yellow.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.yellowAccent.png)
 ///
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lime.png)
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.limeAccent.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lime.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.limeAccent.png)
 ///
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lightGreen.png)
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lightGreenAccent.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lightGreen.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lightGreenAccent.png)
 ///
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.green.png)
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.greenAccent.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.green.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.greenAccent.png)
 ///
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.teal.png)
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.tealAccent.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.teal.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.tealAccent.png)
 ///
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.cyan.png)
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.cyanAccent.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.cyan.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.cyanAccent.png)
 ///
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lightBlue.png)
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lightBlueAccent.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lightBlue.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lightBlueAccent.png)
 ///
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.blue.png)
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.blueAccent.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.blue.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.blueAccent.png)
 ///
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.indigo.png)
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.indigoAccent.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.indigo.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.indigoAccent.png)
 ///
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.purple.png)
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.purpleAccent.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.purple.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.purpleAccent.png)
 ///
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.deepPurple.png)
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.deepPurpleAccent.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.deepPurple.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.deepPurpleAccent.png)
 ///
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.blueGrey.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.blueGrey.png)
 ///
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.brown.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.brown.png)
 ///
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.grey.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.grey.png)
 ///
 /// ## Blacks and whites
 ///
@@ -178,8 +183,8 @@ class MaterialAccentColor extends ColorSwatch<int> {
 /// levels (e.g. [Colors.white12] and [Colors.white10]) are very hard to see and
 /// should be avoided in general. They are intended for very subtle effects.
 ///
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.blacks.png)
-/// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.whites.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.blacks.png)
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.whites.png)
 ///
 /// The [Colors.transparent] color isn't shown here because it is entirely
 /// invisible!
@@ -187,11 +192,11 @@ class Colors {
   Colors._();
 
   /// Completely invisible.
-  static const Color transparent = const Color(0x00000000);
+  static const Color transparent = Color(0x00000000);
 
   /// Completely opaque black.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.blacks.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.blacks.png)
   ///
   /// See also:
   ///
@@ -199,13 +204,13 @@ class Colors {
   ///    are variants on this color but with different opacities.
   ///  * [white], a solid white color.
   ///  * [transparent], a fully-transparent color.
-  static const Color black   = const Color(0xFF000000);
+  static const Color black = Color(0xFF000000);
 
   /// Black with 87% opacity.
   ///
   /// This is a good contrasting color for text in light themes.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.blacks.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.blacks.png)
   ///
   /// See also:
   ///
@@ -214,14 +219,14 @@ class Colors {
   ///    rather than hard-coding colors in your build methods.
   ///  * [black], [black54], [black45], [black38], [black26], [black12], which
   ///    are variants on this color but with different opacities.
-  static const Color black87 = const Color(0xDD000000);
+  static const Color black87 = Color(0xDD000000);
 
   /// Black with 54% opacity.
   ///
   /// This is a color commonly used for headings in light themes. It's also used
   /// as the mask color behind dialogs.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.blacks.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.blacks.png)
   ///
   /// See also:
   ///
@@ -230,37 +235,37 @@ class Colors {
   ///    rather than hard-coding colors in your build methods.
   ///  * [black], [black87], [black45], [black38], [black26], [black12], which
   ///    are variants on this color but with different opacities.
-  static const Color black54 = const Color(0x8A000000);
+  static const Color black54 = Color(0x8A000000);
 
   /// Black with 45% opacity.
   ///
   /// Used for disabled icons.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.blacks.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.blacks.png)
   ///
   /// See also:
   ///
   ///  * [black], [black87], [black54], [black38], [black26], [black12], which
   ///    are variants on this color but with different opacities.
-  static const Color black45 = const Color(0x73000000);
+  static const Color black45 = Color(0x73000000);
 
   /// Black with 38% opacity.
   ///
   /// Used for the placeholder text in data tables in light themes.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.blacks.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.blacks.png)
   ///
   /// See also:
   ///
   ///  * [black], [black87], [black54], [black45], [black26], [black12], which
   ///    are variants on this color but with different opacities.
-  static const Color black38 = const Color(0x61000000);
+  static const Color black38 = Color(0x61000000);
 
   /// Black with 26% opacity.
   ///
   /// Used for disabled radio buttons and the text of disabled flat buttons in light themes.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.blacks.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.blacks.png)
   ///
   /// See also:
   ///
@@ -269,11 +274,11 @@ class Colors {
   ///    rather than hard-coding colors in your build methods.
   ///  * [black], [black87], [black54], [black45], [black38], [black12], which
   ///    are variants on this color but with different opacities.
-  static const Color black26 = const Color(0x42000000);
+  static const Color black26 = Color(0x42000000);
 
   /// Black with 12% opacity.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.blacks.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.blacks.png)
   ///
   /// Used for the background of disabled raised buttons in light themes.
   ///
@@ -281,14 +286,14 @@ class Colors {
   ///
   ///  * [black], [black87], [black54], [black45], [black38], [black26], which
   ///    are variants on this color but with different opacities.
-  static const Color black12 = const Color(0x1F000000);
+  static const Color black12 = Color(0x1F000000);
 
   /// Completely opaque white.
   ///
   /// This is a good contrasting color for the [ThemeData.primaryColor] in the
   /// dark theme. See [ThemeData.brightness].
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.whites.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.whites.png)
   ///
   /// See also:
   ///
@@ -299,13 +304,13 @@ class Colors {
   ///    but with different opacities.
   ///  * [black], a solid black color.
   ///  * [transparent], a fully-transparent color.
-  static const Color white   = const Color(0xFFFFFFFF);
+  static const Color white = Color(0xFFFFFFFF);
 
   /// White with 70% opacity.
   ///
   /// This is a color commonly used for headings in dark themes.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.whites.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.whites.png)
   ///
   /// See also:
   ///
@@ -314,13 +319,26 @@ class Colors {
   ///    rather than hard-coding colors in your build methods.
   ///  * [white, white30, white12, white10], which are variants on this color
   ///    but with different opacities.
-  static const Color white70 = const Color(0xB3FFFFFF);
+  static const Color white70 = Color(0xB3FFFFFF);
+
+  /// White with 54% opacity.
+  ///
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.whites.png)
+  ///
+  /// See also:
+  ///
+  ///  * [ExpandIcon], which uses this color for dark themes.
+  ///  * [Theme.of], which allows you to select colors from the current theme
+  ///    rather than hard-coding colors in your build methods.
+  ///  * [white, white30, white12, white10], which are variants on this color
+  ///    but with different opacities.
+  static const Color white54 = Color(0x8AFFFFFF);
 
   /// White with 32% opacity.
   ///
   /// Used for disabled radio buttons and the text of disabled flat buttons in dark themes.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.whites.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.whites.png)
   ///
   /// See also:
   ///
@@ -329,11 +347,23 @@ class Colors {
   ///    rather than hard-coding colors in your build methods.
   ///  * [white, white70, white12, white10], which are variants on this color
   ///    but with different opacities.
-  static const Color white30 = const Color(0x4DFFFFFF);
+  static const Color white30 = Color(0x4DFFFFFF);
+
+  /// White with 24% opacity.
+  ///
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.whites.png)
+  ///
+  /// Used for the splash color for filled buttons.
+  ///
+  /// See also:
+  ///
+  ///  * [white, white70, white30, white10], which are variants on this color
+  ///    but with different opacities.
+  static const Color white24 = Color(0x3DFFFFFF);
 
   /// White with 12% opacity.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.whites.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.whites.png)
   ///
   /// Used for the background of disabled raised buttons in dark themes.
   ///
@@ -341,34 +371,34 @@ class Colors {
   ///
   ///  * [white, white70, white30, white10], which are variants on this color
   ///    but with different opacities.
-  static const Color white12 = const Color(0x1FFFFFFF);
+  static const Color white12 = Color(0x1FFFFFFF);
 
   /// White with 10% opacity.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.whites.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.whites.png)
   ///
   /// See also:
   ///
   ///  * [white, white70, white30, white12], which are variants on this color
   ///    but with different opacities.
   ///  * [transparent], a fully-transparent color, not far from this one.
-  static const Color white10 = const Color(0x1AFFFFFF);
+  static const Color white10 = Color(0x1AFFFFFF);
 
   /// The red primary color and swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.red.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.redAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.red.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.redAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.deepOrange.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.deepOrangeAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.deepOrange.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.deepOrangeAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.pink.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.pinkAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.pink.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.pinkAccent.png)
   ///
   /// ## Sample code
   ///
   /// ```dart
-  /// new Icon(
+  /// Icon(
   ///   Icons.widgets,
   ///   color: Colors.red[400],
   /// )
@@ -380,38 +410,38 @@ class Colors {
   ///  * [deepOrange] and [pink], similar colors.
   ///  * [Theme.of], which allows you to select colors from the current theme
   ///    rather than hard-coding colors in your build methods.
-  static const MaterialColor red = const MaterialColor(
+  static const MaterialColor red = MaterialColor(
     _redPrimaryValue,
-    const <int, Color>{
-       50: const Color(0xFFFFEBEE),
-      100: const Color(0xFFFFCDD2),
-      200: const Color(0xFFEF9A9A),
-      300: const Color(0xFFE57373),
-      400: const Color(0xFFEF5350),
-      500: const Color(_redPrimaryValue),
-      600: const Color(0xFFE53935),
-      700: const Color(0xFFD32F2F),
-      800: const Color(0xFFC62828),
-      900: const Color(0xFFB71C1C),
+    <int, Color>{
+       50: Color(0xFFFFEBEE),
+      100: Color(0xFFFFCDD2),
+      200: Color(0xFFEF9A9A),
+      300: Color(0xFFE57373),
+      400: Color(0xFFEF5350),
+      500: Color(_redPrimaryValue),
+      600: Color(0xFFE53935),
+      700: Color(0xFFD32F2F),
+      800: Color(0xFFC62828),
+      900: Color(0xFFB71C1C),
     },
   );
   static const int _redPrimaryValue = 0xFFF44336;
 
   /// The red accent swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.red.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.redAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.red.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.redAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.deepOrange.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.deepOrangeAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.deepOrange.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.deepOrangeAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.pink.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.pinkAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.pink.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.pinkAccent.png)
   ///
   /// ## Sample code
   ///
   /// ```dart
-  /// new Icon(
+  /// Icon(
   ///   Icons.widgets,
   ///   color: Colors.redAccent[400],
   /// )
@@ -423,32 +453,32 @@ class Colors {
   ///  * [deepOrangeAccent] and [pinkAccent], similar colors.
   ///  * [Theme.of], which allows you to select colors from the current theme
   ///    rather than hard-coding colors in your build methods.
-  static const MaterialAccentColor redAccent = const MaterialAccentColor(
+  static const MaterialAccentColor redAccent = MaterialAccentColor(
     _redAccentValue,
-    const <int, Color>{
-      100: const Color(0xFFFF8A80),
-      200: const Color(_redAccentValue),
-      400: const Color(0xFFFF1744),
-      700: const Color(0xFFD50000),
+    <int, Color>{
+      100: Color(0xFFFF8A80),
+      200: Color(_redAccentValue),
+      400: Color(0xFFFF1744),
+      700: Color(0xFFD50000),
     },
   );
   static const int _redAccentValue = 0xFFFF5252;
 
   /// The pink primary color and swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.pink.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.pinkAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.pink.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.pinkAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.red.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.redAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.red.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.redAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.purple.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.purpleAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.purple.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.purpleAccent.png)
   ///
   /// ## Sample code
   ///
   /// ```dart
-  /// new Icon(
+  /// Icon(
   ///   Icons.widgets,
   ///   color: Colors.pink[400],
   /// )
@@ -460,38 +490,38 @@ class Colors {
   ///  * [red] and [purple], similar colors.
   ///  * [Theme.of], which allows you to select colors from the current theme
   ///    rather than hard-coding colors in your build methods.
-  static const MaterialColor pink = const MaterialColor(
+  static const MaterialColor pink = MaterialColor(
     _pinkPrimaryValue,
-    const <int, Color>{
-       50: const Color(0xFFFCE4EC),
-      100: const Color(0xFFF8BBD0),
-      200: const Color(0xFFF48FB1),
-      300: const Color(0xFFF06292),
-      400: const Color(0xFFEC407A),
-      500: const Color(_pinkPrimaryValue),
-      600: const Color(0xFFD81B60),
-      700: const Color(0xFFC2185B),
-      800: const Color(0xFFAD1457),
-      900: const Color(0xFF880E4F),
+    <int, Color>{
+       50: Color(0xFFFCE4EC),
+      100: Color(0xFFF8BBD0),
+      200: Color(0xFFF48FB1),
+      300: Color(0xFFF06292),
+      400: Color(0xFFEC407A),
+      500: Color(_pinkPrimaryValue),
+      600: Color(0xFFD81B60),
+      700: Color(0xFFC2185B),
+      800: Color(0xFFAD1457),
+      900: Color(0xFF880E4F),
     },
   );
   static const int _pinkPrimaryValue = 0xFFE91E63;
 
   /// The pink accent color swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.pink.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.pinkAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.pink.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.pinkAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.red.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.redAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.red.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.redAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.purple.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.purpleAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.purple.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.purpleAccent.png)
   ///
   /// ## Sample code
   ///
   /// ```dart
-  /// new Icon(
+  /// Icon(
   ///   Icons.widgets,
   ///   color: Colors.pinkAccent[400],
   /// )
@@ -503,32 +533,32 @@ class Colors {
   ///  * [redAccent] and [purpleAccent], similar colors.
   ///  * [Theme.of], which allows you to select colors from the current theme
   ///    rather than hard-coding colors in your build methods.
-  static const MaterialAccentColor pinkAccent = const MaterialAccentColor(
+  static const MaterialAccentColor pinkAccent = MaterialAccentColor(
     _pinkAccentPrimaryValue,
-    const <int, Color>{
-      100: const Color(0xFFFF80AB),
-      200: const Color(_pinkAccentPrimaryValue),
-      400: const Color(0xFFF50057),
-      700: const Color(0xFFC51162),
+    <int, Color>{
+      100: Color(0xFFFF80AB),
+      200: Color(_pinkAccentPrimaryValue),
+      400: Color(0xFFF50057),
+      700: Color(0xFFC51162),
     },
   );
   static const int _pinkAccentPrimaryValue = 0xFFFF4081;
 
   /// The purple primary color and swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.purple.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.purpleAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.purple.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.purpleAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.deepPurple.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.deepPurpleAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.deepPurple.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.deepPurpleAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.pink.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.pinkAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.pink.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.pinkAccent.png)
   ///
   /// ## Sample code
   ///
   /// ```dart
-  /// new Icon(
+  /// Icon(
   ///   Icons.widgets,
   ///   color: Colors.purple[400],
   /// )
@@ -540,38 +570,38 @@ class Colors {
   ///  * [deepPurple] and [pink], similar colors.
   ///  * [Theme.of], which allows you to select colors from the current theme
   ///    rather than hard-coding colors in your build methods.
-  static const MaterialColor purple = const MaterialColor(
+  static const MaterialColor purple = MaterialColor(
     _purplePrimaryValue,
-    const <int, Color>{
-       50: const Color(0xFFF3E5F5),
-      100: const Color(0xFFE1BEE7),
-      200: const Color(0xFFCE93D8),
-      300: const Color(0xFFBA68C8),
-      400: const Color(0xFFAB47BC),
-      500: const Color(_purplePrimaryValue),
-      600: const Color(0xFF8E24AA),
-      700: const Color(0xFF7B1FA2),
-      800: const Color(0xFF6A1B9A),
-      900: const Color(0xFF4A148C),
+    <int, Color>{
+       50: Color(0xFFF3E5F5),
+      100: Color(0xFFE1BEE7),
+      200: Color(0xFFCE93D8),
+      300: Color(0xFFBA68C8),
+      400: Color(0xFFAB47BC),
+      500: Color(_purplePrimaryValue),
+      600: Color(0xFF8E24AA),
+      700: Color(0xFF7B1FA2),
+      800: Color(0xFF6A1B9A),
+      900: Color(0xFF4A148C),
     },
   );
   static const int _purplePrimaryValue = 0xFF9C27B0;
 
   /// The purple accent color and swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.purple.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.purpleAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.purple.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.purpleAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.deepPurple.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.deepPurpleAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.deepPurple.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.deepPurpleAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.pink.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.pinkAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.pink.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.pinkAccent.png)
   ///
   /// ## Sample code
   ///
   /// ```dart
-  /// new Icon(
+  /// Icon(
   ///   Icons.widgets,
   ///   color: Colors.purpleAccent[400],
   /// )
@@ -583,32 +613,32 @@ class Colors {
   ///  * [deepPurpleAccent] and [pinkAccent], similar colors.
   ///  * [Theme.of], which allows you to select colors from the current theme
   ///    rather than hard-coding colors in your build methods.
-  static const MaterialAccentColor purpleAccent = const MaterialAccentColor(
+  static const MaterialAccentColor purpleAccent = MaterialAccentColor(
     _purpleAccentPrimaryValue,
-    const <int, Color>{
-      100: const Color(0xFFEA80FC),
-      200: const Color(_purpleAccentPrimaryValue),
-      400: const Color(0xFFD500F9),
-      700: const Color(0xFFAA00FF),
+    <int, Color>{
+      100: Color(0xFFEA80FC),
+      200: Color(_purpleAccentPrimaryValue),
+      400: Color(0xFFD500F9),
+      700: Color(0xFFAA00FF),
     },
   );
   static const int _purpleAccentPrimaryValue = 0xFFE040FB;
 
   /// The deep purple primary color and swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.deepPurple.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.deepPurpleAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.deepPurple.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.deepPurpleAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.purple.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.purpleAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.purple.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.purpleAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.indigo.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.indigoAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.indigo.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.indigoAccent.png)
   ///
   /// ## Sample code
   ///
   /// ```dart
-  /// new Icon(
+  /// Icon(
   ///   Icons.widgets,
   ///   color: Colors.deepPurple[400],
   /// )
@@ -620,38 +650,38 @@ class Colors {
   ///  * [purple] and [indigo], similar colors.
   ///  * [Theme.of], which allows you to select colors from the current theme
   ///    rather than hard-coding colors in your build methods.
-  static const MaterialColor deepPurple = const MaterialColor(
+  static const MaterialColor deepPurple = MaterialColor(
     _deepPurplePrimaryValue,
-    const <int, Color>{
-       50: const Color(0xFFEDE7F6),
-      100: const Color(0xFFD1C4E9),
-      200: const Color(0xFFB39DDB),
-      300: const Color(0xFF9575CD),
-      400: const Color(0xFF7E57C2),
-      500: const Color(_deepPurplePrimaryValue),
-      600: const Color(0xFF5E35B1),
-      700: const Color(0xFF512DA8),
-      800: const Color(0xFF4527A0),
-      900: const Color(0xFF311B92),
+    <int, Color>{
+       50: Color(0xFFEDE7F6),
+      100: Color(0xFFD1C4E9),
+      200: Color(0xFFB39DDB),
+      300: Color(0xFF9575CD),
+      400: Color(0xFF7E57C2),
+      500: Color(_deepPurplePrimaryValue),
+      600: Color(0xFF5E35B1),
+      700: Color(0xFF512DA8),
+      800: Color(0xFF4527A0),
+      900: Color(0xFF311B92),
     },
   );
   static const int _deepPurplePrimaryValue = 0xFF673AB7;
 
   /// The deep purple accent color and swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.deepPurple.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.deepPurpleAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.deepPurple.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.deepPurpleAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.purple.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.purpleAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.purple.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.purpleAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.indigo.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.indigoAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.indigo.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.indigoAccent.png)
   ///
   /// ## Sample code
   ///
   /// ```dart
-  /// new Icon(
+  /// Icon(
   ///   Icons.widgets,
   ///   color: Colors.deepPurpleAccent[400],
   /// )
@@ -663,32 +693,32 @@ class Colors {
   ///  * [purpleAccent] and [indigoAccent], similar colors.
   ///  * [Theme.of], which allows you to select colors from the current theme
   ///    rather than hard-coding colors in your build methods.
-  static const MaterialAccentColor deepPurpleAccent = const MaterialAccentColor(
+  static const MaterialAccentColor deepPurpleAccent = MaterialAccentColor(
     _deepPurpleAccentPrimaryValue,
-    const <int, Color>{
-      100: const Color(0xFFB388FF),
-      200: const Color(_deepPurpleAccentPrimaryValue),
-      400: const Color(0xFF651FFF),
-      700: const Color(0xFF6200EA),
+    <int, Color>{
+      100: Color(0xFFB388FF),
+      200: Color(_deepPurpleAccentPrimaryValue),
+      400: Color(0xFF651FFF),
+      700: Color(0xFF6200EA),
     },
   );
   static const int _deepPurpleAccentPrimaryValue = 0xFF7C4DFF;
 
   /// The indigo primary color and swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.indigo.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.indigoAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.indigo.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.indigoAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.blue.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.blueAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.blue.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.blueAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.deepPurple.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.deepPurpleAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.deepPurple.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.deepPurpleAccent.png)
   ///
   /// ## Sample code
   ///
   /// ```dart
-  /// new Icon(
+  /// Icon(
   ///   Icons.widgets,
   ///   color: Colors.indigo[400],
   /// )
@@ -700,38 +730,38 @@ class Colors {
   ///  * [blue] and [deepPurple], similar colors.
   ///  * [Theme.of], which allows you to select colors from the current theme
   ///    rather than hard-coding colors in your build methods.
-  static const MaterialColor indigo = const MaterialColor(
+  static const MaterialColor indigo = MaterialColor(
     _indigoPrimaryValue,
-    const <int, Color>{
-       50: const Color(0xFFE8EAF6),
-      100: const Color(0xFFC5CAE9),
-      200: const Color(0xFF9FA8DA),
-      300: const Color(0xFF7986CB),
-      400: const Color(0xFF5C6BC0),
-      500: const Color(_indigoPrimaryValue),
-      600: const Color(0xFF3949AB),
-      700: const Color(0xFF303F9F),
-      800: const Color(0xFF283593),
-      900: const Color(0xFF1A237E),
+    <int, Color>{
+       50: Color(0xFFE8EAF6),
+      100: Color(0xFFC5CAE9),
+      200: Color(0xFF9FA8DA),
+      300: Color(0xFF7986CB),
+      400: Color(0xFF5C6BC0),
+      500: Color(_indigoPrimaryValue),
+      600: Color(0xFF3949AB),
+      700: Color(0xFF303F9F),
+      800: Color(0xFF283593),
+      900: Color(0xFF1A237E),
     },
   );
   static const int _indigoPrimaryValue = 0xFF3F51B5;
 
   /// The indigo accent color and swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.indigo.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.indigoAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.indigo.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.indigoAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.blue.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.blueAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.blue.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.blueAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.deepPurple.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.deepPurpleAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.deepPurple.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.deepPurpleAccent.png)
   ///
   /// ## Sample code
   ///
   /// ```dart
-  /// new Icon(
+  /// Icon(
   ///   Icons.widgets,
   ///   color: Colors.indigoAccent[400],
   /// )
@@ -743,34 +773,34 @@ class Colors {
   ///  * [blueAccent] and [deepPurpleAccent], similar colors.
   ///  * [Theme.of], which allows you to select colors from the current theme
   ///    rather than hard-coding colors in your build methods.
-  static const MaterialAccentColor indigoAccent = const MaterialAccentColor(
+  static const MaterialAccentColor indigoAccent = MaterialAccentColor(
     _indigoAccentPrimaryValue,
-    const <int, Color>{
-      100: const Color(0xFF8C9EFF),
-      200: const Color(_indigoAccentPrimaryValue),
-      400: const Color(0xFF3D5AFE),
-      700: const Color(0xFF304FFE),
+    <int, Color>{
+      100: Color(0xFF8C9EFF),
+      200: Color(_indigoAccentPrimaryValue),
+      400: Color(0xFF3D5AFE),
+      700: Color(0xFF304FFE),
     },
   );
   static const int _indigoAccentPrimaryValue = 0xFF536DFE;
 
   /// The blue primary color and swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.blue.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.blueAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.blue.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.blueAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.indigo.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.indigoAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.indigo.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.indigoAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lightBlue.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lightBlueAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lightBlue.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lightBlueAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.blueGrey.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.blueGrey.png)
   ///
   /// ## Sample code
   ///
   /// ```dart
-  /// new Icon(
+  /// Icon(
   ///   Icons.widgets,
   ///   color: Colors.blue[400],
   /// )
@@ -782,38 +812,38 @@ class Colors {
   ///  * [indigo], [lightBlue], and [blueGrey], similar colors.
   ///  * [Theme.of], which allows you to select colors from the current theme
   ///    rather than hard-coding colors in your build methods.
-  static const MaterialColor blue = const MaterialColor(
+  static const MaterialColor blue = MaterialColor(
     _bluePrimaryValue,
-    const <int, Color>{
-       50: const Color(0xFFE3F2FD),
-      100: const Color(0xFFBBDEFB),
-      200: const Color(0xFF90CAF9),
-      300: const Color(0xFF64B5F6),
-      400: const Color(0xFF42A5F5),
-      500: const Color(_bluePrimaryValue),
-      600: const Color(0xFF1E88E5),
-      700: const Color(0xFF1976D2),
-      800: const Color(0xFF1565C0),
-      900: const Color(0xFF0D47A1),
+    <int, Color>{
+       50: Color(0xFFE3F2FD),
+      100: Color(0xFFBBDEFB),
+      200: Color(0xFF90CAF9),
+      300: Color(0xFF64B5F6),
+      400: Color(0xFF42A5F5),
+      500: Color(_bluePrimaryValue),
+      600: Color(0xFF1E88E5),
+      700: Color(0xFF1976D2),
+      800: Color(0xFF1565C0),
+      900: Color(0xFF0D47A1),
     },
   );
   static const int _bluePrimaryValue = 0xFF2196F3;
 
   /// The blue accent color and swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.blue.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.blueAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.blue.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.blueAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.indigo.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.indigoAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.indigo.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.indigoAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lightBlue.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lightBlueAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lightBlue.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lightBlueAccent.png)
   ///
   /// ## Sample code
   ///
   /// ```dart
-  /// new Icon(
+  /// Icon(
   ///   Icons.widgets,
   ///   color: Colors.blueAccent[400],
   /// )
@@ -825,32 +855,32 @@ class Colors {
   ///  * [indigoAccent] and [lightBlueAccent], similar colors.
   ///  * [Theme.of], which allows you to select colors from the current theme
   ///    rather than hard-coding colors in your build methods.
-  static const MaterialAccentColor blueAccent = const MaterialAccentColor(
+  static const MaterialAccentColor blueAccent = MaterialAccentColor(
     _blueAccentPrimaryValue,
-    const <int, Color>{
-      100: const Color(0xFF82B1FF),
-      200: const Color(_blueAccentPrimaryValue),
-      400: const Color(0xFF2979FF),
-      700: const Color(0xFF2962FF),
+    <int, Color>{
+      100: Color(0xFF82B1FF),
+      200: Color(_blueAccentPrimaryValue),
+      400: Color(0xFF2979FF),
+      700: Color(0xFF2962FF),
     },
   );
   static const int _blueAccentPrimaryValue = 0xFF448AFF;
 
   /// The light blue primary color and swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lightBlue.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lightBlueAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lightBlue.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lightBlueAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.blue.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.blueAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.blue.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.blueAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.cyan.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.cyanAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.cyan.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.cyanAccent.png)
   ///
   /// ## Sample code
   ///
   /// ```dart
-  /// new Icon(
+  /// Icon(
   ///   Icons.widgets,
   ///   color: Colors.lightBlue[400],
   /// )
@@ -862,38 +892,38 @@ class Colors {
   ///  * [blue] and [cyan], similar colors.
   ///  * [Theme.of], which allows you to select colors from the current theme
   ///    rather than hard-coding colors in your build methods.
-  static const MaterialColor lightBlue = const MaterialColor(
+  static const MaterialColor lightBlue = MaterialColor(
     _lightBluePrimaryValue,
-    const <int, Color>{
-       50: const Color(0xFFE1F5FE),
-      100: const Color(0xFFB3E5FC),
-      200: const Color(0xFF81D4FA),
-      300: const Color(0xFF4FC3F7),
-      400: const Color(0xFF29B6F6),
-      500: const Color(_lightBluePrimaryValue),
-      600: const Color(0xFF039BE5),
-      700: const Color(0xFF0288D1),
-      800: const Color(0xFF0277BD),
-      900: const Color(0xFF01579B),
+    <int, Color>{
+       50: Color(0xFFE1F5FE),
+      100: Color(0xFFB3E5FC),
+      200: Color(0xFF81D4FA),
+      300: Color(0xFF4FC3F7),
+      400: Color(0xFF29B6F6),
+      500: Color(_lightBluePrimaryValue),
+      600: Color(0xFF039BE5),
+      700: Color(0xFF0288D1),
+      800: Color(0xFF0277BD),
+      900: Color(0xFF01579B),
     },
   );
   static const int _lightBluePrimaryValue = 0xFF03A9F4;
 
   /// The light blue accent swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lightBlue.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lightBlueAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lightBlue.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lightBlueAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.blue.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.blueAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.blue.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.blueAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.cyan.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.cyanAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.cyan.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.cyanAccent.png)
   ///
   /// ## Sample code
   ///
   /// ```dart
-  /// new Icon(
+  /// Icon(
   ///   Icons.widgets,
   ///   color: Colors.lightBlueAccent[400],
   /// )
@@ -905,34 +935,34 @@ class Colors {
   ///  * [blueAccent] and [cyanAccent], similar colors.
   ///  * [Theme.of], which allows you to select colors from the current theme
   ///    rather than hard-coding colors in your build methods.
-  static const MaterialAccentColor lightBlueAccent = const MaterialAccentColor(
+  static const MaterialAccentColor lightBlueAccent = MaterialAccentColor(
     _lightBlueAccentPrimaryValue,
-    const <int, Color>{
-      100: const Color(0xFF80D8FF),
-      200: const Color(_lightBlueAccentPrimaryValue),
-      400: const Color(0xFF00B0FF),
-      700: const Color(0xFF0091EA),
+    <int, Color>{
+      100: Color(0xFF80D8FF),
+      200: Color(_lightBlueAccentPrimaryValue),
+      400: Color(0xFF00B0FF),
+      700: Color(0xFF0091EA),
     },
   );
   static const int _lightBlueAccentPrimaryValue = 0xFF40C4FF;
 
   /// The cyan primary color and swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.cyan.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.cyanAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.cyan.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.cyanAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lightBlue.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lightBlueAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lightBlue.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lightBlueAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.teal.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.tealAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.teal.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.tealAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.blueGrey.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.blueGrey.png)
   ///
   /// ## Sample code
   ///
   /// ```dart
-  /// new Icon(
+  /// Icon(
   ///   Icons.widgets,
   ///   color: Colors.cyan[400],
   /// )
@@ -944,38 +974,38 @@ class Colors {
   ///  * [lightBlue], [teal], and [blueGrey], similar colors.
   ///  * [Theme.of], which allows you to select colors from the current theme
   ///    rather than hard-coding colors in your build methods.
-  static const MaterialColor cyan = const MaterialColor(
+  static const MaterialColor cyan = MaterialColor(
     _cyanPrimaryValue,
-    const <int, Color>{
-       50: const Color(0xFFE0F7FA),
-      100: const Color(0xFFB2EBF2),
-      200: const Color(0xFF80DEEA),
-      300: const Color(0xFF4DD0E1),
-      400: const Color(0xFF26C6DA),
-      500: const Color(_cyanPrimaryValue),
-      600: const Color(0xFF00ACC1),
-      700: const Color(0xFF0097A7),
-      800: const Color(0xFF00838F),
-      900: const Color(0xFF006064),
+    <int, Color>{
+       50: Color(0xFFE0F7FA),
+      100: Color(0xFFB2EBF2),
+      200: Color(0xFF80DEEA),
+      300: Color(0xFF4DD0E1),
+      400: Color(0xFF26C6DA),
+      500: Color(_cyanPrimaryValue),
+      600: Color(0xFF00ACC1),
+      700: Color(0xFF0097A7),
+      800: Color(0xFF00838F),
+      900: Color(0xFF006064),
     },
   );
   static const int _cyanPrimaryValue = 0xFF00BCD4;
 
   /// The cyan accent color and swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.cyan.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.cyanAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.cyan.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.cyanAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lightBlue.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lightBlueAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lightBlue.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lightBlueAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.teal.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.tealAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.teal.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.tealAccent.png)
   ///
   /// ## Sample code
   ///
   /// ```dart
-  /// new Icon(
+  /// Icon(
   ///   Icons.widgets,
   ///   color: Colors.cyanAccent[400],
   /// )
@@ -987,32 +1017,32 @@ class Colors {
   ///  * [lightBlueAccent] and [tealAccent], similar colors.
   ///  * [Theme.of], which allows you to select colors from the current theme
   ///    rather than hard-coding colors in your build methods.
-  static const MaterialAccentColor cyanAccent = const MaterialAccentColor(
+  static const MaterialAccentColor cyanAccent = MaterialAccentColor(
     _cyanAccentPrimaryValue,
-    const <int, Color>{
-      100: const Color(0xFF84FFFF),
-      200: const Color(_cyanAccentPrimaryValue),
-      400: const Color(0xFF00E5FF),
-      700: const Color(0xFF00B8D4),
+    <int, Color>{
+      100: Color(0xFF84FFFF),
+      200: Color(_cyanAccentPrimaryValue),
+      400: Color(0xFF00E5FF),
+      700: Color(0xFF00B8D4),
     },
   );
   static const int _cyanAccentPrimaryValue = 0xFF18FFFF;
 
   /// The teal primary color and swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.teal.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.tealAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.teal.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.tealAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.green.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.greenAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.green.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.greenAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.cyan.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.cyanAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.cyan.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.cyanAccent.png)
   ///
   /// ## Sample code
   ///
   /// ```dart
-  /// new Icon(
+  /// Icon(
   ///   Icons.widgets,
   ///   color: Colors.teal[400],
   /// )
@@ -1024,38 +1054,38 @@ class Colors {
   ///  * [green] and [cyan], similar colors.
   ///  * [Theme.of], which allows you to select colors from the current theme
   ///    rather than hard-coding colors in your build methods.
-  static const MaterialColor teal = const MaterialColor(
+  static const MaterialColor teal = MaterialColor(
     _tealPrimaryValue,
-    const <int, Color>{
-       50: const Color(0xFFE0F2F1),
-      100: const Color(0xFFB2DFDB),
-      200: const Color(0xFF80CBC4),
-      300: const Color(0xFF4DB6AC),
-      400: const Color(0xFF26A69A),
-      500: const Color(_tealPrimaryValue),
-      600: const Color(0xFF00897B),
-      700: const Color(0xFF00796B),
-      800: const Color(0xFF00695C),
-      900: const Color(0xFF004D40),
+    <int, Color>{
+       50: Color(0xFFE0F2F1),
+      100: Color(0xFFB2DFDB),
+      200: Color(0xFF80CBC4),
+      300: Color(0xFF4DB6AC),
+      400: Color(0xFF26A69A),
+      500: Color(_tealPrimaryValue),
+      600: Color(0xFF00897B),
+      700: Color(0xFF00796B),
+      800: Color(0xFF00695C),
+      900: Color(0xFF004D40),
     },
   );
   static const int _tealPrimaryValue = 0xFF009688;
 
   /// The teal accent color and swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.teal.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.tealAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.teal.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.tealAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.green.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.greenAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.green.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.greenAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.cyan.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.cyanAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.cyan.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.cyanAccent.png)
   ///
   /// ## Sample code
   ///
   /// ```dart
-  /// new Icon(
+  /// Icon(
   ///   Icons.widgets,
   ///   color: Colors.tealAccent[400],
   /// )
@@ -1067,35 +1097,35 @@ class Colors {
   ///  * [greenAccent] and [cyanAccent], similar colors.
   ///  * [Theme.of], which allows you to select colors from the current theme
   ///    rather than hard-coding colors in your build methods.
-  static const MaterialAccentColor tealAccent = const MaterialAccentColor(
+  static const MaterialAccentColor tealAccent = MaterialAccentColor(
     _tealAccentPrimaryValue,
-    const <int, Color>{
-      100: const Color(0xFFA7FFEB),
-      200: const Color(_tealAccentPrimaryValue),
-      400: const Color(0xFF1DE9B6),
-      700: const Color(0xFF00BFA5),
+    <int, Color>{
+      100: Color(0xFFA7FFEB),
+      200: Color(_tealAccentPrimaryValue),
+      400: Color(0xFF1DE9B6),
+      700: Color(0xFF00BFA5),
     },
   );
   static const int _tealAccentPrimaryValue = 0xFF64FFDA;
 
   /// The green primary color and swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.green.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.greenAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.green.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.greenAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.teal.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.tealAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.teal.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.tealAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lightGreen.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lightGreenAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lightGreen.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lightGreenAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lime.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.limeAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lime.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.limeAccent.png)
   ///
   /// ## Sample code
   ///
   /// ```dart
-  /// new Icon(
+  /// Icon(
   ///   Icons.widgets,
   ///   color: Colors.green[400],
   /// )
@@ -1107,41 +1137,41 @@ class Colors {
   ///  * [teal], [lightGreen], and [lime], similar colors.
   ///  * [Theme.of], which allows you to select colors from the current theme
   ///    rather than hard-coding colors in your build methods.
-  static const MaterialColor green = const MaterialColor(
+  static const MaterialColor green = MaterialColor(
     _greenPrimaryValue,
-    const <int, Color>{
-       50: const Color(0xFFE8F5E9),
-      100: const Color(0xFFC8E6C9),
-      200: const Color(0xFFA5D6A7),
-      300: const Color(0xFF81C784),
-      400: const Color(0xFF66BB6A),
-      500: const Color(_greenPrimaryValue),
-      600: const Color(0xFF43A047),
-      700: const Color(0xFF388E3C),
-      800: const Color(0xFF2E7D32),
-      900: const Color(0xFF1B5E20),
+    <int, Color>{
+       50: Color(0xFFE8F5E9),
+      100: Color(0xFFC8E6C9),
+      200: Color(0xFFA5D6A7),
+      300: Color(0xFF81C784),
+      400: Color(0xFF66BB6A),
+      500: Color(_greenPrimaryValue),
+      600: Color(0xFF43A047),
+      700: Color(0xFF388E3C),
+      800: Color(0xFF2E7D32),
+      900: Color(0xFF1B5E20),
     },
   );
   static const int _greenPrimaryValue = 0xFF4CAF50;
 
   /// The green accent color and swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.green.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.greenAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.green.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.greenAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.teal.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.tealAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.teal.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.tealAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lightGreen.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lightGreenAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lightGreen.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lightGreenAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lime.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.limeAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lime.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.limeAccent.png)
   ///
   /// ## Sample code
   ///
   /// ```dart
-  /// new Icon(
+  /// Icon(
   ///   Icons.widgets,
   ///   color: Colors.greenAccent[400],
   /// )
@@ -1153,32 +1183,32 @@ class Colors {
   ///  * [tealAccent], [lightGreenAccent], and [limeAccent], similar colors.
   ///  * [Theme.of], which allows you to select colors from the current theme
   ///    rather than hard-coding colors in your build methods.
-  static const MaterialAccentColor greenAccent = const MaterialAccentColor(
+  static const MaterialAccentColor greenAccent = MaterialAccentColor(
     _greenAccentPrimaryValue,
-    const <int, Color>{
-      100: const Color(0xFFB9F6CA),
-      200: const Color(_greenAccentPrimaryValue),
-      400: const Color(0xFF00E676),
-      700: const Color(0xFF00C853),
+    <int, Color>{
+      100: Color(0xFFB9F6CA),
+      200: Color(_greenAccentPrimaryValue),
+      400: Color(0xFF00E676),
+      700: Color(0xFF00C853),
     },
   );
   static const int _greenAccentPrimaryValue = 0xFF69F0AE;
 
   /// The light green primary color and swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lightGreen.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lightGreenAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lightGreen.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lightGreenAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.green.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.greenAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.green.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.greenAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lime.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.limeAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lime.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.limeAccent.png)
   ///
   /// ## Sample code
   ///
   /// ```dart
-  /// new Icon(
+  /// Icon(
   ///   Icons.widgets,
   ///   color: Colors.lightGreen[400],
   /// )
@@ -1190,38 +1220,38 @@ class Colors {
   ///  * [green] and [lime], similar colors.
   ///  * [Theme.of], which allows you to select colors from the current theme
   ///    rather than hard-coding colors in your build methods.
-  static const MaterialColor lightGreen = const MaterialColor(
+  static const MaterialColor lightGreen = MaterialColor(
     _lightGreenPrimaryValue,
-    const <int, Color>{
-       50: const Color(0xFFF1F8E9),
-      100: const Color(0xFFDCEDC8),
-      200: const Color(0xFFC5E1A5),
-      300: const Color(0xFFAED581),
-      400: const Color(0xFF9CCC65),
-      500: const Color(_lightGreenPrimaryValue),
-      600: const Color(0xFF7CB342),
-      700: const Color(0xFF689F38),
-      800: const Color(0xFF558B2F),
-      900: const Color(0xFF33691E),
+    <int, Color>{
+       50: Color(0xFFF1F8E9),
+      100: Color(0xFFDCEDC8),
+      200: Color(0xFFC5E1A5),
+      300: Color(0xFFAED581),
+      400: Color(0xFF9CCC65),
+      500: Color(_lightGreenPrimaryValue),
+      600: Color(0xFF7CB342),
+      700: Color(0xFF689F38),
+      800: Color(0xFF558B2F),
+      900: Color(0xFF33691E),
     },
   );
   static const int _lightGreenPrimaryValue = 0xFF8BC34A;
 
   /// The light green accent color and swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lightGreen.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lightGreenAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lightGreen.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lightGreenAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.green.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.greenAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.green.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.greenAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lime.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.limeAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lime.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.limeAccent.png)
   ///
   /// ## Sample code
   ///
   /// ```dart
-  /// new Icon(
+  /// Icon(
   ///   Icons.widgets,
   ///   color: Colors.lightGreenAccent[400],
   /// )
@@ -1233,32 +1263,32 @@ class Colors {
   ///  * [greenAccent] and [limeAccent], similar colors.
   ///  * [Theme.of], which allows you to select colors from the current theme
   ///    rather than hard-coding colors in your build methods.
-  static const MaterialAccentColor lightGreenAccent = const MaterialAccentColor(
+  static const MaterialAccentColor lightGreenAccent = MaterialAccentColor(
     _lightGreenAccentPrimaryValue,
-    const <int, Color>{
-      100: const Color(0xFFCCFF90),
-      200: const Color(_lightGreenAccentPrimaryValue),
-      400: const Color(0xFF76FF03),
-      700: const Color(0xFF64DD17),
+    <int, Color>{
+      100: Color(0xFFCCFF90),
+      200: Color(_lightGreenAccentPrimaryValue),
+      400: Color(0xFF76FF03),
+      700: Color(0xFF64DD17),
     },
   );
   static const int _lightGreenAccentPrimaryValue = 0xFFB2FF59;
 
   /// The lime primary color and swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lime.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.limeAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lime.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.limeAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lightGreen.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lightGreenAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lightGreen.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lightGreenAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.yellow.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.yellowAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.yellow.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.yellowAccent.png)
   ///
   /// ## Sample code
   ///
   /// ```dart
-  /// new Icon(
+  /// Icon(
   ///   Icons.widgets,
   ///   color: Colors.lime[400],
   /// )
@@ -1270,38 +1300,38 @@ class Colors {
   ///  * [lightGreen] and [yellow], similar colors.
   ///  * [Theme.of], which allows you to select colors from the current theme
   ///    rather than hard-coding colors in your build methods.
-  static const MaterialColor lime = const MaterialColor(
+  static const MaterialColor lime = MaterialColor(
     _limePrimaryValue,
-    const <int, Color>{
-       50: const Color(0xFFF9FBE7),
-      100: const Color(0xFFF0F4C3),
-      200: const Color(0xFFE6EE9C),
-      300: const Color(0xFFDCE775),
-      400: const Color(0xFFD4E157),
-      500: const Color(_limePrimaryValue),
-      600: const Color(0xFFC0CA33),
-      700: const Color(0xFFAFB42B),
-      800: const Color(0xFF9E9D24),
-      900: const Color(0xFF827717),
+    <int, Color>{
+       50: Color(0xFFF9FBE7),
+      100: Color(0xFFF0F4C3),
+      200: Color(0xFFE6EE9C),
+      300: Color(0xFFDCE775),
+      400: Color(0xFFD4E157),
+      500: Color(_limePrimaryValue),
+      600: Color(0xFFC0CA33),
+      700: Color(0xFFAFB42B),
+      800: Color(0xFF9E9D24),
+      900: Color(0xFF827717),
     },
   );
   static const int _limePrimaryValue = 0xFFCDDC39;
 
   /// The lime accent primary color and swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lime.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.limeAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lime.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.limeAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lightGreen.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lightGreenAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lightGreen.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lightGreenAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.yellow.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.yellowAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.yellow.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.yellowAccent.png)
   ///
   /// ## Sample code
   ///
   /// ```dart
-  /// new Icon(
+  /// Icon(
   ///   Icons.widgets,
   ///   color: Colors.limeAccent[400],
   /// )
@@ -1313,32 +1343,32 @@ class Colors {
   ///  * [lightGreenAccent] and [yellowAccent], similar colors.
   ///  * [Theme.of], which allows you to select colors from the current theme
   ///    rather than hard-coding colors in your build methods.
-  static const MaterialAccentColor limeAccent = const MaterialAccentColor(
+  static const MaterialAccentColor limeAccent = MaterialAccentColor(
     _limeAccentPrimaryValue,
-    const <int, Color>{
-      100: const Color(0xFFF4FF81),
-      200: const Color(_limeAccentPrimaryValue),
-      400: const Color(0xFFC6FF00),
-      700: const Color(0xFFAEEA00),
+    <int, Color>{
+      100: Color(0xFFF4FF81),
+      200: Color(_limeAccentPrimaryValue),
+      400: Color(0xFFC6FF00),
+      700: Color(0xFFAEEA00),
     },
   );
   static const int _limeAccentPrimaryValue = 0xFFEEFF41;
 
   /// The yellow primary color and swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.yellow.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.yellowAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.yellow.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.yellowAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lime.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.limeAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lime.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.limeAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.amber.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.amberAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.amber.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.amberAccent.png)
   ///
   /// ## Sample code
   ///
   /// ```dart
-  /// new Icon(
+  /// Icon(
   ///   Icons.widgets,
   ///   color: Colors.yellow[400],
   /// )
@@ -1350,38 +1380,38 @@ class Colors {
   ///  * [lime] and [amber], similar colors.
   ///  * [Theme.of], which allows you to select colors from the current theme
   ///    rather than hard-coding colors in your build methods.
-  static const MaterialColor yellow = const MaterialColor(
+  static const MaterialColor yellow = MaterialColor(
     _yellowPrimaryValue,
-    const <int, Color>{
-       50: const Color(0xFFFFFDE7),
-      100: const Color(0xFFFFF9C4),
-      200: const Color(0xFFFFF59D),
-      300: const Color(0xFFFFF176),
-      400: const Color(0xFFFFEE58),
-      500: const Color(_yellowPrimaryValue),
-      600: const Color(0xFFFDD835),
-      700: const Color(0xFFFBC02D),
-      800: const Color(0xFFF9A825),
-      900: const Color(0xFFF57F17),
+    <int, Color>{
+       50: Color(0xFFFFFDE7),
+      100: Color(0xFFFFF9C4),
+      200: Color(0xFFFFF59D),
+      300: Color(0xFFFFF176),
+      400: Color(0xFFFFEE58),
+      500: Color(_yellowPrimaryValue),
+      600: Color(0xFFFDD835),
+      700: Color(0xFFFBC02D),
+      800: Color(0xFFF9A825),
+      900: Color(0xFFF57F17),
     },
   );
   static const int _yellowPrimaryValue = 0xFFFFEB3B;
 
   /// The yellow accent color and swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.yellow.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.yellowAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.yellow.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.yellowAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.lime.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.limeAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.lime.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.limeAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.amber.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.amberAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.amber.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.amberAccent.png)
   ///
   /// ## Sample code
   ///
   /// ```dart
-  /// new Icon(
+  /// Icon(
   ///   Icons.widgets,
   ///   color: Colors.yellowAccent[400],
   /// )
@@ -1393,32 +1423,32 @@ class Colors {
   ///  * [limeAccent] and [amberAccent], similar colors.
   ///  * [Theme.of], which allows you to select colors from the current theme
   ///    rather than hard-coding colors in your build methods.
-  static const MaterialAccentColor yellowAccent = const MaterialAccentColor(
+  static const MaterialAccentColor yellowAccent = MaterialAccentColor(
     _yellowAccentPrimaryValue,
-    const <int, Color>{
-      100: const Color(0xFFFFFF8D),
-      200: const Color(_yellowAccentPrimaryValue),
-      400: const Color(0xFFFFEA00),
-      700: const Color(0xFFFFD600),
+    <int, Color>{
+      100: Color(0xFFFFFF8D),
+      200: Color(_yellowAccentPrimaryValue),
+      400: Color(0xFFFFEA00),
+      700: Color(0xFFFFD600),
     },
   );
   static const int _yellowAccentPrimaryValue = 0xFFFFFF00;
 
   /// The amber primary color and swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.amber.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.amberAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.amber.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.amberAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.yellow.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.yellowAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.yellow.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.yellowAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.orange.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.orangeAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.orange.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.orangeAccent.png)
   ///
   /// ## Sample code
   ///
   /// ```dart
-  /// new Icon(
+  /// Icon(
   ///   Icons.widgets,
   ///   color: Colors.amber[400],
   /// )
@@ -1430,38 +1460,38 @@ class Colors {
   ///  * [yellow] and [orange], similar colors.
   ///  * [Theme.of], which allows you to select colors from the current theme
   ///    rather than hard-coding colors in your build methods.
-  static const MaterialColor amber = const MaterialColor(
+  static const MaterialColor amber = MaterialColor(
     _amberPrimaryValue,
-    const <int, Color>{
-       50: const Color(0xFFFFF8E1),
-      100: const Color(0xFFFFECB3),
-      200: const Color(0xFFFFE082),
-      300: const Color(0xFFFFD54F),
-      400: const Color(0xFFFFCA28),
-      500: const Color(_amberPrimaryValue),
-      600: const Color(0xFFFFB300),
-      700: const Color(0xFFFFA000),
-      800: const Color(0xFFFF8F00),
-      900: const Color(0xFFFF6F00),
+    <int, Color>{
+       50: Color(0xFFFFF8E1),
+      100: Color(0xFFFFECB3),
+      200: Color(0xFFFFE082),
+      300: Color(0xFFFFD54F),
+      400: Color(0xFFFFCA28),
+      500: Color(_amberPrimaryValue),
+      600: Color(0xFFFFB300),
+      700: Color(0xFFFFA000),
+      800: Color(0xFFFF8F00),
+      900: Color(0xFFFF6F00),
     },
   );
   static const int _amberPrimaryValue = 0xFFFFC107;
 
   /// The amber accent color and swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.amber.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.amberAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.amber.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.amberAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.yellow.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.yellowAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.yellow.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.yellowAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.orange.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.orangeAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.orange.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.orangeAccent.png)
   ///
   /// ## Sample code
   ///
   /// ```dart
-  /// new Icon(
+  /// Icon(
   ///   Icons.widgets,
   ///   color: Colors.amberAccent[400],
   /// )
@@ -1473,34 +1503,34 @@ class Colors {
   ///  * [yellowAccent] and [orangeAccent], similar colors.
   ///  * [Theme.of], which allows you to select colors from the current theme
   ///    rather than hard-coding colors in your build methods.
-  static const MaterialAccentColor amberAccent = const MaterialAccentColor(
+  static const MaterialAccentColor amberAccent = MaterialAccentColor(
     _amberAccentPrimaryValue,
-    const <int, Color>{
-      100: const Color(0xFFFFE57F),
-      200: const Color(_amberAccentPrimaryValue),
-      400: const Color(0xFFFFC400),
-      700: const Color(0xFFFFAB00),
+    <int, Color>{
+      100: Color(0xFFFFE57F),
+      200: Color(_amberAccentPrimaryValue),
+      400: Color(0xFFFFC400),
+      700: Color(0xFFFFAB00),
     },
   );
   static const int _amberAccentPrimaryValue = 0xFFFFD740;
 
   /// The orange primary color and swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.orange.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.orangeAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.orange.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.orangeAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.amber.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.amberAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.amber.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.amberAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.deepOrange.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.deepOrangeAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.deepOrange.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.deepOrangeAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.brown.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.brown.png)
   ///
   /// ## Sample code
   ///
   /// ```dart
-  /// new Icon(
+  /// Icon(
   ///   Icons.widgets,
   ///   color: Colors.orange[400],
   /// )
@@ -1512,38 +1542,38 @@ class Colors {
   ///  * [amber], [deepOrange], and [brown], similar colors.
   ///  * [Theme.of], which allows you to select colors from the current theme
   ///    rather than hard-coding colors in your build methods.
-  static const MaterialColor orange = const MaterialColor(
+  static const MaterialColor orange = MaterialColor(
     _orangePrimaryValue,
-    const <int, Color>{
-       50: const Color(0xFFFFF3E0),
-      100: const Color(0xFFFFE0B2),
-      200: const Color(0xFFFFCC80),
-      300: const Color(0xFFFFB74D),
-      400: const Color(0xFFFFA726),
-      500: const Color(_orangePrimaryValue),
-      600: const Color(0xFFFB8C00),
-      700: const Color(0xFFF57C00),
-      800: const Color(0xFFEF6C00),
-      900: const Color(0xFFE65100),
+    <int, Color>{
+       50: Color(0xFFFFF3E0),
+      100: Color(0xFFFFE0B2),
+      200: Color(0xFFFFCC80),
+      300: Color(0xFFFFB74D),
+      400: Color(0xFFFFA726),
+      500: Color(_orangePrimaryValue),
+      600: Color(0xFFFB8C00),
+      700: Color(0xFFF57C00),
+      800: Color(0xFFEF6C00),
+      900: Color(0xFFE65100),
     },
   );
   static const int _orangePrimaryValue = 0xFFFF9800;
 
   /// The orange accent color and swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.orange.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.orangeAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.orange.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.orangeAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.amber.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.amberAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.amber.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.amberAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.deepOrange.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.deepOrangeAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.deepOrange.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.deepOrangeAccent.png)
   ///
   /// ## Sample code
   ///
   /// ```dart
-  /// new Icon(
+  /// Icon(
   ///   Icons.widgets,
   ///   color: Colors.orangeAccent[400],
   /// )
@@ -1555,34 +1585,34 @@ class Colors {
   ///  * [amberAccent] and [deepOrangeAccent], similar colors.
   ///  * [Theme.of], which allows you to select colors from the current theme
   ///    rather than hard-coding colors in your build methods.
-  static const MaterialAccentColor orangeAccent = const MaterialAccentColor(
+  static const MaterialAccentColor orangeAccent = MaterialAccentColor(
     _orangeAccentPrimaryValue,
-    const <int, Color>{
-      100: const Color(0xFFFFD180),
-      200: const Color(_orangeAccentPrimaryValue),
-      400: const Color(0xFFFF9100),
-      700: const Color(0xFFFF6D00),
+    <int, Color>{
+      100: Color(0xFFFFD180),
+      200: Color(_orangeAccentPrimaryValue),
+      400: Color(0xFFFF9100),
+      700: Color(0xFFFF6D00),
     },
   );
   static const int _orangeAccentPrimaryValue = 0xFFFFAB40;
 
   /// The deep orange primary color and swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.deepOrange.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.deepOrangeAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.deepOrange.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.deepOrangeAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.orange.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.orangeAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.orange.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.orangeAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.red.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.redAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.red.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.redAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.brown.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.brown.png)
   ///
   /// ## Sample code
   ///
   /// ```dart
-  /// new Icon(
+  /// Icon(
   ///   Icons.widgets,
   ///   color: Colors.deepOrange[400],
   /// )
@@ -1594,38 +1624,38 @@ class Colors {
   ///  * [orange], [red], and [brown], similar colors.
   ///  * [Theme.of], which allows you to select colors from the current theme
   ///    rather than hard-coding colors in your build methods.
-  static const MaterialColor deepOrange = const MaterialColor(
+  static const MaterialColor deepOrange = MaterialColor(
     _deepOrangePrimaryValue,
-    const <int, Color>{
-       50: const Color(0xFFFBE9E7),
-      100: const Color(0xFFFFCCBC),
-      200: const Color(0xFFFFAB91),
-      300: const Color(0xFFFF8A65),
-      400: const Color(0xFFFF7043),
-      500: const Color(_deepOrangePrimaryValue),
-      600: const Color(0xFFF4511E),
-      700: const Color(0xFFE64A19),
-      800: const Color(0xFFD84315),
-      900: const Color(0xFFBF360C),
+    <int, Color>{
+       50: Color(0xFFFBE9E7),
+      100: Color(0xFFFFCCBC),
+      200: Color(0xFFFFAB91),
+      300: Color(0xFFFF8A65),
+      400: Color(0xFFFF7043),
+      500: Color(_deepOrangePrimaryValue),
+      600: Color(0xFFF4511E),
+      700: Color(0xFFE64A19),
+      800: Color(0xFFD84315),
+      900: Color(0xFFBF360C),
     },
   );
   static const int _deepOrangePrimaryValue = 0xFFFF5722;
 
   /// The deep orange accent color and swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.deepOrange.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.deepOrangeAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.deepOrange.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.deepOrangeAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.orange.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.orangeAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.orange.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.orangeAccent.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.red.png)
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.redAccent.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.red.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.redAccent.png)
   ///
   /// ## Sample code
   ///
   /// ```dart
-  /// new Icon(
+  /// Icon(
   ///   Icons.widgets,
   ///   color: Colors.deepOrangeAccent[400],
   /// )
@@ -1637,31 +1667,31 @@ class Colors {
   ///  * [orangeAccent] [redAccent], similar colors.
   ///  * [Theme.of], which allows you to select colors from the current theme
   ///    rather than hard-coding colors in your build methods.
-  static const MaterialAccentColor deepOrangeAccent = const MaterialAccentColor(
+  static const MaterialAccentColor deepOrangeAccent = MaterialAccentColor(
     _deepOrangeAccentPrimaryValue,
-    const <int, Color>{
-      100: const Color(0xFFFF9E80),
-      200: const Color(_deepOrangeAccentPrimaryValue),
-      400: const Color(0xFFFF3D00),
-      700: const Color(0xFFDD2C00),
+    <int, Color>{
+      100: Color(0xFFFF9E80),
+      200: Color(_deepOrangeAccentPrimaryValue),
+      400: Color(0xFFFF3D00),
+      700: Color(0xFFDD2C00),
     },
   );
   static const int _deepOrangeAccentPrimaryValue = 0xFFFF6E40;
 
   /// The brown primary color and swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.brown.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.brown.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.orange.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.orange.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.blueGrey.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.blueGrey.png)
   ///
   /// This swatch has no corresponding accent color and swatch.
   ///
   /// ## Sample code
   ///
   /// ```dart
-  /// new Icon(
+  /// Icon(
   ///   Icons.widgets,
   ///   color: Colors.brown[400],
   /// )
@@ -1672,30 +1702,30 @@ class Colors {
   ///  * [orange] and [blueGrey], vaguely similar colors.
   ///  * [Theme.of], which allows you to select colors from the current theme
   ///    rather than hard-coding colors in your build methods.
-  static const MaterialColor brown = const MaterialColor(
+  static const MaterialColor brown = MaterialColor(
     _brownPrimaryValue,
-    const <int, Color>{
-       50: const Color(0xFFEFEBE9),
-      100: const Color(0xFFD7CCC8),
-      200: const Color(0xFFBCAAA4),
-      300: const Color(0xFFA1887F),
-      400: const Color(0xFF8D6E63),
-      500: const Color(_brownPrimaryValue),
-      600: const Color(0xFF6D4C41),
-      700: const Color(0xFF5D4037),
-      800: const Color(0xFF4E342E),
-      900: const Color(0xFF3E2723),
+    <int, Color>{
+       50: Color(0xFFEFEBE9),
+      100: Color(0xFFD7CCC8),
+      200: Color(0xFFBCAAA4),
+      300: Color(0xFFA1887F),
+      400: Color(0xFF8D6E63),
+      500: Color(_brownPrimaryValue),
+      600: Color(0xFF6D4C41),
+      700: Color(0xFF5D4037),
+      800: Color(0xFF4E342E),
+      900: Color(0xFF3E2723),
     },
   );
   static const int _brownPrimaryValue = 0xFF795548;
 
   /// The grey primary color and swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.grey.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.grey.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.blueGrey.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.blueGrey.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.brown.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.brown.png)
   ///
   /// This swatch has no corresponding accent swatch.
   ///
@@ -1707,7 +1737,7 @@ class Colors {
   /// ## Sample code
   ///
   /// ```dart
-  /// new Icon(
+  /// Icon(
   ///   Icons.widgets,
   ///   color: Colors.grey[400],
   /// )
@@ -1720,41 +1750,41 @@ class Colors {
   ///    provide a different approach to showing shades of grey.
   ///  * [Theme.of], which allows you to select colors from the current theme
   ///    rather than hard-coding colors in your build methods.
-  static const MaterialColor grey = const MaterialColor(
+  static const MaterialColor grey = MaterialColor(
     _greyPrimaryValue,
-    const <int, Color>{
-       50: const Color(0xFFFAFAFA),
-      100: const Color(0xFFF5F5F5),
-      200: const Color(0xFFEEEEEE),
-      300: const Color(0xFFE0E0E0),
-      350: const Color(0xFFD6D6D6), // only for raised button while pressed in light theme
-      400: const Color(0xFFBDBDBD),
-      500: const Color(_greyPrimaryValue),
-      600: const Color(0xFF757575),
-      700: const Color(0xFF616161),
-      800: const Color(0xFF424242),
-      850: const Color(0xFF303030), // only for background color in dark theme
-      900: const Color(0xFF212121),
+    <int, Color>{
+       50: Color(0xFFFAFAFA),
+      100: Color(0xFFF5F5F5),
+      200: Color(0xFFEEEEEE),
+      300: Color(0xFFE0E0E0),
+      350: Color(0xFFD6D6D6), // only for raised button while pressed in light theme
+      400: Color(0xFFBDBDBD),
+      500: Color(_greyPrimaryValue),
+      600: Color(0xFF757575),
+      700: Color(0xFF616161),
+      800: Color(0xFF424242),
+      850: Color(0xFF303030), // only for background color in dark theme
+      900: Color(0xFF212121),
     },
   );
   static const int _greyPrimaryValue = 0xFF9E9E9E;
 
   /// The blue-grey primary color and swatch.
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.blueGrey.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.blueGrey.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.grey.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.grey.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.cyan.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.cyan.png)
   ///
-  /// ![](https://flutter.github.io/assets-for-api-docs/material/Colors.blue.png)
+  /// ![](https://flutter.github.io/assets-for-api-docs/assets/material/Colors.blue.png)
   ///
   /// This swatch has no corresponding accent swatch.
   ///
   /// ## Sample code
   ///
   /// ```dart
-  /// new Icon(
+  /// Icon(
   ///   Icons.widgets,
   ///   color: Colors.blueGrey[400],
   /// )
@@ -1765,25 +1795,25 @@ class Colors {
   ///  * [grey], [cyan], and [blue], similar colors.
   ///  * [Theme.of], which allows you to select colors from the current theme
   ///    rather than hard-coding colors in your build methods.
-  static const MaterialColor blueGrey = const MaterialColor(
+  static const MaterialColor blueGrey = MaterialColor(
     _blueGreyPrimaryValue,
-    const <int, Color>{
-       50: const Color(0xFFECEFF1),
-      100: const Color(0xFFCFD8DC),
-      200: const Color(0xFFB0BEC5),
-      300: const Color(0xFF90A4AE),
-      400: const Color(0xFF78909C),
-      500: const Color(_blueGreyPrimaryValue),
-      600: const Color(0xFF546E7A),
-      700: const Color(0xFF455A64),
-      800: const Color(0xFF37474F),
-      900: const Color(0xFF263238),
+    <int, Color>{
+       50: Color(0xFFECEFF1),
+      100: Color(0xFFCFD8DC),
+      200: Color(0xFFB0BEC5),
+      300: Color(0xFF90A4AE),
+      400: Color(0xFF78909C),
+      500: Color(_blueGreyPrimaryValue),
+      600: Color(0xFF546E7A),
+      700: Color(0xFF455A64),
+      800: Color(0xFF37474F),
+      900: Color(0xFF263238),
     },
   );
   static const int _blueGreyPrimaryValue = 0xFF607D8B;
 
   /// The material design primary color swatches, excluding grey.
-  static const List<MaterialColor> primaries = const <MaterialColor>[
+  static const List<MaterialColor> primaries = <MaterialColor>[
     red,
     pink,
     purple,
@@ -1808,7 +1838,7 @@ class Colors {
   ];
 
   /// The material design accent color swatches.
-  static const List<MaterialAccentColor> accents = const <MaterialAccentColor>[
+  static const List<MaterialAccentColor> accents = <MaterialAccentColor>[
     redAccent,
     pinkAccent,
     purpleAccent,


### PR DESCRIPTION
- update the colors icon provider to the latest from package:flutter
- fix some regressions in identifying in-line colors and icons due to optional `const`
- add tests for the editor annotation provider (for icons and colors)