### PR TITLE
Turn the new bazel test runner to enabled-by-default

### DIFF
--- a/src/io/flutter/settings/FlutterSettings.java
+++ b/src/io/flutter/settings/FlutterSettings.java
@@ -267,11 +267,11 @@ public class FlutterSettings {
   }
 
   private boolean shouldUseNewBazelTestRunner() {
-    return getPropertiesComponent().getBoolean(newBazelTestRunnerKey, false);
+    return getPropertiesComponent().getBoolean(newBazelTestRunnerKey, true);
   }
 
   public void setUseNewBazelTestRunner(boolean value) {
-    getPropertiesComponent().setValue(newBazelTestRunnerKey, value, false);
+    getPropertiesComponent().setValue(newBazelTestRunnerKey, value, true);
     fireEvent();
   }
 


### PR DESCRIPTION
We've seen no instability in it in g3, so we'll turn it on by default for new users.