### PR TITLE
handle NoClassDefFoundError in the memory view

### DIFF
--- a/src/io/flutter/view/InspectorMemoryTab.java
+++ b/src/io/flutter/view/InspectorMemoryTab.java
@@ -87,10 +87,10 @@ public class InspectorMemoryTab extends JPanel implements InspectorTabPanel {
       assert app.getVMServiceManager() != null;
       app.getVMServiceManager().addPollingClient();
     }
-    catch (ClassNotFoundException | NoSuchMethodException |
+    catch (ClassNotFoundException | NoSuchMethodException | NoClassDefFoundError |
       InstantiationException | IllegalAccessException |
       InvocationTargetException e) {
-      LOG.warn("Problem loading Flutter Memory Profiler - " + e.getMessage());
+      LOG.info("Unable to load Flutter Memory Profiler: " + e.getMessage());
 
       final JLabel warningLabel = new JLabel(
         "Memory profiling is only available in Android Studio.", null, SwingConstants.CENTER);


### PR DESCRIPTION
- also handle `NoClassDefFoundError` in the memory view (for the case when it's opened in IntelliJ)
- fix https://github.com/flutter/flutter-intellij/issues/2774

@terrylucas @jacob314 