### PR TITLE
add org.apache.commons.io. to the list of imports to avoid

### DIFF
--- a/tool/plugin/lib/lint.dart
+++ b/tool/plugin/lib/lint.dart
@@ -77,6 +77,9 @@ class LintCommand extends Command {
       'javax.annotation.Nullable',
       'org.apache.commons.lang3.StringUtils',
       'org.apache.commons.lang3.builder.HashCodeBuilder',
+      // Not technically a bad import, but not all IntelliJ platforms provide
+      // this library.
+      'org.apache.commons.io.',
     ];
 
     for (var import in proscribedImports) {
@@ -84,7 +87,7 @@ class LintCommand extends Command {
 
       final result = Process.runSync(
         'git',
-        ['grep', 'import $import;'],
+        ['grep', 'import $import'],
       );
 
       final String results = result.stdout.trim();


### PR DESCRIPTION
- add org.apache.commons.io. to the list of imports to avoid

@pq - this is not yet something we can land - I don't know how to circumlocute around `org.apache.commons.io.IOUtils`.
