### PR TITLE
Basic Flutter Error extension event handling.

### DIFF
--- a/src/io/flutter/logging/FlutterLog.java
+++ b/src/io/flutter/logging/FlutterLog.java
@@ -173,8 +173,6 @@ public class FlutterLog implements FlutterLogEntry.ContentListener {
     // No-op if disabled.
     if (!isLoggingEnabled()) return;
 
-    System.out.println("FlutterLog.listenToVm");
-
     logEntryParser.setupInspector(app, vmService);
 
     // TODO(pq): consider moving into VMServiceManager to consolidate vm service listeners.
@@ -196,8 +194,6 @@ public class FlutterLog implements FlutterLogEntry.ContentListener {
   }
 
   private void onVmServiceReceived(String id, Event event) {
-    System.out.println("FlutterLog.onVmServiceReceived");
-    System.out.println("  id = [" + id + "], event = [" + event + "]");
     final List<FlutterLogEntry> entries = logEntryParser.parse(id, event);
     if (entries != null) {
       entries.forEach(this::onEntry);

--- a/src/io/flutter/logging/FlutterLog.java
+++ b/src/io/flutter/logging/FlutterLog.java
@@ -19,6 +19,7 @@ import com.intellij.openapi.util.Key;
 import com.intellij.util.EventDispatcher;
 import io.flutter.FlutterUtils;
 import io.flutter.run.FlutterDebugProcess;
+import io.flutter.run.daemon.FlutterApp;
 import io.flutter.server.vmService.ServiceExtensions;
 import io.flutter.server.vmService.VmServiceConsumers;
 import io.flutter.settings.FlutterSettings;
@@ -86,6 +87,7 @@ public class FlutterLog implements FlutterLogEntry.ContentListener {
 
   // TODO(pq): consider limiting size.
   private final List<FlutterLogEntry> entries = new ArrayList<>();
+  private FlutterApp app;
 
   public static boolean isLoggingEnabled() {
     return FlutterSettings.getInstance().useFlutterLogView();
@@ -171,6 +173,10 @@ public class FlutterLog implements FlutterLogEntry.ContentListener {
     // No-op if disabled.
     if (!isLoggingEnabled()) return;
 
+    System.out.println("FlutterLog.listenToVm");
+
+    logEntryParser.setupInspector(app, vmService);
+
     // TODO(pq): consider moving into VMServiceManager to consolidate vm service listeners.
     vmService.addVmServiceListener(new VmServiceListenerAdapter() {
       @Override
@@ -190,7 +196,12 @@ public class FlutterLog implements FlutterLogEntry.ContentListener {
   }
 
   private void onVmServiceReceived(String id, Event event) {
-    onEntry(logEntryParser.parse(id, event));
+    System.out.println("FlutterLog.onVmServiceReceived");
+    System.out.println("  id = [" + id + "], event = [" + event + "]");
+    final List<FlutterLogEntry> entries = logEntryParser.parse(id, event);
+    if (entries != null) {
+      entries.forEach(this::onEntry);
+    }
   }
 
   @SuppressWarnings("EmptyMethod")
@@ -198,8 +209,8 @@ public class FlutterLog implements FlutterLogEntry.ContentListener {
     // TODO(pq): handle VM connection closed.
   }
 
-  public void setFlutterDebugProcess(FlutterDebugProcess process) {
-    logEntryParser.setDebugProcess(process);
+  public void setFlutterApp(FlutterApp app) {
+    this.app = app;
   }
 
   @Override

--- a/src/io/flutter/logging/FlutterLog.java
+++ b/src/io/flutter/logging/FlutterLog.java
@@ -173,7 +173,7 @@ public class FlutterLog implements FlutterLogEntry.ContentListener {
     // No-op if disabled.
     if (!isLoggingEnabled()) return;
 
-    logEntryParser.setupInspector(app, vmService);
+    logEntryParser.setVmServices(app, vmService);
 
     // TODO(pq): consider moving into VMServiceManager to consolidate vm service listeners.
     vmService.addVmServiceListener(new VmServiceListenerAdapter() {

--- a/src/io/flutter/logging/FlutterLogColors.java
+++ b/src/io/flutter/logging/FlutterLogColors.java
@@ -11,10 +11,14 @@ import org.jetbrains.annotations.NotNull;
 
 import java.awt.Color;
 
-public class FlutterLogColors {
+import static io.flutter.logging.FlutterLogEntryParser.ERROR_CATEGORY;
 
+public class FlutterLogColors {
   @NotNull
   public static Color forCategory(@NotNull String category) {
+    if (category.equals(ERROR_CATEGORY)) {
+      return JBColor.red;
+    }
     if (category.startsWith("flutter.")) {
       return JBColor.gray;
     }

--- a/src/io/flutter/logging/FlutterLogEntryParser.java
+++ b/src/io/flutter/logging/FlutterLogEntryParser.java
@@ -21,7 +21,6 @@ import com.intellij.openapi.util.Key;
 import com.intellij.ui.SimpleTextAttributes;
 import com.intellij.util.EventDispatcher;
 import com.jetbrains.lang.dart.ide.runner.DartConsoleFilter;
-import io.flutter.FlutterUtils;
 import io.flutter.console.FlutterConsoleFilter;
 import io.flutter.inspector.DiagnosticsNode;
 import io.flutter.inspector.InspectorService;
@@ -91,23 +90,6 @@ public class FlutterLogEntryParser {
     }
   }
 
-  static class InspectorHelper {
-    @NotNull
-    private final InspectorService inspectorService;
-    @NotNull
-    private final InspectorService.ObjectGroup consoleGroup;
-
-    InspectorHelper(@NotNull InspectorService inspectorService) {
-      this.inspectorService = inspectorService;
-      this.consoleGroup = inspectorService.createObjectGroup("console-group");
-    }
-
-    public DiagnosticsNode createDiagnosticsNode(JsonObject json) {
-      return new DiagnosticsNode(json, consoleGroup, false, null);
-    }
-  }
-
-  private InspectorHelper inspector;
   private final LineHandler lineHandler;
   private CompletableFuture<InspectorService.ObjectGroup> inspectorObjectGroup;
 
@@ -289,14 +271,8 @@ public class FlutterLogEntryParser {
 
   @Nullable
   private DiagnosticsNode parseDiagnosticsNode(@NotNull JsonObject json) {
-    if (inspectorObjectGroup == null) {
-      FlutterUtils.warn(LOG, "Attempt to create a diagnostics node before the object group is set.");
-      return null;
-    }
-    if (app == null) {
-      FlutterUtils.warn(LOG, "Attempt to create a diagnostics node before the app is set.");
-      return null;
-    }
+    assert(inspectorObjectGroup != null);
+    assert(app != null);
     return new DiagnosticsNode(json, inspectorObjectGroup, app, false, null);
   }
 
@@ -397,7 +373,7 @@ public class FlutterLogEntryParser {
     return null;
   }
 
-  public void setupInspector(@NotNull FlutterApp app, @NotNull VmService vmService) {
+  public void setVmServices(@NotNull FlutterApp app, @NotNull VmService vmService) {
     this.app = app;
     inspectorObjectGroup = InspectorService.createGroup(app, app.getFlutterDebugProcess(), vmService, "console-group");
   }

--- a/src/io/flutter/logging/FlutterLogView.java
+++ b/src/io/flutter/logging/FlutterLogView.java
@@ -450,6 +450,9 @@ public class FlutterLogView extends JPanel implements ConsoleView, DataProvider,
         }
       }
       setText(text);
+
+      // Scroll to start.
+      setCaretPosition(0);
     }
   }
 

--- a/src/io/flutter/run/daemon/FlutterApp.java
+++ b/src/io/flutter/run/daemon/FlutterApp.java
@@ -565,7 +565,7 @@ public class FlutterApp {
 
   public void setFlutterDebugProcess(FlutterDebugProcess flutterDebugProcess) {
     myFlutterDebugProcess = flutterDebugProcess;
-    myFlutterLog.setFlutterDebugProcess(flutterDebugProcess);
+    myFlutterLog.setFlutterApp(this);
   }
 
   public FlutterDebugProcess getFlutterDebugProcess() {

--- a/testSrc/unit/io/flutter/logging/text/LineParserTest.java
+++ b/testSrc/unit/io/flutter/logging/text/LineParserTest.java
@@ -8,15 +8,14 @@ package io.flutter.logging.text;
 import com.intellij.execution.filters.BrowserHyperlinkInfo;
 import com.intellij.execution.filters.UrlFilter;
 import com.intellij.ui.SimpleTextAttributes;
-import com.intellij.util.ReflectionUtil;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.awt.*;
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
+
+import static io.flutter.logging.text.StyledTextTestUtils.*;
 
 public class LineParserTest {
   static final SimpleTextAttributes PLAIN_RED = new SimpleTextAttributes(SimpleTextAttributes.STYLE_PLAIN, Color.RED);
@@ -55,10 +54,6 @@ public class LineParserTest {
     expectParsesTo("\u001b[9;31mHello", text("Hello", STRIKEOUT_RED));
     expectParsesTo("\u001b[31;1mHello\u001b[0m\u001b[34;1m World\u001b[0m",
                    text("Hello", BOLD_RED), text(" World", BOLD_BLUE));
-  }
-
-  static StyledText text(String string, SimpleTextAttributes style) {
-    return new StyledText(string, style);
   }
 
   @Test
@@ -102,55 +97,9 @@ public class LineParserTest {
     assertEquals(arrayOf(text("Hello", BOLD_RED), text(" World", BOLD_RED), text("!", null)), parser.parsed);
   }
 
-  private static StyledText[] arrayOf(StyledText... texts) {
-    return texts;
-  }
-
   private static void expectParsesTo(String str, StyledText... results) {
     final TestParser parser = new TestParser();
     parser.parse(str);
     assertEquals(results, parser.parsed);
-  }
-
-  private static void assertEquals(StyledText[] expected, List<StyledText> actual) {
-    for (int i = 0; i < expected.length; ++i) {
-      assertEquals(expected[i], actual.get(i));
-    }
-  }
-
-  private static void assertEquals(StyledText expected, StyledText actual) {
-    Assert.assertEquals(expected.getText(), actual.getText());
-    assertEquals(expected.getStyle(), actual.getStyle());
-    final String expectedUrl = getUrl(expected.getTag());
-    // If a tag is specified, check it.
-    if (expectedUrl != null) {
-      Assert.assertEquals(expectedUrl, getUrl(actual.getTag()));
-    }
-  }
-
-  private static String getUrl(Object tag) {
-    if (tag instanceof BrowserHyperlinkInfo) {
-      final Field field = ReflectionUtil.getDeclaredField(tag.getClass(), "myUrl");
-      if (field != null) {
-        try {
-          return (String)field.get(tag);
-        }
-        catch (Throwable ignored) {
-        }
-      }
-    }
-    return null;
-  }
-
-  private static void assertEquals(SimpleTextAttributes expected, SimpleTextAttributes actual) {
-    if (expected == null) {
-      Assert.assertNull(actual);
-    }
-    else {
-      Assert.assertNotNull(actual);
-      Assert.assertEquals(expected.getStyle(), actual.getStyle());
-      Assert.assertEquals(expected.getFontStyle(), actual.getFontStyle());
-      Assert.assertEquals(expected.getFgColor(), actual.getFgColor());
-    }
   }
 }

--- a/testSrc/unit/io/flutter/logging/text/StyledTextTestUtils.java
+++ b/testSrc/unit/io/flutter/logging/text/StyledTextTestUtils.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2019 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.logging.text;
+
+import com.intellij.execution.filters.BrowserHyperlinkInfo;
+import com.intellij.ui.SimpleTextAttributes;
+import com.intellij.util.ReflectionUtil;
+import org.junit.Assert;
+
+import java.lang.reflect.Field;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class StyledTextTestUtils {
+
+  public static StyledText text(String string, SimpleTextAttributes style) {
+    return new StyledText(string, style);
+  }
+
+  public static StyledText[] arrayOf(StyledText... texts) {
+    return texts;
+  }
+
+  public static void assertEquals(StyledText[] expected, List<StyledText> actual) {
+    for (int i = 0; i < expected.length; ++i) {
+      assertEquals(expected[i], actual.get(i));
+    }
+  }
+
+  public static void assertEquals(StyledText expected, StyledText actual) {
+    Assert.assertEquals(expected.getText(), actual.getText());
+    assertEquals(expected.getStyle(), actual.getStyle());
+    final String expectedUrl = getUrl(expected.getTag());
+    // If a tag is specified, check it.
+    if (expectedUrl != null) {
+      Assert.assertEquals(expectedUrl, getUrl(actual.getTag()));
+    }
+  }
+
+  public static void assertEquals(SimpleTextAttributes expected, SimpleTextAttributes actual) {
+    if (expected == null) {
+      Assert.assertNull(actual);
+    }
+    else {
+      assertNotNull(actual);
+      Assert.assertEquals(expected.getStyle(), actual.getStyle());
+      Assert.assertEquals(expected.getFontStyle(), actual.getFontStyle());
+      Assert.assertEquals(expected.getFgColor(), actual.getFgColor());
+    }
+  }
+
+  private static String getUrl(Object tag) {
+    if (tag instanceof BrowserHyperlinkInfo) {
+      final Field field = ReflectionUtil.getDeclaredField(tag.getClass(), "myUrl");
+      if (field != null) {
+        try {
+          return (String)field.get(tag);
+        }
+        catch (Throwable ignored) {
+        }
+      }
+    }
+    return null;
+  }
+}


### PR DESCRIPTION
Basic Flutter Error extension event handling.

![image](https://user-images.githubusercontent.com/67586/51641119-404e6100-1f1a-11e9-8611-71288b45ecb1.png)

As a next step we'll want to do something sensible w/ the parsed `DiagnosticsNode` pending UI exploration in the devtools version.  In the meantime this proves out inspector service initialization and interaction.

/cc @jacob314 