### PR TITLE
Reorder console filters

### DIFF
--- a/src/io/flutter/run/SdkAttachConfig.java
+++ b/src/io/flutter/run/SdkAttachConfig.java
@@ -20,7 +20,6 @@ import com.intellij.execution.Executor;
 import com.intellij.execution.configurations.GeneralCommandLine;
 import com.intellij.execution.configurations.RunConfiguration;
 import com.intellij.execution.configurations.RuntimeConfigurationError;
-import com.intellij.execution.filters.TextConsoleBuilder;
 import com.intellij.execution.runners.ExecutionEnvironment;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleUtilCore;
@@ -30,11 +29,9 @@ import com.intellij.openapi.util.Disposer;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.psi.PsiElement;
 import com.intellij.refactoring.listeners.RefactoringElementListener;
-import com.jetbrains.lang.dart.ide.runner.DartConsoleFilter;
 import com.jetbrains.lang.dart.sdk.DartConfigurable;
 import com.jetbrains.lang.dart.sdk.DartSdk;
 import io.flutter.FlutterBundle;
-import io.flutter.console.FlutterConsoleFilter;
 import io.flutter.dart.DartPlugin;
 import io.flutter.pub.PubRoot;
 import io.flutter.run.daemon.FlutterApp;
@@ -102,15 +99,7 @@ public class SdkAttachConfig extends SdkRunConfig {
     };
 
     LaunchState launcher = new AttachState(env, mainFile.getAppDir(), mainFile.getFile(), this, createAppCallback);
-
-    // Set up additional console filters.
-    TextConsoleBuilder builder = launcher.getConsoleBuilder();
-    builder.addFilter(new DartConsoleFilter(env.getProject(), mainFile.getFile()));
-
-    if (module != null) {
-      builder.addFilter(new FlutterConsoleFilter(module));
-    }
-
+    addConsoleFilters(launcher, env, mainFile, module);
     return launcher;
   }
 

--- a/src/io/flutter/run/daemon/DaemonConsoleView.java
+++ b/src/io/flutter/run/daemon/DaemonConsoleView.java
@@ -9,7 +9,6 @@ import com.intellij.execution.configurations.CommandLineState;
 import com.intellij.execution.configurations.SearchScopeProvider;
 import com.intellij.execution.filters.TextConsoleBuilder;
 import com.intellij.execution.filters.TextConsoleBuilderImpl;
-import com.intellij.execution.filters.UrlFilter;
 import com.intellij.execution.impl.ConsoleViewImpl;
 import com.intellij.execution.runners.ExecutionEnvironment;
 import com.intellij.execution.ui.ConsoleView;
@@ -47,7 +46,6 @@ public class DaemonConsoleView extends ConsoleViewImpl {
 
     // Set up basic console filters. (More may be added later.)
     builder.addFilter(new DartRelativePathsConsoleFilter(env.getProject(), workDir.getPath()));
-    builder.addFilter(new UrlFilter());
     launcher.setConsoleBuilder(builder);
   }
 


### PR DESCRIPTION
Reorder console filters to ensure that generic URL handling is last. If it is placed too early in the list it overrides alternative handlers that recognize specific forms of URL.

Fixes #3106

@pq 