### PR TITLE
Report dart errors

### DIFF
--- a/src/io/flutter/FlutterConstants.java
+++ b/src/io/flutter/FlutterConstants.java
@@ -98,6 +98,9 @@ public class FlutterConstants {
     "watcher",
     "yaml");
 
+  // Aligned w/ VSCode (https://github.com/flutter/flutter-intellij/issues/2682)
+  public static String RELOAD_REASON_SAVE = "save";
+  public static String RELOAD_REASON_MANUAL = "manual";
 
   public static final String FLUTTER_SETTINGS_PAGE_ID = "flutter.settings";
   public static final String INDEPENDENT_PATH_SEPARATOR = "/";

--- a/src/io/flutter/FlutterErrorReportSubmitter.java
+++ b/src/io/flutter/FlutterErrorReportSubmitter.java
@@ -3,11 +3,6 @@
  * Use of this source code is governed by a BSD-style license that can be
  * found in the LICENSE file.
  */
-
-// Not sure how others debug this but here's one technique.
-// Edit com.intellij.ide.plugins.PluginManagerCore.
-// Add this line at the top of getPluginByClassName():
-// if (true) return getPlugins()[getPlugins().length-1].getPluginId(); // DEBUG do not merge
 package io.flutter;
 
 import static com.intellij.openapi.actionSystem.CommonDataKeys.PROJECT;
@@ -41,6 +36,10 @@ import java.util.concurrent.TimeUnit;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+// Not sure how others debug this but here's one technique.
+// Edit com.intellij.ide.plugins.PluginManagerCore.
+// Add this line at the top of getPluginByClassName():
+// if (true) return getPlugins()[getPlugins().length-1].getPluginId(); // DEBUG do not merge
 public class FlutterErrorReportSubmitter extends ErrorReportSubmitter {
   private static final Logger LOG = Logger.getInstance(FlutterErrorReportSubmitter.class);
   private static final String[] KNOWN_ERRORS = new String[]{"Bad state: No element"};
@@ -63,7 +62,6 @@ public class FlutterErrorReportSubmitter extends ErrorReportSubmitter {
     }
 
     String stackTrace = null, errorMessage = null;
-    String destUrl = "https://github.com/flutter/flutter-intellij/issues/new";
     for (IdeaLoggingEvent event : events) {
       String stackTraceText = event.getThrowableText();
       if (stackTraceText.startsWith(COMPLETION_EXCEPTION_PREFIX)) {
@@ -85,8 +83,6 @@ public class FlutterErrorReportSubmitter extends ErrorReportSubmitter {
                 if (endOfDartStack > 0) {
                   // Get only the part between quotes. If the format is wrong just use the whole thing.
                   stackTrace = stackTrace.substring(1, endOfDartStack);
-                  // Only send it to Flutter if it is a known issue and in the expected format.
-                  destUrl = "https://github.com/flutter/flutter/issues/new";
                 }
                 break;
               }
@@ -105,7 +101,7 @@ public class FlutterErrorReportSubmitter extends ErrorReportSubmitter {
     final StringBuilder builder = new StringBuilder();
 
     builder.append("Please file this bug report at ");
-    builder.append(destUrl);
+    builder.append("https://github.com/flutter/flutter-intellij/issues/new");
     builder.append(".\n");
     builder.append("\n");
     builder.append("---\n");

--- a/src/io/flutter/FlutterErrorReportSubmitter.java
+++ b/src/io/flutter/FlutterErrorReportSubmitter.java
@@ -4,15 +4,21 @@
  * found in the LICENSE file.
  */
 
+// Not sure how others debug this but here's one technique.
+// Edit com.intellij.ide.plugins.PluginManagerCore.
+// Add this line at the top of getPluginByClassName():
+// if (true) return getPlugins()[getPlugins().length-1].getPluginId(); // DEBUG do not merge
 package io.flutter;
 
+import static com.intellij.openapi.actionSystem.CommonDataKeys.PROJECT;
+
+import com.intellij.diagnostic.IdeaReportingEvent;
 import com.intellij.ide.DataManager;
 import com.intellij.ide.plugins.IdeaPluginDescriptor;
 import com.intellij.ide.plugins.PluginManager;
 import com.intellij.ide.scratch.ScratchRootType;
 import com.intellij.lang.Language;
 import com.intellij.openapi.actionSystem.DataContext;
-import com.intellij.openapi.actionSystem.PlatformDataKeys;
 import com.intellij.openapi.application.ApplicationInfo;
 import com.intellij.openapi.diagnostic.ErrorReportSubmitter;
 import com.intellij.openapi.diagnostic.IdeaLoggingEvent;
@@ -24,19 +30,21 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.util.Consumer;
+import io.flutter.run.daemon.DaemonApi;
 import io.flutter.sdk.FlutterSdk;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-
-import java.awt.*;
+import java.awt.Component;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class FlutterErrorReportSubmitter extends ErrorReportSubmitter {
   private static final Logger LOG = Logger.getInstance(FlutterErrorReportSubmitter.class);
+  private static final String[] KNOWN_ERRORS = new String[]{"Bad state: No element"};
+  private static final String COMPLETION_EXCEPTION_PREFIX = "java.util.concurrent.CompletionException: java.io.IOException: ";
 
   @NotNull
   @Override
@@ -51,22 +59,55 @@ public class FlutterErrorReportSubmitter extends ErrorReportSubmitter {
                           @NotNull Component parentComponent,
                           @NotNull Consumer<SubmittedReportInfo> consumer) {
     if (events.length == 0) {
-      consumer.consume(new SubmittedReportInfo(
-        null,
-        null,
-        SubmittedReportInfo.SubmissionStatus.FAILED));
+      fail(consumer);
       return;
     }
 
+    String stackTrace = null, errorMessage = null;
+    String destUrl = "https://github.com/flutter/flutter-intellij/issues/new";
+    for (IdeaLoggingEvent event : events) {
+      String stackTraceText = event.getThrowableText();
+      if (stackTraceText.startsWith(COMPLETION_EXCEPTION_PREFIX)) {
+        stackTraceText = stackTraceText.substring(COMPLETION_EXCEPTION_PREFIX.length());
+        if (stackTraceText.startsWith(DaemonApi.FLUTTER_ERROR_PREFIX)) {
+          String message = stackTraceText.substring(DaemonApi.FLUTTER_ERROR_PREFIX.length());
+          int start = message.indexOf(": ") + 2;
+          if (start == 0) continue;
+          int end = message.indexOf('\n');
+          if (end < 0) end = message.length();
+          String error = message.substring(start, end);
+          stackTrace = message.substring(end + 1);
+          for (String err : KNOWN_ERRORS) {
+            if (error.contains(err)) {
+              if (end != message.length()) {
+                // Dart stack trace included so extract it and set the issue target to the Flutter repo.
+                errorMessage = err;
+                int endOfDartStack = stackTrace.indexOf("\\n\"\n");
+                if (endOfDartStack > 0) {
+                  // Get only the part between quotes. If the format is wrong just use the whole thing.
+                  stackTrace = stackTrace.substring(1, endOfDartStack);
+                  // Only send it to Flutter if it is a known issue and in the expected format.
+                  destUrl = "https://github.com/flutter/flutter/issues/new";
+                }
+                break;
+              }
+            }
+          }
+        }
+      }
+    }
+
     final DataContext dataContext = DataManager.getInstance().getDataContext(parentComponent);
-    Project project = PlatformDataKeys.PROJECT.getData(dataContext);
+    Project project = PROJECT.getData(dataContext);
     if (project == null) {
       project = ProjectManager.getInstance().getDefaultProject();
     }
 
     final StringBuilder builder = new StringBuilder();
 
-    builder.append("Please file this bug report at https://github.com/flutter/flutter-intellij/issues/new.\n");
+    builder.append("Please file this bug report at ");
+    builder.append(destUrl);
+    builder.append(".\n");
     builder.append("\n");
     builder.append("---\n");
     builder.append("\n");
@@ -95,7 +136,6 @@ public class FlutterErrorReportSubmitter extends ErrorReportSubmitter {
 
     final IdeaPluginDescriptor dartPlugin = PluginManager.getPlugin(PluginId.getId("Dart"));
     if (dartPlugin != null) {
-      //noinspection ConstantConditions
       builder.append(" • Dart plugin `").append(dartPlugin.getVersion()).append("`");
     }
     builder.append("\n\n");
@@ -115,20 +155,33 @@ public class FlutterErrorReportSubmitter extends ErrorReportSubmitter {
     }
     builder.append("\n");
 
-    for (IdeaLoggingEvent event : events) {
-      builder.append("## Exception\n");
-      builder.append("\n");
-      builder.append(event.getMessage()).append("\n");
-      builder.append("\n");
-
-      if (event.getThrowable() != null) {
-        builder.append("```\n");
-        builder.append(event.getThrowableText().trim()).append("\n");
-        builder.append("```\n");
+    if (stackTrace == null) {
+      for (IdeaLoggingEvent event : events) {
+        builder.append("## Exception\n");
+        builder.append("\n");
+        builder.append(event.getMessage()).append("\n");
         builder.append("\n");
 
-        FlutterInitializer.getAnalytics().sendException(event.getThrowable(), false);
+        if (event.getThrowable() != null) {
+          builder.append("```\n");
+          builder.append(event.getThrowableText().trim()).append("\n");
+          builder.append("```\n");
+          builder.append("\n");
+
+          FlutterInitializer.getAnalytics().sendException(event.getThrowable(), false);
+        }
       }
+    }
+    else {
+
+      builder.append("## Exception\n");
+      builder.append("\n");
+      builder.append(errorMessage).append("\n");
+      builder.append("\n");
+      builder.append("```\n");
+      builder.append(stackTrace.replaceAll("\\\\n", "\n")).append("\n");
+      builder.append("```\n");
+      builder.append("\n");
     }
 
     final String text = builder.toString().trim() + "\n";
@@ -143,10 +196,7 @@ public class FlutterErrorReportSubmitter extends ErrorReportSubmitter {
       new OpenFileDescriptor(project, file).navigate(true);
     }
     else {
-      consumer.consume(new SubmittedReportInfo(
-        null,
-        null,
-        SubmittedReportInfo.SubmissionStatus.FAILED));
+      fail(consumer);
     }
 
     consumer.consume(new SubmittedReportInfo(
@@ -162,7 +212,7 @@ public class FlutterErrorReportSubmitter extends ErrorReportSubmitter {
     return new SubmittedReportInfo(null, "0", SubmittedReportInfo.SubmissionStatus.FAILED);
   }
 
-  private String getFlutterVersion(final FlutterSdk sdk) {
+  private static String getFlutterVersion(final FlutterSdk sdk) {
     try {
       final String flutterPath = sdk.getHomePath() + "/bin/flutter";
       final ProcessBuilder builder = new ProcessBuilder(flutterPath, "--version");
@@ -177,7 +227,15 @@ public class FlutterErrorReportSubmitter extends ErrorReportSubmitter {
     }
   }
 
+  private static void fail(@NotNull Consumer<SubmittedReportInfo> consumer) {
+    consumer.consume(new SubmittedReportInfo(
+      null,
+      null,
+      SubmittedReportInfo.SubmissionStatus.FAILED));
+  }
+
   private static byte[] readFully(InputStream in) throws IOException {
+    //noinspection resource
     final ByteArrayOutputStream out = new ByteArrayOutputStream();
     final byte[] temp = new byte[4096];
     int count = in.read(temp);

--- a/src/io/flutter/FlutterErrorReportSubmitter.java
+++ b/src/io/flutter/FlutterErrorReportSubmitter.java
@@ -12,7 +12,6 @@ package io.flutter;
 
 import static com.intellij.openapi.actionSystem.CommonDataKeys.PROJECT;
 
-import com.intellij.diagnostic.IdeaReportingEvent;
 import com.intellij.ide.DataManager;
 import com.intellij.ide.plugins.IdeaPluginDescriptor;
 import com.intellij.ide.plugins.PluginManager;
@@ -194,15 +193,14 @@ public class FlutterErrorReportSubmitter extends ErrorReportSubmitter {
     if (file != null) {
       // Open the file.
       new OpenFileDescriptor(project, file).navigate(true);
+      consumer.consume(new SubmittedReportInfo(
+        null,
+        "",
+        SubmittedReportInfo.SubmissionStatus.NEW_ISSUE));
     }
     else {
       fail(consumer);
     }
-
-    consumer.consume(new SubmittedReportInfo(
-      null,
-      "",
-      SubmittedReportInfo.SubmissionStatus.NEW_ISSUE));
   }
 
   @SuppressWarnings("deprecation")

--- a/src/io/flutter/FlutterErrorReportSubmitter.java
+++ b/src/io/flutter/FlutterErrorReportSubmitter.java
@@ -11,6 +11,7 @@
 package io.flutter;
 
 import static com.intellij.openapi.actionSystem.CommonDataKeys.PROJECT;
+import static io.flutter.run.daemon.DaemonApi.COMPLETION_EXCEPTION_PREFIX;
 
 import com.intellij.ide.DataManager;
 import com.intellij.ide.plugins.IdeaPluginDescriptor;
@@ -43,7 +44,6 @@ import org.jetbrains.annotations.Nullable;
 public class FlutterErrorReportSubmitter extends ErrorReportSubmitter {
   private static final Logger LOG = Logger.getInstance(FlutterErrorReportSubmitter.class);
   private static final String[] KNOWN_ERRORS = new String[]{"Bad state: No element"};
-  private static final String COMPLETION_EXCEPTION_PREFIX = "java.util.concurrent.CompletionException: java.io.IOException: ";
 
   @NotNull
   @Override

--- a/src/io/flutter/actions/ReloadFlutterApp.java
+++ b/src/io/flutter/actions/ReloadFlutterApp.java
@@ -11,6 +11,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Computable;
 import icons.FlutterIcons;
 import io.flutter.FlutterBundle;
+import io.flutter.FlutterConstants;
 import io.flutter.FlutterInitializer;
 import io.flutter.run.FlutterReloadManager;
 import io.flutter.run.daemon.FlutterApp;
@@ -31,7 +32,7 @@ public class ReloadFlutterApp extends FlutterAppAction {
   }
 
   @Override
-  public void actionPerformed(AnActionEvent e) {
+  public void actionPerformed(@NotNull AnActionEvent e) {
     final Project project = getEventProject(e);
     if (project == null) {
       return;
@@ -43,12 +44,12 @@ public class ReloadFlutterApp extends FlutterAppAction {
 
     if (shouldRestart) {
       FlutterInitializer.sendAnalyticsAction(RestartFlutterApp.class.getSimpleName());
-      FlutterReloadManager.getInstance(project).saveAllAndRestart(getApp());
+      FlutterReloadManager.getInstance(project).saveAllAndRestart(getApp(), FlutterConstants.RELOAD_REASON_MANUAL);
     }
     else {
       // Else perform a hot reload.
       FlutterInitializer.sendAnalyticsAction(this);
-      FlutterReloadManager.getInstance(project).saveAllAndReload(getApp());
+      FlutterReloadManager.getInstance(project).saveAllAndReload(getApp(), FlutterConstants.RELOAD_REASON_MANUAL);
     }
   }
 }

--- a/src/io/flutter/actions/RestartFlutterApp.java
+++ b/src/io/flutter/actions/RestartFlutterApp.java
@@ -11,6 +11,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Computable;
 import icons.FlutterIcons;
 import io.flutter.FlutterBundle;
+import io.flutter.FlutterConstants;
 import io.flutter.FlutterInitializer;
 import io.flutter.run.FlutterReloadManager;
 import io.flutter.run.daemon.FlutterApp;
@@ -29,7 +30,7 @@ public class RestartFlutterApp extends FlutterAppAction {
   }
 
   @Override
-  public void actionPerformed(AnActionEvent e) {
+  public void actionPerformed(@NotNull AnActionEvent e) {
     final Project project = getEventProject(e);
     if (project == null) {
       return;
@@ -37,6 +38,6 @@ public class RestartFlutterApp extends FlutterAppAction {
 
     FlutterInitializer.sendAnalyticsAction(this);
 
-    FlutterReloadManager.getInstance(project).saveAllAndRestart(getApp());
+    FlutterReloadManager.getInstance(project).saveAllAndRestart(getApp(), FlutterConstants.RELOAD_REASON_MANUAL);
   }
 }

--- a/src/io/flutter/console/FlutterConsoleFilter.java
+++ b/src/io/flutter/console/FlutterConsoleFilter.java
@@ -21,6 +21,7 @@ import com.intellij.openapi.roots.ModuleRootManager;
 import com.intellij.openapi.ui.Messages;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
+import io.flutter.FlutterConstants;
 import io.flutter.FlutterInitializer;
 import io.flutter.FlutterMessages;
 import io.flutter.FlutterUtils;
@@ -195,7 +196,7 @@ public class FlutterConsoleFilter implements Filter {
       }
 
       FlutterInitializer.sendAnalyticsAction(RestartFlutterApp.class.getSimpleName());
-      FlutterReloadManager.getInstance(project).saveAllAndRestart(app);
+      FlutterReloadManager.getInstance(project).saveAllAndRestart(app, FlutterConstants.RELOAD_REASON_MANUAL);
     }
   }
 

--- a/src/io/flutter/logging/FlutterLogTree.java
+++ b/src/io/flutter/logging/FlutterLogTree.java
@@ -8,6 +8,7 @@ package io.flutter.logging;
 import com.intellij.execution.filters.Filter;
 import com.intellij.execution.filters.HyperlinkInfo;
 import com.intellij.execution.filters.UrlFilter;
+import com.intellij.icons.AllIcons;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.actionSystem.*;
 import com.intellij.openapi.application.ApplicationManager;
@@ -22,9 +23,11 @@ import com.intellij.ui.treeStructure.treetable.TreeTableTree;
 import com.intellij.util.Alarm;
 import com.intellij.util.EventDispatcher;
 import com.intellij.util.ui.ColumnInfo;
+import com.intellij.util.ui.JBUI;
 import com.jetbrains.lang.dart.ide.runner.DartConsoleFilter;
 import io.flutter.console.FlutterConsoleFilter;
 import io.flutter.run.daemon.FlutterApp;
+import io.flutter.utils.JsonUtils;
 import org.apache.commons.lang.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -198,6 +201,10 @@ public class FlutterLogTree extends TreeTable {
       MessageCellRenderer(@NotNull FlutterApp app) {
         this.app = app;
         filters = createMessageFilters().toArray(new Filter[0]);
+        setIconTextGap(JBUI.scale(5));
+        setIconOnTheRight(true);
+        setIconOpaque(false);
+        setTransparentIconBackground(true);
       }
 
       @NotNull
@@ -252,7 +259,10 @@ public class FlutterLogTree extends TreeTable {
           appendStyled(entry, message.substring(cursor));
         }
 
-        // TODO(pq): consider appending a badge if entry.getData() != null
+        // append data badge
+        if (JsonUtils.hasJsonData(entry.getData())) {
+          setIcon(AllIcons.General.Information);
+        }
       }
     }
 

--- a/src/io/flutter/logging/FlutterLogView.java
+++ b/src/io/flutter/logging/FlutterLogView.java
@@ -40,6 +40,7 @@ import com.intellij.util.ui.JBUI;
 import com.intellij.util.ui.UIUtil;
 import io.flutter.logging.FlutterLog.Level;
 import io.flutter.run.daemon.FlutterApp;
+import io.flutter.utils.JsonUtils;
 import io.flutter.utils.UIUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -423,7 +424,8 @@ public class FlutterLogView extends JPanel implements ConsoleView, DataProvider,
       if (!nodes.isEmpty()) {
         // First selection.
         final String data = nodes.get(0).entry.getData();
-        if (data != null && !Objects.equals(data, "null")) {
+        if (JsonUtils.hasJsonData(data)) {
+          @SuppressWarnings("ConstantConditions")
           final JsonElement jsonElement = new JsonParser().parse(data);
           text = gsonHelper.toJson(jsonElement);
         }

--- a/src/io/flutter/preview/RenderHelper.java
+++ b/src/io/flutter/preview/RenderHelper.java
@@ -15,6 +15,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService;
+import io.flutter.FlutterConstants;
 import io.flutter.pub.PubRoot;
 import io.flutter.run.daemon.DaemonApi;
 import io.flutter.run.daemon.FlutterApp;
@@ -333,7 +334,8 @@ class RenderThread extends Thread {
       if (myProcessRequest != null && myApp != null) {
         if (Objects.equals(myProcessRequest.pubRoot.getPath(), packagePath)) {
           try {
-            final DaemonApi.RestartResult restartResult = myApp.performHotReload(false).get(5000, TimeUnit.MILLISECONDS);
+            final DaemonApi.RestartResult restartResult =
+              myApp.performHotReload(false, FlutterConstants.RELOAD_REASON_SAVE).get(5000, TimeUnit.MILLISECONDS);
             if (restartResult.ok()) {
               canRenderWithCurrentProcess = true;
             }

--- a/src/io/flutter/run/FlutterReloadManager.java
+++ b/src/io/flutter/run/FlutterReloadManager.java
@@ -43,6 +43,7 @@ import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService;
 import com.jetbrains.lang.dart.analyzer.DartServerData;
 import com.jetbrains.lang.dart.ide.errorTreeView.DartProblemsView;
 import icons.FlutterIcons;
+import io.flutter.FlutterConstants;
 import io.flutter.actions.FlutterAppAction;
 import io.flutter.actions.ProjectActions;
 import io.flutter.actions.ReloadFlutterApp;
@@ -114,7 +115,7 @@ public class FlutterReloadManager {
       private @Nullable Project eventProject;
       private @Nullable Editor eventEditor;
 
-      public void beforeActionPerformed(AnAction action, DataContext dataContext, AnActionEvent event) {
+      public void beforeActionPerformed(@NotNull AnAction action, @NotNull DataContext dataContext, AnActionEvent event) {
         if (action instanceof SaveAllAction) {
           // Save the current project value here. If we access later (in afterActionPerformed), we can get
           // exceptions if another event occurs before afterActionPerformed is called.
@@ -134,7 +135,7 @@ public class FlutterReloadManager {
       }
 
       @Override
-      public void afterActionPerformed(AnAction action, DataContext dataContext, AnActionEvent event) {
+      public void afterActionPerformed(AnAction action, @NotNull DataContext dataContext, AnActionEvent event) {
         if (!(action instanceof SaveAllAction)) {
           return;
         }
@@ -206,7 +207,7 @@ public class FlutterReloadManager {
       final Notification notification = showRunNotification(app, null, "Reloading…", false);
       final long startTime = System.currentTimeMillis();
 
-      app.performHotReload(supportsPauseAfterReload()).thenAccept(result -> {
+      app.performHotReload(supportsPauseAfterReload(), FlutterConstants.RELOAD_REASON_SAVE).thenAccept(result -> {
         if (!result.ok()) {
           notification.expire();
           showRunNotification(app, "Hot Reload Error", result.getMessage(), true);
@@ -232,11 +233,11 @@ public class FlutterReloadManager {
     }, reloadDelayMs, TimeUnit.MILLISECONDS);
   }
 
-  public void saveAllAndReload(@NotNull FlutterApp app) {
+  public void saveAllAndReload(@NotNull FlutterApp app, String reason) {
     if (app.isStarted()) {
       FileDocumentManager.getInstance().saveAllDocuments();
 
-      app.performHotReload(supportsPauseAfterReload()).thenAccept(result -> {
+      app.performHotReload(supportsPauseAfterReload(), reason).thenAccept(result -> {
         if (!result.ok()) {
           showRunNotification(app, "Hot Reload", result.getMessage(), true);
         }
@@ -250,10 +251,10 @@ public class FlutterReloadManager {
     }
   }
 
-  public void saveAllAndRestart(@NotNull FlutterApp app) {
+  public void saveAllAndRestart(@NotNull FlutterApp app, String reason) {
     if (app.isStarted()) {
       FileDocumentManager.getInstance().saveAllDocuments();
-      app.performRestartApp().thenAccept(result -> {
+      app.performRestartApp(reason).thenAccept(result -> {
         if (!result.ok()) {
           showRunNotification(app, "Hot Restart", result.getMessage(), true);
         }

--- a/src/io/flutter/run/LaunchState.java
+++ b/src/io/flutter/run/LaunchState.java
@@ -38,6 +38,7 @@ import com.intellij.xdebugger.XDebugSession;
 import com.intellij.xdebugger.XDebuggerManager;
 import com.jetbrains.lang.dart.ide.runner.DartExecutionHelper;
 import com.jetbrains.lang.dart.util.DartUrlResolver;
+import io.flutter.FlutterConstants;
 import io.flutter.FlutterInitializer;
 import io.flutter.actions.RestartFlutterApp;
 import io.flutter.dart.DartPlugin;
@@ -399,7 +400,7 @@ public class LaunchState extends CommandLineState {
               // Map a re-run action to a flutter hot restart.
               FileDocumentManager.getInstance().saveAllDocuments();
               FlutterInitializer.sendAnalyticsAction(RestartFlutterApp.class.getSimpleName());
-              app.performRestartApp();
+              app.performRestartApp(FlutterConstants.RELOAD_REASON_SAVE);
             }
           }
 

--- a/src/io/flutter/run/daemon/DaemonApi.java
+++ b/src/io/flutter/run/daemon/DaemonApi.java
@@ -67,8 +67,8 @@ public class DaemonApi {
 
   // app domain
 
-  CompletableFuture<RestartResult> restartApp(@NotNull String appId, boolean fullRestart, boolean pause) {
-    return send("app.restart", new AppRestart(appId, fullRestart, pause));
+  CompletableFuture<RestartResult> restartApp(@NotNull String appId, boolean fullRestart, boolean pause, @NotNull String reason) {
+    return send("app.restart", new AppRestart(appId, fullRestart, pause, reason));
   }
 
   CompletableFuture<Boolean> stopApp(@NotNull String appId) {
@@ -391,11 +391,13 @@ public class DaemonApi {
     @NotNull final String appId;
     final boolean fullRestart;
     final boolean pause;
+    @NotNull final String reason;
 
-    AppRestart(@NotNull String appId, boolean fullRestart, boolean pause) {
+    AppRestart(@NotNull String appId, boolean fullRestart, boolean pause, @NotNull String reason) {
       this.appId = appId;
       this.fullRestart = fullRestart;
       this.pause = pause;
+      this.reason = reason;
     }
 
     @Override

--- a/src/io/flutter/run/daemon/DaemonApi.java
+++ b/src/io/flutter/run/daemon/DaemonApi.java
@@ -62,8 +62,6 @@ public class DaemonApi {
    */
   private final Deque<String> stderr = new ArrayDeque<>();
 
-  // app domain
-
   /**
    * Creates an Api that sends JSON to a callback.
    */
@@ -87,8 +85,6 @@ public class DaemonApi {
   CompletableFuture<Boolean> stopApp(@NotNull String appId) {
     return send("app.stop", new AppStop(appId));
   }
-
-  // device domain
 
   void cancelPending() {
     final List<Command> commands;

--- a/src/io/flutter/run/daemon/DaemonApi.java
+++ b/src/io/flutter/run/daemon/DaemonApi.java
@@ -48,6 +48,7 @@ import org.jetbrains.annotations.Nullable;
  */
 public class DaemonApi {
   public static final String FLUTTER_ERROR_PREFIX = "error from";
+  public static final String COMPLETION_EXCEPTION_PREFIX = "java.util.concurrent.CompletionException: java.io.IOException: ";
 
   private static final int STDERR_LINES_TO_KEEP = 100;
   private static final Gson GSON = new Gson();
@@ -195,6 +196,7 @@ public class DaemonApi {
         if (trace != null) {
           message += "\n" + trace;
         }
+        // Be sure to keep this statement in sync with COMPLETION_EXCEPTION_PREFIX.
         cmd.completeExceptionally(new IOException(message));
       }
       else {

--- a/src/io/flutter/run/daemon/DaemonApi.java
+++ b/src/io/flutter/run/daemon/DaemonApi.java
@@ -6,7 +6,12 @@
 package io.flutter.run.daemon;
 
 import com.google.common.base.Charsets;
-import com.google.gson.*;
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSyntaxException;
 import com.intellij.execution.process.ProcessAdapter;
 import com.intellij.execution.process.ProcessEvent;
 import com.intellij.execution.process.ProcessHandler;
@@ -15,18 +20,22 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.util.Key;
 import io.flutter.settings.FlutterSettings;
 import io.flutter.utils.StdoutJsonParser;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
-import java.util.*;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Sends JSON commands to a flutter daemon process, assigning a new id to each one.
@@ -38,18 +47,21 @@ import java.util.function.Function;
  * >The Flutter Daemon Mode</a>.
  */
 public class DaemonApi {
-  private static final int STDERR_LINES_TO_KEEP = 100;
+  public static final String FLUTTER_ERROR_PREFIX = "error from";
 
+  private static final int STDERR_LINES_TO_KEEP = 100;
+  private static final Gson GSON = new Gson();
+  private static final Logger LOG = Logger.getInstance(DaemonApi.class);
   @NotNull private final Consumer<String> callback;
   private final AtomicInteger nextId = new AtomicInteger();
   private final Map<Integer, Command> pending = new LinkedHashMap<>();
-
   private final StdoutJsonParser stdoutParser = new StdoutJsonParser();
-
   /**
    * A ring buffer holding the last few lines that the process sent to stderr.
    */
   private final Deque<String> stderr = new ArrayDeque<>();
+
+  // app domain
 
   /**
    * Creates an Api that sends JSON to a callback.
@@ -75,6 +87,8 @@ public class DaemonApi {
     return send("app.stop", new AppStop(appId));
   }
 
+  // device domain
+
   void cancelPending() {
     final List<Command> commands;
 
@@ -96,8 +110,6 @@ public class DaemonApi {
                                                         @NotNull Map<String, Object> params) {
     return send("app.callServiceExtension", new AppServiceExtension(appId, methodName, params));
   }
-
-  // device domain
 
   CompletableFuture enableDeviceEvents() {
     return send("device.enable", null);
@@ -178,7 +190,12 @@ public class DaemonApi {
 
       final JsonElement error = obj.get("error");
       if (error != null) {
-        cmd.completeExceptionally(new IOException("error from " + cmd.method + ": " + error));
+        final JsonElement trace = obj.get("trace");
+        String message = FLUTTER_ERROR_PREFIX + " " + cmd.method + ": " + error;
+        if (trace != null) {
+          message += "\n" + trace;
+        }
+        cmd.completeExceptionally(new IOException(message));
       }
       else {
         cmd.complete(obj.get("result"));
@@ -205,12 +222,21 @@ public class DaemonApi {
       final int id = nextId.getAndIncrement();
       final Command<T> command = new Command<>(method, params, id);
       final String json = command.toString();
+      //noinspection NestedSynchronizedStatement
       synchronized (pending) {
         pending.put(id, command);
       }
       callback.accept(json);
       return command.done;
     }
+  }
+
+  /**
+   * Returns the last lines written to stderr.
+   */
+  public String getStderrTail() {
+    final String[] lines = stderr.toArray(new String[]{});
+    return String.join("", lines);
   }
 
   /**
@@ -258,7 +284,7 @@ public class DaemonApi {
       }
 
       try {
-        final int id = idField.getAsInt();
+        idField.getAsInt();
         return obj;
       }
       catch (NumberFormatException e) {
@@ -293,14 +319,7 @@ public class DaemonApi {
     return new PrintWriter(new OutputStreamWriter(stdin, Charsets.UTF_8));
   }
 
-  /**
-   * Returns the last lines written to stderr.
-   */
-  public String getStderrTail() {
-    final String[] lines = stderr.toArray(new String[]{});
-    return String.join("", lines);
-  }
-
+  @SuppressWarnings("unused")
   public static class RestartResult {
     private int code;
     private String message;
@@ -443,7 +462,4 @@ public class DaemonApi {
       return obj;
     }
   }
-
-  private static final Gson GSON = new Gson();
-  private static final Logger LOG = Logger.getInstance(DaemonApi.class);
 }

--- a/src/io/flutter/run/daemon/FlutterApp.java
+++ b/src/io/flutter/run/daemon/FlutterApp.java
@@ -305,7 +305,7 @@ public class FlutterApp {
   /**
    * Perform a hot restart of the the app.
    */
-  public CompletableFuture<DaemonApi.RestartResult> performRestartApp() {
+  public CompletableFuture<DaemonApi.RestartResult> performRestartApp(@NotNull String reason) {
     if (myAppId == null) {
       LOG.warn("cannot restart Flutter app because app id is not set");
 
@@ -324,7 +324,7 @@ public class FlutterApp {
     changeState(State.RESTARTING);
 
     final CompletableFuture<DaemonApi.RestartResult> future =
-      myDaemonApi.restartApp(myAppId, true, false);
+      myDaemonApi.restartApp(myAppId, true, false, reason);
     future.thenAccept(result -> changeState(State.STARTED));
     future.thenRun(this::notifyAppRestarted);
     return future;
@@ -352,7 +352,7 @@ public class FlutterApp {
   /**
    * Perform a hot reload of the app.
    */
-  public CompletableFuture<DaemonApi.RestartResult> performHotReload(boolean pauseAfterRestart) {
+  public CompletableFuture<DaemonApi.RestartResult> performHotReload(boolean pauseAfterRestart, @NotNull String reason) {
     if (myAppId == null) {
       LOG.warn("cannot reload Flutter app because app id is not set");
 
@@ -371,7 +371,7 @@ public class FlutterApp {
     changeState(State.RELOADING);
 
     final CompletableFuture<DaemonApi.RestartResult> future =
-      myDaemonApi.restartApp(myAppId, false, pauseAfterRestart);
+      myDaemonApi.restartApp(myAppId, false, pauseAfterRestart, reason);
     future.thenAccept(result -> changeState(State.STARTED));
     future.thenRun(this::notifyAppReloaded);
     return future;

--- a/src/io/flutter/utils/JsonUtils.java
+++ b/src/io/flutter/utils/JsonUtils.java
@@ -9,12 +9,14 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
+import org.apache.commons.lang.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 public class JsonUtils {
 
@@ -47,5 +49,9 @@ public class JsonUtils {
     rawValues.forEach(element -> values.add(element.getAsString()));
 
     return values;
+  }
+
+  public static boolean hasJsonData(@Nullable String data) {
+    return StringUtils.isNotEmpty(data) && !Objects.equals(data, "null");
   }
 }

--- a/testSrc/unit/io/flutter/run/daemon/DaemonApiTest.java
+++ b/testSrc/unit/io/flutter/run/daemon/DaemonApiTest.java
@@ -37,9 +37,9 @@ public class DaemonApiTest {
 
   @Test
   public void canRestartApp() throws Exception {
-    final Future<DaemonApi.RestartResult> result = api.restartApp("foo", true, false);
+    final Future<DaemonApi.RestartResult> result = api.restartApp("foo", true, false, "manual");
     checkSent(result, "app.restart",
-              curly("appId:\"foo\"", "fullRestart:true", "pause:false"));
+              curly("appId:\"foo\"", "fullRestart:true", "pause:false", "reason:\"manual\""));
 
     replyWithResult(result, curly("code:42", "message:\"sorry\""));
     assertFalse(result.get().ok());


### PR DESCRIPTION
Recognize Dart stack traces. Send error reports to the Flutter repo when they are recognized as such. If we can't be sure what we have, but we think it is a Dart stack trace, send it to this repo. Unfortunately, DaemonApi was not properly arranged so the methods got moved around when it was reformatted. The main change in it was fetching the Dart stack trace at line 188.

Fixes #2657

Sample report (with simulated error):
[bug-report.txt](https://github.com/flutter/flutter-intellij/files/2567831/bug-report.txt)

@devoncarew 
