### PR TITLE
Restore ‘no app running’ inspector message (#2762)

### DIFF
--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -82,6 +82,8 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
     boolean sendRestartNotificationOnNextFrame = false;
   }
 
+  private Content emptyContent;
+
   public static final String TOOL_WINDOW_ID = "Flutter Inspector";
 
   public static final String WIDGET_TAB_LABEL = "Widgets";
@@ -409,6 +411,12 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
       return;
     }
 
+    if (emptyContent != null) {
+      final ContentManager contentManager = toolWindow.getContentManager();
+      contentManager.removeContent(emptyContent, true);
+      emptyContent = null;
+    }
+
     toolWindow.setIcon(ExecutionUtil.getLiveIndicator(FlutterIcons.Flutter_13));
 
     listenForRenderTreeActivations(toolWindow);
@@ -473,6 +481,15 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
     }
 
     toolWindow.setIcon(FlutterIcons.Flutter_13);
+
+    // Display a 'No running applications' message.
+    final ContentManager contentManager = toolWindow.getContentManager();
+    final JPanel panel = new JPanel(new BorderLayout());
+    final JLabel label = new JLabel("No running applications", SwingConstants.CENTER);
+    label.setForeground(UIUtil.getLabelDisabledForeground());
+    panel.add(label, BorderLayout.CENTER);
+    emptyContent = contentManager.getFactory().createContent(panel, null, false);
+    contentManager.addContent(emptyContent);
   }
 
   private static void listenForRenderTreeActivations(@NotNull ToolWindow toolWindow) {

--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -484,7 +484,7 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
     // Display a 'No running applications' message.
     final ContentManager contentManager = toolWindow.getContentManager();
     final JPanel panel = new JPanel(new BorderLayout());
-    final JLabel label = new JLabel("No running applications", SwingConstants.CENTER);
+    final JBLabel label = new JBLabel("No running applications", SwingConstants.CENTER);
     label.setForeground(UIUtil.getLabelDisabledForeground());
     panel.add(label, BorderLayout.CENTER);
     emptyContent = contentManager.getFactory().createContent(panel, null, false);


### PR DESCRIPTION
Fixes: #2762.

Confirmed this works in 2018.3 and AS 3.2.1.

Happy to add a check for earlier versions if you all think it's prudent?

/cc @jacob314 @devoncarew 