### PR TITLE
Refactor of how metrics are calculated to make adding additional metics easier.

### DIFF
--- a/src/io/flutter/inspector/InspectorService.java
+++ b/src/io/flutter/inspector/InspectorService.java
@@ -888,11 +888,20 @@ public class InspectorService implements Disposable {
     }
   }
 
+  public static String getFileUriPrefix() {
+    return SystemInfo.isWindows ? "file:///" : "file://";
+  }
+
   // TODO(jacobr): remove this method as soon as the
   // track-widget-creation kernel transformer is fixed to return paths instead
   // of URIs.
   public static String toSourceLocationUri(String path) {
-    return "file://" + path;
+    return getFileUriPrefix() + path;
+  }
+
+  public static String fromSourceLocationUri(String path) {
+    final String filePrefix = getFileUriPrefix();
+    return (path.startsWith(filePrefix)) ? path.substring(filePrefix.length()) : path;
   }
 
   public enum FlutterTreeType {

--- a/src/io/flutter/inspector/InspectorSourceLocation.java
+++ b/src/io/flutter/inspector/InspectorSourceLocation.java
@@ -41,10 +41,7 @@ public class InspectorSourceLocation {
     // TODO(jacobr): remove this workaround after the code in package:flutter
     // is fixed to return operating system paths instead of URIs.
     // https://github.com/flutter/flutter-intellij/issues/2217
-    final String filePrefix = SystemInfo.isWindows ? "file:///" : "file://";
-    if (fileName.startsWith(filePrefix)) {
-      fileName = fileName.substring(filePrefix.length());
-    }
+    fileName = InspectorService.fromSourceLocationUri(fileName);
 
     final VirtualFile virtualFile = LocalFileSystem.getInstance().findFileByPath(fileName);
     if (virtualFile != null && !virtualFile.exists()) {

--- a/src/io/flutter/perf/EditorPerfDecorations.java
+++ b/src/io/flutter/perf/EditorPerfDecorations.java
@@ -5,6 +5,7 @@
  */
 package io.flutter.perf;
 
+import com.intellij.codeInsight.hint.HintManager;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.application.ApplicationManager;
@@ -23,9 +24,11 @@ import com.intellij.openapi.wm.ex.ToolWindowManagerEx;
 import com.intellij.ui.ColorUtil;
 import com.intellij.ui.JBColor;
 import icons.FlutterIcons;
+import com.intellij.xdebugger.XSourcePosition;
 import io.flutter.run.daemon.FlutterApp;
 import io.flutter.utils.AnimatedIcon;
 import io.flutter.view.FlutterPerfView;
+import io.flutter.utils.AsyncUtils;
 import io.flutter.view.InspectorPerfTab;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -161,7 +164,7 @@ class EditorPerfDecorations implements EditorMouseListener, EditorPerfModel {
 
   @Override
   public boolean isAnimationActive() {
-    return getStats().getCountPastSecond() > 0;
+    return getStats().getTotalValue(PerfMetric.peakRecent) > 0;
   }
 
   @Override
@@ -303,12 +306,12 @@ class PerfGutterIconRenderer extends GutterIconRenderer {
     return perfModelForFile.getApp();
   }
 
-  private int getCountPastSecond() {
-    return perfModelForFile.getStats().getCountPastSecond(range);
+  private int getCurrentValue() {
+    return perfModelForFile.getStats().getCurrentValue(range);
   }
 
   private boolean isActive() {
-    return perfModelForFile.isHoveredOverLineMarkerArea() || getCountPastSecond() > 0;
+    return perfModelForFile.isHoveredOverLineMarkerArea() || getCurrentValue() > 0;
   }
 
   RangeHighlighter getHighlighter() {
@@ -345,7 +348,17 @@ class PerfGutterIconRenderer extends GutterIconRenderer {
     String message = "<html><body>" +
                      getTooltipHtmlFragment() +
                      "</body></html>";
-    inspectorPerfTab.getWidgetPerfPanel().setPerfStatusMessage(perfModelForFile.getTextEditor(), range, message);
+    final Iterable<SummaryStats> current = perfModelForFile.getStats().getRangeStats(range);
+    if (current.iterator().hasNext()) {
+      final SummaryStats first = current.iterator().next();
+      final XSourcePosition position = first.getLocation().getXSourcePosition();
+      if (position != null) {
+        AsyncUtils.invokeLater(() -> {
+          position.createNavigatable(getApp().getProject()).navigate(true);
+          HintManager.getInstance().showInformationHint(perfModelForFile.getTextEditor().getEditor(), message);
+        });
+      }
+    }
   }
 
   @NotNull
@@ -362,7 +375,7 @@ class PerfGutterIconRenderer extends GutterIconRenderer {
   }
 
   public Icon getIconInternal() {
-    final int count = getCountPastSecond();
+    final int count = getCurrentValue();
     if (count == 0) {
       return perfModelForFile.isHoveredOverLineMarkerArea() ? FlutterIcons.CustomInfo : EMPTY_ICON;
     }
@@ -374,7 +387,7 @@ class PerfGutterIconRenderer extends GutterIconRenderer {
 
   Color getErrorStripeMarkColor() {
     // TODO(jacobr): tween from green or blue to red depending on the count.
-    final int count = getCountPastSecond();
+    final int count = getCurrentValue();
     if (count == 0) {
       return null;
     }
@@ -385,7 +398,7 @@ class PerfGutterIconRenderer extends GutterIconRenderer {
   }
 
   public void updateUI(boolean repaint) {
-    final int count = getCountPastSecond();
+    final int count = getCurrentValue();
     final TextAttributes textAttributes = highlighter.getTextAttributes();
     assert textAttributes != null;
     boolean changed = false;
@@ -435,13 +448,14 @@ class PerfGutterIconRenderer extends GutterIconRenderer {
       sb.append(" counts for: <strong>" + stats.getDescription());
       sb.append("</strong></p>");
       sb.append("<p style='padding-left: 8px'>");
-      sb.append("In past second: " + stats.getPastSecond() + "<br>");
-      sb.append("Since last route change: " + stats.getTotalSinceNavigation() + "<br>");
-      sb.append("Since last hot reload/restart: " + stats.getTotal());
+      sb.append("For last frame: " + stats.getValue(PerfMetric.lastFrame) + "<br>");
+      sb.append("In past second: " + stats.getValue(PerfMetric.pastSecond) + "<br>");
+      sb.append("Since last route change: " + stats.getValue(PerfMetric.totalSinceRouteChange) + "<br>");
+      sb.append("Since last hot reload/restart: " + stats.getValue(PerfMetric.total));
       sb.append("</p>");
     }
     if (sb.length() == 0) {
-      sb.append("<p><b>No widget rebuilds or repaints detected for line.</p></b>");
+      sb.append("<p><b>No widget rebuilds detected for line.</p></b>");
     }
     return sb.toString();
   }
@@ -457,12 +471,12 @@ class PerfGutterIconRenderer extends GutterIconRenderer {
       return false;
     }
     final PerfGutterIconRenderer other = (PerfGutterIconRenderer)obj;
-    return other.getCountPastSecond() == getCountPastSecond();
+    return other.getCurrentValue() == getCurrentValue();
   }
 
   @Override
   public int hashCode() {
-    return getCountPastSecond();
+    return getCurrentValue();
   }
 
   private static class EmptyIcon implements Icon {

--- a/src/io/flutter/perf/EditorPerfDecorations.java
+++ b/src/io/flutter/perf/EditorPerfDecorations.java
@@ -455,7 +455,7 @@ class PerfGutterIconRenderer extends GutterIconRenderer {
       sb.append("</p>");
     }
     if (sb.length() == 0) {
-      sb.append("<p><b>No widget rebuilds detected for line.</p></b>");
+      sb.append("<p><b>No widget rebuilds detected for line.</b></p>");
     }
     return sb.toString();
   }

--- a/src/io/flutter/perf/EditorPerfModel.java
+++ b/src/io/flutter/perf/EditorPerfModel.java
@@ -19,7 +19,7 @@ import java.util.List;
  * the text editor along with the actual perf stats accessible via the
  * getStats method.
  */
-public interface EditorPerfModel extends Disposable {
+public interface EditorPerfModel extends PerfModel, Disposable {
   @NotNull
   FilePerfInfo getStats();
 
@@ -30,13 +30,5 @@ public interface EditorPerfModel extends Disposable {
 
   boolean isHoveredOverLineMarkerArea();
 
-  void markAppIdle();
-
-  void clear();
-
-  void onFrame();
-
   void setPerfInfo(FilePerfInfo stats);
-
-  boolean isAnimationActive();
 }

--- a/src/io/flutter/perf/FileLocationMapperFactory.java
+++ b/src/io/flutter/perf/FileLocationMapperFactory.java
@@ -5,8 +5,6 @@
  */
 package io.flutter.perf;
 
-import com.intellij.openapi.fileEditor.TextEditor;
-
 public interface  FileLocationMapperFactory {
-  FileLocationMapper create(TextEditor fileEditor);
+  FileLocationMapper create(String path);
 }

--- a/src/io/flutter/perf/FilePerfInfo.java
+++ b/src/io/flutter/perf/FilePerfInfo.java
@@ -12,51 +12,6 @@ import com.intellij.openapi.util.TextRange;
 import java.util.Collection;
 
 /**
- * Statistics summarizing how frequently an event as occurred overall and in
- * the past second.
- */
-class SummaryStats {
-  private final PerfReportKind kind;
-  private final SlidingWindowStatsSummary entry;
-  private final String description;
-  boolean active = true;
-
-  SummaryStats(PerfReportKind kind, SlidingWindowStatsSummary entry, String description) {
-    this.kind = kind;
-    this.entry = entry;
-    this.description = description;
-  }
-
-  PerfReportKind getKind() {
-    return kind;
-  }
-
-  int getTotal() {
-    return entry.getTotal();
-  }
-
-  int getTotalSinceNavigation() {
-    return entry.getTotalSinceNavigation();
-  }
-
-  int getPastSecond() {
-    return active ? entry.getPastSecond() : 0;
-  }
-
-  public void markAppIdle() {
-    active = false;
-  }
-
-  public String getDescription() {
-    return description;
-  }
-
-  public Location getLocation() {
-    return entry.getLocation();
-  }
-}
-
-/**
  * Performance stats for a single source file.
  * <p>
  * Typically the TextRange objects correspond to widget constructor locations.
@@ -66,12 +21,14 @@ class SummaryStats {
 class FilePerfInfo {
   private final Multimap<TextRange, SummaryStats> stats = LinkedListMultimap.create();
   long maxTimestamp = -1;
-  private int totalPastSecond = 0;
+  private final int[] totalForMetric = new int[PerfMetric.values().length];
 
   public void clear() {
     stats.clear();
     maxTimestamp = -1;
-    totalPastSecond = 0;
+    for (int i = 0; i < totalForMetric.length; ++i) {
+      totalForMetric[i] = 0;
+    }
   }
 
   public Iterable<TextRange> getLocations() {
@@ -86,30 +43,18 @@ class FilePerfInfo {
     return stats.containsKey(range);
   }
 
-  public int getCountPastSecond() {
-    return totalPastSecond;
+  public int getTotalValue(PerfMetric metric) {
+    return totalForMetric[metric.ordinal()];
   }
 
-  public int getCountPastSecond(TextRange range) {
+  public int getValue(TextRange range, PerfMetric metric) {
     final Collection<SummaryStats> entries = stats.get(range);
     if (entries == null) {
       return 0;
     }
     int count = 0;
     for (SummaryStats entry : entries) {
-      count += entry.getPastSecond();
-    }
-    return count;
-  }
-
-  public int getTotalCount(TextRange range) {
-    final Collection<SummaryStats> entries = stats.get(range);
-    if (entries == null) {
-      return 0;
-    }
-    int count = 0;
-    for (SummaryStats entry : entries) {
-      count += entry.getTotal();
+      count += entry.getValue(metric);
     }
     return count;
   }
@@ -124,13 +69,24 @@ class FilePerfInfo {
 
   public void add(TextRange range, SummaryStats entry) {
     stats.put(range, entry);
-    totalPastSecond += entry.getPastSecond();
+    for (PerfMetric metric : PerfMetric.values()) {
+      totalForMetric[metric.ordinal()] += entry.getValue(metric);
+    }
   }
 
   public void markAppIdle() {
-    totalPastSecond = 0;
+    for (PerfMetric metric : PerfMetric.values()) {
+      if (metric.timeIntervalMetric) {
+        totalForMetric[metric.ordinal()] = 0;
+      }
+    }
+
     for (SummaryStats stats : stats.values()) {
       stats.markAppIdle();
     }
+  }
+
+  public int getCurrentValue(TextRange range) {
+    return getValue(range, PerfMetric.peakRecent);
   }
 }

--- a/src/io/flutter/perf/FlutterWidgetPerfManager.java
+++ b/src/io/flutter/perf/FlutterWidgetPerfManager.java
@@ -71,6 +71,8 @@ public class FlutterWidgetPerfManager implements Disposable, FlutterApp.FlutterA
 
   private final List<StreamSubscription<Boolean>> streamSubscriptions = new ArrayList<>();
 
+
+  @NotNull
   public Set<TextEditor> getSelectedEditors() {
     return lastSelectedEditors;
   }
@@ -184,7 +186,7 @@ public class FlutterWidgetPerfManager implements Disposable, FlutterApp.FlutterA
       isProfilingEnabled(),
       new VmServiceWidgetPerfProvider(app),
       (TextEditor textEditor) -> new EditorPerfDecorations(textEditor, app),
-      (TextEditor textEditor) -> new TextEditorFileLocationMapper(textEditor, app.getProject())
+      path -> new DocumentFileLocationMapper(path, app.getProject())
     );
   }
 
@@ -269,6 +271,11 @@ public class FlutterWidgetPerfManager implements Disposable, FlutterApp.FlutterA
   }
 
   private void notifyPerf() {
+    if (!trackRepaintWidgets && !trackRebuildWidgets && currentStats != null) {
+      // TODO(jacobr): consider just marking as idle.
+      currentStats.clear();
+    }
+
     if (currentStats == null) {
       return;
     }

--- a/src/io/flutter/perf/PerfMetric.java
+++ b/src/io/flutter/perf/PerfMetric.java
@@ -13,12 +13,22 @@ package io.flutter.perf;
  * the SlidingWindowStats class.
  */
 public enum PerfMetric {
-  total("total"),
-  totalSinceRouteChange("totalSinceRouteChange"),
-  lastSecond("lastSecond");
-  public final String name;
+  lastFrame("Last Frame", true),
+  peakRecent("Peak Recent", true),
+  pastSecond("Past Second", true),
+  totalSinceRouteChange("Route Change", false),
+  total("Total", false);
 
-  PerfMetric(String name) {
+  public final String name;
+  public final boolean timeIntervalMetric;
+
+  PerfMetric(String name, boolean timeIntervalMetric) {
     this.name = name;
+    this.timeIntervalMetric = timeIntervalMetric;
+  }
+
+  @Override
+  public String toString() {
+    return name;
   }
 }

--- a/src/io/flutter/perf/PerfModel.java
+++ b/src/io/flutter/perf/PerfModel.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2018 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.perf;
+
+import com.intellij.openapi.Disposable;
+
+/**
+ * Base class for all view models displaying performance stats
+ */
+public interface PerfModel {
+  void markAppIdle();
+
+  void clear();
+
+  void onFrame();
+
+  boolean isAnimationActive();
+}

--- a/src/io/flutter/perf/PerfTipRule.java
+++ b/src/io/flutter/perf/PerfTipRule.java
@@ -12,6 +12,7 @@ import io.netty.util.collection.IntObjectHashMap;
 import javax.swing.*;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 /**
  * Rule describing when to generate a performance tip.
@@ -73,6 +74,28 @@ public class PerfTipRule {
     return analyticsId;
   }
 
+  public static boolean equalTipRule(PerfTip a, PerfTip b) {
+    if (a == null || b == null) {
+      return a == b;
+    }
+    return Objects.equal(a.getRule(), b.getRule());
+  }
+
+  public static boolean equivalentPerfTips(List<PerfTip> a, List<PerfTip> b) {
+    if (a == null || b == null) {
+      return a == b;
+    }
+    if (a.size() != b.size()) {
+      return false;
+    }
+    for (int i = 0; i < a.size(); ++i) {
+      if (!equalTipRule(a.get(i), b.get(i))) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   public String getMessage() {
     return message;
   }
@@ -97,8 +120,8 @@ public class PerfTipRule {
   }
 
   boolean matchesFrequency(SummaryStats summary) {
-    return (minSinceNavigate > 0 && summary.getTotalSinceNavigation() >= minSinceNavigate) ||
-           (minPerSecond > 0 && summary.getPastSecond() >= minPerSecond);
+    return (minSinceNavigate > 0 && summary.getValue(PerfMetric.totalSinceRouteChange) >= minSinceNavigate) ||
+           (minPerSecond > 0 && summary.getValue(PerfMetric.pastSecond) >= minPerSecond);
   }
 
 

--- a/src/io/flutter/perf/SlidingWindowStats.java
+++ b/src/io/flutter/perf/SlidingWindowStats.java
@@ -99,4 +99,45 @@ class SlidingWindowStats {
       _start = -1;
     }
   }
+
+  public int getPeakWithinWindow(int windowStart) {
+    if (_next == _start) {
+      return 0;
+    }
+    final int end = _start >= 0 ? _start : _next;
+    int i = _next;
+    int peakValue = 0;
+    while (true) {
+      i -= 2;
+      if (i < 0) {
+        i += _windowLength;
+      }
+
+      if (_window[i] < windowStart) {
+        break;
+      }
+      peakValue = Math.max(peakValue, _window[i + 1]);
+      if (i == end) {
+        break;
+      }
+    }
+    return peakValue;
+  }
+
+  public int getValue(PerfMetric metric, int currentTime) {
+    switch (metric) {
+      case total:
+        return getTotal();
+      case pastSecond:
+        return getTotalWithinWindow(currentTime - 999);
+      case lastFrame:
+        return getPeakWithinWindow(currentTime);
+      case peakRecent:
+        return getPeakWithinWindow(currentTime - 499);
+      case totalSinceRouteChange:
+        return getTotalSinceNavigation();
+      default:
+        return 0;
+    }
+  }
 }

--- a/src/io/flutter/perf/SlidingWindowStatsSummary.java
+++ b/src/io/flutter/perf/SlidingWindowStatsSummary.java
@@ -9,31 +9,22 @@ package io.flutter.perf;
  * Snapshot of a SlidingWindowStats object for a specific time.
  */
 public class SlidingWindowStatsSummary {
-  final int total;
-  final int pastSecond;
-  final int totalSinceNavigation;
+  final int[] cachedStats;
   private final Location location;
 
-  SlidingWindowStatsSummary(SlidingWindowStats stats, int currentTime, Location location) {
-    total = stats.getTotal();
-    pastSecond = stats.getTotalWithinWindow(currentTime - 999);
-    totalSinceNavigation = stats.getTotalSinceNavigation();
+  public SlidingWindowStatsSummary(SlidingWindowStats stats, int currentTime, Location location) {
+    cachedStats = new int[PerfMetric.values().length];
+    for (PerfMetric metric : PerfMetric.values()) {
+      cachedStats[metric.ordinal()] = stats.getValue(metric, currentTime);
+    }
     this.location = location;
-  }
-
-  public int getTotal() {
-    return total;
-  }
-
-  public int getPastSecond() {
-    return pastSecond;
-  }
-
-  public int getTotalSinceNavigation() {
-    return totalSinceNavigation;
   }
 
   public Location getLocation() {
     return location;
+  }
+
+  public int getValue(PerfMetric metric) {
+    return cachedStats[metric.ordinal()];
   }
 }

--- a/src/io/flutter/perf/SummaryStats.java
+++ b/src/io/flutter/perf/SummaryStats.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.perf;
+
+/**
+ * Statistics summarizing how frequently an event has occurred overall and in
+ * the past second.
+ */
+public class SummaryStats {
+  private final PerfReportKind kind;
+  private final SlidingWindowStatsSummary entry;
+  private final String description;
+  boolean active = true;
+
+  SummaryStats(PerfReportKind kind, SlidingWindowStatsSummary entry, String description) {
+    this.kind = kind;
+    this.entry = entry;
+    this.description = description;
+  }
+
+  public PerfReportKind getKind() {
+    return kind;
+  }
+
+  public int getValue(PerfMetric metric) {
+    if (metric.timeIntervalMetric && !active) {
+      return 0;
+    }
+    return entry.getValue(metric);
+  }
+
+  public void markAppIdle() {
+    active = false;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public Location getLocation() {
+    return entry.getLocation();
+  }
+}

--- a/src/io/flutter/perf/WidgetPerfLinter.java
+++ b/src/io/flutter/perf/WidgetPerfLinter.java
@@ -105,10 +105,7 @@ public class WidgetPerfLinter {
   public CompletableFuture<ArrayList<PerfTip>> getTipsFor(Set<TextEditor> textEditors) {
     final ArrayList<PerfTipRule> candidateRules = new ArrayList<>();
     final Set<Location> candidateLocations = new HashSet<>();
-    final ArrayList<FilePerfInfo> allFileStats = new ArrayList<>();
-    for (TextEditor textEditor : textEditors) {
-      allFileStats.add(widgetPerf.buildSummaryStats(textEditor));
-    }
+    final ArrayList<FilePerfInfo> allFileStats = widgetPerf.buildAllSummaryStats(textEditors);
     for (PerfTipRule rule : getAllTips()) {
       for (FilePerfInfo fileStats : allFileStats) {
         for (SummaryStats stats : fileStats.getStats()) {

--- a/src/io/flutter/perf/WidgetPerfListener.java
+++ b/src/io/flutter/perf/WidgetPerfListener.java
@@ -16,4 +16,6 @@ public interface WidgetPerfListener {
   void requestRepaint(When when);
   void onWidgetPerfEvent(PerfReportKind kind, JsonObject json);
   void onNavigation();
+
+  void addPerfListener(PerfModel listener);
 }


### PR DESCRIPTION
Refactor of FlutterWidgetPerf so that widget names are always available instead
of only available when displaying gutter icons. The problem was we were calculating widget names for given offsets
when generating the EditorPerfDecorations instead of keeping a global cache
of widget names. The new approach is more efficient and needed for
work to display a table of the most frequent widget rebuilds.