### PR TITLE
Add spinning icons to table.

### DIFF
--- a/src/io/flutter/perf/EditorPerfModel.java
+++ b/src/io/flutter/perf/EditorPerfModel.java
@@ -28,7 +28,9 @@ public interface EditorPerfModel extends PerfModel, Disposable {
 
   FlutterApp getApp();
 
-  boolean isHoveredOverLineMarkerArea();
+  boolean getAlwaysShowLineMarkers();
+
+  void setAlwaysShowLineMarkersOverride(boolean show);
 
   void setPerfInfo(FilePerfInfo stats);
 }

--- a/src/io/flutter/perf/FlutterWidgetPerf.java
+++ b/src/io/flutter/perf/FlutterWidgetPerf.java
@@ -16,7 +16,6 @@ import com.intellij.concurrency.JobScheduler;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.application.Application;
 import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.application.ReadAction;
 import com.intellij.openapi.fileEditor.TextEditor;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -423,6 +422,12 @@ public class FlutterWidgetPerf implements Disposable, WidgetPerfListener {
         editors.remove();
         editorPerfDecorations.dispose();
       }
+    }
+  }
+
+  public void setAlwaysShowLineMarkersOverride(boolean show) {
+    for (EditorPerfModel model : editorDecorations.values()) {
+      model.setAlwaysShowLineMarkersOverride(show);
     }
   }
 

--- a/testSrc/unit/io/flutter/perf/FlutterWidgetPerfTest.java
+++ b/testSrc/unit/io/flutter/perf/FlutterWidgetPerfTest.java
@@ -145,8 +145,12 @@ class MockEditorPerfModel extends MockPerfModel implements EditorPerfModel {
   }
 
   @Override
-  public boolean isHoveredOverLineMarkerArea() {
+  public boolean getAlwaysShowLineMarkers() {
     return isHoveredOverLineMarkerAreaOverride;
+  }
+
+  @Override
+  public void setAlwaysShowLineMarkersOverride(boolean show) {
   }
 
   @Override


### PR DESCRIPTION
Add spinning icons to table indicating which rebuilds are actively occurring.
Show icons in source file when mousing over table.
Fix bugs in logic navigating to source location of the selected row.