### PR TITLE
add keyboard shortcut for widget extraction

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -687,6 +687,7 @@
     <!-- refactoring menu -->
     <action class="io.flutter.actions.ExtractWidgetAction" id="Flutter.ExtractWidget" text="Flutter Widget...">
       <add-to-group group-id="IntroduceActionsGroup" anchor="after" relative-to-action="ExtractMethod"/>
+      <keyboard-shortcut keymap="$default" first-keystroke="ctrl alt W"/>
     </action>
 
     <!-- help menu -->

--- a/resources/META-INF/plugin_template.xml
+++ b/resources/META-INF/plugin_template.xml
@@ -163,6 +163,7 @@
     <!-- refactoring menu -->
     <action class="io.flutter.actions.ExtractWidgetAction" id="Flutter.ExtractWidget" text="Flutter Widget...">
       <add-to-group group-id="IntroduceActionsGroup" anchor="after" relative-to-action="ExtractMethod"/>
+      <keyboard-shortcut keymap="$default" first-keystroke="ctrl alt W"/>
     </action>
 
     <!-- help menu -->


### PR DESCRIPTION
![screen shot 2019-01-10 at 12 28 03](https://user-images.githubusercontent.com/9283414/50962573-37e63700-14d3-11e9-8315-b99955d5b0b6.png)
Make sense to have it ```⌥⌘W``` since all extracting methods starts with ```⌥⌘```