### PR TITLE
Build 33

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,8 @@ script: ./tool/travis.sh
 env:
   - DART_BOT=true
   - CHECK_BOT=true
-  - IDEA_VERSION=3.3
+  - IDEA_VERSION=2018.2.5
+  - IDEA_VERSION=3.3.1
   - IDEA_VERSION=3.4
   - IDEA_VERSION=2018.3
   - IDEA_VERSION=2019.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 33.0
+- update build for Android Studio 3.3.1
+- reorder console filters so links work
+- more intelligently enable support for detaching from Flutter apps on exit
+- change the icon used for paint baselines
+- prevent bazel test run configurations from generating in a non-bazel workspace
+- support 2019.1 eap
+- mention 'Dart' in the plugin description
+- correct the bazel output for debugging bazel tests
+- simplify the bazel parameters we pass to Bazel Run configurations
+- pin flutter error events in the log
+- propagate node selections to inspector
+- link support for log data entries
+- fix category cell rendering
+- add sample creation banner
+- add sample apps to Android Studio New Project Wizard
+- update log entry data badge
+
 ## 32.0
 - address an NPE in FlutterWidgetPerfManager.java
 - added overlay renderered for GC, snapshot and memory reset events

--- a/flutter-studio/src/io/flutter/FlutterStudioStartupActivity.java
+++ b/flutter-studio/src/io/flutter/FlutterStudioStartupActivity.java
@@ -5,7 +5,6 @@
  */
 package io.flutter;
 
-import com.android.tools.idea.flags.StudioFlags;
 import com.intellij.openapi.actionSystem.ActionManager;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.project.Project;
@@ -21,7 +20,6 @@ import org.jetbrains.annotations.NotNull;
 public class FlutterStudioStartupActivity implements StartupActivity {
   @Override
   public void runActivity(@NotNull Project project) {
-    StudioFlags.SELECT_DEVICE_SNAPSHOT_COMBO_BOX_VISIBLE.override(Boolean.TRUE);
     if (!FlutterModuleUtils.hasFlutterModule(project)) {
       return;
     }
@@ -38,7 +36,6 @@ public class FlutterStudioStartupActivity implements StartupActivity {
       // TODO(messick): Remove the flag once this sync mechanism is stable.
       AndroidModuleLibraryManager.startWatching(project);
     }
-    StudioFlags.SELECT_DEVICE_SNAPSHOT_COMBO_BOX_VISIBLE.override(Boolean.FALSE);
   }
 
   public static void replaceAction(@NotNull String actionId, @NotNull AnAction newAction) {

--- a/flutter-studio/src/io/flutter/FlutterStudioStartupActivity.java
+++ b/flutter-studio/src/io/flutter/FlutterStudioStartupActivity.java
@@ -5,6 +5,7 @@
  */
 package io.flutter;
 
+import com.android.tools.idea.flags.StudioFlags;
 import com.intellij.openapi.actionSystem.ActionManager;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.project.Project;
@@ -20,6 +21,7 @@ import org.jetbrains.annotations.NotNull;
 public class FlutterStudioStartupActivity implements StartupActivity {
   @Override
   public void runActivity(@NotNull Project project) {
+    StudioFlags.SELECT_DEVICE_SNAPSHOT_COMBO_BOX_VISIBLE.override(Boolean.TRUE);
     if (!FlutterModuleUtils.hasFlutterModule(project)) {
       return;
     }
@@ -36,6 +38,7 @@ public class FlutterStudioStartupActivity implements StartupActivity {
       // TODO(messick): Remove the flag once this sync mechanism is stable.
       AndroidModuleLibraryManager.startWatching(project);
     }
+    StudioFlags.SELECT_DEVICE_SNAPSHOT_COMBO_BOX_VISIBLE.override(Boolean.FALSE);
   }
 
   public static void replaceAction(@NotNull String actionId, @NotNull AnAction newAction) {

--- a/product-matrix.json
+++ b/product-matrix.json
@@ -1,9 +1,9 @@
 {
   "list": [
     {
-      "comments": "AS 3.3 and IntelliJ 2018.2.5",
+      "comments": "IntelliJ 2018.2.5",
       "name": "IntelliJ",
-      "version": "3.3",
+      "version": "2018.2.5",
       "ideaProduct": "android-studio",
       "ideaVersion": "182.5199772",
       "dartPluginVersion": "182.5124",
@@ -11,23 +11,33 @@
       "untilBuild": "182.*"
     },
     {
+      "comments": "AS 3.3.1",
+      "name": "Android Studio",
+      "version": "3.3.1",
+      "ideaProduct": "android-studio",
+      "ideaVersion": "182.5264788",
+      "dartPluginVersion": "182.5215",
+      "sinceBuild": "182.5107.16",
+      "untilBuild": "182.*"
+    },
+    {
       "comments": "AS 3.4 beta",
       "name": "Android Studio",
       "version": "3.4",
       "ideaProduct": "android-studio",
-      "ideaVersion": "183.5217543",
-      "dartPluginVersion": "183.4886.3",
+      "ideaVersion": "183.5256591",
+      "dartPluginVersion": "183.5901",
       "sinceBuild": "183.0",
-      "untilBuild": "183.4886.37.34.*"
+      "untilBuild": "183.5153.38.34.*"
     },
     {
       "comments": "IntelliJ 2018.3, AS 3.5 canary",
-      "name": "Android Studio",
+      "name": "IntelliJ",
       "version": "2018.3",
       "ideaProduct": "android-studio",
-      "ideaVersion": "183.5215047",
-      "dartPluginVersion": "183.4886.3",
-      "sinceBuild": "183.4886.37.35",
+      "ideaVersion": "183.5256920",
+      "dartPluginVersion": "183.5901",
+      "sinceBuild": "183.5153.38.34.*",
       "untilBuild": "183.*"
     },
     {

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -29,6 +29,25 @@
 
   <change-notes>
     <![CDATA[
+<h2>33.0</h2>
+<ul>
+  <li>update build for Android Studio 3.3.1</li>
+  <li>reorder console filters so links work</li>
+  <li>more intelligently enable support for detaching from Flutter apps on exit</li>
+  <li>change the icon used for paint baselines</li>
+  <li>prevent bazel test run configurations from generating in a non-bazel workspace</li>
+  <li>support 2019.1 eap</li>
+  <li>mention 'Dart' in the plugin description</li>
+  <li>correct the bazel output for debugging bazel tests</li>
+  <li>simplify the bazel parameters we pass to Bazel Run configurations</li>
+  <li>pin flutter error events in the log</li>
+  <li>propagate node selections to inspector</li>
+  <li>link support for log data entries</li>
+  <li>fix category cell rendering</li>
+  <li>add sample creation banner</li>
+  <li>add sample apps to Android Studio New Project Wizard</li>
+  <li>update log entry data badge</li>
+</ul>
 <h2>32.0</h2>
 <ul>
   <li>address an NPE in FlutterWidgetPerfManager.java</li>

--- a/tool/plugin/lib/plugin.dart
+++ b/tool/plugin/lib/plugin.dart
@@ -535,9 +535,9 @@ class BuildCommand extends ProductCommand {
       // TODO: Remove this when we no longer support AS 3.3 (IJ 2018.2.5) or AS 3.4
       var files = <File, String>{};
       var processedFile, source;
-      if ((spec.version == '3.3') || (spec.version == '3.4')) {
+      if ((spec.version == '2018.2.5') || (spec.version == '3.3.1')) {
         log('spec.version: ${spec.version}');
-        if (spec.version == '3.3') {
+        if (spec.version == '2018.2.5' || spec.version == "3.3.1") {
           processedFile = File(
               'flutter-studio/src/io/flutter/project/FlutterProjectCreator.java');
           source = processedFile.readAsStringSync();
@@ -554,17 +554,19 @@ class BuildCommand extends ProductCommand {
           processedFile.writeAsStringSync(source);
         }
 
-        processedFile = File(
-            'flutter-studio/src/io/flutter/android/AndroidModuleLibraryManager.java');
-        source = processedFile.readAsStringSync();
-        files[processedFile] = source;
-        source = source.replaceAll(
-            'import static com.google.wireless.android.sdk.stats.GradleSyncStats.Trigger.TRIGGER_PROJECT_MODIFIED;',
-            '');
-        source = source.replaceAll(
-            'new GradleSyncInvoker.Request(TRIGGER_PROJECT_MODIFIED);',
-            'GradleSyncInvoker.Request.projectModified();');
-        processedFile.writeAsStringSync(source);
+        if (spec.version == "2018.2.5") {
+          processedFile = File(
+              'flutter-studio/src/io/flutter/android/AndroidModuleLibraryManager.java');
+          source = processedFile.readAsStringSync();
+          files[processedFile] = source;
+          source = source.replaceAll(
+              'import static com.google.wireless.android.sdk.stats.GradleSyncStats.Trigger.TRIGGER_PROJECT_MODIFIED;',
+              '');
+          source = source.replaceAll(
+              'new GradleSyncInvoker.Request(TRIGGER_PROJECT_MODIFIED);',
+              'GradleSyncInvoker.Request.projectModified();');
+          processedFile.writeAsStringSync(source);
+        }
       }
 
       try {

--- a/tool/plugin/test/plugin_test.dart
+++ b/tool/plugin/test/plugin_test.dart
@@ -38,6 +38,7 @@ void main() {
               'android-studio',
               'android-studio',
               'android-studio',
+              'android-studio',
               'ideaIC',
             ]));
       });
@@ -54,6 +55,7 @@ void main() {
               'android-studio',
               'android-studio',
               'android-studio',
+              'android-studio',
               'ideaIC',
             ]));
       });
@@ -67,6 +69,7 @@ void main() {
         expect(
             specs.map((spec) => spec.ideaProduct).toList(),
             orderedEquals([
+              'android-studio',
               'android-studio',
               'android-studio',
               'android-studio',
@@ -147,7 +150,8 @@ void main() {
       expect(
           cmd.paths.map((p) => p.substring(p.indexOf('releases'))),
           orderedEquals([
-            'releases/release_19/3.3/flutter-intellij.zip',
+            'releases/release_19/2018.2.5/flutter-intellij.zip',
+            'releases/release_19/3.3.1/flutter-intellij.zip',
             'releases/release_19/3.4/flutter-intellij.zip',
             'releases/release_19/2018.3/flutter-intellij.zip',
             'releases/release_19/2019.1/flutter-intellij.zip',


### PR DESCRIPTION
@pq @devoncarew 

Update the build to make artifacts for Android Studio 3.3.1, 3.4, 3.5, and IntelliJ 2018.2.5, 2018.3, 2019.1. Might not need 2018.2.5 but if so we can simply not publish it and remove it later.