### PR TITLE
Refactor service extensions and set button text based on extension state.

### DIFF
--- a/src/io/flutter/inspector/InspectorService.java
+++ b/src/io/flutter/inspector/InspectorService.java
@@ -11,6 +11,7 @@ import com.intellij.openapi.Disposable;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.util.SystemInfo;
 import com.intellij.xdebugger.XSourcePosition;
+import io.flutter.server.vmService.ServiceExtensions;
 import io.flutter.server.vmService.VmServiceConsumers;
 import io.flutter.server.vmService.frame.DartVmServiceValue;
 import io.flutter.pub.PubRoot;
@@ -102,7 +103,7 @@ public class InspectorService implements Disposable {
 
     assert (app.getVMServiceManager() != null);
     setPubRootDirectoriesSubscription =
-      app.getVMServiceManager().hasServiceExtension("ext.flutter.inspector.setPubRootDirectories", (Boolean available) -> {
+      app.getVMServiceManager().hasServiceExtension(ServiceExtensions.setPubRootDirectories, (Boolean available) -> {
         if (!available) {
           return;
         }
@@ -268,13 +269,14 @@ public class InspectorService implements Disposable {
   }
 
   CompletableFuture<JsonElement> invokeServiceMethodDaemonNoGroup(String methodName, Map<String, Object> params) {
-    return getApp().callServiceExtension("ext.flutter.inspector." + methodName, params).thenApply((JsonObject json) -> {
-      if (json.has("errorMessage")) {
-        String message = json.get("errorMessage").getAsString();
-        throw new RuntimeException(methodName + " -- " + message);
-      }
-      return json.get("result");
-    });
+    return getApp().callServiceExtension(ServiceExtensions.inspectorPrefix + methodName, params)
+      .thenApply((JsonObject json) -> {
+        if (json.has("errorMessage")) {
+          String message = json.get("errorMessage").getAsString();
+          throw new RuntimeException(methodName + " -- " + message);
+        }
+        return json.get("result");
+      });
   }
 
   /**
@@ -435,14 +437,16 @@ public class InspectorService implements Disposable {
 
     // All calls to invokeServiceMethodDaemon bottom out to this call.
     CompletableFuture<JsonElement> invokeServiceMethodDaemon(String methodName, Map<String, Object> params) {
-      return getInspectorLibrary().addRequest(this, () -> getApp().callServiceExtension("ext.flutter.inspector." + methodName, params)
-        .thenApply((JsonObject json) -> nullValueIfDisposed(() -> {
-          if (json.has("errorMessage")) {
-            String message = json.get("errorMessage").getAsString();
-            throw new RuntimeException(methodName + " -- " + message);
-          }
-          return json.get("result");
-        })));
+      return getInspectorLibrary().addRequest(
+        this,
+        () -> getApp().callServiceExtension(ServiceExtensions.inspectorPrefix + methodName, params)
+          .thenApply((JsonObject json) -> nullValueIfDisposed(() -> {
+            if (json.has("errorMessage")) {
+              String message = json.get("errorMessage").getAsString();
+              throw new RuntimeException(methodName + " -- " + message);
+            }
+            return json.get("result");
+          })));
     }
 
     CompletableFuture<JsonElement> invokeServiceMethodDaemon(String methodName, InspectorInstanceRef arg) {

--- a/src/io/flutter/logging/FlutterLog.java
+++ b/src/io/flutter/logging/FlutterLog.java
@@ -18,6 +18,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Key;
 import com.intellij.util.EventDispatcher;
 import io.flutter.run.FlutterDebugProcess;
+import io.flutter.server.vmService.ServiceExtensions;
 import io.flutter.server.vmService.VmServiceConsumers;
 import io.flutter.settings.FlutterSettings;
 import io.flutter.utils.VmServiceListenerAdapter;
@@ -114,7 +115,7 @@ public class FlutterLog implements FlutterLogEntry.ContentListener {
   public CompletableFuture<List<LoggingChannel>> getLoggingChannels() {
     final FlutterDebugProcess debugProcess = getDebugProcess();
     if (debugProcess != null) {
-      return debugProcess.getApp().callServiceExtension("ext.flutter.logs.loggingChannels").thenApply((response) -> {
+      return debugProcess.getApp().callServiceExtension(ServiceExtensions.loggingChannels).thenApply((response) -> {
         final JsonObject value = response.getAsJsonObject("value");
         final List<LoggingChannel> channels = new ArrayList<>();
         for (String channel : value.keySet()) {
@@ -135,7 +136,7 @@ public class FlutterLog implements FlutterLogEntry.ContentListener {
       final Map<String, Object> params = new HashMap<>();
       params.put("channel", channel.name);
       params.put("enabled", subscribe);
-      debugProcess.getApp().callServiceExtension("ext.flutter.logs.enable", params);
+      debugProcess.getApp().callServiceExtension(ServiceExtensions.enableLogs, params);
     }
   }
 

--- a/src/io/flutter/perf/FlutterWidgetPerfManager.java
+++ b/src/io/flutter/perf/FlutterWidgetPerfManager.java
@@ -19,6 +19,7 @@ import io.flutter.FlutterInitializer;
 import io.flutter.FlutterUtils;
 import io.flutter.run.FlutterAppManager;
 import io.flutter.run.daemon.FlutterApp;
+import io.flutter.server.vmService.ServiceExtensions;
 import io.flutter.utils.StreamSubscription;
 import io.flutter.view.FlutterViewMessages;
 import org.jetbrains.annotations.NotNull;
@@ -44,10 +45,6 @@ import java.util.Set;
  * actually fetch performance information and display them.
  */
 public class FlutterWidgetPerfManager implements Disposable, FlutterApp.FlutterAppListener {
-
-  // Service extensions used by the perf manager.
-  public static final String TRACK_REBUILD_WIDGETS = "ext.flutter.inspector.trackRebuildDirtyWidgets";
-  public static final String TRACK_REPAINT_WIDGETS = "ext.flutter.inspector.trackRepaintWidgets";
 
   // Whether each of the performance metrics tracked should be tracked by
   // default when starting a new application.
@@ -191,8 +188,8 @@ public class FlutterWidgetPerfManager implements Disposable, FlutterApp.FlutterA
     }
 
     app.addStateListener(this);
-    syncBooleanServiceExtension(TRACK_REBUILD_WIDGETS, () -> trackRebuildWidgets);
-    syncBooleanServiceExtension(TRACK_REPAINT_WIDGETS, () -> trackRepaintWidgets);
+    syncBooleanServiceExtension(ServiceExtensions.trackRebuildWidgets.getExtension(), () -> trackRebuildWidgets);
+    syncBooleanServiceExtension(ServiceExtensions.trackRepaintWidgets.getExtension(), () -> trackRepaintWidgets);
 
     currentStats = new FlutterWidgetPerf(
       isProfilingEnabled(),
@@ -225,15 +222,17 @@ public class FlutterWidgetPerfManager implements Disposable, FlutterApp.FlutterA
   }
 
   private void updateTrackWidgetRebuilds() {
-    app.maybeCallBooleanExtension(TRACK_REBUILD_WIDGETS, trackRebuildWidgets).whenCompleteAsync((v, e) -> {
-      notifyPerf();
-    });
+    app.maybeCallBooleanExtension(ServiceExtensions.trackRebuildWidgets.getExtension(), trackRebuildWidgets)
+      .whenCompleteAsync((v, e) -> {
+        notifyPerf();
+      });
   }
 
   private void updateTrackWidgetRepaints() {
-    app.maybeCallBooleanExtension(TRACK_REPAINT_WIDGETS, trackRepaintWidgets).whenCompleteAsync((v, e) -> {
-      notifyPerf();
-    });
+    app.maybeCallBooleanExtension(ServiceExtensions.trackRepaintWidgets.getExtension(), trackRepaintWidgets)
+      .whenCompleteAsync((v, e) -> {
+        notifyPerf();
+      });
   }
 
   private void syncBooleanServiceExtension(String serviceExtension, Computable<Boolean> valueProvider) {

--- a/src/io/flutter/preview/RenderHelper.java
+++ b/src/io/flutter/preview/RenderHelper.java
@@ -23,6 +23,7 @@ import io.flutter.run.daemon.FlutterDevice;
 import io.flutter.run.daemon.RunMode;
 import io.flutter.sdk.FlutterCommand;
 import io.flutter.sdk.FlutterSdk;
+import io.flutter.server.vmService.ServiceExtensions;
 import org.dartlang.analysis.server.protocol.FlutterOutline;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -397,7 +398,7 @@ class RenderThread extends Thread {
       // Ask to render the widget.
       final CountDownLatch responseReceivedLatch = new CountDownLatch(1);
       final AtomicReference<JsonObject> responseRef = new AtomicReference<>();
-      myApp.callServiceExtension("ext.flutter.designer.render").thenAccept((response) -> {
+      myApp.callServiceExtension(ServiceExtensions.designerRender).thenAccept((response) -> {
         responseRef.set(response);
         responseReceivedLatch.countDown();
       });

--- a/src/io/flutter/run/daemon/FlutterApp.java
+++ b/src/io/flutter/run/daemon/FlutterApp.java
@@ -32,6 +32,7 @@ import com.intellij.util.concurrency.AppExecutorUtil;
 import com.jetbrains.lang.dart.ide.runner.ObservatoryConnector;
 import io.flutter.FlutterInitializer;
 import io.flutter.logging.FlutterLog;
+import io.flutter.server.vmService.ServiceExtensions;
 import io.flutter.server.vmService.VMServiceManager;
 import io.flutter.pub.PubRoot;
 import io.flutter.pub.PubRoots;
@@ -384,7 +385,7 @@ public class FlutterApp {
       return CompletableFuture.completedFuture(null);
     }
 
-    final CompletableFuture<JsonObject> result = callServiceExtension("ext.flutter.platformOverride");
+    final CompletableFuture<JsonObject> result = callServiceExtension(ServiceExtensions.togglePlatformMode.getExtension());
     return result.thenApply(obj -> {
       //noinspection CodeBlock2Expr
       return obj != null && "android".equals(obj.get("value").getAsString());
@@ -399,10 +400,11 @@ public class FlutterApp {
 
     final Map<String, Object> params = new HashMap<>();
     params.put("value", showAndroid ? "android" : "iOS");
-    return callServiceExtension("ext.flutter.platformOverride", params).thenApply(obj -> {
-      //noinspection CodeBlock2Expr
-      return obj != null && "android".equals(obj.get("value").getAsString());
-    });
+    return callServiceExtension(ServiceExtensions.togglePlatformMode.getExtension(), params)
+      .thenApply(obj -> {
+        //noinspection CodeBlock2Expr
+        return obj != null && "android".equals(obj.get("value").getAsString());
+      });
   }
 
   public CompletableFuture<JsonObject> callServiceExtension(String methodName) {

--- a/src/io/flutter/server/vmService/ServiceExtensions.java
+++ b/src/io/flutter/server/vmService/ServiceExtensions.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2019 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.server.vmService;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+// Each service extension needs to be manually added to [toggleableExtensionDescriptions].
+public class ServiceExtensions {
+  // TODO(kenzie): Alter these values to match other extensions once service extension states are restored from device.
+  // These values are currently configured differently because we invert the value of this service extension state.
+  public static final ToggleableServiceExtensionDescription<Boolean> debugAllowBanner =
+    new ToggleableServiceExtensionDescription<>(
+      "ext.flutter.debugAllowBanner",
+      false,
+      true,
+      "Show Debug Mode Banner",
+      "Hide Debug Mode Banner");
+
+  public static final ToggleableServiceExtensionDescription<Boolean> debugPaint =
+    new ToggleableServiceExtensionDescription<>(
+      "ext.flutter.debugPaint",
+      true,
+      false,
+      "Hide Debug Paint",
+      "Show Debug Paint");
+
+  public static final ToggleableServiceExtensionDescription<Boolean> debugPaintBaselines =
+    new ToggleableServiceExtensionDescription<>(
+      "ext.flutter.debugPaintBaselinesEnabled",
+      true,
+      false,
+      "Hide Paint Baselines",
+      "Show Paint Baselines");
+
+  public static final ToggleableServiceExtensionDescription<Boolean> performanceOverlay =
+    new ToggleableServiceExtensionDescription<>(
+      "ext.flutter.showPerformanceOverlay",
+      true,
+      false,
+      "Hide Performance Overlay",
+      "Show Performance Overlay");
+
+  public static final ToggleableServiceExtensionDescription<Boolean> repaintRainbow =
+    new ToggleableServiceExtensionDescription<>(
+      "ext.flutter.repaintRainbow",
+      true,
+      false,
+      "Hide Repaint Rainbow",
+      "Show Repaint Rainbow");
+
+  public static final ToggleableServiceExtensionDescription<Double> slowAnimations =
+    new ToggleableServiceExtensionDescription<>(
+      "ext.flutter.timeDilation",
+      5.0,
+      1.0,
+      "Disable Slow Animations",
+      "Enable Slow Animations");
+
+  public static final ToggleableServiceExtensionDescription<String> togglePlatformMode =
+    new ToggleableServiceExtensionDescription<>(
+      "ext.flutter.platformOverride",
+      "iOS",
+      "android",
+      "Toggle Platform",
+      "Toggle Platform");
+
+  public static final ToggleableServiceExtensionDescription<Boolean> toggleSelectWidgetMode =
+    new ToggleableServiceExtensionDescription<>(
+      "ext.flutter.inspector.show",
+      true,
+      false,
+      "Disable Select Widget Mode",
+      "Enable Select Widget Mode");
+
+  public static final ToggleableServiceExtensionDescription<Boolean> trackRebuildWidgets =
+    new ToggleableServiceExtensionDescription<>(
+      "ext.flutter.inspector.trackRebuildDirtyWidgets",
+      true,
+      false,
+      "Track Widget Rebuilds",
+      "Do Not Track Widget Rebuilds");
+
+  public static final ToggleableServiceExtensionDescription<Boolean> trackRepaintWidgets =
+    new ToggleableServiceExtensionDescription<>(
+      "ext.flutter.inspector.trackRepaintWidgets",
+      true,
+      false,
+      "Track Widget Repaints",
+      "Do Not Track Widget Repaints");
+
+  // This extension should never be displayed as a button so does not need to be a
+  // ToggleableServiceExtensionDescription object.
+  public static final String didSendFirstFrameEvent = "ext.flutter.didSendFirstFrameEvent";
+
+  // These extensions are not toggleable and do not need to be stored as a ToggleableServiceExtensionDescription object.
+  public static final String flutterPrefix = "ext.flutter.";
+  public static final String inspectorPrefix = "ext.flutter.inspector.";
+  public static final String setPubRootDirectories = "ext.flutter.inspector.setPubRootDirectories";
+  public static final String enableLogs = "ext.flutter.logs.enable";
+  public static final String loggingChannels = "ext.flutter.logs.loggingChannels";
+  public static final String designerRender = "ext.flutter.designer.render";
+
+  static final List<ToggleableServiceExtensionDescription> toggleableExtensionDescriptions = Arrays.asList(
+    debugAllowBanner,
+    debugPaint,
+    debugPaintBaselines,
+    performanceOverlay,
+    repaintRainbow,
+    slowAnimations,
+    togglePlatformMode,
+    toggleSelectWidgetMode,
+    trackRebuildWidgets,
+    trackRepaintWidgets);
+
+  public static final Map<String, ToggleableServiceExtensionDescription> toggleableExtensionsWhitelist =
+    toggleableExtensionDescriptions.stream().collect(
+      Collectors.toMap(
+        ToggleableServiceExtensionDescription::getExtension,
+        extensionDescription -> extensionDescription));
+}

--- a/src/io/flutter/server/vmService/ToggleableServiceExtensionDescription.java
+++ b/src/io/flutter/server/vmService/ToggleableServiceExtensionDescription.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.server.vmService;
+
+public class ToggleableServiceExtensionDescription<T> {
+  private final String extension;
+  private final T enabledValue;
+  private final T disabledValue;
+  private final String enabledText;
+  private final String disabledText;
+
+  public ToggleableServiceExtensionDescription(
+    String extension, T enabledValue, T disabledValue, String enabledText, String disabledText) {
+    this.extension = extension;
+    this.enabledValue = enabledValue;
+    this.disabledValue = disabledValue;
+    this.enabledText = enabledText;
+    this.disabledText = disabledText;
+  }
+
+  public String getExtension() {
+    return extension;
+  }
+
+  public T getEnabledValue() {
+    return enabledValue;
+  }
+
+  public T getDisabledValue() {
+    return disabledValue;
+  }
+
+  public String getEnabledText() {
+    return enabledText;
+  }
+
+  public String getDisabledText() {
+    return disabledText;
+  }
+}

--- a/src/io/flutter/server/vmService/VMServiceManager.java
+++ b/src/io/flutter/server/vmService/VMServiceManager.java
@@ -97,7 +97,7 @@ public class VMServiceManager implements FlutterApp.FlutterAppListener {
               if (flutterIsolateRefStream.getValue() == null) {
                 if (isolate.getExtensionRPCs() != null) {
                   for (String extensionName : isolate.getExtensionRPCs()) {
-                    if (extensionName.startsWith("ext.flutter.")) {
+                    if (extensionName.startsWith(ServiceExtensions.flutterPrefix)) {
                       setFlutterIsolate(isolateRef);
                       break;
                     }
@@ -250,7 +250,7 @@ public class VMServiceManager implements FlutterApp.FlutterAppListener {
       if (event.getKind() == EventKind.ServiceExtensionAdded) {
         final String extensionName = event.getExtensionRPC();
 
-        if (extensionName.startsWith("ext.flutter.")) {
+        if (extensionName.startsWith(ServiceExtensions.flutterPrefix)) {
           setFlutterIsolate(event.getIsolate());
         }
       }
@@ -315,7 +315,7 @@ public class VMServiceManager implements FlutterApp.FlutterAppListener {
 
   private void restoreServiceExtensionState(String name) {
     if (app.isSessionActive()) {
-      if (StringUtil.equals(name, "ext.flutter.inspector.show")) {
+      if (StringUtil.equals(name, ServiceExtensions.toggleSelectWidgetMode.getExtension())) {
         // Do not call the service extension for this extension. We do not want to persist showing the
         // inspector on app restart.
         return;

--- a/src/io/flutter/view/DebugPaintAction.java
+++ b/src/io/flutter/view/DebugPaintAction.java
@@ -14,7 +14,8 @@ class DebugPaintAction extends FlutterViewToggleableAction {
   DebugPaintAction(@NotNull FlutterApp app) {
     super(app, FlutterBundle.message("flutter.view.debugPaint.text"), FlutterBundle.message("flutter.view.debugPaint.description"),
           FlutterIcons.DebugPaint);
-
     setExtensionCommand("ext.flutter.debugPaint");
+    setEnabledText("Hide Debug Paint");
+    setDisabledText("Show Debug Paint");
   }
 }

--- a/src/io/flutter/view/DebugPaintAction.java
+++ b/src/io/flutter/view/DebugPaintAction.java
@@ -6,20 +6,12 @@
 package io.flutter.view;
 
 import icons.FlutterIcons;
-import io.flutter.FlutterBundle;
 import io.flutter.run.daemon.FlutterApp;
+import io.flutter.server.vmService.ServiceExtensions;
 import org.jetbrains.annotations.NotNull;
 
 class DebugPaintAction extends FlutterViewToggleableAction {
   DebugPaintAction(@NotNull FlutterApp app) {
-    super(
-      app,
-      FlutterBundle.message("flutter.view.debugPaint.text"),
-      "Hide Debug Paint",
-      "Show Debug Paint",
-      FlutterBundle.message("flutter.view.debugPaint.description"),
-      FlutterIcons.DebugPaint);
-
-    setExtensionCommand("ext.flutter.debugPaint");
+    super(app, FlutterIcons.DebugPaint, ServiceExtensions.debugPaint);
   }
 }

--- a/src/io/flutter/view/DebugPaintAction.java
+++ b/src/io/flutter/view/DebugPaintAction.java
@@ -12,10 +12,14 @@ import org.jetbrains.annotations.NotNull;
 
 class DebugPaintAction extends FlutterViewToggleableAction {
   DebugPaintAction(@NotNull FlutterApp app) {
-    super(app, FlutterBundle.message("flutter.view.debugPaint.text"), FlutterBundle.message("flutter.view.debugPaint.description"),
-          FlutterIcons.DebugPaint);
+    super(
+      app,
+      FlutterBundle.message("flutter.view.debugPaint.text"),
+      "Hide Debug Paint",
+      "Show Debug Paint",
+      FlutterBundle.message("flutter.view.debugPaint.description"),
+      FlutterIcons.DebugPaint);
+
     setExtensionCommand("ext.flutter.debugPaint");
-    setEnabledText("Hide Debug Paint");
-    setDisabledText("Show Debug Paint");
   }
 }

--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -631,19 +631,29 @@ class RepaintRainbowAction extends FlutterViewToggleableAction {
   public static final String SHOW_REPAINT_RAINBOW = "ext.flutter.repaintRainbow";
 
   RepaintRainbowAction(@NotNull FlutterApp app) {
-    super(app, "Show Repaint Rainbow", "Show Repaint Rainbow", FlutterIcons.RepaintRainbow);
+    super(
+      app,
+      "Show Repaint Rainbow",
+      "Hide Repaint Rainbow",
+      "Show Repaint Rainbow",
+      "Show Repaint Rainbow",
+      FlutterIcons.RepaintRainbow);
+
     setExtensionCommand(SHOW_REPAINT_RAINBOW);
-    setEnabledText("Hide Repaint Rainbow");
-    setDisabledText("Show Repaint Rainbow");
   }
 }
 
 class ToggleInspectModeAction extends FlutterViewToggleableAction {
   ToggleInspectModeAction(@NotNull FlutterApp app) {
-    super(app, "Toggle Select Widget Mode", "Toggle Select Widget Mode", AllIcons.General.LocateHover);
+    super(
+      app,
+      "Toggle Select Widget Mode",
+      "Disable Select Widget Mode",
+      "Enable Select Widget Mode",
+      "Toggle Select Widget Mode",
+      AllIcons.General.LocateHover);
+
     setExtensionCommand("ext.flutter.inspector.show");
-    setEnabledText("Disable Select Widget Mode");
-    setDisabledText("Enable Select Widget Mode");
   }
 
   @Override
@@ -706,11 +716,16 @@ class ForceRefreshAction extends FlutterViewAction {
 
 class HideDebugModeBannerAction extends FlutterViewToggleableAction {
   HideDebugModeBannerAction(@NotNull FlutterApp app) {
-    super(app, "Hide Debug Mode Banner", "Hide Debug Mode Banner", FlutterIcons.DebugBanner);
+    super(
+      app,
+      "Hide Debug Mode Banner",
+      "Show Debug Mode Banner",
+      "Hide Debug Mode Banner",
+      "Hide Debug Mode Banner",
+      FlutterIcons.DebugBanner);
+
     setExtensionCommand("ext.flutter.debugAllowBanner");
     setEnabledStateValue(false);
-    setEnabledText("Show Debug Mode Banner");
-    setDisabledText("Hide Debug Mode Banner");
   }
 
   @Override

--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -632,16 +632,18 @@ class RepaintRainbowAction extends FlutterViewToggleableAction {
 
   RepaintRainbowAction(@NotNull FlutterApp app) {
     super(app, "Show Repaint Rainbow", "Show Repaint Rainbow", FlutterIcons.RepaintRainbow);
-
     setExtensionCommand(SHOW_REPAINT_RAINBOW);
+    setEnabledText("Hide Repaint Rainbow");
+    setDisabledText("Show Repaint Rainbow");
   }
 }
 
 class ToggleInspectModeAction extends FlutterViewToggleableAction {
   ToggleInspectModeAction(@NotNull FlutterApp app) {
     super(app, "Toggle Select Widget Mode", "Toggle Select Widget Mode", AllIcons.General.LocateHover);
-
     setExtensionCommand("ext.flutter.inspector.show");
+    setEnabledText("Disable Select Widget Mode");
+    setDisabledText("Enable Select Widget Mode");
   }
 
   @Override
@@ -705,9 +707,10 @@ class ForceRefreshAction extends FlutterViewAction {
 class HideDebugModeBannerAction extends FlutterViewToggleableAction {
   HideDebugModeBannerAction(@NotNull FlutterApp app) {
     super(app, "Hide Debug Mode Banner", "Hide Debug Mode Banner", FlutterIcons.DebugBanner);
-
     setExtensionCommand("ext.flutter.debugAllowBanner");
     setEnabledStateValue(false);
+    setEnabledText("Show Debug Mode Banner");
+    setDisabledText("Hide Debug Mode Banner");
   }
 
   @Override

--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -53,6 +53,7 @@ import io.flutter.run.daemon.FlutterApp;
 import io.flutter.run.daemon.FlutterDevice;
 import io.flutter.sdk.FlutterSdk;
 import io.flutter.sdk.FlutterSdkVersion;
+import io.flutter.server.vmService.ServiceExtensions;
 import io.flutter.settings.FlutterSettings;
 import io.flutter.utils.AsyncUtils;
 import io.flutter.utils.EventStream;
@@ -627,33 +628,14 @@ class OpenTimelineViewAction extends FlutterViewAction {
 }
 
 class RepaintRainbowAction extends FlutterViewToggleableAction {
-
-  public static final String SHOW_REPAINT_RAINBOW = "ext.flutter.repaintRainbow";
-
   RepaintRainbowAction(@NotNull FlutterApp app) {
-    super(
-      app,
-      "Show Repaint Rainbow",
-      "Hide Repaint Rainbow",
-      "Show Repaint Rainbow",
-      "Show Repaint Rainbow",
-      FlutterIcons.RepaintRainbow);
-
-    setExtensionCommand(SHOW_REPAINT_RAINBOW);
+    super(app, FlutterIcons.RepaintRainbow, ServiceExtensions.repaintRainbow);
   }
 }
 
 class ToggleInspectModeAction extends FlutterViewToggleableAction {
   ToggleInspectModeAction(@NotNull FlutterApp app) {
-    super(
-      app,
-      "Toggle Select Widget Mode",
-      "Disable Select Widget Mode",
-      "Enable Select Widget Mode",
-      "Toggle Select Widget Mode",
-      AllIcons.General.LocateHover);
-
-    setExtensionCommand("ext.flutter.inspector.show");
+    super(app, AllIcons.General.LocateHover, ServiceExtensions.toggleSelectWidgetMode);
   }
 
   @Override
@@ -716,22 +698,14 @@ class ForceRefreshAction extends FlutterViewAction {
 
 class HideDebugModeBannerAction extends FlutterViewToggleableAction {
   HideDebugModeBannerAction(@NotNull FlutterApp app) {
-    super(
-      app,
-      "Hide Debug Mode Banner",
-      "Show Debug Mode Banner",
-      "Hide Debug Mode Banner",
-      "Hide Debug Mode Banner",
-      FlutterIcons.DebugBanner);
-
-    setExtensionCommand("ext.flutter.debugAllowBanner");
-    setEnabledStateValue(false);
+    super(app, FlutterIcons.DebugBanner, ServiceExtensions.debugAllowBanner, true);
   }
 
+  // TODO(kenzie): remove this override once service extension states are restored from device.
   @Override
   protected void perform(@Nullable AnActionEvent event) {
     if (app.isSessionActive()) {
-      app.callBooleanExtension("ext.flutter.debugAllowBanner", !isSelected());
+      app.callBooleanExtension(ServiceExtensions.debugAllowBanner.getExtension(), !isSelected());
     }
   }
 }

--- a/src/io/flutter/view/FlutterViewToggleableAction.java
+++ b/src/io/flutter/view/FlutterViewToggleableAction.java
@@ -21,18 +21,35 @@ import javax.swing.*;
 abstract class FlutterViewToggleableAction extends FlutterViewAction implements Toggleable, Disposable {
   private String extensionCommand;
   private Object enabledStateValue = true;
+  private String enabledText;
+  private String disabledText;
   private StreamSubscription<ServiceExtensionState> currentValueSubscription;
 
   FlutterViewToggleableAction(@NotNull FlutterApp app, @Nullable String text) {
     super(app, text);
+    setDefaultTextValues(text);
   }
 
   FlutterViewToggleableAction(@NotNull FlutterApp app, @Nullable String text, @Nullable String description, @Nullable Icon icon) {
     super(app, text, description, icon);
+    setDefaultTextValues(text);
+  }
+
+  private void setDefaultTextValues(String text) {
+    enabledText = text;
+    disabledText = text;
   }
 
   protected void setExtensionCommand(String extensionCommand) {
     this.extensionCommand = extensionCommand;
+  }
+
+  protected void setEnabledText(String enabledText) {
+    this.enabledText = enabledText;
+  }
+
+  protected void setDisabledText(String disabledText) {
+    this.disabledText = disabledText;
   }
 
   // Overrides the default enabledStateValue for Actions whose enabled value is not a boolean.
@@ -61,6 +78,8 @@ abstract class FlutterViewToggleableAction extends FlutterViewAction implements 
           }
         }, true);
     }
+
+    presentation.setText(isSelected() ? enabledText : disabledText);
 
     app.hasServiceExtension(extensionCommand, (enabled) -> {
         e.getPresentation().setEnabled(app.isSessionActive() && enabled);

--- a/src/io/flutter/view/FlutterViewToggleableAction.java
+++ b/src/io/flutter/view/FlutterViewToggleableAction.java
@@ -25,19 +25,21 @@ abstract class FlutterViewToggleableAction extends FlutterViewAction implements 
   private String disabledText;
   private StreamSubscription<ServiceExtensionState> currentValueSubscription;
 
-  FlutterViewToggleableAction(@NotNull FlutterApp app, @Nullable String text) {
+  FlutterViewToggleableAction(
+    @NotNull FlutterApp app, @Nullable String text, @Nullable String enabledText, @Nullable String disabledText) {
     super(app, text);
-    setDefaultTextValues(text);
+    setActionTextValues(text, enabledText, disabledText);
   }
 
-  FlutterViewToggleableAction(@NotNull FlutterApp app, @Nullable String text, @Nullable String description, @Nullable Icon icon) {
+  FlutterViewToggleableAction(
+    @NotNull FlutterApp app, @Nullable String text, @Nullable String enabledText, @Nullable String disabledText, @Nullable String description, @Nullable Icon icon) {
     super(app, text, description, icon);
-    setDefaultTextValues(text);
+    setActionTextValues(text, enabledText, disabledText);
   }
 
-  private void setDefaultTextValues(String text) {
-    enabledText = text;
-    disabledText = text;
+  private void setActionTextValues(String text, String enabledText, String disabledText) {
+    this.enabledText = enabledText != null ? enabledText : text;
+    this.disabledText = disabledText != null ? disabledText : text;
   }
 
   protected void setExtensionCommand(String extensionCommand) {

--- a/src/io/flutter/view/InspectorPerfTab.java
+++ b/src/io/flutter/view/InspectorPerfTab.java
@@ -74,18 +74,8 @@ public class InspectorPerfTab extends JBPanel implements InspectorTabPanel {
 
     final FlutterWidgetPerfManager widgetPerfManager = FlutterWidgetPerfManager.getInstance(app.getProject());
 
-    showPerfOverlay =
-      new BoolServiceExtensionCheckbox(
-        app,
-        ServiceExtensions.performanceOverlay.getExtension(),
-        ServiceExtensions.performanceOverlay.getDisabledText(),
-        "");
-    showRepaintRainbow =
-      new BoolServiceExtensionCheckbox(
-        app,
-        ServiceExtensions.repaintRainbow.getExtension(),
-        ServiceExtensions.repaintRainbow.getDisabledText(),
-        "");
+    showPerfOverlay = new BoolServiceExtensionCheckbox(app, ServiceExtensions.performanceOverlay, "");
+    showRepaintRainbow = new BoolServiceExtensionCheckbox(app, ServiceExtensions.repaintRainbow, "");
 
     buildUI();
 

--- a/src/io/flutter/view/InspectorPerfTab.java
+++ b/src/io/flutter/view/InspectorPerfTab.java
@@ -24,6 +24,7 @@ import io.flutter.perf.PerfReportKind;
 import io.flutter.run.FlutterLaunchMode;
 import io.flutter.run.daemon.FlutterApp;
 import io.flutter.server.vmService.FlutterFramesMonitor;
+import io.flutter.server.vmService.ServiceExtensions;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
@@ -32,9 +33,6 @@ import java.awt.event.ComponentEvent;
 import java.awt.event.ComponentListener;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
-
-import static io.flutter.view.PerformanceOverlayAction.SHOW_PERFORMANCE_OVERLAY;
-import static io.flutter.view.RepaintRainbowAction.SHOW_REPAINT_RAINBOW;
 
 public class InspectorPerfTab extends JBPanel implements InspectorTabPanel {
   /**
@@ -76,8 +74,18 @@ public class InspectorPerfTab extends JBPanel implements InspectorTabPanel {
 
     final FlutterWidgetPerfManager widgetPerfManager = FlutterWidgetPerfManager.getInstance(app.getProject());
 
-    showPerfOverlay = new BoolServiceExtensionCheckbox(app, SHOW_PERFORMANCE_OVERLAY, "Show performance overlay", "");
-    showRepaintRainbow = new BoolServiceExtensionCheckbox(app, SHOW_REPAINT_RAINBOW, "Show repaint rainbow", "");
+    showPerfOverlay =
+      new BoolServiceExtensionCheckbox(
+        app,
+        ServiceExtensions.performanceOverlay.getExtension(),
+        ServiceExtensions.performanceOverlay.getDisabledText(),
+        "");
+    showRepaintRainbow =
+      new BoolServiceExtensionCheckbox(
+        app,
+        ServiceExtensions.repaintRainbow.getExtension(),
+        ServiceExtensions.repaintRainbow.getDisabledText(),
+        "");
 
     buildUI();
 
@@ -86,9 +94,10 @@ public class InspectorPerfTab extends JBPanel implements InspectorTabPanel {
       trackRepaintsCheckbox.setSelected(widgetPerfManager.isTrackRepaintWidgets());
     }
 
-    app.hasServiceExtension(FlutterWidgetPerfManager.TRACK_REBUILD_WIDGETS, trackRebuildsCheckbox::setEnabled, parentDisposable);
+    app.hasServiceExtension(ServiceExtensions.trackRebuildWidgets.getExtension(), trackRebuildsCheckbox::setEnabled, parentDisposable);
+
     if (ENABLE_TRACK_REPAINTS) {
-      app.hasServiceExtension(FlutterWidgetPerfManager.TRACK_REPAINT_WIDGETS, trackRepaintsCheckbox::setEnabled, parentDisposable);
+      app.hasServiceExtension(ServiceExtensions.trackRepaintWidgets.getExtension(), trackRepaintsCheckbox::setEnabled, parentDisposable);
     }
 
     trackRebuildsCheckbox.addChangeListener((l) -> {

--- a/src/io/flutter/view/PerformanceOverlayAction.java
+++ b/src/io/flutter/view/PerformanceOverlayAction.java
@@ -17,5 +17,7 @@ class PerformanceOverlayAction extends FlutterViewToggleableAction {
   PerformanceOverlayAction(@NotNull FlutterApp app) {
     super(app, "Toggle Performance Overlay", "Toggle Performance Overlay", AllIcons.Modules.Library);
     setExtensionCommand(SHOW_PERFORMANCE_OVERLAY);
+    setEnabledText("Hide Performance Overlay");
+    setDisabledText("Show Performance Overlay");
   }
 }

--- a/src/io/flutter/view/PerformanceOverlayAction.java
+++ b/src/io/flutter/view/PerformanceOverlayAction.java
@@ -8,21 +8,11 @@ package io.flutter.view;
 
 import com.intellij.icons.AllIcons;
 import io.flutter.run.daemon.FlutterApp;
+import io.flutter.server.vmService.ServiceExtensions;
 import org.jetbrains.annotations.NotNull;
 
 class PerformanceOverlayAction extends FlutterViewToggleableAction {
-
-  public static final String SHOW_PERFORMANCE_OVERLAY = "ext.flutter.showPerformanceOverlay";
-
   PerformanceOverlayAction(@NotNull FlutterApp app) {
-    super(
-      app,
-      "Toggle Performance Overlay",
-      "Hide Performance Overlay",
-      "Show Performance Overlay",
-      "Toggle Performance Overlay",
-      AllIcons.Modules.Library);
-
-    setExtensionCommand(SHOW_PERFORMANCE_OVERLAY);
+    super(app, AllIcons.Modules.Library, ServiceExtensions.performanceOverlay);
   }
 }

--- a/src/io/flutter/view/PerformanceOverlayAction.java
+++ b/src/io/flutter/view/PerformanceOverlayAction.java
@@ -15,9 +15,14 @@ class PerformanceOverlayAction extends FlutterViewToggleableAction {
   public static final String SHOW_PERFORMANCE_OVERLAY = "ext.flutter.showPerformanceOverlay";
 
   PerformanceOverlayAction(@NotNull FlutterApp app) {
-    super(app, "Toggle Performance Overlay", "Toggle Performance Overlay", AllIcons.Modules.Library);
+    super(
+      app,
+      "Toggle Performance Overlay",
+      "Hide Performance Overlay",
+      "Show Performance Overlay",
+      "Toggle Performance Overlay",
+      AllIcons.Modules.Library);
+
     setExtensionCommand(SHOW_PERFORMANCE_OVERLAY);
-    setEnabledText("Hide Performance Overlay");
-    setDisabledText("Show Performance Overlay");
   }
 }

--- a/src/io/flutter/view/ShowPaintBaselinesAction.java
+++ b/src/io/flutter/view/ShowPaintBaselinesAction.java
@@ -7,18 +7,11 @@ package io.flutter.view;
 
 import icons.FlutterIcons;
 import io.flutter.run.daemon.FlutterApp;
+import io.flutter.server.vmService.ServiceExtensions;
 import org.jetbrains.annotations.NotNull;
 
 class ShowPaintBaselinesAction extends FlutterViewToggleableAction {
   ShowPaintBaselinesAction(@NotNull FlutterApp app, boolean showIcon) {
-    super(
-      app,
-      "Show Paint Baselines",
-      "Hide Paint Baselines",
-      "Show Paint Baselines",
-      null,
-      showIcon ? FlutterIcons.Painting : null);
-
-    setExtensionCommand("ext.flutter.debugPaintBaselinesEnabled");
+    super(app, showIcon ? FlutterIcons.Painting : null, ServiceExtensions.debugPaintBaselines);
   }
 }

--- a/src/io/flutter/view/ShowPaintBaselinesAction.java
+++ b/src/io/flutter/view/ShowPaintBaselinesAction.java
@@ -12,7 +12,8 @@ import org.jetbrains.annotations.NotNull;
 class ShowPaintBaselinesAction extends FlutterViewToggleableAction {
   ShowPaintBaselinesAction(@NotNull FlutterApp app, boolean showIcon) {
     super(app, "Show Paint Baselines", null, showIcon ? FlutterIcons.Painting : null);
-
     setExtensionCommand("ext.flutter.debugPaintBaselinesEnabled");
+    setEnabledText("Hide Paint Baselines");
+    setDisabledText("Show Paint Baselines");
   }
 }

--- a/src/io/flutter/view/ShowPaintBaselinesAction.java
+++ b/src/io/flutter/view/ShowPaintBaselinesAction.java
@@ -11,9 +11,14 @@ import org.jetbrains.annotations.NotNull;
 
 class ShowPaintBaselinesAction extends FlutterViewToggleableAction {
   ShowPaintBaselinesAction(@NotNull FlutterApp app, boolean showIcon) {
-    super(app, "Show Paint Baselines", null, showIcon ? FlutterIcons.Painting : null);
+    super(
+      app,
+      "Show Paint Baselines",
+      "Hide Paint Baselines",
+      "Show Paint Baselines",
+      null,
+      showIcon ? FlutterIcons.Painting : null);
+
     setExtensionCommand("ext.flutter.debugPaintBaselinesEnabled");
-    setEnabledText("Hide Paint Baselines");
-    setDisabledText("Show Paint Baselines");
   }
 }

--- a/src/io/flutter/view/TimeDilationAction.java
+++ b/src/io/flutter/view/TimeDilationAction.java
@@ -8,6 +8,7 @@ package io.flutter.view;
 import com.intellij.icons.AllIcons;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import io.flutter.run.daemon.FlutterApp;
+import io.flutter.server.vmService.ServiceExtensions;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -16,24 +17,19 @@ import java.util.Map;
 
 class TimeDilationAction extends FlutterViewToggleableAction {
   TimeDilationAction(@NotNull FlutterApp app, boolean showIcon) {
-    super(
-      app,
-      "Enable Slow Animations",
-      "Disable Slow Animations",
-      "Enable Slow Animations",
-      null,
-      showIcon ? AllIcons.Vcs.History : null);
-
-    setExtensionCommand("ext.flutter.timeDilation");
-    setEnabledStateValue(5.0);
+    super(app, showIcon ? AllIcons.Vcs.History : null, ServiceExtensions.slowAnimations);
   }
 
   @Override
   protected void perform(@Nullable AnActionEvent event) {
     final Map<String, Object> params = new HashMap<>();
-    params.put("timeDilation", isSelected() ? 5.0 : 1.0);
+    params.put(
+      "timeDilation",
+      isSelected()
+      ? ServiceExtensions.slowAnimations.getEnabledValue()
+      : ServiceExtensions.slowAnimations.getDisabledValue());
     if (app.isSessionActive()) {
-      app.callServiceExtension("ext.flutter.timeDilation", params);
+      app.callServiceExtension(ServiceExtensions.slowAnimations.getExtension(), params);
     }
   }
 }

--- a/src/io/flutter/view/TimeDilationAction.java
+++ b/src/io/flutter/view/TimeDilationAction.java
@@ -17,9 +17,10 @@ import java.util.Map;
 class TimeDilationAction extends FlutterViewToggleableAction {
   TimeDilationAction(@NotNull FlutterApp app, boolean showIcon) {
     super(app, "Enable Slow Animations", null, showIcon ? AllIcons.Vcs.History : null);
-
     setExtensionCommand("ext.flutter.timeDilation");
     setEnabledStateValue(5.0);
+    setEnabledText("Disable Slow Animations");
+    setDisabledText("Enable Slow Animations");
   }
 
   @Override

--- a/src/io/flutter/view/TimeDilationAction.java
+++ b/src/io/flutter/view/TimeDilationAction.java
@@ -16,11 +16,16 @@ import java.util.Map;
 
 class TimeDilationAction extends FlutterViewToggleableAction {
   TimeDilationAction(@NotNull FlutterApp app, boolean showIcon) {
-    super(app, "Enable Slow Animations", null, showIcon ? AllIcons.Vcs.History : null);
+    super(
+      app,
+      "Enable Slow Animations",
+      "Disable Slow Animations",
+      "Enable Slow Animations",
+      null,
+      showIcon ? AllIcons.Vcs.History : null);
+
     setExtensionCommand("ext.flutter.timeDilation");
     setEnabledStateValue(5.0);
-    setEnabledText("Disable Slow Animations");
-    setDisabledText("Enable Slow Animations");
   }
 
   @Override

--- a/src/io/flutter/view/TogglePlatformAction.java
+++ b/src/io/flutter/view/TogglePlatformAction.java
@@ -10,19 +10,19 @@ import com.intellij.icons.AllIcons;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import io.flutter.FlutterBundle;
 import io.flutter.run.daemon.FlutterApp;
+import io.flutter.server.vmService.ServiceExtensions;
+import io.flutter.server.vmService.ToggleableServiceExtensionDescription;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.concurrent.CompletableFuture;
 
 class TogglePlatformAction extends FlutterViewAction {
-  private static final String PLATFORM_OVERRIDE = "ext.flutter.platformOverride";
+  private static final ToggleableServiceExtensionDescription extensionDescription = ServiceExtensions.togglePlatformMode;
   private Boolean isCurrentlyAndroid;
   CompletableFuture<Boolean> cachedHasExtensionFuture;
 
   TogglePlatformAction(@NotNull FlutterApp app) {
-    super(app, FlutterBundle.message("flutter.view.togglePlatform.text"),
-          FlutterBundle.message("flutter.view.togglePlatform.description"),
-          AllIcons.RunConfigurations.Application);
+    super(app, extensionDescription.getDisabledText(), null, AllIcons.RunConfigurations.Application);
   }
 
   @Override
@@ -33,11 +33,7 @@ class TogglePlatformAction extends FlutterViewAction {
       return;
     }
 
-    app.togglePlatform().thenAccept(isAndroid -> {
-      e.getPresentation().setText(isAndroid ? "Toggle Platform to iOS" : "Toggle Platform to Android");
-    });
-
-    app.hasServiceExtension(PLATFORM_OVERRIDE, (enabled) -> {
+    app.hasServiceExtension(extensionDescription.getExtension(), (enabled) -> {
       e.getPresentation().setEnabled(app.isSessionActive() && enabled);
     });
   }
@@ -60,9 +56,11 @@ class TogglePlatformAction extends FlutterViewAction {
               ConsoleViewContentType.SYSTEM_OUTPUT);
 
             app.getVMServiceManager().setServiceExtensionState(
-              PLATFORM_OVERRIDE,
+              extensionDescription.getExtension(),
               true,
-              isNowAndroid ? "android" : "iOS");
+              isNowAndroid
+              ? extensionDescription.getDisabledValue()
+              : extensionDescription.getEnabledValue());
           }
         });
       });

--- a/src/io/flutter/view/TogglePlatformAction.java
+++ b/src/io/flutter/view/TogglePlatformAction.java
@@ -33,6 +33,10 @@ class TogglePlatformAction extends FlutterViewAction {
       return;
     }
 
+    app.togglePlatform().thenAccept(isAndroid -> {
+      e.getPresentation().setText(isAndroid ? "Toggle Platform to iOS" : "Toggle Platform to Android");
+    });
+
     app.hasServiceExtension(PLATFORM_OVERRIDE, (enabled) -> {
       e.getPresentation().setEnabled(app.isSessionActive() && enabled);
     });


### PR DESCRIPTION
Service extension data is now stored in ServiceExtensions.java. Button text now reflects extension state.

Performance overlay example:
When the extension is enabled, the tooltip will now read "Hide Performance Overlay".
When the extension is disabled, the tooltip will now read "Show Performance Overlay".

This applies to all the service extension buttons, including those with visible text in the inspector dropdown menu.