### PR TITLE
UI test update

### DIFF
--- a/flutter-studio/testSrc/io/flutter/tests/gui/NewModuleTest.java
+++ b/flutter-studio/testSrc/io/flutter/tests/gui/NewModuleTest.java
@@ -25,18 +25,18 @@ import java.io.IOException;
 
 import static com.google.common.truth.Truth.assertThat;
 
-@RunWith(NewModuleTest.CustomRunner.class)
+@RunWith(NewModuleTest.GuiTestRemoteRunner.class)
 public class NewModuleTest {
 
   /**
-   * CustomRunner sets a custom path to the GUI tests.
+   * This custom runner sets a custom path to the GUI tests.
    * This needs to be done by the test runner because the test framework
    * initializes the path before the test class is loaded.
    */
-  public static class CustomRunner extends GuiTestSuiteRunner {
+  public static class GuiTestRemoteRunner extends com.intellij.testGuiFramework.framework.GuiTestRemoteRunner {
 
-    public CustomRunner(Class<?> suiteClass, RunnerBuilder builder) throws InitializationError, IOException {
-      super(suiteClass, builder);
+    public GuiTestRemoteRunner(Class<?> suiteClass) {
+      super(suiteClass);
       System.setProperty("gui.tests.root.dir.path", "somewhere");
     }
 

--- a/flutter-studio/testSrc/io/flutter/tests/util/WizardUtils.java
+++ b/flutter-studio/testSrc/io/flutter/tests/util/WizardUtils.java
@@ -28,7 +28,7 @@ public class WizardUtils {
 
   public static void createNewProject(@NotNull FlutterGuiTestRule guiTest, @NotNull FlutterProjectType type,
                                       String name, String description, String domain, Boolean isKotlin, Boolean isSwift) {
-    String sdkPath = System.getProperty("flutter.home");
+    String sdkPath = "/Users/messick/src/flutter/flutter";// TODO: System.getenv("flutter.home");
     if (sdkPath == null) {
       // Fail fast if the Flutter SDK is not given.
       System.out.println("Add -Dflutter.home=/path/to/flutter/sdk to the VM options");

--- a/flutter-studio/testSrc/io/flutter/tests/util/WizardUtils.java
+++ b/flutter-studio/testSrc/io/flutter/tests/util/WizardUtils.java
@@ -8,6 +8,7 @@ package io.flutter.tests.util;
 import com.android.tools.idea.tests.gui.framework.FlutterGuiTestRule;
 import com.android.tools.idea.tests.gui.framework.fixture.newProjectWizard.NewFlutterProjectWizardFixture;
 import io.flutter.module.FlutterProjectType;
+import io.flutter.sdk.FlutterSdkUtil;
 import org.jetbrains.annotations.NotNull;
 
 public class WizardUtils {
@@ -28,11 +29,11 @@ public class WizardUtils {
 
   public static void createNewProject(@NotNull FlutterGuiTestRule guiTest, @NotNull FlutterProjectType type,
                                       String name, String description, String domain, Boolean isKotlin, Boolean isSwift) {
-    String sdkPath = "/Users/messick/src/flutter/flutter";// TODO: System.getenv("flutter.home");
+    String sdkPath =  FlutterSdkUtil.locateSdkFromPath();
     if (sdkPath == null) {
-      // Fail fast if the Flutter SDK is not given.
-      System.out.println("Add -Dflutter.home=/path/to/flutter/sdk to the VM options");
-      throw new IllegalStateException("flutter.home not set");
+      // Fail fast if the Flutter SDK is not found.
+      System.out.println("Ensure the 'flutter' tool is on your PATH. 'which flutter' is used to find the SDK");
+      throw new IllegalStateException("flutter not installed properly");
     }
     String projectType;
     switch (type) {


### PR DESCRIPTION
@pq @devoncarew @jacob314 

The test framework requires the runner to be named GuiTestRemoteRunner, which is why there is a strange class definition.

Tests run but do not pass. Apparently, we need to have some react native stuff on the path to create a default run config. Still investigating that.