### PR TITLE
trim unoptimized text from stack frame names

### DIFF
--- a/src/io/flutter/run/FlutterReloadManager.java
+++ b/src/io/flutter/run/FlutterReloadManager.java
@@ -38,7 +38,6 @@ import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.psi.search.ProjectAndLibrariesScope;
 import com.intellij.ui.LightweightHint;
 import com.intellij.util.ui.UIUtil;
-import com.jetbrains.lang.dart.DartPluginCapabilities;
 import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService;
 import com.jetbrains.lang.dart.analyzer.DartServerData;
 import com.jetbrains.lang.dart.ide.errorTreeView.DartProblemsView;
@@ -207,7 +206,7 @@ public class FlutterReloadManager {
       final Notification notification = showRunNotification(app, null, "Reloading…", false);
       final long startTime = System.currentTimeMillis();
 
-      app.performHotReload(supportsPauseAfterReload(), FlutterConstants.RELOAD_REASON_SAVE).thenAccept(result -> {
+      app.performHotReload(true, FlutterConstants.RELOAD_REASON_SAVE).thenAccept(result -> {
         if (!result.ok()) {
           notification.expire();
           showRunNotification(app, "Hot Reload Error", result.getMessage(), true);
@@ -237,7 +236,7 @@ public class FlutterReloadManager {
     if (app.isStarted()) {
       FileDocumentManager.getInstance().saveAllDocuments();
 
-      app.performHotReload(supportsPauseAfterReload(), reason).thenAccept(result -> {
+      app.performHotReload(true, reason).thenAccept(result -> {
         if (!result.ok()) {
           showRunNotification(app, "Hot Reload", result.getMessage(), true);
         }
@@ -340,10 +339,6 @@ public class FlutterReloadManager {
   private FlutterApp getApp() {
     final AnAction action = ProjectActions.getAction(myProject, ReloadFlutterApp.ID);
     return action instanceof FlutterAppAction ? ((FlutterAppAction)action).getApp() : null;
-  }
-
-  private boolean supportsPauseAfterReload() {
-    return DartPluginCapabilities.isSupported("supports.pausePostRequest");
   }
 
   private boolean hasErrors(@NotNull Project project, @Nullable Module module, @NotNull Document document) {

--- a/src/io/flutter/server/vmService/frame/DartVmServiceStackFrame.java
+++ b/src/io/flutter/server/vmService/frame/DartVmServiceStackFrame.java
@@ -75,7 +75,11 @@ public class DartVmServiceStackFrame extends XStackFrame {
 
   @Override
   public void customizePresentation(@NotNull final ColoredTextContainer component) {
-    final String name = StringUtil.trimEnd(myVmFrame.getCode().getName(), "="); // trim setter postfix
+    final String unoptimizedPrefix = "[Unoptimized] ";
+
+    String name = StringUtil.trimEnd(myVmFrame.getCode().getName(), "="); // trim setter postfix
+    name = StringUtil.trimStart(name, unoptimizedPrefix);
+
     final boolean causal = myVmFrame.getKind() == FrameKind.AsyncCausal;
     component.append(name, causal ? SimpleTextAttributes.REGULAR_ITALIC_ATTRIBUTES : SimpleTextAttributes.REGULAR_ATTRIBUTES);
 
@@ -84,7 +88,7 @@ public class DartVmServiceStackFrame extends XStackFrame {
       component.append(text, SimpleTextAttributes.GRAY_ATTRIBUTES);
     }
 
-    component.setIcon(AllIcons.Debugger.StackFrame);
+    component.setIcon(AllIcons.Debugger.Frame);
   }
 
   @NotNull


### PR DESCRIPTION
- trim prefix text on dart stack frames (`[Unoptimized] `)
- move to using a non-deprecated icon; I'll need to see whether this compiles on our oldest IDEs before committing this PR
- unrelated, but remove the check for `supports.pausePostRequest` - this has been in VMs for a very long time now

@stevemessick for review