### PR TITLE
Support for creating projects w/ sample content.

### DIFF
--- a/src/io/flutter/FlutterBundle.properties
+++ b/src/io/flutter/FlutterBundle.properties
@@ -111,6 +111,7 @@ flutter.module.create.settings.type.package=Package
 flutter.module.create.settings.type.module=Module
 flutter.module.create.settings.type.import_module=Import Module
 flutter.module.create.settings.type.tip=Select a project type.
+flutter.module.create.settings.sample.tip=Select sample content.
 flutter.module.create.settings.radios.org.label=&Organization:
 flutter.module.create.settings.org.default_text=com.example
 flutter.module.create.settings.org.tip=Enter a domain.

--- a/src/io/flutter/FlutterBundle.properties
+++ b/src/io/flutter/FlutterBundle.properties
@@ -112,6 +112,7 @@ flutter.module.create.settings.type.module=Module
 flutter.module.create.settings.type.import_module=Import Module
 flutter.module.create.settings.type.tip=Select a project type.
 flutter.module.create.settings.sample.tip=Select sample content.
+flutter.module.create.settings.sample.text=Generate sample content:
 flutter.module.create.settings.radios.org.label=&Organization:
 flutter.module.create.settings.org.default_text=com.example
 flutter.module.create.settings.org.tip=Enter a domain.

--- a/src/io/flutter/module/settings/FlutterCreateAdditionalSettingsFields.java
+++ b/src/io/flutter/module/settings/FlutterCreateAdditionalSettingsFields.java
@@ -37,13 +37,14 @@ public class FlutterCreateAdditionalSettingsFields {
     projectTypeForm = new ProjectType();
     projectTypeForm.addListener(e -> {
       settings.setType(projectTypeForm.getType());
+      settings.setSampleContent(projectTypeForm.getSample());
       changeVisibility(projectTypeForm.getType() != FlutterProjectType.PACKAGE);
     });
 
     orgField = new JTextField();
     orgField.getDocument().addDocumentListener(new DocumentAdapter() {
       @Override
-      protected void textChanged(DocumentEvent e) {
+      protected void textChanged(@NotNull DocumentEvent e) {
         settings.setOrg(orgField.getText());
       }
     });
@@ -53,7 +54,7 @@ public class FlutterCreateAdditionalSettingsFields {
     descriptionField = new JTextField();
     descriptionField.getDocument().addDocumentListener(new DocumentAdapter() {
       @Override
-      protected void textChanged(DocumentEvent e) {
+      protected void textChanged(@NotNull DocumentEvent e) {
         settings.setDescription(descriptionField.getText());
       }
     });
@@ -113,6 +114,7 @@ public class FlutterCreateAdditionalSettingsFields {
       .setKotlin(androidLanguageRadios.isRadio2Selected() ? true : null)
       .setOrg(!orgField.getText().trim().isEmpty() ? orgField.getText().trim() : null)
       .setSwift(iosLanguageRadios.isRadio2Selected() ? true : null)
+      .setSampleContent(projectTypeForm.getSample())
       .setOffline(createParams.isOfflineSelected())
       .build();
   }

--- a/src/io/flutter/module/settings/ProjectType.form
+++ b/src/io/flutter/module/settings/ProjectType.form
@@ -1,31 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="io.flutter.module.settings.ProjectType">
-  <grid id="27dc6" binding="projectTypePanel" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="projectTypePanel" layout-manager="GridLayoutManager" row-count="2" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="500" height="400"/>
+      <xy x="20" y="20" width="400" height="400"/>
     </constraints>
     <properties/>
     <border type="none"/>
     <children>
       <component id="2e1c4" class="com.intellij.openapi.ui.ComboBox" binding="projectTypeCombo" custom-create="true">
         <constraints>
-          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <toolTipText resource-bundle="io/flutter/FlutterBundle" key="flutter.module.create.settings.type.tip"/>
         </properties>
       </component>
-      <hspacer id="7b9fe">
-        <constraints>
-          <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
-        </constraints>
-      </hspacer>
       <vspacer id="7f479">
         <constraints>
           <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
+      <component id="ffd7" class="com.intellij.openapi.ui.ComboBox" binding="snippetSelectorCombo" custom-create="true">
+        <constraints>
+          <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+      </component>
+      <component id="5527c" class="javax.swing.JCheckBox" binding="generateSampleContentCheckBox" custom-create="true" default-binding="true">
+        <constraints>
+          <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="generate s&amp;ample content:"/>
+        </properties>
+      </component>
     </children>
   </grid>
 </form>

--- a/src/io/flutter/module/settings/ProjectType.java
+++ b/src/io/flutter/module/settings/ProjectType.java
@@ -99,9 +99,6 @@ public class ProjectType {
   }
 
   private class FlutterSampleCellRenderer extends ColoredListCellRenderer<FlutterSample> {
-
-
-
     @Override
     protected void customizeCellRenderer(@NotNull JList<? extends FlutterSample> list,
                                          FlutterSample sample,
@@ -143,7 +140,7 @@ public class ProjectType {
     snippetSelectorCombo.setEnabled(false);
 
     generateSampleContentCheckBox = new JCheckBox();
-    generateSampleContentCheckBox.setText("generate sample content:");
+    generateSampleContentCheckBox.setText(FlutterBundle.message("flutter.module.create.settings.sample.text"));
     generateSampleContentCheckBox.addItemListener(e -> snippetSelectorCombo.setEnabled(e.getStateChange() == ItemEvent.SELECTED));
 
   }

--- a/src/io/flutter/module/settings/ProjectType.java
+++ b/src/io/flutter/module/settings/ProjectType.java
@@ -6,11 +6,16 @@
 package io.flutter.module.settings;
 
 import com.intellij.openapi.ui.ComboBox;
+import com.intellij.ui.ColoredListCellRenderer;
+import com.intellij.ui.SimpleTextAttributes;
 import io.flutter.FlutterBundle;
 import io.flutter.module.FlutterProjectType;
+import io.flutter.samples.FlutterSample;
+import io.flutter.samples.FlutterSampleManager;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
+import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
 import java.util.ArrayList;
 import java.util.EnumSet;
@@ -58,14 +63,89 @@ public class ProjectType {
     }
   }
 
+  private static final class FlutterSampleComboBoxModel extends AbstractListModel<FlutterSample>
+    implements ComboBoxModel<FlutterSample> {
+    private final List<FlutterSample> myList = FlutterSampleManager.getSamples();
+    private FlutterSample mySelected;
+
+    public FlutterSampleComboBoxModel() {
+      mySelected = myList.get(0);
+    }
+
+    @Override
+    public int getSize() {
+      return myList.size();
+    }
+
+    @Override
+    public FlutterSample getElementAt(int index) {
+      return myList.get(index);
+    }
+
+    @Override
+    public void setSelectedItem(Object item) {
+      setSelectedItem((FlutterSample)item);
+    }
+
+    @Override
+    public FlutterSample getSelectedItem() {
+      return mySelected;
+    }
+
+    public void setSelectedItem(FlutterSample item) {
+      mySelected = item;
+      fireContentsChanged(this, 0, getSize());
+    }
+  }
+
+  private class FlutterSampleCellRenderer extends ColoredListCellRenderer<FlutterSample> {
+
+
+
+    @Override
+    protected void customizeCellRenderer(@NotNull JList<? extends FlutterSample> list,
+                                         FlutterSample sample,
+                                         int index,
+                                         boolean selected,
+                                         boolean hasFocus) {
+      final SimpleTextAttributes style = snippetSelectorCombo.isEnabled() ? SimpleTextAttributes.REGULAR_ATTRIBUTES : SimpleTextAttributes.GRAY_ATTRIBUTES;
+      append(sample.getElement(), style);
+      // Add details when enabled.
+      if (snippetSelectorCombo.isEnabled()) {
+        append("  (" + sample.getLibrary() + ")", SimpleTextAttributes.GRAY_ATTRIBUTES);
+      }
+    }
+  }
+
   private JPanel projectTypePanel;
   private ComboBox projectTypeCombo;
+  private ComboBox<FlutterSample> snippetSelectorCombo;
+  private JCheckBox generateSampleContentCheckBox;
 
   private void createUIComponents() {
     projectTypeCombo = new ComboBox<>();
     //noinspection unchecked
     projectTypeCombo.setModel(new ProjectTypeComboBoxModel());
     projectTypeCombo.setToolTipText(FlutterBundle.message("flutter.module.create.settings.type.tip"));
+    projectTypeCombo.addItemListener(e -> {
+      final boolean appType = getType() == FlutterProjectType.APP;
+      if (!appType) {
+        // Make sure sample generattion is de-selected in non-app contexts.
+        generateSampleContentCheckBox.setSelected(false);
+      }
+      generateSampleContentCheckBox.setEnabled(appType);
+    });
+
+    snippetSelectorCombo = new ComboBox<>();
+    snippetSelectorCombo.setModel(new FlutterSampleComboBoxModel());
+    snippetSelectorCombo.setRenderer(new FlutterSampleCellRenderer());
+    snippetSelectorCombo.setToolTipText(FlutterBundle.message("flutter.module.create.settings.sample.tip"));
+    snippetSelectorCombo.setEnabled(false);
+
+    generateSampleContentCheckBox = new JCheckBox();
+    generateSampleContentCheckBox.setText("generate sample content:");
+    generateSampleContentCheckBox.addItemListener(e -> snippetSelectorCombo.setEnabled(e.getStateChange() == ItemEvent.SELECTED));
+
   }
 
   @NotNull
@@ -77,7 +157,13 @@ public class ProjectType {
     return (FlutterProjectType)projectTypeCombo.getSelectedItem();
   }
 
+  public FlutterSample getSample() {
+    return generateSampleContentCheckBox.isVisible() && generateSampleContentCheckBox.isSelected() ? (FlutterSample)snippetSelectorCombo.getSelectedItem() : null;
+  }
+
+
   public void addListener(ItemListener listener) {
     projectTypeCombo.addItemListener(listener);
+    snippetSelectorCombo.addItemListener(listener);
   }
 }

--- a/src/io/flutter/samples/FlutterSample.java
+++ b/src/io/flutter/samples/FlutterSample.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.samples;
+
+import org.jetbrains.annotations.NotNull;
+
+public class FlutterSample {
+  @NotNull
+  private final String element;
+  @NotNull
+  private final String library;
+  @NotNull
+  private final String id;
+  @NotNull
+  private final String file;
+  @NotNull
+  private final String description;
+
+  private String relativePath;
+
+  FlutterSample(@NotNull String element, @NotNull String library, @NotNull String id, @NotNull String file,
+                @NotNull String description) {
+    this.element = element;
+    this.library = library;
+    this.id = id;
+    this.file = file;
+    this.description = description;
+  }
+
+  @Override
+  public String toString() {
+    return getElement() + " (" + getLibrary() + ")";
+  }
+
+  @NotNull
+  public String getLibrary() {
+    return library;
+  }
+
+  @NotNull
+  public String getId() {
+    return id;
+  }
+
+  @NotNull
+  public String getElement() {
+    return element;
+  }
+
+  @NotNull
+  public String getDescription() {
+    return description;
+  }
+
+  @NotNull
+  public String getFile() {
+    return file;
+  }
+
+  public String getRelativePath() {
+    if (relativePath == null) {
+      // Chomp .dart suffix
+      relativePath = file.substring(file.length() - 5);
+      // material.sample => material/sample
+      relativePath = relativePath.replaceAll("\\.", "/");
+      // Re-add suffix.
+      relativePath += ".dart";
+    }
+    return relativePath;
+  }
+}

--- a/src/io/flutter/samples/FlutterSampleManager.java
+++ b/src/io/flutter/samples/FlutterSampleManager.java
@@ -5,11 +5,12 @@
  */
 package io.flutter.samples;
 
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import com.intellij.openapi.diagnostic.Logger;
 import org.apache.commons.io.IOUtils;
-import org.codehaus.jettison.json.JSONArray;
-import org.codehaus.jettison.json.JSONException;
-import org.codehaus.jettison.json.JSONObject;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -38,18 +39,17 @@ public class FlutterSampleManager {
       // TODO(pq): replace w/ index read from repo (https://github.com/flutter/flutter/pull/25515).
       final URL url = FlutterSampleManager.class.getResource("index.json");
       final String contents = IOUtils.toString(url.toURI(), "UTF-8");
-      final JSONArray jsonArray = new JSONArray(contents);
-
-      for (int i = 0; i < jsonArray.length(); i++) {
-        final JSONObject sample = jsonArray.getJSONObject(i);
-        samples.add(new FlutterSample(sample.getString("element"),
-                                      sample.getString("library"),
-                                      sample.getString("id"),
-                                      sample.getString("file"),
-                                      sample.getString("description")));
+      final JsonArray jsonArray = new JsonParser().parse(contents).getAsJsonArray();
+      for (JsonElement element : jsonArray) {
+        final JsonObject sample = element.getAsJsonObject();
+        samples.add(new FlutterSample(sample.getAsJsonPrimitive("element").getAsString(),
+                                      sample.getAsJsonPrimitive("library").getAsString(),
+                                      sample.getAsJsonPrimitive("id").getAsString(),
+                                      sample.getAsJsonPrimitive("file").getAsString(),
+                                      sample.getAsJsonPrimitive("description").getAsString()));
       }
     }
-    catch (URISyntaxException | IOException | JSONException e) {
+    catch (URISyntaxException | IOException e) {
       LOG.warn(e);
     }
 

--- a/src/io/flutter/samples/FlutterSampleManager.java
+++ b/src/io/flutter/samples/FlutterSampleManager.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2018 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.samples;
+
+import com.intellij.openapi.diagnostic.Logger;
+import org.apache.commons.io.IOUtils;
+import org.codehaus.jettison.json.JSONArray;
+import org.codehaus.jettison.json.JSONException;
+import org.codehaus.jettison.json.JSONObject;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+public class FlutterSampleManager {
+
+  private static final Logger LOG = Logger.getInstance(FlutterSampleManager.class);
+
+  private static List<FlutterSample> SAMPLES;
+
+  public static List<FlutterSample> getSamples() {
+    if (SAMPLES == null) {
+      // When we're reading from the repo and the file may be changing, consider a fresh read on each access.
+      SAMPLES = loadSamples();
+    }
+    return SAMPLES;
+  }
+
+  private static List<FlutterSample> loadSamples() {
+    final List<FlutterSample> samples = new ArrayList<>();
+    try {
+      // TODO(pq): replace w/ index read from repo (https://github.com/flutter/flutter/pull/25515).
+      final URL url = FlutterSampleManager.class.getResource("index.json");
+      final String contents = IOUtils.toString(url.toURI(), "UTF-8");
+      final JSONArray jsonArray = new JSONArray(contents);
+
+      for (int i = 0; i < jsonArray.length(); i++) {
+        final JSONObject sample = jsonArray.getJSONObject(i);
+        samples.add(new FlutterSample(sample.getString("element"),
+                                      sample.getString("library"),
+                                      sample.getString("id"),
+                                      sample.getString("file"),
+                                      sample.getString("description")));
+      }
+    }
+    catch (URISyntaxException | IOException | JSONException e) {
+      LOG.warn(e);
+    }
+
+    // Sort by name and library.
+    samples.sort(Comparator.comparing(s -> (s.getElement() + s.getLibrary())));
+    return samples;
+  }
+}

--- a/src/io/flutter/samples/index.json
+++ b/src/io/flutter/samples/index.json
@@ -1,0 +1,82 @@
+[
+    {
+        "package": "flutter",
+        "library": "material",
+        "element": "Scaffold",
+        "id": "material.Scaffold",
+        "file": "material.Scaffold.dart",
+        "description": "This example shows a [Scaffold] with an [AppBar], a [BottomAppBar] and a\n[FloatingActionButton]. The [body] is a [Text] placed in a [Center] in order\nto center the text within the [Scaffold] and the [FloatingActionButton] is\ncentered and docked within the [BottomAppBar] using\n[FloatingActionButtonLocation.centerDocked]. The [FloatingActionButton] is\nconnected to a callback that increments a counter."
+    },
+    {
+        "package": "flutter",
+        "library": "scaffold",
+        "element": "Scaffold",
+        "id": "scaffold.Scaffold",
+        "file": "scaffold.Scaffold.dart",
+        "description": "This example shows a [Scaffold] with an [AppBar], a [BottomAppBar] and a\n[FloatingActionButton]. The [body] is a [Text] placed in a [Center] in order\nto center the text within the [Scaffold] and the [FloatingActionButton] is\ncentered and docked within the [BottomAppBar] using\n[FloatingActionButtonLocation.centerDocked]. The [FloatingActionButton] is\nconnected to a callback that increments a counter."
+    },
+    {
+        "package": "flutter",
+        "library": "material",
+        "element": "DeletableChipAttributes.onDeleted",
+        "id": "material.DeletableChipAttributes.onDeleted",
+        "file": "material.DeletableChipAttributes.onDeleted.dart",
+        "description": "This sample shows how to use [onDeleted] to remove an entry when the\ndelete button is tapped."
+    },
+    {
+        "package": "flutter",
+        "library": "chip",
+        "element": "DeletableChipAttributes.onDeleted",
+        "id": "chip.DeletableChipAttributes.onDeleted",
+        "file": "chip.DeletableChipAttributes.onDeleted.dart",
+        "description": "This sample shows how to use [onDeleted] to remove an entry when the\ndelete button is tapped."
+    },
+    {
+        "package": "flutter",
+        "library": "icon_button",
+        "element": "IconButton",
+        "id": "icon_button.IconButton",
+        "file": "icon_button.IconButton.dart",
+        "description": "This sample shows an `IconButton` that uses the Material icon \"volume_up\" to\nincrease the volume."
+    },
+    {
+        "package": "flutter",
+        "library": "material",
+        "element": "Card",
+        "id": "material.Card",
+        "file": "material.Card.dart",
+        "description": "This sample shows creation of a [Card] widget that shows album information\nand two actions."
+    },
+    {
+        "package": "flutter",
+        "library": "app_bar",
+        "element": "AppBar.actions",
+        "id": "app_bar.AppBar.actions",
+        "file": "app_bar.AppBar.actions.dart",
+        "description": "This sample shows adding an action to an [AppBar] that opens a shopping cart."
+    },
+    {
+        "package": "flutter",
+        "library": "card",
+        "element": "Card",
+        "id": "card.Card",
+        "file": "card.Card.dart",
+        "description": "This sample shows creation of a [Card] widget that shows album information\nand two actions."
+    },
+    {
+        "package": "flutter",
+        "library": "material",
+        "element": "AppBar.actions",
+        "id": "material.AppBar.actions",
+        "file": "material.AppBar.actions.dart",
+        "description": "This sample shows adding an action to an [AppBar] that opens a shopping cart."
+    },
+    {
+        "package": "flutter",
+        "library": "material",
+        "element": "IconButton",
+        "id": "material.IconButton",
+        "file": "material.IconButton.dart",
+        "description": "This sample shows an `IconButton` that uses the Material icon \"volume_up\" to\nincrease the volume."
+    }
+]

--- a/src/io/flutter/sdk/FlutterCreateAdditionalSettings.java
+++ b/src/io/flutter/sdk/FlutterCreateAdditionalSettings.java
@@ -7,6 +7,7 @@ package io.flutter.sdk;
 
 import com.intellij.openapi.util.text.StringUtil;
 import io.flutter.module.FlutterProjectType;
+import io.flutter.samples.FlutterSample;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
@@ -27,6 +28,8 @@ public class FlutterCreateAdditionalSettings {
   private Boolean kotlin;
   @Nullable
   private Boolean offlineMode;
+  @Nullable
+  private FlutterSample sampleContent;
 
   public FlutterCreateAdditionalSettings() {
     type = FlutterProjectType.APP;
@@ -40,6 +43,7 @@ public class FlutterCreateAdditionalSettings {
                                           @Nullable String org,
                                           @Nullable Boolean swift,
                                           @Nullable Boolean kotlin,
+                                          @Nullable FlutterSample sampleContent,
                                           @Nullable Boolean offlineMode) {
     this.includeDriverTest = includeDriverTest;
     this.type = type;
@@ -47,6 +51,7 @@ public class FlutterCreateAdditionalSettings {
     this.org = org;
     this.swift = swift;
     this.kotlin = kotlin;
+    this.sampleContent = sampleContent;
     this.offlineMode = offlineMode;
   }
 
@@ -69,6 +74,10 @@ public class FlutterCreateAdditionalSettings {
 
   public void setKotlin(boolean value) {
     kotlin = value;
+  }
+
+  public void setSampleContent(@Nullable FlutterSample sampleContent) {
+    this.sampleContent = sampleContent;
   }
 
   public List<String> getArgs() {
@@ -105,6 +114,13 @@ public class FlutterCreateAdditionalSettings {
     if (Boolean.TRUE.equals(kotlin)) {
       args.add("--android-language");
       args.add("kotlin");
+    }
+
+    if (sampleContent != null) {
+      args.add("--sample");
+      args.add(sampleContent.getId());
+      // Samples need to overwrite default IDEA project content.
+      args.add("--overwrite");
     }
 
     return args;
@@ -144,6 +160,8 @@ public class FlutterCreateAdditionalSettings {
     private Boolean kotlin;
     @Nullable
     private Boolean offlineMode;
+    @Nullable
+    private FlutterSample sampleContent;
 
     public Builder() {
     }
@@ -183,8 +201,13 @@ public class FlutterCreateAdditionalSettings {
       return this;
     }
 
+    public Builder setSampleContent(@Nullable FlutterSample sampleContent) {
+      this.sampleContent = sampleContent;
+      return this;
+    }
+
     public FlutterCreateAdditionalSettings build() {
-      return new FlutterCreateAdditionalSettings(includeDriverTest, type, description, org, swift, kotlin, offlineMode);
+      return new FlutterCreateAdditionalSettings(includeDriverTest, type, description, org, swift, kotlin, sampleContent, offlineMode);
     }
   }
 }


### PR DESCRIPTION
Adds support for specifying sample content in new project creation in IDEA.

![image](https://user-images.githubusercontent.com/67586/50562102-0ba60b80-0cc6-11e9-9ced-8675f05d6b9d.png)

![image](https://user-images.githubusercontent.com/67586/50562104-0d6fcf00-0cc6-11e9-84fa-47ed51f657da.png)

Note that index format (and location) is still under development (see https://github.com/flutter/flutter/issues/25461 and https://github.com/flutter/flutter/pull/25515) so this works from a local copy that reflects the stable samples in 1.0.


Fixes: #2974

@stevemessick 

fyi @DanTup 