### PR TITLE
re-order the Flutter Run menu items

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -643,7 +643,6 @@
     <!-- run menu actions -->
     <group id="Flutter.MenuActions.Run">
       <separator/>
-      <reference ref="AttachDebuggerAction"/>
       <reference ref="Flutter.Toolbar.ReloadAction"/>
       <action id="Flutter.Toolbar.RestartAction" class="io.flutter.actions.RestartFlutterAppRetarget"
               description="Restart"
@@ -651,6 +650,7 @@
         <keyboard-shortcut keymap="$default" first-keystroke="ctrl shift BACK_SLASH"/>
         <keyboard-shortcut keymap="$default" first-keystroke="ctrl shift S"/>
       </action>
+      <separator/>
       <action id="Flutter.Menu.RunProfileAction" class="io.flutter.actions.RunProfileFlutterApp"
               description="Flutter Run Profile Mode"
               icon="AllIcons.Actions.Execute">
@@ -659,6 +659,7 @@
               description="Flutter Run Release Mode"
               icon="AllIcons.Actions.Execute">
       </action>
+      <reference ref="AttachDebuggerAction"/>
       <separator/>
       <add-to-group group-id="RunMenu" anchor="after" relative-to-action="Stop"/>
     </group>

--- a/resources/META-INF/plugin_template.xml
+++ b/resources/META-INF/plugin_template.xml
@@ -139,7 +139,6 @@
     <!-- run menu actions -->
     <group id="Flutter.MenuActions.Run">
       <separator/>
-      <reference ref="AttachDebuggerAction"/>
       <reference ref="Flutter.Toolbar.ReloadAction"/>
       <action id="Flutter.Toolbar.RestartAction" class="io.flutter.actions.RestartFlutterAppRetarget"
               description="Restart"
@@ -147,6 +146,7 @@
         <keyboard-shortcut keymap="$default" first-keystroke="ctrl shift BACK_SLASH"/>
         <keyboard-shortcut keymap="$default" first-keystroke="ctrl shift S"/>
       </action>
+      <separator/>
       <action id="Flutter.Menu.RunProfileAction" class="io.flutter.actions.RunProfileFlutterApp"
               description="Flutter Run Profile Mode"
               icon="AllIcons.Actions.Execute">
@@ -155,6 +155,7 @@
               description="Flutter Run Release Mode"
               icon="AllIcons.Actions.Execute">
       </action>
+      <reference ref="AttachDebuggerAction"/>
       <separator/>
       <add-to-group group-id="RunMenu" anchor="after" relative-to-action="Stop"/>
     </group>


### PR DESCRIPTION
- adjust the order of the Flutter `Run` menu items

@stevemessick 

<img width="408" alt="screen shot 2018-11-26 at 4 00 38 pm" src="https://user-images.githubusercontent.com/1269969/49049626-a45fdd80-f194-11e8-9d61-69827974a087.png">
