### PR TITLE
Disallow importing app templates into Android apps

### DIFF
--- a/flutter-studio/src/io/flutter/module/FlutterModuleImporter.java
+++ b/flutter-studio/src/io/flutter/module/FlutterModuleImporter.java
@@ -58,14 +58,10 @@ public class FlutterModuleImporter {
       return;
     }
 
-    String newPath = Paths.get(myRelativePath, "android", "include_flutter.groovy").normalize().toString();
+    String newPath = Paths.get(myRelativePath, ".android", "include_flutter.groovy").normalize().toString();
     if (!new File(moduleRoot.getParent().getPath(), newPath).exists()) {
-      // For old modules
-      newPath = Paths.get(myRelativePath, ".android", "include_flutter.groovy").normalize().toString();
-      if (!new File(moduleRoot.getParent().getPath(), newPath).exists()) {
-        showHowToEditDialog();
-        return;
-      }
+      showHowToEditDialog();
+      return;
     }
     myRelativePath = StringUtil.escapeBackSlashes(newPath);
     VirtualFile settingsFile = projectRoot.findChild("settings.gradle");


### PR DESCRIPTION
The module project template is not going away anytime soon. The app template does not work for importing into an Android app so don't allow it to be selected.

@pq 