### PR TITLE
Refactor the Bazel Test configuration to support running tests on a single file or a single test

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -686,7 +686,9 @@
     <programRunner implementation="io.flutter.run.bazel.BazelRunner"/>
 
     <configurationType implementation="io.flutter.run.bazelTest.FlutterBazelTestConfigurationType"/>
+    <runConfigurationProducer implementation="io.flutter.run.bazelTest.BazelTestConfigProducer"/>
     <programRunner implementation="io.flutter.run.bazelTest.BazelTestRunner"/>
+    <runLineMarkerContributor language="Dart" implementationClass="io.flutter.run.bazelTest.FlutterBazelTestLineMarkerContributor"/>
 
     <configurationType implementation="io.flutter.run.test.TestConfigType"/>
     <runConfigurationProducer implementation="io.flutter.run.test.TestConfigProducer"/>

--- a/resources/META-INF/plugin_template.xml
+++ b/resources/META-INF/plugin_template.xml
@@ -200,6 +200,7 @@
     <runConfigurationProducer implementation="io.flutter.run.test.TestConfigProducer"/>
     <programRunner implementation="io.flutter.run.test.DebugTestRunner"/>
     <runLineMarkerContributor language="Dart" implementationClass="io.flutter.run.test.FlutterTestLineMarkerContributor"/>
+    <runLineMarkerContributor language="Dart" implementationClass="io.flutter.run.bazelTest.FlutterBazelTestLineMarkerContributor"/>
 
     <defaultLiveTemplatesProvider implementation="io.flutter.template.FlutterLiveTemplatesProvider"/>
     <liveTemplateContext implementation="io.flutter.template.DartToplevelTemplateContextType"/>

--- a/src/io/flutter/bazel/PluginConfig.java
+++ b/src/io/flutter/bazel/PluginConfig.java
@@ -46,6 +46,11 @@ class PluginConfig {
     return fields.launchScript;
   }
 
+  @Nullable
+  String getTestScript() {
+    return fields.testScript;
+  }
+
   @Override
   public boolean equals(Object obj) {
     if (!(obj instanceof PluginConfig)) return false;
@@ -108,10 +113,16 @@ class PluginConfig {
     private String doctorScript;
 
     /**
-     *
+     * The script to run to start 'bazel'
      */
     @SerializedName("launchScript")
     private String launchScript;
+
+    /**
+     * The script to run to start 'flutter test'
+     */
+    @SerializedName("testScript")
+    private String testScript;
 
     Fields() {
     }
@@ -122,7 +133,8 @@ class PluginConfig {
       final Fields other = (Fields)obj;
       return Objects.equal(daemonScript, other.daemonScript)
              && Objects.equal(doctorScript, other.doctorScript)
-             && Objects.equal(launchScript, other.launchScript);
+             && Objects.equal(launchScript, other.launchScript)
+             && Objects.equal(testScript, other.testScript);
     }
 
     @Override

--- a/src/io/flutter/bazel/Workspace.java
+++ b/src/io/flutter/bazel/Workspace.java
@@ -35,15 +35,18 @@ public class Workspace {
   @Nullable private final PluginConfig config;
   @Nullable private final String daemonScript;
   @Nullable private final String doctorScript;
+  @Nullable private final String testScript;
 
   private Workspace(@NotNull VirtualFile root,
                     @Nullable PluginConfig config,
                     @Nullable String daemonScript,
-                    @Nullable String doctorScript) {
+                    @Nullable String doctorScript,
+                    @Nullable String testScript) {
     this.root = root;
     this.config = config;
     this.daemonScript = daemonScript;
     this.doctorScript = doctorScript;
+    this.testScript = testScript;
   }
 
   /**
@@ -120,6 +123,14 @@ public class Workspace {
   }
 
   /**
+   * Returns the script that starts 'flutter test', or null if not configured.
+   */
+  @Nullable
+  public String getTestScript() {
+    return testScript;
+  }
+
+  /**
    * Returns true if the plugin config was loaded.
    */
   public boolean hasPluginConfig() {
@@ -171,44 +182,36 @@ public class Workspace {
     }
     final PluginConfig config = configFile == null ? null : PluginConfig.load(configFile);
 
-    final String daemonScript;
-    if (config == null || config.getDaemonScript() == null) {
-      daemonScript = null;
-    }
-    else {
-      final String script = config.getDaemonScript();
-      final String readonlyScript = readonlyPath + "/" + script;
-      if (root.findFileByRelativePath(script) != null) {
-        daemonScript = script;
-      }
-      else if (root.findFileByRelativePath(readonlyScript) != null) {
-        daemonScript = readonlyScript;
-      }
-      else {
-        daemonScript = null;
-      }
-    }
+    final String daemonScript = config == null ? null : getScriptFromPath(root, readonlyPath, config.getDaemonScript());
 
-    final String doctorScript;
-    if (config == null || config.getDoctorScript() == null) {
-      doctorScript = null;
-    }
-    else {
-      final String script = config.getDoctorScript();
-      final String readonlyScript = readonlyPath + "/" + script;
-      if (root.findFileByRelativePath(script) != null) {
-        doctorScript = script;
-      }
-      else if (root.findFileByRelativePath(readonlyScript) != null) {
-        doctorScript = readonlyScript;
-      }
-      else {
-        doctorScript = null;
-      }
-    }
+    final String doctorScript = config == null ? null : getScriptFromPath(root, readonlyPath, config.getDoctorScript());
 
-    return new Workspace(root, config, daemonScript, doctorScript);
+    final String testScript = config == null ? null : getScriptFromPath(root, readonlyPath, config.getTestScript());
+
+    return new Workspace(root, config, daemonScript, doctorScript, testScript);
   }
+
+  /**
+   * Attempts to find a script inside of the workspace.
+   * @param root the workspace root.
+   * @param readonlyPath the relative path to the readonly contents of the workspace.
+   * @param relativeScriptPath the relative path to the desired script inside of the workspace.
+   * @return the script's path relative to the workspace, or null if it was not found.
+   */
+  private static String getScriptFromPath(VirtualFile root, String readonlyPath, @Nullable String relativeScriptPath) {
+    if (relativeScriptPath == null) {
+      return null;
+    }
+    final String readonlyScriptPath = readonlyPath + "/" + relativeScriptPath;
+    if (root.findFileByRelativePath(relativeScriptPath) != null) {
+      return relativeScriptPath;
+    }
+    if (root.findFileByRelativePath(readonlyScriptPath) != null) {
+      return readonlyScriptPath;
+    }
+    return null;
+  }
+
 
   /**
    * Returns the Bazel WORKSPACE file for a Project, or null if not using Bazel.

--- a/src/io/flutter/run/bazelTest/BazelTestConfig.java
+++ b/src/io/flutter/run/bazelTest/BazelTestConfig.java
@@ -15,6 +15,7 @@ import com.intellij.openapi.util.InvalidDataException;
 import com.intellij.openapi.util.WriteExternalException;
 import com.intellij.util.xmlb.SkipDefaultValuesSerializationFilters;
 import com.intellij.util.xmlb.XmlSerializer;
+import io.flutter.bazel.Workspace;
 import org.jdom.Element;
 import org.jetbrains.annotations.NotNull;
 
@@ -22,10 +23,12 @@ import org.jetbrains.annotations.NotNull;
  * The Bazel version of the {@link io.flutter.run.test.TestConfig}.
  */
 public class BazelTestConfig extends LocatableConfigurationBase {
-  @NotNull private BazelTestFields fields = new BazelTestFields();
+  @NotNull private BazelTestFields fields;
 
   BazelTestConfig(@NotNull final Project project, @NotNull final ConfigurationFactory factory, @NotNull final String name) {
     super(project, factory, name);
+    final Workspace workspace = Workspace.load(project);
+    fields = new BazelTestFields(null, null, workspace.getLaunchScript(), null);
   }
 
   @NotNull
@@ -72,12 +75,12 @@ public class BazelTestConfig extends LocatableConfigurationBase {
   @Override
   public void writeExternal(@NotNull final Element element) throws WriteExternalException {
     super.writeExternal(element);
-    XmlSerializer.serializeInto(fields, element, new SkipDefaultValuesSerializationFilters());
+    fields.writeTo(element);
   }
 
   @Override
   public void readExternal(@NotNull final Element element) throws InvalidDataException {
     super.readExternal(element);
-    XmlSerializer.deserializeInto(fields, element);
+    fields = BazelTestFields.readFrom(element);
   }
 }

--- a/src/io/flutter/run/bazelTest/BazelTestConfig.java
+++ b/src/io/flutter/run/bazelTest/BazelTestConfig.java
@@ -28,7 +28,7 @@ public class BazelTestConfig extends LocatableConfigurationBase {
   BazelTestConfig(@NotNull final Project project, @NotNull final ConfigurationFactory factory, @NotNull final String name) {
     super(project, factory, name);
     final Workspace workspace = Workspace.load(project);
-    fields = new BazelTestFields(null, null, workspace.getLaunchScript(), null);
+    fields = new BazelTestFields(null, null, null);
   }
 
   @NotNull

--- a/src/io/flutter/run/bazelTest/BazelTestConfigProducer.java
+++ b/src/io/flutter/run/bazelTest/BazelTestConfigProducer.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2018 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.run.bazelTest;
+
+import com.intellij.execution.actions.ConfigurationContext;
+import com.intellij.execution.actions.ConfigurationFromContext;
+import com.intellij.execution.actions.RunConfigurationProducer;
+import com.intellij.openapi.util.Ref;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiDirectory;
+import com.intellij.psi.PsiElement;
+import com.jetbrains.lang.dart.psi.DartFile;
+import io.flutter.FlutterUtils;
+import io.flutter.dart.DartPlugin;
+import io.flutter.pub.PubRoot;
+import io.flutter.run.FlutterRunConfigurationProducer;
+import io.flutter.run.test.TestConfig;
+import io.flutter.run.test.TestConfigType;
+import io.flutter.run.test.TestConfigUtils;
+import io.flutter.run.test.TestFields;
+import io.flutter.sdk.FlutterSdk;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Determines when we can run a test using "flutter test".
+ */
+public class BazelTestConfigProducer extends RunConfigurationProducer<TestConfig> {
+
+  protected BazelTestConfigProducer() {
+    super(TestConfigType.getInstance());
+  }
+
+  private static boolean isFlutterContext(@NotNull ConfigurationContext context) {
+    final PsiElement location = context.getPsiLocation();
+    return location != null && FlutterUtils.isInFlutterProject(location);
+  }
+
+  /**
+   * If the current file looks like a Flutter test, initializes the run config to run it.
+   * <p>
+   * Returns true if successfully set up.
+   */
+  @Override
+  protected boolean setupConfigurationFromContext(TestConfig config, ConfigurationContext context, Ref<PsiElement> sourceElement) {
+    if (!isFlutterContext(context)) return false;
+
+    final PsiElement elt = context.getPsiLocation();
+    if (elt instanceof PsiDirectory) {
+      return setupForDirectory(config, (PsiDirectory)elt);
+    }
+
+    final DartFile file = FlutterRunConfigurationProducer.getDartFile(context);
+    if (file == null) {
+      return false;
+    }
+
+    if (supportsFiltering(config.getSdk())) {
+      final String testName = TestConfigUtils.findTestName(elt);
+      if (testName != null) {
+        return setupForSingleTest(config, context, file, testName);
+      }
+    }
+
+    return setupForDartFile(config, context, file);
+  }
+
+  private boolean supportsFiltering(@Nullable FlutterSdk sdk) {
+    return sdk != null && sdk.getVersion().flutterTestSupportsFiltering();
+  }
+
+  private boolean setupForSingleTest(TestConfig config, ConfigurationContext context, DartFile file, String testName) {
+    final VirtualFile testFile = verifyFlutterTestFile(config, context, file);
+    if (testFile == null) return false;
+
+    config.setFields(TestFields.forTestName(testName, testFile.getPath()));
+    config.setGeneratedName();
+
+    return true;
+  }
+
+  private boolean setupForDartFile(TestConfig config, ConfigurationContext context, DartFile file) {
+    final VirtualFile testFile = verifyFlutterTestFile(config, context, file);
+    if (testFile == null) return false;
+
+    config.setFields(TestFields.forFile(testFile.getPath()));
+    config.setGeneratedName();
+
+    return true;
+  }
+
+  private VirtualFile verifyFlutterTestFile(TestConfig config, ConfigurationContext context, DartFile file) {
+    final VirtualFile candidate = FlutterRunConfigurationProducer.getFlutterEntryFile(context, false, false);
+    if (candidate == null) return null;
+
+    return FlutterUtils.isInTestDir(file) ?  candidate : null;
+  }
+
+  private boolean setupForDirectory(TestConfig config, PsiDirectory dir) {
+    final PubRoot root = PubRoot.forDescendant(dir.getVirtualFile(), dir.getProject());
+    if (root == null) return false;
+
+    if (!root.hasTests(dir.getVirtualFile())) return false;
+
+    config.setFields(TestFields.forDir(dir.getVirtualFile().getPath()));
+    config.setGeneratedName();
+    return true;
+  }
+
+  /**
+   * Returns true if a run config was already created for this file. If so we will reuse it.
+   */
+  @Override
+  public boolean isConfigurationFromContext(TestConfig config, ConfigurationContext context) {
+    final VirtualFile fileOrDir = config.getFields().getFileOrDir();
+    if (fileOrDir == null) return false;
+
+    final PsiElement target = context.getPsiLocation();
+    if (target instanceof PsiDirectory) {
+      return ((PsiDirectory)target).getVirtualFile().equals(fileOrDir);
+    }
+
+    if (!FlutterRunConfigurationProducer.hasDartFile(context, fileOrDir.getPath())) return false;
+
+    final String testName = TestConfigUtils.findTestName(context.getPsiLocation());
+    if (config.getFields().getScope() == TestFields.Scope.NAME) {
+      return testName != null && testName.equals(config.getFields().getTestName());
+    }
+    else {
+      return testName == null;
+    }
+  }
+
+  @Override
+  public boolean shouldReplace(@NotNull ConfigurationFromContext self, @NotNull ConfigurationFromContext other) {
+    return DartPlugin.isDartTestConfiguration(other.getConfigurationType());
+  }
+}

--- a/src/io/flutter/run/bazelTest/BazelTestConfigUtils.java
+++ b/src/io/flutter/run/bazelTest/BazelTestConfigUtils.java
@@ -24,7 +24,7 @@ import javax.swing.*;
 import java.util.Arrays;
 import java.util.List;
 
-public class TestConfigUtils {
+public class BazelTestConfigUtils {
 
   /**
    * Widget test function as defined in package:flutter_test/src/widget_tester.dart.

--- a/src/io/flutter/run/bazelTest/BazelTestConfigUtils.java
+++ b/src/io/flutter/run/bazelTest/BazelTestConfigUtils.java
@@ -31,10 +31,14 @@ public class BazelTestConfigUtils {
    */
   public static final String WIDGET_TEST_FUNCTION = "testWidgets";
 
+  public static boolean isFlutterTest(DartFile file) {
+    return true;
+  }
+
   @Nullable
   public static TestType asTestCall(@NotNull PsiElement element) {
     final DartFile file = FlutterUtils.getDartFile(element);
-    if (FlutterUtils.isInTestDir(file)/* && FlutterUtils.isInFlutterProject(element)*/) {
+    if (isFlutterTest(file)/* && FlutterUtils.isInFlutterProject(element)*/) {
       // Named tests.
       final TestType namedTestCall = findNamedTestCall(element);
       if (namedTestCall != null) return namedTestCall;

--- a/src/io/flutter/run/bazelTest/BazelTestFields.java
+++ b/src/io/flutter/run/bazelTest/BazelTestFields.java
@@ -11,63 +11,111 @@ import com.intellij.execution.configurations.RuntimeConfigurationError;
 import com.intellij.execution.process.OSProcessHandler;
 import com.intellij.execution.process.ProcessHandler;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.InvalidDataException;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.CharsetToolkit;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.sun.corba.se.spi.orbutil.threadpool.Work;
 import io.flutter.bazel.Workspace;
 import io.flutter.bazel.WorkspaceCache;
 import io.flutter.run.MainFile;
 import io.flutter.run.bazel.BazelFields;
 import io.flutter.run.daemon.RunMode;
+import io.flutter.run.test.TestFields;
+import io.flutter.utils.ElementIO;
+import org.jdom.Element;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * The fields in a Bazel test run configuration, see {@link io.flutter.run.test.TestFields}.
  */
 public class BazelTestFields {
 
-  @Nullable private String entryFile;
-  @Nullable private String launchScript;
-  @Nullable private String bazelTarget;
+  @Nullable private final String testName;
+  @Nullable private final String entryFile;
+  @Nullable private final String launchScript;
+  @Nullable private final String bazelTarget;
 
-  BazelTestFields() {
+  BazelTestFields(@Nullable String testName, @Nullable String entryFile, @Nullable String launchScript, @Nullable String bazelTarget) {
+    if (launchScript == null) {
+      throw new IllegalArgumentException("launchScript must be non-null");
+    }
+    else if (testName != null && entryFile == null) {
+      throw new IllegalArgumentException("testName must be specified with an entryFile");
+    }
+    this.testName = testName;
+    this.entryFile = entryFile;
+    this.launchScript = launchScript;
+    this.bazelTarget = bazelTarget;
   }
 
   /**
    * Copy constructor
    */
-  private BazelTestFields(@NotNull final BazelTestFields original) {
-    entryFile = original.entryFile;
-    launchScript = original.launchScript;
-    bazelTarget = original.bazelTarget;
+  BazelTestFields(@NotNull BazelTestFields template) {
+    this(template.testName, template.entryFile, template.launchScript, template.bazelTarget);
   }
 
   /**
    * Create non-template from template.
    */
   private BazelTestFields(@NotNull final BazelTestFields template, @NotNull final Workspace workspace) {
-    this(template);
-    if (StringUtil.isEmptyOrSpaces(launchScript)) {
-      launchScript = workspace.getLaunchScript();
-      if (launchScript != null && !launchScript.startsWith("/")) {
-        launchScript = workspace.getRoot().getPath() + "/" + launchScript;
-      }
+    this(
+      template.testName,
+      template.entryFile,
+      StringUtil.isEmptyOrSpaces(template.launchScript) ? getLaunchScriptFromWorkspace(workspace) : template.launchScript,
+      template.bazelTarget
+    );
+  }
+
+  private static String getLaunchScriptFromWorkspace(@NotNull final Workspace workspace) {
+    String launchScript = workspace.getLaunchScript();
+    if (launchScript != null && !launchScript.startsWith("/")) {
+      launchScript = workspace.getRoot().getPath() + "/" + launchScript;
     }
+    return launchScript;
   }
 
   /**
-   * The file containing the main function that starts the Flutter app.
+   * Creates settings for running tests with the given name within a Dart file.
+   */
+  @NotNull
+  public static BazelTestFields forTestName(@NotNull String testName, @NotNull String path, @NotNull final Workspace workspace) {
+    return new BazelTestFields(testName, path, workspace.getLaunchScript(), null);
+  }
+
+  /**
+   * Creates settings for running all the tests in a Dart file.
+   */
+  public static BazelTestFields forFile(@NotNull String path, @NotNull final Workspace workspace) {
+    return new BazelTestFields(null, path, null, null);
+  }
+
+  /**
+   * Creates settings for running all the tests in a Bazel target
+   */
+  public static BazelTestFields forTarget(@NotNull String target, @NotNull final Workspace workspace) {
+    return new BazelTestFields(null, null, workspace.getLaunchScript(), target);
+  }
+
+
+  @Nullable
+  public String getTestName() {
+    return testName;
+  }
+
+  /**
+   * The file containing the main function that starts the Flutter test.
    */
   @Nullable
   public String getEntryFile() {
     return entryFile;
-  }
-
-  public void setEntryFile(@Nullable final String entryFile) {
-    this.entryFile = entryFile;
   }
 
   /**
@@ -80,41 +128,14 @@ public class BazelTestFields {
     return LocalFileSystem.getInstance().findFileByPath(path);
   }
 
-  /**
-   * Present only for deserializing old run configs.
-   */
-  @SuppressWarnings("SameReturnValue")
-  @Deprecated
-  public String getWorkingDirectory() {
-    return null;
-  }
-
-  /**
-   * Used only for deserializing old run configs.
-   */
-  @Deprecated
-  public void setWorkingDirectory(@Nullable final String workDir) {
-    if (entryFile == null && workDir != null) {
-      entryFile = workDir + "/lib/main.dart";
-    }
-  }
-
   @Nullable
   public String getLaunchingScript() {
     return launchScript;
   }
 
-  public void setLaunchingScript(@Nullable final String launchScript) {
-    this.launchScript = launchScript;
-  }
-
   @Nullable
   public String getBazelTarget() {
     return bazelTarget;
-  }
-
-  public void setBazelTarget(@Nullable final String bazelTarget) {
-    this.bazelTarget = bazelTarget;
   }
 
   @NotNull
@@ -168,18 +189,116 @@ public class BazelTestFields {
     final String launchingScript = getLaunchingScript();
     assert launchingScript != null; // already checked
 
-    final String target = getBazelTarget();
-    assert target != null; // already checked
+    Workspace workspace = Workspace.load(project);
 
-    final GeneralCommandLine commandLine = new GeneralCommandLine().withWorkDirectory(appDir.getPath());
+    final GeneralCommandLine commandLine = new GeneralCommandLine().withWorkDirectory(workspace.getRoot().getPath());
     commandLine.setCharset(CharsetToolkit.UTF8_CHARSET);
-    commandLine.setExePath(FileUtil.toSystemDependentName(launchingScript));
-
-    commandLine.addParameter(target);
+    commandLine.setExePath(FileUtil.toSystemDependentName(workspace.getTestScript()));
+    String relativeEntryFilePath = FileUtil.getRelativePath(workspace.getRoot().getPath(), entryFile, '/');
+    commandLine.addParameter("--no-color");
+    switch (getScope()) {
+      case NAME:
+        commandLine.addParameter("--name=" + testName);
+        commandLine.addParameter(relativeEntryFilePath);
+        break;
+      case FILE:
+        commandLine.addParameter(relativeEntryFilePath);
+        break;
+      case TARGET_PATTERN:
+        commandLine.addParameter(bazelTarget);
+        break;
+    }
 
     if (mode == RunMode.DEBUG) {
       commandLine.addParameters("--", "--enable-debugging");
     }
     return commandLine;
+  }
+
+
+  /**
+   * Determines the type of test invocation we need to run: test-by-name, test-by-file, or test-by-bazel-target.
+   *
+   * <p>
+   * We can assume the following about this BazelTestFields instance based on the Scope returned.
+   *
+   * <p>
+   * <ul>
+   *   <li>Scope.NAME: The testName and entryFile fields are both non-null.  The bazelTarget field may be null.</li>
+   *   <li>Scope.FILE: The entryFile field is non-null.  The bazelTarget field may be null.</li>
+   *   <li>Scope.TARGET_PATTERN: The testName and entryFile fields may both be null.  If the bazelTarget field is non-null, this target is
+   *   runnable.</li>
+   * </ul>
+   *
+   */
+  @NotNull
+  public Scope getScope() {
+    if (testName != null && entryFile != null) {
+      return Scope.NAME;
+    }
+    else if (entryFile != null) {
+      return Scope.FILE;
+    }
+    else {
+      return Scope.TARGET_PATTERN;
+    }
+  }
+
+  public void writeTo(Element element) {
+    ElementIO.addOption(element, "launchingScript", launchScript);
+    ElementIO.addOption(element, "testName", testName);
+    ElementIO.addOption(element, "entryFile", entryFile);
+    ElementIO.addOption(element, "bazelTarget", bazelTarget);
+  }
+
+  public static BazelTestFields readFrom(Element element) {
+    final Map<String, String> options = ElementIO.readOptions(element);
+
+    final String testName = options.get("testName");
+    final String entryFile = options.get("entryFile");
+    final String launchScript = options.get("launchingScript");
+    final String bazelTarget = options.get("bazelTarget");
+
+    try {
+      return new BazelTestFields(testName, entryFile, launchScript, bazelTarget);
+    } catch (IllegalArgumentException e) {
+      throw new InvalidDataException(e.getMessage());
+    }
+  }
+
+  public enum Scope {
+    NAME("Tests in file, filtered by name") {
+      @Override
+      public void checkRunnable(@NotNull BazelTestFields fields, @NotNull Project project) throws RuntimeConfigurationError {
+        FILE.checkRunnable(fields, project);
+      }
+    },
+
+    FILE("All tests in a file") {
+      @Override
+      public void checkRunnable(@NotNull BazelTestFields fields, @NotNull Project project) throws RuntimeConfigurationError {
+        final MainFile.Result main = MainFile.verify(fields.entryFile, project);
+        if (!main.canLaunch()) {
+          throw new RuntimeConfigurationError(main.getError());
+        }
+      }
+    },
+
+    TARGET_PATTERN("All tests in a bazel target or matching a bazel target pattern") {
+      @Override
+      public void checkRunnable(@NotNull BazelTestFields fields, @NotNull Project project) {}
+    };
+
+    private final String displayName;
+
+    Scope(String displayName) {
+      this.displayName = displayName;
+    }
+
+    public String getDisplayName() {
+      return displayName;
+    }
+
+    public abstract void checkRunnable(@NotNull BazelTestFields fields, @NotNull Project project) throws RuntimeConfigurationError;
   }
 }

--- a/src/io/flutter/run/bazelTest/BazelTestFields.java
+++ b/src/io/flutter/run/bazelTest/BazelTestFields.java
@@ -198,7 +198,7 @@ public class BazelTestFields {
     commandLine.addParameter("--no-color");
     switch (getScope()) {
       case NAME:
-        commandLine.addParameter("--name=" + testName);
+        commandLine.addParameters("--name", testName);
         commandLine.addParameter(relativeEntryFilePath);
         break;
       case FILE:
@@ -210,7 +210,7 @@ public class BazelTestFields {
     }
 
     if (mode == RunMode.DEBUG) {
-      commandLine.addParameters("--", "--enable-debugging");
+      commandLine.addParameters("--", "--enable-debugging", "--machine");
     }
     return commandLine;
   }

--- a/src/io/flutter/run/bazelTest/BazelTestRunner.java
+++ b/src/io/flutter/run/bazelTest/BazelTestRunner.java
@@ -127,10 +127,10 @@ public class BazelTestRunner extends GenericProgramRunner {
           stdoutParser.appendOutput(text);
 
           for (String line : stdoutParser.getAvailableLines()) {
-            if (line.startsWith("[{")) {
+            if (line.startsWith("{")) {
               line = line.trim();
 
-              final String json = line.substring(1, line.length() - 1);
+              final String json = line;
               dispatchJson(json);
             }
           }
@@ -202,7 +202,7 @@ public class BazelTestRunner extends GenericProgramRunner {
         return;
       }
 
-      final JsonPrimitive primEvent = obj.getAsJsonPrimitive("event");
+      final JsonPrimitive primEvent = obj.getAsJsonPrimitive("type");
       if (primEvent == null) {
         LOG.error("Missing event field in JSON from Flutter test: " + obj);
         return;

--- a/src/io/flutter/run/bazelTest/FlutterBazelTestConfigurationEditorForm.form
+++ b/src/io/flutter/run/bazelTest/FlutterBazelTestConfigurationEditorForm.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="io.flutter.run.bazelTest.FlutterBazelTestConfigurationEditorForm">
-  <grid id="27dc6" binding="myMainPanel" default-binding="true" layout-manager="GridLayoutManager" row-count="11" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="myMainPanel" default-binding="true" layout-manager="GridLayoutManager" row-count="9" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="720" height="320"/>
@@ -8,27 +8,9 @@
     <properties/>
     <border type="none"/>
     <children>
-      <component id="55077" class="javax.swing.JLabel" binding="myLaunchingScriptLabel">
-        <constraints>
-          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <inheritsPopupMenu value="true"/>
-          <labelFor value="17e7b"/>
-          <text value="Launching &amp;script:"/>
-        </properties>
-      </component>
-      <component id="17e7b" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="myLaunchingScript">
-        <constraints>
-          <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <focusable value="true"/>
-        </properties>
-      </component>
       <component id="7b563" class="javax.swing.JLabel" binding="myBuildTargetLabel">
         <constraints>
-          <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <labelFor value="ada9f"/>
@@ -37,27 +19,18 @@
       </component>
       <component id="ada9f" class="javax.swing.JTextField" binding="myBuildTarget">
         <constraints>
-          <grid row="6" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
       </component>
       <vspacer id="3f5de">
         <constraints>
-          <grid row="10" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="8" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
-      <component id="8e5b7" class="javax.swing.JLabel" binding="myLaunchingScriptHintLabel">
-        <constraints>
-          <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <enabled value="false"/>
-          <text value="The absolute path to a Bazel launching script."/>
-        </properties>
-      </component>
       <component id="eff55" class="javax.swing.JLabel" binding="myBuildTargetHintLabel">
         <constraints>
-          <grid row="7" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="5" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <enabled value="false"/>
@@ -66,7 +39,7 @@
       </component>
       <component id="60b32" class="javax.swing.JLabel" binding="myTestNameLabel">
         <constraints>
-          <grid row="8" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Test Name:"/>
@@ -74,7 +47,7 @@
       </component>
       <component id="e602a" class="javax.swing.JLabel" binding="myTestNameHintLabel">
         <constraints>
-          <grid row="9" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="7" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <enabled value="false"/>
@@ -83,7 +56,7 @@
       </component>
       <component id="6457d" class="javax.swing.JTextField" binding="myTestName">
         <constraints>
-          <grid row="8" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+          <grid row="6" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
             <preferred-size width="150" height="-1"/>
           </grid>
         </constraints>
@@ -91,7 +64,7 @@
       </component>
       <component id="55076" class="javax.swing.JLabel" binding="myEntryFileLabel">
         <constraints>
-          <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <inheritsPopupMenu value="true"/>
@@ -101,7 +74,7 @@
       </component>
       <component id="bff6f" class="javax.swing.JLabel" binding="myEntryFileHintLabel">
         <constraints>
-          <grid row="5" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <enabled value="false"/>
@@ -110,7 +83,7 @@
       </component>
       <component id="17e7a" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="myEntryFile">
         <constraints>
-          <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <focusable value="true"/>
@@ -118,7 +91,7 @@
       </component>
       <component id="e0e39" class="javax.swing.JComboBox" binding="scope">
         <constraints>
-          <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="2" anchor="8" fill="0" indent="0" use-parent-layout="false">
+          <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="2" anchor="8" fill="0" indent="0" use-parent-layout="false">
             <preferred-size width="150" height="-1"/>
           </grid>
         </constraints>
@@ -126,7 +99,7 @@
       </component>
       <component id="42f6b" class="javax.swing.JLabel">
         <constraints>
-          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
             <preferred-size width="110" height="-1"/>
           </grid>
         </constraints>
@@ -136,7 +109,7 @@
       </component>
       <component id="4e13d" class="javax.swing.JLabel" binding="scopeLabelHint">
         <constraints>
-          <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <enabled value="false"/>

--- a/src/io/flutter/run/bazelTest/FlutterBazelTestConfigurationEditorForm.form
+++ b/src/io/flutter/run/bazelTest/FlutterBazelTestConfigurationEditorForm.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="io.flutter.run.bazelTest.FlutterBazelTestConfigurationEditorForm">
-  <grid id="27dc6" binding="myMainPanel" default-binding="true" layout-manager="GridLayoutManager" row-count="7" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="myMainPanel" default-binding="true" layout-manager="GridLayoutManager" row-count="11" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="720" height="320"/>
@@ -8,27 +8,9 @@
     <properties/>
     <border type="none"/>
     <children>
-      <component id="55076" class="javax.swing.JLabel" binding="myEntryFileLabel">
-        <constraints>
-          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <inheritsPopupMenu value="true"/>
-          <labelFor value=""/>
-          <text value="Dart &amp;entrypoint:"/>
-        </properties>
-      </component>
-      <component id="17e7a" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="myEntryFile">
-        <constraints>
-          <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <focusable value="true"/>
-        </properties>
-      </component>
       <component id="55077" class="javax.swing.JLabel" binding="myLaunchingScriptLabel">
         <constraints>
-          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <inheritsPopupMenu value="true"/>
@@ -38,15 +20,15 @@
       </component>
       <component id="17e7b" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="myLaunchingScript">
         <constraints>
-          <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <focusable value="true"/>
         </properties>
       </component>
-      <component id="7b563" class="javax.swing.JLabel">
+      <component id="7b563" class="javax.swing.JLabel" binding="myBuildTargetLabel">
         <constraints>
-          <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <labelFor value="ada9f"/>
@@ -55,40 +37,110 @@
       </component>
       <component id="ada9f" class="javax.swing.JTextField" binding="myBuildTarget">
         <constraints>
-          <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="6" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
       </component>
       <vspacer id="3f5de">
         <constraints>
-          <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="10" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
-      <component id="bff6f" class="javax.swing.JLabel">
+      <component id="8e5b7" class="javax.swing.JLabel" binding="myLaunchingScriptHintLabel">
         <constraints>
           <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <enabled value="false"/>
-          <text value="The absolute entry-point path for the application (e.g. /.../lib/main_test.dart)."/>
-        </properties>
-      </component>
-      <component id="8e5b7" class="javax.swing.JLabel">
-        <constraints>
-          <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <enabled value="false"/>
           <text value="The absolute path to a Bazel launching script."/>
         </properties>
       </component>
-      <component id="eff55" class="javax.swing.JLabel">
+      <component id="eff55" class="javax.swing.JLabel" binding="myBuildTargetHintLabel">
+        <constraints>
+          <grid row="7" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <enabled value="false"/>
+          <text value="The Bazel target (e.g. //a/b/c:name)."/>
+        </properties>
+      </component>
+      <component id="60b32" class="javax.swing.JLabel" binding="myTestNameLabel">
+        <constraints>
+          <grid row="8" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="Test Name:"/>
+        </properties>
+      </component>
+      <component id="e602a" class="javax.swing.JLabel" binding="myTestNameHintLabel">
+        <constraints>
+          <grid row="9" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <enabled value="false"/>
+          <text value="Some pattern to match test names by."/>
+        </properties>
+      </component>
+      <component id="6457d" class="javax.swing.JTextField" binding="myTestName">
+        <constraints>
+          <grid row="8" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+            <preferred-size width="150" height="-1"/>
+          </grid>
+        </constraints>
+        <properties/>
+      </component>
+      <component id="55076" class="javax.swing.JLabel" binding="myEntryFileLabel">
+        <constraints>
+          <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <inheritsPopupMenu value="true"/>
+          <labelFor value=""/>
+          <text value="Dart &amp;entrypoint:"/>
+        </properties>
+      </component>
+      <component id="bff6f" class="javax.swing.JLabel" binding="myEntryFileHintLabel">
         <constraints>
           <grid row="5" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <enabled value="false"/>
-          <text value="The Bazel target (e.g. //a/b/c:name)."/>
+          <text value="The absolute entry-point path for the application (e.g. /.../lib/main_test.dart)."/>
+        </properties>
+      </component>
+      <component id="17e7a" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="myEntryFile">
+        <constraints>
+          <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <focusable value="true"/>
+        </properties>
+      </component>
+      <component id="e0e39" class="javax.swing.JComboBox" binding="scope">
+        <constraints>
+          <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="2" anchor="8" fill="0" indent="0" use-parent-layout="false">
+            <preferred-size width="150" height="-1"/>
+          </grid>
+        </constraints>
+        <properties/>
+      </component>
+      <component id="42f6b" class="javax.swing.JLabel">
+        <constraints>
+          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+            <preferred-size width="110" height="-1"/>
+          </grid>
+        </constraints>
+        <properties>
+          <text value="Test &amp;scope:"/>
+        </properties>
+      </component>
+      <component id="4e13d" class="javax.swing.JLabel" binding="scopeLabelHint">
+        <constraints>
+          <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <enabled value="false"/>
+          <text value="Scope of the test: either file, bazel target pattern, or specific tests in a file filtered by name."/>
         </properties>
       </component>
     </children>

--- a/src/io/flutter/run/bazelTest/FlutterBazelTestConfigurationEditorForm.java
+++ b/src/io/flutter/run/bazelTest/FlutterBazelTestConfigurationEditorForm.java
@@ -12,22 +12,59 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.TextFieldWithBrowseButton;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.ui.ListCellRendererWrapper;
 import com.jetbrains.lang.dart.ide.runner.server.ui.DartCommandLineConfigurationEditorForm;
+import io.flutter.run.bazelTest.BazelTestFields.Scope;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
 
+import java.awt.event.ActionEvent;
+
+import static io.flutter.run.bazelTest.BazelTestFields.Scope.FILE;
+import static io.flutter.run.bazelTest.BazelTestFields.Scope.NAME;
+import static io.flutter.run.bazelTest.BazelTestFields.Scope.TARGET_PATTERN;
+
 public class FlutterBazelTestConfigurationEditorForm extends SettingsEditor<BazelTestConfig> {
   private JPanel myMainPanel;
+  private JLabel scopeLabelHint;
+  private JComboBox<Scope> scope;
 
   private JLabel myEntryFileLabel;
   private TextFieldWithBrowseButton myEntryFile;
+  private JLabel myEntryFileHintLabel;
 
   private JLabel myLaunchingScriptLabel;
   private TextFieldWithBrowseButton myLaunchingScript;
+  private JLabel myLaunchingScriptHintLabel;
+
   private JTextField myBuildTarget;
+  private JLabel myBuildTargetHintLabel;
+  private JLabel myBuildTargetLabel;
+
+  private JLabel myTestNameLabel;
+  private JTextField myTestName;
+  private JLabel myTestNameHintLabel;
+
+  private Scope displayedScope;
 
   public FlutterBazelTestConfigurationEditorForm(final Project project) {
+    scope.setModel(new DefaultComboBoxModel<>(new Scope[]{TARGET_PATTERN, FILE, NAME}));
+    scope.addActionListener((ActionEvent e) -> {
+      final Scope next = getScope();
+      updateFields(next);
+      render(next);
+    });
+    scope.setRenderer(new ListCellRendererWrapper<Scope>() {
+      @Override
+      public void customize(final JList list,
+                            final Scope value,
+                            final int index,
+                            final boolean selected,
+                            final boolean hasFocus) {
+        setText(value.getDisplayName());
+      }
+    });
     final FileChooserDescriptor descriptor = FileChooserDescriptorFactory.createSingleFileDescriptor();
     myLaunchingScript.addBrowseFolderListener("Select Launching Script", "Choose launching script", project, descriptor);
 
@@ -40,14 +77,23 @@ public class FlutterBazelTestConfigurationEditorForm extends SettingsEditor<Baze
     myEntryFile.setText(FileUtil.toSystemDependentName(StringUtil.notNullize(fields.getEntryFile())));
     myBuildTarget.setText(StringUtil.notNullize(fields.getBazelTarget()));
     myLaunchingScript.setText(FileUtil.toSystemDependentName(StringUtil.notNullize(fields.getLaunchingScript())));
+    final Scope next = fields.getScope();
+    scope.setSelectedItem(next);
+    render(next);
   }
 
   @Override
   protected void applyEditorTo(@NotNull final BazelTestConfig configuration) {
-    final BazelTestFields fields = new BazelTestFields();
-    fields.setEntryFile(StringUtil.nullize(FileUtil.toSystemIndependentName(myEntryFile.getText().trim()), true));
-    fields.setBazelTarget(StringUtil.nullize(myBuildTarget.getText().trim(), true));
-    fields.setLaunchingScript(StringUtil.nullize(FileUtil.toSystemIndependentName(myLaunchingScript.getText().trim()), true));
+    final String testName = StringUtil.nullize(this.myTestName.getText().trim(), true);
+    final String entryFile = StringUtil.nullize(FileUtil.toSystemIndependentName(myEntryFile.getText().trim()), true);
+    final String launchScript = StringUtil.nullize(FileUtil.toSystemIndependentName(myLaunchingScript.getText().trim()), true);
+    final String bazelTarget = StringUtil.nullize(myBuildTarget.getText().trim(), true);
+    final BazelTestFields fields = new BazelTestFields(
+      testName,
+      entryFile,
+      launchScript,
+      bazelTarget
+    );
     configuration.setFields(fields);
   }
 
@@ -55,5 +101,49 @@ public class FlutterBazelTestConfigurationEditorForm extends SettingsEditor<Baze
   @Override
   protected JComponent createEditor() {
     return myMainPanel;
+  }
+
+
+  /**
+   * When switching between file and directory scope, update the next field to
+   * a suitable default.
+   */
+  private void updateFields(Scope next) {
+    if (next == Scope.TARGET_PATTERN && displayedScope != Scope.TARGET_PATTERN) {
+    }
+    else if (next != Scope.TARGET_PATTERN) {
+      if (myEntryFile.getText().isEmpty()) {
+        myEntryFile.setText(myBuildTarget.getText().replace("//", ""));
+      }
+    }
+  }
+
+  @NotNull
+  private Scope getScope() {
+    final Object item = scope.getSelectedItem();
+    // Set in resetEditorForm.
+    assert (item != null);
+    return (Scope)item;
+  }
+
+
+  /**
+   * Show and hide fields as appropriate for the next scope.
+   */
+  private void render(Scope next) {
+
+    myEntryFile.setVisible(next == Scope.FILE || next == Scope.NAME);
+    myEntryFileLabel.setVisible(next == Scope.FILE || next == Scope.NAME);
+    myEntryFileHintLabel.setVisible(next == Scope.FILE || next == Scope.NAME);
+
+    myTestName.setVisible(next == Scope.NAME);
+    myTestNameLabel.setVisible(next == Scope.NAME);
+    myTestNameHintLabel.setVisible(next == Scope.NAME);
+
+    myBuildTarget.setVisible(next == Scope.TARGET_PATTERN);
+    myBuildTargetLabel.setVisible(next == Scope.TARGET_PATTERN);
+    myBuildTargetHintLabel.setVisible(next == Scope.TARGET_PATTERN);
+
+    displayedScope = next;
   }
 }

--- a/src/io/flutter/run/bazelTest/FlutterBazelTestConfigurationEditorForm.java
+++ b/src/io/flutter/run/bazelTest/FlutterBazelTestConfigurationEditorForm.java
@@ -34,10 +34,6 @@ public class FlutterBazelTestConfigurationEditorForm extends SettingsEditor<Baze
   private TextFieldWithBrowseButton myEntryFile;
   private JLabel myEntryFileHintLabel;
 
-  private JLabel myLaunchingScriptLabel;
-  private TextFieldWithBrowseButton myLaunchingScript;
-  private JLabel myLaunchingScriptHintLabel;
-
   private JTextField myBuildTarget;
   private JLabel myBuildTargetHintLabel;
   private JLabel myBuildTargetLabel;
@@ -66,7 +62,6 @@ public class FlutterBazelTestConfigurationEditorForm extends SettingsEditor<Baze
       }
     });
     final FileChooserDescriptor descriptor = FileChooserDescriptorFactory.createSingleFileDescriptor();
-    myLaunchingScript.addBrowseFolderListener("Select Launching Script", "Choose launching script", project, descriptor);
 
     DartCommandLineConfigurationEditorForm.initDartFileTextWithBrowse(project, myEntryFile);
   }
@@ -77,7 +72,6 @@ public class FlutterBazelTestConfigurationEditorForm extends SettingsEditor<Baze
     myTestName.setText(fields.getTestName());
     myEntryFile.setText(FileUtil.toSystemDependentName(StringUtil.notNullize(fields.getEntryFile())));
     myBuildTarget.setText(StringUtil.notNullize(fields.getBazelTarget()));
-    myLaunchingScript.setText(FileUtil.toSystemDependentName(StringUtil.notNullize(fields.getLaunchingScript())));
     final Scope next = fields.getScope();
     scope.setSelectedItem(next);
     render(next);
@@ -87,12 +81,10 @@ public class FlutterBazelTestConfigurationEditorForm extends SettingsEditor<Baze
   protected void applyEditorTo(@NotNull final BazelTestConfig configuration) {
     final String testName = StringUtil.nullize(this.myTestName.getText().trim(), true);
     final String entryFile = StringUtil.nullize(FileUtil.toSystemIndependentName(myEntryFile.getText().trim()), true);
-    final String launchScript = StringUtil.nullize(FileUtil.toSystemIndependentName(myLaunchingScript.getText().trim()), true);
     final String bazelTarget = StringUtil.nullize(myBuildTarget.getText().trim(), true);
     final BazelTestFields fields = new BazelTestFields(
       testName,
       entryFile,
-      launchScript,
       bazelTarget
     );
     configuration.setFields(fields);

--- a/src/io/flutter/run/bazelTest/FlutterBazelTestConfigurationEditorForm.java
+++ b/src/io/flutter/run/bazelTest/FlutterBazelTestConfigurationEditorForm.java
@@ -74,6 +74,7 @@ public class FlutterBazelTestConfigurationEditorForm extends SettingsEditor<Baze
   @Override
   protected void resetEditorFrom(@NotNull final BazelTestConfig configuration) {
     final BazelTestFields fields = configuration.getFields();
+    myTestName.setText(fields.getTestName());
     myEntryFile.setText(FileUtil.toSystemDependentName(StringUtil.notNullize(fields.getEntryFile())));
     myBuildTarget.setText(StringUtil.notNullize(fields.getBazelTarget()));
     myLaunchingScript.setText(FileUtil.toSystemDependentName(StringUtil.notNullize(fields.getLaunchingScript())));

--- a/src/io/flutter/run/bazelTest/FlutterBazelTestConfigurationType.java
+++ b/src/io/flutter/run/bazelTest/FlutterBazelTestConfigurationType.java
@@ -9,10 +9,12 @@ import com.intellij.execution.ExecutionBundle;
 import com.intellij.execution.configurations.ConfigurationFactory;
 import com.intellij.execution.configurations.ConfigurationTypeBase;
 import com.intellij.execution.configurations.RunConfiguration;
+import com.intellij.openapi.extensions.Extensions;
 import com.intellij.openapi.project.Project;
 import icons.FlutterIcons;
 import io.flutter.FlutterBundle;
 import io.flutter.run.bazel.FlutterBazelRunConfigurationType;
+import io.flutter.run.test.TestConfigType;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -20,10 +22,14 @@ import org.jetbrains.annotations.NotNull;
  */
 public class FlutterBazelTestConfigurationType extends ConfigurationTypeBase {
 
-  public FlutterBazelTestConfigurationType() {
+  protected FlutterBazelTestConfigurationType() {
     super("FlutterBazelTestConfigurationType", FlutterBundle.message("runner.flutter.bazel.test.configuration.name"),
           FlutterBundle.message("runner.flutter.bazel.configuration.description"), FlutterIcons.BazelRun);
     addFactory(new Factory(this));
+  }
+
+  public static FlutterBazelTestConfigurationType getInstance() {
+    return Extensions.findExtension(CONFIGURATION_TYPE_EP, FlutterBazelTestConfigurationType.class);
   }
 
   private static class Factory extends ConfigurationFactory {

--- a/src/io/flutter/run/bazelTest/FlutterBazelTestLineMarkerContributor.java
+++ b/src/io/flutter/run/bazelTest/FlutterBazelTestLineMarkerContributor.java
@@ -34,7 +34,7 @@ public class FlutterBazelTestLineMarkerContributor extends RunLineMarkerContribu
   @Nullable
   @Override
   public Info getInfo(@NotNull PsiElement element) {
-    final TestConfigUtils.TestType testCall = TestConfigUtils.asTestCall(element);
+    final BazelTestConfigUtils.TestType testCall = BazelTestConfigUtils.asTestCall(element);
     if (testCall != null) {
       final Icon icon = getTestStateIcon(element, testCall.getIcon());
       final Function<PsiElement, String> tooltipProvider =

--- a/src/io/flutter/run/bazelTest/FlutterBazelTestLineMarkerContributor.java
+++ b/src/io/flutter/run/bazelTest/FlutterBazelTestLineMarkerContributor.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2018 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.run.bazelTest;
+
+import com.intellij.execution.TestStateStorage;
+import com.intellij.execution.lineMarker.ExecutorAction;
+import com.intellij.execution.lineMarker.RunLineMarkerContributor;
+import com.intellij.execution.testframework.TestIconMapper;
+import com.intellij.execution.testframework.sm.runner.states.TestStateInfo;
+import com.intellij.icons.AllIcons;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiDocumentManager;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiInvalidElementAccessException;
+import com.intellij.util.Function;
+import com.intellij.util.Time;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+import java.util.Date;
+import java.util.Map;
+
+
+public class FlutterBazelTestLineMarkerContributor extends RunLineMarkerContributor {
+
+  private static final int SCANNED_TEST_RESULT_LIMIT = 1024;
+
+  @Nullable
+  @Override
+  public Info getInfo(@NotNull PsiElement element) {
+    final TestConfigUtils.TestType testCall = TestConfigUtils.asTestCall(element);
+    if (testCall != null) {
+      final Icon icon = getTestStateIcon(element, testCall.getIcon());
+      final Function<PsiElement, String> tooltipProvider =
+        psiElement -> testCall.getTooltip(element);
+      return new Info(icon, tooltipProvider, ExecutorAction.getActions());
+    }
+
+    return null;
+  }
+
+  @NotNull
+  private static Icon getTestStateIcon(@NotNull PsiElement element, @NotNull Icon defaultIcon) {
+
+    // SMTTestProxy maps test run data to a URI derived from a location hint produced by `package:test`.
+    // If we can find corresponding data, we can provide state-aware icons. If not, we default to
+    // a standard Run state.
+
+    PsiFile containingFile;
+    try {
+      containingFile = element.getContainingFile();
+    }
+    catch (PsiInvalidElementAccessException e) {
+      containingFile = null;
+    }
+
+    final Project project = element.getProject();
+    final PsiDocumentManager psiDocumentManager = PsiDocumentManager.getInstance(project);
+
+    final Document document = containingFile == null ? null : psiDocumentManager.getDocument(containingFile);
+    if (document != null) {
+      final int textOffset = element.getTextOffset();
+      final int lineNumber = document.getLineNumber(textOffset);
+
+      // e.g., dart_location:///Users/pq/IdeaProjects/untitled1298891289891/test/unit_test.dart,3,2,["my first unit test"]
+      final String path = containingFile.getVirtualFile().getPath();
+      final String testLocationPrefix = "dart_location://" + path + "," + lineNumber;
+
+      final TestStateStorage storage = TestStateStorage.getInstance(project);
+      if (storage != null) {
+        final Map<String, TestStateStorage.Record> tests =
+          storage.getRecentTests(SCANNED_TEST_RESULT_LIMIT, getSinceDate());
+        if (tests != null) {
+          //TODO(pq): investigate performance implications.
+          for (Map.Entry<String, TestStateStorage.Record> entry : tests.entrySet()) {
+            if (entry.getKey().startsWith(testLocationPrefix)) {
+              final TestStateStorage.Record state = entry.getValue();
+              final TestStateInfo.Magnitude magnitude = TestIconMapper.getMagnitude(state.magnitude);
+              if (magnitude != null) {
+                switch (magnitude) {
+                  case IGNORED_INDEX:
+                    return AllIcons.RunConfigurations.TestState.Yellow2;
+                  case ERROR_INDEX:
+                  case FAILED_INDEX:
+                    return AllIcons.RunConfigurations.TestState.Red2;
+                  case PASSED_INDEX:
+                  case COMPLETE_INDEX:
+                    return AllIcons.RunConfigurations.TestState.Green2;
+                  default:
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    return defaultIcon;
+  }
+
+  private static Date getSinceDate() {
+    return new Date(System.currentTimeMillis() - Time.DAY);
+  }
+}

--- a/src/io/flutter/run/bazelTest/TestConfigUtils.java
+++ b/src/io/flutter/run/bazelTest/TestConfigUtils.java
@@ -1,9 +1,9 @@
 /*
- * Copyright 2017 The Chromium Authors. All rights reserved.
+ * Copyright 2018 The Chromium Authors. All rights reserved.
  * Use of this source code is governed by a BSD-style license that can be
  * found in the LICENSE file.
  */
-package io.flutter.run.test;
+package io.flutter.run.bazelTest;
 
 
 import com.google.common.annotations.VisibleForTesting;

--- a/src/io/flutter/run/test/TestFields.java
+++ b/src/io/flutter/run/test/TestFields.java
@@ -16,6 +16,7 @@ import io.flutter.run.MainFile;
 import io.flutter.run.daemon.RunMode;
 import io.flutter.sdk.FlutterCommandStartResult;
 import io.flutter.sdk.FlutterSdk;
+import io.flutter.utils.ElementIO;
 import org.jdom.Element;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -175,9 +176,9 @@ public class TestFields {
   }
 
   void writeTo(Element elt) {
-    addOption(elt, "testName", testName);
-    addOption(elt, "testFile", testFile);
-    addOption(elt, "testDir", testDir);
+    ElementIO.addOption(elt, "testName", testName);
+    ElementIO.addOption(elt, "testFile", testFile);
+    ElementIO.addOption(elt, "testDir", testDir);
   }
 
   /**
@@ -185,7 +186,7 @@ public class TestFields {
    */
   @NotNull
   static TestFields readFrom(Element elt) throws InvalidDataException {
-    final Map<String, String> options = readOptions(elt);
+    final Map<String, String> options = ElementIO.readOptions(elt);
 
     final String testName = options.get("testName");
     final String testFile = options.get("testFile");
@@ -237,29 +238,6 @@ public class TestFields {
     if (FlutterSdk.getFlutterSdk(project) == null) {
       throw new RuntimeConfigurationError("Flutter SDK isn't set");
     }
-  }
-
-  private void addOption(@NotNull Element elt, @NotNull String name, @Nullable String value) {
-    if (value == null) return;
-
-    final Element child = new Element("option");
-    child.setAttribute("name", name);
-    child.setAttribute("value", value);
-    elt.addContent(child);
-  }
-
-  private static Map<String, String> readOptions(Element elt) {
-    final Map<String, String> result = new HashMap<>();
-    for (Element child : elt.getChildren()) {
-      if ("option".equals(child.getName())) {
-        final String name = child.getAttributeValue("name");
-        final String value = child.getAttributeValue("value");
-        if (name != null && value != null) {
-          result.put(name, value);
-        }
-      }
-    }
-    return result;
   }
 
   /**

--- a/src/io/flutter/utils/ElementIO.java
+++ b/src/io/flutter/utils/ElementIO.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.utils;
+
+import org.jdom.Element;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Utilities for reading and writing IntelliJ run configurations to and from the disk.
+ */
+public class ElementIO {
+  public static void addOption(@NotNull Element element, @NotNull String name, @Nullable String value) {
+    if (value == null) return;
+
+    final Element child = new Element("option");
+    child.setAttribute("name", name);
+    child.setAttribute("value", value);
+    element.addContent(child);
+  }
+
+  public static Map<String, String> readOptions(Element element) {
+    final Map<String, String> result = new HashMap<>();
+    for (Element child : element.getChildren()) {
+      if ("option".equals(child.getName())) {
+        final String name = child.getAttributeValue("name");
+        final String value = child.getAttributeValue("value");
+        if (name != null && value != null) {
+          result.put(name, value);
+        }
+      }
+    }
+    return result;
+  }
+}


### PR DESCRIPTION
I have a few questions I need to answer and fixes I need to make before submitting this:

* [ ] How can I test the linecontributor that I added to be sure it will work?
* [ ] Do we have a system for adding this feature behind a configuration option that users can turn off?  I don't want to roll this out and have to roll back if it breaks a few bazel users' workflows.
* [ ] Refactor common logic from the test configuration producers and line contributors into a common utility so that we have a smaller surface to test.

I would like an initial review and some thoughts on the 3 questions I have left.  Thanks!
