### PR TITLE
Avoid NPE if addPerfListener is called out of order with creating perfManager.getCurrentStats()

### DIFF
--- a/src/io/flutter/perf/FlutterWidgetPerf.java
+++ b/src/io/flutter/perf/FlutterWidgetPerf.java
@@ -63,7 +63,7 @@ public class FlutterWidgetPerf implements Disposable, WidgetPerfListener {
   private boolean requestInProgress = false;
   private long lastRequestTime;
 
-  private final List<PerfModel> perfListeners = new ArrayList<>();
+  private final Set<PerfModel> perfListeners = new HashSet<>();
 
   private final Map<TextEditor, EditorPerfModel> editorDecorations = new HashMap<>();
   private final TIntObjectHashMap<Location> knownLocationIds = new TIntObjectHashMap<>();
@@ -244,6 +244,11 @@ public class FlutterWidgetPerf implements Disposable, WidgetPerfListener {
   @Override
   public void addPerfListener(PerfModel listener) {
     perfListeners.add(listener);
+  }
+
+  @Override
+  public void removePerfListener(PerfModel listener) {
+    perfListeners.remove(listener);
   }
 
   private StatsForReportKind getStatsForKind(PerfReportKind kind) {

--- a/src/io/flutter/perf/FlutterWidgetPerfManager.java
+++ b/src/io/flutter/perf/FlutterWidgetPerfManager.java
@@ -62,6 +62,8 @@ public class FlutterWidgetPerfManager implements Disposable, FlutterApp.FlutterA
   private boolean trackRepaintWidgets = trackRepaintWidgetsDefault;
   private boolean debugIsActive;
 
+  private final Set<PerfModel> listeners = new HashSet<>();
+
   /**
    * File editors visible to the user that might contain widgets.
    */
@@ -197,6 +199,10 @@ public class FlutterWidgetPerfManager implements Disposable, FlutterApp.FlutterA
       (TextEditor textEditor) -> new EditorPerfDecorations(textEditor, app),
       path -> new DocumentFileLocationMapper(path, app.getProject())
     );
+
+    for (PerfModel listener : listeners) {
+      currentStats.addPerfListener(listener);
+    }
   }
 
   public void stateChanged(FlutterApp.State newState) {
@@ -318,6 +324,21 @@ public class FlutterWidgetPerfManager implements Disposable, FlutterApp.FlutterA
     if (currentStats != null) {
       currentStats.dispose();
       currentStats = null;
+      listeners.clear();
+    }
+  }
+
+  public void addPerfListener(PerfModel listener) {
+    listeners.add(listener);
+    if (currentStats != null) {
+      currentStats.addPerfListener(listener);
+    }
+  }
+
+  public void removePerfListener(PerfModel listener) {
+    listeners.remove(listener);
+    if (currentStats != null) {
+      currentStats.removePerfListener(listener);
     }
   }
 }

--- a/src/io/flutter/perf/WidgetPerfListener.java
+++ b/src/io/flutter/perf/WidgetPerfListener.java
@@ -18,4 +18,5 @@ public interface WidgetPerfListener {
   void onNavigation();
 
   void addPerfListener(PerfModel listener);
+  void removePerfListener(PerfModel listener);
 }

--- a/src/io/flutter/view/WidgetPerfSummaryView.java
+++ b/src/io/flutter/view/WidgetPerfSummaryView.java
@@ -19,7 +19,7 @@ import javax.swing.*;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 
-class WidgetPerfSummaryView extends JPanel {
+class WidgetPerfSummaryView extends JPanel implements Disposable {
   private static final int REFRESH_TABLE_DELAY = 100;
   private final FlutterApp app;
   private final FlutterWidgetPerfManager perfManager;
@@ -45,14 +45,19 @@ class WidgetPerfSummaryView extends JPanel {
 
     table = new WidgetPerfTable(app, parentDisposable, metric);
 
-    perfManager.getCurrentStats().addPerfListener(table);
+    Disposer.register(parentDisposable, this);
+
+    perfManager.addPerfListener(table);
 
     add(ScrollPaneFactory.createScrollPane(table), BorderLayout.CENTER);
 
     // Perf info and tips
     myWidgetPerfTipsPanel = new WidgetPerfTipsPanel(parentDisposable, app);
+  }
 
-    Disposer.register(parentDisposable, refreshTableTimer::stop);
+  public void dispose() {
+    perfManager.removePerfListener(table);
+    refreshTableTimer.stop();
   }
 
   public WidgetPerfTipsPanel getWidgetPerfTipsPanel() {

--- a/testSrc/unit/io/flutter/perf/FlutterWidgetPerfTest.java
+++ b/testSrc/unit/io/flutter/perf/FlutterWidgetPerfTest.java
@@ -515,6 +515,8 @@ public class FlutterWidgetPerfTest {
     // Verify that an idle event occurs once we wait the idle time delay.
     Thread.sleep(IDLE_DELAY_MILISECONDS);
     assertEquals(1, perfModel.idleCount);
+
+    flutterWidgetPerf.removePerfListener(perfModel);
     flutterWidgetPerf.dispose();
   }
 }


### PR DESCRIPTION
This should fix
https://github.com/flutter/flutter-intellij/issues/3173