### PR TITLE
add url checking to the build

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,3 +5,4 @@ dependencies:
   path: any
 dev_dependencies:
   grinder: ^0.8.0
+  http: ^0.12.0

--- a/src/io/flutter/FlutterBundle.properties
+++ b/src/io/flutter/FlutterBundle.properties
@@ -82,6 +82,10 @@ flutter.reload.firstRun.title=Flutter supports hot reload!
 flutter.reload.firstRun.content=Apply changes to your app in place, instantly.
 flutter.reload.firstRun.url=https://flutter.io/docs/development/tools/hot-reload
 
+flutter.io.gettingStarted.url=https://flutter.io/docs/get-started/install
+flutter.io.gettingStarted.IDE.url=https://flutter.io/docs/development/tools/ide
+flutter.io.runAndDebug.url=https://flutter.io/docs/development/tools/ide/android-studio#running-and-debugging
+
 flutter.view.debugPaint.text=Toggle Debug Paint
 flutter.view.debugPaint.description=Toggle Debug Paint
 flutter.view.togglePlatform.text=Toggle Platform Mode

--- a/src/io/flutter/FlutterConstants.java
+++ b/src/io/flutter/FlutterConstants.java
@@ -117,9 +117,9 @@ public class FlutterConstants {
   public static final String INDEPENDENT_PATH_SEPARATOR = "/";
   public static final int MAX_MODULE_NAME_LENGTH = 30;
 
-  public static final String URL_GETTING_STARTED = "https://flutter.io/docs/get-started/install";
-  public static final String URL_GETTING_STARTED_IDE = "https://flutter.io/docs/development/tools/ide";
-  public static final String URL_RUN_AND_DEBUG = "https://flutter.io/docs/development/tools/ide/android-studio#running-and-debugging";
+  public static final String URL_GETTING_STARTED = FlutterBundle.message("flutter.io.gettingStarted.url");
+  public static final String URL_GETTING_STARTED_IDE = FlutterBundle.message("flutter.io.gettingStarted.IDE.url");
+  public static final String URL_RUN_AND_DEBUG = FlutterBundle.message("flutter.io.runAndDebug.url");
 
   private FlutterConstants() {
 

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -7,7 +7,32 @@ import 'dart:io';
 
 import 'package:grinder/grinder.dart';
 
+import 'package:http/http.dart' as http;
+
 main(List<String> args) => grind(args);
+
+@Task('Check plugin URLs for liveness')
+checkUrls() async {
+  log('checking URLs in FlutterBundle.properties...');
+  var lines =
+      await new File('src/io/flutter/FlutterBundle.properties').readAsLines();
+  for (var line in lines) {
+    var split = line.split('=');
+    if (split.length == 2) {
+      // flutter.io.gettingStarted.url | flutter.analytics.privacyUrl
+      if (split[0].toLowerCase().endsWith('url')) {
+        var url = split[1];
+        var response = await http.get(url);
+        log('checking: $url...');
+        if (response.statusCode != 200) {
+          fail(
+              '$url GET failed: [${response.statusCode}] ${response.reasonPhrase}');
+        }
+      }
+    }
+  }
+  log('OK!');
+}
 
 @Task()
 @Depends(colors, icons)

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -38,6 +38,10 @@ else
   # Run some validations on the repo code.
   ./bin/plugin lint
 
+  # Check plugin-referenced urls for liveness.
+  pub global activate grinder
+  grind check-urls
+
   # Run the build.
   ./bin/plugin build --only-version=$IDEA_VERSION
 fi

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -39,8 +39,7 @@ else
   ./bin/plugin lint
 
   # Check plugin-referenced urls for liveness.
-  pub global activate grinder
-  grind check-urls
+  dart tool/grind.dart check-urls
 
   # Run the build.
   ./bin/plugin build --only-version=$IDEA_VERSION


### PR DESCRIPTION
add url checking to the build

* moves action URLs into bundle
* adds grind task that checks URLs in bundle
* adds grinder call to travis build

Fixes: #2819 

a few things to consider:

* I’m using a heuristic to grab URL bundle properties; we could be more eager
* where in the build this happens is open to debate — perhaps we ultimately should have a separate bot that does this and `./bin/plugin lint` ? dunno.

/cc @devoncarew @stevemessick 