### PR TITLE
sample creation banner

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -778,6 +778,7 @@
     <editorNotificationProvider implementation="io.flutter.editor.FlutterPubspecNotificationProvider"/>
     <editorNotificationProvider implementation="io.flutter.inspections.SdkConfigurationNotificationProvider"/>
     <editorNotificationProvider implementation="io.flutter.editor.NativeEditorNotificationProvider"/>
+    <editorNotificationProvider implementation="io.flutter.samples.FlutterSampleNotificationProvider"/>
 
     <projectService serviceInterface="io.flutter.run.FlutterReloadManager"
                     serviceImplementation="io.flutter.run.FlutterReloadManager"

--- a/resources/META-INF/plugin_template.xml
+++ b/resources/META-INF/plugin_template.xml
@@ -254,6 +254,7 @@
     <editorNotificationProvider implementation="io.flutter.editor.FlutterPubspecNotificationProvider"/>
     <editorNotificationProvider implementation="io.flutter.inspections.SdkConfigurationNotificationProvider"/>
     <editorNotificationProvider implementation="io.flutter.editor.NativeEditorNotificationProvider"/>
+    <editorNotificationProvider implementation="io.flutter.samples.FlutterSampleNotificationProvider"/>
 
     <projectService serviceInterface="io.flutter.run.FlutterReloadManager"
                     serviceImplementation="io.flutter.run.FlutterReloadManager"

--- a/src/io/flutter/module/FlutterModuleBuilder.java
+++ b/src/io/flutter/module/FlutterModuleBuilder.java
@@ -282,11 +282,11 @@ public class FlutterModuleBuilder extends ModuleBuilder {
    * Returns the PubRoot if successful.
    */
   @Nullable
-  private static PubRoot runFlutterCreateWithProgress(@NotNull VirtualFile baseDir,
-                                                      @NotNull FlutterSdk sdk,
-                                                      @NotNull Project project,
-                                                      @Nullable ProcessListener processListener,
-                                                      @Nullable FlutterCreateAdditionalSettings additionalSettings) {
+  public static PubRoot runFlutterCreateWithProgress(@NotNull VirtualFile baseDir,
+                                                     @NotNull FlutterSdk sdk,
+                                                     @NotNull Project project,
+                                                     @Nullable ProcessListener processListener,
+                                                     @Nullable FlutterCreateAdditionalSettings additionalSettings) {
     final ProgressManager progress = ProgressManager.getInstance();
     final AtomicReference<PubRoot> result = new AtomicReference<>(null);
 

--- a/src/io/flutter/samples/FlutterSample.java
+++ b/src/io/flutter/samples/FlutterSample.java
@@ -5,6 +5,8 @@
  */
 package io.flutter.samples;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.petebevin.markdown.MarkdownProcessor;
 import org.jetbrains.annotations.NotNull;
 
 public class FlutterSample {
@@ -43,6 +45,44 @@ public class FlutterSample {
     // TODO(pq): add disambiguation once it's needed.
     return getElement();
   }
+
+  public String getShortHtmlDescription() {
+    return "<html>" + parseShortHtmlDescription(description) + "</html>";
+  }
+
+  @VisibleForTesting
+  public static String parseShortHtmlDescription(@NotNull String description) {
+    // Trim to first sentence.
+    int sentenceBreakIndex = description.indexOf(". ");
+    if (sentenceBreakIndex == -1) {
+      sentenceBreakIndex = description.indexOf(".\n");
+    }
+    if (sentenceBreakIndex != -1) {
+      description = description.substring(0, sentenceBreakIndex + 1);
+    }
+
+    return parseHtmlDescription(description);
+  }
+
+  @VisibleForTesting
+  public static String parseHtmlDescription(@NotNull String description) {
+    // Remove newlines.
+    description = description.replace('\n', ' ');
+
+    // Remove links: [Card] => **Card**
+    final StringBuilder builder = new StringBuilder();
+    for (int i=0; i < description.length(); ++i) {
+      final char c = description.charAt(i);
+      if ((c == '[' || c == ']') && (i == 0 || description.charAt(i-1) != '\\')) {
+        builder.append("**");
+      } else {
+        builder.append(c);
+      }
+    }
+
+    return new MarkdownProcessor().markdown(builder.toString()).trim();
+  }
+
 
   @NotNull
   public String getLibrary() {

--- a/src/io/flutter/samples/FlutterSampleActionsPanel.java
+++ b/src/io/flutter/samples/FlutterSampleActionsPanel.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2019 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.samples;
+
+import com.intellij.openapi.editor.colors.ColorKey;
+import com.intellij.openapi.editor.colors.EditorColors;
+import com.intellij.openapi.editor.colors.EditorColorsManager;
+import com.intellij.openapi.editor.colors.EditorColorsScheme;
+import com.intellij.openapi.project.Project;
+import com.intellij.ui.JBColor;
+import com.intellij.ui.components.JBLabel;
+import com.intellij.ui.components.panels.NonOpaquePanel;
+import com.intellij.util.ui.JBUI;
+import com.intellij.util.ui.UIUtil;
+import icons.FlutterIcons;
+import io.flutter.FlutterMessages;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.util.List;
+
+public class FlutterSampleActionsPanel extends JPanel {
+
+  protected final JLabel myLabel = new JLabel();
+  protected final JBLabel goLink;
+
+  @NotNull private final List<FlutterSample> samples;
+  @NotNull private final Project project;
+  protected Color myBackgroundColor;
+  protected ColorKey myBackgroundColorKey;
+
+  final JEditorPane descriptionText;
+
+  // Combo or label.
+  JComponent sampleSelector;
+
+  FlutterSampleActionsPanel(@NotNull List<FlutterSample> samples, @NotNull Project project) {
+    super(new BorderLayout());
+    this.samples = samples;
+    this.project = project;
+
+    myBackgroundColorKey = EditorColors.GUTTER_BACKGROUND;
+
+    myLabel.setIcon(FlutterIcons.Flutter);
+    myLabel.setText("Open sample project:");
+    myLabel.setBorder(JBUI.Borders.emptyRight(5));
+
+    goLink = new JBLabel("<html><a href=\"\">Go...</a></html>");
+    goLink.setBorder(JBUI.Borders.emptyLeft(8));
+    goLink.setCursor(new Cursor(Cursor.HAND_CURSOR));
+    goLink.addMouseListener(new MouseAdapter() {
+      @Override
+      public void mouseClicked(MouseEvent e) {
+        doCreate();
+      }
+    });
+
+
+    sampleSelector = setupSelectorComponent();
+
+    descriptionText = new JEditorPane();
+    descriptionText.setBackground(getBackground());
+    descriptionText.setContentType("text/html");
+    descriptionText.putClientProperty(JEditorPane.HONOR_DISPLAY_PROPERTIES, true);
+    descriptionText.setBorder(JBUI.Borders.emptyLeft(3));
+
+    final FlutterSample selectedSample = getSelectedSample();
+    descriptionText.setText(selectedSample.getShortHtmlDescription());
+    descriptionText.setEditable(false);
+
+    descriptionText.setFont(getFont());
+    descriptionText.setForeground(JBColor.gray);
+
+    setupPanel();
+  }
+
+
+  JComponent setupSelectorComponent() {
+    if (samples.size() == 1) {
+      return new JBLabel(samples.get(0).getDisplayLabel());
+    }
+
+    final FlutterSampleComboBox sampleCombo = new FlutterSampleComboBox(samples);
+    sampleCombo.addActionListener(e -> updateSelection(sampleCombo.getSelectedItem()));
+
+    return sampleCombo;
+  }
+
+  private void updateSelection(@NotNull FlutterSample item) {
+    descriptionText.setText(item.getShortHtmlDescription());
+  }
+
+  private void setupPanel() {
+    // LABEL | SELECTOR | LINK...
+    final JPanel subPanel = new NonOpaquePanel(new BorderLayout(0, 10));
+    subPanel.add(BorderLayout.WEST, myLabel);
+    subPanel.add(BorderLayout.CENTER, sampleSelector);
+    subPanel.add(BorderLayout.EAST, goLink);
+    final JPanel selectionPanel = new NonOpaquePanel(new BorderLayout(10, 0));
+    selectionPanel.add(BorderLayout.NORTH, subPanel);
+    add(BorderLayout.WEST, selectionPanel);
+
+    // DESCRIPTION
+    final JPanel descriptionPanel = new NonOpaquePanel(new BorderLayout());
+    final int descriptionTopNudge = sampleSelector instanceof FlutterSampleComboBox ? -7 : -14;
+    descriptionPanel.setBorder(JBUI.Borders.empty(descriptionTopNudge, 12, 5, 5));
+    descriptionPanel.add(BorderLayout.NORTH, descriptionText);
+    add(BorderLayout.CENTER, descriptionPanel);
+
+    // PLACEHOLDER (to force reflow on resize)
+    add(BorderLayout.EAST, new NonOpaquePanel(new BorderLayout()));
+
+    setBorder(JBUI.Borders.empty(10, 10));
+  }
+
+  @Override
+  public Color getBackground() {
+    final EditorColorsScheme globalScheme = EditorColorsManager.getInstance().getGlobalScheme();
+    if (myBackgroundColor != null) return myBackgroundColor;
+    if (myBackgroundColorKey != null) {
+      final Color color = globalScheme.getColor(myBackgroundColorKey);
+      if (color != null) return color;
+    }
+    final Color color = globalScheme.getColor(EditorColors.NOTIFICATION_BACKGROUND);
+    return color != null ? color : UIUtil.getToolTipBackground();
+  }
+
+  @NotNull
+  FlutterSample getSelectedSample() {
+    return samples.size() == 1 ? samples.get(0) : ((FlutterSampleComboBox)sampleSelector).getSelectedItem();
+  }
+
+  private void doCreate() {
+    final FlutterSample sample = getSelectedSample();
+    final String status = FlutterSampleManager.createSampleProject(sample, project);
+    if (status != null) {
+      FlutterMessages.showError("Sample Project Creation", "Error: " + status);
+    }
+  }
+}

--- a/src/io/flutter/samples/FlutterSampleActionsPanel.java
+++ b/src/io/flutter/samples/FlutterSampleActionsPanel.java
@@ -116,7 +116,7 @@ public class FlutterSampleActionsPanel extends JPanel {
     // PLACEHOLDER (to force reflow on resize)
     add(BorderLayout.EAST, new NonOpaquePanel(new BorderLayout()));
 
-    setBorder(JBUI.Borders.empty(10, 10));
+    setBorder(JBUI.Borders.empty(10, 10, 5,  10));
   }
 
   @Override

--- a/src/io/flutter/samples/FlutterSampleComboBox.java
+++ b/src/io/flutter/samples/FlutterSampleComboBox.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2019 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.samples;
+
+import com.intellij.openapi.ui.ComboBox;
+import com.intellij.ui.ColoredListCellRenderer;
+import com.intellij.ui.SimpleTextAttributes;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+import java.util.List;
+
+public class FlutterSampleComboBox extends ComboBox<FlutterSample> {
+
+  private static final class SampleModel extends AbstractListModel<FlutterSample>
+    implements ComboBoxModel<FlutterSample> {
+    @NotNull
+    private final List<FlutterSample> myList;
+    private FlutterSample mySelected;
+
+    SampleModel(@NotNull List<FlutterSample> samples) {
+      myList = samples;
+      mySelected = !myList.isEmpty() ? myList.get(0) : null;
+    }
+
+    @Override
+    public int getSize() {
+      return myList.size();
+    }
+
+    @Override
+    public FlutterSample getElementAt(int index) {
+      return myList.get(index);
+    }
+
+    @Override
+    public void setSelectedItem(Object item) {
+      setSelectedItem((FlutterSample)item);
+    }
+
+    @Override
+    public FlutterSample getSelectedItem() {
+      return mySelected;
+    }
+
+    public void setSelectedItem(FlutterSample item) {
+      mySelected = item;
+      fireContentsChanged(this, 0, getSize());
+    }
+  }
+
+  private class SampleCellRenderer extends ColoredListCellRenderer<FlutterSample> {
+    @Override
+    protected void customizeCellRenderer(@NotNull JList<? extends FlutterSample> list,
+                                         FlutterSample sample,
+                                         int index,
+                                         boolean selected,
+                                         boolean hasFocus) {
+      final SimpleTextAttributes style = isEnabled() ? SimpleTextAttributes.REGULAR_ATTRIBUTES : SimpleTextAttributes.GRAY_ATTRIBUTES;
+      append(sample.getDisplayLabel(), style);
+    }
+  }
+
+  FlutterSampleComboBox() {
+    this(FlutterSampleManager.getSamples());
+  }
+
+  FlutterSampleComboBox(@NotNull List<FlutterSample> samples) {
+    super(new SampleModel(samples));
+    setRenderer(new SampleCellRenderer());
+  }
+
+  @NotNull
+  @Override
+  public FlutterSample getSelectedItem() {
+    final FlutterSample selected = (FlutterSample)super.getSelectedItem();
+    return selected != null ? selected : getModel().getElementAt(0);
+  }
+}

--- a/src/io/flutter/samples/FlutterSampleManager.java
+++ b/src/io/flutter/samples/FlutterSampleManager.java
@@ -9,10 +9,27 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.intellij.execution.OutputListener;
+import com.intellij.execution.process.ProcessEvent;
+import com.intellij.ide.impl.ProjectUtil;
 import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Key;
+import com.intellij.openapi.util.io.FileUtil;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.projectImport.ProjectOpenProcessor;
+import io.flutter.FlutterBundle;
 import io.flutter.FlutterUtils;
+import io.flutter.module.FlutterModuleBuilder;
+import io.flutter.module.FlutterProjectType;
+import io.flutter.pub.PubRoot;
+import io.flutter.sdk.FlutterCreateAdditionalSettings;
+import io.flutter.sdk.FlutterSdk;
 import org.apache.commons.io.IOUtils;
+import org.jetbrains.annotations.NotNull;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -38,9 +55,7 @@ public class FlutterSampleManager {
     final List<FlutterSample> samples = new ArrayList<>();
     try {
       // TODO(pq): replace w/ index read from repo (https://github.com/flutter/flutter/pull/25515).
-
       //https://docs.flutter.io/snippets/index.json
-      //https://master-docs-flutter-io.firebaseapp.com/snippets/index.json
 
       final URL url = FlutterSampleManager.class.getResource("index.json");
       final String contents = IOUtils.toString(url.toURI(), "UTF-8");
@@ -62,5 +77,65 @@ public class FlutterSampleManager {
     // Sort by display label.
     samples.sort(Comparator.comparing(FlutterSample::getDisplayLabel));
     return samples;
+  }
+
+  public static String createSampleProject(@NotNull FlutterSample sample, @NotNull Project project) {
+    final FlutterSdk sdk = FlutterSdk.getFlutterSdk(project);
+    if (sdk == null) {
+      return "unable to find Flutter SDK";
+    }
+
+    final File projectRoot = new File(ProjectUtil.getBaseDir());
+    final String projectNamePrefix = deriveValidPackageName(sample.getElement());
+    final String projectDir = FileUtil.createSequentFileName(projectRoot, projectNamePrefix + "_sample", "");
+
+    final File dir = new File(projectRoot, projectDir);
+    if (!dir.mkdir()) {
+      return "unable to create project root:  " + dir.getPath();
+    }
+
+    final VirtualFile baseDir = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(dir);
+    if (baseDir == null) {
+      return "unable to find project root (" + dir.getPath() +") on refresh";
+    }
+
+    final OutputListener outputListener = new OutputListener() {
+      @Override
+      public void onTextAvailable(@NotNull ProcessEvent event, @NotNull Key outputType) {
+        // TODO(pq): consider showing progress in the status line.
+      }
+
+      @Override
+      public void processTerminated(@NotNull ProcessEvent event) {
+        // TODO(pq): handle event.getExitCode().
+      }
+    };
+
+
+    final PubRoot root =
+      FlutterModuleBuilder.runFlutterCreateWithProgress(baseDir, sdk, project, outputListener, getCreateSettings(sample));
+    final ProjectOpenProcessor openProcessor = ProjectOpenProcessor.getImportProvider(baseDir);
+    if (openProcessor == null) {
+      return "unable to find a processor to finish opening the project: " + baseDir.getPath();
+    }
+
+    openProcessor.doOpenProject(baseDir, null, true);
+    return null;
+  }
+
+  private static String deriveValidPackageName(String name) {
+    return name.split("\\.")[0].toLowerCase();
+  }
+
+  private static FlutterCreateAdditionalSettings getCreateSettings(@NotNull FlutterSample sample) {
+    return new FlutterCreateAdditionalSettings.Builder()
+      .setDescription(sample.getElement() + " Sample Project")
+      .setType(FlutterProjectType.APP)
+      .setKotlin(false)
+      .setOrg(FlutterBundle.message("flutter.module.create.settings.org.default_text"))
+      .setSwift(false)
+      .setSampleContent(sample)
+      .setOffline(false)
+      .build();
   }
 }

--- a/src/io/flutter/samples/FlutterSampleNotificationProvider.java
+++ b/src/io/flutter/samples/FlutterSampleNotificationProvider.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2018 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.samples;
+
+import com.intellij.openapi.fileEditor.FileEditor;
+import com.intellij.openapi.project.DumbAware;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Key;
+import com.intellij.openapi.util.io.FileUtil;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.ui.EditorNotifications;
+import io.flutter.sdk.FlutterSdk;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class FlutterSampleNotificationProvider extends EditorNotifications.Provider<JPanel> implements DumbAware {
+  private static final Key<JPanel> KEY = Key.create("flutter.sample");
+
+  @NotNull private final Project project;
+
+  public FlutterSampleNotificationProvider(@NotNull Project project) {
+    this.project = project;
+  }
+
+  @NotNull
+  @Override
+  public Key<JPanel> getKey() {
+    return KEY;
+  }
+
+  @Nullable
+  @Override
+  public JPanel createNotificationPanel(@NotNull VirtualFile file, @NotNull FileEditor editor) {
+    final List<FlutterSample> samples = getSamplesForFile(file);
+    return !samples.isEmpty() ? new FlutterSampleActionsPanel(samples, project) : null;
+  }
+
+  private FlutterSdk getSdk() {
+    return FlutterSdk.getFlutterSdk(project);
+  }
+
+  private List<FlutterSample> getSamplesForFile(@NotNull VirtualFile file) {
+    final FlutterSdk sdk = getSdk();
+    if (sdk == null) {
+      return Collections.emptyList();
+    }
+
+    final String filePath = FileUtil.normalize(file.getPath());
+    final String pathSuffix = FileUtil.normalize(sdk.getHomePath()) + "/packages/flutter/";
+
+    final List<FlutterSample> samples = new ArrayList<>();
+    for (FlutterSample sample : FlutterSampleManager.getSamples()) {
+      final String samplePath = pathSuffix + sample.getSourcePath();
+      if (filePath.equals(samplePath)) {
+        samples.add(sample);
+      }
+    }
+
+    return samples;
+  }
+}
+

--- a/testSrc/unit/io/flutter/samples/FlutterSampleTest.java
+++ b/testSrc/unit/io/flutter/samples/FlutterSampleTest.java
@@ -44,7 +44,7 @@ public class FlutterSampleTest {
   static final String CARD_DESC = "This sample shows creation of a [Card] widget that shows album information\nand two actions.";
 
   @Test
-  public void testParseCardlDescription() {
+  public void testParseCardDescription() {
     assertEquals("<p>This sample shows creation of a <strong>Card</strong> widget that shows album information and two actions.</p>",
                  parse(CARD_DESC));
   }
@@ -53,7 +53,7 @@ public class FlutterSampleTest {
     "This example shows a [Scaffold] with an [AppBar], a [BottomAppBar] and a\n[FloatingActionButton]. The [body] is a [Text] placed in a [Center] in order\nto center the text within the [Scaffold] and the [FloatingActionButton] is\ncentered and docked within the [BottomAppBar] using\n[FloatingActionButtonLocation.centerDocked]. The [FloatingActionButton] is\nconnected to a callback that increments a counter.";
 
   @Test
-  public void testScaffoldlDescription() {
+  public void testScaffoldDescription() {
     assertEquals(
       "<p>This example shows a <strong>Scaffold</strong> with an <strong>AppBar</strong>, a <strong>BottomAppBar</strong> and a <strong>FloatingActionButton</strong>. The <strong>body</strong> is a <strong>Text</strong> placed in a <strong>Center</strong> in order to center the text within the <strong>Scaffold</strong> and the <strong>FloatingActionButton</strong> is centered and docked within the <strong>BottomAppBar</strong> using <strong>FloatingActionButtonLocation.centerDocked</strong>. The <strong>FloatingActionButton</strong> is connected to a callback that increments a counter.</p>",
       parse(SCAFFOLD_DESC));

--- a/testSrc/unit/io/flutter/samples/FlutterSampleTest.java
+++ b/testSrc/unit/io/flutter/samples/FlutterSampleTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.samples;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+
+public class FlutterSampleTest {
+
+  static String parseShort(String description) {
+    return FlutterSample.parseShortHtmlDescription(description);
+  }
+
+  static String parse(String description) {
+    return FlutterSample.parseHtmlDescription(description);
+  }
+
+  @Test
+  public void testParseShortHtmlDescription() {
+    assertEquals("<p>One line.</p>", parseShort("One line. And another."));
+    assertEquals("<p>One line.</p>", parseShort("One line.\nAnd another."));
+  }
+
+  @Test
+  public void testParseHtmlDescription() {
+    assertEquals("<p>One line. And another.</p>", parse("One line. And another."));
+  }
+
+  @Test
+  public void testParseDocLink() {
+    assertEquals("<p><strong>Card</strong></p>", parse("[Card]"));
+  }
+
+  @Test
+  public void testParseEscapes() {
+    assertEquals("<p>[Card]</p>", parse("\\[Card\\]"));
+  }
+
+  static final String CARD_DESC = "This sample shows creation of a [Card] widget that shows album information\nand two actions.";
+
+  @Test
+  public void testParseCardlDescription() {
+    assertEquals("<p>This sample shows creation of a <strong>Card</strong> widget that shows album information and two actions.</p>",
+                 parse(CARD_DESC));
+  }
+
+  static final String SCAFFOLD_DESC =
+    "This example shows a [Scaffold] with an [AppBar], a [BottomAppBar] and a\n[FloatingActionButton]. The [body] is a [Text] placed in a [Center] in order\nto center the text within the [Scaffold] and the [FloatingActionButton] is\ncentered and docked within the [BottomAppBar] using\n[FloatingActionButtonLocation.centerDocked]. The [FloatingActionButton] is\nconnected to a callback that increments a counter.";
+
+  @Test
+  public void testScaffoldlDescription() {
+    assertEquals(
+      "<p>This example shows a <strong>Scaffold</strong> with an <strong>AppBar</strong>, a <strong>BottomAppBar</strong> and a <strong>FloatingActionButton</strong>. The <strong>body</strong> is a <strong>Text</strong> placed in a <strong>Center</strong> in order to center the text within the <strong>Scaffold</strong> and the <strong>FloatingActionButton</strong> is centered and docked within the <strong>BottomAppBar</strong> using <strong>FloatingActionButtonLocation.centerDocked</strong>. The <strong>FloatingActionButton</strong> is connected to a callback that increments a counter.</p>",
+      parse(SCAFFOLD_DESC));
+  }
+}


### PR DESCRIPTION
Adds a sample creation banner to framework files w/ samples.

In the common (and current case), presents a simple label for the active sample.

![single_gif](https://user-images.githubusercontent.com/67586/51629705-22263800-1efd-11e9-8305-a575a1643982.gif)

In case there is more than one sample (promised for the future), provides a chooser.

![combo_gif](https://user-images.githubusercontent.com/67586/51629749-3c601600-1efd-11e9-989d-2a99ee527598.gif)

(Note this example above is showing more IDs than are appropriate for this file in order to demo the chooser behavior.)

**NOTE:** not for landing in M32 since we'll need to shore up the implementation in Android Studio.

/cc @stevemessick 

Fixes: #2976. 