### PR TITLE
pin flutter error events in the log

### DIFF
--- a/src/io/flutter/logging/FlutterLogEntry.java
+++ b/src/io/flutter/logging/FlutterLogEntry.java
@@ -25,7 +25,7 @@ public class FlutterLogEntry {
   public enum Kind {
     RELOAD,
     RESTART,
-    WIDGET_ERROR_START,
+    FLUTTER_ERROR,
     UNSPECIFIED
   }
 
@@ -46,7 +46,7 @@ public class FlutterLogEntry {
   private int sequenceNumber = -1;
 
   @NotNull
-  private final Kind kind;
+  private Kind kind;
   private List<StyledText> styledText;
 
   @NotNull
@@ -93,6 +93,10 @@ public class FlutterLogEntry {
   @NotNull
   public Kind getKind() {
     return kind;
+  }
+
+  public void setKind(@NotNull Kind kind) {
+    this.kind = kind;
   }
 
   public long getTimestamp() {

--- a/src/io/flutter/logging/FlutterLogEntryParser.java
+++ b/src/io/flutter/logging/FlutterLogEntryParser.java
@@ -208,9 +208,9 @@ public class FlutterLogEntryParser {
       if (message.equals("Performing hot restart...") || message.equals("Initializing hot restart...")) {
         return Kind.RESTART;
       }
-      // TODO(pq): remove string matching in favor of some kind of tag coming from the framework.
+      // TODO(pq): remove string matching once all widget errors are coming as "Flutter.Error" exension events.
       if (message.startsWith("══╡ EXCEPTION CAUGHT BY WIDGETS LIBRARY")) {
-        return Kind.WIDGET_ERROR_START;
+        return Kind.FLUTTER_ERROR;
       }
     }
     return Kind.UNSPECIFIED;
@@ -260,6 +260,7 @@ public class FlutterLogEntryParser {
     final DiagnosticsNode diagnosticsNode = parseDiagnosticsNode(extensionData.getAsJsonObject());
     final String description = diagnosticsNode.toString();
     final FlutterLogEntry entry = lineHandler.parseEntry(description, ERROR_CATEGORY, FlutterLog.Level.SEVERE.value);
+    entry.setKind(Kind.FLUTTER_ERROR);
     entry.setData(diagnosticsNode);
     entries.add(entry);
     return entries;

--- a/src/io/flutter/logging/FlutterLogView.java
+++ b/src/io/flutter/logging/FlutterLogView.java
@@ -357,7 +357,11 @@ public class FlutterLogView extends JPanel implements ConsoleView, DataProvider,
 
     @Override
     public void actionPerformed(@NotNull AnActionEvent e) {
-      ApplicationManager.getApplication().invokeLater(logTree::clearEntries);
+      ApplicationManager.getApplication().invokeLater(() -> {
+        logTree.clearEntries();
+        // Flush state.
+        clear();
+      });
     }
 
     @Override
@@ -512,6 +516,8 @@ public class FlutterLogView extends JPanel implements ConsoleView, DataProvider,
   private Splitter treeSplitter;
 
   private final Gson gsonHelper = new GsonBuilder().setPrettyPrinting().create();
+  boolean isPinned;
+  boolean prePinAutoScroll;
 
   public FlutterLogView(@NotNull FlutterApp app) {
     this.app = app;
@@ -740,10 +746,13 @@ public class FlutterLogView extends JPanel implements ConsoleView, DataProvider,
 
   @Override
   public void onEvent(@NotNull FlutterLogEntry entry) {
-    logTree.append(entry);
-    if (entry.getKind() == FlutterLogEntry.Kind.WIDGET_ERROR_START) {
-      // Stop auto-scroll on a widget error.
+    final boolean isError = entry.getKind() == FlutterLogEntry.Kind.FLUTTER_ERROR;
+    logTree.append(entry, isError && !isPinned);
+
+    if (isError) {
+      prePinAutoScroll = logModel.autoScrollToEnd;
       scrollToEndAction.disableIfNeeded();
+      isPinned = true;
     }
   }
 
@@ -759,7 +768,15 @@ public class FlutterLogView extends JPanel implements ConsoleView, DataProvider,
 
   @Override
   public void clear() {
-    // TODO(pq): called on restart; should (optionally) clear _or_ set a visible marker.
+    // Unpin
+    if (prePinAutoScroll) {
+      scrollToEndAction.enableIfNeeded();
+    }
+    else {
+      scrollToEndAction.disableIfNeeded();
+    }
+    isPinned = false;
+    dataPane.setVisible(false);
   }
 
   @Override


### PR DESCRIPTION
Select the first received error and stop auto-scrolling.

![pin](https://user-images.githubusercontent.com/67586/52018144-4b673b00-249e-11e9-92b4-a198c8de61f8.gif)

Some smarts to clear state on reload/restart but we'll want to iterate a bit after some experimenting.

/cc @jacob314 