### PR TITLE
various UI and layout tweaks to the perf tab

### DIFF
--- a/src/io/flutter/inspector/WidgetPerfTipsPanel.java
+++ b/src/io/flutter/inspector/WidgetPerfTipsPanel.java
@@ -8,22 +8,18 @@ package io.flutter.inspector;
 import com.google.common.collect.ArrayListMultimap;
 import com.intellij.ide.browsers.BrowserLauncher;
 import com.intellij.openapi.Disposable;
-import com.intellij.openapi.fileEditor.*;
+import com.intellij.openapi.fileEditor.FileEditorManagerEvent;
+import com.intellij.openapi.fileEditor.FileEditorManagerListener;
+import com.intellij.openapi.fileEditor.TextEditor;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Disposer;
-import com.intellij.openapi.util.TextRange;
-import com.intellij.ui.components.JBLabel;
+import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.ui.components.labels.LinkLabel;
 import com.intellij.ui.components.labels.LinkListener;
-import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.ui.components.panels.VerticalLayout;
 import com.intellij.util.messages.MessageBusConnection;
 import com.intellij.util.ui.JBUI;
 import io.flutter.FlutterInitializer;
-import io.flutter.perf.FlutterWidgetPerf;
-import io.flutter.perf.FlutterWidgetPerfManager;
-import io.flutter.perf.PerfTip;
-import io.flutter.perf.WidgetPerfLinter;
 import io.flutter.perf.*;
 import io.flutter.run.daemon.FlutterApp;
 import io.flutter.utils.AsyncUtils;
@@ -56,16 +52,17 @@ public class WidgetPerfTipsPanel extends JPanel {
   private TextEditor currentEditor;
   private ArrayList<TextEditor> currentTextEditors;
 
-  LinkListener<PerfTip> linkListener;
+  final LinkListener<PerfTip> linkListener;
   private boolean visible = true;
-  private ArrayList<PerfTip> currentTips;
+  private List<PerfTip> currentTips;
 
   public WidgetPerfTipsPanel(Disposable parentDisposable, @NotNull FlutterApp app) {
-    setLayout(new VerticalLayout(5));
     this.app = app;
+
+    setLayout(new VerticalLayout(5));
+
     perfManager = FlutterWidgetPerfManager.getInstance(app.getProject());
     perfTips = new JPanel();
-    perfTips.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(), "Perf Tips"));
     perfTips.setLayout(new VerticalLayout(0));
 
     linkListener = (source, tip) -> handleTipSelection(tip);
@@ -107,6 +104,8 @@ public class WidgetPerfTipsPanel extends JPanel {
   void hidePerfTip() {
     currentTips = null;
     remove(perfTips);
+
+    setVisible(hasPerfTips());
   }
 
   private void selectedEditorChanged() {
@@ -180,6 +179,12 @@ public class WidgetPerfTipsPanel extends JPanel {
     }
 
     add(perfTips, 0);
+
+    setVisible(hasPerfTips());
+  }
+
+  private boolean hasPerfTips() {
+    return currentTips != null && !currentTips.isEmpty();
   }
 
   public void setVisibleToUser(boolean visible) {

--- a/src/io/flutter/perf/SlidingWindowStatsSummary.java
+++ b/src/io/flutter/perf/SlidingWindowStatsSummary.java
@@ -9,7 +9,7 @@ package io.flutter.perf;
  * Snapshot of a SlidingWindowStats object for a specific time.
  */
 public class SlidingWindowStatsSummary {
-  final int[] cachedStats;
+  private final int[] cachedStats;
   private final Location location;
 
   public SlidingWindowStatsSummary(SlidingWindowStats stats, int currentTime, Location location) {

--- a/src/io/flutter/view/FlutterPerfView.java
+++ b/src/io/flutter/view/FlutterPerfView.java
@@ -193,11 +193,12 @@ public class FlutterPerfView implements Disposable {
                                            @NotNull FlutterApp app,
                                            Disposable parentDisposable) {
     final DefaultActionGroup toolbarGroup = new DefaultActionGroup();
-    toolbarGroup.add(registerAction(new DebugPaintAction(app)));
-    toolbarGroup.add(registerAction(new TogglePlatformAction(app)));
     toolbarGroup.add(registerAction(new PerformanceOverlayAction(app)));
+    toolbarGroup.add(registerAction(new TogglePlatformAction(app)));
     toolbarGroup.addSeparator();
+    toolbarGroup.add(registerAction(new DebugPaintAction(app)));
     toolbarGroup.add(registerAction(new ShowPaintBaselinesAction(app, true)));
+    toolbarGroup.addSeparator();
     toolbarGroup.add(registerAction(new TimeDilationAction(app, true)));
 
     return toolbarGroup;
@@ -257,7 +258,7 @@ public class FlutterPerfView implements Disposable {
   }
 
   public InspectorPerfTab showPerfTab(@NotNull FlutterApp app) {
-    PerfViewAppState appState = perAppViewState.get(app);
+    final PerfViewAppState appState = perAppViewState.get(app);
     if (appState != null) {
       final ToolWindow toolWindow = ToolWindowManager.getInstance(myProject).getToolWindow(TOOL_WINDOW_ID);
 

--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -55,7 +55,10 @@ import io.flutter.run.daemon.FlutterDevice;
 import io.flutter.sdk.FlutterSdk;
 import io.flutter.sdk.FlutterSdkVersion;
 import io.flutter.settings.FlutterSettings;
-import io.flutter.utils.*;
+import io.flutter.utils.AsyncUtils;
+import io.flutter.utils.EventStream;
+import io.flutter.utils.UIUtils;
+import io.flutter.utils.VmServiceListenerAdapter;
 import org.dartlang.vm.service.VmService;
 import org.dartlang.vm.service.element.Event;
 import org.jetbrains.annotations.NotNull;
@@ -184,11 +187,12 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
       toolbarGroup.add(registerAction(new ForceRefreshAction(app, inspectorService)));
     }
     toolbarGroup.addSeparator();
-    toolbarGroup.add(registerAction(new DebugPaintAction(app)));
-    toolbarGroup.add(registerAction(new TogglePlatformAction(app)));
     toolbarGroup.add(registerAction(new PerformanceOverlayAction(app)));
+    toolbarGroup.add(registerAction(new TogglePlatformAction(app)));
     toolbarGroup.addSeparator();
+    toolbarGroup.add(registerAction(new DebugPaintAction(app)));
     toolbarGroup.add(registerAction(new ShowPaintBaselinesAction(app, true)));
+    toolbarGroup.addSeparator();
     toolbarGroup.add(registerAction(new TimeDilationAction(app, true)));
 
     return toolbarGroup;

--- a/src/io/flutter/view/InspectorPerfTab.java
+++ b/src/io/flutter/view/InspectorPerfTab.java
@@ -14,8 +14,12 @@ import com.intellij.ui.components.JBLabel;
 import com.intellij.ui.components.JBPanel;
 import com.intellij.ui.components.panels.VerticalLayout;
 import com.intellij.util.ui.JBUI;
-import io.flutter.inspector.*;
-import io.flutter.perf.*;
+import com.intellij.util.ui.UIUtil;
+import io.flutter.inspector.FrameRenderingDisplay;
+import io.flutter.inspector.HeapDisplay;
+import io.flutter.perf.FlutterWidgetPerfManager;
+import io.flutter.perf.PerfMetric;
+import io.flutter.perf.PerfReportKind;
 import io.flutter.run.FlutterLaunchMode;
 import io.flutter.run.daemon.FlutterApp;
 import io.flutter.server.vmService.FlutterFramesMonitor;
@@ -26,58 +30,59 @@ import java.awt.*;
 import java.awt.event.ComponentEvent;
 import java.awt.event.ComponentListener;
 import java.text.DecimalFormat;
+import java.text.NumberFormat;
 
 import static io.flutter.view.PerformanceOverlayAction.SHOW_PERFORMANCE_OVERLAY;
 import static io.flutter.view.RepaintRainbowAction.SHOW_REPAINT_RAINBOW;
 
 public class InspectorPerfTab extends JBPanel implements InspectorTabPanel {
-
   /**
-   * Tracking widget repaints may confuse users so we disable it by default
-   * currently.
+   * Tracking widget repaints may confuse users so we disable it by default currently.
    */
   private static final boolean ENABLE_TRACK_REPAINTS = false;
   private static final boolean SHOW_MEMORY_PANEL = false;
+
+  private static final NumberFormat fpsFormat = new DecimalFormat();
+
+  static {
+    fpsFormat.setMinimumFractionDigits(1);
+    fpsFormat.setMaximumFractionDigits(1);
+  }
 
   private final Disposable parentDisposable;
   private final @NotNull FlutterApp app;
   private final BoolServiceExtensionCheckbox showPerfOverlay;
   private final BoolServiceExtensionCheckbox showRepaintRainbow;
   private final ToolWindow toolWindow;
+  private JPanel rebuildStatsPanel;
   private WidgetPerfSummaryView perfSummaryView;
-  private final FlutterWidgetPerfManager widgetPerfManager;
 
   private JCheckBox trackRebuildsCheckbox;
   private JCheckBox trackRepaintsCheckbox;
 
-  private JBPanel main;
   private JBSplitter treeSplitter;
   private boolean lastUseSplitter = false;
 
-
-  private float lastSplitterProportion = 0.6f;
-  private JPanel bodyPanel;
-  private JPanel rightColumn;
-  private boolean lastSideBySideColumns;
+  private float lastSplitterProportion = 0.5f;
 
   private boolean isSplitterEnabled() {
-    return widgetPerfManager.isTrackRebuildWidgets() || widgetPerfManager.isTrackRebuildWidgets();
+    return true;
+    //return widgetPerfManager.isTrackRebuildWidgets() || widgetPerfManager.isTrackRebuildWidgets();
   }
 
   void updateUseSplitter(boolean force) {
-    final boolean use = isSplitterEnabled();
-    if (lastUseSplitter != use || force) {
-      if (lastUseSplitter != use && !use) {
+    final boolean useSplitter = isSplitterEnabled();
+    if (lastUseSplitter != useSplitter || force) {
+      if (lastUseSplitter != useSplitter && !useSplitter) {
         lastSplitterProportion = treeSplitter.getProportion();
       }
-      treeSplitter.setShowDividerControls(use);
-      treeSplitter.setShowDividerIcon(use);
-      treeSplitter.setResizeEnabled(use);
-      // When the splitter is not used we lock the splitter proportion to 1.0
-      // to hide the second component.
-      treeSplitter.setProportion(use ? lastSplitterProportion : 1.0f);
-      lastUseSplitter = use;
-      treeSplitter.setSecondComponent(use ? perfSummaryView : new JPanel());
+      treeSplitter.setShowDividerControls(useSplitter);
+      treeSplitter.setShowDividerIcon(useSplitter);
+      treeSplitter.setResizeEnabled(useSplitter);
+      // When the splitter is not used we lock the splitter proportion to 1.0 to hide the second component.
+      treeSplitter.setProportion(useSplitter ? lastSplitterProportion : 1.0f);
+      lastUseSplitter = useSplitter;
+      treeSplitter.setSecondComponent(useSplitter ? rebuildStatsPanel : new JPanel());
     }
   }
 
@@ -85,10 +90,11 @@ public class InspectorPerfTab extends JBPanel implements InspectorTabPanel {
     this.app = app;
     this.toolWindow = toolWindow;
     this.parentDisposable = parentDisposable;
-    widgetPerfManager = FlutterWidgetPerfManager.getInstance(app.getProject());
 
-    showPerfOverlay = new BoolServiceExtensionCheckbox(app, SHOW_PERFORMANCE_OVERLAY, "Show Performance Overlay", "");
-    showRepaintRainbow = new BoolServiceExtensionCheckbox(app, SHOW_REPAINT_RAINBOW, "Show Repaint Rainbow", "");
+    final FlutterWidgetPerfManager widgetPerfManager = FlutterWidgetPerfManager.getInstance(app.getProject());
+
+    showPerfOverlay = new BoolServiceExtensionCheckbox(app, SHOW_PERFORMANCE_OVERLAY, "Show performance overlay", "");
+    showRepaintRainbow = new BoolServiceExtensionCheckbox(app, SHOW_REPAINT_RAINBOW, "Show repaint rainbow", "");
 
     buildUI();
 
@@ -116,17 +122,13 @@ public class InspectorPerfTab extends JBPanel implements InspectorTabPanel {
   }
 
   private void buildUI() {
-    setLayout(new BorderLayout());
-    treeSplitter = new JBSplitter(false, "io.flutter.view.InspectorPerfTab", lastSplitterProportion);
-    add(treeSplitter);
-
-    main = new JBPanel();
-    main.setLayout(new BorderLayout());
+    setLayout(new BorderLayout(0, 8));
+    setBorder(JBUI.Borders.empty(3));
 
     // Header
     final JPanel labels = new JPanel(new BorderLayout(6, 0));
-    labels.setBorder(JBUI.Borders.empty(3, 10));
-    main.add(labels, BorderLayout.NORTH);
+    labels.setBorder(JBUI.Borders.empty(0, 8));
+    add(labels, BorderLayout.NORTH);
 
     labels.add(
       new JBLabel("Running in " + app.getLaunchMode() + " mode"),
@@ -139,12 +141,16 @@ public class InspectorPerfTab extends JBPanel implements InspectorTabPanel {
       labels.add(label, BorderLayout.CENTER);
     }
 
+    treeSplitter = new JBSplitter(false, "io.flutter.view.InspectorPerfTab", lastSplitterProportion);
+    add(treeSplitter, BorderLayout.CENTER);
+
     // FPS
     assert app.getVMServiceManager() != null;
     final FlutterFramesMonitor flutterFramesMonitor = app.getVMServiceManager().getFlutterFramesMonitor();
-    final JBLabel fpsLabel = new JBLabel("Frames per second: ");
+    final JBLabel fpsLabel = new JBLabel(" ", SwingConstants.CENTER);
+    fpsLabel.setForeground(UIUtil.getLabelDisabledForeground());
     final FlutterFramesMonitor.Listener listener = event -> {
-      fpsLabel.setText("Frames per second: " + new DecimalFormat().format(flutterFramesMonitor.getFPS()));
+      fpsLabel.setText(fpsFormat.format(flutterFramesMonitor.getFPS()) + " frames per second");
       SwingUtilities.invokeLater(fpsLabel::repaint);
     };
     flutterFramesMonitor.addListener(listener);
@@ -154,62 +160,66 @@ public class InspectorPerfTab extends JBPanel implements InspectorTabPanel {
     // Frame Rendering
     final JPanel frameRenderingPanel = new JPanel(new BorderLayout());
     final JPanel frameRenderingDisplay = FrameRenderingDisplay.createJPanelView(parentDisposable, app);
+    frameRenderingPanel.add(fpsLabel, BorderLayout.NORTH);
     frameRenderingPanel.add(frameRenderingDisplay, BorderLayout.CENTER);
-    frameRenderingPanel.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(), "Frame Rendering Time"));
+    frameRenderingPanel.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(), "Frame rendering time"));
 
+    // Memory
     JPanel memoryPanel = null;
     if (SHOW_MEMORY_PANEL) {
-      // Memory
       memoryPanel = new JPanel(new BorderLayout());
       final JPanel heapDisplay = HeapDisplay.createJPanelView(parentDisposable, app);
       memoryPanel.add(heapDisplay, BorderLayout.CENTER);
-      memoryPanel.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(), "Memory"));
+      memoryPanel.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(), "Memory usage"));
     }
 
     // Performance settings
     final JPanel perfSettings = new JPanel(new VerticalLayout(5));
-    trackRebuildsCheckbox = new JCheckBox("Show Widget Rebuild Profiler");
+    perfSettings.add(showPerfOverlay.getComponent());
+    perfSettings.add(showRepaintRainbow.getComponent());
+    perfSettings.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(), "Framework settings"));
+
+    final JBPanel generalPerfPanel = new JBPanel(new VerticalLayout(5));
+    generalPerfPanel.add(perfSettings);
+    generalPerfPanel.add(frameRenderingPanel);
+    if (memoryPanel != null) {
+      generalPerfPanel.add(memoryPanel);
+    }
+
+    Disposer.register(parentDisposable, treeSplitter::dispose);
+    treeSplitter.setFirstComponent(generalPerfPanel);
+    rebuildStatsPanel = new JPanel(new BorderLayout(0, 5));
+
+    // rebuild stats
+    final JPanel perfView = new JPanel(new BorderLayout());
+    perfView.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(), "Rebuild stats"));
+    final JPanel perfViewSettings = new JPanel(new VerticalLayout(5));
+    trackRebuildsCheckbox = new JCheckBox("Collect widget rebuild information");
     trackRebuildsCheckbox.setHorizontalAlignment(JLabel.LEFT);
     trackRebuildsCheckbox.setToolTipText(
-      "<html><body><p><b>This profiler identifies widgets that are rebuilt when the UI changes.</b></p>"+
+      "<html><body><p><b>This profiler identifies widgets that are rebuilt when the UI changes.</b></p>" +
       "<br>" +
       "<p>Look for the indicators on the left margin of the code editor<br>and a list of the top rebuilt widgets in this window.</p>" +
       "</body></html>");
-    perfSettings.add(trackRebuildsCheckbox);
+    perfViewSettings.add(trackRebuildsCheckbox);
     if (ENABLE_TRACK_REPAINTS) {
-      trackRepaintsCheckbox = new JCheckBox("Show widget repaint indicators");
-      perfSettings.add(trackRepaintsCheckbox);
+      trackRepaintsCheckbox = new JCheckBox("Collect widget repaint information");
+      perfViewSettings.add(trackRepaintsCheckbox);
     }
-    perfSettings.add(showRepaintRainbow.getComponent());
-    perfSettings.add(showPerfOverlay.getComponent());
+    perfViewSettings.add(new JSeparator());
+    perfSummaryView = new WidgetPerfSummaryView(parentDisposable, app, PerfMetric.lastFrame, PerfReportKind.rebuild);
+    perfView.add(perfViewSettings, BorderLayout.NORTH);
+    perfView.add(perfSummaryView, BorderLayout.CENTER);
+    rebuildStatsPanel.add(perfView, BorderLayout.CENTER);
 
-    final JPanel leftColumn = new JPanel(new BorderLayout());
-    leftColumn.add(fpsLabel, BorderLayout.NORTH);
-    leftColumn.add(frameRenderingPanel, BorderLayout.CENTER);
-    if (memoryPanel != null) {
-      leftColumn.add(memoryPanel);
-    }
+    // perf tips
+    final JPanel perfTipsPanel = perfSummaryView.getWidgetPerfTipsPanel();
+    rebuildStatsPanel.add(perfTipsPanel, BorderLayout.SOUTH);
+    perfTipsPanel.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(), "Performance tips"));
+    perfTipsPanel.setVisible(false);
 
-    rightColumn = new JPanel(new VerticalLayout(5));
-    rightColumn.add(perfSettings);
-
-    bodyPanel = new JPanel(new BorderLayout());
-    bodyPanel.setBorder(JBUI.Borders.empty(5));
-    bodyPanel.add(leftColumn, BorderLayout.CENTER);
-    bodyPanel.add(rightColumn, BorderLayout.SOUTH);
-    main.add(bodyPanel, BorderLayout.CENTER);
-
-    Disposer.register(parentDisposable, treeSplitter::dispose);
-    treeSplitter.setFirstComponent(main);
-    perfSummaryView = new WidgetPerfSummaryView(
-      parentDisposable,
-      app,
-      PerfMetric.lastFrame,
-      PerfReportKind.rebuild
-    );
     treeSplitter.setHonorComponentsMinimumSize(false);
     updateUseSplitter(true);
-
 
     toolWindow.getComponent().addComponentListener(new ComponentListener() {
       @Override
@@ -219,7 +229,6 @@ public class InspectorPerfTab extends JBPanel implements InspectorTabPanel {
 
       @Override
       public void componentMoved(ComponentEvent e) {
-
       }
 
       @Override
@@ -238,21 +247,11 @@ public class InspectorPerfTab extends JBPanel implements InspectorTabPanel {
   private void layoutUiOnResize() {
     final int windowWidth = toolWindow.getComponent().getWidth();
     final int windowHeight = toolWindow.getComponent().getHeight();
-    final double aspectRatio = (double) windowWidth / (double) windowHeight;
+    final double aspectRatio = (double)windowWidth / (double)windowHeight;
     final boolean vertical = aspectRatio < 1.4 && windowWidth < 500;
-    boolean sideBySideColumns = !vertical;
-    if (windowHeight > 250) {
-      sideBySideColumns = false;
-    }
 
     if (vertical != treeSplitter.getOrientation()) {
       treeSplitter.setOrientation(vertical);
-    }
-
-    if (sideBySideColumns != this.lastSideBySideColumns) {
-      lastSideBySideColumns = sideBySideColumns;
-      bodyPanel.remove(rightColumn);
-      bodyPanel.add(rightColumn, sideBySideColumns ? BorderLayout.EAST : BorderLayout.SOUTH);
     }
   }
 

--- a/src/io/flutter/view/InspectorPerfTab.java
+++ b/src/io/flutter/view/InspectorPerfTab.java
@@ -194,7 +194,7 @@ public class InspectorPerfTab extends JBPanel implements InspectorTabPanel {
     final JPanel perfView = new JPanel(new BorderLayout());
     perfView.setBorder(BorderFactory.createTitledBorder(BorderFactory.createEtchedBorder(), "Rebuild stats"));
     final JPanel perfViewSettings = new JPanel(new VerticalLayout(5));
-    trackRebuildsCheckbox = new JCheckBox("Collect widget rebuild information");
+    trackRebuildsCheckbox = new JCheckBox("Show widget rebuild information");
     trackRebuildsCheckbox.setHorizontalAlignment(JLabel.LEFT);
     trackRebuildsCheckbox.setToolTipText(
       "<html><body><p><b>This profiler identifies widgets that are rebuilt when the UI changes.</b></p>" +
@@ -203,7 +203,7 @@ public class InspectorPerfTab extends JBPanel implements InspectorTabPanel {
       "</body></html>");
     perfViewSettings.add(trackRebuildsCheckbox);
     if (ENABLE_TRACK_REPAINTS) {
-      trackRepaintsCheckbox = new JCheckBox("Collect widget repaint information");
+      trackRepaintsCheckbox = new JCheckBox("Show widget repaint information");
       perfViewSettings.add(trackRepaintsCheckbox);
     }
     perfViewSettings.add(new JSeparator());

--- a/src/io/flutter/view/WidgetPerfSummaryView.java
+++ b/src/io/flutter/view/WidgetPerfSummaryView.java
@@ -26,7 +26,6 @@ class WidgetPerfSummaryView extends JPanel {
   private final Timer refreshTableTimer;
   private final WidgetPerfTable table;
   private final PerfReportKind reportKind;
-  //private final JBLabel tableTitle;
 
   private final WidgetPerfTipsPanel myWidgetPerfTipsPanel;
   private boolean visible = true;
@@ -47,14 +46,6 @@ class WidgetPerfSummaryView extends JPanel {
     table = new WidgetPerfTable(app, parentDisposable, metric);
 
     perfManager.getCurrentStats().addPerfListener(table);
-    //final JPanel header = new JPanel();
-    //header.setLayout(new VerticalLayout(5));
-    //header.setBorder(JBUI.Borders.empty(5));
-    //add(header, BorderLayout.NORTH);
-    // Update header message.
-    //tableTitle = new JBLabel();
-    setTableTitle(reportKind);
-    //header.add(tableTitle);
 
     add(ScrollPaneFactory.createScrollPane(table), BorderLayout.CENTER);
 
@@ -66,10 +57,6 @@ class WidgetPerfSummaryView extends JPanel {
 
   public WidgetPerfTipsPanel getWidgetPerfTipsPanel() {
     return myWidgetPerfTipsPanel;
-  }
-
-  private void setTableTitle(PerfReportKind kind) {
-    //tableTitle.setText("Widget " + reportKind.name + " stats for the current screen:");
   }
 
   private void onUpdateTable(ActionEvent event) {

--- a/src/io/flutter/view/WidgetPerfSummaryView.java
+++ b/src/io/flutter/view/WidgetPerfSummaryView.java
@@ -8,15 +8,14 @@ package io.flutter.view;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.util.Disposer;
 import com.intellij.ui.ScrollPaneFactory;
-import com.intellij.ui.components.JBLabel;
-import com.intellij.ui.components.panels.VerticalLayout;
-import com.intellij.util.ui.JBUI;
 import io.flutter.inspector.WidgetPerfTipsPanel;
-import io.flutter.perf.*;
+import io.flutter.perf.FlutterWidgetPerf;
+import io.flutter.perf.FlutterWidgetPerfManager;
+import io.flutter.perf.PerfMetric;
+import io.flutter.perf.PerfReportKind;
 import io.flutter.run.daemon.FlutterApp;
 
 import javax.swing.*;
-import javax.swing.Timer;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 
@@ -27,7 +26,8 @@ class WidgetPerfSummaryView extends JPanel {
   private final Timer refreshTableTimer;
   private final WidgetPerfTable table;
   private final PerfReportKind reportKind;
-  private final JBLabel tableTitle;
+  //private final JBLabel tableTitle;
+
   private final WidgetPerfTipsPanel myWidgetPerfTipsPanel;
   private boolean visible = true;
 
@@ -47,28 +47,29 @@ class WidgetPerfSummaryView extends JPanel {
     table = new WidgetPerfTable(app, parentDisposable, metric);
 
     perfManager.getCurrentStats().addPerfListener(table);
-    final JPanel header = new JPanel();
-    header.setLayout(new VerticalLayout(5));
-    header.setBorder(JBUI.Borders.empty(5));
-    add(header, BorderLayout.NORTH);
+    //final JPanel header = new JPanel();
+    //header.setLayout(new VerticalLayout(5));
+    //header.setBorder(JBUI.Borders.empty(5));
+    //add(header, BorderLayout.NORTH);
     // Update header message.
-    tableTitle = new JBLabel();
+    //tableTitle = new JBLabel();
     setTableTitle(reportKind);
-    header.add(tableTitle);
+    //header.add(tableTitle);
 
     add(ScrollPaneFactory.createScrollPane(table), BorderLayout.CENTER);
 
     // Perf info and tips
     myWidgetPerfTipsPanel = new WidgetPerfTipsPanel(parentDisposable, app);
-    add(myWidgetPerfTipsPanel, BorderLayout.SOUTH);
 
     Disposer.register(parentDisposable, refreshTableTimer::stop);
   }
 
+  public WidgetPerfTipsPanel getWidgetPerfTipsPanel() {
+    return myWidgetPerfTipsPanel;
+  }
+
   private void setTableTitle(PerfReportKind kind) {
-    final String name = reportKind.name;
-    final String upperCaseName = name.substring(0, 1).toUpperCase() + name.substring(1);
-    tableTitle.setText("Widget " + upperCaseName + " Stats for the Current Screen");
+    //tableTitle.setText("Widget " + reportKind.name + " stats for the current screen:");
   }
 
   private void onUpdateTable(ActionEvent event) {
@@ -85,6 +86,7 @@ class WidgetPerfSummaryView extends JPanel {
 
   public void setVisibleToUser(boolean visible) {
     myWidgetPerfTipsPanel.setVisibleToUser(visible);
+
     if (visible != this.visible) {
       this.visible = visible;
       if (visible) {

--- a/src/io/flutter/view/WidgetPerfTable.java
+++ b/src/io/flutter/view/WidgetPerfTable.java
@@ -19,7 +19,6 @@ import com.intellij.ui.treeStructure.treetable.ListTreeTableModelOnColumns;
 import com.intellij.ui.treeStructure.treetable.TreeTable;
 import com.intellij.util.PathUtil;
 import com.intellij.util.ui.ColumnInfo;
-import com.intellij.util.ui.JBEmptyBorder;
 import com.intellij.xdebugger.XSourcePosition;
 import gnu.trove.TIntArrayList;
 import io.flutter.inspector.InspectorActions;
@@ -149,6 +148,7 @@ class WidgetPerfTable extends TreeTable implements DataProvider, PerfModel {
 
   private void updateIconUIAnimations() {
     int lastActive = -1;
+    // TODO(devoncarew): We've seen NPEs from here.
     for (int i = 0; i < entries.size() && entries.get(i).getValue(metric) > 0; ++i) {
       lastActive = i;
     }
@@ -337,7 +337,6 @@ class WidgetPerfTable extends TreeTable implements DataProvider, PerfModel {
   }
 
   private static class WidgetNameRenderer extends SimpleColoredRenderer implements TableCellRenderer {
-
     @Override
     public final Component getTableCellRendererComponent(JTable table, @Nullable Object value,
                                                          boolean isSelected, boolean hasFocus, int row, int col) {
@@ -352,7 +351,10 @@ class WidgetPerfTable extends TreeTable implements DataProvider, PerfModel {
         final JBLabel label = new JBLabel(stats.getLocation().name);
         label.setHorizontalAlignment(SwingConstants.RIGHT);
         panel.add(label, BorderLayout.CENTER);
-        panel.add(Box.createHorizontalStrut(16), BorderLayout.EAST);
+
+        if (isSelected) {
+          label.setForeground(table.getSelectionForeground());
+        }
       }
 
       clear();
@@ -363,6 +365,7 @@ class WidgetPerfTable extends TreeTable implements DataProvider, PerfModel {
       if (isSelected) {
         panel.setBackground(table.getSelectionBackground());
       }
+
       return panel;
     }
   }
@@ -374,7 +377,6 @@ class WidgetPerfTable extends TreeTable implements DataProvider, PerfModel {
       final JPanel panel = new JPanel();
       if (value == null) return panel;
       panel.setLayout(new BorderLayout());
-      panel.setBorder(new JBEmptyBorder(0, 8, 0, 8));
 
       if (value instanceof SlidingWindowStatsSummary) {
         final SlidingWindowStatsSummary stats = (SlidingWindowStatsSummary)value;
@@ -388,8 +390,14 @@ class WidgetPerfTable extends TreeTable implements DataProvider, PerfModel {
         label.setHorizontalAlignment(SwingConstants.RIGHT);
         panel.add(Box.createHorizontalGlue());
         panel.add(label, BorderLayout.CENTER);
+
         final JBLabel lineLabel = new JBLabel(":" + location.line);
         panel.add(lineLabel, BorderLayout.EAST);
+
+        if (isSelected) {
+          label.setForeground(table.getSelectionForeground());
+          lineLabel.setForeground(table.getSelectionForeground());
+        }
       }
 
       clear();
@@ -427,11 +435,15 @@ class WidgetPerfTable extends TreeTable implements DataProvider, PerfModel {
 
         final JBLabel label = new JBLabel(Integer.toString(count));
         if (metric.timeIntervalMetric) {
-          label.setIcon(getIconForCount(idle ? 0 : count, true));
+          label.setIcon(getIconForCount(idle ? 0 : count, false));
         }
         panel.add(Box.createHorizontalGlue());
         panel.add(label);
-        panel.add(Box.createHorizontalStrut(16));
+        panel.add(Box.createHorizontalStrut(8));
+
+        if (isSelected) {
+          label.setForeground(table.getSelectionForeground());
+        }
       }
 
       clear();


### PR DESCRIPTION
Several and various UI and layout tweaks to the perf tab. A few of these changes could probably use discussion; happy to have feedback about them.

- have the `profile mode` text extend across the full with of the tool window (instead of just across the left hand component)
- have the splitter default to a 50/50 split (instead of 60/40)
- re-order and re-group the toolbar actions
- the FPS display now consistently displays one decimal point (`60.0`)
- change to always having the rebuild stats area displayed; I think this will facilitate discovery of the feature, and won't really negatively impact the area available to the other UI (FPS display)
- unify the use of titled borders around the various areas
- move the enablement of the rebuild stats table into the rebuild stats panel
- remove the title of the rebuild stats table (`Rebuild widgets stats for the current screen`); this took up some vertical space, and I'm banking on users being able to figure out the table from context
- fix an issue with the text color of selected rows
- choose to not display icons for rows that are not changing; the grey circle icon didn't provide a lot of info, and the addition and remove of the icon draws the eye to changing rows

@jacob314 @terrylucas @kenzieschmoll 

<img width="830" alt="screen shot 2018-11-21 at 2 05 12 pm" src="https://user-images.githubusercontent.com/1269969/48873752-764d5880-eda4-11e8-8f07-62806e930ad4.png">

<img width="827" alt="screen shot 2018-11-21 at 2 20 12 pm" src="https://user-images.githubusercontent.com/1269969/48873757-7e0cfd00-eda4-11e8-9e2d-1703158fd7dd.png">
