### PR TITLE
handle cases where script.tokenPosTable is null

### DIFF
--- a/src/io/flutter/run/ObservatoryFile.java
+++ b/src/io/flutter/run/ObservatoryFile.java
@@ -35,7 +35,7 @@ class ObservatoryFile {
   /**
    * Maps an observatory token id to its line and column.
    */
-  @NotNull
+  @Nullable
   private final TIntObjectHashMap<Position> positionMap;
 
   /**
@@ -50,8 +50,14 @@ class ObservatoryFile {
   private final LightVirtualFile snapshot;
 
   ObservatoryFile(@NotNull Script script, boolean wantSnapshot) {
-    positionMap = createPositionMap(script.getTokenPosTable());
-    snapshot = !wantSnapshot ? null : createSnapshot(script);
+    final @Nullable List<List<Integer>> tokenPosTable = script.getTokenPosTable();
+    if (tokenPosTable != null) {
+      positionMap = createPositionMap(tokenPosTable);
+    }
+    else {
+      positionMap = null;
+    }
+    snapshot = wantSnapshot ? createSnapshot(script) : null;
   }
 
   boolean hasSnapshot() {
@@ -68,6 +74,10 @@ class ObservatoryFile {
   XSourcePosition createPosition(@Nullable VirtualFile local, int tokenPos) {
     final VirtualFile fileToUse = local == null ? snapshot : local;
     if (fileToUse == null) return null;
+
+    if (positionMap == null) {
+      return null;
+    }
 
     final Position pos = positionMap.get(tokenPos);
     if (pos == null) {

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/VmServiceBase.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/VmServiceBase.java
@@ -202,7 +202,7 @@ abstract class VmServiceBase implements VmServiceConst {
   /**
    * A list of objects to which {@link Event}s from the VM are forwarded.
    */
-  private final List<VmServiceListener> vmListeners = new ArrayList<>();
+  private final List<VmServiceListener> vmListeners = new ArrayList<VmServiceListener>();
 
   /**
    * A list of objects to which {@link Event}s from the VM are forwarded.

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/element/Element.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/element/Element.java
@@ -43,6 +43,9 @@ public class Element {
    */
   List<List<Integer>> getListListInt(String memberName) {
     JsonArray array = json.getAsJsonArray(memberName);
+    if (array == null) {
+      return null;
+    }
     int size = array.size();
     List<List<Integer>> result = new ArrayList<List<Integer>>();
     for (int index = 0; index < size; ++index) {

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/element/Script.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/element/Script.java
@@ -46,6 +46,8 @@ public class Script extends Obj {
 
   /**
    * A table encoding a mapping from token position to line and column.
+   *
+   * Can return <code>null</code>.
    */
   public List<List<Integer>> getTokenPosTable() {
     return getListListInt("tokenPosTable");


### PR DESCRIPTION
- handle situations where `Script.tokenPosTable` can be null (now possible w/ the VM sending null for dart: sdk sources)
- fix https://github.com/flutter/flutter-intellij/issues/2938

This in includes some upstream null handling changes in the vm_service_drivers repo.