### PR TITLE
Add service extensions after first frame event received.

### DIFF
--- a/src/io/flutter/server/vmService/VMServiceManager.java
+++ b/src/io/flutter/server/vmService/VMServiceManager.java
@@ -246,22 +246,26 @@ public class VMServiceManager implements FlutterApp.FlutterAppListener {
   }
 
   private void maybeAddServiceExtension(String name) {
-    if (firstFrameEventReceived) {
-      addServiceExtension(name);
-      if (!pendingServiceExtensions.isEmpty()) {
-        addPendingServiceExtensions();
+    synchronized (pendingServiceExtensions) {
+      if (firstFrameEventReceived) {
+        addServiceExtension(name);
+        if (!pendingServiceExtensions.isEmpty()) {
+          addPendingServiceExtensions();
+        }
       }
-    }
-    else {
-      pendingServiceExtensions.add(name);
+      else {
+        pendingServiceExtensions.add(name);
+      }
     }
   }
 
   private void addPendingServiceExtensions() {
-    for (String extensionName : pendingServiceExtensions) {
-      addServiceExtension(extensionName);
+    synchronized (pendingServiceExtensions) {
+      for (String extensionName : pendingServiceExtensions) {
+        addServiceExtension(extensionName);
+      }
+      pendingServiceExtensions.clear();
     }
-    pendingServiceExtensions.clear();
   }
 
   /**

--- a/src/io/flutter/server/vmService/VMServiceManager.java
+++ b/src/io/flutter/server/vmService/VMServiceManager.java
@@ -9,9 +9,7 @@ import com.intellij.openapi.Disposable;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.util.Disposer;
 import com.intellij.openapi.util.text.StringUtil;
-import com.jetbrains.lang.dart.flutter.FlutterUtil;
 import gnu.trove.THashMap;
-import io.flutter.FlutterUtils;
 import io.flutter.run.daemon.FlutterApp;
 import io.flutter.server.vmService.HeapMonitor.HeapListener;
 import io.flutter.utils.EventStream;
@@ -25,6 +23,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
@@ -46,6 +45,13 @@ public class VMServiceManager implements FlutterApp.FlutterAppListener {
 
   private boolean isRunning;
   private int polledCount;
+
+  private boolean firstFrameEventReceived = false;
+  /**
+   * Temporarily stores service extensions that we need to add. We should not add extensions until the first frame event
+   * has been received [firstFrameEventReceived].
+   */
+  private List<String> pendingServiceExtensions = new ArrayList<>();
 
   public VMServiceManager(@NotNull FlutterApp app, @NotNull VmService vmService) {
     this.app = app;
@@ -199,22 +205,23 @@ public class VMServiceManager implements FlutterApp.FlutterAppListener {
     if (flutterIsolateRef != null) {
       if (event.getKind() == EventKind.IsolateExit && StringUtil.equals(event.getIsolate().getId(), flutterIsolateRef.getId())) {
         setFlutterIsolate(null);
+        firstFrameEventReceived = false;
         resetAvailableExtensions();
       }
     }
 
+    // Track whether we have received the first frame event and add pending service extensions if we have.
+    if (event.getKind() == EventKind.Extension && event.getExtensionKind().startsWith("Flutter.FirstFrame")) {
+      firstFrameEventReceived = true;
+      addPendingServiceExtensions();
+    }
+
     if (event.getKind() == EventKind.ServiceExtensionAdded) {
-      addServiceExtension(event.getExtensionRPC());
+      maybeAddServiceExtension(event.getExtensionRPC());
     }
 
     // Check to see if there's a new Flutter isolate.
     if (flutterIsolateRefStream.getValue() == null) {
-      // Check for Flutter frame events.
-      if (event.getKind() == EventKind.Extension && event.getExtensionKind().startsWith("Flutter.")) {
-        // Flutter.FrameworkInitialization, Flutter.FirstFrame, Flutter.Frame
-        setFlutterIsolate(event.getIsolate());
-      }
-
       // Check for service extension registrations.
       if (event.getKind() == EventKind.ServiceExtensionAdded) {
         final String extensionName = event.getExtensionRPC();
@@ -236,6 +243,25 @@ public class VMServiceManager implements FlutterApp.FlutterAppListener {
 
       heapMonitor.handleGCEvent(isolateRef, newHeapSpace, oldHeapSpace);
     }
+  }
+
+  private void maybeAddServiceExtension(String name) {
+    if (firstFrameEventReceived) {
+      addServiceExtension(name);
+      if (pendingServiceExtensions.size() > 0) {
+        addPendingServiceExtensions();
+      }
+    }
+    else {
+      pendingServiceExtensions.add(name);
+    }
+  }
+
+  private void addPendingServiceExtensions() {
+    for (String extensionName : pendingServiceExtensions) {
+      addServiceExtension(extensionName);
+    }
+    pendingServiceExtensions.clear();
   }
 
   /**
@@ -407,11 +433,12 @@ public class VMServiceManager implements FlutterApp.FlutterAppListener {
   public void stateChanged(FlutterApp.State newState) {
     if (newState == FlutterApp.State.RESTARTING) {
       // The set of service extensions available may be different once the app
-      // restarts and no service extensions will be availabe until the app is
+      // restarts and no service extensions will be available until the app is
       // suitably far along in the restart process. It turns out the
       // IsolateExit event cannot be relied on to track when a restart is
       // occurring for unclear reasons.
       resetAvailableExtensions();
+      firstFrameEventReceived = false;
     }
   }
 }

--- a/src/io/flutter/server/vmService/VMServiceManager.java
+++ b/src/io/flutter/server/vmService/VMServiceManager.java
@@ -248,7 +248,7 @@ public class VMServiceManager implements FlutterApp.FlutterAppListener {
   private void maybeAddServiceExtension(String name) {
     if (firstFrameEventReceived) {
       addServiceExtension(name);
-      if (pendingServiceExtensions.size() > 0) {
+      if (!pendingServiceExtensions.isEmpty()) {
         addPendingServiceExtensions();
       }
     }


### PR DESCRIPTION
Prevents a crash in the framework. 

Crash was occurring if the Performance Overlay or Hide Debug Mode Banner settings were enabled before performing a hot restart.