### PR TITLE
Add org.apache.commons.io.IOUtils to the classpath for the source build

### DIFF
--- a/flutter-intellij-community.iml
+++ b/flutter-intellij-community.iml
@@ -50,5 +50,6 @@
     <orderEntry type="library" exported="" name="Dart Packages" level="project" />
     <orderEntry type="library" name="miglayout-swing" level="project" />
     <orderEntry type="library" name="netty-codec-http" level="project" />
+    <orderEntry type="library" name="commons-io" level="project" />
   </component>
 </module>


### PR DESCRIPTION
@pq @devoncarew 

Fix a compilation error in FlutterSampleManager.