### PR TITLE
Make Find Action search prefs

### DIFF
--- a/src/io/flutter/sdk/FlutterSearchableOptionContributor.java
+++ b/src/io/flutter/sdk/FlutterSearchableOptionContributor.java
@@ -30,7 +30,7 @@ public class FlutterSearchableOptionContributor extends SearchableOptionContribu
   }
 
   private static void add(@NotNull SearchableOptionProcessor processor, @NotNull String key) {
-    processor.addOptions(key, null, null, FlutterConstants.FLUTTER_SETTINGS_PAGE_ID,
+    processor.addOptions(key, null, key, FlutterConstants.FLUTTER_SETTINGS_PAGE_ID,
                          FlutterSettingsConfigurable.FLUTTER_SETTINGS_PAGE_NAME, true);
   }
 }


### PR DESCRIPTION
Adds the Preference search strings to the database searched by `Help > Find Action`.

I didn't include this in M31 because I wasn't comfortable with it, but it looks safe enough. We'll have some time to check it out before M32.