### PR TITLE
propagate node selections to inspector

### DIFF
--- a/src/io/flutter/logging/tree/DataPanel.java
+++ b/src/io/flutter/logging/tree/DataPanel.java
@@ -28,6 +28,8 @@ import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
 import javax.swing.event.HyperlinkEvent;
+import javax.swing.event.TreeSelectionEvent;
+import javax.swing.event.TreeSelectionListener;
 import javax.swing.text.html.HTMLEditorKit;
 import javax.swing.tree.TreeCellRenderer;
 import javax.swing.tree.TreePath;
@@ -223,10 +225,15 @@ public class DataPanel extends JPanel {
   }
 
   private void linkSelected(URL url) {
-    // TODO(pq): handle links
+    // TODO(pq): handle html links
   }
 
   public void update(@NotNull FlutterLogEntry entry) {
+    // Avoid unneeded updates.
+    if (entry == this.entry) {
+      return;
+    }
+
     this.entry = entry;
     final Object data = entry.getData();
 
@@ -329,6 +336,12 @@ public class DataPanel extends JPanel {
         tree.clearSelection();
       }
     });
+    tree.addTreeSelectionListener(new TreeSelectionListener() {
+      @Override
+      public void valueChanged(TreeSelectionEvent e) {
+        selectionChanged(tree);
+      }
+    });
 
     final MouseHandler mouseHandler = new MouseHandler(tree, project);
     tree.addMouseListener(mouseHandler);
@@ -337,6 +350,14 @@ public class DataPanel extends JPanel {
     final NonOpaquePanel panel = new NonOpaquePanel();
     panel.add(tree);
     add(panel);
+  }
+
+  private void selectionChanged(@NotNull JTree tree) {
+    final Object pathComponent = tree.getLastSelectedPathComponent();
+    if (pathComponent instanceof DiagnosticsNode) {
+      final DiagnosticsNode diagnostics = (DiagnosticsNode)pathComponent;
+      diagnostics.setSelection(diagnostics.getValueRef(), false);
+    }
   }
 
   private JEditorPane createEditorPane() {


### PR DESCRIPTION
Error node selections propagated to the inspector.


![diagnostics selections](https://user-images.githubusercontent.com/67586/52004659-7fc9ff80-247c-11e9-9ba1-f14606d959e3.gif)


See: #3139 

/cc @jacob314 