### PR TITLE
rebuild/repaint analytics

### DIFF
--- a/src/io/flutter/perf/FlutterWidgetPerfManager.java
+++ b/src/io/flutter/perf/FlutterWidgetPerfManager.java
@@ -15,6 +15,7 @@ import com.intellij.openapi.util.Computable;
 import com.intellij.openapi.util.Disposer;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.util.messages.MessageBusConnection;
+import io.flutter.FlutterInitializer;
 import io.flutter.FlutterUtils;
 import io.flutter.run.FlutterAppManager;
 import io.flutter.run.daemon.FlutterApp;
@@ -145,6 +146,10 @@ public class FlutterWidgetPerfManager implements Disposable, FlutterApp.FlutterA
     if (debugIsActive && app != null && app.isSessionActive()) {
       updateTrackWidgetRebuilds();
     }
+    // Send analytics.
+    if (trackRebuildWidgets) {
+      FlutterInitializer.getAnalytics().sendEvent("intellij", "TrackWidgetRebuilds");
+    }
   }
 
   public boolean isTrackRepaintWidgets() {
@@ -159,6 +164,10 @@ public class FlutterWidgetPerfManager implements Disposable, FlutterApp.FlutterA
     onProfilingFlagsChanged();
     if (debugIsActive && app != null && app.isSessionActive()) {
       updateTrackWidgetRepaints();
+    }
+    // Send analytics.
+    if (trackRepaintWidgets) {
+      FlutterInitializer.getAnalytics().sendEvent("intellij", "TrackRepaintWidgets");
     }
   }
 


### PR DESCRIPTION
Generates perf analytics in a format compatible for comparison w/ other IDE actions.

See for example:

![image](https://user-images.githubusercontent.com/67586/48801120-665c4880-ecc0-11e8-8e1d-9f4b3f37e493.png)

(Repaint is disabled currently by default but will capture analytics once turned on.)

Fixes: #2758

/cc @jacob314 
