### PR TITLE
Remove size specification from WidgetPerfPanel. 

### DIFF
--- a/src/io/flutter/inspector/WidgetPerfPanel.java
+++ b/src/io/flutter/inspector/WidgetPerfPanel.java
@@ -37,7 +37,6 @@ import java.util.ArrayList;
  * file.
  */
 public class WidgetPerfPanel extends JPanel {
-  static final int PANEL_HEIGHT = 240;
   static final int PERF_TIP_COMPUTE_DELAY = 1000;
   private final JBLabel perfMessage;
   private final FlutterApp app;
@@ -70,8 +69,6 @@ public class WidgetPerfPanel extends JPanel {
     this.app = app;
     perfManager = FlutterWidgetPerfManager.getInstance(app.getProject());
 
-    setPreferredSize(new Dimension(-1, PANEL_HEIGHT));
-    setMaximumSize(new Dimension(Short.MAX_VALUE, PANEL_HEIGHT));
     perfMessage = new JBLabel();
     final Box labelBox = Box.createHorizontalBox();
     labelBox.add(perfMessage);


### PR DESCRIPTION
Prevents perf tips from being clipped:
![screen shot 2018-11-14 at 9 10 58 am](https://user-images.githubusercontent.com/43759233/48502099-99e83000-e7f3-11e8-9f29-aad8fe29c66f.png)
Now the layout can extend as much as it needs to (see exaggerated example):
![screen shot 2018-11-14 at 9 58 43 am](https://user-images.githubusercontent.com/43759233/48502243-edf31480-e7f3-11e8-956b-e96486802256.png)
