### PR TITLE
guard against bad config json (#2763)

### DIFF
--- a/src/io/flutter/sdk/FlutterSdk.java
+++ b/src/io/flutter/sdk/FlutterSdk.java
@@ -480,6 +480,11 @@ public class FlutterSdk {
         try {
           final JsonParser jp = new JsonParser();
           final JsonElement elem = jp.parse(stdout.toString());
+          if (elem.isJsonNull()) {
+            LOG.warn("Invalid Json from flutter config");
+            return null;
+          }
+
           final JsonObject obj = elem.getAsJsonObject();
           final JsonPrimitive primitive = obj.getAsJsonPrimitive(key);
           if (primitive != null) {


### PR DESCRIPTION
Fixes: #2763.

I can't track down why it would happen but in at least this reported case the JSON coming back from the call to `flutter config --machine` is invalid.  In the absence of a fix on the flutter tools side, this guards against it.

/cc @devoncarew 