### PR TITLE
Log entry ansi color support (and styling re-work)

### DIFF
--- a/src/io/flutter/logging/FlutterLog.java
+++ b/src/io/flutter/logging/FlutterLog.java
@@ -13,6 +13,8 @@ import com.intellij.execution.process.ProcessHandler;
 import com.intellij.execution.ui.ConsoleViewContentType;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Key;
 import com.intellij.util.EventDispatcher;
 import io.flutter.run.FlutterDebugProcess;
@@ -76,13 +78,17 @@ public class FlutterLog {
   private final EventDispatcher<Listener>
     dispatcher = EventDispatcher.create(Listener.class);
 
-  private final FlutterLogEntryParser logEntryParser = new FlutterLogEntryParser();
+  private final FlutterLogEntryParser logEntryParser;
 
   // TODO(pq): consider limiting size.
   private final List<FlutterLogEntry> entries = new ArrayList<>();
 
   public static boolean isLoggingEnabled() {
     return FlutterSettings.getInstance().useFlutterLogView();
+  }
+
+  public FlutterLog(@NotNull Project project, @Nullable Module module) {
+    logEntryParser = new FlutterLogEntryParser(project, module);
   }
 
   public void addConsoleEntry(@NotNull String text, @NotNull ConsoleViewContentType contentType) {

--- a/src/io/flutter/logging/FlutterLogEntry.java
+++ b/src/io/flutter/logging/FlutterLogEntry.java
@@ -6,16 +6,19 @@
 package io.flutter.logging;
 
 import com.intellij.openapi.util.text.StringUtil;
+import io.flutter.logging.util.LineInfo;
+import io.flutter.logging.util.StyledText;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import static io.flutter.logging.FlutterLogEntryParser.TOOLS_CATEGORY;
+import java.util.List;
 
 public class FlutterLogEntry {
 
   public enum Kind {
     RELOAD,
     RESTART,
+    WIDGET_ERROR_START,
     UNSPECIFIED
   }
 
@@ -34,30 +37,24 @@ public class FlutterLogEntry {
 
   @NotNull
   private final Kind kind;
+  @NotNull private final List<StyledText> styledText;
 
-  public FlutterLogEntry(long timestamp, @NotNull String category, int level, @Nullable String message) {
+  public FlutterLogEntry(long timestamp,
+                         @NotNull String category,
+                         int level,
+                         @Nullable String message,
+                         @NotNull Kind kind,
+                         @NotNull List<StyledText> styledText) {
     this.timestamp = timestamp;
     this.category = category;
     this.level = level;
     this.message = StringUtil.notNullize(message);
-    this.kind = parseKind(category, this.message);
+    this.kind = kind;
+    this.styledText = styledText;
   }
 
-  private static Kind parseKind(@NotNull String category, @NotNull String message) {
-    if (category.equals(TOOLS_CATEGORY)) {
-      message = message.trim();
-      if (message.equals("Performing hot reload...") || message.equals("Initializing hot reload...")) {
-        return Kind.RELOAD;
-      }
-      if (message.equals("Performing hot restart...") || message.equals("Initializing hot restart...")) {
-        return Kind.RESTART;
-      }
-    }
-    return Kind.UNSPECIFIED;
-  }
-
-  public FlutterLogEntry(long timestamp, @NotNull String category, @Nullable String message) {
-    this(timestamp, category, UNDEFINED_LEVEL.value, message);
+  public FlutterLogEntry(long timestamp, @NotNull LineInfo info, int level) {
+    this(timestamp, info.getCategory(), level, info.getLine(), info.getKind(), info.getStyledText());
   }
 
   @Nullable
@@ -95,6 +92,11 @@ public class FlutterLogEntry {
   @NotNull
   public String getMessage() {
     return message;
+  }
+
+  @NotNull
+  public List<StyledText> getStyledText() {
+    return styledText;
   }
 
   /**

--- a/src/io/flutter/logging/FlutterLogEntryParser.java
+++ b/src/io/flutter/logging/FlutterLogEntryParser.java
@@ -167,6 +167,7 @@ public class FlutterLogEntryParser {
       if (message.equals("Performing hot restart...") || message.equals("Initializing hot restart...")) {
         return Kind.RESTART;
       }
+      // TODO(pq): remove string matching in favor of some kind of tag coming from the framework.
       if (message.startsWith("══╡ EXCEPTION CAUGHT BY WIDGETS LIBRARY")) {
         return Kind.WIDGET_ERROR_START;
       }

--- a/src/io/flutter/logging/FlutterLogEntryParser.java
+++ b/src/io/flutter/logging/FlutterLogEntryParser.java
@@ -9,12 +9,21 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
+import com.intellij.execution.filters.Filter;
+import com.intellij.execution.filters.UrlFilter;
 import com.intellij.execution.process.ProcessEvent;
 import com.intellij.execution.ui.ConsoleViewContentType;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Key;
-import io.flutter.server.vmService.HeapMonitor;
+import com.jetbrains.lang.dart.ide.runner.DartConsoleFilter;
+import io.flutter.console.FlutterConsoleFilter;
+import io.flutter.logging.util.LineInfo;
+import io.flutter.logging.util.LineParser;
+import io.flutter.logging.util.StyledText;
 import io.flutter.run.FlutterDebugProcess;
 import io.flutter.run.daemon.DaemonApi;
+import io.flutter.server.vmService.HeapMonitor;
 import io.flutter.utils.StdoutJsonParser;
 import org.dartlang.vm.service.VmService;
 import org.dartlang.vm.service.consumer.GetObjectConsumer;
@@ -24,11 +33,17 @@ import org.jetbrains.annotations.Nullable;
 
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 import static io.flutter.logging.FlutterLog.LOGGING_STREAM_ID;
+import static io.flutter.logging.FlutterLogEntry.Kind;
+import static io.flutter.logging.FlutterLogEntry.UNDEFINED_LEVEL;
 
 public class FlutterLogEntryParser {
   // Known entry categories.
+  public static final String GC_CATEGORY = "runtime.gc";
   public static final String LOG_CATEGORY = "flutter.log";
   public static final String TOOLS_CATEGORY = "flutter.tools";
   public static final String STDIO_STDOUT_CATEGORY = "stdout";
@@ -44,6 +59,12 @@ public class FlutterLogEntryParser {
   }
 
   private FlutterDebugProcess debugProcess;
+
+  private final LineHandler lineHandler;
+
+  public FlutterLogEntryParser(@NotNull Project project, @Nullable Module module) {
+    lineHandler = new LineHandler(project, module);
+  }
 
   public void setDebugProcess(FlutterDebugProcess debugProcess) {
     this.debugProcess = debugProcess;
@@ -70,7 +91,7 @@ public class FlutterLogEntryParser {
       }
     }
 
-    int level = FlutterLogEntry.UNDEFINED_LEVEL.value;
+    int level = UNDEFINED_LEVEL.value;
     final JsonElement levelElement = logRecord.getAsJsonObject().get("level");
     if (levelElement instanceof JsonPrimitive) {
       final int setLevel = levelElement.getAsInt();
@@ -87,7 +108,8 @@ public class FlutterLogEntryParser {
       messageStr += "...";
     }
 
-    final FlutterLogEntry entry = new FlutterLogEntry(timestamp(event), category, level, messageStr);
+    final LineInfo lineInfo = parseLine(messageStr, category);
+    final FlutterLogEntry entry =  new FlutterLogEntry(timestamp(), lineInfo, level);
 
     final Instance data = new Instance(logRecord.getAsJsonObject().get("error").getAsJsonObject());
     if (!data.getValueAsStringIsTruncated()) {
@@ -117,7 +139,7 @@ public class FlutterLogEntryParser {
   }
 
   @NotNull
-  private static FlutterLogEntry parseGCEvent(@NotNull Event event) {
+  private FlutterLogEntry parseGCEvent(@NotNull Event event) {
     final IsolateRef isolateRef = event.getIsolate();
     final HeapMonitor.HeapSpace newHeapSpace = new HeapMonitor.HeapSpace(event.getJson().getAsJsonObject("new"));
     final HeapMonitor.HeapSpace oldHeapSpace = new HeapMonitor.HeapSpace(event.getJson().getAsJsonObject("old"));
@@ -130,14 +152,26 @@ public class FlutterLogEntryParser {
     final long timeMs = Math.round(time * 1000);
     final double usedMB = used / (1024.0 * 1024.0);
     final double maxMB = maxHeap / (1024.0 * 1024.0);
+    final String message = "collection time " + nf.format(timeMs) + "ms • " +  df1.format(usedMB) + "MB used of " + df1.format(maxMB) + "MB • " + isolateRef.getId();
 
-    return new FlutterLogEntry(
-      timestamp(event),
-      "runtime.gc", GC_EVENT_LEVEL,
-      "collection time " +
-      nf.format(timeMs) + "ms • " +
-      df1.format(usedMB) + "MB used of " + df1.format(maxMB) + "MB • " +
-      isolateRef.getId());
+    final LineInfo lineInfo = parseLine(message, GC_CATEGORY);
+    return new FlutterLogEntry(timestamp(), lineInfo, UNDEFINED_LEVEL.value);
+  }
+
+  private static Kind parseKind(@NotNull String message, @NotNull String category) {
+    if (category.equals(TOOLS_CATEGORY)) {
+      message = message.trim();
+      if (message.equals("Performing hot reload...") || message.equals("Initializing hot reload...")) {
+        return Kind.RELOAD;
+      }
+      if (message.equals("Performing hot restart...") || message.equals("Initializing hot restart...")) {
+        return Kind.RESTART;
+      }
+      if (message.startsWith("══╡ EXCEPTION CAUGHT BY WIDGETS LIBRARY")) {
+        return Kind.WIDGET_ERROR_START;
+      }
+    }
+    return Kind.UNSPECIFIED;
   }
 
   private static long timestamp() {
@@ -177,6 +211,41 @@ public class FlutterLogEntryParser {
     return parseDaemonEvent(text);
   }
 
+  static class LineHandler extends LineParser {
+    final List<StyledText> parsed = new ArrayList<>();
+
+    LineHandler(@NotNull Project project, @Nullable Module module) {
+      super(createMessageFilters(project, module));
+    }
+
+    @Override
+    public void write(@NotNull StyledText styledText) {
+      parsed.add(styledText);
+    }
+
+    List<StyledText> parseLine(@NotNull String line) {
+      parse(line);
+      // Copy results and clear.
+      final ArrayList<StyledText> results = new ArrayList<>(parsed);
+      parsed.clear();
+      return results;
+    }
+
+    @NotNull
+    static List<Filter> createMessageFilters(@NotNull Project project, @Nullable Module module) {
+      final List<Filter> filters = new ArrayList<>();
+      if (module != null) {
+        filters.add(new FlutterConsoleFilter(module));
+      }
+      filters.addAll(Arrays.asList(
+        new DartConsoleFilter(project, project.getBaseDir()),
+        new UrlFilter()
+      ));
+      return filters;
+    }
+  }
+
+
   @VisibleForTesting
   @Nullable
   public FlutterLogEntry parseDaemonEvent(@NotNull String eventText) {
@@ -189,11 +258,31 @@ public class FlutterLogEntryParser {
         // Skip.
       }
       else {
-        return new FlutterLogEntry(timestamp(), TOOLS_CATEGORY, line);
+        // Trim "flutter: " prefix (made redundant by category).
+        if (line.startsWith("flutter:")) {
+          line = line.substring(8);
+        }
+        // Fix unicode escape codes.
+        line = line.replaceAll("\\\\\\^\\[", "\u001b");
+
+        final LineInfo lineInfo = parseLine(line, TOOLS_CATEGORY);
+        return new FlutterLogEntry(timestamp(), lineInfo, UNDEFINED_LEVEL.value);
       }
     }
 
     return null;
+  }
+
+
+  LineInfo parseLine(@NotNull String line, @NotNull String category) {
+    final Kind kind = parseKind(line, category);
+    // On reloads / restarts, clear cached styles in case we're in the middle of an unterminated style block.
+    if (kind == FlutterLogEntry.Kind.RELOAD || kind == FlutterLogEntry.Kind.RESTART) {
+      lineHandler.clear();
+    }
+
+    final List<StyledText> styledText = lineHandler.parseLine(line);
+    return new LineInfo(line, styledText, kind, category);
   }
 
   public FlutterLogEntry parseConsoleEvent(String text, ConsoleViewContentType type) {

--- a/src/io/flutter/logging/FlutterLogView.java
+++ b/src/io/flutter/logging/FlutterLogView.java
@@ -425,8 +425,7 @@ public class FlutterLogView extends JPanel implements ConsoleView, DataProvider,
         // First selection.
         final String data = nodes.get(0).entry.getData();
         if (JsonUtils.hasJsonData(data)) {
-          @SuppressWarnings("ConstantConditions")
-          final JsonElement jsonElement = new JsonParser().parse(data);
+          @SuppressWarnings("ConstantConditions") final JsonElement jsonElement = new JsonParser().parse(data);
           text = gsonHelper.toJson(jsonElement);
         }
       }
@@ -734,6 +733,10 @@ public class FlutterLogView extends JPanel implements ConsoleView, DataProvider,
   @Override
   public void onEvent(@NotNull FlutterLogEntry entry) {
     logTree.append(entry);
+    if (entry.getKind() == FlutterLogEntry.Kind.WIDGET_ERROR_START) {
+      // Stop auto-scroll on a widget error.
+      scrollToEndAction.disableIfNeeded();
+    }
   }
 
   @Override

--- a/src/io/flutter/logging/util/LineInfo.java
+++ b/src/io/flutter/logging/util/LineInfo.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.logging.util;
+
+import io.flutter.logging.FlutterLogEntry;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+public class LineInfo {
+
+  @NotNull private final String line;
+  @NotNull private final List<StyledText> styledText;
+  private final FlutterLogEntry.Kind kind;
+  @NotNull private final String category;
+
+  public LineInfo(@NotNull String line, @NotNull List<StyledText> styledText, FlutterLogEntry.Kind kind, @NotNull String category) {
+    this.line = line;
+    this.styledText = styledText;
+    this.kind = kind;
+    this.category = category;
+  }
+
+  @NotNull
+  public String getLine() {
+    return line;
+  }
+
+  public FlutterLogEntry.Kind getKind() {
+    return kind;
+  }
+
+  @NotNull
+  public List<StyledText> getStyledText() {
+    return styledText;
+  }
+
+  @NotNull
+  public String getCategory() {
+    return category;
+  }
+}

--- a/src/io/flutter/logging/util/LineParser.java
+++ b/src/io/flutter/logging/util/LineParser.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright 2019 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.logging.util;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.intellij.execution.filters.Filter;
+import com.intellij.execution.filters.HyperlinkInfo;
+import com.intellij.ui.JBColor;
+import com.intellij.ui.SimpleTextAttributes;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.awt.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+
+public abstract class LineParser {
+
+  private final StringBuilder buffer = new StringBuilder();
+  private final List<Filter> filters;
+  @VisibleForTesting
+  protected SimpleTextAttributes style;
+  private String str;
+  private int index;
+  private int length;
+  private boolean flush;
+  private boolean reset;
+  private SimpleTextAttributes previousStyle;
+  private boolean flushPrevious;
+
+  public LineParser(Filter... filter) {
+    this(Arrays.asList(filter));
+  }
+
+  public LineParser(List<Filter> filters) {
+    this.filters = filters;
+  }
+
+  private static Object toStyle(String str) {
+    switch (str) {
+      case "1":
+        return SimpleTextAttributes.STYLE_BOLD;
+      case "3":
+        return SimpleTextAttributes.STYLE_ITALIC;
+      case "4":
+        return SimpleTextAttributes.STYLE_UNDERLINE;
+      case "9":
+        return SimpleTextAttributes.STYLE_STRIKEOUT;
+      case "30":
+        return JBColor.BLACK;
+      case "31":
+        return JBColor.RED;
+      case "32":
+        return JBColor.GREEN;
+      case "33":
+        return JBColor.YELLOW;
+      case "34":
+        return JBColor.BLUE;
+      case "35":
+        return JBColor.MAGENTA;
+      case "36":
+        return JBColor.CYAN;
+      case "37":
+        return JBColor.WHITE;
+      case "38":
+        return JBColor.GRAY;
+      default:
+        return null;
+    }
+  }
+
+  protected void write(@NotNull String string, @Nullable SimpleTextAttributes style) {
+    write(string, style, null);
+  }
+
+  protected void write(@NotNull String string, @Nullable SimpleTextAttributes style, @Nullable Object tag) {
+    write(new StyledText(string, style, tag));
+  }
+
+  public abstract void write(@NotNull StyledText styledText);
+
+  public void parse(@NotNull String str) {
+    if (str.isEmpty()) {
+      return;
+    }
+
+    final List<Filter.ResultItem> resultItems = new ArrayList<>();
+    for (Filter filter : filters) {
+      final Filter.Result result = filter.applyFilter(str, str.length());
+      if (result == null) {
+        continue;
+      }
+      resultItems.addAll(result.getResultItems());
+    }
+    resultItems.sort(Comparator.comparingInt(Filter.ResultItem::getHighlightStartOffset));
+
+    int cursor = 0;
+    for (Filter.ResultItem item : resultItems) {
+      final HyperlinkInfo hyperlinkInfo = item.getHyperlinkInfo();
+      if (hyperlinkInfo != null) {
+        final int start = item.getHighlightStartOffset();
+        final int end = item.getHighlightEndOffset();
+        // Leading text.
+        if (cursor < start) {
+          parseChunk(str.substring(cursor, start));
+        }
+        write(str.substring(start, end), SimpleTextAttributes.LINK_ATTRIBUTES, hyperlinkInfo);
+        cursor = end;
+      }
+    }
+
+    // Trailing text
+    if (cursor < str.length()) {
+      parseChunk(str.substring(cursor));
+    }
+  }
+
+  private void parseChunk(@NotNull String str) {
+    this.str = str;
+    length = str.length();
+    index = 0;
+    while (hasNext()) {
+      parseNext();
+    }
+  }
+
+  private void parseNext() {
+    while (hasNext()) {
+      final char next = advance();
+      if (next == '\u001b') {
+        final boolean readEscape = readEscape();
+        if (!readEscape) {
+          append(next);
+        }
+        else {
+          flush();
+        }
+      }
+      else {
+        append(next);
+      }
+    }
+
+    flush = true;
+    flush();
+  }
+
+  private boolean readEscape() {
+    final boolean reset = readReset();
+    if (reset) {
+      this.reset = true;
+      return true;
+    }
+    else {
+      final SimpleTextAttributes style = readStyle();
+      if (style != null) {
+        flushPrevious = true;
+        previousStyle = this.style;
+        this.style = style;
+        flush = true;
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private void flush() {
+    if (flush || reset) {
+      if (buffer.length() > 0) {
+        write(buffer.toString(), flushPrevious ? previousStyle : style);
+        buffer.setLength(0);
+      }
+      flush = false;
+      flushPrevious = false;
+    }
+    if (reset) {
+      style = null;
+      reset = false;
+    }
+  }
+
+  private void append(char ch) {
+    flush();
+    buffer.append(ch);
+  }
+
+  private boolean readReset() {
+    if (peek(3).equals("[0m")) {
+      eat(3);
+      return true;
+    }
+    return false;
+  }
+
+  @Nullable
+  private SimpleTextAttributes readStyle() {
+    if (!peek(1).equals("[")) {
+      return null;
+    }
+
+    final String remainder = str.substring(index);
+    final int escapeEndIndex = remainder.indexOf("m");
+    if (escapeEndIndex == -1) {
+      return null;
+    }
+
+    final String paramString = remainder.substring(1, escapeEndIndex);
+
+    // Eat params + leading [ and trailing m
+    eat(paramString.length() + 2);
+
+    Color color = null;
+    int fontStyle = SimpleTextAttributes.STYLE_PLAIN;
+
+    for (String param : paramString.split(";")) {
+      final Object style = toStyle(param);
+      if (style instanceof Color) {
+        color = (Color)style;
+      }
+      else if (style instanceof Integer) {
+        fontStyle |= (int)style;
+      }
+    }
+
+    //noinspection MagicConstant
+    return new SimpleTextAttributes(fontStyle, color);
+  }
+
+  private String peek(int n) {
+    return index + n > length ? "" : str.substring(index, index + n);
+  }
+
+  private void eat(int n) {
+    index += n;
+  }
+
+  private char advance() {
+    return str.charAt(index++);
+  }
+
+  boolean hasNext() {
+    return index < str.length();
+  }
+
+  boolean atEnd() {
+    return index >= str.length();
+  }
+
+  public void clear() {
+    this.style = null;
+  }
+}

--- a/src/io/flutter/logging/util/StyledText.java
+++ b/src/io/flutter/logging/util/StyledText.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.logging.util;
+
+import com.intellij.ui.SimpleTextAttributes;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class StyledText {
+  @NotNull private final String text;
+  @Nullable private final SimpleTextAttributes style;
+  @Nullable private final Object tag;
+
+  public StyledText(@NotNull String text, @Nullable SimpleTextAttributes style) {
+    this(text, style, null);
+  }
+
+  public StyledText(@NotNull String text, @Nullable SimpleTextAttributes style, @Nullable Object tag) {
+    this.text = text;
+    this.style = style;
+    this.tag = tag;
+  }
+
+  @Nullable
+  public SimpleTextAttributes getStyle() {
+    return style;
+  }
+
+  @NotNull
+  public String getText() {
+    return text;
+  }
+
+  @Nullable
+  public Object getTag() {
+    return tag;
+  }
+}

--- a/src/io/flutter/run/daemon/FlutterApp.java
+++ b/src/io/flutter/run/daemon/FlutterApp.java
@@ -93,7 +93,7 @@ public class FlutterApp {
   private final AtomicReference<State> myState = new AtomicReference<>(State.STARTING);
   private final EventDispatcher<FlutterAppListener> listenersDispatcher = EventDispatcher.create(FlutterAppListener.class);
 
-  private @NotNull final FlutterLog myFlutterLog = new FlutterLog();
+  private @NotNull final FlutterLog myFlutterLog;
   private final ObservatoryConnector myConnector;
   private FlutterDebugProcess myFlutterDebugProcess;
   private @Nullable VmService myVmService;
@@ -120,6 +120,7 @@ public class FlutterApp {
              @NotNull GeneralCommandLine command) {
     myProject = project;
     myModule = module;
+    myFlutterLog = new FlutterLog(project, module);
     myMode = mode;
     myDevice = device;
     myProcessHandler = processHandler;

--- a/testSrc/unit/io/flutter/logging/util/LineParserTest.java
+++ b/testSrc/unit/io/flutter/logging/util/LineParserTest.java
@@ -18,7 +18,6 @@ import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 
-@SuppressWarnings("UseJBColor")
 public class LineParserTest {
   static final SimpleTextAttributes PLAIN_RED = new SimpleTextAttributes(SimpleTextAttributes.STYLE_PLAIN, Color.RED);
   static final SimpleTextAttributes BOLD_RED = new SimpleTextAttributes(SimpleTextAttributes.STYLE_BOLD, Color.RED);

--- a/testSrc/unit/io/flutter/logging/util/LineParserTest.java
+++ b/testSrc/unit/io/flutter/logging/util/LineParserTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2019 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.logging.util;
+
+import com.intellij.execution.filters.BrowserHyperlinkInfo;
+import com.intellij.execution.filters.UrlFilter;
+import com.intellij.ui.SimpleTextAttributes;
+import com.intellij.util.ReflectionUtil;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.awt.*;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+
+@SuppressWarnings("UseJBColor")
+public class LineParserTest {
+  static final SimpleTextAttributes PLAIN_RED = new SimpleTextAttributes(SimpleTextAttributes.STYLE_PLAIN, Color.RED);
+  static final SimpleTextAttributes BOLD_RED = new SimpleTextAttributes(SimpleTextAttributes.STYLE_BOLD, Color.RED);
+  static final SimpleTextAttributes STRIKEOUT_RED = new SimpleTextAttributes(SimpleTextAttributes.STYLE_STRIKEOUT, Color.RED);
+  static final SimpleTextAttributes BOLD_BLUE = new SimpleTextAttributes(SimpleTextAttributes.STYLE_BOLD, Color.BLUE);
+  static final SimpleTextAttributes LINK = SimpleTextAttributes.LINK_ATTRIBUTES;
+
+  static class TestParser extends LineParser {
+    final List<StyledText> parsed = new ArrayList<>();
+
+    TestParser() {
+      super(new UrlFilter());
+    }
+
+    @Override
+    public void write(@NotNull StyledText styledText) {
+      parsed.add(styledText);
+    }
+  }
+
+  @Test
+  public void test8bitBasic() {
+    expectParsesTo("Hello", new StyledText("Hello", null));
+    expectParsesTo("\u001b[31mHello", new StyledText("Hello", PLAIN_RED));
+    expectParsesTo("\u001b[31mHello\u001b[0m World",
+                   new StyledText("Hello", PLAIN_RED), new StyledText(" World", null));
+  }
+
+  @Test
+  public void test8bitFontStyle() {
+    expectParsesTo("\u001b[31;1mHello", text("Hello", BOLD_RED));
+    expectParsesTo("Hello \u001b[31;1mWorld\u001b[0m", text("Hello ", null), text("World", BOLD_RED));
+    expectParsesTo("\u001b[34;1mHello", text("Hello", BOLD_BLUE));
+    expectParsesTo("\u001b[31;1mHello\u001b[0m World", text("Hello", BOLD_RED), text(" World", null));
+    expectParsesTo("\u001b[9;31mHello", text("Hello", STRIKEOUT_RED));
+    expectParsesTo("\u001b[31;1mHello\u001b[0m\u001b[34;1m World\u001b[0m",
+                   text("Hello", BOLD_RED), text(" World", BOLD_BLUE));
+  }
+
+  static StyledText text(String string, SimpleTextAttributes style) {
+    return new StyledText(string, style);
+  }
+
+  @Test
+  public void testLinks() {
+    expectParsesTo("https://www.dartlang.org", text("https://www.dartlang.org", LINK));
+    expectParsesTo("Hello https://www.dartlang.org", text("Hello ", null), text("https://www.dartlang.org", LINK));
+    expectParsesTo("Hello https://www.dartlang.org from test",
+                   text("Hello ", null),
+                   text("https://www.dartlang.org", LINK),
+                   text(" from test", null));
+    expectParsesTo("Hello https://www.dartlang.org from \u001b[31;1mtest\u001b[0m",
+                   text("Hello ", null),
+                   text("https://www.dartlang.org", LINK),
+                   text(" from ", null),
+                   text("test", BOLD_RED));
+  }
+
+  @Test
+  public void testLinkTag() {
+    expectParsesTo("https://www.dartlang.org", new StyledText("https://www.dartlang.org", LINK,
+                                                              new BrowserHyperlinkInfo("https://www.dartlang.org")));
+  }
+
+  @Test
+  public void testParse() {
+    final TestParser parser = new TestParser();
+    parser.parse("\u001b[31;1mHello");
+    // Validate styles stick.
+    assertEquals(BOLD_RED, parser.style);
+    assertEquals(arrayOf(text("Hello", BOLD_RED)), parser.parsed);
+
+    parser.parse(" World");
+    assertEquals(BOLD_RED, parser.style);
+    assertEquals(arrayOf(text("Hello", BOLD_RED), text(" World", BOLD_RED)), parser.parsed);
+
+    // Reset.
+    parser.parse("\u001b[0m");
+    assertEquals(null, parser.style);
+
+    parser.parse("!");
+    assertEquals(arrayOf(text("Hello", BOLD_RED), text(" World", BOLD_RED), text("!", null)), parser.parsed);
+  }
+
+  private static StyledText[] arrayOf(StyledText... texts) {
+    return texts;
+  }
+
+  private static void expectParsesTo(String str, StyledText... results) {
+    final TestParser parser = new TestParser();
+    parser.parse(str);
+    assertEquals(results, parser.parsed);
+  }
+
+  private static void assertEquals(StyledText[] expected, List<StyledText> actual) {
+    for (int i = 0; i < expected.length; ++i) {
+      assertEquals(expected[i], actual.get(i));
+    }
+  }
+
+  private static void assertEquals(StyledText expected, StyledText actual) {
+    Assert.assertEquals(expected.getText(), actual.getText());
+    assertEquals(expected.getStyle(), actual.getStyle());
+    final String expectedUrl = getUrl(expected.getTag());
+    // If a tag is specified, check it.
+    if (expectedUrl != null) {
+      Assert.assertEquals(expectedUrl, getUrl(actual.getTag()));
+    }
+  }
+
+  private static String getUrl(Object tag) {
+    if (tag instanceof BrowserHyperlinkInfo) {
+      final Field field = ReflectionUtil.getDeclaredField(tag.getClass(), "myUrl");
+      if (field != null) {
+        try {
+          return (String)field.get(tag);
+        }
+        catch (Throwable ignored) {
+        }
+      }
+    }
+    return null;
+  }
+
+  private static void assertEquals(SimpleTextAttributes expected, SimpleTextAttributes actual) {
+    if (expected == null) {
+      Assert.assertNull(actual);
+    }
+    else {
+      Assert.assertNotNull(actual);
+      Assert.assertEquals(expected.getStyle(), actual.getStyle());
+      Assert.assertEquals(expected.getFontStyle(), actual.getFontStyle());
+      Assert.assertEquals(expected.getFgColor(), actual.getFgColor());
+    }
+  }
+}


### PR DESCRIPTION
Adds basic ANSI color escape handling and generally reworks when/how we calculate styles for log entry rendering.

High points:

* supports 8 bit colors and styles that correspond to the error reporting presentation improvements being exploring w/ @InMatrix (fixes: #2552)
* disables auto-scroll on widget errors (fixes: #3033)
* parses style information on entry receipt once (and not on every rendering)

Example output (w/ a version of Flutter patched to include ansi colors):

![image](https://user-images.githubusercontent.com/67586/50616592-f4ba1180-0e9d-11e9-84fb-274930af67c2.png)

While the render fixes are a definite performance improvement, there's still some more work there (see #2776 for example) and the styling will evolve to track requirements driven by framework changes but this is complete enough I think to not hide behind a flag.  Happy to reconsider if anyone feels differently though.  👍 



/cc @jacob314 @devoncarew