### PR TITLE
Added package:flutter/* for filter dialog and fixed a few bugs.

### DIFF
--- a/flutter-studio/src/io/flutter/profiler/FilterLibraryDialog.java
+++ b/flutter-studio/src/io/flutter/profiler/FilterLibraryDialog.java
@@ -38,7 +38,10 @@ import org.jetbrains.annotations.NotNull;
 public class FilterLibraryDialog extends DialogWrapper {
   // String to represent all Dart libraries in filter dialog.
   public static final String ALL_DART_LIBRARIES = "dart:*";
+  public static final String ALL_FLUTTER_LIBRARIES = "package:flutter/*";
+
   public static final String DART_LIBRARY_PREFIX = "dart:";
+  public static final String FLUTTER_LIBRARY_PREFIX = "package:flutter/";
 
   private String[] allLibraries;
   private PopupLibraryFilter popupDialog;

--- a/flutter-studio/src/io/flutter/profiler/FlutterStudioMonitorStageView.java
+++ b/flutter-studio/src/io/flutter/profiler/FlutterStudioMonitorStageView.java
@@ -41,7 +41,9 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.Stack;
+import java.util.TreeSet;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.BiConsumer;
 import javax.swing.border.Border;
 import javax.swing.border.EmptyBorder;
 import javax.swing.event.TreeExpansionEvent;
@@ -77,7 +79,10 @@ import static com.android.tools.adtui.common.AdtUiUtils.DEFAULT_VERTICAL_BORDERS
 import static com.android.tools.profilers.ProfilerLayout.MARKER_LENGTH;
 import static com.android.tools.profilers.ProfilerLayout.MONITOR_LABEL_PADDING;
 import static com.android.tools.profilers.ProfilerLayout.Y_AXIS_TOP_MARGIN;
+import static io.flutter.profiler.FilterLibraryDialog.ALL_DART_LIBRARIES;
+import static io.flutter.profiler.FilterLibraryDialog.ALL_FLUTTER_LIBRARIES;
 import static io.flutter.profiler.FilterLibraryDialog.DART_LIBRARY_PREFIX;
+import static io.flutter.profiler.FilterLibraryDialog.FLUTTER_LIBRARY_PREFIX;
 
 /**
  * Bird eye view displaying high-level information across all profilers.
@@ -131,10 +136,13 @@ public class FlutterStudioMonitorStageView extends FlutterStageView<FlutterStudi
   // Used to manage fetching instances status.
   boolean runningComputingInstances;
 
+  // Any library name key in allLibraries prefixed with "%%" is not displayed in the filter dialog.
+  final static String PREFIX_LIBRARY_NAME_HIDDEN = "%%";
+
   // All Dart Libraries associated with the Flutter application, key is name and value is Uri as String.
   final Map<String, LibraryRef> allLibraries = new HashMap<>();
-  boolean hideDartLibraries = true;
   final Map<String, LibraryRef> dartLibraries = new HashMap<>();
+  final Map<String, LibraryRef> flutterLibraries = new HashMap<>();
 
   // TODO(terry): Remove below debugging before checking in.
   LineChartModel debugModel;
@@ -409,30 +417,23 @@ public class FlutterStudioMonitorStageView extends FlutterStageView<FlutterStudi
           LibraryRef ref = iterator.next();
 
           if (ref.getName().length() > 0) {
-            // Non-empty string is the library name (use it for key)
-            if (ref.getName().startsWith("dart.")) {
-              dartLibraries.put(ref.getName(), ref);
-            }
-            else if (ref.getUri().startsWith("file:///")) {
-              // Is user code (not in a package or library)
-              // TODO(terry): Need to store local file names for each libraryRef we'll always display classes from user code.
-              allLibraries.put(ref.getName(), ref);
-            }
-            else {
-              if (ref.getUri().startsWith(DART_LIBRARY_PREFIX)) {
-                // Library named 'nativewrappers' but URI is 'dart:nativewrappers' is a Dart library.
-                dartLibraries.put(ref.getName(), ref);
-              }
-              else {
-                allLibraries.put(ref.getUri(), ref);
-              }
-            }
+            rememberLibrary(ref.getName(), ref);
+          } else {
+            // No unique name to display use the Uri and don't display in list of known library/packages.
+            rememberLibrary(PREFIX_LIBRARY_NAME_HIDDEN + ref.getUri(), ref);
           }
         }
-        allLibraries.put("dart:*", null);   // All Dart libraries are in this entry.
+        allLibraries.put(ALL_DART_LIBRARIES, null);       // All Dart libraries are in this entry.
+        allLibraries.put(ALL_FLUTTER_LIBRARIES, null);    // All Flutter libraries are in this entry.
 
+        Set<String> displayedLibraries = new TreeSet<String>();
         // The initial list of selected libraries is all of them.
-        getProfilersView().setInitialSelectedLibraries(allLibraries.keySet());
+        for (String s : allLibraries.keySet()) {
+          if (!s.startsWith(PREFIX_LIBRARY_NAME_HIDDEN)) {
+            displayedLibraries.add(s);
+          }
+        }
+        getProfilersView().setInitialSelectedLibraries(displayedLibraries);
 
         isolateFuture.complete(response);
       }
@@ -444,6 +445,31 @@ public class FlutterStudioMonitorStageView extends FlutterStageView<FlutterStudi
       }
     });
     return isolateFuture;
+  }
+
+  void rememberLibrary(String name, LibraryRef ref) {
+    assert name.length() > 0;
+
+    if (name.startsWith("dart.")) {
+      dartLibraries.put(name, ref);
+    }
+    else if (name.startsWith("file:///")) {
+      // Is user code (not in a package or library)
+      // TODO(terry): Need to store local file names for each libraryRef we'll always display classes from user code.
+      allLibraries.put(name, ref);
+    }
+    else {
+      if (ref.getUri().startsWith(DART_LIBRARY_PREFIX)) {
+        // Library named 'nativewrappers' but URI is 'dart:nativewrappers' is a Dart library.
+        dartLibraries.put(name, ref);
+      }
+      else if (ref.getUri().startsWith(FLUTTER_LIBRARY_PREFIX)) {
+        flutterLibraries.put(name, ref);
+      }
+      else {
+        allLibraries.put(name, ref);
+      }
+    }
   }
 
   public CompletableFuture<JsonObject> vmGetObject(String classOrInstanceRefId) {
@@ -899,10 +925,12 @@ public class FlutterStudioMonitorStageView extends FlutterStageView<FlutterStudi
         SwingUtilities.invokeLater(() -> {
           memorySnapshot.myInstancesTreeModel.reload(parent);
         });
-      } else if (instance.getKind() == InstanceKind.List) {
+      }
+      else if (instance.getKind() == InstanceKind.List) {
         // Empty list.
         addNode(parent, "", "[]");
-      } else if (instance.getKind() == InstanceKind.Map) {
+      }
+      else if (instance.getKind() == InstanceKind.Map) {
         // Empty list.
         addNode(parent, "", "{}");
       }

--- a/flutter-studio/src/io/flutter/profiler/FlutterStudioMonitorStageView.java
+++ b/flutter-studio/src/io/flutter/profiler/FlutterStudioMonitorStageView.java
@@ -426,7 +426,7 @@ public class FlutterStudioMonitorStageView extends FlutterStageView<FlutterStudi
         allLibraries.put(ALL_DART_LIBRARIES, null);       // All Dart libraries are in this entry.
         allLibraries.put(ALL_FLUTTER_LIBRARIES, null);    // All Flutter libraries are in this entry.
 
-        Set<String> displayedLibraries = new TreeSet<String>();
+        Set<String> displayedLibraries = new TreeSet<>();
         // The initial list of selected libraries is all of them.
         for (String s : allLibraries.keySet()) {
           if (!s.startsWith(PREFIX_LIBRARY_NAME_HIDDEN)) {

--- a/flutter-studio/src/io/flutter/profiler/FlutterStudioProfilersView.java
+++ b/flutter-studio/src/io/flutter/profiler/FlutterStudioProfilersView.java
@@ -50,6 +50,8 @@ import static com.android.tools.adtui.common.AdtUiUtils.DEFAULT_BOTTOM_BORDER;
 import static com.android.tools.profilers.ProfilerFonts.H4_FONT;
 import static com.android.tools.profilers.ProfilerLayout.TOOLBAR_HEIGHT;
 import static io.flutter.profiler.FilterLibraryDialog.ALL_DART_LIBRARIES;
+import static io.flutter.profiler.FilterLibraryDialog.ALL_FLUTTER_LIBRARIES;
+import static io.flutter.profiler.FlutterStudioMonitorStageView.PREFIX_LIBRARY_NAME_HIDDEN;
 import static java.awt.event.InputEvent.CTRL_DOWN_MASK;
 import static java.awt.event.InputEvent.META_DOWN_MASK;
 
@@ -252,6 +254,8 @@ public class FlutterStudioProfilersView
       FlutterStudioMonitorStageView view = (FlutterStudioMonitorStageView)(this.getStageView());
 
       Set<String> libraryKeys = view.allLibraries.keySet();
+
+      libraryKeys.removeIf((String libraryName) -> libraryName.startsWith(PREFIX_LIBRARY_NAME_HIDDEN));
       List<String> libraryNames = Arrays.asList(libraryKeys.toArray(new String[libraryKeys.size()]));
       Collections.sort((libraryNames));
 
@@ -422,7 +426,7 @@ public class FlutterStudioProfilersView
     selectedLibraries.forEach((String libraryName) -> {
       LibraryRef libraryRef = view.allLibraries.get(libraryName);
       if (libraryRef == null) {
-        if (libraryName == ALL_DART_LIBRARIES) {
+        if (libraryName.equals(ALL_DART_LIBRARIES)) {
           // Filter all dart libraries.
           view.dartLibraries.forEach((String key, LibraryRef dartLibraryRef) -> {
             String dartLibraryId = dartLibraryRef.getId();
@@ -432,7 +436,18 @@ public class FlutterStudioProfilersView
             }
           });
         }
-        LOG.warn("Library not found " + libraryName);
+        else if (libraryName.equals(ALL_FLUTTER_LIBRARIES)) {
+          // Filter all dart libraries.
+          view.flutterLibraries.forEach((String key, LibraryRef flutterLibraryRef) -> {
+            String flutterLibraryId = flutterLibraryRef.getId();
+            view.filteredLibraries.add(flutterLibraryId);
+            if (processTheLibrary) {
+              processLibrary(view, flutterLibraryId);
+            }
+          });
+        } else {
+          LOG.warn("Library not found " + libraryName);
+        }
       }
       else {
         String libraryId = libraryRef.getId();


### PR DESCRIPTION
Added grouping of all package:flutter to one entry in the filter dialog "package:flutter/*".
Fixed bug initial selections didn't include all libraries (some libraries have an empty name only URI).
Fixed allLibraries to include non-name libraries.
Fixed bogus error that dart:* not a library (it isn't and was skipped (re-mapped to all dart:* libraries).