### PR TITLE
Debug eap

### DIFF
--- a/product-matrix.json
+++ b/product-matrix.json
@@ -29,6 +29,16 @@
       "dartPluginVersion": "191.4899",
       "sinceBuild": "191.0",
       "untilBuild": "191.*"
+    },
+    {
+      "comments": "IntelliJ 2019.2 EAP",
+      "name": "IntelliJ 2019.1 EAP",
+      "version": "2019.1",
+      "ideaProduct": "ideaIC",
+      "ideaVersion": "191.4738.6",
+      "dartPluginVersion": "191.4899",
+      "sinceBuild": "192.0",
+      "untilBuild": "192.SNAPSHOT"
     }
   ]
 }

--- a/product-matrix.json
+++ b/product-matrix.json
@@ -32,8 +32,8 @@
     },
     {
       "comments": "IntelliJ 2019.2 EAP",
-      "name": "IntelliJ 2019.1 EAP",
-      "version": "2019.1",
+      "name": "IntelliJ 2019.2 EAP",
+      "version": "2019.2",
       "ideaProduct": "ideaIC",
       "ideaVersion": "191.4738.6",
       "dartPluginVersion": "191.4899",

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -13,7 +13,7 @@
 
   <category>Custom Languages</category>
   
-  <idea-version since-build="182.5107.16" until-build="191.*"/>
+  <idea-version since-build="182.5107.16" until-build="192.SNAPSHOT"/>
 
   <depends>Dart</depends>
 

--- a/tool/plugin/lib/plugin.dart
+++ b/tool/plugin/lib/plugin.dart
@@ -141,7 +141,8 @@ void genTravisYml(List<BuildSpec> specs) {
   var file = new File(p.join(rootPath, '.travis.yml'));
   var env = '';
   for (var spec in specs) {
-    env += '  - IDEA_VERSION=${spec.version}\n';
+    if (!spec.untilBuild.contains('SNAPSHOT'))
+      env += '  - IDEA_VERSION=${spec.version}\n';
   }
 
   var templateFile = new File(p.join(rootPath, '.travis_template.yml'));

--- a/tool/plugin/test/plugin_test.dart
+++ b/tool/plugin/test/plugin_test.dart
@@ -38,6 +38,7 @@ void main() {
               'android-studio',
               'android-studio',
               'ideaIC',
+              'ideaIC',
             ]));
       });
     });
@@ -53,6 +54,7 @@ void main() {
               'android-studio',
               'android-studio',
               'ideaIC',
+              'ideaIC',
             ]));
       });
     });
@@ -67,6 +69,7 @@ void main() {
             orderedEquals([
               'android-studio',
               'android-studio',
+              'ideaIC',
               'ideaIC',
             ]));
       });
@@ -147,6 +150,7 @@ void main() {
             'releases/release_19/3.3.1/flutter-intellij.zip',
             'releases/release_19/2018.3/flutter-intellij.zip',
             'releases/release_19/2019.1/flutter-intellij.zip',
+            'releases/release_19/2019.2/flutter-intellij.zip',
           ]));
     });
   });


### PR DESCRIPTION
Update the product matrix to allow debugging with 2019.1 EAP (which has 2019.2 as its version). I'm using the SNAPSHOT convention to avoid breaking travis.