### PR TITLE
Refactor DiagnosticsNode to accept a Future<ObjectGroup>

### DIFF
--- a/src/io/flutter/inspector/DiagnosticsNode.java
+++ b/src/io/flutter/inspector/DiagnosticsNode.java
@@ -50,6 +50,7 @@ import java.util.function.BiConsumer;
  */
 public class DiagnosticsNode {
   private static final CustomIconMaker iconMaker = new CustomIconMaker();
+  private final FlutterApp app;
 
   private InspectorSourceLocation location;
   private DiagnosticsNode parent;
@@ -63,8 +64,20 @@ public class DiagnosticsNode {
                          boolean isProperty,
                          DiagnosticsNode parent) {
     this.json = json;
+    this.inspectorService = CompletableFuture.completedFuture(inspectorService);
+    this.isProperty = isProperty;
+    this.app = inspectorService.getApp();
+  }
+
+  public DiagnosticsNode(JsonObject json,
+                         CompletableFuture<InspectorService.ObjectGroup> inspectorService,
+                         FlutterApp app,
+                         boolean isProperty,
+                         DiagnosticsNode parent) {
+    this.json = json;
     this.inspectorService = inspectorService;
     this.isProperty = isProperty;
+    this.app = app;
   }
 
   @Override
@@ -84,6 +97,17 @@ public class DiagnosticsNode {
     }
 
     return name + getSeparator() + ' ' + getDescription();
+  }
+
+  public boolean isDisposed() {
+    try {
+      final InspectorService.ObjectGroup service = inspectorService.getNow(null);
+      // If the service isn't yet been create it can't have been disposed.
+      return service != null && service.isDisposed();
+    } catch (Exception e) {
+      // If the service can't be acquired then it is disposed.
+      return false;
+    }
   }
 
   /**
@@ -452,7 +476,7 @@ public class DiagnosticsNode {
    * Service used to retrieve more detailed information about the value of
    * the property and its children and properties.
    */
-  private final InspectorService.ObjectGroup inspectorService;
+  private final CompletableFuture<InspectorService.ObjectGroup> inspectorService;
 
   /**
    * JSON describing the diagnostic node.
@@ -538,7 +562,12 @@ public class DiagnosticsNode {
       }
       if (isEnumProperty()) {
         // Populate all the enum property values.
-        valueProperties = inspectorService.getEnumPropertyValues(getValueRef());
+        valueProperties = inspectorService.thenComposeAsync((service) -> {
+          if (service == null) {
+            return null;
+          }
+          return service.getEnumPropertyValues(getValueRef());
+        });
         return valueProperties;
       }
 
@@ -556,7 +585,12 @@ public class DiagnosticsNode {
           valueProperties = CompletableFuture.completedFuture(null);
           return valueProperties;
       }
-      valueProperties = inspectorService.getDartObjectProperties(getValueRef(), propertyNames);
+      valueProperties = inspectorService.thenComposeAsync((service) -> {
+        if (service == null) {
+          return null;
+        }
+        return service.getDartObjectProperties(getValueRef(), propertyNames);
+      });
     }
     return valueProperties;
   }
@@ -604,13 +638,18 @@ public class DiagnosticsNode {
         final JsonArray jsonArray = json.get("children").getAsJsonArray();
         final ArrayList<DiagnosticsNode> nodes = new ArrayList<>();
         for (JsonElement element : jsonArray) {
-          DiagnosticsNode child = new DiagnosticsNode(element.getAsJsonObject(), inspectorService, false, parent);
+          DiagnosticsNode child = new DiagnosticsNode(element.getAsJsonObject(), inspectorService,  app,false, parent);
           child.setParent(this);
           nodes.add(child);
         }
         children = CompletableFuture.completedFuture(nodes);
       } else  if (hasChildren()) {
-        children = inspectorService.getChildren(getDartDiagnosticRef(), isSummaryTree(), this);
+        children = inspectorService.thenComposeAsync((service) -> {
+          if (service == null) {
+            return null;
+          }
+          return service.getChildren(getDartDiagnosticRef(), isSummaryTree(), this);
+        });
       }
       else {
         // Known to have no children so we can provide the children immediately.
@@ -637,7 +676,7 @@ public class DiagnosticsNode {
       if (json.has("properties")) {
         final JsonArray jsonArray = json.get("properties").getAsJsonArray();
         for (JsonElement element : jsonArray) {
-          cachedProperties.add(new DiagnosticsNode(element.getAsJsonObject(), inspectorService, true, parent));
+          cachedProperties.add(new DiagnosticsNode(element.getAsJsonObject(), inspectorService, app, true, parent));
         }
         trackPropertiesMatchingParameters(cachedProperties);
       }
@@ -689,12 +728,12 @@ public class DiagnosticsNode {
   private CompletableFuture<String> createPropertyDocFurure() {
     final DiagnosticsNode parent = getParent();
     if (parent != null) {
-      return inspectorService.toDartVmServiceValueForSourceLocation(parent.getValueRef())
+      return inspectorService.thenComposeAsync((service) -> service.toDartVmServiceValueForSourceLocation(parent.getValueRef())
         .thenComposeAsync((DartVmServiceValue vmValue) -> {
           if (vmValue == null) {
             return CompletableFuture.completedFuture(null);
           }
-          return inspectorService.getPropertyLocation(vmValue.getInstanceRef(), getName())
+          return inspectorService.getNow(null).getPropertyLocation(vmValue.getInstanceRef(), getName())
           .thenApplyAsync((XSourcePosition sourcePosition) -> {
             if (sourcePosition != null) {
               final VirtualFile file = sourcePosition.getFile();
@@ -711,7 +750,7 @@ public class DiagnosticsNode {
             }
             return "Unable to find property source";
           });
-        });
+        }));
     }
 
     return CompletableFuture.completedFuture("Unable to find property source");
@@ -719,7 +758,6 @@ public class DiagnosticsNode {
 
   @Nullable
   private Project getProject(@NotNull VirtualFile file) {
-    final FlutterApp app = inspectorService.getApp();
     return app != null ? app.getProject() : ProjectUtil.guessProjectForFile(file);
   }
 
@@ -727,7 +765,7 @@ public class DiagnosticsNode {
     this.location = location;
   }
 
-  public InspectorService.ObjectGroup getInspectorService() {
+  public CompletableFuture<InspectorService.ObjectGroup> getInspectorService() {
     return inspectorService;
   }
 
@@ -784,6 +822,29 @@ public class DiagnosticsNode {
    * InspectorService group is still alive when the Future completes.
    */
   public <T> void safeWhenComplete(CompletableFuture<T> future, BiConsumer<? super T, ? super Throwable> action) {
-    inspectorService.safeWhenComplete(future, action);
+    try {
+      final InspectorService.ObjectGroup service = inspectorService.getNow(null);
+      if (service != null) {
+        service.safeWhenComplete(future, action);
+        return;
+      }
+      inspectorService.whenCompleteAsync((group, t) -> {
+        if (group == null || t != null) {
+          return;
+        }
+        group.safeWhenComplete(future, action);
+      });
+    } catch (Exception e) {
+      // Nothing to do if the service can't be acquired.
+    }
+  }
+
+  public void setSelection(InspectorInstanceRef ref, boolean uiAlreadyUpdated) {
+    inspectorService.thenAcceptAsync((service) -> {
+      if (service == null) {
+        return;
+      }
+      service.setSelection(ref, uiAlreadyUpdated);
+    });
   }
 }

--- a/src/io/flutter/inspector/DiagnosticsNode.java
+++ b/src/io/flutter/inspector/DiagnosticsNode.java
@@ -102,7 +102,7 @@ public class DiagnosticsNode {
   public boolean isDisposed() {
     try {
       final InspectorService.ObjectGroup service = inspectorService.getNow(null);
-      // If the service isn't yet been create it can't have been disposed.
+      // If the service isn't created yet it can't have been disposed.
       return service != null && service.isDisposed();
     } catch (Exception e) {
       // If the service can't be acquired then it is disposed.

--- a/src/io/flutter/inspector/InspectorService.java
+++ b/src/io/flutter/inspector/InspectorService.java
@@ -45,7 +45,17 @@ public class InspectorService implements Disposable {
 
   private final StreamSubscription<Boolean> setPubRootDirectoriesSubscription;
 
-  public static CompletableFuture<InspectorService> create(@NotNull FlutterApp app,
+  /**
+   * Convenience ObjectGroup constructor for users who need to use
+   * DiagnosticsNode objects before the InspectorService is available.
+   */
+  public static CompletableFuture<InspectorService.ObjectGroup> createGroup(
+    @NotNull FlutterApp app, @NotNull FlutterDebugProcess debugProcess,
+    @NotNull VmService vmService, String groupName) {
+    return create(app, debugProcess, vmService).thenApplyAsync((service) -> service.createObjectGroup(groupName));
+  }
+
+    public static CompletableFuture<InspectorService> create(@NotNull FlutterApp app,
                                                            @NotNull FlutterDebugProcess debugProcess,
                                                            @NotNull VmService vmService) {
     assert app.getVMServiceManager() != null;

--- a/src/io/flutter/inspector/JumpToSourceActionBase.java
+++ b/src/io/flutter/inspector/JumpToSourceActionBase.java
@@ -55,9 +55,9 @@ public abstract class JumpToSourceActionBase extends InspectorTreeActionBase {
       return;
     }
     // We have to get a DartVmServiceValue to compute the source position.
-    final InspectorService.ObjectGroup inspectorService = diagnosticsNode.getInspectorService();
+    final CompletableFuture<InspectorService.ObjectGroup> inspectorService = diagnosticsNode.getInspectorService();
     final CompletableFuture<DartVmServiceValue> valueFuture =
-      inspectorService.toDartVmServiceValueForSourceLocation(diagnosticsNode.getValueRef());
+      inspectorService.thenComposeAsync((service) -> service.toDartVmServiceValueForSourceLocation(diagnosticsNode.getValueRef()));
     AsyncUtils.whenCompleteUiThread(valueFuture, (DartVmServiceValue value, Throwable throwable) -> {
       if (throwable != null) {
         return;

--- a/src/io/flutter/view/InspectorPanel.java
+++ b/src/io/flutter/view/InspectorPanel.java
@@ -1120,7 +1120,7 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
           // assuming the first parent is a regular node.
           toSelect = getDiagnosticNode((DefaultMutableTreeNode)path.getPathComponent(path.getPathCount() - 2));
         }
-        toSelect.getInspectorService().setSelection(toSelect.getValueRef(), true);
+        toSelect.setSelection(toSelect.getValueRef(), true);
       }
     }
 
@@ -1130,7 +1130,7 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
     else if (diagnostic != null) {
       // We can't rely on the details tree to update the selection on the server in this case.
       DiagnosticsNode selection = detailsSelection != null ? detailsSelection : diagnostic;
-      selection.getInspectorService().setSelection(selection.getValueRef(), true);
+      selection.setSelection(selection.getValueRef(), true);
     }
   }
 
@@ -1419,7 +1419,7 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
 
     public void showProperties(DiagnosticsNode diagnostic) {
       this.diagnostic = diagnostic;
-      if (diagnostic == null || diagnostic.getInspectorService().isDisposed()) {
+      if (diagnostic == null || diagnostic.isDisposed()) {
         shutdownTree(false);
         return;
       }
@@ -1496,7 +1496,7 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
       // until we have tested whether the properties are identical.
 
       groups.cancelNext(); // Cancel any existing pending next state.
-      if (diagnostic.getInspectorService().isDisposed()) {
+      if (diagnostic.isDisposed()) {
         // We are getting properties for a stale object. Wait until the next frame when we will have new properties.
         return;
       }

--- a/src/io/flutter/view/InspectorTreeMouseListener.java
+++ b/src/io/flutter/view/InspectorTreeMouseListener.java
@@ -154,7 +154,7 @@ class InspectorTreeMouseListener extends MouseAdapter {
             }
             else {
               tooltip = "Loading dart docs...";
-              diagnostic.getInspectorService().safeWhenComplete(propertyDoc, (String tip, Throwable th) -> {
+              diagnostic.safeWhenComplete(propertyDoc, (String tip, Throwable th) -> {
                 if (th != null) {
                   LOG.error(th);
                 }
@@ -169,7 +169,7 @@ class InspectorTreeMouseListener extends MouseAdapter {
             if (diagnostic.isEnumProperty()) {
               // We can display a better tooltip as we have access to introspection
               // via the observatory service.
-              diagnostic.getInspectorService().safeWhenComplete(diagnostic.getValueProperties(), (properties, th) -> {
+              diagnostic.safeWhenComplete(diagnostic.getValueProperties(), (properties, th) -> {
                 if (properties == null || lastHover != node) {
                   return;
                 }


### PR DESCRIPTION
and add a convenience method to InspectorService to create a
Future<ObjectGroup> directly.

This unblocks letting the logging view display DiagnosticsNode structured
errors before the InspectorService is available.

With async await and FutureOr, this would have taken 20 lines of code and 10 minutes instead of an hour and 100 lines of code.