### PR TITLE
Fix NPE

### DIFF
--- a/src/io/flutter/preview/ModelUtils.java
+++ b/src/io/flutter/preview/ModelUtils.java
@@ -17,6 +17,9 @@ public class ModelUtils {
   }
 
   public static boolean isBuildMethod(@NotNull Element element) {
+    if (element.getName() == null || element.getParameters() == null) {
+      return false;
+    }
     return StringUtil.equals("build", element.getName()) &&
            StringUtil.startsWith(element.getParameters(), "(BuildContext ");
   }


### PR DESCRIPTION
Apparently, Element.getParameters() can return null. It isn't annotated. This fixes the NPE that got thrown a minute ago.

