### PR TITLE
Restore service extension states from device on start and attach.

### DIFF
--- a/src/io/flutter/server/vmService/ServiceExtensions.java
+++ b/src/io/flutter/server/vmService/ServiceExtensions.java
@@ -12,15 +12,13 @@ import java.util.stream.Collectors;
 
 // Each service extension needs to be manually added to [toggleableExtensionDescriptions].
 public class ServiceExtensions {
-  // TODO(kenzie): Alter these values to match other extensions once service extension states are restored from device.
-  // These values are currently configured differently because we invert the value of this service extension state.
   public static final ToggleableServiceExtensionDescription<Boolean> debugAllowBanner =
     new ToggleableServiceExtensionDescription<>(
       "ext.flutter.debugAllowBanner",
-      false,
       true,
-      "Show Debug Mode Banner",
-      "Hide Debug Mode Banner");
+      false,
+      "Hide Debug Mode Banner",
+      "Show Debug Mode Banner");
 
   public static final ToggleableServiceExtensionDescription<Boolean> debugPaint =
     new ToggleableServiceExtensionDescription<>(

--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -696,17 +696,9 @@ class ForceRefreshAction extends FlutterViewAction {
   }
 }
 
-class HideDebugModeBannerAction extends FlutterViewToggleableAction {
-  HideDebugModeBannerAction(@NotNull FlutterApp app) {
-    super(app, FlutterIcons.DebugBanner, ServiceExtensions.debugAllowBanner, true);
-  }
-
-  // TODO(kenzie): remove this override once service extension states are restored from device.
-  @Override
-  protected void perform(@Nullable AnActionEvent event) {
-    if (app.isSessionActive()) {
-      app.callBooleanExtension(ServiceExtensions.debugAllowBanner.getExtension(), !isSelected());
-    }
+class ShowDebugBannerAction extends FlutterViewToggleableAction {
+  ShowDebugBannerAction(@NotNull FlutterApp app) {
+    super(app, FlutterIcons.DebugBanner, ServiceExtensions.debugAllowBanner);
   }
 }
 
@@ -750,7 +742,7 @@ class OverflowAction extends ToolbarComboBoxAction implements RightAlignedToolba
 
     group.add(view.registerAction(new RepaintRainbowAction(app)));
     group.addSeparator();
-    group.add(view.registerAction(new HideDebugModeBannerAction(app)));
+    group.add(view.registerAction(new ShowDebugBannerAction(app)));
     group.addSeparator();
     group.add(view.registerAction(new AutoHorizontalScrollAction(app, view.shouldAutoHorizontalScroll)));
     group.add(view.registerAction(new HighlightNodesShownInBothTrees(app, view.highlightNodesShownInBothTrees)));

--- a/src/io/flutter/view/FlutterViewToggleableAction.java
+++ b/src/io/flutter/view/FlutterViewToggleableAction.java
@@ -29,21 +29,6 @@ abstract class FlutterViewToggleableAction extends FlutterViewAction implements 
     this.extensionDescription = extensionDescription;
   }
 
-  // TODO(kenzie): remove this constructor once service extension states are restored from device.
-  //  This is currently only needed for HideDebugModeBannerAction.
-  FlutterViewToggleableAction(
-    @NotNull FlutterApp app,
-    @Nullable Icon icon,
-    ToggleableServiceExtensionDescription extensionDescription,
-    boolean actionEnabledByDefault) {
-    super(
-      app,
-      actionEnabledByDefault ? extensionDescription.getEnabledText() : extensionDescription.getDisabledText(),
-      null,
-      icon);
-    this.extensionDescription = extensionDescription;
-  }
-
   @Override
   public final void update(@NotNull AnActionEvent e) {
     // selected


### PR DESCRIPTION
This also allows us to stop inverting the debug mode banner extension. This extension is default-enabled on the device for a debug build. Querying the device for the extension state on start/attach allows us to set our extension state accordingly.