### PR TITLE
Improve UI for Frame Rendering Graph (formerly called FPS).

### DIFF
--- a/src/io/flutter/inspector/FPSDisplay.java
+++ b/src/io/flutter/inspector/FPSDisplay.java
@@ -171,7 +171,11 @@ class FPSPanel extends JPanel {
           widget = new JLabel();
           widget.setOpaque(true);
           widget.setBackground(frame.isSlowFrame() ? JBColor.RED : UIUtil.getLabelForeground());
-          widget.setToolTipText(FPSDisplay.df.format(frame.elapsedMicros / 1000.0d) + "ms");
+          widget.setToolTipText(frame.isSlowFrame()
+                                ? "This frame took " +
+                                  FPSDisplay.df.format(frame.elapsedMicros / 1000.0d) +
+                                  "ms to render, which can cause frame rate to drop below 60 FPS"
+                                : "This frame took " + FPSDisplay.df.format(frame.elapsedMicros / 1000.0d) + "ms to render");
           frameWidgets.put(frame, widget);
           add(widget);
         }

--- a/src/io/flutter/inspector/FrameRenderingDisplay.java
+++ b/src/io/flutter/inspector/FrameRenderingDisplay.java
@@ -59,7 +59,7 @@ public class FrameRenderingDisplay {
     targetFrameTimeLabel.setForeground(UIUtil.getLabelDisabledForeground());
     targetFrameTimeLabel.setBorder(JBUI.Borders.empty(2));
     targetFrameTimeLabel.setOpaque(false);
-    targetFrameTimeLabel.setToolTipText("Targeting 16ms per frame will\n result in 60 frames per second.");
+    targetFrameTimeLabel.setToolTipText("Targeting 16ms per frame will\nresult in 60 frames per second.");
     final JBPanel targetFrameTimePanel = new JBPanel();
     targetFrameTimePanel.setLayout(new BoxLayout(targetFrameTimePanel, BoxLayout.Y_AXIS));
     targetFrameTimePanel.setOpaque(false);
@@ -141,6 +141,7 @@ class FrameRenderingPanel extends JPanel {
     try {
       g2.setStroke(STROKE);
       final Path2D path = new Path2D.Float();
+      // Slight left indent to allow space for [targetFrameTimeLabel].
       path.moveTo(34, height - y);
       path.lineTo(bounds.width, height - y);
       g2.draw(path);
@@ -183,7 +184,7 @@ class FrameRenderingPanel extends JPanel {
           widget.setToolTipText(frame.isSlowFrame()
                                 ? "This frame took " +
                                   FrameRenderingDisplay.df.format(frame.elapsedMicros / 1000.0d) +
-                                  "ms to render, which\n can cause frame rate to drop below 60 FPS."
+                                  "ms to render, which\ncan cause frame rate to drop below 60 FPS."
                                 : "This frame took " + FrameRenderingDisplay.df.format(frame.elapsedMicros / 1000.0d) + "ms to render.");
           frameWidgets.put(frame, widget);
           add(widget);

--- a/src/io/flutter/inspector/FrameRenderingDisplay.java
+++ b/src/io/flutter/inspector/FrameRenderingDisplay.java
@@ -9,6 +9,7 @@ import com.intellij.openapi.Disposable;
 import com.intellij.openapi.util.Disposer;
 import com.intellij.ui.JBColor;
 import com.intellij.ui.components.JBLabel;
+import com.intellij.ui.components.JBPanel;
 import com.intellij.util.ui.JBUI;
 import com.intellij.util.ui.UIUtil;
 import io.flutter.run.daemon.FlutterApp;
@@ -21,12 +22,14 @@ import java.text.DecimalFormat;
 import java.util.*;
 import java.util.List;
 
-public class FPSDisplay {
+public class FrameRenderingDisplay {
   static final DecimalFormat df = new DecimalFormat();
 
   static {
     df.setMaximumFractionDigits(1);
   }
+
+  private static final String TARGET_FRAME_RENDERING_TIME = "16ms";
 
   public static JPanel createJPanelView(Disposable parentDisposable, FlutterApp app) {
     final JPanel panel = new JPanel(new StackLayout());
@@ -37,41 +40,47 @@ public class FPSDisplay {
     assert app.getVMServiceManager() != null;
     final FlutterFramesMonitor flutterFramesMonitor = app.getVMServiceManager().getFlutterFramesMonitor();
 
-    final FPSPanel fpsPanel = new FPSPanel(flutterFramesMonitor);
+    final FrameRenderingPanel frameRenderingPanel = new FrameRenderingPanel(flutterFramesMonitor);
 
-    final JPanel labelsPanel = new JPanel();
-    labelsPanel.setOpaque(false);
-    labelsPanel.setLayout(new BoxLayout(labelsPanel, BoxLayout.X_AXIS));
-    panel.add(fpsPanel);
-    panel.add(labelsPanel);
+    final JBLabel latestFrameTimeLabel = new JBLabel();
+    latestFrameTimeLabel.setAlignmentX(Component.RIGHT_ALIGNMENT);
+    latestFrameTimeLabel.setFont(UIUtil.getLabelFont(UIUtil.FontSize.SMALL));
+    latestFrameTimeLabel.setForeground(UIUtil.getLabelDisabledForeground());
+    latestFrameTimeLabel.setBorder(JBUI.Borders.empty(0, 4));
+    latestFrameTimeLabel.setOpaque(false);
+    latestFrameTimeLabel.setToolTipText("Rendering time of latest frame.");
+    final JBPanel latestFrameTimePanel = new JBPanel();
+    latestFrameTimePanel.setLayout(new BoxLayout(latestFrameTimePanel, BoxLayout.Y_AXIS));
+    latestFrameTimePanel.setOpaque(false);
+    latestFrameTimePanel.add(latestFrameTimeLabel);
 
-    final JBLabel fpsLabel = new JBLabel();
-    fpsLabel.setAlignmentY(Component.TOP_ALIGNMENT);
-    fpsLabel.setFont(UIUtil.getLabelFont(UIUtil.FontSize.SMALL));
-    fpsLabel.setForeground(UIUtil.getLabelDisabledForeground());
-    fpsLabel.setOpaque(false);
-    fpsLabel.setBorder(JBUI.Borders.empty(4));
+    final JBLabel targetFrameTimeLabel = new JBLabel(TARGET_FRAME_RENDERING_TIME);
+    targetFrameTimeLabel.setFont(UIUtil.getLabelFont(UIUtil.FontSize.SMALL));
+    targetFrameTimeLabel.setForeground(UIUtil.getLabelDisabledForeground());
+    targetFrameTimeLabel.setBorder(JBUI.Borders.empty(2));
+    targetFrameTimeLabel.setOpaque(false);
+    targetFrameTimeLabel.setToolTipText("Targeting 16ms per frame will\n result in 60 frames per second.");
+    final JBPanel targetFrameTimePanel = new JBPanel();
+    targetFrameTimePanel.setLayout(new BoxLayout(targetFrameTimePanel, BoxLayout.Y_AXIS));
+    targetFrameTimePanel.setOpaque(false);
+    targetFrameTimePanel.add(Box.createVerticalGlue());
+    targetFrameTimePanel.add(targetFrameTimeLabel);
+    targetFrameTimePanel.add(Box.createVerticalGlue());
 
-    final JBLabel elapsedLabel = new JBLabel("", SwingConstants.RIGHT);
-    elapsedLabel.setAlignmentY(Component.TOP_ALIGNMENT);
-    elapsedLabel.setFont(UIUtil.getLabelFont(UIUtil.FontSize.SMALL));
-    elapsedLabel.setForeground(UIUtil.getLabelDisabledForeground());
-    elapsedLabel.setOpaque(false);
-    elapsedLabel.setBorder(JBUI.Borders.empty(4));
-
-    labelsPanel.add(fpsLabel);
-    labelsPanel.add(Box.createHorizontalGlue());
-    labelsPanel.add(elapsedLabel);
+    panel.add(frameRenderingPanel);
+    panel.add(latestFrameTimePanel);
+    panel.add(targetFrameTimePanel);
 
     final FlutterFramesMonitor.Listener listener = event -> {
-      fpsPanel.update();
+      frameRenderingPanel.update();
 
       final int ms = Math.round(event.elapsedMicros / 1000.0f);
-      elapsedLabel.setText(ms + "ms");
-      SwingUtilities.invokeLater(elapsedLabel::repaint);
+      latestFrameTimeLabel.setText(ms + "ms");
+      SwingUtilities.invokeLater(latestFrameTimeLabel::repaint);
 
-      fpsLabel.setText(df.format(flutterFramesMonitor.getFPS()) + " FPS");
-      SwingUtilities.invokeLater(fpsLabel::repaint);
+      // Repaint this after each frame so that the label does not get painted over by the frame rendering panel.
+      targetFrameTimeLabel.setText(TARGET_FRAME_RENDERING_TIME);
+      SwingUtilities.invokeLater(targetFrameTimeLabel::repaint);
     };
 
     flutterFramesMonitor.addListener(listener);
@@ -81,14 +90,14 @@ public class FPSDisplay {
   }
 }
 
-class FPSPanel extends JPanel {
+class FrameRenderingPanel extends JPanel {
   private final FlutterFramesMonitor framesMonitor;
 
   private final Map<FlutterFramesMonitor.FlutterFrameEvent, JComponent> frameWidgets = new HashMap<>();
 
   private Rectangle lastSavedBounds;
 
-  FPSPanel(FlutterFramesMonitor framesMonitor) {
+  FrameRenderingPanel(FlutterFramesMonitor framesMonitor) {
     this.framesMonitor = framesMonitor;
 
     setLayout(null);
@@ -132,7 +141,7 @@ class FPSPanel extends JPanel {
     try {
       g2.setStroke(STROKE);
       final Path2D path = new Path2D.Float();
-      path.moveTo(0, height - y);
+      path.moveTo(34, height - y);
       path.lineTo(bounds.width, height - y);
       g2.draw(path);
     }
@@ -173,9 +182,9 @@ class FPSPanel extends JPanel {
           widget.setBackground(frame.isSlowFrame() ? JBColor.RED : UIUtil.getLabelForeground());
           widget.setToolTipText(frame.isSlowFrame()
                                 ? "This frame took " +
-                                  FPSDisplay.df.format(frame.elapsedMicros / 1000.0d) +
-                                  "ms to render, which can cause frame rate to drop below 60 FPS"
-                                : "This frame took " + FPSDisplay.df.format(frame.elapsedMicros / 1000.0d) + "ms to render");
+                                  FrameRenderingDisplay.df.format(frame.elapsedMicros / 1000.0d) +
+                                  "ms to render, which\n can cause frame rate to drop below 60 FPS."
+                                : "This frame took " + FrameRenderingDisplay.df.format(frame.elapsedMicros / 1000.0d) + "ms to render.");
           frameWidgets.put(frame, widget);
           add(widget);
         }

--- a/src/io/flutter/view/InspectorPerfTab.java
+++ b/src/io/flutter/view/InspectorPerfTab.java
@@ -88,7 +88,7 @@ public class InspectorPerfTab extends JBPanel implements InspectorTabPanel {
     final JPanel fpsPanel = new JPanel(new BorderLayout());
     final JPanel fpsDisplay = FPSDisplay.createJPanelView(parentDisposable, app);
     fpsPanel.add(fpsDisplay, BorderLayout.CENTER);
-    fpsPanel.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(), "FPS"));
+    fpsPanel.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(), "Frames Per Second"));
 
     // Memory
     final JPanel memoryPanel = new JPanel(new BorderLayout());

--- a/src/io/flutter/view/InspectorPerfTab.java
+++ b/src/io/flutter/view/InspectorPerfTab.java
@@ -6,6 +6,7 @@
 package io.flutter.view;
 
 import com.intellij.openapi.Disposable;
+import com.intellij.openapi.util.Disposer;
 import com.intellij.ui.JBColor;
 import com.intellij.ui.components.JBLabel;
 import com.intellij.ui.components.JBPanel;
@@ -15,10 +16,12 @@ import io.flutter.inspector.*;
 import io.flutter.perf.FlutterWidgetPerfManager;
 import io.flutter.run.FlutterLaunchMode;
 import io.flutter.run.daemon.FlutterApp;
+import io.flutter.server.vmService.FlutterFramesMonitor;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
 import java.awt.*;
+import java.text.DecimalFormat;
 
 import static io.flutter.view.PerformanceOverlayAction.SHOW_PERFORMANCE_OVERLAY;
 import static io.flutter.view.RepaintRainbowAction.SHOW_REPAINT_RAINBOW;
@@ -85,10 +88,22 @@ public class InspectorPerfTab extends JBPanel implements InspectorTabPanel {
     }
 
     // FPS
-    final JPanel fpsPanel = new JPanel(new BorderLayout());
-    final JPanel fpsDisplay = FPSDisplay.createJPanelView(parentDisposable, app);
-    fpsPanel.add(fpsDisplay, BorderLayout.CENTER);
-    fpsPanel.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(), "Frames Per Second"));
+    assert app.getVMServiceManager() != null;
+    final FlutterFramesMonitor flutterFramesMonitor = app.getVMServiceManager().getFlutterFramesMonitor();
+    final JBLabel fpsLabel = new JBLabel("Frames per second: ");
+    final FlutterFramesMonitor.Listener listener = event -> {
+      fpsLabel.setText("Frames per second: " + new DecimalFormat().format(flutterFramesMonitor.getFPS()));
+      SwingUtilities.invokeLater(fpsLabel::repaint);
+    };
+    flutterFramesMonitor.addListener(listener);
+    Disposer.register(parentDisposable, () -> flutterFramesMonitor.removeListener(listener));
+    fpsLabel.setBorder(JBUI.Borders.empty(0, 5));
+
+    // Frame Rendering
+    final JPanel frameRenderingPanel = new JPanel(new BorderLayout());
+    final JPanel frameRenderingDisplay = FrameRenderingDisplay.createJPanelView(parentDisposable, app);
+    frameRenderingPanel.add(frameRenderingDisplay, BorderLayout.CENTER);
+    frameRenderingPanel.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(), "Frame Rendering Time"));
 
     // Memory
     final JPanel memoryPanel = new JPanel(new BorderLayout());
@@ -113,18 +128,19 @@ public class InspectorPerfTab extends JBPanel implements InspectorTabPanel {
     // Perf info and tips
     widgetPerfPanel = new WidgetPerfPanel(parentDisposable, app);
 
-    final JPanel fpsAndMemoryContainer = new JPanel(new VerticalLayout(5));
-    fpsAndMemoryContainer.add(fpsPanel);
-    fpsAndMemoryContainer.add(memoryPanel);
+    final JPanel leftColumn = new JPanel(new VerticalLayout(5));
+    leftColumn.add(fpsLabel);
+    leftColumn.add(frameRenderingPanel);
+    leftColumn.add(memoryPanel);
 
-    final JPanel settingsAndWidgetPerfContainer = new JPanel(new VerticalLayout(5));
-    settingsAndWidgetPerfContainer.add(perfSettings);
-    settingsAndWidgetPerfContainer.add(widgetPerfPanel);
+    final JPanel rightColumn = new JPanel(new VerticalLayout(5));
+    rightColumn.add(perfSettings);
+    rightColumn.add(widgetPerfPanel);
 
     final JPanel bodyPanel = new JPanel(new GridLayout(1, 2, 5, 5));
     bodyPanel.setBorder(JBUI.Borders.empty(5));
-    bodyPanel.add(fpsAndMemoryContainer);
-    bodyPanel.add(settingsAndWidgetPerfContainer);
+    bodyPanel.add(leftColumn);
+    bodyPanel.add(rightColumn);
     add(bodyPanel, BorderLayout.CENTER);
   }
 


### PR DESCRIPTION
- Rename chart to more accurately reflect functionality.
- Label target line
- Improve existing tooltips and new ones
- Move FPS calculation outside of chart
![screen shot 2018-11-15 at 12 54 38 pm](https://user-images.githubusercontent.com/43759233/48581071-a47af600-e8d5-11e8-8475-0a91226c3134.png)
![screen shot 2018-11-15 at 12 55 23 pm](https://user-images.githubusercontent.com/43759233/48581146-d724ee80-e8d5-11e8-8c9e-22e3fa08c4cd.png)
![screen shot 2018-11-15 at 12 31 24 pm](https://user-images.githubusercontent.com/43759233/48581176-eb68eb80-e8d5-11e8-8707-d0e825d71af9.png)
![screen shot 2018-11-15 at 12 30 21 pm](https://user-images.githubusercontent.com/43759233/48580964-68479580-e8d5-11e8-8cf3-6a64b1c32c45.png)
![screen shot 2018-11-15 at 12 29 19 pm](https://user-images.githubusercontent.com/43759233/48580975-6c73b300-e8d5-11e8-820f-dafad767a3e1.png)




 