### PR TITLE
force "allow running in parallel"

### DIFF
--- a/src/io/flutter/FlutterUtils.java
+++ b/src/io/flutter/FlutterUtils.java
@@ -76,13 +76,20 @@ public class FlutterUtils {
     return StringUtil.equals(PlatformUtils.getPlatformPrefix(), "AndroidStudio");
   }
 
-  public static boolean is2017_3() {
-    final ApplicationInfo appInfo = ApplicationInfo.getInstance();
-    if (appInfo == null) {
-      return false;
-    }
+  public static boolean is2018_3_or_higher() {
+    return getBaselineVersion() >= 183;
+  }
 
-    return appInfo.getBuild().getBaselineVersion() == 173;
+  public static boolean is2017_3() {
+    return getBaselineVersion() == 173;
+  }
+
+  private static int getBaselineVersion() {
+    final ApplicationInfo appInfo = ApplicationInfo.getInstance();
+    if (appInfo != null) {
+      return appInfo.getBuild().getBaselineVersion();
+    }
+    return -1;
   }
 
   public static void disableGradleProjectMigrationNotification(@NotNull Project project) {

--- a/src/io/flutter/run/SdkRunner.java
+++ b/src/io/flutter/run/SdkRunner.java
@@ -28,10 +28,12 @@ public class SdkRunner extends LaunchState.Runner<SdkRunConfig> {
     return "FlutterRunner";
   }
 
+  @SuppressWarnings("Duplicates")
   @Override
   protected RunContentDescriptor doExecute(@NotNull RunProfileState state, @NotNull ExecutionEnvironment env) throws ExecutionException {
     if (FlutterUtils.is2018_3_or_higher()) {
       // Force "allow running in parallel" (see: #2875).
+      // TODO(pq): when 2018.3 is our lower bound, migrate to using `RunConfigurationSingletonPolicy` (see: #2897).
       final RunnerAndConfigurationSettings settings = env.getRunnerAndConfigurationSettings();
       if (settings != null) {
         settings.setSingleton(false);

--- a/src/io/flutter/run/SdkRunner.java
+++ b/src/io/flutter/run/SdkRunner.java
@@ -5,6 +5,11 @@
  */
 package io.flutter.run;
 
+import com.intellij.execution.ExecutionException;
+import com.intellij.execution.RunnerAndConfigurationSettings;
+import com.intellij.execution.configurations.RunProfileState;
+import com.intellij.execution.runners.ExecutionEnvironment;
+import com.intellij.execution.ui.RunContentDescriptor;
 import io.flutter.sdk.FlutterSdk;
 import org.jetbrains.annotations.NotNull;
 
@@ -20,6 +25,16 @@ public class SdkRunner extends LaunchState.Runner<SdkRunConfig> {
   @Override
   public String getRunnerId() {
     return "FlutterRunner";
+  }
+
+  @Override
+  protected RunContentDescriptor doExecute(@NotNull RunProfileState state, @NotNull ExecutionEnvironment env) throws ExecutionException {
+    // Force "allow running in parallel" (see: #2875).
+    final RunnerAndConfigurationSettings settings = env.getRunnerAndConfigurationSettings();
+    if (settings != null) {
+      settings.setSingleton(false);
+    }
+    return super.doExecute(state, env);
   }
 
   @Override

--- a/src/io/flutter/run/SdkRunner.java
+++ b/src/io/flutter/run/SdkRunner.java
@@ -10,6 +10,7 @@ import com.intellij.execution.RunnerAndConfigurationSettings;
 import com.intellij.execution.configurations.RunProfileState;
 import com.intellij.execution.runners.ExecutionEnvironment;
 import com.intellij.execution.ui.RunContentDescriptor;
+import io.flutter.FlutterUtils;
 import io.flutter.sdk.FlutterSdk;
 import org.jetbrains.annotations.NotNull;
 
@@ -29,10 +30,12 @@ public class SdkRunner extends LaunchState.Runner<SdkRunConfig> {
 
   @Override
   protected RunContentDescriptor doExecute(@NotNull RunProfileState state, @NotNull ExecutionEnvironment env) throws ExecutionException {
-    // Force "allow running in parallel" (see: #2875).
-    final RunnerAndConfigurationSettings settings = env.getRunnerAndConfigurationSettings();
-    if (settings != null) {
-      settings.setSingleton(false);
+    if (FlutterUtils.is2018_3_or_higher()) {
+      // Force "allow running in parallel" (see: #2875).
+      final RunnerAndConfigurationSettings settings = env.getRunnerAndConfigurationSettings();
+      if (settings != null) {
+        settings.setSingleton(false);
+      }
     }
     return super.doExecute(state, env);
   }

--- a/src/io/flutter/run/bazel/BazelRunner.java
+++ b/src/io/flutter/run/bazel/BazelRunner.java
@@ -31,6 +31,7 @@ public class BazelRunner extends LaunchState.Runner<BazelRunConfig> {
   protected RunContentDescriptor doExecute(@NotNull RunProfileState state, @NotNull ExecutionEnvironment env) throws ExecutionException {
     if (FlutterUtils.is2018_3_or_higher()) {
       // Force "allow running in parallel" (see: #2875).
+      // TODO(pq): when 2018.3 is our lower bound, migrate to using `RunConfigurationSingletonPolicy` (see: #2897).
       final RunnerAndConfigurationSettings settings = env.getRunnerAndConfigurationSettings();
       if (settings != null) {
         settings.setSingleton(false);

--- a/src/io/flutter/run/bazel/BazelRunner.java
+++ b/src/io/flutter/run/bazel/BazelRunner.java
@@ -5,6 +5,12 @@
  */
 package io.flutter.run.bazel;
 
+import com.intellij.execution.ExecutionException;
+import com.intellij.execution.RunnerAndConfigurationSettings;
+import com.intellij.execution.configurations.RunProfileState;
+import com.intellij.execution.runners.ExecutionEnvironment;
+import com.intellij.execution.ui.RunContentDescriptor;
+import io.flutter.FlutterUtils;
 import io.flutter.run.LaunchState;
 import org.jetbrains.annotations.NotNull;
 
@@ -18,5 +24,18 @@ public class BazelRunner extends LaunchState.Runner<BazelRunConfig> {
   @Override
   public String getRunnerId() {
     return "FlutterBazelRunner";
+  }
+
+  @SuppressWarnings("Duplicates")
+  @Override
+  protected RunContentDescriptor doExecute(@NotNull RunProfileState state, @NotNull ExecutionEnvironment env) throws ExecutionException {
+    if (FlutterUtils.is2018_3_or_higher()) {
+      // Force "allow running in parallel" (see: #2875).
+      final RunnerAndConfigurationSettings settings = env.getRunnerAndConfigurationSettings();
+      if (settings != null) {
+        settings.setSingleton(false);
+      }
+    }
+    return super.doExecute(state, env);
   }
 }


### PR DESCRIPTION
A band-aid to address the re-run behavior regression in 2018.3.  

Additionally I wonder if this couldn't be fixed when we create our initial launch configs?  (Although that doesn't help with migration.)

Fixes: #2875.

/cc @devoncarew @stevemessick 