### PR TITLE
Fix buttons

### DIFF
--- a/src/io/flutter/run/FlutterDebugProcess.java
+++ b/src/io/flutter/run/FlutterDebugProcess.java
@@ -14,6 +14,7 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.util.Computable;
 import com.intellij.ui.GuiUtils;
 import com.intellij.ui.content.Content;
+import com.intellij.util.ui.JBUI;
 import com.intellij.xdebugger.XDebugSession;
 import com.jetbrains.lang.dart.util.DartUrlResolver;
 import io.flutter.actions.ReloadFlutterApp;
@@ -144,7 +145,7 @@ public class FlutterDebugProcess extends DartVmServiceDebugProcess {
     }
   }
 
-  private static class OverflowAction extends ComboBoxAction {
+  private static class OverflowAction extends ToolbarComboBoxAction {
     private final @NotNull FlutterApp myApp;
     private final DefaultActionGroup myActionGroup;
 
@@ -165,13 +166,6 @@ public class FlutterDebugProcess extends DartVmServiceDebugProcess {
     public final void update(AnActionEvent e) {
       e.getPresentation().setText("More Actions");
       e.getPresentation().setEnabled(myApp.isSessionActive());
-    }
-
-    @Override
-    protected ComboBoxButton createComboBoxButton(Presentation presentation) {
-      final ComboBoxButton button = super.createComboBoxButton(presentation);
-      button.setBorder(null);
-      return button;
     }
 
     private static DefaultActionGroup createPopupActionGroup(FlutterApp app, Computable<Boolean> observatoryAvailable) {

--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -14,7 +14,6 @@ import com.intellij.ide.browsers.BrowserLauncher;
 import com.intellij.ide.plugins.PluginManager;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.actionSystem.*;
-import com.intellij.openapi.actionSystem.ex.ComboBoxAction;
 import com.intellij.openapi.actionSystem.ex.CustomComponentAction;
 import com.intellij.openapi.actionSystem.impl.ActionButton;
 import com.intellij.openapi.application.ApplicationInfo;
@@ -889,7 +888,7 @@ class ShowPaintBaselinesAction extends FlutterViewToggleableAction {
   }
 }
 
-class OverflowAction extends ComboBoxAction implements RightAlignedToolbarAction {
+class OverflowAction extends ToolbarComboBoxAction implements RightAlignedToolbarAction {
   private final @NotNull FlutterApp app;
   private final DefaultActionGroup myActionGroup;
 
@@ -897,7 +896,6 @@ class OverflowAction extends ComboBoxAction implements RightAlignedToolbarAction
     super();
 
     this.app = app;
-
     myActionGroup = createPopupActionGroup(view, app);
   }
 
@@ -911,13 +909,6 @@ class OverflowAction extends ComboBoxAction implements RightAlignedToolbarAction
   public final void update(AnActionEvent e) {
     e.getPresentation().setText("More Actions");
     e.getPresentation().setEnabled(app.isSessionActive());
-  }
-
-  @Override
-  protected ComboBoxButton createComboBoxButton(Presentation presentation) {
-    final ComboBoxButton button = super.createComboBoxButton(presentation);
-    button.setBorder(null);
-    return button;
   }
 
   private static DefaultActionGroup createPopupActionGroup(FlutterView view, FlutterApp app) {

--- a/src/io/flutter/view/ToolbarComboBoxAction.java
+++ b/src/io/flutter/view/ToolbarComboBoxAction.java
@@ -1,0 +1,353 @@
+// Copyright 2000-2018 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
+package com.intellij.openapi.actionSystem.ex;
+
+import com.intellij.icons.AllIcons;
+import com.intellij.ide.DataManager;
+import com.intellij.ide.HelpTooltip;
+import com.intellij.openapi.actionSystem.*;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ModalityState;
+import com.intellij.openapi.keymap.KeymapUtil;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.popup.JBPopup;
+import com.intellij.openapi.ui.popup.JBPopupFactory;
+import com.intellij.openapi.ui.popup.ListPopup;
+import com.intellij.openapi.util.Condition;
+import com.intellij.openapi.util.IconLoader;
+import com.intellij.openapi.util.registry.Registry;
+import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.openapi.wm.IdeFocusManager;
+import com.intellij.openapi.wm.IdeFrame;
+import com.intellij.openapi.wm.WindowManager;
+import com.intellij.ui.UserActivityProviderComponent;
+import com.intellij.util.ui.*;
+import com.intellij.util.ui.accessibility.ScreenReader;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseMotionAdapter;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
+
+public abstract class ComboBoxAction extends AnAction implements CustomComponentAction {
+  private static Icon myIcon = null;
+  private static Icon myDisabledIcon = null;
+  private static Icon myWin10ComboDropTriangleIcon = null;
+
+  public static Icon getArrowIcon(boolean enabled) {
+    if (UIUtil.isUnderWin10LookAndFeel()) {
+      if (myWin10ComboDropTriangleIcon == null) {
+        myWin10ComboDropTriangleIcon = IconLoader.findLafIcon("win10/comboDropTriangle", ComboBoxAction.class, true);
+      }
+      return myWin10ComboDropTriangleIcon;
+    }
+    if (myIcon != AllIcons.General.ArrowDown) {
+      myIcon = AllIcons.General.ArrowDown;
+      myDisabledIcon = IconLoader.getDisabledIcon(myIcon);
+    }
+    return enabled ? myIcon : myDisabledIcon;
+  }
+
+  private boolean mySmallVariant = true;
+  private String myPopupTitle;
+
+  protected ComboBoxAction() {
+  }
+
+  @Override
+  public void actionPerformed(@NotNull AnActionEvent e) {
+    Project project = e.getProject();
+    if (project == null) return;
+
+    JFrame frame = WindowManager.getInstance().getFrame(project);
+    if (!(frame instanceof IdeFrame)) return;
+
+    ListPopup popup = createActionPopup(e.getDataContext(), ((IdeFrame)frame).getComponent(), null);
+    popup.showCenteredInCurrentWindow(project);
+  }
+
+  @NotNull
+  private ListPopup createActionPopup(@NotNull DataContext context, @NotNull JComponent component, @Nullable Runnable disposeCallback) {
+    DefaultActionGroup group = createPopupActionGroup(component, context);
+    ListPopup popup = JBPopupFactory.getInstance().createActionGroupPopup(
+      myPopupTitle, group, context, false, shouldShowDisabledActions(), false, disposeCallback, getMaxRows(), getPreselectCondition());
+    popup.setMinimumSize(new Dimension(getMinWidth(), getMinHeight()));
+    return popup;
+  }
+
+  @NotNull
+  @Override
+  public JComponent createCustomComponent(@NotNull Presentation presentation) {
+    JPanel panel = new JPanel(new GridBagLayout());
+    ComboBoxButton button = createComboBoxButton(presentation);
+    panel.add(button,
+              new GridBagConstraints(0, 0, 1, 1, 1, 1, GridBagConstraints.CENTER, GridBagConstraints.BOTH, JBUI.insets(0, 3), 0, 0));
+    return panel;
+  }
+
+  protected ComboBoxButton createComboBoxButton(Presentation presentation) {
+    return new ComboBoxButton(presentation);
+  }
+
+  public boolean isSmallVariant() {
+    return mySmallVariant;
+  }
+
+  public void setSmallVariant(boolean smallVariant) {
+    mySmallVariant = smallVariant;
+  }
+
+  public void setPopupTitle(String popupTitle) {
+    myPopupTitle = popupTitle;
+  }
+
+  protected boolean shouldShowDisabledActions() {
+    return false;
+  }
+
+  @NotNull
+  protected abstract DefaultActionGroup createPopupActionGroup(JComponent button);
+
+  @NotNull
+  protected DefaultActionGroup createPopupActionGroup(JComponent button, @NotNull  DataContext dataContext) {
+    return createPopupActionGroup(button);
+  }
+
+  protected int getMaxRows() {
+    return 30;
+  }
+
+  protected int getMinHeight() {
+    return 1;
+  }
+
+  protected int getMinWidth() {
+    return 1;
+  }
+
+  protected class ComboBoxButton extends JButton implements UserActivityProviderComponent {
+    private final Presentation myPresentation;
+    private boolean myForcePressed = false;
+    private PropertyChangeListener myButtonSynchronizer;
+
+    public ComboBoxButton(Presentation presentation) {
+      myPresentation = presentation;
+      setModel(new MyButtonModel());
+      getModel().setEnabled(myPresentation.isEnabled());
+      setVisible(presentation.isVisible());
+      setHorizontalAlignment(LEFT);
+      setFocusable(ScreenReader.isActive());
+      putClientProperty("styleCombo", ComboBoxAction.this);
+      setMargin(JBUI.insets(0, 5, 0, 2));
+      if (isSmallVariant()) {
+        setFont(JBUI.Fonts.toolbarSmallComboBoxFont());
+      }
+
+      addMouseListener(new MouseAdapter() {
+        @Override
+        public void mousePressed(final MouseEvent e) {
+          if (SwingUtilities.isLeftMouseButton(e)) {
+            e.consume();
+            doClick();
+          }
+        }
+      });
+      addMouseMotionListener(new MouseMotionAdapter() {
+        @Override
+        public void mouseDragged(MouseEvent e) {
+          mouseMoved(MouseEventAdapter.convert(e, e.getComponent(),
+                                               MouseEvent.MOUSE_MOVED,
+                                               e.getWhen(),
+                                               e.getModifiers() | e.getModifiersEx(),
+                                               e.getX(),
+                                               e.getY()));
+        }
+      });
+    }
+
+    @Override
+    protected void fireActionPerformed(ActionEvent event) {
+      if (!myForcePressed) {
+        IdeFocusManager.getGlobalInstance().doWhenFocusSettlesDown(() -> showPopup());
+      }
+    }
+
+    @NotNull
+    private Runnable setForcePressed() {
+      myForcePressed = true;
+      repaint();
+
+      return () -> {
+        // give the button a chance to handle action listener
+        ApplicationManager.getApplication().invokeLater(() -> {
+          myForcePressed = false;
+          repaint();
+        }, ModalityState.any());
+        repaint();
+        fireStateChanged();
+      };
+    }
+
+    @Nullable
+    @Override
+    public String getToolTipText() {
+      return myForcePressed || Registry.is("ide.helptooltip.enabled") ? null : super.getToolTipText();
+    }
+
+    public void showPopup() {
+      JBPopup popup = createPopup(setForcePressed());
+      if (Registry.is("ide.helptooltip.enabled")) {
+        HelpTooltip.setMasterPopup(this, popup);
+      }
+
+      popup.showUnderneathOf(this);
+    }
+
+    protected JBPopup createPopup(Runnable onDispose) {
+      return createActionPopup(getDataContext(), this, onDispose);
+    }
+
+    protected DataContext getDataContext() {
+      return DataManager.getInstance().getDataContext(this);
+    }
+
+    @Override
+    public void removeNotify() {
+      if (myButtonSynchronizer != null) {
+        myPresentation.removePropertyChangeListener(myButtonSynchronizer);
+        myButtonSynchronizer = null;
+      }
+      super.removeNotify();
+    }
+
+    @Override
+    public void addNotify() {
+      super.addNotify();
+      if (myButtonSynchronizer == null) {
+        myButtonSynchronizer = new MyButtonSynchronizer();
+        myPresentation.addPropertyChangeListener(myButtonSynchronizer);
+      }
+      initButton();
+    }
+
+    private void initButton() {
+      setIcon(myPresentation.getIcon());
+      setText(myPresentation.getText());
+      updateTooltipText(myPresentation.getDescription());
+      updateButtonSize();
+    }
+
+    private void updateTooltipText(String description) {
+      String tooltip = KeymapUtil.createTooltipText(description, ComboBoxAction.this);
+      if (Registry.is("ide.helptooltip.enabled") && StringUtil.isNotEmpty(tooltip)) {
+        HelpTooltip.dispose(this);
+        new HelpTooltip().setDescription(tooltip).setLocation(HelpTooltip.Alignment.BOTTOM).installOn(this);
+      } else {
+        setToolTipText(!tooltip.isEmpty() ? tooltip : null);
+      }
+    }
+
+    protected class MyButtonModel extends DefaultButtonModel {
+      @Override
+      public boolean isPressed() {
+        return myForcePressed || super.isPressed();
+      }
+
+      @Override
+      public boolean isArmed() {
+        return myForcePressed || super.isArmed();
+      }
+    }
+
+    private class MyButtonSynchronizer implements PropertyChangeListener {
+      @Override
+      public void propertyChange(PropertyChangeEvent evt) {
+        String propertyName = evt.getPropertyName();
+        if (Presentation.PROP_TEXT.equals(propertyName)) {
+          setText((String)evt.getNewValue());
+          updateButtonSize();
+        }
+        else if (Presentation.PROP_DESCRIPTION.equals(propertyName)) {
+          updateTooltipText((String)evt.getNewValue());
+        }
+        else if (Presentation.PROP_ICON.equals(propertyName)) {
+          setIcon((Icon)evt.getNewValue());
+          updateButtonSize();
+        }
+        else if (Presentation.PROP_ENABLED.equals(propertyName)) {
+          setEnabled(((Boolean)evt.getNewValue()).booleanValue());
+        }
+      }
+    }
+
+    @Override
+    public boolean isOpaque() {
+      return !isSmallVariant();
+    }
+
+    @Override
+    public Dimension getPreferredSize() {
+      Dimension prefSize = super.getPreferredSize();
+      int width = prefSize.width
+                  + (myPresentation != null && isArrowVisible(myPresentation) ? getArrowIcon(isEnabled()).getIconWidth() : 0)
+                  + (StringUtil.isNotEmpty(getText()) ? getIconTextGap() : 0)
+                  + (UIUtil.isUnderWin10LookAndFeel() ? JBUI.scale(6) : 0);
+
+      Dimension size = new Dimension(width, isSmallVariant() ? JBUI.scale(24) : Math.max(JBUI.scale(24), prefSize.height));
+      JBInsets.addTo(size, getMargin());
+      return size;
+    }
+
+    @Override
+    public Dimension getMinimumSize() {
+      return new Dimension(super.getMinimumSize().width, getPreferredSize().height);
+    }
+
+    @Override
+    public Font getFont() {
+      return isSmallVariant() ? UIUtil.getToolbarFont() : UIUtil.getLabelFont();
+    }
+
+    @Override
+    protected Graphics getComponentGraphics(Graphics graphics) {
+      return JBSwingUtilities.runGlobalCGTransform(this, super.getComponentGraphics(graphics));
+    }
+
+    @Override
+    public void paint(Graphics g) {
+      super.paint(g);
+      if (!isArrowVisible(myPresentation)) {
+        return;
+      }
+      Icon icon = getArrowIcon(isEnabled());
+      int x = getWidth() - icon.getIconWidth() - getInsets().right - getMargin().right -
+              (UIUtil.isUnderWin10LookAndFeel() ? JBUI.scale(3) : 0); // Different icons correction
+
+      icon.paintIcon(null, g, x, (getHeight() - icon.getIconHeight()) / 2);
+    }
+
+    protected boolean isArrowVisible(@NotNull Presentation presentation) {
+      return true;
+    }
+
+    @Override public void updateUI() {
+      super.updateUI();
+      setMargin(JBUI.insets(0, 5, 0, 2));
+      updateButtonSize();
+    }
+
+    protected void updateButtonSize() {
+      invalidate();
+      repaint();
+      setSize(getPreferredSize());
+      repaint();
+    }
+  }
+
+  protected Condition<AnAction> getPreselectCondition() { return null; }
+}


### PR DESCRIPTION
The existing toolbar combobox was throwing an exception when not under darkula as a null border wasn't supported and using an empty border resulted in button ui we didn't want.
I couldn't figure out a way to fix this without forking the base ComboBoxAction class so we could customize things a bit. The first patch in the CL is the baseline for the ComboBox class. The second patch is the actual change.
As a bonus reduced the space between the icon and the text and changed the arrow icon so it is black instead of grey which matches other similar ui in intellij better.

We should test this under windows 10 at some point to make sure it looks ok.
Here is what the new UI looks like both dark, light, and when disabled.

<img width="325" alt="screen shot 2018-11-07 at 12 55 53 pm" src="https://user-images.githubusercontent.com/1226812/48160851-d664da80-e28d-11e8-8a32-0de221d3a77e.png">
<img width="325" alt="screen shot 2018-11-07 at 12 55 34 pm" src="https://user-images.githubusercontent.com/1226812/48160853-d6fd7100-e28d-11e8-806a-4b6e0e5fabcd.png">
<img width="87" alt="screen shot 2018-11-07 at 12 50 09 pm" src="https://user-images.githubusercontent.com/1226812/48160854-d6fd7100-e28d-11e8-91f5-77ccd83c7d51.png">
