### PR TITLE
Update the build for M32

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,6 @@ script: ./tool/travis.sh
 env:
   - DART_BOT=true
   - CHECK_BOT=true
-  - IDEA_VERSION=2018.1
-  - IDEA_VERSION=2018.2.2
-  - IDEA_VERSION=2018.2.4
+  - IDEA_VERSION=3.3
+  - IDEA_VERSION=3.4
   - IDEA_VERSION=2018.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,38 +1,26 @@
 ## 32.0
 - address an NPE in FlutterWidgetPerfManager.java
-- update IDE versions
 - added overlay renderered for GC, snapshot and memory reset events
 - consolidated all adt-ui API changes in FlutterStudioMonitorStageView
-- support for creating projects w/ sample content
-- log entry ansi color support (and styling re-work)
-- add code of conduct
-- add org.apache.commons.io.IOUtils to the classpath for the source build
-- restore log level combo
-- fill in truncated log entries
-- tweak presentation for no level filter
+- support for creating projects w/ sample content from the IDEA New Project Wizard
+- basic ansi color support for entries in the Flutter Logging View
+- restore log level combo to the Logging View
+- support to fill in truncated log entries
 - add keyboard shortcut for widget extraction
-- update README.md
-- log tree class refactor
 - add debugPaint and debugAllowBanner icons
 - add repaint rainbow icon
-- don't use completeExceptionally
 - handle cases where script.tokenPosTable is null
 - auto-hide details pane
 - guard against disposed when querying project type
 - fix an issue with escaped test names
-- update CONTRIBUTING.md
 - refactor service extensions and set button text based on extension state
 - shorten message for debug mode perf disclaimer
-- update sample json format
 - listen for ServiceExtensionStateChanged events
-- refactor DiagnosticsNode to accept a Future<ObjectGroup>
 - restore service extension states from device on start and attach
 - don't use LOG.error()
 - refactor the Bazel Test configuration to support running tests on a single file or a single test
 - fix enabled/disabled text for service extensions
 - fix NPE in bazel config
-- remove stale cocoapods known issue
-- add proxy issue link
 
 ## 31.3
 - fix NPE in sdk installation (#2965)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,39 @@
+## 32.0
+- address an NPE in FlutterWidgetPerfManager.java
+- update IDE versions
+- added overlay renderered for GC, snapshot and memory reset events
+- consolidated all adt-ui API changes in FlutterStudioMonitorStageView
+- support for creating projects w/ sample content
+- log entry ansi color support (and styling re-work)
+- add code of conduct
+- add org.apache.commons.io.IOUtils to the classpath for the source build
+- restore log level combo
+- fill in truncated log entries
+- tweak presentation for no level filter
+- add keyboard shortcut for widget extraction
+- update README.md
+- log tree class refactor
+- add debugPaint and debugAllowBanner icons
+- add repaint rainbow icon
+- don't use completeExceptionally
+- handle cases where script.tokenPosTable is null
+- auto-hide details pane
+- guard against disposed when querying project type
+- fix an issue with escaped test names
+- update CONTRIBUTING.md
+- refactor service extensions and set button text based on extension state
+- shorten message for debug mode perf disclaimer
+- update sample json format
+- listen for ServiceExtensionStateChanged events
+- refactor DiagnosticsNode to accept a Future<ObjectGroup>
+- restore service extension states from device on start and attach
+- don't use LOG.error()
+- refactor the Bazel Test configuration to support running tests on a single file or a single test
+- fix enabled/disabled text for service extensions
+- fix NPE in bazel config
+- remove stale cocoapods known issue
+- add proxy issue link
+
 ## 31.3
 - fix NPE in sdk installation (#2965)
 - fix NPE caused by internal inconsistency (#2963)

--- a/flutter-studio/flutter-studio.iml
+++ b/flutter-studio/flutter-studio.iml
@@ -48,5 +48,8 @@
     <orderEntry type="module" module-name="intellij.android.artwork" />
     <orderEntry type="module" module-name="android.sdktools.common" />
     <orderEntry type="module" module-name="intellij.java" />
+    <orderEntry type="library" name="studio-analytics-proto" level="project" />
+    <orderEntry type="library" name="protobuf" level="project" />
+    <orderEntry type="module" module-name="intellij.android.projectSystem.tests" />
   </component>
 </module>

--- a/flutter-studio/src/io/flutter/android/AndroidModuleLibraryManager.java
+++ b/flutter-studio/src/io/flutter/android/AndroidModuleLibraryManager.java
@@ -7,6 +7,7 @@ package io.flutter.android;
 
 import static io.flutter.android.AndroidModuleLibraryType.LIBRARY_KIND;
 import static io.flutter.android.AndroidModuleLibraryType.LIBRARY_NAME;
+import static com.google.wireless.android.sdk.stats.GradleSyncStats.Trigger.TRIGGER_PROJECT_MODIFIED;
 
 import com.android.tools.idea.gradle.project.sync.GradleSyncInvoker;
 import com.android.tools.idea.gradle.project.sync.GradleSyncListener;
@@ -233,7 +234,7 @@ public class AndroidModuleLibraryManager extends AbstractLibraryManager<AndroidM
       }
     };
 
-    GradleSyncInvoker.Request request = GradleSyncInvoker.Request.projectModified();
+    GradleSyncInvoker.Request request = new GradleSyncInvoker.Request(TRIGGER_PROJECT_MODIFIED);
     request.runInBackground = true;
     GradleSyncInvoker gradleSyncInvoker = ServiceManager.getService(GradleSyncInvoker.class);
     gradleSyncInvoker.requestProjectSync(androidProject, request, listener);

--- a/flutter-studio/src/io/flutter/profiler/FlutterStudioProfilers.java
+++ b/flutter-studio/src/io/flutter/profiler/FlutterStudioProfilers.java
@@ -170,7 +170,7 @@ public class FlutterStudioProfilers
 
     // These need to be fired every time the process list changes so that
     // the device/process dropdown always reflects the latest.
-    changed(ProfilerAspect.DEVICES);
+    //changed(ProfilerAspect.DEVICES);
     changed(ProfilerAspect.PROCESSES);
   }
 

--- a/flutter-studio/testSrc/com/android/tools/idea/tests/gui/framework/FlutterGuiTestRule.java
+++ b/flutter-studio/testSrc/com/android/tools/idea/tests/gui/framework/FlutterGuiTestRule.java
@@ -12,8 +12,7 @@ import com.android.tools.idea.tests.gui.framework.fixture.FlutterFrameFixture;
 import com.android.tools.idea.tests.gui.framework.fixture.FlutterWelcomeFrameFixture;
 import com.android.tools.idea.tests.gui.framework.fixture.IdeFrameFixture;
 import com.android.tools.idea.tests.gui.framework.fixture.IdeaFrameFixture;
-import com.android.tools.idea.tests.gui.framework.guitestprojectsystem.GuiTestProjectSystem;
-import com.android.tools.idea.tests.gui.framework.guitestsystem.CurrentGuiTestProjectSystem;
+import com.android.tools.idea.projectsystem.TestProjectSystem;
 import com.android.tools.idea.tests.gui.framework.matcher.Matchers;
 import com.google.common.collect.ImmutableList;
 import com.intellij.openapi.application.ApplicationManager;
@@ -90,7 +89,6 @@ public class FlutterGuiTestRule implements TestRule {
 
   private final RobotTestRule myRobotTestRule = new RobotTestRule();
   private final LeakCheck myLeakCheck = new LeakCheck();
-  private final CurrentGuiTestProjectSystem myCurrentProjectSystem = new CurrentGuiTestProjectSystem();
 
   private Timeout myTimeout = new Timeout(5, TimeUnit.MINUTES);
 
@@ -116,11 +114,11 @@ public class FlutterGuiTestRule implements TestRule {
   @NotNull
   @Override
   public Statement apply(final Statement base, final Description description) {
+    // TODO(messick) Update this.
     RuleChain chain = RuleChain.emptyRuleChain()
       .around(new LogStartAndStop())
       .around(new BlockReloading())
       .around(new BazelUndeclaredOutputs())
-      .around(myCurrentProjectSystem)
       .around(myRobotTestRule)
       .around(myLeakCheck)
       .around(new IdeHandling())
@@ -305,7 +303,7 @@ public class FlutterGuiTestRule implements TestRule {
 
   public FlutterFrameFixture importProjectAndWaitForProjectSyncToFinish(@NotNull String projectDirName, @Nullable String buildFilePath) throws IOException {
     importProject(projectDirName, buildFilePath);
-    testSystem().waitForProjectSyncToFinish(baseIdeFrame());
+    //testSystem().waitForProjectSyncToFinish(baseIdeFrame());
     return ideFrame();
   }
 
@@ -315,7 +313,7 @@ public class FlutterGuiTestRule implements TestRule {
 
   public FlutterFrameFixture importProject(@NotNull String projectDirName, @Nullable String buildFilePath) throws IOException {
     File testProjectDir = setUpProject(projectDirName);
-    testSystem().importProject(testProjectDir, robot(), buildFilePath);
+    //testSystem().importProject(testProjectDir, robot(), buildFilePath);
     return ideFrame();
   }
 
@@ -415,10 +413,6 @@ public class FlutterGuiTestRule implements TestRule {
     return myRobotTestRule.getRobot();
   }
 
-  public GuiTestProjectSystem testSystem() {
-    return myCurrentProjectSystem.getTestProjectSystem();
-  }
-
   @NotNull
   public File getProjectPath() {
     return ideFrame().getProjectPath();
@@ -441,7 +435,6 @@ public class FlutterGuiTestRule implements TestRule {
       // and registers it with GradleSyncState. This keeps adding more and more listeners, and the new recent listeners are only updated
       // with gradle State when that State changes. This means the listeners may have outdated info.
       myIdeFrameFixture = FlutterFrameFixture.find(robot());
-      myIdeFrameFixture.setTestProjectSystem(myCurrentProjectSystem.getTestProjectSystem());
       myIdeFrameFixture.requestFocusIfLost();
     }
     return myIdeFrameFixture;
@@ -454,7 +447,6 @@ public class FlutterGuiTestRule implements TestRule {
       // and registers it with GradleSyncState. This keeps adding more and more listeners, and the new recent listeners are only updated
       // with gradle State when that State changes. This means the listeners may have outdated info.
       myOldIdeFrameFixture = IdeFrameFixture.find(robot());
-      myOldIdeFrameFixture.setTestProjectSystem(myCurrentProjectSystem.getTestProjectSystem());
       myOldIdeFrameFixture.requestFocusIfLost();
     }
     return myOldIdeFrameFixture;

--- a/flutter-studio/testSrc/com/android/tools/idea/tests/gui/framework/fixture/IdeaFrameFixture.java
+++ b/flutter-studio/testSrc/com/android/tools/idea/tests/gui/framework/fixture/IdeaFrameFixture.java
@@ -26,7 +26,7 @@ import com.android.tools.idea.tests.gui.framework.fixture.avdmanager.AvdManagerD
 import com.android.tools.idea.tests.gui.framework.fixture.gradle.GradleBuildModelFixture;
 import com.android.tools.idea.tests.gui.framework.fixture.gradle.GradleProjectEventListener;
 import com.android.tools.idea.tests.gui.framework.fixture.gradle.GradleToolWindowFixture;
-import com.android.tools.idea.tests.gui.framework.guitestprojectsystem.GuiTestProjectSystem;
+import com.android.tools.idea.projectsystem.TestProjectSystem;
 import com.android.tools.idea.tests.gui.framework.matcher.Matchers;
 import com.android.tools.idea.ui.GuiTestingService;
 import com.google.common.collect.Lists;
@@ -92,7 +92,7 @@ public class IdeaFrameFixture extends ComponentFixture<IdeaFrameFixture, IdeFram
   @NotNull private final Modules myModules;
   @NotNull private final IdeFrameFixture myIdeFrameFixture; // Replaces 'this' when creating component fixtures.
 
-  private GuiTestProjectSystem myTestProjectSystem;
+  private TestProjectSystem myTestProjectSystem;
   private EditorFixture myEditor;
   private boolean myIsClosed;
 
@@ -363,14 +363,7 @@ public class IdeaFrameFixture extends ComponentFixture<IdeaFrameFixture, IdeFram
     //noinspection Contract
     assertFalse("Should use '/' in test relative paths, not File.separator", relativePath.contains("\\"));
 
-    VirtualFile projectRootDir;
-    if (myTestProjectSystem != null) {
-      projectRootDir = myTestProjectSystem.getProjectRootDirectory(getProject());
-    }
-    else {
-      projectRootDir = getProject().getBaseDir();
-    }
-
+    VirtualFile projectRootDir = getProject().getBaseDir();
     projectRootDir.refresh(false, true);
     VirtualFile file = projectRootDir.findFileByRelativePath(relativePath);
     if (requireExists) {
@@ -380,7 +373,7 @@ public class IdeaFrameFixture extends ComponentFixture<IdeaFrameFixture, IdeFram
     return file;
   }
 
-  public void setTestProjectSystem(GuiTestProjectSystem testProjectSystem) {
+  public void setTestProjectSystem(TestProjectSystem testProjectSystem) {
     myTestProjectSystem = testProjectSystem;
   }
 
@@ -495,11 +488,6 @@ public class IdeaFrameFixture extends ComponentFixture<IdeaFrameFixture, IdeFram
   @NotNull
   public BuildVariantsToolWindowFixture getBuildVariantsWindow() {
     return new BuildVariantsToolWindowFixture(myIdeFrameFixture);
-  }
-
-  @NotNull
-  public MessagesToolWindowFixture getMessagesToolWindow() {
-    return new MessagesToolWindowFixture(getProject(), robot());
   }
 
   @NotNull

--- a/product-matrix.json
+++ b/product-matrix.json
@@ -1,43 +1,33 @@
 {
   "list": [
     {
-      "comments": "AS 3.2 and IntelliJ 2018.1",
+      "comments": "AS 3.3 and IntelliJ 2018.2.5",
       "name": "IntelliJ",
-      "version": "2018.1",
+      "version": "3.3",
       "ideaProduct": "android-studio",
-      "ideaVersion": "181.4847800",
-      "dartPluginVersion": "181.4892.1",
-      "sinceBuild": "181.0",
-      "untilBuild": "181.*"
-    },
-    {
-      "comments": "IntelliJ 2018.2",
-      "name": "IntelliJ",
-      "version": "2018.2.2",
-      "ideaProduct": "ideaIU",
-      "ideaVersion": "2018.2.2",
-      "dartPluginVersion": "182.4129.13",
-      "sinceBuild": "182.0",
-      "untilBuild": "182.4505"
-    },
-    {
-      "comments": "AS 3.3 Beta and IntelliJ 2018.4",
-      "name": "IntelliJ",
-      "version": "2018.2.4",
-      "ideaProduct": "android-studio",
-      "ideaVersion": "182.5073496",
-      "dartPluginVersion": "182.4999",
-      "sinceBuild": "182.4505",
+      "ideaVersion": "182.5199772",
+      "dartPluginVersion": "182.5124",
+      "sinceBuild": "182.5107.7",
       "untilBuild": "182.*"
     },
     {
-      "comments": "IntelliJ 2018.3",
-      "name": "IntelliJ",
+      "comments": "AS 3.4 beta",
+      "name": "Android Studio",
+      "version": "3.4",
+      "ideaProduct": "android-studio",
+      "ideaVersion": "183.5217543",
+      "dartPluginVersion": "183.4886.3",
+      "sinceBuild": "183.0",
+      "untilBuild": "183.4886.37.34.*"
+    },
+    {
+      "comments": "IntelliJ 2018.3, AS 3.5 canary",
+      "name": "Android Studio",
       "version": "2018.3",
       "ideaProduct": "android-studio",
-      "ideaVersion": "183.5081642",
-      "dartPluginVersion": "183.2153.10",
-      "sinceBuild": "183.0",
+      "ideaVersion": "183.5215047",
+      "dartPluginVersion": "183.4886.3",
+      "sinceBuild": "183.4886.37.35",
       "untilBuild": "183.*"
     }
   ]

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -30,39 +30,27 @@
 <h2>32.0</h2>
 <ul>
   <li>address an NPE in FlutterWidgetPerfManager.java</li>
-  <li>update IDE versions</li>
   <li>added overlay renderered for GC, snapshot and memory reset events</li>
   <li>consolidated all adt-ui API changes in FlutterStudioMonitorStageView</li>
-  <li>support for creating projects w/ sample content</li>
-  <li>log entry ansi color support (and styling re-work)</li>
-  <li>add code of conduct</li>
-  <li>add org.apache.commons.io.IOUtils to the classpath for the source build</li>
-  <li>restore log level combo</li>
-  <li>fill in truncated log entries</li>
-  <li>tweak presentation for no level filter</li>
+  <li>support for creating projects w/ sample content from the IDEA New Project Wizard</li>
+  <li>basic ansi color support for entries in the Flutter Logging View</li>
+  <li>restore log level combo to the Logging View</li>
+  <li>support to fill in truncated log entries</li>
   <li>add keyboard shortcut for widget extraction</li>
-  <li>update README.md</li>
-  <li>log tree class refactor</li>
   <li>add debugPaint and debugAllowBanner icons</li>
   <li>add repaint rainbow icon</li>
-  <li>don't use completeExceptionally</li>
   <li>handle cases where script.tokenPosTable is null</li>
   <li>auto-hide details pane</li>
   <li>guard against disposed when querying project type</li>
   <li>fix an issue with escaped test names</li>
-  <li>update CONTRIBUTING.md</li>
   <li>refactor service extensions and set button text based on extension state</li>
   <li>shorten message for debug mode perf disclaimer</li>
-  <li>update sample json format</li>
   <li>listen for ServiceExtensionStateChanged events</li>
-  <li>refactor DiagnosticsNode to accept a Future<ObjectGroup></li>
   <li>restore service extension states from device on start and attach</li>
   <li>don't use LOG.error()</li>
   <li>refactor the Bazel Test configuration to support running tests on a single file or a single test</li>
   <li>fix enabled/disabled text for service extensions</li>
   <li>fix NPE in bazel config</li>
-  <li>remove stale cocoapods known issue</li>
-  <li>add proxy issue link</li>
 </ul>
 <h2>31.3</h2>
 <ul>

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -11,7 +11,7 @@
 
   <category>Custom Languages</category>
   
-  <idea-version since-build="181.0" until-build="183.*"/>
+  <idea-version since-build="182.5107.7" until-build="183.*"/>
 
   <depends>Dart</depends>
 
@@ -27,6 +27,43 @@
 
   <change-notes>
     <![CDATA[
+<h2>32.0</h2>
+<ul>
+  <li>address an NPE in FlutterWidgetPerfManager.java</li>
+  <li>update IDE versions</li>
+  <li>added overlay renderered for GC, snapshot and memory reset events</li>
+  <li>consolidated all adt-ui API changes in FlutterStudioMonitorStageView</li>
+  <li>support for creating projects w/ sample content</li>
+  <li>log entry ansi color support (and styling re-work)</li>
+  <li>add code of conduct</li>
+  <li>add org.apache.commons.io.IOUtils to the classpath for the source build</li>
+  <li>restore log level combo</li>
+  <li>fill in truncated log entries</li>
+  <li>tweak presentation for no level filter</li>
+  <li>add keyboard shortcut for widget extraction</li>
+  <li>update README.md</li>
+  <li>log tree class refactor</li>
+  <li>add debugPaint and debugAllowBanner icons</li>
+  <li>add repaint rainbow icon</li>
+  <li>don't use completeExceptionally</li>
+  <li>handle cases where script.tokenPosTable is null</li>
+  <li>auto-hide details pane</li>
+  <li>guard against disposed when querying project type</li>
+  <li>fix an issue with escaped test names</li>
+  <li>update CONTRIBUTING.md</li>
+  <li>refactor service extensions and set button text based on extension state</li>
+  <li>shorten message for debug mode perf disclaimer</li>
+  <li>update sample json format</li>
+  <li>listen for ServiceExtensionStateChanged events</li>
+  <li>refactor DiagnosticsNode to accept a Future<ObjectGroup></li>
+  <li>restore service extension states from device on start and attach</li>
+  <li>don't use LOG.error()</li>
+  <li>refactor the Bazel Test configuration to support running tests on a single file or a single test</li>
+  <li>fix enabled/disabled text for service extensions</li>
+  <li>fix NPE in bazel config</li>
+  <li>remove stale cocoapods known issue</li>
+  <li>add proxy issue link</li>
+</ul>
 <h2>31.3</h2>
 <ul>
   <li>fix NPE in sdk installation (#2965)</li>

--- a/tool/plugin/lib/plugin.dart
+++ b/tool/plugin/lib/plugin.dart
@@ -544,6 +544,14 @@ class BuildCommand extends ProductCommand {
           files[processedFile] = source;
           source = source.replaceAll('List<? extends File>', 'List<File>');
           processedFile.writeAsStringSync(source);
+
+          processedFile = File(
+              'flutter-studio/src/io/flutter/profiler/FlutterStudioProfilers.java');
+          source = processedFile.readAsStringSync();
+          files[processedFile] = source;
+          source = source.replaceAll('//changed(ProfilerAspect.DEVICES);',
+              'changed(ProfilerAspect.DEVICES);');
+          processedFile.writeAsStringSync(source);
         }
 
         processedFile = File(

--- a/tool/plugin/lib/plugin.dart
+++ b/tool/plugin/lib/plugin.dart
@@ -532,46 +532,31 @@ class BuildCommand extends ProductCommand {
         }
       }
 
-      // TODO: Remove this when we no longer support AS 3.2 or IJ 2018.2
+      // TODO: Remove this when we no longer support AS 3.3 (IJ 2018.2.5) or AS 3.4
       var files = <File, String>{};
       var processedFile, source;
-      if (spec.version == '2018.1') {
+      if ((spec.version == '3.3') || (spec.version == '3.4')) {
+        log('spec.version: ${spec.version}');
+        if (spec.version == '3.3') {
+          processedFile = File(
+              'flutter-studio/src/io/flutter/project/FlutterProjectCreator.java');
+          source = processedFile.readAsStringSync();
+          files[processedFile] = source;
+          source = source.replaceAll('List<? extends File>', 'List<File>');
+          processedFile.writeAsStringSync(source);
+        }
 
         processedFile = File(
-            'flutter-studio/src/io/flutter/project/FlutterProjectSystem.java');
+            'flutter-studio/src/io/flutter/android/AndroidModuleLibraryManager.java');
         source = processedFile.readAsStringSync();
         files[processedFile] = source;
-        source = source.replaceAll('.LightResourceClassService', '.*');
-        source = source.replaceAll(' LightResourceClassService', ' Object');
         source = source.replaceAll(
-            'gradleProjectSystem.getLightResourceClassService()', 'null');
+            'import static com.google.wireless.android.sdk.stats.GradleSyncStats.Trigger.TRIGGER_PROJECT_MODIFIED;',
+            '');
+        source = source.replaceAll(
+            'new GradleSyncInvoker.Request(TRIGGER_PROJECT_MODIFIED);',
+            'GradleSyncInvoker.Request.projectModified();');
         processedFile.writeAsStringSync(source);
-
-        processedFile = File(
-            'flutter-studio/src/io/flutter/profiler/FlutterStudioMonitorStageView.java');
-        source = processedFile.readAsStringSync();
-        files[processedFile] = source;
-        source = source.replaceAll('usedMemoryRange.getXRange()', '100');
-        source = source.replaceAll('.setHostInsets(new Insets(Y_AXIS_TOP_MARGIN, 0, 100, 0))', '');
-        source = source.replaceAll('.setHostInsets(new Insets(Y_AXIS_TOP_MARGIN, 0, 0, 0))', '');
-        processedFile.writeAsStringSync(source);
-
-        processedFile = File(
-            'flutter-studio/src/io/flutter/project/FlutterProjectCreator.java');
-        source = processedFile.readAsStringSync();
-        files[processedFile] = source;
-        source = source.replaceAll('List<? extends File>', 'List<File>');
-        processedFile.writeAsStringSync(source);
-
-      } else if (spec.version == '2018.2.4') {
-
-        processedFile = File(
-            'flutter-studio/src/io/flutter/project/FlutterProjectCreator.java');
-        source = processedFile.readAsStringSync();
-        files[processedFile] = source;
-        source = source.replaceAll('List<? extends File>', 'List<File>');
-        processedFile.writeAsStringSync(source);
-
       }
 
       try {

--- a/tool/plugin/pubspec.yaml
+++ b/tool/plugin/pubspec.yaml
@@ -12,4 +12,4 @@ dependencies:
   path: ^1.6.2
 
 dev_dependencies:
-  test: ^1.3.0
+  test: ^1.5.0

--- a/tool/plugin/test/plugin_test.dart
+++ b/tool/plugin/test/plugin_test.dart
@@ -36,7 +36,6 @@ void main() {
             specs.map((spec) => spec.ideaProduct).toList(),
             orderedEquals([
               'android-studio',
-              'ideaIU',
               'android-studio',
               'android-studio',
             ]));
@@ -52,7 +51,6 @@ void main() {
             specs.map((spec) => spec.ideaProduct).toList(),
             orderedEquals([
               'android-studio',
-              'ideaIU',
               'android-studio',
               'android-studio',
             ]));
@@ -68,7 +66,6 @@ void main() {
             specs.map((spec) => spec.ideaProduct).toList(),
             orderedEquals([
               'android-studio',
-              'ideaIU',
               'android-studio',
               'android-studio',
             ]));
@@ -147,10 +144,9 @@ void main() {
       expect(
           cmd.paths.map((p) => p.substring(p.indexOf('releases'))),
           orderedEquals([
-            'releases/release_19/2018.1/flutter-intellij.zip',
-            'releases/release_19/2018.2.2/flutter-intellij.zip',
-            'releases/release_19/2018.2.4/flutter-intellij.zip',
-            'releases/release_19/2018.3/flutter-intellij.zip',
+            'releases/release_19/3.3/flutter-intellij.zip',
+            'releases/release_19/3.4/flutter-intellij.zip',
+            'releases/release_19/2018.3/flutter-intellij.zip'
           ]));
     });
   });


### PR DESCRIPTION
@devoncarew @pq @jacob314 @terrylucas @kenzieschmoll @DaveShuckerow
/cc @DanTup @keertip 

This gets us ready for building M32 for AS 3.3 stable, AS 3.4 beta, AS 3.5 canary, and IJ 2018.3. (IJ 2019.1 is still to come.)

The change log is a bit excessive. I was unfamiliar with most of the work so I just added a line for every commit in the git log. We ought to have a convention to identify user-facing changes so we don't need to call out every commit.

I changed the versioning to hopefully make it more intuitive. '3.3' and '3.4' are for Android Studio. '2018.3' is for IJ and AS 3.5. These become the build directories that you download and install the plugin from during testing. (You are planning to help with testing, right? :)

`ProfilerAspect.DEVICES` was removed. Not sure if my fix is right.

You can ignore changes to `testSrc` files. They are going to be rewritten but I didn't want to remove them yet.

After this is committed, anyone working with the Android Studio sources will need to update to latest.