### PR TITLE
Open tool

### DIFF
--- a/src/io/flutter/actions/FlutterExternalIdeActionGroup.java
+++ b/src/io/flutter/actions/FlutterExternalIdeActionGroup.java
@@ -31,12 +31,12 @@ public class FlutterExternalIdeActionGroup extends DefaultActionGroup {
       FlutterUtils.isXcodeProjectFileName(file.getName()) || OpenInAndroidStudioAction.isProjectFileName(file.getName());
   }
 
-  private static boolean isAndroidDirectory(@NotNull VirtualFile file) {
-    return file.isDirectory() && file.getName().equals("android");
+  public static boolean isAndroidDirectory(@NotNull VirtualFile file) {
+    return file.isDirectory() && (file.getName().equals("android") || file.getName().equals(".android"));
   }
 
-  private static boolean isIOsDirectory(@NotNull VirtualFile file) {
-    return file.isDirectory() && file.getName().equals("ios");
+  public static boolean isIOsDirectory(@NotNull VirtualFile file) {
+    return file.isDirectory() && (file.getName().equals("ios") || file.getName().equals(".ios"));
   }
 
   protected static boolean isWithinAndroidDirectory(@NotNull VirtualFile file, @NotNull Project project) {

--- a/src/io/flutter/actions/OpenInAndroidStudioAction.java
+++ b/src/io/flutter/actions/OpenInAndroidStudioAction.java
@@ -18,11 +18,13 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.Messages;
 import com.intellij.openapi.util.SystemInfo;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.openapi.vfs.newvfs.impl.VirtualDirectoryImpl;
 import io.flutter.FlutterBundle;
 import io.flutter.FlutterMessages;
 import io.flutter.pub.PubRoot;
 import io.flutter.pub.PubRoots;
 import io.flutter.sdk.FlutterSdk;
+import java.util.Arrays;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -178,9 +180,15 @@ public class OpenInAndroidStudioAction extends AnAction {
         if (isProjectFileName(child.getName())) {
           return child;
         }
+        if (FlutterExternalIdeActionGroup.isAndroidDirectory(child)) {
+          for (VirtualFile androidChild : child.getChildren()) {
+            if (isProjectFileName(androidChild.getName())) {
+              return androidChild;
+            }
+          }
+        }
       }
     }
-
     return null;
   }
 
@@ -233,12 +241,16 @@ public class OpenInAndroidStudioAction extends AnAction {
     if (project != null && isAndroidWithApp(project)) {
       return project;
     }
+    project = dir.findChild(".android");
+    if (project != null && isAndroidWithApp(project)) {
+      return project;
+    }
     return null;
   }
 
   // Return true if the directory is named android and contains either an app (for applications) or a src (for plugins) directory.
   private static boolean isAndroidWithApp(@NotNull VirtualFile file) {
-    return file.getName().equals("android") && (file.findChild("app") != null || file.findChild("src") != null);
+    return FlutterExternalIdeActionGroup.isAndroidDirectory(file) && (file.findChild("app") != null || file.findChild("src") != null);
   }
 
   // Return true if the directory has the structure of a plugin example application: a pubspec.yaml and an

--- a/src/io/flutter/actions/OpenInAndroidStudioAction.java
+++ b/src/io/flutter/actions/OpenInAndroidStudioAction.java
@@ -18,17 +18,14 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.Messages;
 import com.intellij.openapi.util.SystemInfo;
 import com.intellij.openapi.vfs.VirtualFile;
-import com.intellij.openapi.vfs.newvfs.impl.VirtualDirectoryImpl;
 import io.flutter.FlutterBundle;
 import io.flutter.FlutterMessages;
 import io.flutter.pub.PubRoot;
 import io.flutter.pub.PubRoots;
 import io.flutter.sdk.FlutterSdk;
-import java.util.Arrays;
+import java.io.File;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
-import java.io.File;
 
 public class OpenInAndroidStudioAction extends AnAction {
   private static final String LABEL_FILE = FlutterBundle.message("flutter.androidstudio.open.file.text");

--- a/src/io/flutter/pub/PubRoot.java
+++ b/src/io/flutter/pub/PubRoot.java
@@ -332,7 +332,11 @@ public class PubRoot {
    */
   @Nullable
   public VirtualFile getAndroidDir() {
-    return root.findChild("android");
+    VirtualFile dir = root.findChild("android");
+    if (dir == null) {
+      dir = root.findChild(".android");
+    }
+    return dir;
   }
 
   /**
@@ -340,7 +344,11 @@ public class PubRoot {
    */
   @Nullable
   public VirtualFile getiOsDir() {
-    return root.findChild("ios");
+    VirtualFile dir = root.findChild("ios");
+    if (dir == null) {
+      dir = root.findChild(".ios");
+    }
+    return dir;
   }
 
   /**


### PR DESCRIPTION
The add2app project changed the name of native code directories. In addition to `android` and `ios` we also have to recognize `.ios` and `.android`. A project will have all four directories after doing `flutter make-host-app-editable`.

Fixes #2850