### PR TITLE
badge log entries w/ associated data

### DIFF
--- a/src/io/flutter/logging/FlutterLogTree.java
+++ b/src/io/flutter/logging/FlutterLogTree.java
@@ -8,6 +8,7 @@ package io.flutter.logging;
 import com.intellij.execution.filters.Filter;
 import com.intellij.execution.filters.HyperlinkInfo;
 import com.intellij.execution.filters.UrlFilter;
+import com.intellij.icons.AllIcons;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.actionSystem.*;
 import com.intellij.openapi.application.ApplicationManager;
@@ -22,9 +23,11 @@ import com.intellij.ui.treeStructure.treetable.TreeTableTree;
 import com.intellij.util.Alarm;
 import com.intellij.util.EventDispatcher;
 import com.intellij.util.ui.ColumnInfo;
+import com.intellij.util.ui.JBUI;
 import com.jetbrains.lang.dart.ide.runner.DartConsoleFilter;
 import io.flutter.console.FlutterConsoleFilter;
 import io.flutter.run.daemon.FlutterApp;
+import io.flutter.utils.JsonUtils;
 import org.apache.commons.lang.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -198,6 +201,10 @@ public class FlutterLogTree extends TreeTable {
       MessageCellRenderer(@NotNull FlutterApp app) {
         this.app = app;
         filters = createMessageFilters().toArray(new Filter[0]);
+        setIconTextGap(JBUI.scale(5));
+        setIconOnTheRight(true);
+        setIconOpaque(false);
+        setTransparentIconBackground(true);
       }
 
       @NotNull
@@ -252,7 +259,10 @@ public class FlutterLogTree extends TreeTable {
           appendStyled(entry, message.substring(cursor));
         }
 
-        // TODO(pq): consider appending a badge if entry.getData() != null
+        // append data badge
+        if (JsonUtils.hasJsonData(entry.getData())) {
+          setIcon(AllIcons.General.Information);
+        }
       }
     }
 

--- a/src/io/flutter/logging/FlutterLogView.java
+++ b/src/io/flutter/logging/FlutterLogView.java
@@ -40,6 +40,7 @@ import com.intellij.util.ui.JBUI;
 import com.intellij.util.ui.UIUtil;
 import io.flutter.logging.FlutterLog.Level;
 import io.flutter.run.daemon.FlutterApp;
+import io.flutter.utils.JsonUtils;
 import io.flutter.utils.UIUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -423,7 +424,8 @@ public class FlutterLogView extends JPanel implements ConsoleView, DataProvider,
       if (!nodes.isEmpty()) {
         // First selection.
         final String data = nodes.get(0).entry.getData();
-        if (data != null && !Objects.equals(data, "null")) {
+        if (JsonUtils.hasJsonData(data)) {
+          @SuppressWarnings("ConstantConditions")
           final JsonElement jsonElement = new JsonParser().parse(data);
           text = gsonHelper.toJson(jsonElement);
         }

--- a/src/io/flutter/utils/JsonUtils.java
+++ b/src/io/flutter/utils/JsonUtils.java
@@ -9,12 +9,14 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
+import org.apache.commons.lang.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 public class JsonUtils {
 
@@ -47,5 +49,9 @@ public class JsonUtils {
     rawValues.forEach(element -> values.add(element.getAsString()));
 
     return values;
+  }
+
+  public static boolean hasJsonData(@Nullable String data) {
+    return StringUtils.isNotEmpty(data) && !Objects.equals(data, "null");
   }
 }


### PR DESCRIPTION
Adds a badge to log entries that have associated data.

![image](https://user-images.githubusercontent.com/67586/48267990-9e25df00-e3e8-11e8-9960-15e222f56f5e.png)

![image](https://user-images.githubusercontent.com/67586/48267993-9fefa280-e3e8-11e8-8415-1ec8bc3bfbbe.png)

**Note:** this is not currently user facing since only logging events produced by `package:logs` will associate JSON data with entries.

(Also: this is certainly not pressing to land; just playing around over ☕️.)

/cc @devoncarew 
