### PR TITLE
Update the run mode setup to match the bazel allowed run configurations

### DIFF
--- a/src/io/flutter/run/bazel/BazelFields.java
+++ b/src/io/flutter/run/bazel/BazelFields.java
@@ -201,6 +201,9 @@ public class BazelFields {
     }
   }
 
+  /**
+   * Returns the app directory that corresponds to the entryFile and the given project.
+   */
   protected VirtualFile getAppDir(@NotNull Project project) {
     return MainFile.verify(entryFile, project).get().getAppDir();
   }

--- a/src/io/flutter/run/bazel/BazelFields.java
+++ b/src/io/flutter/run/bazel/BazelFields.java
@@ -201,6 +201,10 @@ public class BazelFields {
     }
   }
 
+  protected VirtualFile getAppDir(@NotNull Project project) {
+    return MainFile.verify(entryFile, project).get().getAppDir();
+  }
+
   /**
    * Returns the command to use to launch the Flutter app. (Via running the Bazel target.)
    */
@@ -215,7 +219,7 @@ public class BazelFields {
       throw new ExecutionException(e);
     }
 
-    final VirtualFile appDir = MainFile.verify(entryFile, project).get().getAppDir();
+    final VirtualFile appDir = getAppDir(project);
 
     final String launchingScript = getLaunchingScript();
     assert launchingScript != null; // already checked

--- a/src/io/flutter/run/bazel/BazelFields.java
+++ b/src/io/flutter/run/bazel/BazelFields.java
@@ -27,6 +27,8 @@ import io.flutter.run.daemon.RunMode;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import static io.flutter.run.daemon.RunMode.*;
+
 /**
  * The fields in a Bazel run configuration.
  */
@@ -227,12 +229,22 @@ public class BazelFields {
     commandLine.setCharset(CharsetToolkit.UTF8_CHARSET);
     commandLine.setExePath(FileUtil.toSystemDependentName(launchingScript));
 
-    // Set the mode.
+    // Set the mode. We track the bazel versions of the flutter_build_mode parameters.
     if (enableReleaseMode) {
       commandLine.addParameters("--define", "flutter_build_mode=release");
     }
-    else if (mode != RunMode.DEBUG) {
-      commandLine.addParameters("--define", "flutter_build_mode=" + mode.name());
+    else {
+      switch (mode) {
+        case PROFILE:
+          commandLine.addParameters("--define", "flutter_build_mode=profile");
+          break;
+        case RUN:
+        case DEBUG:
+        default:
+          commandLine.addParameters("--define", "flutter_build_mode=debug");
+          break;
+
+      }
     }
     // (the implicit else here is the debug case)
 
@@ -280,7 +292,7 @@ public class BazelFields {
     commandLine.addParameter("--machine");
 
     // Pause the app at startup in order to set breakpoints.
-    if (!enableReleaseMode && mode == RunMode.DEBUG) {
+    if (!enableReleaseMode && mode == DEBUG) {
       commandLine.addParameter("--start-paused");
     }
 

--- a/src/io/flutter/run/bazel/BazelFields.java
+++ b/src/io/flutter/run/bazel/BazelFields.java
@@ -247,7 +247,6 @@ public class BazelFields {
         default:
           commandLine.addParameters("--define", "flutter_build_mode=debug");
           break;
-
       }
     }
     // (the implicit else here is the debug case)

--- a/src/io/flutter/run/daemon/FlutterDevice.java
+++ b/src/io/flutter/run/daemon/FlutterDevice.java
@@ -18,7 +18,7 @@ public class FlutterDevice {
   private final @Nullable String myPlatform;
   private final boolean myEmulator;
 
-  FlutterDevice(@NotNull String deviceId, @NotNull String deviceName, @Nullable String platform, boolean emulator) {
+  public FlutterDevice(@NotNull String deviceId, @NotNull String deviceName, @Nullable String platform, boolean emulator) {
     myDeviceId = deviceId;
     myDeviceName = deviceName;
     myPlatform = platform;

--- a/testSrc/integration/io/flutter/testing/FlutterModuleFixture.java
+++ b/testSrc/integration/io/flutter/testing/FlutterModuleFixture.java
@@ -34,11 +34,13 @@ public class FlutterModuleFixture extends ExternalResource {
   protected void before() throws Exception {
     Testing.runOnDispatchThread(() -> {
       FlutterTestUtils.configureFlutterSdk(parent.getModule(), testRoot, realSdk);
-      final FlutterSdk sdk = FlutterSdk.getFlutterSdk(parent.getProject());
-      assert(sdk != null);
-      final String path = sdk.getHomePath();
-      final String dartSdkPath = path + "/bin/cache/dart-sdk";
-      System.setProperty("dart.sdk", dartSdkPath);
+      if (realSdk) {
+        final FlutterSdk sdk = FlutterSdk.getFlutterSdk(parent.getProject());
+        assert (sdk != null);
+        final String path = sdk.getHomePath();
+        final String dartSdkPath = path + "/bin/cache/dart-sdk";
+        System.setProperty("dart.sdk", dartSdkPath);
+      }
       DartTestUtils.configureDartSdk(parent.getModule(), testRoot, realSdk);
     });
   }

--- a/testSrc/integration/io/flutter/testing/FlutterModuleFixture.java
+++ b/testSrc/integration/io/flutter/testing/FlutterModuleFixture.java
@@ -19,21 +19,27 @@ import org.junit.rules.ExternalResource;
 public class FlutterModuleFixture extends ExternalResource {
   private final ProjectFixture parent;
   private final Disposable testRoot = () -> {};
+  private final boolean realSdk;
 
   public FlutterModuleFixture(ProjectFixture parent) {
+    this(parent, true);
+  }
+
+  public FlutterModuleFixture(ProjectFixture parent, boolean realSdk) {
     this.parent = parent;
+    this.realSdk = realSdk;
   }
 
   @Override
   protected void before() throws Exception {
     Testing.runOnDispatchThread(() -> {
-      FlutterTestUtils.configureFlutterSdk(parent.getModule(), testRoot, true);
+      FlutterTestUtils.configureFlutterSdk(parent.getModule(), testRoot, realSdk);
       final FlutterSdk sdk = FlutterSdk.getFlutterSdk(parent.getProject());
       assert(sdk != null);
       final String path = sdk.getHomePath();
       final String dartSdkPath = path + "/bin/cache/dart-sdk";
       System.setProperty("dart.sdk", dartSdkPath);
-      DartTestUtils.configureDartSdk(parent.getModule(), testRoot, true);
+      DartTestUtils.configureDartSdk(parent.getModule(), testRoot, realSdk);
     });
   }
 

--- a/testSrc/unit/io/flutter/run/bazel/BazelFieldsTest.java
+++ b/testSrc/unit/io/flutter/run/bazel/BazelFieldsTest.java
@@ -7,10 +7,14 @@ package io.flutter.run.bazel;
 
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configurations.GeneralCommandLine;
+import com.intellij.execution.configurations.RuntimeConfigurationError;
+import com.intellij.mock.MockVirtualFileSystem;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.util.xmlb.SkipDefaultValuesSerializationFilters;
 import com.intellij.util.xmlb.XmlSerializer;
 import io.flutter.dart.DartPlugin;
+import io.flutter.run.MainFile;
 import io.flutter.run.daemon.FlutterDevice;
 import io.flutter.run.daemon.RunMode;
 import io.flutter.testing.FlutterModuleFixture;
@@ -18,6 +22,8 @@ import io.flutter.testing.FlutterTestUtils;
 import io.flutter.testing.ProjectFixture;
 import io.flutter.testing.Testing;
 import org.jdom.Element;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -36,12 +42,6 @@ import static org.hamcrest.CoreMatchers.*;
  * Verifies run configuration persistence.
  */
 public class BazelFieldsTest {
-  @Rule
-  public ProjectFixture projectFixture = Testing.makeCodeInsightModule();
-
-  @Rule
-  public FlutterModuleFixture flutterFixture = new FlutterModuleFixture(projectFixture, false);
-
   @Test
   public void shouldReadFieldsFromXml() {
     final Element elt = new Element("test");
@@ -103,26 +103,6 @@ public class BazelFieldsTest {
     assertEquals("args", after.getAdditionalArgs());
   }
 
-  @Test
-  public void shouldProduceCorrectCommandLine() {
-    final BazelFields fields = new BazelFields();
-    fields.setEntryFile("/tmp/foo/lib/main.dart");
-    fields.setLaunchingScript("launch");
-    fields.setBazelTarget("target");
-    fields.setEnableReleaseMode(true);
-    fields.setAdditionalArgs("args");
-
-    FlutterDevice device = FlutterDevice.getTester();
-    GeneralCommandLine launchCommand = null;
-    try {
-      launchCommand = fields.getLaunchCommand(flutterFixture.getModule().getProject(), device, RunMode.DEBUG);
-    } catch (ExecutionException e) {
-      e.printStackTrace();
-    }
-    final List<String> expectedParameters = new ArrayList<>();
-    expectedParameters.add("");
-    assertThat(launchCommand.getParametersList(), equalTo(expectedParameters));
-  }
 
   private void addOption(Element elt, String name, String value) {
     final Element child = new Element("option");

--- a/testSrc/unit/io/flutter/run/bazel/BazelFieldsTest.java
+++ b/testSrc/unit/io/flutter/run/bazel/BazelFieldsTest.java
@@ -5,43 +5,22 @@
  */
 package io.flutter.run.bazel;
 
-import com.intellij.execution.ExecutionException;
-import com.intellij.execution.configurations.GeneralCommandLine;
-import com.intellij.execution.configurations.RuntimeConfigurationError;
-import com.intellij.mock.MockVirtualFileSystem;
-import com.intellij.openapi.project.Project;
-import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.util.xmlb.SkipDefaultValuesSerializationFilters;
 import com.intellij.util.xmlb.XmlSerializer;
-import io.flutter.dart.DartPlugin;
-import io.flutter.run.MainFile;
-import io.flutter.run.daemon.FlutterDevice;
-import io.flutter.run.daemon.RunMode;
-import io.flutter.testing.FlutterModuleFixture;
-import io.flutter.testing.FlutterTestUtils;
-import io.flutter.testing.ProjectFixture;
-import io.flutter.testing.Testing;
 import org.jdom.Element;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-import org.junit.Assert;
-import org.junit.Rule;
 import org.junit.Test;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.hamcrest.CoreMatchers.*;
 
 /**
  * Verifies run configuration persistence.
  */
 public class BazelFieldsTest {
+
   @Test
   public void shouldReadFieldsFromXml() {
     final Element elt = new Element("test");
@@ -102,7 +81,6 @@ public class BazelFieldsTest {
     assertEquals(true, after.getEnableReleaseMode());
     assertEquals("args", after.getAdditionalArgs());
   }
-
 
   private void addOption(Element elt, String name, String value) {
     final Element child = new Element("option");

--- a/testSrc/unit/io/flutter/run/bazel/LaunchCommandsTest.java
+++ b/testSrc/unit/io/flutter/run/bazel/LaunchCommandsTest.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2018 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.run.bazel;
+
+import com.intellij.execution.ExecutionException;
+import com.intellij.execution.configurations.GeneralCommandLine;
+import com.intellij.mock.MockVirtualFileSystem;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import io.flutter.run.daemon.FlutterDevice;
+import io.flutter.run.daemon.RunMode;
+import io.flutter.testing.FlutterModuleFixture;
+import io.flutter.testing.ProjectFixture;
+import io.flutter.testing.Testing;
+import org.fest.util.Strings;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class LaunchCommandsTest {
+  @Rule
+  public ProjectFixture projectFixture = Testing.makeCodeInsightModule();
+
+  @Rule
+  public FlutterModuleFixture flutterFixture = new FlutterModuleFixture(projectFixture, false);
+
+  @Test
+  public void shouldProduceCorrectCommandLineInReleaseMode() {
+    final BazelFields fields = new FakeBazelTestFields();
+    fields.setEntryFile("/tmp/foo/lib/main.dart");
+    fields.setLaunchingScript("bazel-run.sh");
+    fields.setBazelTarget("bazel_target");
+    fields.setEnableReleaseMode(true);
+    fields.setAdditionalArgs("additional_args");
+
+    final FlutterDevice device = FlutterDevice.getTester();
+    GeneralCommandLine launchCommand = null;
+    try {
+      launchCommand = fields.getLaunchCommand(flutterFixture.getModule().getProject(), device, RunMode.RUN);
+    } catch (ExecutionException e) {
+      e.printStackTrace();
+    }
+    final List<String> expectedCommandLine = new ArrayList<>();
+    expectedCommandLine.add("bazel-run.sh");
+    expectedCommandLine.add("--define");
+    expectedCommandLine.add("flutter_build_mode=release");
+    expectedCommandLine.add("bazel_target");
+    expectedCommandLine.add("--");
+    expectedCommandLine.add("--machine");
+    expectedCommandLine.add("additional_args");
+    expectedCommandLine.add("-d");
+    expectedCommandLine.add("flutter-tester");
+    assertThat(launchCommand.getCommandLineString(), equalTo(String.join(" ", expectedCommandLine)));
+
+    // When release mode is enabled, using different RunModes has no effect.
+
+    launchCommand = null;
+    try {
+      launchCommand = fields.getLaunchCommand(flutterFixture.getModule().getProject(), device, RunMode.DEBUG);
+    } catch (ExecutionException e) {
+      e.printStackTrace();
+    }
+    assertThat(launchCommand.getCommandLineString(), equalTo(String.join(" ", expectedCommandLine)));
+
+    launchCommand = null;
+    try {
+      launchCommand = fields.getLaunchCommand(flutterFixture.getModule().getProject(), device, RunMode.PROFILE);
+    } catch (ExecutionException e) {
+      e.printStackTrace();
+    }
+    assertThat(launchCommand.getCommandLineList(null), equalTo(expectedCommandLine));
+  }
+
+  @Test
+  public void shouldProduceCorrectCommandLineInRunMode() {
+    final BazelFields fields = new FakeBazelTestFields();
+    fields.setEntryFile("/tmp/foo/lib/main.dart");
+    fields.setLaunchingScript("bazel-run.sh");
+    fields.setBazelTarget("bazel_target");
+    fields.setEnableReleaseMode(false);
+    fields.setAdditionalArgs("additional_args");
+
+    final FlutterDevice device = FlutterDevice.getTester();
+    GeneralCommandLine launchCommand = null;
+    try {
+      launchCommand = fields.getLaunchCommand(flutterFixture.getModule().getProject(), device, RunMode.RUN);
+    } catch (ExecutionException e) {
+      e.printStackTrace();
+    }
+    final List<String> expectedCommandLine = new ArrayList<>();
+    expectedCommandLine.add("bazel-run.sh");
+    expectedCommandLine.add("--define");
+    expectedCommandLine.add("flutter_build_mode=debug");
+    expectedCommandLine.add("bazel_target");
+    expectedCommandLine.add("--");
+    expectedCommandLine.add("--machine");
+    expectedCommandLine.add("additional_args");
+    expectedCommandLine.add("-d");
+    expectedCommandLine.add("flutter-tester");
+    assertThat(launchCommand.getCommandLineList(null), equalTo(expectedCommandLine));
+  }
+
+  @Test
+  public void shouldProduceCorrectCommandLineInDebugMode() {
+    final BazelFields fields = new FakeBazelTestFields();
+    fields.setEntryFile("/tmp/foo/lib/main.dart");
+    fields.setLaunchingScript("bazel-run.sh");
+    fields.setBazelTarget("bazel_target");
+    fields.setEnableReleaseMode(false);
+    fields.setAdditionalArgs("additional_args");
+
+    final FlutterDevice device = FlutterDevice.getTester();
+    GeneralCommandLine launchCommand = null;
+    try {
+      launchCommand = fields.getLaunchCommand(flutterFixture.getModule().getProject(), device, RunMode.DEBUG);
+    } catch (ExecutionException e) {
+      e.printStackTrace();
+    }
+    final List<String> expectedCommandLine = new ArrayList<>();
+    expectedCommandLine.add("bazel-run.sh");
+    expectedCommandLine.add("--define");
+    expectedCommandLine.add("flutter_build_mode=debug");
+    expectedCommandLine.add("bazel_target");
+    expectedCommandLine.add("--");
+    expectedCommandLine.add("--machine");
+    expectedCommandLine.add("additional_args");
+    expectedCommandLine.add("-d");
+    expectedCommandLine.add("flutter-tester");
+    assertThat(launchCommand.getCommandLineList(null), equalTo(expectedCommandLine));
+  }
+
+  @Test
+  public void shouldProduceCorrectCommandLineInProfileMode() {
+    final BazelFields fields = new FakeBazelTestFields();
+    fields.setEntryFile("/tmp/foo/lib/main.dart");
+    fields.setLaunchingScript("bazel-run.sh");
+    fields.setBazelTarget("bazel_target");
+    fields.setEnableReleaseMode(false);
+    fields.setAdditionalArgs("additional_args");
+
+    final FlutterDevice device = FlutterDevice.getTester();
+    GeneralCommandLine launchCommand = null;
+    try {
+      launchCommand = fields.getLaunchCommand(flutterFixture.getModule().getProject(), device, RunMode.PROFILE);
+    } catch (ExecutionException e) {
+      e.printStackTrace();
+    }
+    final List<String> expectedCommandLine = new ArrayList<>();
+    expectedCommandLine.add("bazel-run.sh");
+    expectedCommandLine.add("--define");
+    expectedCommandLine.add("flutter_build_mode=profile");
+    expectedCommandLine.add("bazel_target");
+    expectedCommandLine.add("--");
+    expectedCommandLine.add("--machine");
+    expectedCommandLine.add("additional_args");
+    expectedCommandLine.add("-d");
+    expectedCommandLine.add("flutter-tester");
+    assertThat(launchCommand.getCommandLineList(null), equalTo(expectedCommandLine));
+  }
+
+  private static class FakeBazelTestFields extends BazelFields {
+    MockVirtualFileSystem fs = new MockVirtualFileSystem();
+
+    @Override
+    void checkRunnable(@NotNull Project project) {}
+
+    @Override
+    @Nullable
+    protected VirtualFile getAppDir(@NotNull Project project) {
+      if (getEntryFile() == null)
+        return null;
+      @NotNull
+      final String entryFile = getEntryFile();
+      return fs.refreshAndFindFileByPath(entryFile.replace("main.dart", ""));
+    }
+  }
+}

--- a/testSrc/unit/io/flutter/run/bazel/LaunchCommandsTest.java
+++ b/testSrc/unit/io/flutter/run/bazel/LaunchCommandsTest.java
@@ -236,6 +236,9 @@ public class LaunchCommandsTest {
   }
 
 
+  /**
+   * Gets the command line to run a test app.
+   */
   @Nullable
   private static GeneralCommandLine getLaunchCommand(BazelFields fields,
                                                      FlutterDevice device,
@@ -252,6 +255,9 @@ public class LaunchCommandsTest {
   }
 
 
+  /**
+   * Default configuration for the bazel test fields.
+   */
   private void setupBazelFields(BazelFields fields) {
     fields.setEntryFile("/tmp/foo/lib/main.dart");
     fields.setLaunchingScript("bazel-run.sh");
@@ -259,6 +265,9 @@ public class LaunchCommandsTest {
     fields.setEnableReleaseMode(false);
   }
 
+  /**
+   * Fake bazel test fields that doesn't depend on the Dart SDK.
+   */
   private static class FakeBazelTestFields extends BazelFields {
     MockVirtualFileSystem fs = new MockVirtualFileSystem();
 
@@ -272,7 +281,9 @@ public class LaunchCommandsTest {
         return null;
       @NotNull
       final String entryFile = getEntryFile();
-      return fs.refreshAndFindFileByPath(entryFile.replace("main.dart", ""));
+      
+      // With the default entryFile from setupBazelFields, the application directory is the container of lib/main.dart.
+      return fs.refreshAndFindFileByPath(entryFile.replace("lib/main.dart", ""));
     }
   }
 }

--- a/testSrc/unit/io/flutter/run/bazel/LaunchCommandsTest.java
+++ b/testSrc/unit/io/flutter/run/bazel/LaunchCommandsTest.java
@@ -35,7 +35,7 @@ public class LaunchCommandsTest {
   public FlutterModuleFixture flutterFixture = new FlutterModuleFixture(projectFixture, false);
 
   @Test
-  public void shouldProduceCorrectCommandLineInReleaseMode() {
+  public void producesCorrectCommandLineInReleaseMode() {
     final BazelFields fields = new FakeBazelTestFields();
     fields.setEntryFile("/tmp/foo/lib/main.dart");
     fields.setLaunchingScript("bazel-run.sh");
@@ -82,7 +82,7 @@ public class LaunchCommandsTest {
   }
 
   @Test
-  public void shouldProduceCorrectCommandLineInRunMode() {
+  public void producesCorrectCommandLineInRunMode() {
     final BazelFields fields = new FakeBazelTestFields();
     fields.setEntryFile("/tmp/foo/lib/main.dart");
     fields.setLaunchingScript("bazel-run.sh");
@@ -111,7 +111,34 @@ public class LaunchCommandsTest {
   }
 
   @Test
-  public void shouldProduceCorrectCommandLineInDebugMode() {
+  public void producesCorrectCommandLineWithoutAdditionalArgs() {
+    final BazelFields fields = new FakeBazelTestFields();
+    fields.setEntryFile("/tmp/foo/lib/main.dart");
+    fields.setLaunchingScript("bazel-run.sh");
+    fields.setBazelTarget("bazel_target");
+    fields.setEnableReleaseMode(false);
+
+    final FlutterDevice device = FlutterDevice.getTester();
+    GeneralCommandLine launchCommand = null;
+    try {
+      launchCommand = fields.getLaunchCommand(flutterFixture.getModule().getProject(), device, RunMode.RUN);
+    } catch (ExecutionException e) {
+      e.printStackTrace();
+    }
+    final List<String> expectedCommandLine = new ArrayList<>();
+    expectedCommandLine.add("bazel-run.sh");
+    expectedCommandLine.add("--define");
+    expectedCommandLine.add("flutter_build_mode=debug");
+    expectedCommandLine.add("bazel_target");
+    expectedCommandLine.add("--");
+    expectedCommandLine.add("--machine");
+    expectedCommandLine.add("-d");
+    expectedCommandLine.add("flutter-tester");
+    assertThat(launchCommand.getCommandLineList(null), equalTo(expectedCommandLine));
+  }
+
+  @Test
+  public void producesCorrectCommandLineInDebugMode() {
     final BazelFields fields = new FakeBazelTestFields();
     fields.setEntryFile("/tmp/foo/lib/main.dart");
     fields.setLaunchingScript("bazel-run.sh");
@@ -133,6 +160,7 @@ public class LaunchCommandsTest {
     expectedCommandLine.add("bazel_target");
     expectedCommandLine.add("--");
     expectedCommandLine.add("--machine");
+    expectedCommandLine.add("--start-paused");
     expectedCommandLine.add("additional_args");
     expectedCommandLine.add("-d");
     expectedCommandLine.add("flutter-tester");
@@ -140,7 +168,7 @@ public class LaunchCommandsTest {
   }
 
   @Test
-  public void shouldProduceCorrectCommandLineInProfileMode() {
+  public void producesCorrectCommandLineInProfileMode() {
     final BazelFields fields = new FakeBazelTestFields();
     fields.setEntryFile("/tmp/foo/lib/main.dart");
     fields.setLaunchingScript("bazel-run.sh");
@@ -165,6 +193,125 @@ public class LaunchCommandsTest {
     expectedCommandLine.add("additional_args");
     expectedCommandLine.add("-d");
     expectedCommandLine.add("flutter-tester");
+    assertThat(launchCommand.getCommandLineList(null), equalTo(expectedCommandLine));
+  }
+
+  @Test
+  public void producesCorrectCommandLineWithAndroidDevice() {
+    final BazelFields fields = new FakeBazelTestFields();
+    fields.setEntryFile("/tmp/foo/lib/main.dart");
+    fields.setLaunchingScript("bazel-run.sh");
+    fields.setBazelTarget("bazel_target");
+    fields.setEnableReleaseMode(false);
+    fields.setAdditionalArgs("additional_args");
+
+    final FlutterDevice device = new FlutterDevice("android-tester", "android device", "android", false);
+    GeneralCommandLine launchCommand = null;
+    try {
+      launchCommand = fields.getLaunchCommand(flutterFixture.getModule().getProject(), device, RunMode.RUN);
+    } catch (ExecutionException e) {
+      e.printStackTrace();
+    }
+    final List<String> expectedCommandLine = new ArrayList<>();
+    expectedCommandLine.add("bazel-run.sh");
+    expectedCommandLine.add("--define");
+    expectedCommandLine.add("flutter_build_mode=debug");
+    expectedCommandLine.add("bazel_target");
+    expectedCommandLine.add("--");
+    expectedCommandLine.add("--machine");
+    expectedCommandLine.add("additional_args");
+    expectedCommandLine.add("-d");
+    expectedCommandLine.add("android-tester");
+    assertThat(launchCommand.getCommandLineList(null), equalTo(expectedCommandLine));
+  }
+
+
+  @Test
+  public void producesCorrectCommandLineWithAndroidEmulator() {
+    final BazelFields fields = new FakeBazelTestFields();
+    fields.setEntryFile("/tmp/foo/lib/main.dart");
+    fields.setLaunchingScript("bazel-run.sh");
+    fields.setBazelTarget("bazel_target");
+    fields.setEnableReleaseMode(false);
+    fields.setAdditionalArgs("additional_args");
+
+    final FlutterDevice device = new FlutterDevice("android-tester", "android device", "android", true);
+    GeneralCommandLine launchCommand = null;
+    try {
+      launchCommand = fields.getLaunchCommand(flutterFixture.getModule().getProject(), device, RunMode.RUN);
+    } catch (ExecutionException e) {
+      e.printStackTrace();
+    }
+    final List<String> expectedCommandLine = new ArrayList<>();
+    expectedCommandLine.add("bazel-run.sh");
+    expectedCommandLine.add("--define");
+    expectedCommandLine.add("flutter_build_mode=debug");
+    expectedCommandLine.add("bazel_target");
+    expectedCommandLine.add("--");
+    expectedCommandLine.add("--machine");
+    expectedCommandLine.add("additional_args");
+    expectedCommandLine.add("-d");
+    expectedCommandLine.add("android-tester");
+    assertThat(launchCommand.getCommandLineList(null), equalTo(expectedCommandLine));
+  }
+
+  @Test
+  public void producesCorrectCommandLineWithIosDevice() {
+    final BazelFields fields = new FakeBazelTestFields();
+    fields.setEntryFile("/tmp/foo/lib/main.dart");
+    fields.setLaunchingScript("bazel-run.sh");
+    fields.setBazelTarget("bazel_target");
+    fields.setEnableReleaseMode(false);
+    fields.setAdditionalArgs("additional_args");
+
+    final FlutterDevice device = new FlutterDevice("ios-tester", "ios device", "ios", false);
+    GeneralCommandLine launchCommand = null;
+    try {
+      launchCommand = fields.getLaunchCommand(flutterFixture.getModule().getProject(), device, RunMode.RUN);
+    } catch (ExecutionException e) {
+      e.printStackTrace();
+    }
+    final List<String> expectedCommandLine = new ArrayList<>();
+    expectedCommandLine.add("bazel-run.sh");
+    expectedCommandLine.add("--define");
+    expectedCommandLine.add("flutter_build_mode=debug");
+    expectedCommandLine.add("--ios_multi_cpus=arm64");
+    expectedCommandLine.add("bazel_target");
+    expectedCommandLine.add("--");
+    expectedCommandLine.add("--machine");
+    expectedCommandLine.add("additional_args");
+    expectedCommandLine.add("-d");
+    expectedCommandLine.add("ios-tester");
+    assertThat(launchCommand.getCommandLineList(null), equalTo(expectedCommandLine));
+  }
+
+  @Test
+  public void producesCorrectCommandLineWithIosSimulator() {
+    final BazelFields fields = new FakeBazelTestFields();
+    fields.setEntryFile("/tmp/foo/lib/main.dart");
+    fields.setLaunchingScript("bazel-run.sh");
+    fields.setBazelTarget("bazel_target");
+    fields.setEnableReleaseMode(false);
+    fields.setAdditionalArgs("additional_args");
+
+    final FlutterDevice device = new FlutterDevice("ios-tester", "ios device", "ios", true);
+    GeneralCommandLine launchCommand = null;
+    try {
+      launchCommand = fields.getLaunchCommand(flutterFixture.getModule().getProject(), device, RunMode.RUN);
+    } catch (ExecutionException e) {
+      e.printStackTrace();
+    }
+    final List<String> expectedCommandLine = new ArrayList<>();
+    expectedCommandLine.add("bazel-run.sh");
+    expectedCommandLine.add("--define");
+    expectedCommandLine.add("flutter_build_mode=debug");
+    expectedCommandLine.add("--ios_multi_cpus=x86_64");
+    expectedCommandLine.add("bazel_target");
+    expectedCommandLine.add("--");
+    expectedCommandLine.add("--machine");
+    expectedCommandLine.add("additional_args");
+    expectedCommandLine.add("-d");
+    expectedCommandLine.add("ios-tester");
     assertThat(launchCommand.getCommandLineList(null), equalTo(expectedCommandLine));
   }
 

--- a/testSrc/unit/io/flutter/run/bazel/LaunchCommandsTest.java
+++ b/testSrc/unit/io/flutter/run/bazel/LaunchCommandsTest.java
@@ -51,20 +51,10 @@ public class LaunchCommandsTest {
 
     // When release mode is enabled, using different RunModes has no effect.
 
-    launchCommand = null;
-    try {
-      launchCommand = fields.getLaunchCommand(projectFixture.getProject(), device, RunMode.DEBUG);
-    } catch (ExecutionException e) {
-      e.printStackTrace();
-    }
+    launchCommand = getLaunchCommand(fields, device, projectFixture, RunMode.DEBUG);
     assertThat(launchCommand.getCommandLineString(), equalTo(String.join(" ", expectedCommandLine)));
 
-    launchCommand = null;
-    try {
-      launchCommand = fields.getLaunchCommand(projectFixture.getProject(), device, RunMode.PROFILE);
-    } catch (ExecutionException e) {
-      e.printStackTrace();
-    }
+    launchCommand = getLaunchCommand(fields, device, projectFixture, RunMode.PROFILE);
     assertThat(launchCommand.getCommandLineList(null), equalTo(expectedCommandLine));
   }
 
@@ -281,7 +271,7 @@ public class LaunchCommandsTest {
         return null;
       @NotNull
       final String entryFile = getEntryFile();
-      
+
       // With the default entryFile from setupBazelFields, the application directory is the container of lib/main.dart.
       return fs.refreshAndFindFileByPath(entryFile.replace("lib/main.dart", ""));
     }


### PR DESCRIPTION
Uses lower-case `release`, `profile`, and `debug` modes to correspond to the bazel configurations defined by g3.

Adds tests to verify that we produce the correct command line and prevent regressions.