### PR TITLE
Fill in truncated log entries

### DIFF
--- a/src/io/flutter/logging/FlutterLogEntry.java
+++ b/src/io/flutter/logging/FlutterLogEntry.java
@@ -5,7 +5,9 @@
  */
 package io.flutter.logging;
 
+import com.intellij.execution.filters.Filter;
 import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.ui.SimpleTextAttributes;
 import io.flutter.logging.util.LineInfo;
 import io.flutter.logging.util.StyledText;
 import org.jetbrains.annotations.NotNull;
@@ -29,7 +31,7 @@ public class FlutterLogEntry {
   private final String category;
   private final int level;
   @NotNull
-  private final String message;
+  private String message;
   // TODO(pq): consider making data an Instance or JsonElement
   @Nullable
   private String data;
@@ -37,24 +39,37 @@ public class FlutterLogEntry {
 
   @NotNull
   private final Kind kind;
-  @NotNull private final List<StyledText> styledText;
+  private List<StyledText> styledText;
+
+  @NotNull private final List<Filter> filters;
+
+  /**
+   * Describes any style info that was inherited from previously parsed lines.
+   */
+  @Nullable
+  private final SimpleTextAttributes inheritedStyle;
 
   public FlutterLogEntry(long timestamp,
                          @NotNull String category,
                          int level,
                          @Nullable String message,
                          @NotNull Kind kind,
-                         @NotNull List<StyledText> styledText) {
+                         @NotNull List<StyledText> styledText,
+                         @NotNull List<Filter> filters,
+                         @Nullable SimpleTextAttributes inheritedStyle) {
     this.timestamp = timestamp;
     this.category = category;
     this.level = level;
     this.message = StringUtil.notNullize(message);
     this.kind = kind;
     this.styledText = styledText;
+    this.filters = filters;
+    this.inheritedStyle = inheritedStyle;
   }
 
   public FlutterLogEntry(long timestamp, @NotNull LineInfo info, int level) {
-    this(timestamp, info.getCategory(), level, info.getLine(), info.getKind(), info.getStyledText());
+    this(timestamp, info.getCategory(), level, info.getLine(), info.getKind(), info.getStyledText(), info.getFilters(),
+         info.getInheritedStyle());
   }
 
   @Nullable
@@ -94,10 +109,25 @@ public class FlutterLogEntry {
     return message;
   }
 
+  public void setMessage(@NotNull String message) {
+    this.message = message;
+    this.styledText = null;
+  }
+
   @NotNull
   public List<StyledText> getStyledText() {
+    if (styledText == null) {
+      styledText = calculateStyledText();
+    }
     return styledText;
   }
+
+  private List<StyledText> calculateStyledText() {
+    final FlutterLogEntryParser.LineHandler lineHandler = new FlutterLogEntryParser.LineHandler(filters, inheritedStyle);
+    final LineInfo lineInfo = lineHandler.parseLineInfo(getMessage(), getCategory());
+    return lineInfo.getStyledText();
+  }
+
 
   /**
    * Return a sequence number, or -1 if unset.

--- a/src/io/flutter/logging/FlutterLogEntryParser.java
+++ b/src/io/flutter/logging/FlutterLogEntryParser.java
@@ -16,6 +16,7 @@ import com.intellij.execution.ui.ConsoleViewContentType;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Key;
+import com.intellij.ui.SimpleTextAttributes;
 import com.jetbrains.lang.dart.ide.runner.DartConsoleFilter;
 import io.flutter.console.FlutterConsoleFilter;
 import io.flutter.logging.util.LineInfo;
@@ -63,7 +64,7 @@ public class FlutterLogEntryParser {
   private final LineHandler lineHandler;
 
   public FlutterLogEntryParser(@NotNull Project project, @Nullable Module module) {
-    lineHandler = new LineHandler(project, module);
+    lineHandler = new LineHandler(createMessageFilters(project, module), null);
   }
 
   public void setDebugProcess(FlutterDebugProcess debugProcess) {
@@ -101,15 +102,29 @@ public class FlutterLogEntryParser {
       }
     }
 
-    // TODO(pq): If message.getValueAsStringIsTruncated() is true, we'll need to retrieve the full string
-    // value and update this entry after creation.
-    String messageStr = message.getValueAsString();
-    if (message.getValueAsStringIsTruncated()) {
-      messageStr += "...";
-    }
+    final String messageStr = message.getValueAsString();
+    final FlutterLogEntry entry = lineHandler.parseEntry(messageStr, category, level);
 
-    final LineInfo lineInfo = parseLine(messageStr, category);
-    final FlutterLogEntry entry =  new FlutterLogEntry(timestamp(), lineInfo, level);
+    if (message.getValueAsStringIsTruncated()) {
+      entry.setMessage(messageStr + "...");
+      final Isolate isolate = new Isolate(json.get("isolate").getAsJsonObject());
+      debugProcess.getVmServiceWrapper().getObject(isolate.getId(), message.getId(), new GetObjectConsumer() {
+        @Override
+        public void received(Obj response) {
+          entry.setMessage(((Instance)response).getValueAsString());
+        }
+
+        @Override
+        public void received(Sentinel response) {
+          // TODO(pq): handle?
+        }
+
+        @Override
+        public void onError(RPCError error) {
+          // TODO(pq): log?
+        }
+      });
+    }
 
     final Instance data = new Instance(logRecord.getAsJsonObject().get("error").getAsJsonObject());
     if (!data.getValueAsStringIsTruncated()) {
@@ -152,10 +167,16 @@ public class FlutterLogEntryParser {
     final long timeMs = Math.round(time * 1000);
     final double usedMB = used / (1024.0 * 1024.0);
     final double maxMB = maxHeap / (1024.0 * 1024.0);
-    final String message = "collection time " + nf.format(timeMs) + "ms • " +  df1.format(usedMB) + "MB used of " + df1.format(maxMB) + "MB • " + isolateRef.getId();
+    final String message = "collection time " +
+                           nf.format(timeMs) +
+                           "ms • " +
+                           df1.format(usedMB) +
+                           "MB used of " +
+                           df1.format(maxMB) +
+                           "MB • " +
+                           isolateRef.getId();
 
-    final LineInfo lineInfo = parseLine(message, GC_CATEGORY);
-    return new FlutterLogEntry(timestamp(), lineInfo, UNDEFINED_LEVEL.value);
+    return lineHandler.parseEntry(message, GC_CATEGORY, UNDEFINED_LEVEL.value);
   }
 
   private static Kind parseKind(@NotNull String message, @NotNull String category) {
@@ -215,8 +236,9 @@ public class FlutterLogEntryParser {
   static class LineHandler extends LineParser {
     final List<StyledText> parsed = new ArrayList<>();
 
-    LineHandler(@NotNull Project project, @Nullable Module module) {
-      super(createMessageFilters(project, module));
+    LineHandler(@NotNull List<Filter> filters, @Nullable SimpleTextAttributes initialStyle) {
+      super(filters);
+      this.style = initialStyle;
     }
 
     @Override
@@ -224,7 +246,7 @@ public class FlutterLogEntryParser {
       parsed.add(styledText);
     }
 
-    List<StyledText> parseLine(@NotNull String line) {
+    private List<StyledText> parseLineStyle(@NotNull String line) {
       parse(line);
       // Copy results and clear.
       final ArrayList<StyledText> results = new ArrayList<>(parsed);
@@ -232,20 +254,39 @@ public class FlutterLogEntryParser {
       return results;
     }
 
-    @NotNull
-    static List<Filter> createMessageFilters(@NotNull Project project, @Nullable Module module) {
-      final List<Filter> filters = new ArrayList<>();
-      if (module != null) {
-        filters.add(new FlutterConsoleFilter(module));
+    LineInfo parseLineInfo(@NotNull String line, @NotNull String category) {
+      // Any carried over style info needs to be stored so it can be used by lines that need to be re-rendered.
+      // (For example, if they are truncated on arrival and need to be reconstituted with full content.)
+      final SimpleTextAttributes carriedOverStyle = style;
+
+      final Kind kind = parseKind(line, category);
+      // On reloads / restarts, clear cached styles in case we're in the middle of an unterminated style block.
+      if (kind == FlutterLogEntry.Kind.RELOAD || kind == FlutterLogEntry.Kind.RESTART) {
+        clear();
       }
-      filters.addAll(Arrays.asList(
-        new DartConsoleFilter(project, project.getBaseDir()),
-        new UrlFilter()
-      ));
-      return filters;
+
+      final List<StyledText> styledText = parseLineStyle(line);
+      return new LineInfo(line, styledText, kind, category, filters, carriedOverStyle);
+    }
+
+    FlutterLogEntry parseEntry(@NotNull String line, @NotNull String category, int level) {
+      final LineInfo lineInfo = parseLineInfo(line, category);
+      return new FlutterLogEntry(timestamp(), lineInfo, level);
     }
   }
 
+  @NotNull
+  static List<Filter> createMessageFilters(@NotNull Project project, @Nullable Module module) {
+    final List<Filter> filters = new ArrayList<>();
+    if (module != null) {
+      filters.add(new FlutterConsoleFilter(module));
+    }
+    filters.addAll(Arrays.asList(
+      new DartConsoleFilter(project, project.getBaseDir()),
+      new UrlFilter()
+    ));
+    return filters;
+  }
 
   @VisibleForTesting
   @Nullable
@@ -265,25 +306,11 @@ public class FlutterLogEntryParser {
         }
         // Fix unicode escape codes.
         line = line.replaceAll("\\\\\\^\\[", "\u001b");
-
-        final LineInfo lineInfo = parseLine(line, TOOLS_CATEGORY);
-        return new FlutterLogEntry(timestamp(), lineInfo, UNDEFINED_LEVEL.value);
+        return lineHandler.parseEntry(line, TOOLS_CATEGORY, UNDEFINED_LEVEL.value);
       }
     }
 
     return null;
-  }
-
-
-  LineInfo parseLine(@NotNull String line, @NotNull String category) {
-    final Kind kind = parseKind(line, category);
-    // On reloads / restarts, clear cached styles in case we're in the middle of an unterminated style block.
-    if (kind == FlutterLogEntry.Kind.RELOAD || kind == FlutterLogEntry.Kind.RESTART) {
-      lineHandler.clear();
-    }
-
-    final List<StyledText> styledText = lineHandler.parseLine(line);
-    return new LineInfo(line, styledText, kind, category);
   }
 
   public FlutterLogEntry parseConsoleEvent(String text, ConsoleViewContentType type) {

--- a/src/io/flutter/logging/util/LineInfo.java
+++ b/src/io/flutter/logging/util/LineInfo.java
@@ -5,8 +5,11 @@
  */
 package io.flutter.logging.util;
 
+import com.intellij.execution.filters.Filter;
+import com.intellij.ui.SimpleTextAttributes;
 import io.flutter.logging.FlutterLogEntry;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
@@ -16,17 +19,31 @@ public class LineInfo {
   @NotNull private final List<StyledText> styledText;
   private final FlutterLogEntry.Kind kind;
   @NotNull private final String category;
+  @NotNull private final List<Filter> filters;
+  @Nullable private final SimpleTextAttributes inheritedStyle;
 
-  public LineInfo(@NotNull String line, @NotNull List<StyledText> styledText, FlutterLogEntry.Kind kind, @NotNull String category) {
+  public LineInfo(@NotNull String line,
+                  @NotNull List<StyledText> styledText,
+                  FlutterLogEntry.Kind kind,
+                  @NotNull String category,
+                  @NotNull List<Filter> filters,
+                  @Nullable SimpleTextAttributes inheritedStyle) {
     this.line = line;
     this.styledText = styledText;
     this.kind = kind;
     this.category = category;
+    this.filters = filters;
+    this.inheritedStyle = inheritedStyle;
   }
 
   @NotNull
   public String getLine() {
     return line;
+  }
+
+  @NotNull
+  public List<Filter> getFilters() {
+    return filters;
   }
 
   public FlutterLogEntry.Kind getKind() {
@@ -41,5 +58,10 @@ public class LineInfo {
   @NotNull
   public String getCategory() {
     return category;
+  }
+
+  @Nullable
+  public SimpleTextAttributes getInheritedStyle() {
+    return inheritedStyle;
   }
 }

--- a/src/io/flutter/logging/util/LineParser.java
+++ b/src/io/flutter/logging/util/LineParser.java
@@ -22,7 +22,7 @@ import java.util.List;
 public abstract class LineParser {
 
   private final StringBuilder buffer = new StringBuilder();
-  private final List<Filter> filters;
+  protected final List<Filter> filters;
   @VisibleForTesting
   protected SimpleTextAttributes style;
   private String str;


### PR DESCRIPTION
Adds support for truncated log entries.

* requests full entry from the debugProcess
* preserves any inherited / carried over color-styling

![image](https://user-images.githubusercontent.com/67586/50903029-6c71ca00-13d1-11e9-8140-a786d0a45128.png)

Fixes: #3052 

/cc @jacob314 @devoncarew 