### PR TITLE
cool runtime label under light theme

### DIFF
--- a/src/io/flutter/logging/FlutterLogColors.java
+++ b/src/io/flutter/logging/FlutterLogColors.java
@@ -6,6 +6,7 @@
 package io.flutter.logging;
 
 import com.intellij.ui.JBColor;
+import com.intellij.util.ui.UIUtil;
 import org.jetbrains.annotations.NotNull;
 
 import java.awt.*;
@@ -18,7 +19,7 @@ public class FlutterLogColors {
       return JBColor.gray;
     }
     if (category.startsWith("runtime.")) {
-      return JBColor.magenta;
+      return UIUtil.isUnderDarcula() ? JBColor.magenta : JBColor.pink;
     }
     if (category.equals("http")) {
       return JBColor.blue;


### PR DESCRIPTION
It's on my short-list to make the category colors theme better.  This cooling off of the runtime magenta is just a first (and interim) step while I'm thinking of it...

![image](https://user-images.githubusercontent.com/67586/48165245-e1be0300-e299-11e8-9c2f-3f8ccbbee547.png)

![image](https://user-images.githubusercontent.com/67586/48165252-e4b8f380-e299-11e8-8733-cebc12a8076e.png)


/cc @jacob314 