### PR TITLE
fix an issue with escaped test names

### DIFF
--- a/src/io/flutter/run/test/FlutterTestLineMarkerContributor.java
+++ b/src/io/flutter/run/test/FlutterTestLineMarkerContributor.java
@@ -47,7 +47,6 @@ public class FlutterTestLineMarkerContributor extends RunLineMarkerContributor {
 
   @NotNull
   private static Icon getTestStateIcon(@NotNull PsiElement element, @NotNull Icon defaultIcon) {
-
     // SMTTestProxy maps test run data to a URI derived from a location hint produced by `package:test`.
     // If we can find corresponding data, we can provide state-aware icons. If not, we default to
     // a standard Run state.

--- a/src/io/flutter/run/test/TestConfigUtils.java
+++ b/src/io/flutter/run/test/TestConfigUtils.java
@@ -14,6 +14,7 @@ import com.intellij.psi.util.PsiTreeUtil;
 import com.jetbrains.lang.dart.psi.DartCallExpression;
 import com.jetbrains.lang.dart.psi.DartFile;
 import com.jetbrains.lang.dart.psi.DartStringLiteralExpression;
+import groovy.json.StringEscapeUtils;
 import io.flutter.FlutterUtils;
 import io.flutter.dart.DartSyntax;
 import org.apache.commons.lang.StringUtils;
@@ -89,7 +90,10 @@ public class TestConfigUtils {
     final DartStringLiteralExpression lit = DartSyntax.getArgument(call, 0, DartStringLiteralExpression.class);
     if (lit == null) return null;
 
-    return DartSyntax.unquote(lit);
+    final String name = DartSyntax.unquote(lit);
+    if (name == null) return null;
+
+    return StringEscapeUtils.unescapeJava(name);
   }
 
   enum TestType {


### PR DESCRIPTION
- fix an issue with escaped test names; we unescape them now (the test execution later re-escapes any necessary chars, like double quotes)
- fix https://github.com/flutter/flutter-intellij/issues/3058

@pq 
