### PR TITLE
don't use LOG.error()

### DIFF
--- a/flutter-studio/src/io/flutter/android/GradleDependencyFetcher.java
+++ b/flutter-studio/src/io/flutter/android/GradleDependencyFetcher.java
@@ -62,7 +62,7 @@ public class GradleDependencyFetcher {
   private void runIn(@NotNull File base) {
     File gradlew = new File(base, isWindows() ? FN_GRADLE_WRAPPER_WIN : FN_GRADLE_WRAPPER_UNIX);
     if (!gradlew.exists() || !gradlew.canExecute()) {
-      LOG.error("Cannot run gradle");
+      LOG.warn("Cannot run gradle");
       return;
     }
     File pwd = base.getAbsoluteFile();
@@ -81,7 +81,7 @@ public class GradleDependencyFetcher {
       cmdLine.withEnvironment("ANDROID_SDK_HOME", AndroidLocation.getFolder());
     }
     catch (AndroidLocation.AndroidLocationException e) {
-      LOG.error("No Android SDK", e);
+      LOG.warn("No Android SDK", e);
       return;
     }
     String result = "NO OUTPUT";
@@ -90,20 +90,20 @@ public class GradleDependencyFetcher {
       int timeoutInMilliseconds = 2 * 60 * 1000;
       ProcessOutput processOutput = process.runProcess(timeoutInMilliseconds, true);
       if (processOutput.isTimeout()) {
-        LOG.error("Dependency processing time-out");
+        LOG.warn("Dependency processing time-out");
         return;
       }
       String errors = processOutput.getStderr();
       String output = processOutput.getStdout();
       int exitCode = processOutput.getExitCode();
       if (exitCode != 0) {
-        LOG.error("Error " + String.valueOf(exitCode) + " during dependency analysis: " + errors);
+        LOG.warn("Error " + String.valueOf(exitCode) + " during dependency analysis: " + errors);
         return;
       }
       result = output;
     }
     catch (ExecutionException e) {
-      LOG.error("Dependency process exception", e);
+      LOG.warn("Dependency process exception", e);
     }
     parseDependencies(result);
   }
@@ -114,7 +114,7 @@ public class GradleDependencyFetcher {
       reader.lines().forEach(this::parseLine);
     }
     catch (IOException ex) {
-      LOG.error(ex);
+      LOG.warn(ex);
     }
   }
 

--- a/flutter-studio/src/io/flutter/android/GradleDependencyFetcher.java
+++ b/flutter-studio/src/io/flutter/android/GradleDependencyFetcher.java
@@ -62,7 +62,7 @@ public class GradleDependencyFetcher {
   private void runIn(@NotNull File base) {
     File gradlew = new File(base, isWindows() ? FN_GRADLE_WRAPPER_WIN : FN_GRADLE_WRAPPER_UNIX);
     if (!gradlew.exists() || !gradlew.canExecute()) {
-      LOG.warn("Cannot run gradle");
+      FlutterUtils.warn(LOG, "Cannot run gradle");
       return;
     }
     File pwd = base.getAbsoluteFile();
@@ -81,7 +81,7 @@ public class GradleDependencyFetcher {
       cmdLine.withEnvironment("ANDROID_SDK_HOME", AndroidLocation.getFolder());
     }
     catch (AndroidLocation.AndroidLocationException e) {
-      LOG.warn("No Android SDK", e);
+      FlutterUtils.warn(LOG, "No Android SDK", e);
       return;
     }
     String result = "NO OUTPUT";
@@ -90,20 +90,20 @@ public class GradleDependencyFetcher {
       int timeoutInMilliseconds = 2 * 60 * 1000;
       ProcessOutput processOutput = process.runProcess(timeoutInMilliseconds, true);
       if (processOutput.isTimeout()) {
-        LOG.warn("Dependency processing time-out");
+        FlutterUtils.warn(LOG, "Dependency processing time-out");
         return;
       }
       String errors = processOutput.getStderr();
       String output = processOutput.getStdout();
       int exitCode = processOutput.getExitCode();
       if (exitCode != 0) {
-        LOG.warn("Error " + String.valueOf(exitCode) + " during dependency analysis: " + errors);
+        FlutterUtils.warn(LOG, "Error " + String.valueOf(exitCode) + " during dependency analysis: " + errors);
         return;
       }
       result = output;
     }
     catch (ExecutionException e) {
-      LOG.warn("Dependency process exception", e);
+      FlutterUtils.warn(LOG, "Dependency process exception", e);
     }
     parseDependencies(result);
   }
@@ -114,7 +114,7 @@ public class GradleDependencyFetcher {
       reader.lines().forEach(this::parseLine);
     }
     catch (IOException ex) {
-      LOG.warn(ex);
+      FlutterUtils.warn(LOG, ex);
     }
   }
 

--- a/flutter-studio/src/io/flutter/android/GradleDependencyFetcher.java
+++ b/flutter-studio/src/io/flutter/android/GradleDependencyFetcher.java
@@ -18,6 +18,7 @@ import com.intellij.execution.process.ProcessOutput;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.util.containers.hash.HashMap;
+import io.flutter.FlutterUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.BufferedReader;

--- a/flutter-studio/src/io/flutter/profiler/FlutterStudioMonitorStageView.java
+++ b/flutter-studio/src/io/flutter/profiler/FlutterStudioMonitorStageView.java
@@ -33,6 +33,7 @@ import com.intellij.ui.table.JBTable;
 import com.intellij.ui.treeStructure.Tree;
 import icons.FlutterIcons;
 import icons.StudioIcons;
+import io.flutter.FlutterUtils;
 import io.flutter.server.vmService.VMServiceManager;
 import io.flutter.utils.AsyncUtils;
 import io.flutter.utils.StreamSubscription;

--- a/flutter-studio/src/io/flutter/profiler/FlutterStudioMonitorStageView.java
+++ b/flutter-studio/src/io/flutter/profiler/FlutterStudioMonitorStageView.java
@@ -573,7 +573,7 @@ public class FlutterStudioMonitorStageView extends FlutterStageView<FlutterStudi
     vmService.getAllocationProfile(isolateId, null, reset ? true : null, new AllocationProfileConsumer() {
       @Override
       public void onError(RPCError error) {
-        LOG.error("Allocation Profile - " + error.getDetails());
+        LOG.warn("Allocation Profile - " + error.getDetails());
         future.completeExceptionally(new RuntimeException(error.toString()));
       }
 
@@ -597,7 +597,7 @@ public class FlutterStudioMonitorStageView extends FlutterStageView<FlutterStudi
     vmService.getAllocationProfile(isolateId, "full", null, new AllocationProfileConsumer() {
       @Override
       public void onError(RPCError error) {
-        LOG.error("Allocation Profile during gcNow - " + error.getDetails());
+        LOG.warn("Allocation Profile during gcNow - " + error.getDetails());
         future.completeExceptionally(new RuntimeException(error.toString()));
       }
 
@@ -958,7 +958,7 @@ public class FlutterStudioMonitorStageView extends FlutterStageView<FlutterStudi
                 addNode(parent, fieldName, " = " + fieldValue);
               }
               catch (Exception e) {
-                LOG.error("Error getting value " + valueRef.getKind(), e);
+                LOG.warn("Error getting value " + valueRef.getKind(), e);
               }
               break;
 
@@ -967,7 +967,7 @@ public class FlutterStudioMonitorStageView extends FlutterStageView<FlutterStudi
               // Pointing to a nested class.
               if (valueRef == null) {
                 // TODO(terry): This shouldn't happen.
-                LOG.error("ValueRef is NULL");
+                LOG.warn("ValueRef is NULL");
               }
               final String nestedObjectRef1 = valueRef.getId();    // Pull the object/Class we're pointing too.
               final DefaultMutableTreeNode node1 = addNode(parent, fieldName, " [" + nestedObjectRef1 + "]");
@@ -1000,7 +1000,7 @@ public class FlutterStudioMonitorStageView extends FlutterStageView<FlutterStudi
               // Pointing to a nested class.
               if (valueRef == null) {
                 // TODO(terry): This shouldn't happen.
-                LOG.error("ValueRef is NULL for nnnnnList");
+                LOG.warn("ValueRef is NULL for nnnnnList");
               }
               break;
 
@@ -1008,7 +1008,7 @@ public class FlutterStudioMonitorStageView extends FlutterStageView<FlutterStudi
               // Pointing to a nested class.
               if (valueRef == null) {
                 // TODO(terry): This shouldn't happen.
-                LOG.error("ValueRef is NULL");
+                LOG.warn("ValueRef is NULL");
               }
               final String nestedObjectRef = valueRef.getId();    // Pull the object/Class we're pointing too.
               final DefaultMutableTreeNode node = addNode(parent, fieldName, " [" + nestedObjectRef + "]");

--- a/flutter-studio/src/io/flutter/profiler/FlutterStudioMonitorStageView.java
+++ b/flutter-studio/src/io/flutter/profiler/FlutterStudioMonitorStageView.java
@@ -520,7 +520,7 @@ public class FlutterStudioMonitorStageView extends FlutterStageView<FlutterStudi
     return profilers.getApp().callServiceExtension("_getInstances", params)
       .thenApply((response) -> response)
       .exceptionally(err -> {
-        LOG.warn(err);
+        FlutterUtils.warn(LOG, err);
         return null;
       });
   }
@@ -573,7 +573,7 @@ public class FlutterStudioMonitorStageView extends FlutterStageView<FlutterStudi
     vmService.getAllocationProfile(isolateId, null, reset ? true : null, new AllocationProfileConsumer() {
       @Override
       public void onError(RPCError error) {
-        LOG.warn("Allocation Profile - " + error.getDetails());
+        FlutterUtils.warn(LOG, "Allocation Profile - " + error.getDetails());
         future.completeExceptionally(new RuntimeException(error.toString()));
       }
 
@@ -597,7 +597,7 @@ public class FlutterStudioMonitorStageView extends FlutterStageView<FlutterStudi
     vmService.getAllocationProfile(isolateId, "full", null, new AllocationProfileConsumer() {
       @Override
       public void onError(RPCError error) {
-        LOG.warn("Allocation Profile during gcNow - " + error.getDetails());
+        FlutterUtils.warn(LOG, "Allocation Profile during gcNow - " + error.getDetails());
         future.completeExceptionally(new RuntimeException(error.toString()));
       }
 
@@ -958,7 +958,7 @@ public class FlutterStudioMonitorStageView extends FlutterStageView<FlutterStudi
                 addNode(parent, fieldName, " = " + fieldValue);
               }
               catch (Exception e) {
-                LOG.warn("Error getting value " + valueRef.getKind(), e);
+                FlutterUtils.warn(LOG, "Error getting value " + valueRef.getKind(), e);
               }
               break;
 
@@ -967,7 +967,7 @@ public class FlutterStudioMonitorStageView extends FlutterStageView<FlutterStudi
               // Pointing to a nested class.
               if (valueRef == null) {
                 // TODO(terry): This shouldn't happen.
-                LOG.warn("ValueRef is NULL");
+                FlutterUtils.warn(LOG, "ValueRef is NULL");
               }
               final String nestedObjectRef1 = valueRef.getId();    // Pull the object/Class we're pointing too.
               final DefaultMutableTreeNode node1 = addNode(parent, fieldName, " [" + nestedObjectRef1 + "]");
@@ -1000,7 +1000,7 @@ public class FlutterStudioMonitorStageView extends FlutterStageView<FlutterStudi
               // Pointing to a nested class.
               if (valueRef == null) {
                 // TODO(terry): This shouldn't happen.
-                LOG.warn("ValueRef is NULL for nnnnnList");
+                FlutterUtils.warn(LOG, "ValueRef is NULL for nnnnnList");
               }
               break;
 
@@ -1008,7 +1008,7 @@ public class FlutterStudioMonitorStageView extends FlutterStageView<FlutterStudi
               // Pointing to a nested class.
               if (valueRef == null) {
                 // TODO(terry): This shouldn't happen.
-                LOG.warn("ValueRef is NULL");
+                FlutterUtils.warn(LOG, "ValueRef is NULL");
               }
               final String nestedObjectRef = valueRef.getId();    // Pull the object/Class we're pointing too.
               final DefaultMutableTreeNode node = addNode(parent, fieldName, " [" + nestedObjectRef + "]");

--- a/flutter-studio/src/io/flutter/profiler/FlutterStudioProfilersView.java
+++ b/flutter-studio/src/io/flutter/profiler/FlutterStudioProfilersView.java
@@ -32,6 +32,7 @@ import com.intellij.util.ui.EmptyIcon;
 import com.intellij.util.ui.JBEmptyBorder;
 import icons.FlutterIcons;
 import icons.StudioIcons;
+import io.flutter.FlutterUtils;
 import io.flutter.utils.AsyncUtils;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;

--- a/flutter-studio/src/io/flutter/profiler/FlutterStudioProfilersView.java
+++ b/flutter-studio/src/io/flutter/profiler/FlutterStudioProfilersView.java
@@ -521,7 +521,7 @@ public class FlutterStudioProfilersView
           });
         }
         else {
-          LOG.warn("Library not found " + libraryName);
+          FlutterUtils.warn(LOG, "Library not found " + libraryName);
         }
       }
       else {

--- a/flutter-studio/src/io/flutter/profiler/Memory.java
+++ b/flutter-studio/src/io/flutter/profiler/Memory.java
@@ -27,6 +27,7 @@ import javax.swing.table.TableModel;
 import javax.swing.table.TableRowSorter;
 import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.DefaultTreeModel;
+import io.flutter.FlutterUtils;
 import org.dartlang.vm.service.element.AllocationProfile;
 import org.dartlang.vm.service.element.ClassHeapStats;
 import org.dartlang.vm.service.element.ClassObj;

--- a/flutter-studio/src/io/flutter/profiler/Memory.java
+++ b/flutter-studio/src/io/flutter/profiler/Memory.java
@@ -126,7 +126,7 @@ class Memory {
         case ACCUMULATED_INSTNACE_COUNT_COLUMN_INDEX:
           return classNode.getAccumulatedInstancesCount();
         default:
-          Log.warn("Unexpected columnIndex: " + columnIndex);
+          FlutterUtils.warn(LOG, "Unexpected columnIndex: " + columnIndex);
           return "";
       }
     }

--- a/flutter-studio/src/io/flutter/profiler/Memory.java
+++ b/flutter-studio/src/io/flutter/profiler/Memory.java
@@ -126,7 +126,7 @@ class Memory {
         case ACCUMULATED_INSTNACE_COUNT_COLUMN_INDEX:
           return classNode.getAccumulatedInstancesCount();
         default:
-          Log.error("Unexpected columnIndex: " + columnIndex);
+          Log.warn("Unexpected columnIndex: " + columnIndex);
           return "";
       }
     }

--- a/flutter-studio/src/io/flutter/project/FlutterProjectCreator.java
+++ b/flutter-studio/src/io/flutter/project/FlutterProjectCreator.java
@@ -39,6 +39,7 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.wm.IdeFocusManager;
 import com.intellij.openapi.wm.IdeFrame;
 import com.intellij.platform.PlatformProjectOpenProcessor;
+import io.flutter.FlutterUtils;
 import io.flutter.FlutterMessages;
 import io.flutter.module.FlutterModuleBuilder;
 import io.flutter.pub.PubRoot;

--- a/flutter-studio/src/io/flutter/project/FlutterProjectCreator.java
+++ b/flutter-studio/src/io/flutter/project/FlutterProjectCreator.java
@@ -147,7 +147,7 @@ public class FlutterProjectCreator {
     final VirtualFile baseDir = ApplicationManager.getApplication().runWriteAction(
       (Computable<VirtualFile>)() -> LocalFileSystem.getInstance().refreshAndFindFileByIoFile(baseFile));
     if (baseDir == null) {
-      LOG.warn("Couldn't find '" + location + "' in VFS");
+      FlutterUtils.warn(LOG, "Couldn't find '" + location + "' in VFS");
       return;
     }
     // TODO(messick): Remove the project converter when it is no longer needed (probably by the AS 3.2 release).

--- a/flutter-studio/src/io/flutter/project/FlutterProjectCreator.java
+++ b/flutter-studio/src/io/flutter/project/FlutterProjectCreator.java
@@ -147,7 +147,7 @@ public class FlutterProjectCreator {
     final VirtualFile baseDir = ApplicationManager.getApplication().runWriteAction(
       (Computable<VirtualFile>)() -> LocalFileSystem.getInstance().refreshAndFindFileByIoFile(baseFile));
     if (baseDir == null) {
-      LOG.error("Couldn't find '" + location + "' in VFS");
+      LOG.warn("Couldn't find '" + location + "' in VFS");
       return;
     }
     // TODO(messick): Remove the project converter when it is no longer needed (probably by the AS 3.2 release).
@@ -237,7 +237,7 @@ public class FlutterProjectCreator {
         }
       }
       catch (Exception e) {
-        LOG.error(String.format("Exception thrown when creating target project location: %1$s", projectLocation), e);
+        LOG.warn(String.format("Exception thrown when creating target project location: %1$s", projectLocation), e);
       }
       return false;
     });

--- a/flutter-studio/src/io/flutter/project/FlutterProjectSystem.java
+++ b/flutter-studio/src/io/flutter/project/FlutterProjectSystem.java
@@ -90,7 +90,7 @@ public class FlutterProjectSystem implements AndroidProjectSystem {
     // TODO(messick): Delete the remainder of this method and use the previous line once AS 3.1 is no longer supported.
     Method finders = ReflectionUtil.getMethod(gradleProjectSystem.getClass(), "getAvailableDependency");
     if (finders == null) {
-      LOG.error("No method found: GradleProjectSystem.getAvailableDependency()");
+      LOG.warn("No method found: GradleProjectSystem.getAvailableDependency()");
       return null;
     }
     try {
@@ -108,7 +108,7 @@ public class FlutterProjectSystem implements AndroidProjectSystem {
   public Collection<PsiElementFinder> getPsiElementFinders() {
     Method finders = ReflectionUtil.getMethod(gradleProjectSystem.getClass(), "getPsiElementFinders");
     if (finders == null) {
-      LOG.error("No method found: GradleProjectSystem.getPsiElementFinders()");
+      LOG.warn("No method found: GradleProjectSystem.getPsiElementFinders()");
       return Collections.emptyList();
     }
     try {

--- a/flutter-studio/src/io/flutter/project/FlutterProjectSystem.java
+++ b/flutter-studio/src/io/flutter/project/FlutterProjectSystem.java
@@ -50,7 +50,7 @@ public class FlutterProjectSystem implements AndroidProjectSystem {
   @Override
   public void buildProject() {
     // flutter build ?
-    LOG.warn("FlutterProjectSystem.buildProject() called but not (properly) implemented.");
+    FlutterUtils.warn(LOG, "FlutterProjectSystem.buildProject() called but not (properly) implemented.");
   }
 
   @Override
@@ -90,7 +90,7 @@ public class FlutterProjectSystem implements AndroidProjectSystem {
     // TODO(messick): Delete the remainder of this method and use the previous line once AS 3.1 is no longer supported.
     Method finders = ReflectionUtil.getMethod(gradleProjectSystem.getClass(), "getAvailableDependency");
     if (finders == null) {
-      LOG.warn("No method found: GradleProjectSystem.getAvailableDependency()");
+      FlutterUtils.warn(LOG, "No method found: GradleProjectSystem.getAvailableDependency()");
       return null;
     }
     try {
@@ -108,7 +108,7 @@ public class FlutterProjectSystem implements AndroidProjectSystem {
   public Collection<PsiElementFinder> getPsiElementFinders() {
     Method finders = ReflectionUtil.getMethod(gradleProjectSystem.getClass(), "getPsiElementFinders");
     if (finders == null) {
-      LOG.warn("No method found: GradleProjectSystem.getPsiElementFinders()");
+      FlutterUtils.warn(LOG, "No method found: GradleProjectSystem.getPsiElementFinders()");
       return Collections.emptyList();
     }
     try {

--- a/flutter-studio/src/io/flutter/project/FlutterProjectSystem.java
+++ b/flutter-studio/src/io/flutter/project/FlutterProjectSystem.java
@@ -18,6 +18,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiElementFinder;
 import com.intellij.util.ReflectionUtil;
+import io.flutter.FlutterUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 

--- a/src/io/flutter/FlutterUtils.java
+++ b/src/io/flutter/FlutterUtils.java
@@ -14,6 +14,7 @@ import com.intellij.ide.util.PropertiesComponent;
 import com.intellij.openapi.application.ApplicationInfo;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ModalityState;
+import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.extensions.PluginId;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleUtil;
@@ -63,7 +64,6 @@ public class FlutterUtils {
       ModalityState.defaultModalityState());
   }
 
-  @SuppressWarnings("BooleanMethodIsAlwaysInverted")
   public static boolean isFlutteryFile(@NotNull VirtualFile file) {
     return isDartFile(file) || PubRoot.isPubspec(file);
   }
@@ -80,8 +80,31 @@ public class FlutterUtils {
     return getBaselineVersion() >= 183;
   }
 
-  public static boolean is2017_3() {
-    return getBaselineVersion() == 173;
+  /**
+   * Write a warning message to the IntelliJ log.
+   * <p>
+   * This is separate from LOG.warn() to allow us to decorate the behavior.
+   */
+  public static void warn(Logger logger, @NotNull Throwable t) {
+    logger.warn(t);
+  }
+
+  /**
+   * Write a warning message to the IntelliJ log.
+   * <p>
+   * This is separate from LOG.warn() to allow us to decorate the behavior.
+   */
+  public static void warn(Logger logger, String message) {
+    logger.warn(message);
+  }
+
+  /**
+   * Write a warning message to the IntelliJ log.
+   * <p>
+   * This is separate from LOG.warn() to allow us to decorate the behavior.
+   */
+  public static void warn(Logger logger, String message, @NotNull Throwable t) {
+    logger.warn(message, t);
   }
 
   private static int getBaselineVersion() {

--- a/src/io/flutter/actions/FlutterDoctorAction.java
+++ b/src/io/flutter/actions/FlutterDoctorAction.java
@@ -39,7 +39,7 @@ public class FlutterDoctorAction extends FlutterSdkAction {
     if (doctorScript != null) {
       runWorkspaceFlutterDoctorScript(project, workspace.getRoot().getPath(), doctorScript);
     } else {
-      LOG.error("No \"doctorScript\" script in the flutter.json file.");
+      LOG.warn("No \"doctorScript\" script in the flutter.json file.");
     }
   }
 

--- a/src/io/flutter/actions/FlutterDoctorAction.java
+++ b/src/io/flutter/actions/FlutterDoctorAction.java
@@ -13,6 +13,7 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.vfs.CharsetToolkit;
+import io.flutter.FlutterUtils;
 import io.flutter.bazel.Workspace;
 import io.flutter.console.FlutterConsoles;
 import io.flutter.pub.PubRoot;
@@ -39,7 +40,7 @@ public class FlutterDoctorAction extends FlutterSdkAction {
     if (doctorScript != null) {
       runWorkspaceFlutterDoctorScript(project, workspace.getRoot().getPath(), doctorScript);
     } else {
-      LOG.warn("No \"doctorScript\" script in the flutter.json file.");
+      FlutterUtils.warn(LOG, "No \"doctorScript\" script in the flutter.json file.");
     }
   }
 

--- a/src/io/flutter/android/AndroidSdk.java
+++ b/src/io/flutter/android/AndroidSdk.java
@@ -17,6 +17,7 @@ import com.intellij.openapi.util.Key;
 import com.intellij.openapi.util.SystemInfo;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
+import io.flutter.FlutterUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -124,7 +125,7 @@ public class AndroidSdk {
       return emulators;
     }
     catch (ExecutionException | RuntimeException e) {
-      LOG.warn("Error listing android emulators", e);
+      FlutterUtils.warn(LOG, "Error listing android emulators", e);
       return Collections.emptyList();
     }
   }

--- a/src/io/flutter/bazel/PluginConfig.java
+++ b/src/io/flutter/bazel/PluginConfig.java
@@ -13,6 +13,7 @@ import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.util.Computable;
 import com.intellij.openapi.vfs.VirtualFile;
+import io.flutter.FlutterUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -74,15 +75,15 @@ class PluginConfig {
         return null;
       }
       catch (IOException e) {
-        LOG.warn("Flutter plugin failed to load config file at " + file.getPath(), e);
+        FlutterUtils.warn(LOG, "Flutter plugin failed to load config file at " + file.getPath(), e);
         return null;
       }
       catch (JsonSyntaxException e) {
-        LOG.warn("Flutter plugin failed to parse JSON in config file at " + file.getPath());
+        FlutterUtils.warn(LOG, "Flutter plugin failed to parse JSON in config file at " + file.getPath());
         return null;
       }
       catch (PatternSyntaxException e) {
-        LOG.warn("Flutter plugin failed to parse directory pattern (" + e.getPattern() + ") in config file at " + file.getPath());
+        FlutterUtils.warn(LOG, "Flutter plugin failed to parse directory pattern (" + e.getPattern() + ") in config file at " + file.getPath());
         return null;
       }
     };

--- a/src/io/flutter/editor/FlutterColors.java
+++ b/src/io/flutter/editor/FlutterColors.java
@@ -47,7 +47,7 @@ public class FlutterColors {
       colors.load(FlutterUtils.class.getResourceAsStream("/flutter/colors.properties"));
     }
     catch (IOException e) {
-      LOG.warn(e);
+      FlutterUtils.warn(LOG, e);
     }
   }
 

--- a/src/io/flutter/editor/FlutterCupertinoIcons.java
+++ b/src/io/flutter/editor/FlutterCupertinoIcons.java
@@ -7,6 +7,7 @@ package io.flutter.editor;
 
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.util.IconLoader;
+import io.flutter.FlutterUtils;
 
 import javax.swing.*;
 import java.io.IOException;
@@ -24,7 +25,7 @@ public class FlutterCupertinoIcons {
       icons.load(FlutterEditorAnnotator.class.getResourceAsStream("/flutter/cupertino_icons.properties"));
     }
     catch (IOException e) {
-      LOG.warn(e);
+      FlutterUtils.warn(LOG, e);
     }
   }
 

--- a/src/io/flutter/editor/FlutterMaterialIcons.java
+++ b/src/io/flutter/editor/FlutterMaterialIcons.java
@@ -7,6 +7,7 @@ package io.flutter.editor;
 
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.util.IconLoader;
+import io.flutter.FlutterUtils;
 
 import javax.swing.*;
 import java.io.IOException;
@@ -24,7 +25,7 @@ public class FlutterMaterialIcons {
       icons.load(FlutterEditorAnnotator.class.getResourceAsStream("/flutter/material_icons.properties"));
     }
     catch (IOException e) {
-      LOG.warn(e);
+      FlutterUtils.warn(LOG, e);
     }
   }
 

--- a/src/io/flutter/inspector/EvalOnDartLibrary.java
+++ b/src/io/flutter/inspector/EvalOnDartLibrary.java
@@ -139,13 +139,11 @@ public class EvalOnDartLibrary implements Disposable {
           new EvaluateConsumer() {
             @Override
             public void onError(RPCError error) {
-              LOG.error(error);
-              future.completeExceptionally(new RuntimeException(error.toString()));
+              future.completeExceptionally(new RuntimeException(error.getMessage()));
             }
 
             @Override
             public void received(ErrorRef response) {
-              LOG.error("Error evaluating expression:\n" + expression + "\nResponse:" + response.getMessage());
               future.completeExceptionally(new RuntimeException(response.toString()));
             }
 

--- a/src/io/flutter/inspector/FlutterWidget.java
+++ b/src/io/flutter/inspector/FlutterWidget.java
@@ -175,7 +175,7 @@ public class FlutterWidget {
         });
       }
       catch (IOException e) {
-        LOG.error(e);
+        LOG.warn(e);
       }
     }
 

--- a/src/io/flutter/inspector/FlutterWidget.java
+++ b/src/io/flutter/inspector/FlutterWidget.java
@@ -13,6 +13,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.intellij.openapi.diagnostic.Logger;
 import icons.FlutterIcons;
+import io.flutter.FlutterUtils;
 import io.flutter.utils.JsonUtils;
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -175,7 +176,7 @@ public class FlutterWidget {
         });
       }
       catch (IOException e) {
-        LOG.warn(e);
+        FlutterUtils.warn(LOG, e);
       }
     }
 

--- a/src/io/flutter/logging/FlutterLog.java
+++ b/src/io/flutter/logging/FlutterLog.java
@@ -17,6 +17,7 @@ import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Key;
 import com.intellij.util.EventDispatcher;
+import io.flutter.FlutterUtils;
 import io.flutter.run.FlutterDebugProcess;
 import io.flutter.server.vmService.ServiceExtensions;
 import io.flutter.server.vmService.VmServiceConsumers;
@@ -123,7 +124,7 @@ public class FlutterLog implements FlutterLogEntry.ContentListener {
         }
         return channels;
       }).exceptionally(e -> {
-        LOG.warn(e);
+        FlutterUtils.warn(LOG, e);
         return Collections.emptyList();
       });
     }

--- a/src/io/flutter/logging/FlutterLogView.java
+++ b/src/io/flutter/logging/FlutterLogView.java
@@ -38,6 +38,7 @@ import com.intellij.ui.content.Content;
 import com.intellij.ui.content.ContentFactory;
 import com.intellij.util.ui.JBUI;
 import com.intellij.util.ui.UIUtil;
+import io.flutter.FlutterUtils;
 import io.flutter.logging.FlutterLog.Level;
 import io.flutter.run.daemon.FlutterApp;
 import io.flutter.utils.JsonUtils;
@@ -700,7 +701,7 @@ public class FlutterLogView extends JPanel implements ConsoleView, DataProvider,
       }
       catch (Exception e) {
         // Should never go here.
-        LOG.warn("Error when get text attributes by log level", e);
+        FlutterUtils.warn(LOG, "Error when get text attributes by log level", e);
       }
     }
   }

--- a/src/io/flutter/module/FlutterModuleBuilder.java
+++ b/src/io/flutter/module/FlutterModuleBuilder.java
@@ -177,7 +177,7 @@ public class FlutterModuleBuilder extends ModuleBuilder {
       }
     }
     catch (ModuleWithNameAlreadyExists | IOException e) {
-      LOG.warn(e);
+      FlutterUtils.warn(LOG, e);
     }
   }
 

--- a/src/io/flutter/module/FlutterSmallIDEProjectGenerator.java
+++ b/src/io/flutter/module/FlutterSmallIDEProjectGenerator.java
@@ -65,7 +65,7 @@ public class FlutterSmallIDEProjectGenerator extends WebProjectTemplate<String> 
       TransactionGuard.getInstance().submitTransactionAndWait(runnable);
     }
     catch (ProcessCanceledException e) {
-      LOG.warn(e);
+      FlutterUtils.warn(LOG, e);
     }
   }
 

--- a/src/io/flutter/module/FlutterSmallIDEProjectGenerator.java
+++ b/src/io/flutter/module/FlutterSmallIDEProjectGenerator.java
@@ -65,7 +65,7 @@ public class FlutterSmallIDEProjectGenerator extends WebProjectTemplate<String> 
       TransactionGuard.getInstance().submitTransactionAndWait(runnable);
     }
     catch (ProcessCanceledException e) {
-      LOG.error(e);
+      LOG.warn(e);
     }
   }
 

--- a/src/io/flutter/project/ProjectWatch.java
+++ b/src/io/flutter/project/ProjectWatch.java
@@ -80,7 +80,7 @@ public class ProjectWatch implements Closeable {
     try {
       callback.run();
     } catch (Exception e) {
-      LOG.error("Uncaught exception in ProjectWatch callback", e);
+      LOG.warn("Uncaught exception in ProjectWatch callback", e);
       close(); // avoid further errors
     }
   }

--- a/src/io/flutter/project/ProjectWatch.java
+++ b/src/io/flutter/project/ProjectWatch.java
@@ -13,6 +13,7 @@ import com.intellij.openapi.project.ProjectManagerListener;
 import com.intellij.openapi.roots.ModuleRootEvent;
 import com.intellij.openapi.roots.ModuleRootListener;
 import com.intellij.util.messages.MessageBusConnection;
+import io.flutter.FlutterUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.Closeable;
@@ -80,7 +81,7 @@ public class ProjectWatch implements Closeable {
     try {
       callback.run();
     } catch (Exception e) {
-      LOG.warn("Uncaught exception in ProjectWatch callback", e);
+      FlutterUtils.warn(LOG, "Uncaught exception in ProjectWatch callback", e);
       close(); // avoid further errors
     }
   }

--- a/src/io/flutter/run/FlutterDebugProcess.java
+++ b/src/io/flutter/run/FlutterDebugProcess.java
@@ -8,19 +8,24 @@ package io.flutter.run;
 import com.intellij.execution.ExecutionResult;
 import com.intellij.execution.runners.ExecutionEnvironment;
 import com.intellij.execution.ui.RunnerLayoutUi;
-import com.intellij.openapi.actionSystem.*;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.DefaultActionGroup;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.util.Computable;
 import com.intellij.ui.GuiUtils;
 import com.intellij.ui.content.Content;
 import com.intellij.xdebugger.XDebugSession;
 import com.jetbrains.lang.dart.util.DartUrlResolver;
+import io.flutter.FlutterUtils;
 import io.flutter.actions.ReloadFlutterApp;
 import io.flutter.actions.RestartFlutterApp;
 import io.flutter.run.daemon.FlutterApp;
 import io.flutter.run.daemon.RunMode;
 import io.flutter.server.vmService.DartVmServiceDebugProcess;
-import io.flutter.view.*;
+import io.flutter.view.FlutterViewMessages;
+import io.flutter.view.OpenFlutterViewAction;
+import io.flutter.view.ToolbarComboBoxAction;
 import org.dartlang.vm.service.VmService;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -137,7 +142,7 @@ public class FlutterDebugProcess extends DartVmServiceDebugProcess {
           GuiUtils.runOrInvokeAndWait(() -> ui.removeContent(c, false /* dispose? */));
         }
         catch (InvocationTargetException | InterruptedException e) {
-          LOG.warn(e);
+          FlutterUtils.warn(LOG, e);
         }
       }
     }

--- a/src/io/flutter/run/FlutterReloadManager.java
+++ b/src/io/flutter/run/FlutterReloadManager.java
@@ -148,7 +148,7 @@ public class FlutterReloadManager {
           handleSaveAllNotification(eventEditor);
         }
         catch (Throwable t) {
-          LOG.error(t);
+          LOG.warn(t);
         }
       }
     }, project);

--- a/src/io/flutter/run/FlutterReloadManager.java
+++ b/src/io/flutter/run/FlutterReloadManager.java
@@ -43,6 +43,7 @@ import com.jetbrains.lang.dart.analyzer.DartServerData;
 import com.jetbrains.lang.dart.ide.errorTreeView.DartProblemsView;
 import icons.FlutterIcons;
 import io.flutter.FlutterConstants;
+import io.flutter.FlutterUtils;
 import io.flutter.actions.FlutterAppAction;
 import io.flutter.actions.ProjectActions;
 import io.flutter.actions.ReloadFlutterApp;
@@ -148,7 +149,7 @@ public class FlutterReloadManager {
           handleSaveAllNotification(eventEditor);
         }
         catch (Throwable t) {
-          LOG.warn(t);
+          FlutterUtils.warn(LOG, t);
         }
       }
     }, project);

--- a/src/io/flutter/run/LaunchState.java
+++ b/src/io/flutter/run/LaunchState.java
@@ -40,6 +40,7 @@ import com.jetbrains.lang.dart.ide.runner.DartExecutionHelper;
 import com.jetbrains.lang.dart.util.DartUrlResolver;
 import io.flutter.FlutterConstants;
 import io.flutter.FlutterInitializer;
+import io.flutter.FlutterUtils;
 import io.flutter.actions.RestartFlutterApp;
 import io.flutter.dart.DartPlugin;
 import io.flutter.logging.FlutterLog;
@@ -191,8 +192,8 @@ public class LaunchState extends CommandLineState {
 
   @NotNull
   protected XDebugSession createDebugSession(@NotNull final ExecutionEnvironment env,
-                                           @NotNull final FlutterApp app,
-                                           @NotNull final ExecutionResult executionResult)
+                                             @NotNull final FlutterApp app,
+                                             @NotNull final ExecutionResult executionResult)
     throws ExecutionException {
 
     final DartUrlResolver resolver = DartUrlResolver.getInstance(env.getProject(), sourceLocation);
@@ -384,13 +385,12 @@ public class LaunchState extends CommandLineState {
             if (!identicalCommands(app.getCommand(), launchState.runConfig.getCommand(env, app.device()))) {
               // To be safe, relaunch as the arguments to launch have changed.
               try {
-                // TODO(jacobr): ideally we shouldn't be synchronously waiting
-                // for futures like this but I don't see a better option.
-                // In practice this seems fine.
+                // TODO(jacobr): ideally we shouldn't be synchronously waiting for futures like this
+                // but I don't see a better option. In practice this seems fine.
                 app.shutdownAsync().get();
               }
               catch (InterruptedException | java.util.concurrent.ExecutionException e) {
-                LOG.warn(e);
+                FlutterUtils.warn(LOG, e);
               }
               return launchState.launch(env);
             }

--- a/src/io/flutter/run/LaunchState.java
+++ b/src/io/flutter/run/LaunchState.java
@@ -390,7 +390,7 @@ public class LaunchState extends CommandLineState {
                 app.shutdownAsync().get();
               }
               catch (InterruptedException | java.util.concurrent.ExecutionException e) {
-                LOG.error(e);
+                LOG.warn(e);
               }
               return launchState.launch(env);
             }

--- a/src/io/flutter/run/PositionMapper.java
+++ b/src/io/flutter/run/PositionMapper.java
@@ -20,6 +20,7 @@ import com.intellij.psi.search.GlobalSearchScopesCore;
 import com.intellij.util.PathUtil;
 import com.intellij.xdebugger.XSourcePosition;
 import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService;
+import io.flutter.FlutterUtils;
 import io.flutter.server.vmService.DartVmServiceDebugProcess;
 import com.jetbrains.lang.dart.util.DartResolveUtil;
 import com.jetbrains.lang.dart.util.DartUrlResolver;
@@ -247,7 +248,7 @@ public class PositionMapper implements DartVmServiceDebugProcess.PositionMapper 
   private XSourcePosition getSourcePosition(@NotNull final String isolateId, @NotNull final String scriptId,
                                             @NotNull final String scriptUri, int tokenPos) {
     if (scriptProvider == null) {
-      LOG.warn("attempted to get source position before connected to observatory");
+      FlutterUtils.warn(LOG, "attempted to get source position before connected to observatory");
       return null;
     }
 
@@ -374,13 +375,13 @@ public class PositionMapper implements DartVmServiceDebugProcess.PositionMapper 
       final DartAnalysisServerService service = DartPlugin.getInstance().getAnalysisService(project);
       if (!service.serverReadyForRequest(project)) {
         // TODO(skybrian) make this required to debug at all? It seems bad for breakpoints to be flaky.
-        LOG.warn("Dart analysis server is not running. Some breakpoints may not work.");
+        FlutterUtils.warn(LOG, "Dart analysis server is not running. Some breakpoints may not work.");
         return null;
       }
 
       final String contextId = service.execution_createContext(sourceLocation.getPath());
       if (contextId == null) {
-        LOG.warn("Failed to get execution context from analysis server. Some breakpoints may not work.");
+        FlutterUtils.warn(LOG, "Failed to get execution context from analysis server. Some breakpoints may not work.");
         return null;
       }
 

--- a/src/io/flutter/run/SdkRunConfig.java
+++ b/src/io/flutter/run/SdkRunConfig.java
@@ -34,6 +34,7 @@ import com.intellij.util.PathUtil;
 import com.intellij.util.xmlb.SkipDefaultValuesSerializationFilters;
 import com.intellij.util.xmlb.XmlSerializer;
 import com.jetbrains.lang.dart.ide.runner.DartConsoleFilter;
+import io.flutter.FlutterUtils;
 import io.flutter.console.FlutterConsoleFilter;
 import io.flutter.run.daemon.FlutterApp;
 import io.flutter.run.daemon.FlutterDevice;
@@ -103,7 +104,7 @@ public class SdkRunConfig extends LocatableConfigurationBase
           Files.delete(file);
         }
         catch (IOException e) {
-          LOG.warn(e);
+          FlutterUtils.warn(LOG, e);
           // TODO(jacobr): consider aborting.
         }
       }
@@ -119,7 +120,7 @@ public class SdkRunConfig extends LocatableConfigurationBase
     @Override
     public FileVisitResult visitFileFailed(Path file,
                                            IOException exc) {
-      LOG.warn(exc);
+      FlutterUtils.warn(LOG, exc);
       return CONTINUE;
     }
   }
@@ -166,7 +167,7 @@ public class SdkRunConfig extends LocatableConfigurationBase
             existingJson = new String(Files.readAllBytes(cachedParametersPath), StandardCharsets.UTF_8);
           }
           catch (IOException e) {
-            LOG.warn("Unable to get existing json from " + cachedParametersPath);
+            FlutterUtils.warn(LOG, "Unable to get existing json from " + cachedParametersPath);
           }
         }
         if (!StringUtil.equals(json, existingJson)) {
@@ -181,13 +182,14 @@ public class SdkRunConfig extends LocatableConfigurationBase
               if (Files.isDirectory(buildPath)) {
                 Files.walkFileTree(buildPath, new RecursiveDeleter("*.{fingerprint,dill}"));
               }
-            } else {
+            }
+            else {
               Files.createDirectory(buildPath);
             }
             Files.write(cachedParametersPath, json.getBytes(StandardCharsets.UTF_8));
           }
           catch (IOException e) {
-            LOG.warn(e);
+            FlutterUtils.warn(LOG, e);
           }
         }
       }

--- a/src/io/flutter/run/SdkRunConfig.java
+++ b/src/io/flutter/run/SdkRunConfig.java
@@ -103,7 +103,7 @@ public class SdkRunConfig extends LocatableConfigurationBase
           Files.delete(file);
         }
         catch (IOException e) {
-          LOG.error(e);
+          LOG.warn(e);
           // TODO(jacobr): consider aborting.
         }
       }
@@ -119,7 +119,7 @@ public class SdkRunConfig extends LocatableConfigurationBase
     @Override
     public FileVisitResult visitFileFailed(Path file,
                                            IOException exc) {
-      LOG.error(exc);
+      LOG.warn(exc);
       return CONTINUE;
     }
   }
@@ -187,7 +187,7 @@ public class SdkRunConfig extends LocatableConfigurationBase
             Files.write(cachedParametersPath, json.getBytes(StandardCharsets.UTF_8));
           }
           catch (IOException e) {
-            LOG.error(e);
+            LOG.warn(e);
           }
         }
       }

--- a/src/io/flutter/run/bazelTest/BazelTestRunner.java
+++ b/src/io/flutter/run/bazelTest/BazelTestRunner.java
@@ -33,6 +33,7 @@ import com.intellij.xdebugger.XDebuggerManager;
 import com.jetbrains.lang.dart.ide.runner.ObservatoryConnector;
 import com.jetbrains.lang.dart.sdk.DartSdkLibUtil;
 import com.jetbrains.lang.dart.util.DartUrlResolver;
+import io.flutter.FlutterUtils;
 import io.flutter.run.PositionMapper;
 import io.flutter.settings.FlutterSettings;
 import io.flutter.utils.StdoutJsonParser;
@@ -191,7 +192,7 @@ public class BazelTestRunner extends GenericProgramRunner {
         obj = elem.getAsJsonObject();
       }
       catch (JsonSyntaxException e) {
-        LOG.warn("Unable to parse JSON from Flutter test", e);
+        FlutterUtils.warn(LOG, "Unable to parse JSON from Flutter test", e);
         return;
       }
 
@@ -204,19 +205,19 @@ public class BazelTestRunner extends GenericProgramRunner {
 
       final JsonPrimitive primEvent = obj.getAsJsonPrimitive("event");
       if (primEvent == null) {
-        LOG.warn("Missing event field in JSON from Flutter test: " + obj);
+        FlutterUtils.warn(LOG, "Missing event field in JSON from Flutter test: " + obj);
         return;
       }
 
       final String eventName = primEvent.getAsString();
       if (eventName == null) {
-        LOG.warn("Unexpected event field in JSON from Flutter test: " + obj);
+        FlutterUtils.warn(LOG, "Unexpected event field in JSON from Flutter test: " + obj);
         return;
       }
 
       final JsonObject params = obj.getAsJsonObject("params");
       if (params == null) {
-        LOG.warn("Missing parameters in event from Flutter test: " + obj);
+        FlutterUtils.warn(LOG, "Missing parameters in event from Flutter test: " + obj);
         return;
       }
 

--- a/src/io/flutter/run/bazelTest/BazelTestRunner.java
+++ b/src/io/flutter/run/bazelTest/BazelTestRunner.java
@@ -191,7 +191,7 @@ public class BazelTestRunner extends GenericProgramRunner {
         obj = elem.getAsJsonObject();
       }
       catch (JsonSyntaxException e) {
-        LOG.error("Unable to parse JSON from Flutter test", e);
+        LOG.warn("Unable to parse JSON from Flutter test", e);
         return;
       }
 
@@ -204,19 +204,19 @@ public class BazelTestRunner extends GenericProgramRunner {
 
       final JsonPrimitive primEvent = obj.getAsJsonPrimitive("event");
       if (primEvent == null) {
-        LOG.error("Missing event field in JSON from Flutter test: " + obj);
+        LOG.warn("Missing event field in JSON from Flutter test: " + obj);
         return;
       }
 
       final String eventName = primEvent.getAsString();
       if (eventName == null) {
-        LOG.error("Unexpected event field in JSON from Flutter test: " + obj);
+        LOG.warn("Unexpected event field in JSON from Flutter test: " + obj);
         return;
       }
 
       final JsonObject params = obj.getAsJsonObject("params");
       if (params == null) {
-        LOG.error("Missing parameters in event from Flutter test: " + obj);
+        LOG.warn("Missing parameters in event from Flutter test: " + obj);
         return;
       }
 

--- a/src/io/flutter/run/daemon/DaemonApi.java
+++ b/src/io/flutter/run/daemon/DaemonApi.java
@@ -13,6 +13,7 @@ import com.intellij.execution.process.ProcessHandler;
 import com.intellij.execution.process.ProcessOutputTypes;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.util.Key;
+import io.flutter.FlutterUtils;
 import io.flutter.settings.FlutterSettings;
 import io.flutter.utils.StdoutJsonParser;
 import org.jetbrains.annotations.NotNull;
@@ -195,7 +196,7 @@ public class DaemonApi {
       cmd = pending.remove(id);
     }
     if (cmd == null) {
-      LOG.warn("received a response for a request that wasn't sent: " + id);
+      FlutterUtils.warn(LOG, "received a response for a request that wasn't sent: " + id);
       return null;
     }
     return cmd;
@@ -281,7 +282,7 @@ public class DaemonApi {
   private static void sendCommand(String json, ProcessHandler handler) {
     final PrintWriter stdin = getStdin(handler);
     if (stdin == null) {
-      LOG.warn("can't write command to Flutter process: " + json);
+      FlutterUtils.warn(LOG, "can't write command to Flutter process: " + json);
       return;
     }
     stdin.write('[');
@@ -293,7 +294,7 @@ public class DaemonApi {
     }
 
     if (stdin.checkError()) {
-      LOG.warn("can't write command to Flutter process: " + json);
+      FlutterUtils.warn(LOG, "can't write command to Flutter process: " + json);
     }
   }
 
@@ -370,7 +371,7 @@ public class DaemonApi {
         done.complete(parseResult.apply(result));
       }
       catch (Exception e) {
-        LOG.warn("Unable to parse response from Flutter daemon. Command was: " + this, e);
+        FlutterUtils.warn(LOG, "Unable to parse response from Flutter daemon. Command was: " + this, e);
         done.completeExceptionally(e);
       }
     }

--- a/src/io/flutter/run/daemon/DeviceDaemon.java
+++ b/src/io/flutter/run/daemon/DeviceDaemon.java
@@ -229,7 +229,7 @@ class DeviceDaemon {
           }
           catch (java.util.concurrent.ExecutionException e) {
             // This is not a user facing crash - we log (and no devices will be discovered).
-            LOG.error(e.getCause());
+            LOG.warn(e.getCause());
           }
         }
       }

--- a/src/io/flutter/run/daemon/DeviceDaemon.java
+++ b/src/io/flutter/run/daemon/DeviceDaemon.java
@@ -17,6 +17,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.vfs.CharsetToolkit;
 import io.flutter.FlutterMessages;
+import io.flutter.FlutterUtils;
 import io.flutter.android.IntelliJAndroidSdk;
 import io.flutter.bazel.Workspace;
 import io.flutter.bazel.WorkspaceCache;
@@ -142,7 +143,7 @@ class DeviceDaemon {
       return new Command(sdk.getHomePath(), path, ImmutableList.of("daemon"), androidHome);
     }
     catch (ExecutionException e) {
-      LOG.warn("Unable to calculate command to watch Flutter devices", e);
+      FlutterUtils.warn(LOG, "Unable to calculate command to watch Flutter devices", e);
       return null;
     }
   }
@@ -229,7 +230,7 @@ class DeviceDaemon {
           }
           catch (java.util.concurrent.ExecutionException e) {
             // This is not a user facing crash - we log (and no devices will be discovered).
-            LOG.warn(e.getCause());
+            FlutterUtils.warn(LOG, e.getCause());
           }
         }
       }
@@ -334,7 +335,7 @@ class DeviceDaemon {
     public void onDeviceAdded(@NotNull DaemonEvent.DeviceAdded event) {
       if (event.id == null) {
         // We can't start a flutter app on this device if it doesn't have a device id.
-        LOG.warn("Ignored an event from a Flutter process without a device id: " + event);
+        FlutterUtils.warn(LOG, "Ignored an event from a Flutter process without a device id: " + event);
         return;
       }
 

--- a/src/io/flutter/run/daemon/DeviceService.java
+++ b/src/io/flutter/run/daemon/DeviceService.java
@@ -149,7 +149,7 @@ public class DeviceService {
           listener.run();
         }
         catch (Exception e) {
-          LOG.error("DeviceDaemon listener threw an exception", e);
+          LOG.warn("DeviceDaemon listener threw an exception", e);
         }
       }
     });

--- a/src/io/flutter/run/daemon/DeviceService.java
+++ b/src/io/flutter/run/daemon/DeviceService.java
@@ -16,6 +16,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ex.ProjectRootManagerEx;
 import com.intellij.openapi.util.Disposer;
 import io.flutter.FlutterMessages;
+import io.flutter.FlutterUtils;
 import io.flutter.bazel.WorkspaceCache;
 import io.flutter.sdk.FlutterSdkManager;
 import io.flutter.utils.Refreshable;
@@ -149,7 +150,7 @@ public class DeviceService {
           listener.run();
         }
         catch (Exception e) {
-          LOG.warn("DeviceDaemon listener threw an exception", e);
+          FlutterUtils.warn(LOG, "DeviceDaemon listener threw an exception", e);
         }
       }
     });

--- a/src/io/flutter/run/daemon/FlutterApp.java
+++ b/src/io/flutter/run/daemon/FlutterApp.java
@@ -31,13 +31,14 @@ import com.intellij.util.EventDispatcher;
 import com.intellij.util.concurrency.AppExecutorUtil;
 import com.jetbrains.lang.dart.ide.runner.ObservatoryConnector;
 import io.flutter.FlutterInitializer;
+import io.flutter.FlutterUtils;
 import io.flutter.logging.FlutterLog;
-import io.flutter.server.vmService.ServiceExtensions;
-import io.flutter.server.vmService.VMServiceManager;
 import io.flutter.pub.PubRoot;
 import io.flutter.pub.PubRoots;
 import io.flutter.run.FlutterDebugProcess;
 import io.flutter.run.FlutterLaunchMode;
+import io.flutter.server.vmService.ServiceExtensions;
+import io.flutter.server.vmService.VMServiceManager;
 import io.flutter.settings.FlutterSettings;
 import io.flutter.utils.ProgressHelper;
 import io.flutter.utils.StreamSubscription;
@@ -309,7 +310,7 @@ public class FlutterApp {
    */
   public CompletableFuture<DaemonApi.RestartResult> performRestartApp(@NotNull String reason) {
     if (myAppId == null) {
-      LOG.warn("cannot restart Flutter app because app id is not set");
+      FlutterUtils.warn(LOG, "cannot restart Flutter app because app id is not set");
 
       final CompletableFuture<DaemonApi.RestartResult> result = new CompletableFuture<>();
       result.completeExceptionally(new IllegalStateException("cannot restart Flutter app because app id is not set"));
@@ -345,7 +346,7 @@ public class FlutterApp {
   }
 
   /**
-   ** @return whether the latest of the version of the file is running.
+   * * @return whether the latest of the version of the file is running.
    */
   public boolean isLatestVersionRunning(VirtualFile file) {
     return file != null && file.getTimeStamp() <= maxFileTimestamp;
@@ -356,7 +357,7 @@ public class FlutterApp {
    */
   public CompletableFuture<DaemonApi.RestartResult> performHotReload(boolean pauseAfterRestart, @NotNull String reason) {
     if (myAppId == null) {
-      LOG.warn("cannot reload Flutter app because app id is not set");
+      FlutterUtils.warn(LOG, "cannot reload Flutter app because app id is not set");
 
       final CompletableFuture<DaemonApi.RestartResult> result = new CompletableFuture<>();
       result.completeExceptionally(new IllegalStateException("cannot reload Flutter app because app id is not set"));
@@ -381,7 +382,7 @@ public class FlutterApp {
 
   public CompletableFuture<Boolean> togglePlatform() {
     if (myAppId == null) {
-      LOG.warn("cannot invoke togglePlatform on Flutter app because app id is not set");
+      FlutterUtils.warn(LOG, "cannot invoke togglePlatform on Flutter app because app id is not set");
       return CompletableFuture.completedFuture(null);
     }
 
@@ -394,7 +395,7 @@ public class FlutterApp {
 
   public CompletableFuture<Boolean> togglePlatform(boolean showAndroid) {
     if (myAppId == null) {
-      LOG.warn("cannot invoke togglePlatform on Flutter app because app id is not set");
+      FlutterUtils.warn(LOG, "cannot invoke togglePlatform on Flutter app because app id is not set");
       return CompletableFuture.completedFuture(null);
     }
 
@@ -413,14 +414,15 @@ public class FlutterApp {
 
   public CompletableFuture<JsonObject> callServiceExtension(String methodName, Map<String, Object> params) {
     if (myAppId == null) {
-      LOG.warn("cannot invoke " + methodName + " on Flutter app because app id is not set");
+      FlutterUtils.warn(LOG, "cannot invoke " + methodName + " on Flutter app because app id is not set");
       return CompletableFuture.completedFuture(null);
     }
     if (isFlutterIsolateSuspended()) {
       return whenFlutterIsolateResumed().thenComposeAsync((ignored) ->
-        myDaemonApi.callAppServiceExtension(myAppId, methodName, params)
+                                                            myDaemonApi.callAppServiceExtension(myAppId, methodName, params)
       );
-    } else {
+    }
+    else {
       return myDaemonApi.callAppServiceExtension(myAppId, methodName, params);
     }
   }
@@ -438,7 +440,7 @@ public class FlutterApp {
   /**
    * Call a boolean service extension only if it is already present, skipping
    * otherwise.
-   *
+   * <p>
    * Only use this method if you are confident there will not be a race
    * condition where the service extension is registered shortly after
    * this method is called.
@@ -521,7 +523,7 @@ public class FlutterApp {
           // continue
         }
         catch (Exception e) {
-          LOG.warn(e);
+          FlutterUtils.warn(LOG, e);
           break;
         }
       }
@@ -683,7 +685,7 @@ class FlutterAppDaemonEventListener implements DaemonEvent.Listener {
       app.shutdownAsync().get();
     }
     catch (Exception e) {
-      LOG.warn("exception while shutting down Flutter App", e);
+      FlutterUtils.warn(LOG, "exception while shutting down Flutter App", e);
     }
   }
 

--- a/src/io/flutter/run/test/DebugTestRunner.java
+++ b/src/io/flutter/run/test/DebugTestRunner.java
@@ -165,7 +165,7 @@ public class DebugTestRunner extends GenericProgramRunner {
         obj = elem.getAsJsonObject();
       }
       catch (JsonSyntaxException e) {
-        LOG.error("Unable to parse JSON from Flutter test", e);
+        LOG.warn("Unable to parse JSON from Flutter test", e);
         return;
       }
 
@@ -178,19 +178,19 @@ public class DebugTestRunner extends GenericProgramRunner {
 
       final JsonPrimitive primEvent = obj.getAsJsonPrimitive("event");
       if (primEvent == null) {
-        LOG.error("Missing event field in JSON from Flutter test: " + obj);
+        LOG.warn("Missing event field in JSON from Flutter test: " + obj);
         return;
       }
 
       final String eventName = primEvent.getAsString();
       if (eventName == null) {
-        LOG.error("Unexpected event field in JSON from Flutter test: " + obj);
+        LOG.warn("Unexpected event field in JSON from Flutter test: " + obj);
         return;
       }
 
       final JsonObject params = obj.getAsJsonObject("params");
       if (params == null) {
-        LOG.error("Missing parameters in event from Flutter test: " + obj);
+        LOG.warn("Missing parameters in event from Flutter test: " + obj);
         return;
       }
 

--- a/src/io/flutter/run/test/DebugTestRunner.java
+++ b/src/io/flutter/run/test/DebugTestRunner.java
@@ -23,6 +23,7 @@ import com.intellij.xdebugger.XDebugSession;
 import com.intellij.xdebugger.XDebuggerManager;
 import com.jetbrains.lang.dart.ide.runner.ObservatoryConnector;
 import com.jetbrains.lang.dart.util.DartUrlResolver;
+import io.flutter.FlutterUtils;
 import io.flutter.run.PositionMapper;
 import io.flutter.sdk.FlutterSdk;
 import io.flutter.settings.FlutterSettings;
@@ -165,7 +166,7 @@ public class DebugTestRunner extends GenericProgramRunner {
         obj = elem.getAsJsonObject();
       }
       catch (JsonSyntaxException e) {
-        LOG.warn("Unable to parse JSON from Flutter test", e);
+        FlutterUtils.warn(LOG, "Unable to parse JSON from Flutter test", e);
         return;
       }
 
@@ -178,19 +179,19 @@ public class DebugTestRunner extends GenericProgramRunner {
 
       final JsonPrimitive primEvent = obj.getAsJsonPrimitive("event");
       if (primEvent == null) {
-        LOG.warn("Missing event field in JSON from Flutter test: " + obj);
+        FlutterUtils.warn(LOG, "Missing event field in JSON from Flutter test: " + obj);
         return;
       }
 
       final String eventName = primEvent.getAsString();
       if (eventName == null) {
-        LOG.warn("Unexpected event field in JSON from Flutter test: " + obj);
+        FlutterUtils.warn(LOG, "Unexpected event field in JSON from Flutter test: " + obj);
         return;
       }
 
       final JsonObject params = obj.getAsJsonObject("params");
       if (params == null) {
-        LOG.warn("Missing parameters in event from Flutter test: " + obj);
+        FlutterUtils.warn(LOG, "Missing parameters in event from Flutter test: " + obj);
         return;
       }
 

--- a/src/io/flutter/samples/FlutterSampleManager.java
+++ b/src/io/flutter/samples/FlutterSampleManager.java
@@ -10,6 +10,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.intellij.openapi.diagnostic.Logger;
+import io.flutter.FlutterUtils;
 import org.apache.commons.io.IOUtils;
 
 import java.io.IOException;
@@ -50,7 +51,7 @@ public class FlutterSampleManager {
       }
     }
     catch (URISyntaxException | IOException e) {
-      LOG.warn(e);
+      FlutterUtils.warn(LOG, e);
     }
 
     // Sort by name and library.

--- a/src/io/flutter/sdk/FlutterSdk.java
+++ b/src/io/flutter/sdk/FlutterSdk.java
@@ -22,6 +22,7 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.vfs.VirtualFileManager;
 import com.intellij.util.ui.EdtInvocationManager;
 import com.jetbrains.lang.dart.sdk.DartSdk;
+import io.flutter.FlutterUtils;
 import io.flutter.dart.DartPlugin;
 import io.flutter.pub.PubRoot;
 import io.flutter.run.FlutterLaunchMode;
@@ -334,7 +335,7 @@ public class FlutterSdk {
       return flutterBin.findFileByRelativePath("cache/dart-sdk") != null;
     }
     catch (InterruptedException e) {
-      LOG.warn(e);
+      FlutterUtils.warn(LOG, e);
       return false;
     }
   }
@@ -368,7 +369,7 @@ public class FlutterSdk {
       }
     }
     catch (InterruptedException e) {
-      LOG.warn(e);
+      FlutterUtils.warn(LOG, e);
       return null;
     }
 
@@ -501,7 +502,7 @@ public class FlutterSdk {
           final JsonParser jp = new JsonParser();
           final JsonElement elem = jp.parse(stdout.toString());
           if (elem.isJsonNull()) {
-            LOG.warn("Invalid Json from flutter config");
+            FlutterUtils.warn(LOG, "Invalid Json from flutter config");
             return null;
           }
 

--- a/src/io/flutter/server/vmService/DartVmServiceDebugProcess.java
+++ b/src/io/flutter/server/vmService/DartVmServiceDebugProcess.java
@@ -567,7 +567,7 @@ public class DartVmServiceDebugProcess extends XDebugProcess {
 
         @Override
         public void onError(RPCError error) {
-          LOG.error(error.toString());
+          LOG.warn(error.toString());
         }
       });
     }

--- a/src/io/flutter/server/vmService/DartVmServiceDebugProcess.java
+++ b/src/io/flutter/server/vmService/DartVmServiceDebugProcess.java
@@ -39,6 +39,7 @@ import com.jetbrains.lang.dart.util.DartUrlResolver;
 import gnu.trove.THashMap;
 import gnu.trove.TIntObjectHashMap;
 import io.flutter.FlutterBundle;
+import io.flutter.FlutterUtils;
 import io.flutter.run.FlutterLaunchMode;
 import io.flutter.server.vmService.frame.DartVmServiceEvaluator;
 import io.flutter.server.vmService.frame.DartVmServiceStackFrame;
@@ -567,7 +568,7 @@ public class DartVmServiceDebugProcess extends XDebugProcess {
 
         @Override
         public void onError(RPCError error) {
-          LOG.warn(error.toString());
+          FlutterUtils.warn(LOG, error.toString());
         }
       });
     }

--- a/src/io/flutter/server/vmService/DartVmServiceListener.java
+++ b/src/io/flutter/server/vmService/DartVmServiceListener.java
@@ -157,7 +157,7 @@ public class DartVmServiceListener implements VmServiceListener {
     else {
       if (vmBreakpoints.size() > 1) {
         // Shouldn't happen. IDE doesn't allow to set 2 breakpoints on one line.
-        LOG.error(vmBreakpoints.size() + " breakpoints hit in one shot.");
+        LOG.warn(vmBreakpoints.size() + " breakpoints hit in one shot.");
       }
 
       // Remove any temporary (run to cursor) breakpoints.

--- a/src/io/flutter/server/vmService/VmOpenSourceLocationListener.java
+++ b/src/io/flutter/server/vmService/VmOpenSourceLocationListener.java
@@ -14,6 +14,7 @@ import de.roderick.weberknecht.WebSocket;
 import de.roderick.weberknecht.WebSocketEventHandler;
 import de.roderick.weberknecht.WebSocketException;
 import de.roderick.weberknecht.WebSocketMessage;
+import io.flutter.FlutterUtils;
 import org.apache.commons.lang.StringUtils;
 import org.jetbrains.annotations.NotNull;
 
@@ -72,7 +73,7 @@ public class VmOpenSourceLocationListener {
           webSocket.send(message.toString());
         }
         catch (WebSocketException e) {
-          LOG.warn(e);
+          FlutterUtils.warn(LOG, e);
         }
       }
 
@@ -82,7 +83,7 @@ public class VmOpenSourceLocationListener {
           webSocket.close();
         }
         catch (WebSocketException e) {
-          LOG.warn(e);
+          FlutterUtils.warn(LOG, e);
         }
       }
     });
@@ -185,7 +186,7 @@ public class VmOpenSourceLocationListener {
       dispatcher.getMulticaster().onRequest(isolateId, scriptId, tokenPos);
 
     } catch (Exception e) {
-      LOG.warn(e);
+      FlutterUtils.warn(LOG, e);
     }
 
     if (id != null) {

--- a/src/io/flutter/utils/FileWatch.java
+++ b/src/io/flutter/utils/FileWatch.java
@@ -127,7 +127,7 @@ public class FileWatch {
     try {
       callback.run();
     } catch (Exception e) {
-      LOG.error("Uncaught exception in FileWatch callback", e);
+      LOG.warn("Uncaught exception in FileWatch callback", e);
       unsubscribe(); // avoid further errors
     }
   }

--- a/src/io/flutter/utils/FileWatch.java
+++ b/src/io/flutter/utils/FileWatch.java
@@ -20,6 +20,7 @@ import com.intellij.openapi.vfs.VirtualFileManager;
 import com.intellij.openapi.vfs.newvfs.BulkFileListener;
 import com.intellij.openapi.vfs.newvfs.events.VFileEvent;
 import com.intellij.util.messages.MessageBusConnection;
+import io.flutter.FlutterUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -127,7 +128,7 @@ public class FileWatch {
     try {
       callback.run();
     } catch (Exception e) {
-      LOG.warn("Uncaught exception in FileWatch callback", e);
+      FlutterUtils.warn(LOG, "Uncaught exception in FileWatch callback", e);
       unsubscribe(); // avoid further errors
     }
   }

--- a/src/io/flutter/utils/Refreshable.java
+++ b/src/io/flutter/utils/Refreshable.java
@@ -11,6 +11,7 @@ import com.intellij.openapi.Disposable;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.util.Disposer;
 import com.intellij.util.concurrency.AppExecutorUtil;
+import io.flutter.FlutterUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -67,8 +68,8 @@ public class Refreshable<T> implements Closeable {
   /**
    * Creates a refreshable variable that reports when it stops using a value that it created.
    *
-   * @param unpublish  will be called when the value is no longer in use. Can be called even though
-   *                   the value was never published. It will run on the Swing dispatch thread.
+   * @param unpublish will be called when the value is no longer in use. Can be called even though
+   *                  the value was never published. It will run on the Swing dispatch thread.
    */
   public Refreshable(Consumer<T> unpublish) {
     this.publisher = new Publisher(unpublish);
@@ -82,7 +83,8 @@ public class Refreshable<T> implements Closeable {
    *
    * <p>Calling getNow() twice during the same Swing event handler will return the same result.
    */
-  public @Nullable T getNow() {
+  public @Nullable
+  T getNow() {
     return publisher.get();
   }
 
@@ -101,7 +103,8 @@ public class Refreshable<T> implements Closeable {
    *
    * @throws IllegalStateException if called on the Swing dispatch thread.
    */
-  public @Nullable T getWhenReady() {
+  public @Nullable
+  T getWhenReady() {
     if (SwingUtilities.isEventDispatchThread()) {
       throw new IllegalStateException("getWhenReady shouldn't be called from Swing dispatch thread");
     }
@@ -115,8 +118,9 @@ public class Refreshable<T> implements Closeable {
 
     try {
       refreshDone.get();
-    } catch (Exception e) {
-      LOG.warn("Unexpected exception waiting for refresh task to finish", e);
+    }
+    catch (Exception e) {
+      FlutterUtils.warn(LOG, "Unexpected exception waiting for refresh task to finish", e);
     }
     return getNow();
   }
@@ -161,7 +165,7 @@ public class Refreshable<T> implements Closeable {
    */
   public void refresh(@NotNull Callback<T> callback) {
     if (publisher.isClosing()) {
-      LOG.warn("attempted to update closed Refreshable");
+      FlutterUtils.warn(LOG, "attempted to update closed Refreshable");
       return;
     }
     schedule.reschedule(new Request<>(this, callback));
@@ -216,13 +220,16 @@ public class Refreshable<T> implements Closeable {
         try {
           final T value = request.callback.call(request);
           publisher.reschedule(value);
-        } catch (CancellationException e) {
+        }
+        catch (CancellationException e) {
           // This is normal.
-        } catch (Exception e) {
+        }
+        catch (Exception e) {
           if (!Objects.equal(e.getMessage(), "expected failure in test")) {
-            LOG.warn("Callback threw an exception while updating a Refreshable", e);
+            FlutterUtils.warn(LOG, "Callback threw an exception while updating a Refreshable", e);
           }
-        } finally {
+        }
+        finally {
           schedule.done(request);
         }
 
@@ -236,11 +243,13 @@ public class Refreshable<T> implements Closeable {
               }
             }
           });
-        } catch (Exception e) {
-          LOG.warn("Unable to publish a value while updating a Refreshable", e);
+        }
+        catch (Exception e) {
+          FlutterUtils.warn(LOG, "Unable to publish a value while updating a Refreshable", e);
         }
       }
-    } finally {
+    }
+    finally {
       publisher.setState(State.IDLE);
       backgroundTask.set(null); // Allow restart on exit.
     }
@@ -251,7 +260,7 @@ public class Refreshable<T> implements Closeable {
   /**
    * A value indicating whether the Refreshable is being updated or not.
    */
-  public enum State { BUSY, IDLE, CLOSED }
+  public enum State {BUSY, IDLE, CLOSED}
 
   /**
    * A function that produces the next value of a Refreshable.
@@ -341,8 +350,9 @@ public class Refreshable<T> implements Closeable {
     /**
      * Returns the next task to run, or null if nothing is scheduled.
      */
-    synchronized @Nullable Request<T> next() {
-      assert(running == null);
+    synchronized @Nullable
+    Request<T> next() {
+      assert (running == null);
       running = scheduled;
       scheduled = null;
       return running;
@@ -352,7 +362,7 @@ public class Refreshable<T> implements Closeable {
      * Indicates that we finished creating a value.
      */
     synchronized void done(@NotNull Request<T> request) {
-      assert(running != null);
+      assert (running != null);
       running = null;
       cancelled = null;
     }
@@ -382,7 +392,10 @@ public class Refreshable<T> implements Closeable {
     private boolean closing;
 
     Publisher(@Nullable Consumer<T> unpublish) {
-      if (unpublish == null) unpublish = (x) -> {};
+      if (unpublish == null) {
+        unpublish = (x) -> {
+        };
+      }
       this.unpublishCallback = unpublish;
     }
 
@@ -434,7 +447,8 @@ public class Refreshable<T> implements Closeable {
     private synchronized T getPrevious() {
       if (needToPublish) {
         return scheduled;
-      } else {
+      }
+      else {
         return published;
       }
     }
@@ -472,7 +486,7 @@ public class Refreshable<T> implements Closeable {
      * Returns true if the value was published.
      */
     boolean publish() {
-      assert(SwingUtilities.isEventDispatchThread());
+      assert (SwingUtilities.isEventDispatchThread());
 
       final T discarded;
       synchronized (this) {
@@ -491,12 +505,13 @@ public class Refreshable<T> implements Closeable {
     }
 
     void unpublish(@Nullable T discarded) {
-      assert(SwingUtilities.isEventDispatchThread());
+      assert (SwingUtilities.isEventDispatchThread());
       if (discarded == null) return;
       try {
         unpublishCallback.accept(discarded);
-      } catch (Exception e) {
-        LOG.warn("An unpublish callback threw an exception while updating a Refreshable", e);
+      }
+      catch (Exception e) {
+        FlutterUtils.warn(LOG, "An unpublish callback threw an exception while updating a Refreshable", e);
       }
     }
 
@@ -508,8 +523,9 @@ public class Refreshable<T> implements Closeable {
 
       try {
         SwingUtilities.invokeAndWait(() -> doSetState(newState));
-      } catch (Exception e) {
-        LOG.warn("Unable to change state of Refreshable", e);
+      }
+      catch (Exception e) {
+        FlutterUtils.warn(LOG, "Unable to change state of Refreshable", e);
       }
     }
 
@@ -524,9 +540,10 @@ public class Refreshable<T> implements Closeable {
       for (Runnable sub : getSubscribers()) {
         try {
           sub.run();
-        } catch (Exception e) {
+        }
+        catch (Exception e) {
           if (!Objects.equal(e.getMessage(), "expected failure in test")) {
-            LOG.warn("A subscriber to a Refreshable threw an exception", e);
+            FlutterUtils.warn(LOG, "A subscriber to a Refreshable threw an exception", e);
           }
         }
       }
@@ -541,8 +558,9 @@ public class Refreshable<T> implements Closeable {
     void waitForFirstValue() {
       try {
         initialized.get();
-      } catch (Exception e) {
-        LOG.warn("Unexpected exception waiting for Refreshable to initialize", e);
+      }
+      catch (Exception e) {
+        FlutterUtils.warn(LOG, "Unexpected exception waiting for Refreshable to initialize", e);
       }
     }
 

--- a/src/io/flutter/utils/Refreshable.java
+++ b/src/io/flutter/utils/Refreshable.java
@@ -509,7 +509,7 @@ public class Refreshable<T> implements Closeable {
       try {
         SwingUtilities.invokeAndWait(() -> doSetState(newState));
       } catch (Exception e) {
-        LOG.error("Unable to change state of Refreshable", e);
+        LOG.warn("Unable to change state of Refreshable", e);
       }
     }
 

--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -392,7 +392,7 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
         InspectorService.create(app, app.getFlutterDebugProcess(), app.getVmService()),
         (InspectorService inspectorService, Throwable throwable) -> {
           if (throwable != null) {
-            LOG.warn(throwable);
+            FlutterUtils.warn(LOG, throwable);
             return;
           }
           debugActiveHelper(app, inspectorService);

--- a/src/io/flutter/view/InspectorPanel.java
+++ b/src/io/flutter/view/InspectorPanel.java
@@ -23,6 +23,7 @@ import com.intellij.util.ui.JBUI;
 import com.intellij.util.ui.tree.TreeUtil;
 import com.intellij.xdebugger.XSourcePosition;
 import io.flutter.FlutterBundle;
+import io.flutter.FlutterUtils;
 import io.flutter.editor.FlutterMaterialIcons;
 import io.flutter.inspector.*;
 import io.flutter.pub.PubRoot;
@@ -572,7 +573,7 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
                                           ? treeGroups.getNext().getDetailsSubtree(subtreeRoot)
                                           : treeGroups.getNext().getRoot(treeType), (final DiagnosticsNode n, Throwable error) -> {
       if (error != null) {
-        LOG.warn(error.toString());
+        FlutterUtils.warn(LOG, error);
         treeGroups.cancelNext();
         return;
       }
@@ -853,7 +854,7 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
       isSummaryTree ? CompletableFuture.allOf(pendingDetailsFuture, pendingSelectionFuture) : pendingSelectionFuture;
     selectionGroups.getNext().safeWhenComplete(selectionsReady, (ignored, error) -> {
       if (error != null) {
-        LOG.warn(error);
+        FlutterUtils.warn(LOG, error);
         selectionGroups.cancelNext();
         return;
       }
@@ -884,7 +885,7 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
         treeGroups.getCurrent()
           .safeWhenComplete(treeGroups.getCurrent().getParentChain(newSelection), (ArrayList<DiagnosticsPathNode> path, Throwable ex) -> {
             if (ex != null) {
-              LOG.warn(ex);
+              FlutterUtils.warn(LOG, ex);
               return;
             }
             DefaultMutableTreeNode treeNode = getRootNode();
@@ -1008,7 +1009,7 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
       if (diagnostic.hasChildren() && treeNode.getChildCount() == 0) {
         diagnostic.safeWhenComplete(diagnostic.getChildren(), (ArrayList<DiagnosticsNode> children, Throwable throwable) -> {
           if (throwable != null) {
-            LOG.warn(throwable);
+            FlutterUtils.warn(LOG, throwable);
             return;
           }
           if (treeNode.getChildCount() == 0) {
@@ -1278,7 +1279,7 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
         node.safeWhenComplete(propertyDoc, (String tooltip, Throwable th) -> {
           // TODO(jacobr): make sure we still care about seeing this tooltip.
           if (th != null) {
-            LOG.warn(th);
+            FlutterUtils.warn(LOG, th);
           }
           setToolTipText(tooltip);
         });
@@ -1430,7 +1431,7 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
           if (throwable != null) {
             getTreeModel().setRoot(new DefaultMutableTreeNode());
             getEmptyText().setText(FlutterBundle.message("app.inspector.error_loading_properties"));
-            LOG.warn(throwable);
+            FlutterUtils.warn(LOG, throwable);
             groups.cancelNext();
             return;
           }
@@ -1451,7 +1452,7 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
         if (errorGettingInstances != null) {
           // TODO(jacobr): show error message explaining properties could not be loaded.
           getTreeModel().setRoot(new DefaultMutableTreeNode());
-          LOG.warn(errorGettingInstances);
+          FlutterUtils.warn(LOG, errorGettingInstances);
           getEmptyText().setText(FlutterBundle.message("app.inspector.error_loading_property_details"));
           groups.cancelNext();
           return;

--- a/src/io/flutter/view/InspectorPanel.java
+++ b/src/io/flutter/view/InspectorPanel.java
@@ -48,8 +48,8 @@ import java.awt.event.ComponentEvent;
 import java.awt.event.ComponentListener;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
-import java.util.*;
 import java.util.List;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 
 public class InspectorPanel extends JPanel implements Disposable, InspectorService.InspectorServiceClient, InspectorTabPanel {
@@ -123,7 +123,7 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
   private DefaultMutableTreeNode selectedNode;
   private DefaultMutableTreeNode lastExpanded;
   private boolean isActive = false;
-  private Map<InspectorInstanceRef, DefaultMutableTreeNode> valueToTreeNode = new HashMap<>();
+  private final Map<InspectorInstanceRef, DefaultMutableTreeNode> valueToTreeNode = new HashMap<>();
 
   /**
    * When visibleToUser is false we should dispose all allocated objects and
@@ -141,7 +141,7 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
                         boolean legacyMode,
                         @NotNull EventStream<Boolean> shouldAutoHorizontalScroll,
                         @NotNull EventStream<Boolean> highlightNodesShownInBothTrees
-                        ) {
+  ) {
     this(flutterView, flutterApp, inspectorService, isApplicable, treeType, false, null, isSummaryTree, legacyMode,
          shouldAutoHorizontalScroll, highlightNodesShownInBothTrees);
   }
@@ -572,7 +572,7 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
                                           ? treeGroups.getNext().getDetailsSubtree(subtreeRoot)
                                           : treeGroups.getNext().getRoot(treeType), (final DiagnosticsNode n, Throwable error) -> {
       if (error != null) {
-        LOG.error(error.toString());
+        LOG.warn(error.toString());
         treeGroups.cancelNext();
         return;
       }
@@ -853,7 +853,7 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
       isSummaryTree ? CompletableFuture.allOf(pendingDetailsFuture, pendingSelectionFuture) : pendingSelectionFuture;
     selectionGroups.getNext().safeWhenComplete(selectionsReady, (ignored, error) -> {
       if (error != null) {
-        LOG.error(error);
+        LOG.warn(error);
         selectionGroups.cancelNext();
         return;
       }
@@ -884,7 +884,7 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
         treeGroups.getCurrent()
           .safeWhenComplete(treeGroups.getCurrent().getParentChain(newSelection), (ArrayList<DiagnosticsPathNode> path, Throwable ex) -> {
             if (ex != null) {
-              LOG.error(ex);
+              LOG.warn(ex);
               return;
             }
             DefaultMutableTreeNode treeNode = getRootNode();
@@ -1008,7 +1008,7 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
       if (diagnostic.hasChildren() && treeNode.getChildCount() == 0) {
         diagnostic.safeWhenComplete(diagnostic.getChildren(), (ArrayList<DiagnosticsNode> children, Throwable throwable) -> {
           if (throwable != null) {
-            LOG.error(throwable);
+            LOG.warn(throwable);
             return;
           }
           if (treeNode.getChildCount() == 0) {
@@ -1278,7 +1278,7 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
         node.safeWhenComplete(propertyDoc, (String tooltip, Throwable th) -> {
           // TODO(jacobr): make sure we still care about seeing this tooltip.
           if (th != null) {
-            LOG.error(th);
+            LOG.warn(th);
           }
           setToolTipText(tooltip);
         });
@@ -1430,7 +1430,7 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
           if (throwable != null) {
             getTreeModel().setRoot(new DefaultMutableTreeNode());
             getEmptyText().setText(FlutterBundle.message("app.inspector.error_loading_properties"));
-            LOG.error(throwable);
+            LOG.warn(throwable);
             groups.cancelNext();
             return;
           }
@@ -1449,10 +1449,9 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
       }
       groups.getNext().safeWhenComplete(loadPropertyMetadata(properties), (Void ignored, Throwable errorGettingInstances) -> {
         if (errorGettingInstances != null) {
-          // TODO(jacobr): show error message explaining properties could not
-          // be loaded.
+          // TODO(jacobr): show error message explaining properties could not be loaded.
           getTreeModel().setRoot(new DefaultMutableTreeNode());
-          LOG.error(errorGettingInstances);
+          LOG.warn(errorGettingInstances);
           getEmptyText().setText(FlutterBundle.message("app.inspector.error_loading_property_details"));
           groups.cancelNext();
           return;

--- a/src/io/flutter/view/InspectorTreeMouseListener.java
+++ b/src/io/flutter/view/InspectorTreeMouseListener.java
@@ -7,6 +7,7 @@ package io.flutter.view;
 
 import com.google.common.base.Joiner;
 import com.intellij.openapi.diagnostic.Logger;
+import io.flutter.FlutterUtils;
 import io.flutter.inspector.DiagnosticsNode;
 import io.flutter.inspector.TreeUtils;
 
@@ -156,7 +157,7 @@ class InspectorTreeMouseListener extends MouseAdapter {
               tooltip = "Loading dart docs...";
               diagnostic.getInspectorService().safeWhenComplete(propertyDoc, (String tip, Throwable th) -> {
                 if (th != null) {
-                  LOG.warn(th);
+                  FlutterUtils.warn(LOG, th);
                 }
                 if (lastHover == node) {
                   // We are still hovering of the same node so show the user the tooltip.

--- a/src/io/flutter/view/InspectorTreeMouseListener.java
+++ b/src/io/flutter/view/InspectorTreeMouseListener.java
@@ -156,7 +156,7 @@ class InspectorTreeMouseListener extends MouseAdapter {
               tooltip = "Loading dart docs...";
               diagnostic.getInspectorService().safeWhenComplete(propertyDoc, (String tip, Throwable th) -> {
                 if (th != null) {
-                  LOG.error(th);
+                  LOG.warn(th);
                 }
                 if (lastHover == node) {
                   // We are still hovering of the same node so show the user the tooltip.

--- a/src/io/flutter/view/MultiIconSimpleColoredComponent.java
+++ b/src/io/flutter/view/MultiIconSimpleColoredComponent.java
@@ -740,7 +740,7 @@ public class MultiIconSimpleColoredComponent extends JComponent implements Acces
       _doPaint(g);
     }
     catch (RuntimeException e) {
-      LOG.error(logSwingPath(), e);
+      LOG.warn(logSwingPath(), e);
       throw e;
     }
   }


### PR DESCRIPTION
- don't use `LOG.error()`
- fix https://github.com/flutter/flutter-intellij/issues/2893, and a number of related issues

Using `LOG.error(...)` will cause an exception dialog to be displayed to the user. We should prefer using LOG.warn / LOG.info, and / or surfacing any errors to the user in whatever mode is best for the situation (a toast, and error dialog, a failed operation, ...).

