### PR TITLE
handle a corner case of daemon protocol parsing

### DIFF
--- a/src/io/flutter/utils/StdoutJsonParser.java
+++ b/src/io/flutter/utils/StdoutJsonParser.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 /**
  * A class to process regular text output intermixed with newline-delimited JSON.
- *
+ * <p>
  * JSON lines starting with [{ are never split into multiple lines even if they
  * are emitted over the course of multiple calls to appendOutput. Regular lines
  * on the other hand are emitted immediately so users do not have to wait for
@@ -24,13 +24,18 @@ public class StdoutJsonParser {
   /**
    * Write new output to this [StdoutJsonParser].
    */
-  public void appendOutput(String output) {
-    for (int i = 0; i < output.length(); ++i) {
-      final char c = output.charAt(i);
+  public void appendOutput(String string) {
+    for (int i = 0; i < string.length(); ++i) {
+      final char c = string.charAt(i);
       buffer.append(c);
+
       if (!bufferIsJson && buffer.length() == 2 && buffer.charAt(0) == '[' && c == '{') {
         bufferIsJson = true;
       }
+      else if (bufferIsJson && c == ']' && possiblyTerminatesJson(string, i, buffer)) {
+        flushLine();
+      }
+
       if (c == '\n') {
         flushLine();
       }
@@ -43,6 +48,22 @@ public class StdoutJsonParser {
     }
   }
 
+  private boolean possiblyTerminatesJson(String string, int stringIndex, StringBuilder output) {
+    // This is an approximate approach to look for json message terminations inside of strings -
+    // where the normally terminating eol gets separated from the json.
+
+    if (output.length() < 2 || stringIndex + 1 >= string.length()) {
+      return false;
+    }
+
+    // Look for '}', ']', and a letter
+    final char prev = output.charAt(output.length() - 2);
+    final char current = output.charAt(output.length() - 1);
+    final char next = string.charAt(stringIndex + 1);
+
+    return prev == '}' && current == ']' && Character.isAlphabetic(next);
+  }
+
   private void flushLine() {
     if (buffer.length() > 0) {
       lines.add(buffer.toString());
@@ -51,9 +72,9 @@ public class StdoutJsonParser {
     bufferIsJson = false;
   }
 
-    /**
-     * Read any lines available from the processed output.
-     */
+  /**
+   * Read any lines available from the processed output.
+   */
   public List<String> getAvailableLines() {
     final List<String> copy = new ArrayList<>(lines);
     lines.clear();

--- a/testSrc/unit/io/flutter/utils/StdoutJsonParserTest.java
+++ b/testSrc/unit/io/flutter/utils/StdoutJsonParserTest.java
@@ -11,7 +11,7 @@ import static org.junit.Assert.assertArrayEquals;
 
 public class StdoutJsonParserTest {
   @Test
-  public void simple() throws Exception {
+  public void simple() {
     final StdoutJsonParser parser = new StdoutJsonParser();
     parser.appendOutput("hello\n");
     parser.appendOutput("there\n");
@@ -26,7 +26,7 @@ public class StdoutJsonParserTest {
   }
 
   @Test
-  public void appendsWithoutLineBreaks() throws Exception {
+  public void appendsWithoutLineBreaks() {
     StdoutJsonParser parser = new StdoutJsonParser();
     parser.appendOutput("hello\nnow\n");
     parser.appendOutput("there");
@@ -50,7 +50,7 @@ public class StdoutJsonParserTest {
   }
 
   @Test
-  public void splitJson() throws Exception {
+  public void splitJson() {
     final StdoutJsonParser parser = new StdoutJsonParser();
     parser.appendOutput("hello\n");
     parser.appendOutput("there\n");
@@ -66,7 +66,7 @@ public class StdoutJsonParserTest {
   }
 
   @Test
-  public void deepNestedJson() throws Exception {
+  public void deepNestedJson() {
     final StdoutJsonParser parser = new StdoutJsonParser();
     parser.appendOutput("hello\n");
     parser.appendOutput("there\n");
@@ -82,17 +82,31 @@ public class StdoutJsonParserTest {
   }
 
   @Test
-  public void unterminatedJson() throws Exception {
+  public void unterminatedJson() {
     final StdoutJsonParser parser = new StdoutJsonParser();
     parser.appendOutput("hello\n");
     parser.appendOutput("there\n");
     parser.appendOutput("[{'foo':");
     parser.appendOutput("[{'bar':'baz'}]");
-    // The JSON has not yet terminated with a \n.
+    // The JSON has not yet terminated with an \n.
 
     assertArrayEquals(
       "validating parser results",
       new String[]{"hello\n", "there\n"},
+      parser.getAvailableLines().toArray()
+    );
+  }
+
+  @Test
+  public void outputConcatenatedJson() {
+    final StdoutJsonParser parser = new StdoutJsonParser();
+    parser.appendOutput(
+      "[{\"event\":\"app.progress\",\"params\":{\"appId\":\"363879f2-74d7-46e5-bfa9-1654a8c69923\",\"id\":\"12\",\"progressId\":\"hot.restart\",\"message\":\"Performing hot restart...\"}}]Performing hot restart…");
+    assertArrayEquals(
+      "validating parser results",
+      new String[]{
+        "[{\"event\":\"app.progress\",\"params\":{\"appId\":\"363879f2-74d7-46e5-bfa9-1654a8c69923\",\"id\":\"12\",\"progressId\":\"hot.restart\",\"message\":\"Performing hot restart...\"}}]",
+        "Performing hot restart…"},
       parser.getAvailableLines().toArray()
     );
   }


### PR DESCRIPTION
- handle a corner case of daemon protocol parsing

This is to properly handle messages we occasionally receive where the eol terminating the daemon json packet comes out of sequence later.

```json
[{"event":"app.progress","params":{"appId":"363879f2-74d7-46e5-bfa9-1654a8c69923","id":"12","progressId":"hot.restart","message":"Performing hot restart..."}}]Performing hot restart…
```
