### PR TITLE
make a newer daemon protocol field optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 33.3
+- Fix an issue with an IllegalArgumentException when running Flutter apps
+
 ## 33.2
 - Support IntelliJ 2018.3.3
 

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -29,6 +29,10 @@
 
   <change-notes>
     <![CDATA[
+<h2>33.3</h2>
+<ul>
+  <li>Fix an issue with an IllegalArgumentException when running Flutter apps</li>
+</ul>
 <h2>33.2</h2>
 <ul>
   <li>Support IntelliJ 2018.3.3</li>

--- a/src/io/flutter/run/daemon/FlutterApp.java
+++ b/src/io/flutter/run/daemon/FlutterApp.java
@@ -86,7 +86,6 @@ public class FlutterApp {
    */
   private @Nullable String myLaunchMode;
 
-
   private @Nullable List<PubRoot> myPubRoots;
 
   private int reloadCount;
@@ -313,7 +312,7 @@ public class FlutterApp {
     myBaseUri = uri;
   }
 
-  void setLaunchMode(@NotNull String launchMode) {
+  void setLaunchMode(@Nullable String launchMode) {
     myLaunchMode = launchMode;
   }
 


### PR DESCRIPTION
- make a newer daemon protocol field optional
- fix https://github.com/flutter/flutter-intellij/issues/3228

@stevemessick @DaveShuckerow 