### PR TITLE
structured error log data ui

### DIFF
--- a/src/io/flutter/inspector/DiagnosticLevel.java
+++ b/src/io/flutter/inspector/DiagnosticLevel.java
@@ -32,6 +32,29 @@ public enum DiagnosticLevel {
   hidden,
 
   /**
+   * Diagnostics that provide a hint about best practices.
+   * For example, a diagnostic providing a hint on  on how to fix an overflow error.
+   */
+  hint,
+
+  /**
+   * Diagnostics that provide a hint for how to fix a problem.
+   * <p>
+   * For example, a diagnostic providing advice for how to fix an overflow error.
+   */
+  fix,
+
+  /**
+   * Diagnostics that describe a contract.
+   * <p>
+   * For example, a diagnostic describing the constraints applying to layout or
+   * invariants that must remain true to correctly compose objects.
+   */
+  contract,
+
+  violation,
+
+  /**
    * A diagnostic that is likely to be low value but where the diagnostic
    * display is just as high quality as a diagnostic with a higher level.
    * <p>

--- a/src/io/flutter/inspector/DiagnosticsTreeStyle.java
+++ b/src/io/flutter/inspector/DiagnosticsTreeStyle.java
@@ -18,6 +18,22 @@ package io.flutter.inspector;
  */
 public enum DiagnosticsTreeStyle {
   /**
+   * Render the tree on a single line without showing children acting like the
+   * line is a header.
+   */
+  headerLine,
+
+  /**
+   * Render the tree without indenting children at all.
+   */
+  flat,
+
+  /**
+   * Style for displaying content describing an error.
+   */
+  error,
+
+  /**
    * Sparse style for displaying trees.
    */
   sparse,
@@ -54,4 +70,20 @@ public enum DiagnosticsTreeStyle {
    * Render the tree on a single line without showing children.
    */
   singleLine,
+
+  /**
+   * Render the tree on a single line with the name and value on separate
+   * lines.
+   */
+  indentedSingleLine,
+
+  /**
+   *
+   */
+  shallow,
+
+  /**
+   * Render only the immediate properties of a node instead of the full tree.
+   */
+  truncateChildren,
 }

--- a/src/io/flutter/logging/FlutterLogEntry.java
+++ b/src/io/flutter/logging/FlutterLogEntry.java
@@ -37,7 +37,10 @@ public class FlutterLogEntry {
   private final int level;
   @NotNull
   private String message;
-  // TODO(pq): consider making data an Instance or JsonElement
+
+  /**
+   * Associated data; may be a JSON string value or diagnostic node.
+   */
   @Nullable
   private Object data;
   private int sequenceNumber = -1;
@@ -46,7 +49,8 @@ public class FlutterLogEntry {
   private final Kind kind;
   private List<StyledText> styledText;
 
-  @NotNull private final List<Filter> filters;
+  @NotNull
+  private final List<Filter> filters;
 
   /**
    * Describes any style info that was inherited from previously parsed lines.

--- a/src/io/flutter/logging/FlutterLogEntry.java
+++ b/src/io/flutter/logging/FlutterLogEntry.java
@@ -39,7 +39,7 @@ public class FlutterLogEntry {
   private String message;
   // TODO(pq): consider making data an Instance or JsonElement
   @Nullable
-  private String data;
+  private Object data;
   private int sequenceNumber = -1;
 
   @NotNull
@@ -78,11 +78,11 @@ public class FlutterLogEntry {
   }
 
   @Nullable
-  public String getData() {
+  public Object getData() {
     return data;
   }
 
-  public void setData(@Nullable String data) {
+  public void setData(@Nullable Object data) {
     this.data = data;
   }
 
@@ -132,7 +132,6 @@ public class FlutterLogEntry {
     final LineInfo lineInfo = lineHandler.parseLineInfo(getMessage(), getCategory());
     return lineInfo.getStyledText();
   }
-
 
   /**
    * Return a sequence number, or -1 if unset.

--- a/src/io/flutter/logging/FlutterLogEntry.java
+++ b/src/io/flutter/logging/FlutterLogEntry.java
@@ -39,7 +39,7 @@ public class FlutterLogEntry {
   private String message;
 
   /**
-   * Associated data; may be a JSON string value or diagnostic node.
+   * Associated data; may be a JSON string value or DiagnosticsNode instance.
    */
   @Nullable
   private Object data;

--- a/src/io/flutter/logging/FlutterLogEntryParser.java
+++ b/src/io/flutter/logging/FlutterLogEntryParser.java
@@ -256,23 +256,19 @@ public class FlutterLogEntryParser {
 
   private List<FlutterLogEntry> parseFlutterError(@NotNull JsonObject json) {
     final List<FlutterLogEntry> entries = new ArrayList<>();
-
     final JsonElement extensionData = json.get("extensionData");
     final DiagnosticsNode diagnosticsNode = parseDiagnosticsNode(extensionData.getAsJsonObject());
-    if (diagnosticsNode != null) {
-      final String description = diagnosticsNode.toString();
-      final FlutterLogEntry entry = lineHandler.parseEntry(description, ERROR_CATEGORY, FlutterLog.Level.SEVERE.value);
-      // TODO(pq): process children: diagnosticsNode.getChildren().getNow(null) and set data to something structured.
-      entry.setData(json.toString());
-      entries.add(entry);
-    }
+    final String description = diagnosticsNode.toString();
+    final FlutterLogEntry entry = lineHandler.parseEntry(description, ERROR_CATEGORY, FlutterLog.Level.SEVERE.value);
+    entry.setData(diagnosticsNode);
+    entries.add(entry);
     return entries;
   }
 
-  @Nullable
+  @NotNull
   private DiagnosticsNode parseDiagnosticsNode(@NotNull JsonObject json) {
-    assert(inspectorObjectGroup != null);
-    assert(app != null);
+    assert (inspectorObjectGroup != null);
+    assert (app != null);
     return new DiagnosticsNode(json, inspectorObjectGroup, app, false, null);
   }
 

--- a/src/io/flutter/logging/FlutterLogTree.java
+++ b/src/io/flutter/logging/FlutterLogTree.java
@@ -324,7 +324,7 @@ public class FlutterLogTree extends TreeTable {
 
   }
 
-  static class FlutterEventNode extends DefaultMutableTreeNode {
+  public static class FlutterEventNode extends DefaultMutableTreeNode {
     final FlutterLogEntry entry;
 
     FlutterEventNode(FlutterLogEntry entry) {

--- a/src/io/flutter/logging/tree/DataPanel.java
+++ b/src/io/flutter/logging/tree/DataPanel.java
@@ -1,0 +1,282 @@
+/*
+ * Copyright 2019 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.logging.tree;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+import com.intellij.ui.ColoredTreeCellRenderer;
+import com.intellij.ui.components.panels.NonOpaquePanel;
+import com.intellij.ui.tree.BaseTreeModel;
+import com.intellij.util.EventDispatcher;
+import com.intellij.util.ui.JBUI;
+import io.flutter.inspector.DiagnosticLevel;
+import io.flutter.inspector.DiagnosticsNode;
+import io.flutter.inspector.DiagnosticsTreeStyle;
+import io.flutter.utils.JsonUtils;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+import javax.swing.event.HyperlinkEvent;
+import javax.swing.text.html.HTMLEditorKit;
+import java.awt.*;
+import java.awt.event.FocusAdapter;
+import java.awt.event.FocusEvent;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.EventListener;
+import java.util.List;
+
+import static io.flutter.utils.HtmlBuilder.*;
+
+@SuppressWarnings("ALL")
+public class DataPanel extends JPanel {
+
+  public static interface ContentListener extends EventListener {
+    void hasContent(boolean hasContent);
+  }
+
+  /*
+   * Swing's support for CSS is limited and doesn't allow for multiple classes so we cons
+   * together css styling as a single style attribute.
+   *
+   * These values are loosely derived from devtools/inspector.css.
+   *
+   * TODO(pq): add theme-awareness.
+   */
+  private static class CssStyle {
+    static String forNode(DiagnosticsNode node) {
+      return attrs("style", forLevel(node.getLevel()) + forStyle(node.getStyle()));
+    }
+
+    static String forLevel(DiagnosticLevel level) {
+      switch (level) {
+        case info:
+          return "padding-left: 16px; ";
+        case error:
+          return "color: rgb(244, 67, 54); padding-left: 16px; ";
+        case hint:
+          return "background-color: #fafad2; padding: 8px 8px 8px 24px; margin: 5px 0; ";
+        default:
+          return "";
+      }
+    }
+
+    static String forStyle(DiagnosticsTreeStyle style) {
+      switch (style) {
+        case error:
+          return "background-color: #f97c7c; padding: 12px; margin:5px 0; ";
+        default:
+          return "";
+      }
+    }
+  }
+
+  class NodeRenderer extends ColoredTreeCellRenderer {
+    @Override
+    public void customizeCellRenderer(@NotNull JTree tree,
+                                      Object value,
+                                      boolean selected,
+                                      boolean expanded,
+                                      boolean leaf,
+                                      int row,
+                                      boolean hasFocus) {
+      if (value instanceof String) {
+        append(value.toString());
+      }
+      else if (value instanceof DiagnosticsNode) {
+        final DiagnosticsNode node = (DiagnosticsNode)value;
+        append(value.toString());
+        if (!node.isProperty()) {
+          final Icon icon = node.getIcon();
+          if (icon != null) {
+            setIcon(icon);
+          }
+        }
+      }
+    }
+  }
+
+  class NodeModel extends BaseTreeModel<Object> {
+    private final DiagnosticsNode node;
+    private final String rootContent;
+
+    public NodeModel(DiagnosticsNode node, String rootContent) {
+      this.node = node;
+      this.rootContent = rootContent;
+    }
+
+    @Override
+    public List<? extends Object> getChildren(Object parent) {
+      if (parent instanceof DiagnosticsNode) {
+        return DataPanel.getChildren((DiagnosticsNode)parent);
+      }
+      if (parent == rootContent) {
+        return DataPanel.getChildren(node);
+      }
+      return null;
+    }
+
+    @Override
+    public Object getRoot() {
+      return rootContent;
+    }
+  }
+
+  private final Gson gsonHelper = new GsonBuilder().setPrettyPrinting().create();
+  private final HTMLEditorKit editorKit;
+
+  private final EventDispatcher<ContentListener>
+    dispatcher = EventDispatcher.create(ContentListener.class);
+
+  private DataPanel() {
+    setBorder(JBUI.Borders.empty());
+    editorKit = new HTMLEditorKit();
+  }
+
+  public static DataPanel create() {
+    final DataPanel panel = new DataPanel();
+    panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
+    return panel;
+  }
+
+  public void onUpdate(@NotNull ContentListener listener) {
+    dispatcher.addListener(listener);
+  }
+
+  private void linkSelected(URL url) {
+    // TODO(pq): handle links
+  }
+
+  public void update(Object data) {
+    // Remove stale content.
+    for (Component c : getComponents()) {
+      remove(c);
+    }
+
+    boolean showDataPane = false;
+    if (data instanceof DiagnosticsNode) {
+      showDataPane = updateNodeData((DiagnosticsNode)data);
+    }
+    else if (data instanceof String && JsonUtils.hasJsonData((String)data)) {
+      showDataPane = updateJsonTextData((String)data);
+    }
+
+    showPane(showDataPane);
+  }
+
+  private void showPane(boolean show) {
+    setVisible(show);
+    if (show) {
+      repaint();
+      revalidate();
+    }
+    dispatcher.getMulticaster().hasContent(show);
+
+    // TODO(pq): set caret position
+    // Scroll to start.
+    // setCaretPosition(0);
+  }
+
+  private boolean updateJsonTextData(String data) {
+    @SuppressWarnings("ConstantConditions") final JsonElement jsonElement = new JsonParser().parse((String)data);
+    final String text = gsonHelper.toJson(jsonElement);
+    if (text.isEmpty()) {
+      return false;
+    }
+
+    final JEditorPane editorPane = createEditorPane();
+    editorPane.setText(html(pre(text)));
+    add(editorPane);
+
+    return true;
+  }
+
+  private boolean updateNodeData(DiagnosticsNode data) {
+    // Header.
+    addText(data.toString(), data);
+
+    // Body.
+    final List<DiagnosticsNode> properties = data.getInlineProperties();
+    for (DiagnosticsNode node : properties) {
+      String contents = "";
+      if (node.getName() != null) {
+        contents += node.getName();
+      }
+
+      final ArrayList<DiagnosticsNode> children = getChildren(node);
+      if (!children.isEmpty() || node.getDescription() != null) {
+        if (!contents.isEmpty()) {
+          contents += ": ";
+        }
+        if (node.getDescription() != null) {
+          contents += node.getDescription();
+        }
+      }
+
+      if (children.isEmpty()) {
+        addText(contents, node);
+      }
+      else {
+        addTree(contents, node);
+      }
+    }
+    return true;
+  }
+
+  private void addText(String contents, DiagnosticsNode node) {
+    final JEditorPane editorPane = createEditorPane();
+    editorPane.setText(html(
+      div(
+        CssStyle.forNode(node),
+        span(contents)
+      )));
+    add(editorPane);
+  }
+
+  private void addTree(String rootLabel, DiagnosticsNode node) {
+    final JTree tree = new JTree();
+    tree.setModel(new NodeModel(node, rootLabel));
+    tree.setCellRenderer(new NodeRenderer());
+    tree.setShowsRootHandles(true);
+    tree.collapseRow(0);
+
+    tree.addFocusListener(new FocusAdapter() {
+      @Override
+      public void focusLost(FocusEvent e) {
+        tree.clearSelection();
+      }
+    });
+
+    final NonOpaquePanel panel = new NonOpaquePanel();
+    panel.add(tree);
+    add(panel);
+  }
+
+  private JEditorPane createEditorPane() {
+    final JEditorPane editorPane = new JEditorPane();
+    editorPane.setEditable(false);
+    editorPane.putClientProperty(JEditorPane.HONOR_DISPLAY_PROPERTIES, true);
+    editorPane.setEditorKit(editorKit);
+    editorPane.addHyperlinkListener(e -> {
+      if (e.getEventType() == HyperlinkEvent.EventType.ACTIVATED) {
+        linkSelected(e.getURL());
+      }
+    });
+
+    return editorPane;
+  }
+
+  private static ArrayList<DiagnosticsNode> getChildren(DiagnosticsNode node) {
+    final ArrayList<DiagnosticsNode> children = node.getChildren().getNow(new ArrayList<>());
+    if (!children.isEmpty()) {
+      return children;
+    }
+
+    return node.getInlineProperties();
+  }
+}

--- a/src/io/flutter/logging/tree/DataPanel.java
+++ b/src/io/flutter/logging/tree/DataPanel.java
@@ -9,7 +9,6 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
-import com.intellij.ui.ColoredTreeCellRenderer;
 import com.intellij.ui.components.panels.NonOpaquePanel;
 import com.intellij.ui.tree.BaseTreeModel;
 import com.intellij.util.EventDispatcher;
@@ -18,6 +17,7 @@ import io.flutter.inspector.DiagnosticLevel;
 import io.flutter.inspector.DiagnosticsNode;
 import io.flutter.inspector.DiagnosticsTreeStyle;
 import io.flutter.utils.JsonUtils;
+import io.flutter.view.InspectorColoredTreeCellRenderer;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
@@ -50,7 +50,7 @@ public class DataPanel extends JPanel {
    */
   private static class CssStyle {
     static String forNode(DiagnosticsNode node) {
-      return attrs("style", forLevel(node.getLevel()) + forStyle(node.getStyle()));
+      return attr("style", forLevel(node.getLevel()) + forStyle(node.getStyle()));
     }
 
     static String forLevel(DiagnosticLevel level) {
@@ -76,7 +76,7 @@ public class DataPanel extends JPanel {
     }
   }
 
-  class NodeRenderer extends ColoredTreeCellRenderer {
+  class NodeRenderer extends InspectorColoredTreeCellRenderer {
     @Override
     public void customizeCellRenderer(@NotNull JTree tree,
                                       Object value,
@@ -101,6 +101,7 @@ public class DataPanel extends JPanel {
     }
   }
 
+  // TODO(pq): consider a model shared w/ the inspector tree.
   class NodeModel extends BaseTreeModel<Object> {
     private final DiagnosticsNode node;
     private final String rootContent;
@@ -203,6 +204,7 @@ public class DataPanel extends JPanel {
     // Body.
     final List<DiagnosticsNode> properties = data.getInlineProperties();
     for (DiagnosticsNode node : properties) {
+      // TODO(pq): refactor to handle edge cases and consider parsing into a list of StyledTexts.
       String contents = "";
       if (node.getName() != null) {
         contents += node.getName();

--- a/src/io/flutter/logging/tree/DataPanel.java
+++ b/src/io/flutter/logging/tree/DataPanel.java
@@ -28,8 +28,11 @@ import java.awt.event.FocusAdapter;
 import java.awt.event.FocusEvent;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.EventListener;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static io.flutter.utils.HtmlBuilder.*;
 
@@ -210,7 +213,7 @@ public class DataPanel extends JPanel {
         contents += node.getName();
       }
 
-      final ArrayList<DiagnosticsNode> children = getChildren(node);
+      final List<DiagnosticsNode> children = getChildren(node);
       if (!children.isEmpty() || node.getDescription() != null) {
         if (!contents.isEmpty()) {
           contents += ": ";
@@ -273,12 +276,8 @@ public class DataPanel extends JPanel {
     return editorPane;
   }
 
-  private static ArrayList<DiagnosticsNode> getChildren(DiagnosticsNode node) {
+  private static List<DiagnosticsNode> getChildren(DiagnosticsNode node) {
     final ArrayList<DiagnosticsNode> children = node.getChildren().getNow(new ArrayList<>());
-    if (!children.isEmpty()) {
-      return children;
-    }
-
-    return node.getInlineProperties();
+    return Stream.of(children, node.getInlineProperties()).flatMap(Collection::stream).collect(Collectors.toList());
   }
 }

--- a/src/io/flutter/logging/tree/MessageCellRenderer.java
+++ b/src/io/flutter/logging/tree/MessageCellRenderer.java
@@ -8,6 +8,7 @@ package io.flutter.logging.tree;
 import com.intellij.icons.AllIcons;
 import com.intellij.ui.SimpleTextAttributes;
 import com.intellij.util.ui.JBUI;
+import io.flutter.inspector.DiagnosticsNode;
 import io.flutter.logging.FlutterLogEntry;
 import io.flutter.logging.FlutterLogTree;
 import io.flutter.logging.text.StyledText;
@@ -18,6 +19,7 @@ import org.jetbrains.annotations.NotNull;
 import static com.intellij.ui.SimpleTextAttributes.STYLE_PLAIN;
 
 public class MessageCellRenderer extends AbstractEntryCellRender {
+  // TODO(pq): use app for link resolution.
   @NotNull
   private final FlutterApp app;
 
@@ -45,7 +47,9 @@ public class MessageCellRenderer extends AbstractEntryCellRender {
     }
 
     // Append data badge
-    if (JsonUtils.hasJsonData(entry.getData())) {
+    final Object data = entry.getData();
+    // TODO(pq): should make this a simple null check.
+    if (data instanceof DiagnosticsNode || (data instanceof String && JsonUtils.hasJsonData((String)data))) {
       // TODO(pq): change to ArrowRight when we're no longer supporting 3.3.
       setIcon(AllIcons.General.ComboArrowRight);
     }

--- a/src/io/flutter/utils/HtmlBuilder.java
+++ b/src/io/flutter/utils/HtmlBuilder.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.utils;
+
+public class HtmlBuilder {
+
+  public static String span(String style, String contents) {
+    return "<span style = \"" + style + "\"> " + contents + "</span>";
+  }
+
+  public static String span(String contents) {
+    return tag("span", contents);
+  }
+
+  public static String attrs(String attribute, String value) {
+    return attribute + " = \"" + value + "\"";
+  }
+
+  public static String html(String... contents) {
+    return tag("html", join(contents));
+  }
+
+  public static String pre(String... contents) {
+    return tag("pre", join(contents));
+  }
+
+  public static String body(String... contents) {
+    return join(contents);
+  }
+
+  private static String join(String... contents) {
+    final StringBuilder sb = new StringBuilder();
+    for (String c : contents) {
+      sb.append(c);
+      sb.append(java.lang.System.lineSeparator());
+    }
+    return sb.toString();
+  }
+
+  public static String tag(String tag, String contents) {
+    return "<" + tag + ">" + contents + "</" + tag + ">";
+  }
+
+  public static String div(String attrs, String contents) {
+    return "<div " + attrs + ">" + contents + "</div>";
+  }
+
+  public static String cls(String value) {
+    return attrs("class", value);
+  }
+}

--- a/src/io/flutter/utils/HtmlBuilder.java
+++ b/src/io/flutter/utils/HtmlBuilder.java
@@ -15,7 +15,7 @@ public class HtmlBuilder {
     return tag("span", contents);
   }
 
-  public static String attrs(String attribute, String value) {
+  public static String attr(String attribute, String value) {
     return attribute + " = \"" + value + "\"";
   }
 
@@ -35,7 +35,7 @@ public class HtmlBuilder {
     final StringBuilder sb = new StringBuilder();
     for (String c : contents) {
       sb.append(c);
-      sb.append(java.lang.System.lineSeparator());
+      sb.append('\n');
     }
     return sb.toString();
   }
@@ -49,6 +49,6 @@ public class HtmlBuilder {
   }
 
   public static String cls(String value) {
-    return attrs("class", value);
+    return attr("class", value);
   }
 }

--- a/src/io/flutter/view/InspectorColoredTreeCellRenderer.java
+++ b/src/io/flutter/view/InspectorColoredTreeCellRenderer.java
@@ -16,7 +16,7 @@ import javax.swing.*;
 import javax.swing.tree.TreeCellRenderer;
 import java.awt.*;
 
-abstract class InspectorColoredTreeCellRenderer extends MultiIconSimpleColoredComponent implements TreeCellRenderer {
+public abstract class InspectorColoredTreeCellRenderer extends MultiIconSimpleColoredComponent implements TreeCellRenderer {
   /**
    * Defines whether the tree has focus or not
    */


### PR DESCRIPTION
An error data UI corresponding to the devtools prototype (https://github.com/flutter/devtools/pull/144).

![image](https://user-images.githubusercontent.com/67586/51914451-becd5780-238d-11e9-9c27-a3e362e4d6da.png)

Still a bunch to do but this proves us out end to end.

On the short-list:
* add hyperlink support to stack traces
* link node selections to inspector
* auto scroll-to-top of error pane
* dark-theme improvements / awareness
* styling in general


/cc @jacob314 