### PR TITLE
restore log level combo

### DIFF
--- a/src/io/flutter/logging/FlutterLogFilterPanel.form
+++ b/src/io/flutter/logging/FlutterLogFilterPanel.form
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="io.flutter.logging.FlutterLogFilterPanel">
-  <grid id="27dc6" binding="root" layout-manager="GridLayoutManager" row-count="1" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="root" layout-manager="GridLayoutManager" row-count="1" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="34" width="500" height="35"/>
     </constraints>
     <properties>
       <enabled value="true"/>
-      <minimumSize width="400" height="35"/>
-      <preferredSize width="400" height="35"/>
+      <minimumSize width="500" height="35"/>
+      <preferredSize width="500" height="35"/>
     </properties>
     <border type="none"/>
     <children>
       <component id="20384" class="javax.swing.JCheckBox" binding="matchCaseCheckBox">
         <constraints>
-          <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Match case"/>
@@ -22,7 +22,7 @@
       </component>
       <component id="d9caf" class="javax.swing.JCheckBox" binding="regexCheckBox">
         <constraints>
-          <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="0" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Regex"/>
@@ -30,12 +30,34 @@
       </component>
       <component id="b7426" class="com.intellij.ui.SearchTextField" binding="textExpression" custom-create="true">
         <constraints>
-          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false">
+          <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false">
             <minimum-size width="50" height="-1"/>
             <preferred-size width="200" height="-1"/>
           </grid>
         </constraints>
         <properties/>
+      </component>
+      <component id="4ad5d" class="javax.swing.JComboBox" binding="logLevelComboBox">
+        <constraints>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="0" indent="0" use-parent-layout="false">
+            <minimum-size width="100" height="-1"/>
+            <preferred-size width="100" height="-1"/>
+            <maximum-size width="100" height="-1"/>
+          </grid>
+        </constraints>
+        <properties>
+          <model>
+            <item value="NONE"/>
+            <item value="FINEST"/>
+            <item value="FINER"/>
+            <item value="FINE"/>
+            <item value="CONFIG"/>
+            <item value="INFO"/>
+            <item value="WARNING"/>
+            <item value="SEVERE"/>
+            <item value="SHOUT"/>
+          </model>
+        </properties>
       </component>
     </children>
   </grid>

--- a/src/io/flutter/logging/FlutterLogFilterPanel.java
+++ b/src/io/flutter/logging/FlutterLogFilterPanel.java
@@ -104,7 +104,7 @@ public class FlutterLogFilterPanel {
     final List<FlutterLog.Level> logLevels = Arrays.stream(FlutterLog.Level.values())
       .collect(Collectors.toList());
     logLevelComboBox.setModel(new CollectionComboBoxModel<>(logLevels));
-    logLevelComboBox.setSelectedItem(FlutterLog.Level.CONFIG);
+    logLevelComboBox.setSelectedItem(FlutterLog.Level.NONE);
     logLevelComboBox.addActionListener(event -> onFilterListener.onFilter(getCurrentFilterParam()));
     logLevelComboBox.setRenderer(new ColoredListCellRenderer<FlutterLog.Level>() {
       @Override

--- a/src/io/flutter/logging/FlutterLogFilterPanel.java
+++ b/src/io/flutter/logging/FlutterLogFilterPanel.java
@@ -6,6 +6,8 @@
 package io.flutter.logging;
 
 import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.ui.CollectionComboBoxModel;
+import com.intellij.ui.ColoredListCellRenderer;
 import com.intellij.ui.SearchTextField;
 import com.intellij.util.ui.UIUtil;
 import org.jetbrains.annotations.NotNull;
@@ -93,6 +95,7 @@ public class FlutterLogFilterPanel {
   private JCheckBox matchCaseCheckBox;
   private JCheckBox regexCheckBox;
   private SearchTextField textExpression;
+  private JComboBox<FlutterLog.Level> logLevelComboBox;
 
   public FlutterLogFilterPanel(@NotNull OnFilterListener onFilterListener) {
     this.onFilterListener = onFilterListener;
@@ -100,11 +103,26 @@ public class FlutterLogFilterPanel {
     regexCheckBox.addItemListener(e -> onFilterListener.onFilter(getCurrentFilterParam()));
     final List<FlutterLog.Level> logLevels = Arrays.stream(FlutterLog.Level.values())
       .collect(Collectors.toList());
+    logLevelComboBox.setModel(new CollectionComboBoxModel<>(logLevels));
+    logLevelComboBox.setSelectedItem(FlutterLog.Level.CONFIG);
+    logLevelComboBox.addActionListener(event -> onFilterListener.onFilter(getCurrentFilterParam()));
+    logLevelComboBox.setRenderer(new ColoredListCellRenderer<FlutterLog.Level>() {
+      @Override
+      protected void customizeCellRenderer(@NotNull JList<? extends FlutterLog.Level> list,
+                                           FlutterLog.Level value,
+                                           int index,
+                                           boolean selected,
+                                           boolean hasFocus) {
+        append(value.toDisplayString());
+      }
+    });
   }
 
   @NotNull
   public FilterParam getCurrentFilterParam() {
-    return new FilterParam(textExpression.getText(), matchCaseCheckBox.isSelected(), regexCheckBox.isSelected(), FlutterLog.Level.NONE);
+    final Object selected = logLevelComboBox.getSelectedItem();
+    final FlutterLog.Level logLevel = selected == null ? FlutterLog.Level.NONE : (FlutterLog.Level)selected;
+    return new FilterParam(textExpression.getText(), matchCaseCheckBox.isSelected(), regexCheckBox.isSelected(), logLevel);
   }
 
   @NotNull
@@ -115,6 +133,7 @@ public class FlutterLogFilterPanel {
   public void initFromPreferences(@NotNull FlutterLogPreferences flutterLogPreferences) {
     regexCheckBox.setSelected(flutterLogPreferences.isToolWindowRegex());
     matchCaseCheckBox.setSelected(flutterLogPreferences.isToolWindowMatchCase());
+    logLevelComboBox.setSelectedItem(FlutterLog.Level.forValue(flutterLogPreferences.getToolWindowLogLevel()));
   }
 
   @Nullable

--- a/src/io/flutter/logging/FlutterLogTree.java
+++ b/src/io/flutter/logging/FlutterLogTree.java
@@ -53,22 +53,6 @@ public class FlutterLogTree extends TreeTable {
   private static final SimpleDateFormat TIMESTAMP_FORMAT = new SimpleDateFormat("HH:mm:ss.SSS");
   private static final Logger LOG = Logger.getInstance(FlutterLogTree.class);
 
-  @NotNull
-  private static final Map<FlutterLog.Level, String> LOG_LEVEL_FILTER;
-
-  static {
-    LOG_LEVEL_FILTER = new HashMap<>();
-    LOG_LEVEL_FILTER.put(FlutterLog.Level.NONE, "NONE|FINEST|FINER|FINE|CONFIG|INFO|WARNING|SEVERE|SHOUT");
-    LOG_LEVEL_FILTER.put(FlutterLog.Level.FINEST, "FINEST|FINER|FINE|CONFIG|INFO|WARNING|SEVERE|SHOUT");
-    LOG_LEVEL_FILTER.put(FlutterLog.Level.FINER, "FINER|FINE|CONFIG|INFO|WARNING|SEVERE|SHOUT");
-    LOG_LEVEL_FILTER.put(FlutterLog.Level.FINE, "FINE|CONFIG|INFO|WARNING|SEVERE|SHOUT");
-    LOG_LEVEL_FILTER.put(FlutterLog.Level.CONFIG, "CONFIG|INFO|WARNING|SEVERE|SHOUT");
-    LOG_LEVEL_FILTER.put(FlutterLog.Level.INFO, "INFO|WARNING|SEVERE|SHOUT");
-    LOG_LEVEL_FILTER.put(FlutterLog.Level.WARNING, "WARNING|SEVERE|SHOUT");
-    LOG_LEVEL_FILTER.put(FlutterLog.Level.SEVERE, "SEVERE|SHOUT");
-    LOG_LEVEL_FILTER.put(FlutterLog.Level.SHOUT, "SHOUT");
-  }
-
   private static class ColumnModel {
 
     private abstract class EntryCellRenderer extends ColoredTableCellRenderer {
@@ -658,13 +642,12 @@ public class FlutterLogTree extends TreeTable {
   }
 
   private RowFilter<TableModel, Object> getRowFilter(@NotNull FlutterLogFilterPanel.FilterParam filter) {
-    // TODO(pq): regexps are heavyweight for level filtering; simplify to use an ordinal.
-    final RowFilter<TableModel, Object> logLevelFilter =
-      RowFilter.regexFilter(LOG_LEVEL_FILTER.get(filter.getLogLevel()), FlutterTreeTableModel.ColumnIndex.LOG_LEVEL.index);
+    final RowFilter<TableModel, Object> logLevelFilter = RowFilter
+      .numberFilter(RowFilter.ComparisonType.AFTER, filter.getLogLevel().value - 1, FlutterTreeTableModel.ColumnIndex.LOG_LEVEL.index);
     final RowFilter<TableModel, Object> expressionFilter = getExpressionFilter(filter);
     return expressionFilter != null ? RowFilter.andFilter(Arrays.asList(logLevelFilter, expressionFilter)) : logLevelFilter;
   }
-  
+
   private RowFilter<TableModel, Object> getExpressionFilter(@NotNull FlutterLogFilterPanel.FilterParam filter) {
     final String nonNullExpression = filter.getExpression() == null ? "" : filter.getExpression();
     if (!nonNullExpression.isEmpty() || filter.isMatchCase() || filter.isRegex()) {

--- a/src/io/flutter/logging/FlutterLogTree.java
+++ b/src/io/flutter/logging/FlutterLogTree.java
@@ -53,6 +53,22 @@ public class FlutterLogTree extends TreeTable {
   private static final SimpleDateFormat TIMESTAMP_FORMAT = new SimpleDateFormat("HH:mm:ss.SSS");
   private static final Logger LOG = Logger.getInstance(FlutterLogTree.class);
 
+  @NotNull
+  private static final Map<FlutterLog.Level, String> LOG_LEVEL_FILTER;
+
+  static {
+    LOG_LEVEL_FILTER = new HashMap<>();
+    LOG_LEVEL_FILTER.put(FlutterLog.Level.NONE, "NONE|FINEST|FINER|FINE|CONFIG|INFO|WARNING|SEVERE|SHOUT");
+    LOG_LEVEL_FILTER.put(FlutterLog.Level.FINEST, "FINEST|FINER|FINE|CONFIG|INFO|WARNING|SEVERE|SHOUT");
+    LOG_LEVEL_FILTER.put(FlutterLog.Level.FINER, "FINER|FINE|CONFIG|INFO|WARNING|SEVERE|SHOUT");
+    LOG_LEVEL_FILTER.put(FlutterLog.Level.FINE, "FINE|CONFIG|INFO|WARNING|SEVERE|SHOUT");
+    LOG_LEVEL_FILTER.put(FlutterLog.Level.CONFIG, "CONFIG|INFO|WARNING|SEVERE|SHOUT");
+    LOG_LEVEL_FILTER.put(FlutterLog.Level.INFO, "INFO|WARNING|SEVERE|SHOUT");
+    LOG_LEVEL_FILTER.put(FlutterLog.Level.WARNING, "WARNING|SEVERE|SHOUT");
+    LOG_LEVEL_FILTER.put(FlutterLog.Level.SEVERE, "SEVERE|SHOUT");
+    LOG_LEVEL_FILTER.put(FlutterLog.Level.SHOUT, "SHOUT");
+  }
+
   private static class ColumnModel {
 
     private abstract class EntryCellRenderer extends ColoredTableCellRenderer {
@@ -642,19 +658,24 @@ public class FlutterLogTree extends TreeTable {
   }
 
   private RowFilter<TableModel, Object> getRowFilter(@NotNull FlutterLogFilterPanel.FilterParam filter) {
+    // TODO(pq): regexps are heavyweight for level filtering; simplify to use an ordinal.
+    final RowFilter<TableModel, Object> logLevelFilter =
+      RowFilter.regexFilter(LOG_LEVEL_FILTER.get(filter.getLogLevel()), FlutterTreeTableModel.ColumnIndex.LOG_LEVEL.index);
+    final RowFilter<TableModel, Object> expressionFilter = getExpressionFilter(filter);
+    return expressionFilter != null ? RowFilter.andFilter(Arrays.asList(logLevelFilter, expressionFilter)) : logLevelFilter;
+  }
+  
+  private RowFilter<TableModel, Object> getExpressionFilter(@NotNull FlutterLogFilterPanel.FilterParam filter) {
     final String nonNullExpression = filter.getExpression() == null ? "" : filter.getExpression();
     if (!nonNullExpression.isEmpty() || filter.isMatchCase() || filter.isRegex()) {
       final String quoteRegex = filter.isRegex() ? nonNullExpression : Pattern.quote(nonNullExpression);
       final String matchCaseRegex = filter.isMatchCase() ? "" : "(?i)";
       final String standardRegex = matchCaseRegex + "(?s).*" + quoteRegex + ".*";
-      final RowFilter<TableModel, Object> logMessageFilter;
-      final RowFilter<TableModel, Object> logLevelFilter;
       try {
         return RowFilter.regexFilter(
           standardRegex,
           FlutterTreeTableModel.ColumnIndex.MESSAGE.index,
-          FlutterTreeTableModel.ColumnIndex.CATEGORY.index,
-          FlutterTreeTableModel.ColumnIndex.LOG_LEVEL.index
+          FlutterTreeTableModel.ColumnIndex.CATEGORY.index
         );
       }
       catch (PatternSyntaxException e) {
@@ -662,7 +683,7 @@ public class FlutterLogTree extends TreeTable {
       }
     }
 
-    return EMPTY_FILTER;
+    return null;
   }
 
   void append(@NotNull FlutterLogEntry entry) {

--- a/src/io/flutter/logging/FlutterTreeTableModel.java
+++ b/src/io/flutter/logging/FlutterTreeTableModel.java
@@ -50,7 +50,7 @@ class FlutterTreeTableModel implements TableModel {
     final ColumnIndex index = ColumnIndex.forIndex(columnIndex);
 
     if (index != ColumnIndex.INVALID && obj instanceof FlutterLogEntry) {
-      return index.toLogString((FlutterLogEntry)obj);
+      return index.toValue((FlutterLogEntry)obj);
     }
     return obj;
   }
@@ -73,26 +73,26 @@ class FlutterTreeTableModel implements TableModel {
   public enum ColumnIndex {
     INVALID(-1) {
       @Override
-      public String toLogString(@NotNull FlutterLogEntry entry) {
-        throw new IllegalStateException("Can't get log string for `INVALID`");
+      public Object toValue(@NotNull FlutterLogEntry entry) {
+        throw new IllegalStateException("Can't get value for `INVALID`");
       }
     },
     MESSAGE(0) {
       @Override
-      public String toLogString(@NotNull FlutterLogEntry entry) {
+      public Object toValue(@NotNull FlutterLogEntry entry) {
         return entry.getMessage();
       }
     },
     CATEGORY(1) {
       @Override
-      public String toLogString(@NotNull FlutterLogEntry entry) {
+      public Object toValue(@NotNull FlutterLogEntry entry) {
         return entry.getCategory();
       }
     },
     LOG_LEVEL(2) {
       @Override
-      public String toLogString(@NotNull FlutterLogEntry entry) {
-        return FlutterLog.Level.forValue(entry.getLevel()).name();
+      public Object toValue(@NotNull FlutterLogEntry entry) {
+        return entry.getLevel();
       }
     };
 
@@ -102,7 +102,7 @@ class FlutterTreeTableModel implements TableModel {
       this.index = index;
     }
 
-    public abstract String toLogString(@NotNull FlutterLogEntry entry);
+    public abstract Object toValue(@NotNull FlutterLogEntry entry);
 
     @NotNull
     public static ColumnIndex forIndex(int index) {


### PR DESCRIPTION
Restores work from @quangson91 based on user feedback.

![image](https://user-images.githubusercontent.com/67586/50800279-7215c580-1294-11e9-8691-e4af68774097.png)

(Level checking has been updated to prefer ordinal value checking over regexps for performance reasons but otherwise this is substantially the same as what was reverted in https://github.com/flutter/flutter-intellij/pull/2686.)

/cc @jacob314  @quangson91 

Fixes: #3039