### PR TITLE
fix NPE in bazel config

### DIFF
--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.java
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.java
@@ -108,7 +108,8 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     mySyncAndroidLibrariesCheckBox.setVisible(FlutterUtils.isAndroidStudio());
 
     // Disable the bazel test runner experiment if no new bazel test script is available.
-    if (Workspace.load(myProject).getTestScript() == null) {
+    final Workspace workspace = Workspace.load(myProject);
+    if (workspace == null || workspace.getTestScript() == null) {
       myUseNewBazelTestRunner.setEnabled(false);
       myUseNewBazelTestRunner.setText(FlutterBundle.message("settings.enable.bazel.test.runner") + " "
                                       + FlutterBundle.message("settings.enable.bazel.test.runner.mustSyncClientWarning"));


### PR DESCRIPTION
Fixes:

```
java.lang.NullPointerException
	at io.flutter.sdk.FlutterSettingsConfigurable.init(FlutterSettingsConfigurable.java:111)
	at io.flutter.sdk.FlutterSettingsConfigurable.<init>(FlutterSettingsConfigurable.java:73)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at org.picocontainer.defaults.InstantiatingComponentAdapter.newInstance(InstantiatingComponentAdapter.java:193)
	at com.intellij.util.pico.CachingConstructorInjectionComponentAdapter.doGetComponentInstance(CachingConstructorInjectionComponentAdapter.java:85)
	at com.intellij.util.pico.CachingConstructorInjectionComponentAdapter.instantiateGuarded(CachingConstructorInjectionComponentAdapter.java:62)
	at com.intellij.util.pico.CachingConstructorInjectionComponentAdapter.getComponentInstance(CachingConstructorInjectionComponentAdapter.java:45)
	at com.intellij.openapi.extensions.AbstractExtensionPointBean.instantiate(AbstractExtensionPointBean.java:68)
	at com.intellij.openapi.options.ConfigurableEP$ClassProducer.createElement(ConfigurableEP.java:334)
	at com.intellij.openapi.options.ConfigurableEP.createConfigurable(ConfigurableEP.java:260)
	at com.intellij.openapi.options.ex.ConfigurableWrapper.createConfigurable(ConfigurableWrapper.java:57)
	at com.intellij.openapi.options.ex.ConfigurableWrapper.getConfigurable(ConfigurableWrapper.java:116)
	at com.intellij.openapi.options.ex.ConfigurableWrapper.cast(ConfigurableWrapper.java:97)
	at com.intellij.openapi.options.ex.ConfigurableCardPanel.prepare(ConfigurableCardPanel.java:42)
	at com.intellij.openapi.options.ex.ConfigurableCardPanel.prepare(ConfigurableCardPanel.java:35)
	at com.intellij.ui.CardLayoutPanel.lambda$selectLater$1(CardLayoutPanel.java:128)
	at com.intellij.openapi.application.impl.ApplicationImpl$1.run(ApplicationImpl.java:314)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run$$$capture(FutureTask.java:266)
	at java.util.concurrent.FutureTask.run(FutureTask.java)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```

@DaveShuckerow @jwren 