### PR TITLE
update the product matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,6 @@ script: ./tool/travis.sh
 env:
   - DART_BOT=true
   - CHECK_BOT=true
-  - IDEA_VERSION=2018.2.5
   - IDEA_VERSION=3.3.1
   - IDEA_VERSION=2018.3
   - IDEA_VERSION=2019.1

--- a/product-matrix.json
+++ b/product-matrix.json
@@ -1,16 +1,6 @@
 {
   "list": [
     {
-      "comments": "IntelliJ 2018.2.5",
-      "name": "IntelliJ",
-      "version": "2018.2.5",
-      "ideaProduct": "android-studio",
-      "ideaVersion": "182.5199772",
-      "dartPluginVersion": "182.5124",
-      "sinceBuild": "182.5107.7",
-      "untilBuild": "182.*"
-    },
-    {
       "comments": "AS 3.3.1",
       "name": "Android Studio",
       "version": "3.3.1",

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -13,7 +13,7 @@
 
   <category>Custom Languages</category>
   
-  <idea-version since-build="182.5107.7" until-build="191.*"/>
+  <idea-version since-build="182.5107.16" until-build="191.*"/>
 
   <depends>Dart</depends>
 

--- a/tool/plugin/test/plugin_test.dart
+++ b/tool/plugin/test/plugin_test.dart
@@ -37,7 +37,6 @@ void main() {
             orderedEquals([
               'android-studio',
               'android-studio',
-              'android-studio',
               'ideaIC',
             ]));
       });
@@ -53,7 +52,6 @@ void main() {
             orderedEquals([
               'android-studio',
               'android-studio',
-              'android-studio',
               'ideaIC',
             ]));
       });
@@ -67,7 +65,6 @@ void main() {
         expect(
             specs.map((spec) => spec.ideaProduct).toList(),
             orderedEquals([
-              'android-studio',
               'android-studio',
               'android-studio',
               'ideaIC',
@@ -147,7 +144,6 @@ void main() {
       expect(
           cmd.paths.map((p) => p.substring(p.indexOf('releases'))),
           orderedEquals([
-            'releases/release_19/2018.2.5/flutter-intellij.zip',
             'releases/release_19/3.3.1/flutter-intellij.zip',
             'releases/release_19/2018.3/flutter-intellij.zip',
             'releases/release_19/2019.1/flutter-intellij.zip',


### PR DESCRIPTION
- update the product matrix

@stevemessick, I noticed that we were shipping nearly the same version ranges for `IntelliJ 2018.2.5` and `AS 3.3.1` (`182.5107.7` - `182.*`). I don't know that the jetbrains plugin server would know which version to distribute, and assume that we no longer need to support IntelliJ 2018.2. I assume this change is correct, but would like your eyes on it.

We may want to add some automation to the bots here - perhaps a dart script which will parse this file, and fail with error if there are any overlapping ranges, or unintentional gaps in ranges.
