### PR TITLE
Add Android libraries to Flutter project

### DIFF
--- a/flutter-studio/flutter-studio.iml
+++ b/flutter-studio/flutter-studio.iml
@@ -25,6 +25,7 @@
     <orderEntry type="module" module-name="intellij.platform.lang.impl" />
     <orderEntry type="module" module-name="intellij.platform.debugger" />
     <orderEntry type="module" module-name="intellij.java.ui" />
+    <orderEntry type="module" module-name="intellij.java.impl" />
     <orderEntry type="module" module-name="intellij.gradle" />
     <orderEntry type="module" module-name="android.sdktools.flags" />
     <orderEntry type="module" module-name="intellij.android.guiTests" scope="TEST" />

--- a/flutter-studio/flutter-studio.iml
+++ b/flutter-studio/flutter-studio.iml
@@ -47,6 +47,6 @@
     <orderEntry type="module" module-name="intellij.javascript.protocolModelGenerator" />
     <orderEntry type="module" module-name="intellij.android.artwork" />
     <orderEntry type="module" module-name="android.sdktools.common" />
-
+    <orderEntry type="module" module-name="intellij.java" />
   </component>
 </module>


### PR DESCRIPTION
Enables code completion for Java and Kotlin. This is ready for review now.

- Gradle sync on start-up and whenever project roots are modified
- After sync, get Android libraries and add to Flutter project
- Add library dep to Android module for each library
- Add dep from Android module to Flutter module so the libraries can be found

Still has a couple TODOs, which I'll work on next. Some are noted in the code. Also:
- Make the Gradle sync run in the background
- See if other Android-like facets should be included (AndroidModuleLibraryManager line 153)

@devoncarew I had to refactor some of the library management code you added a while back.