### PR TITLE
Added ability to turn off Memory Profiling, by default its enabled.

### DIFF
--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.form
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.form
@@ -3,7 +3,7 @@
   <grid id="27dc6" binding="mainPanel" layout-manager="GridLayoutManager" row-count="6" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="802" height="719"/>
+      <xy x="20" y="20" width="802" height="767"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -108,7 +108,7 @@
           </component>
         </children>
       </grid>
-      <grid id="23e52" layout-manager="GridLayoutManager" row-count="4" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="23e52" layout-manager="GridLayoutManager" row-count="5" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -147,6 +147,15 @@
             <properties>
               <text resource-bundle="io/flutter/FlutterBundle" key="settings.enable.android.gradle.sync"/>
               <toolTipText value="Provides advanced editing capabilities for Java and Kotlin code. Uses Gradle to find Android libraries then links them into the Flutter project."/>
+            </properties>
+          </component>
+         <component id="5fae0" class="javax.swing.JCheckBox" binding="myEnableMemoryProfilerCheckBox" default-binding="true">
+            <constraints>
+              <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Enable Memory Profiler"/>
+              <toolTipText value="Enable Profiling tab, displays memory statistics, located inside of the Flutter Performance tool window."/>
             </properties>
           </component>
         </children>

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.form
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.form
@@ -51,7 +51,7 @@
           </component>
         </children>
       </grid>
-      <grid id="e885c" layout-manager="GridLayoutManager" row-count="5" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="e885c" layout-manager="GridLayoutManager" row-count="6" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -88,6 +88,15 @@
               <toolTipText value="Enables verbose logging (this can be useful for diagnostic purposes)."/>
             </properties>
           </component>
+          <component id="5fae0" class="javax.swing.JCheckBox" binding="myDisableMemoryProfilerCheckBox" default-binding="true">
+            <constraints>
+              <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Disable Memory Profiler"/>
+              <toolTipText value="Disable the Profiling tab, displays memory statistics, located inside of the Flutter Performance tool window."/>
+            </properties>
+          </component>
           <component id="a0dd8" class="javax.swing.JCheckBox" binding="myFormatCodeOnSaveCheckBox" default-binding="true">
             <constraints>
               <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
@@ -108,7 +117,7 @@
           </component>
         </children>
       </grid>
-      <grid id="23e52" layout-manager="GridLayoutManager" row-count="5" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="23e52" layout-manager="GridLayoutManager" row-count="4" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -147,15 +156,6 @@
             <properties>
               <text resource-bundle="io/flutter/FlutterBundle" key="settings.enable.android.gradle.sync"/>
               <toolTipText value="Provides advanced editing capabilities for Java and Kotlin code. Uses Gradle to find Android libraries then links them into the Flutter project."/>
-            </properties>
-          </component>
-         <component id="5fae0" class="javax.swing.JCheckBox" binding="myEnableMemoryProfilerCheckBox" default-binding="true">
-            <constraints>
-              <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <text value="Enable Memory Profiler"/>
-              <toolTipText value="Enable Profiling tab, displays memory statistics, located inside of the Flutter Performance tool window."/>
             </properties>
           </component>
         </children>

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.java
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.java
@@ -183,6 +183,10 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
       return true;
     }
 
+    if (settings.isMemoryProfilerEnabled() != myEnableMemoryProfilerCheckBox.isSelected()) {
+      return true;
+    }
+
     return false;
   }
 
@@ -214,6 +218,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     settings.setDisableTrackWidgetCreation(myDisableTrackWidgetCreationCheckBox.isSelected());
     settings.setVerboseLogging(myEnableVerboseLoggingCheckBox.isSelected());
     settings.setSyncingAndroidLibraries(mySyncAndroidLibrariesCheckBox.isSelected());
+    settings.setMemoryProfilerEnabled(myEnableMemoryProfilerCheckBox.isSelected());
 
     reset(); // because we rely on remembering initial state
   }
@@ -243,6 +248,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     myDisableTrackWidgetCreationCheckBox.setSelected(settings.isDisableTrackWidgetCreation());
     myEnableVerboseLoggingCheckBox.setSelected(settings.isVerboseLogging());
     mySyncAndroidLibrariesCheckBox.setSelected(settings.isSyncingAndroidLibraries());
+    myEnableMemoryProfilerCheckBox.setSelected(settings.isMemoryProfilerEnabled());
 
     myOrganizeImportsOnSaveCheckBox.setEnabled(myFormatCodeOnSaveCheckBox.isSelected());
   }

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.java
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.java
@@ -61,7 +61,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
   private JCheckBox myDisableTrackWidgetCreationCheckBox;
   private JCheckBox myUseLogViewCheckBox;
   private JCheckBox mySyncAndroidLibrariesCheckBox;
-  private JCheckBox myEnableMemoryProfilerCheckBox;
+  private JCheckBox myDisableMemoryProfilerCheckBox;
   private final @NotNull Project myProject;
 
   FlutterSettingsConfigurable(@NotNull Project project) {
@@ -183,7 +183,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
       return true;
     }
 
-    if (settings.isMemoryProfilerEnabled() != myEnableMemoryProfilerCheckBox.isSelected()) {
+    if (settings.isMemoryProfilerDisabled() != myDisableMemoryProfilerCheckBox.isSelected()) {
       return true;
     }
 
@@ -218,7 +218,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     settings.setDisableTrackWidgetCreation(myDisableTrackWidgetCreationCheckBox.isSelected());
     settings.setVerboseLogging(myEnableVerboseLoggingCheckBox.isSelected());
     settings.setSyncingAndroidLibraries(mySyncAndroidLibrariesCheckBox.isSelected());
-    settings.setMemoryProfilerEnabled(myEnableMemoryProfilerCheckBox.isSelected());
+    settings.setMemoryProfilerDisabled(myDisableMemoryProfilerCheckBox.isSelected());
 
     reset(); // because we rely on remembering initial state
   }
@@ -248,7 +248,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     myDisableTrackWidgetCreationCheckBox.setSelected(settings.isDisableTrackWidgetCreation());
     myEnableVerboseLoggingCheckBox.setSelected(settings.isVerboseLogging());
     mySyncAndroidLibrariesCheckBox.setSelected(settings.isSyncingAndroidLibraries());
-    myEnableMemoryProfilerCheckBox.setSelected(settings.isMemoryProfilerEnabled());
+    myDisableMemoryProfilerCheckBox.setSelected(settings.isMemoryProfilerDisabled());
 
     myOrganizeImportsOnSaveCheckBox.setEnabled(myFormatCodeOnSaveCheckBox.isSelected());
   }

--- a/src/io/flutter/settings/FlutterSettings.java
+++ b/src/io/flutter/settings/FlutterSettings.java
@@ -30,6 +30,7 @@ public class FlutterSettings {
   private static final String legacyTrackWidgetCreationKey = "io.flutter.trackWidgetCreation";
   private static final String disableTrackWidgetCreationKey = "io.flutter.disableTrackWidgetCreation";
   private static final String useFlutterLogView = "io.flutter.useLogView";
+  private static final String memoryProfilerKey = "io.flutter.memoryProfiler";
 
   public static FlutterSettings getInstance() {
     return ServiceManager.getService(FlutterSettings.class);
@@ -224,6 +225,16 @@ public class FlutterSettings {
 
   public void setVerboseLogging(boolean value) {
     getPropertiesComponent().setValue(verboseLoggingKey, value, false);
+
+    fireEvent();
+  }
+
+  public boolean isMemoryProfilerEnabled() {
+    return getPropertiesComponent().getBoolean(memoryProfilerKey, true);
+  }
+
+  public void setMemoryProfilerEnabled(boolean value) {
+    getPropertiesComponent().setValue(memoryProfilerKey, value, true);
 
     fireEvent();
   }

--- a/src/io/flutter/settings/FlutterSettings.java
+++ b/src/io/flutter/settings/FlutterSettings.java
@@ -229,12 +229,12 @@ public class FlutterSettings {
     fireEvent();
   }
 
-  public boolean isMemoryProfilerEnabled() {
-    return getPropertiesComponent().getBoolean(memoryProfilerKey, true);
+  public boolean isMemoryProfilerDisabled() {
+    return getPropertiesComponent().getBoolean(memoryProfilerKey, false);
   }
 
-  public void setMemoryProfilerEnabled(boolean value) {
-    getPropertiesComponent().setValue(memoryProfilerKey, value, true);
+  public void setMemoryProfilerDisabled(boolean value) {
+    getPropertiesComponent().setValue(memoryProfilerKey, value, false);
 
     fireEvent();
   }

--- a/src/io/flutter/view/FlutterPerfView.java
+++ b/src/io/flutter/view/FlutterPerfView.java
@@ -173,7 +173,7 @@ public class FlutterPerfView implements Disposable {
 
       addPerformanceTab(runnerTabs, app, toolWindow, true);
 
-      if (FlutterUtils.isAndroidStudio() && FlutterSettings.getInstance().isMemoryProfilerEnabled()) {
+      if (FlutterUtils.isAndroidStudio() && !FlutterSettings.getInstance().isMemoryProfilerDisabled()) {
         addMemoryTab(runnerTabs, app, false, state);
       }
 

--- a/src/io/flutter/view/FlutterPerfView.java
+++ b/src/io/flutter/view/FlutterPerfView.java
@@ -33,6 +33,7 @@ import io.flutter.FlutterInitializer;
 import io.flutter.FlutterUtils;
 import io.flutter.run.daemon.FlutterApp;
 import io.flutter.run.daemon.FlutterDevice;
+import io.flutter.settings.FlutterSettings;
 import io.flutter.utils.VmServiceListenerAdapter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -172,7 +173,7 @@ public class FlutterPerfView implements Disposable {
 
       addPerformanceTab(runnerTabs, app, toolWindow, true);
 
-      if (FlutterUtils.isAndroidStudio()) {
+      if (FlutterUtils.isAndroidStudio() && FlutterSettings.getInstance().isMemoryProfilerEnabled()) {
         addMemoryTab(runnerTabs, app, false, state);
       }
 


### PR DESCRIPTION
Added checkbox "Disable Memory Profiler" to the Flutter Settings General group box.  By default memory profiling is enabled.  If this checkbox is enabled then memory profiling will not startup (in case there's any problems).