### PR TITLE
Add support for matching customized Widget tests.

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -18,7 +18,6 @@
     </GroovyCodeStyleSettings>
     <JavaCodeStyleSettings>
       <option name="PREFER_LONGER_NAMES" value="false" />
-      <option name="GENERATE_FINAL_LOCALS" value="false" />
       <option name="PACKAGES_TO_USE_IMPORT_ON_DEMAND">
         <value>
           <package name="java.awt" withSubpackages="false" static="false" />
@@ -482,9 +481,6 @@
       <option name="DOWHILE_BRACE_FORCE" value="1" />
       <option name="WHILE_BRACE_FORCE" value="1" />
       <option name="FOR_BRACE_FORCE" value="1" />
-      <option name="PARENT_SETTINGS_INSTALLED" value="true" />
-    </codeStyleSettings>
-    <codeStyleSettings language="Python">
       <option name="PARENT_SETTINGS_INSTALLED" value="true" />
     </codeStyleSettings>
     <codeStyleSettings language="XML">

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -18,6 +18,7 @@
     </GroovyCodeStyleSettings>
     <JavaCodeStyleSettings>
       <option name="PREFER_LONGER_NAMES" value="false" />
+      <option name="GENERATE_FINAL_LOCALS" value="false" />
       <option name="PACKAGES_TO_USE_IMPORT_ON_DEMAND">
         <value>
           <package name="java.awt" withSubpackages="false" static="false" />
@@ -481,6 +482,9 @@
       <option name="DOWHILE_BRACE_FORCE" value="1" />
       <option name="WHILE_BRACE_FORCE" value="1" />
       <option name="FOR_BRACE_FORCE" value="1" />
+      <option name="PARENT_SETTINGS_INSTALLED" value="true" />
+    </codeStyleSettings>
+    <codeStyleSettings language="Python">
       <option name="PARENT_SETTINGS_INSTALLED" value="true" />
     </codeStyleSettings>
     <codeStyleSettings language="XML">

--- a/src/io/flutter/dart/DartSyntax.java
+++ b/src/io/flutter/dart/DartSyntax.java
@@ -118,9 +118,9 @@ public class DartSyntax {
   }
 
   /**
-   * Check if an element is a call to a function with the given name.
+   * Check if an element is a call to a function with the given {@param functionName}.
    *
-   * @return true if the given element is a call to function, false otherwise
+   * @return true if the given element is a call to the function, false otherwise
    */
   public static boolean isCallToFunctionNamed(@NotNull DartCallExpression element, @NotNull String functionName) {
     final String name = getCalledFunctionName(element);
@@ -128,9 +128,9 @@ public class DartSyntax {
   }
 
   /**
-   * Check if an element is a call to a function matching the given name.
+   * Check if an element is a call to a function matching the given {@param functionRegex}.
    *
-   * @return true if the given element is a call to function, false otherwise
+   * @return true if the given element is a call to the function, false otherwise
    */
   public static boolean isCallToFunctionMatching(@NotNull DartCallExpression element, @NotNull Pattern functionRegex) {
     final String name = getCalledFunctionName(element);

--- a/src/io/flutter/dart/DartSyntax.java
+++ b/src/io/flutter/dart/DartSyntax.java
@@ -36,7 +36,6 @@ public class DartSyntax {
     });
   }
 
-
   /**
    * Finds the enclosing function call where the function being called has a name matching {@param functionRegex}.
    * <p>
@@ -52,9 +51,8 @@ public class DartSyntax {
     });
   }
 
-  private static <T> DartCallExpression findEnclosingFunctionCall(@NotNull PsiElement elt,
-                                                                  @NotNull T functionDescriptor,
-                                                                  @NotNull Equator<T, String> equator) {
+  private static <T> DartCallExpression findEnclosingFunctionCall(
+    @NotNull PsiElement elt, @NotNull T functionDescriptor, @NotNull Equator<T, String> equator) {
     while (elt != null) {
       if (elt instanceof DartCallExpression) {
         final DartCallExpression call = (DartCallExpression)elt;

--- a/src/io/flutter/dart/DartSyntax.java
+++ b/src/io/flutter/dart/DartSyntax.java
@@ -175,7 +175,6 @@ public class DartSyntax {
 
   /**
    * {@link java.util.Comparator}, but for equality checks.
-   * s
    *
    * @param <T>
    * @param <S>

--- a/src/io/flutter/run/common/CommonTestConfigUtils.java
+++ b/src/io/flutter/run/common/CommonTestConfigUtils.java
@@ -21,13 +21,11 @@ import java.util.regex.Pattern;
 /**
  * Common utilities for processing Flutter tests.
  * <p>
- * <p>
  * This class is useful for identifying the {@link TestType} of different Dart objects
  */
 public abstract class CommonTestConfigUtils {
   /**
    * Regex that matches customized versions of the Widget test function from package:flutter_test/src/widget_tester.dart.
-   * <p>
    * <p>
    * This will match all test methods with names that start with 'test', optionally
    * have additional text in the middle, and end with 'Widgets'.

--- a/src/io/flutter/run/common/CommonTestConfigUtils.java
+++ b/src/io/flutter/run/common/CommonTestConfigUtils.java
@@ -20,20 +20,19 @@ import java.util.regex.Pattern;
 
 /**
  * Common utilities for processing Flutter tests.
- *
+ * <p>
  * <p>
  * This class is useful for identifying the {@link TestType} of different Dart objects
  */
 public abstract class CommonTestConfigUtils {
   /**
-   * Widget test function as defined in package:flutter_test/src/widget_tester.dart.
-   */
-  static final String WIDGET_TEST_FUNCTION = "testWidgets";
-
-  /**
    * Regex that matches customized versions of the Widget test function from package:flutter_test/src/widget_tester.dart.
+   * <p>
+   * <p>
+   * This will match all test methods with names that start with 'test', optionally
+   * have additional text in the middle, and end with 'Widgets'.
    */
-  static final Pattern WIDGET_TEST_REGEX = Pattern.compile("test[A-Z]?[A-Za-z0-9]Widgets");
+  public static final Pattern WIDGET_TEST_REGEX = Pattern.compile("test[A-Z]?[A-Za-z0-9]*Widgets");
 
   public abstract TestType asTestCall(@NotNull PsiElement element);
 

--- a/src/io/flutter/run/common/CommonTestConfigUtils.java
+++ b/src/io/flutter/run/common/CommonTestConfigUtils.java
@@ -16,6 +16,8 @@ import org.apache.commons.lang.StringEscapeUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.regex.Pattern;
+
 /**
  * Common utilities for processing Flutter tests.
  *
@@ -26,7 +28,12 @@ public abstract class CommonTestConfigUtils {
   /**
    * Widget test function as defined in package:flutter_test/src/widget_tester.dart.
    */
-  public static final String WIDGET_TEST_FUNCTION = "testWidgets";
+  static final String WIDGET_TEST_FUNCTION = "testWidgets";
+
+  /**
+   * Regex that matches customized versions of the Widget test function from package:flutter_test/src/widget_tester.dart.
+   */
+  static final Pattern WIDGET_TEST_REGEX = Pattern.compile("test[A-Z]?[A-Za-z0-9]Widgets");
 
   public abstract TestType asTestCall(@NotNull PsiElement element);
 

--- a/src/io/flutter/run/common/CommonTestConfigUtils.java
+++ b/src/io/flutter/run/common/CommonTestConfigUtils.java
@@ -32,7 +32,7 @@ public abstract class CommonTestConfigUtils {
    * This will match all test methods with names that start with 'test', optionally
    * have additional text in the middle, and end with 'Widgets'.
    */
-  public static final Pattern WIDGET_TEST_REGEX = Pattern.compile("test[A-Z]?[A-Za-z0-9]*Widgets");
+  public static final Pattern WIDGET_TEST_REGEX = Pattern.compile("test([A-Z][A-Za-z0-9_$]*)?Widgets");
 
   public abstract TestType asTestCall(@NotNull PsiElement element);
 

--- a/src/io/flutter/run/common/TestType.java
+++ b/src/io/flutter/run/common/TestType.java
@@ -64,6 +64,12 @@ public enum TestType {
     return myIcon;
   }
 
+  /**
+   * Describes whether the given {@param element} matches one of the names this {@link TestType} is set up to look for.
+   *
+   * <p>
+   * Does not match the main function.
+   */
   boolean matchesFunction(@NotNull DartCallExpression element) {
     final boolean hasTestFunctionName = myTestFunctionNames.stream().anyMatch(name -> DartSyntax.isCallToFunctionNamed(element, name));
     if (!hasTestFunctionName && myTestFunctionRegex != null) {
@@ -72,6 +78,9 @@ public enum TestType {
     return hasTestFunctionName;
   }
 
+  /**
+   * Describes the tooltip to show on a particular {@param element}.
+   */
   @NotNull
   public String getTooltip(@NotNull PsiElement element, @NotNull CommonTestConfigUtils testConfigUtils) {
     final String testName = testConfigUtils.findTestName(element);
@@ -82,6 +91,9 @@ public enum TestType {
     return "Run Test";
   }
 
+  /**
+   * Finds the closest corresponding test function of this {@link TestType} that encloses the given {@param element}.
+   */
   @Nullable
   public DartCallExpression findCorrespondingCall(@NotNull PsiElement element) {
     for (String name : myTestFunctionNames) {

--- a/src/io/flutter/run/common/TestType.java
+++ b/src/io/flutter/run/common/TestType.java
@@ -106,6 +106,9 @@ public enum TestType {
         return call;
       }
     }
-    return myTestFunctionRegex == null ? null : DartSyntax.findEnclosingFunctionCall(element, myTestFunctionRegex);
+    if (myTestFunctionRegex != null) {
+      return DartSyntax.findEnclosingFunctionCall(element, myTestFunctionRegex);
+    }
+    return null;
   }
 }

--- a/src/io/flutter/run/common/TestType.java
+++ b/src/io/flutter/run/common/TestType.java
@@ -28,6 +28,10 @@ public enum TestType {
   // Note that mapping elements to their most specific enclosing function call depends on the ordering from most to least specific.
   SINGLE(AllIcons.RunConfigurations.TestState.Run, CommonTestConfigUtils.WIDGET_TEST_REGEX, "test"),
   GROUP(AllIcons.RunConfigurations.TestState.Run_run, "group"),
+  /**
+   * This {@link TestType} doesn't know how to detect main methods.
+   * The logic to detect main methods is in {@link CommonTestConfigUtils}.
+   */
   MAIN(AllIcons.RunConfigurations.TestState.Run_run) {
     @NotNull
     public String getTooltip(@NotNull PsiElement element) {

--- a/src/io/flutter/run/common/TestType.java
+++ b/src/io/flutter/run/common/TestType.java
@@ -6,6 +6,7 @@
 package io.flutter.run.common;
 
 import com.intellij.icons.AllIcons;
+import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.psi.PsiElement;
 import com.jetbrains.lang.dart.psi.DartCallExpression;
 import io.flutter.dart.DartSyntax;
@@ -26,7 +27,7 @@ import java.util.regex.Pattern;
  */
 public enum TestType {
   // Note that mapping elements to their most specific enclosing function call depends on the ordering from most to least specific.
-  SINGLE(AllIcons.RunConfigurations.TestState.Run, CommonTestConfigUtils.WIDGET_TEST_REGEX, "test", CommonTestConfigUtils.WIDGET_TEST_FUNCTION),
+  SINGLE(AllIcons.RunConfigurations.TestState.Run, CommonTestConfigUtils.WIDGET_TEST_REGEX, "test"),
   GROUP(AllIcons.RunConfigurations.TestState.Run_run, "group"),
   MAIN(AllIcons.RunConfigurations.TestState.Run_run) {
     @NotNull
@@ -67,7 +68,7 @@ public enum TestType {
   boolean matchesFunction(@NotNull DartCallExpression element) {
     boolean hasTestFunctionName = myTestFunctionNames.stream().anyMatch(name -> DartSyntax.isCallToFunctionNamed(element, name));
     if (!hasTestFunctionName && myTestFunctionRegex != null) {
-      return myTestFunctionRegex.matcher(element.getName()).matches();
+      return myTestFunctionRegex.matcher(StringUtil.notNullize(element.getName())).matches();
     }
     return hasTestFunctionName;
   }

--- a/src/io/flutter/run/common/TestType.java
+++ b/src/io/flutter/run/common/TestType.java
@@ -6,7 +6,6 @@
 package io.flutter.run.common;
 
 import com.intellij.icons.AllIcons;
-import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.psi.PsiElement;
 import com.jetbrains.lang.dart.psi.DartCallExpression;
 import io.flutter.dart.DartSyntax;
@@ -66,9 +65,9 @@ public enum TestType {
   }
 
   boolean matchesFunction(@NotNull DartCallExpression element) {
-    boolean hasTestFunctionName = myTestFunctionNames.stream().anyMatch(name -> DartSyntax.isCallToFunctionNamed(element, name));
+    final boolean hasTestFunctionName = myTestFunctionNames.stream().anyMatch(name -> DartSyntax.isCallToFunctionNamed(element, name));
     if (!hasTestFunctionName && myTestFunctionRegex != null) {
-      return myTestFunctionRegex.matcher(StringUtil.notNullize(element.getName())).matches();
+      return DartSyntax.isCallToFunctionMatching(element, myTestFunctionRegex);
     }
     return hasTestFunctionName;
   }
@@ -91,6 +90,6 @@ public enum TestType {
         return call;
       }
     }
-    return null;
+    return myTestFunctionRegex == null ? null : DartSyntax.findEnclosingFunctionCall(element, myTestFunctionRegex);
   }
 }

--- a/src/io/flutter/run/common/TestType.java
+++ b/src/io/flutter/run/common/TestType.java
@@ -70,7 +70,6 @@ public enum TestType {
 
   /**
    * Describes whether the given {@param element} matches one of the names this {@link TestType} is set up to look for.
-   *
    * <p>
    * Does not match the main function.
    */

--- a/src/io/flutter/run/test/FlutterTestLocationProvider.java
+++ b/src/io/flutter/run/test/FlutterTestLocationProvider.java
@@ -16,8 +16,6 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Objects;
 
-import static io.flutter.run.test.TestConfigUtils.WIDGET_TEST_FUNCTION;
-
 public class FlutterTestLocationProvider extends DartTestLocationProviderZ {
   public static final FlutterTestLocationProvider INSTANCE = new FlutterTestLocationProvider();
 
@@ -27,7 +25,8 @@ public class FlutterTestLocationProvider extends DartTestLocationProviderZ {
   protected Location<PsiElement> getLocationByLineAndColumn(@NotNull PsiFile file, int line, int column) {
     try {
       return super.getLocationByLineAndColumn(file, line, column);
-    } catch (IndexOutOfBoundsException e) {
+    }
+    catch (IndexOutOfBoundsException e) {
       // Line and column info can be wrong, in which case we fall-back on test and group name for test discovery.
     }
 
@@ -36,6 +35,6 @@ public class FlutterTestLocationProvider extends DartTestLocationProviderZ {
 
   @Override
   protected boolean isTest(@NotNull DartCallExpression expression) {
-    return super.isTest(expression) || Objects.equals(WIDGET_TEST_FUNCTION, expression.getExpression().getText());
+    return super.isTest(expression) || TestConfigUtils.WIDGET_TEST_REGEX.matcher(expression.getExpression().getText()).matches();
   }
 }

--- a/testSrc/unit/io/flutter/dart/DartSyntaxTest.java
+++ b/testSrc/unit/io/flutter/dart/DartSyntaxTest.java
@@ -15,6 +15,8 @@ import com.jetbrains.lang.dart.psi.DartStringLiteralExpression;
 import io.flutter.AbstractDartElementTest;
 import org.junit.Test;
 
+import java.util.regex.Pattern;
+
 import static org.junit.Assert.*;
 
 public class DartSyntaxTest extends AbstractDartElementTest {
@@ -26,6 +28,16 @@ public class DartSyntaxTest extends AbstractDartElementTest {
       final DartCallExpression call = DartSyntax.findEnclosingFunctionCall(testIdentifier, "test");
       assert call != null;
       assertTrue(DartSyntax.isCallToFunctionNamed(call, "test"));
+    });
+  }
+
+  @Test
+  public void isTestCallPattern() throws Exception {
+    run(() -> {
+      final PsiElement testIdentifier = setUpDartElement("main() { test('my first test', () {} ); }", "test", LeafPsiElement.class);
+      final DartCallExpression call = DartSyntax.findEnclosingFunctionCall(testIdentifier, "test");
+      assert call != null;
+      assertTrue(DartSyntax.isCallToFunctionMatching(call, Pattern.compile("t.*t")));
     });
   }
 
@@ -45,6 +57,26 @@ public class DartSyntaxTest extends AbstractDartElementTest {
       final PsiElement helloElt = setUpDartElement("main() { test(\"hello\"); }", "hello", LeafPsiElement.class);
 
       final DartCallExpression call = DartSyntax.findEnclosingFunctionCall(helloElt, "test");
+      assertNotNull("findEnclosingFunctionCall() didn't find enclosing function call", call);
+    });
+  }
+
+  @Test
+  public void shouldFindEnclosingFunctionCallPattern() throws Exception {
+    run(() -> {
+      final PsiElement helloElt = setUpDartElement("main() { test(\"hello\"); }", "hello", LeafPsiElement.class);
+
+      final DartCallExpression call = DartSyntax.findEnclosingFunctionCall(helloElt, Pattern.compile("t.*t"));
+      assertNotNull("findEnclosingFunctionCall() didn't find enclosing function call", call);
+    });
+  }
+
+  @Test
+  public void shouldNotFindEnclosingFunctionCallPattern() throws Exception {
+    run(() -> {
+      final PsiElement helloElt = setUpDartElement("main() { test(\"hello\"); }", "hello", LeafPsiElement.class);
+
+      final DartCallExpression call = DartSyntax.findEnclosingFunctionCall(helloElt, Pattern.compile("t.*a"));
       assertNotNull("findEnclosingFunctionCall() didn't find enclosing function call", call);
     });
   }

--- a/testSrc/unit/io/flutter/run/common/TestTypeTest.java
+++ b/testSrc/unit/io/flutter/run/common/TestTypeTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2019 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.run.common;
+
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.impl.source.tree.LeafPsiElement;
+import com.intellij.psi.util.PsiTreeUtil;
+import com.jetbrains.lang.dart.psi.DartCallExpression;
+import com.jetbrains.lang.dart.psi.DartFunctionDeclarationWithBodyOrNative;
+import io.flutter.AbstractDartElementTest;
+import io.flutter.dart.DartSyntax;
+import io.flutter.run.bazelTest.BazelTestConfig;
+import io.flutter.run.bazelTest.BazelTestConfigProducerTest;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.core.IsNot.not;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Verifies run configuration persistence.
+ */
+public class TestTypeTest extends AbstractDartElementTest {
+
+  private static final String fileContents = "void main() {\n" +
+                                             "  test('test 1', () {});\n" +
+                                             "}";
+
+  private static final String fileContents1 = "void main() {\n" +
+                                              "  group('group 0', () {\n" +
+                                              "    test('test 0', () {\n" +
+                                              "      print('test contents');\n" +
+                                              "    });\n" +
+                                              "    testWidgets('test widgets 0', () {\n" +
+                                              "      print('test widgets contents');\n" +
+                                              "    });\n" +
+                                              "    testFooBarWidgets('test foobar widgets 0', () {\n" +
+                                              "      print('test foobar widgets contents');\n" +
+                                              "    });\n" +
+                                              "  });\n" +
+                                              "  test('test 1', () {});\n" +
+                                              "  testingWidgets('does not test widgets');\n" +
+                                              "}";
+
+  @Test
+  public void shouldMatchMain() throws Exception {
+    run(() -> {
+      DartCallExpression mainCall = getMainCall();
+      assertThat(TestType.MAIN.matchesFunction(mainCall), equalTo(true));
+      assertThat(TestType.GROUP.matchesFunction(mainCall), equalTo(false));
+      assertThat(TestType.SINGLE.matchesFunction(mainCall), equalTo(false));
+    });
+  }
+
+
+  @Test
+  public void shouldMatchGroup() throws Exception {
+    run(() -> {
+      assertThat(TestType.MAIN.matchesFunction(getGroupCall()), equalTo(false));
+      assertThat(TestType.GROUP.matchesFunction(getGroupCall()), equalTo(true));
+      assertThat(TestType.SINGLE.matchesFunction(getGroupCall()), equalTo(false));
+    });
+  }
+
+
+  @Test
+  public void shouldMatchTest0() throws Exception {
+    run(() -> {
+      assertThat(TestType.MAIN.matchesFunction(getTestCall("test 0")), equalTo(false));
+      assertThat(TestType.GROUP.matchesFunction(getTestCall("test 0")), equalTo(false));
+      assertThat(TestType.SINGLE.matchesFunction(getTestCall("test 0")), equalTo(true));
+    });
+  }
+
+  @Test
+  public void shouldMatchTestWidgets0() throws Exception {
+    run(() -> {
+      assertThat(TestType.MAIN.matchesFunction(getTestCall("test widgets 0")), equalTo(false));
+      assertThat(TestType.GROUP.matchesFunction(getTestCall("test widgets 0")), equalTo(false));
+      assertThat(TestType.SINGLE.matchesFunction(getTestCall("test widgets 0")), equalTo(true));
+    });
+  }
+
+  @Test
+  public void shouldMatchTestFooBarWidgets0() throws Exception {
+    run(() -> {
+      assertThat(TestType.MAIN.matchesFunction(getTestCall("test foobar widgets 0")), equalTo(false));
+      assertThat(TestType.GROUP.matchesFunction(getTestCall("test foobar widgets 0")), equalTo(false));
+      assertThat(TestType.SINGLE.matchesFunction(getTestCall("test foobar widgets 0")), equalTo(true));
+    });
+  }
+
+  @Test
+  public void shouldMatchTest1() throws Exception {
+    run(() -> {
+      assertThat(TestType.MAIN.matchesFunction(getTestCall("test 1")), equalTo(false));
+      assertThat(TestType.GROUP.matchesFunction(getTestCall("test 1")), equalTo(false));
+      assertThat(TestType.SINGLE.matchesFunction(getTestCall("test 1")), equalTo(true));
+    });
+  }
+
+  @Test
+  public void shouldNotMatchTestingWidgets() throws Exception {
+    run(() -> {
+      assertThat(TestType.MAIN.matchesFunction(getTestCall("does not test widgets")), equalTo(false));
+      assertThat(TestType.GROUP.matchesFunction(getTestCall("does not test widgets")), equalTo(false));
+      assertThat(TestType.SINGLE.matchesFunction(getTestCall("does not test widgets")), equalTo(true));
+    });
+  }
+
+  private DartCallExpression getMainCall() {
+    // Set up fake source code.
+    final PsiElement mainIdentifier = setUpDartElement(
+      fileContents, "main", LeafPsiElement.class);
+    final PsiElement main = PsiTreeUtil.findFirstParent(
+      mainIdentifier, element -> element instanceof DartFunctionDeclarationWithBodyOrNative);
+    assertThat(main, not(equalTo(null)));
+
+    return DartSyntax.findEnclosingFunctionCall(main, "main");
+  }
+
+
+  private DartCallExpression getGroupCall() {
+    // Set up fake source code.
+    final PsiElement groupIdentifier = setUpDartElement(
+      fileContents, "group 0", LeafPsiElement.class);
+
+    return DartSyntax.findEnclosingFunctionCall(groupIdentifier, "group");
+  }
+
+  private DartCallExpression getTestCall(String testName) {
+    // Set up fake source code.
+    final PsiElement testIdentifier = setUpDartElement(
+      fileContents, testName, LeafPsiElement.class);
+    assertThat(testIdentifier, not(equalTo(null)));
+
+    return DartSyntax.findEnclosingFunctionCall(testIdentifier, "test");
+  }
+}

--- a/testSrc/unit/io/flutter/run/common/TestTypeTest.java
+++ b/testSrc/unit/io/flutter/run/common/TestTypeTest.java
@@ -7,13 +7,10 @@ package io.flutter.run.common;
 
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.impl.source.tree.LeafPsiElement;
-import com.intellij.psi.util.PsiTreeUtil;
 import com.jetbrains.lang.dart.psi.DartCallExpression;
-import com.jetbrains.lang.dart.psi.DartFunctionDeclarationWithBodyOrNative;
 import io.flutter.AbstractDartElementTest;
 import io.flutter.dart.DartSyntax;
-import io.flutter.run.bazelTest.BazelTestConfig;
-import io.flutter.run.bazelTest.BazelTestConfigProducerTest;
+import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -26,29 +23,25 @@ import static org.junit.Assert.assertThat;
 public class TestTypeTest extends AbstractDartElementTest {
 
   private static final String fileContents = "void main() {\n" +
+                                             "  group('group 0', () {\n" +
+                                             "    test('test 0', () {\n" +
+                                             "      print('test contents');\n" +
+                                             "    });\n" +
+                                             "    testWidgets('test widgets 0', (tester) {\n" +
+                                             "      print('test widgets contents');\n" +
+                                             "    });\n" +
+                                             "    testFooBarWidgets('test foobar widgets 0', (testers) {\n" +
+                                             "      print('test foobar widgets contents');\n" +
+                                             "    });\n" +
+                                             "  });\n" +
                                              "  test('test 1', () {});\n" +
+                                             "  testingWidgets('does not test widgets');\n" +
                                              "}";
-
-  private static final String fileContents1 = "void main() {\n" +
-                                              "  group('group 0', () {\n" +
-                                              "    test('test 0', () {\n" +
-                                              "      print('test contents');\n" +
-                                              "    });\n" +
-                                              "    testWidgets('test widgets 0', () {\n" +
-                                              "      print('test widgets contents');\n" +
-                                              "    });\n" +
-                                              "    testFooBarWidgets('test foobar widgets 0', () {\n" +
-                                              "      print('test foobar widgets contents');\n" +
-                                              "    });\n" +
-                                              "  });\n" +
-                                              "  test('test 1', () {});\n" +
-                                              "  testingWidgets('does not test widgets');\n" +
-                                              "}";
 
   @Test
   public void shouldMatchMain() throws Exception {
     run(() -> {
-      DartCallExpression mainCall = getMainCall();
+      final DartCallExpression mainCall = getMainCall();
       assertThat(TestType.MAIN.matchesFunction(mainCall), equalTo(true));
       assertThat(TestType.GROUP.matchesFunction(mainCall), equalTo(false));
       assertThat(TestType.SINGLE.matchesFunction(mainCall), equalTo(false));
@@ -59,9 +52,10 @@ public class TestTypeTest extends AbstractDartElementTest {
   @Test
   public void shouldMatchGroup() throws Exception {
     run(() -> {
-      assertThat(TestType.MAIN.matchesFunction(getGroupCall()), equalTo(false));
-      assertThat(TestType.GROUP.matchesFunction(getGroupCall()), equalTo(true));
-      assertThat(TestType.SINGLE.matchesFunction(getGroupCall()), equalTo(false));
+      final DartCallExpression group = getGroupCall();
+      assertThat(TestType.MAIN.matchesFunction(group), equalTo(false));
+      assertThat(TestType.GROUP.matchesFunction(group), equalTo(true));
+      assertThat(TestType.SINGLE.matchesFunction(group), equalTo(false));
     });
   }
 
@@ -69,74 +63,96 @@ public class TestTypeTest extends AbstractDartElementTest {
   @Test
   public void shouldMatchTest0() throws Exception {
     run(() -> {
-      assertThat(TestType.MAIN.matchesFunction(getTestCall("test 0")), equalTo(false));
-      assertThat(TestType.GROUP.matchesFunction(getTestCall("test 0")), equalTo(false));
-      assertThat(TestType.SINGLE.matchesFunction(getTestCall("test 0")), equalTo(true));
+      final DartCallExpression test0 = getTestCall("test", "test 0");
+      assertThat(TestType.MAIN.matchesFunction(test0), equalTo(false));
+      assertThat(TestType.GROUP.matchesFunction(test0), equalTo(false));
+      assertThat(TestType.SINGLE.matchesFunction(test0), equalTo(true));
     });
   }
 
   @Test
   public void shouldMatchTestWidgets0() throws Exception {
     run(() -> {
-      assertThat(TestType.MAIN.matchesFunction(getTestCall("test widgets 0")), equalTo(false));
-      assertThat(TestType.GROUP.matchesFunction(getTestCall("test widgets 0")), equalTo(false));
-      assertThat(TestType.SINGLE.matchesFunction(getTestCall("test widgets 0")), equalTo(true));
+      final DartCallExpression testWidgets0 = getTestCall("testWidgets", "test widgets 0");
+      assertThat(TestType.MAIN.matchesFunction(testWidgets0), equalTo(false));
+      assertThat(TestType.GROUP.matchesFunction(testWidgets0), equalTo(false));
+      assertThat(TestType.SINGLE.matchesFunction(testWidgets0), equalTo(true));
     });
   }
 
   @Test
   public void shouldMatchTestFooBarWidgets0() throws Exception {
     run(() -> {
-      assertThat(TestType.MAIN.matchesFunction(getTestCall("test foobar widgets 0")), equalTo(false));
-      assertThat(TestType.GROUP.matchesFunction(getTestCall("test foobar widgets 0")), equalTo(false));
-      assertThat(TestType.SINGLE.matchesFunction(getTestCall("test foobar widgets 0")), equalTo(true));
+      final DartCallExpression testFooBarWidgets0 = getTestCall("testFooBarWidgets", "test foobar widgets 0");
+      assertThat(TestType.MAIN.matchesFunction(testFooBarWidgets0), equalTo(false));
+      assertThat(TestType.GROUP.matchesFunction(testFooBarWidgets0), equalTo(false));
+      assertThat(TestType.SINGLE.matchesFunction(testFooBarWidgets0), equalTo(true));
     });
   }
 
   @Test
   public void shouldMatchTest1() throws Exception {
     run(() -> {
-      assertThat(TestType.MAIN.matchesFunction(getTestCall("test 1")), equalTo(false));
-      assertThat(TestType.GROUP.matchesFunction(getTestCall("test 1")), equalTo(false));
-      assertThat(TestType.SINGLE.matchesFunction(getTestCall("test 1")), equalTo(true));
+      final DartCallExpression test1 = getTestCall("test", "test 1");
+      assertThat(TestType.MAIN.matchesFunction(test1), equalTo(false));
+      assertThat(TestType.GROUP.matchesFunction(test1), equalTo(false));
+      assertThat(TestType.SINGLE.matchesFunction(test1), equalTo(true));
     });
   }
 
   @Test
   public void shouldNotMatchTestingWidgets() throws Exception {
     run(() -> {
-      assertThat(TestType.MAIN.matchesFunction(getTestCall("does not test widgets")), equalTo(false));
-      assertThat(TestType.GROUP.matchesFunction(getTestCall("does not test widgets")), equalTo(false));
-      assertThat(TestType.SINGLE.matchesFunction(getTestCall("does not test widgets")), equalTo(true));
+      final DartCallExpression testingWidgets = getTestCall("testingWidgets", "does not test widgets");
+      assertThat(TestType.MAIN.matchesFunction(testingWidgets), equalTo(false));
+      assertThat(TestType.GROUP.matchesFunction(testingWidgets), equalTo(false));
+      assertThat(TestType.SINGLE.matchesFunction(testingWidgets), equalTo(false));
     });
   }
 
+  @NotNull
   private DartCallExpression getMainCall() {
     // Set up fake source code.
     final PsiElement mainIdentifier = setUpDartElement(
       fileContents, "main", LeafPsiElement.class);
-    final PsiElement main = PsiTreeUtil.findFirstParent(
-      mainIdentifier, element -> element instanceof DartFunctionDeclarationWithBodyOrNative);
+    assertThat(mainIdentifier, not(equalTo(null)));
+
+    final DartCallExpression main = DartSyntax.findEnclosingFunctionCall(mainIdentifier, "main");
     assertThat(main, not(equalTo(null)));
 
-    return DartSyntax.findEnclosingFunctionCall(main, "main");
+    return main;
   }
 
 
+  @NotNull
   private DartCallExpression getGroupCall() {
     // Set up fake source code.
     final PsiElement groupIdentifier = setUpDartElement(
       fileContents, "group 0", LeafPsiElement.class);
 
-    return DartSyntax.findEnclosingFunctionCall(groupIdentifier, "group");
+    final DartCallExpression group = DartSyntax.findEnclosingFunctionCall(groupIdentifier, "group");
+    assertThat(group, not(equalTo(null)));
+
+    return group;
   }
 
-  private DartCallExpression getTestCall(String testName) {
+  /**
+   * Gets a specific test call.
+   *
+   * @param functionName The name of the function being called, eg test() or testWidgets()
+   * @param testName     The name of the test desired, such as 'test 0' or 'test widgets 0'
+   * @return
+   */
+  @NotNull
+  private DartCallExpression getTestCall(String functionName, String testName) {
     // Set up fake source code.
     final PsiElement testIdentifier = setUpDartElement(
       fileContents, testName, LeafPsiElement.class);
     assertThat(testIdentifier, not(equalTo(null)));
 
-    return DartSyntax.findEnclosingFunctionCall(testIdentifier, "test");
+    final DartCallExpression test = DartSyntax.findEnclosingFunctionCall(testIdentifier, functionName);
+    assertThat(test, not(equalTo(null)));
+
+    return test;
   }
 }

--- a/testSrc/unit/io/flutter/run/common/TestTypeTest.java
+++ b/testSrc/unit/io/flutter/run/common/TestTypeTest.java
@@ -92,17 +92,6 @@ public class TestTypeTest extends AbstractDartElementTest {
   }
 
   @NotNull
-  private PsiElement getMainCall() {
-    // Set up fake source code.
-    final PsiElement mainIdentifier = setUpDartElement(
-      fileContents, "main", LeafPsiElement.class);
-    assertThat(mainIdentifier, not(equalTo(null)));
-
-    return mainIdentifier;
-  }
-
-
-  @NotNull
   private PsiElement getGroupCall() {
     // Set up fake source code.
     final PsiElement groupIdentifier = setUpDartElement(

--- a/testSrc/unit/io/flutter/run/common/TestTypeTest.java
+++ b/testSrc/unit/io/flutter/run/common/TestTypeTest.java
@@ -7,9 +7,7 @@ package io.flutter.run.common;
 
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.impl.source.tree.LeafPsiElement;
-import com.jetbrains.lang.dart.psi.DartCallExpression;
 import io.flutter.AbstractDartElementTest;
-import io.flutter.dart.DartSyntax;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 
@@ -18,7 +16,7 @@ import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertThat;
 
 /**
- * Verifies run configuration persistence.
+ * Verifies that named test targets can be identified correctly as part of a group or as an individual test target.
  */
 public class TestTypeTest extends AbstractDartElementTest {
 
@@ -39,30 +37,11 @@ public class TestTypeTest extends AbstractDartElementTest {
                                              "}";
 
   @Test
-  public void shouldMatchMain() throws Exception {
-    run(() -> {
-<<<<<<< Updated upstream
-      final DartCallExpression mainCall = getMainCall();
-      assertThat(TestType.MAIN.matchesFunction(mainCall), equalTo(true));
-      assertThat(TestType.GROUP.matchesFunction(mainCall), equalTo(false));
-      assertThat(TestType.SINGLE.matchesFunction(mainCall), equalTo(false));
-=======
-      final PsiElement mainCall = getMainCall();
-      assertThat(TestType.MAIN.findCorrespondingCall(mainCall), equalTo(true));
-      assertThat(TestType.GROUP.findCorrespondingCall(mainCall), equalTo(false));
-      assertThat(TestType.SINGLE.findCorrespondingCall(mainCall), equalTo(false));
->>>>>>> Stashed changes
-    });
-  }
-
-
-  @Test
   public void shouldMatchGroup() throws Exception {
     run(() -> {
-      final DartCallExpression group = getGroupCall();
-      assertThat(TestType.MAIN.matchesFunction(group), equalTo(false));
-      assertThat(TestType.GROUP.matchesFunction(group), equalTo(true));
-      assertThat(TestType.SINGLE.matchesFunction(group), equalTo(false));
+      final PsiElement group0 = getGroupCall();
+      assertThat(TestType.GROUP.findCorrespondingCall(group0), not(equalTo(null)));
+      assertThat(TestType.SINGLE.findCorrespondingCall(group0), equalTo(null));
     });
   }
 
@@ -70,77 +49,67 @@ public class TestTypeTest extends AbstractDartElementTest {
   @Test
   public void shouldMatchTest0() throws Exception {
     run(() -> {
-      final DartCallExpression test0 = getTestCall("test", "test 0");
-      assertThat(TestType.MAIN.matchesFunction(test0), equalTo(false));
-      assertThat(TestType.GROUP.matchesFunction(test0), equalTo(false));
-      assertThat(TestType.SINGLE.matchesFunction(test0), equalTo(true));
+      final PsiElement test0 = getTestCall("test", "test 0");
+      assertThat(TestType.GROUP.findCorrespondingCall(test0), not(equalTo(null)));
+      assertThat(TestType.SINGLE.findCorrespondingCall(test0), not(equalTo(null)));
     });
   }
 
   @Test
   public void shouldMatchTestWidgets0() throws Exception {
     run(() -> {
-      final DartCallExpression testWidgets0 = getTestCall("testWidgets", "test widgets 0");
-      assertThat(TestType.MAIN.matchesFunction(testWidgets0), equalTo(false));
-      assertThat(TestType.GROUP.matchesFunction(testWidgets0), equalTo(false));
-      assertThat(TestType.SINGLE.matchesFunction(testWidgets0), equalTo(true));
+      final PsiElement testWidgets0 = getTestCall("testWidgets", "test widgets 0");
+      assertThat(TestType.GROUP.findCorrespondingCall(testWidgets0), not(equalTo(null)));
+      assertThat(TestType.SINGLE.findCorrespondingCall(testWidgets0), not(equalTo(null)));
     });
   }
 
   @Test
   public void shouldMatchTestFooBarWidgets0() throws Exception {
     run(() -> {
-      final DartCallExpression testFooBarWidgets0 = getTestCall("testFooBarWidgets", "test foobar widgets 0");
-      assertThat(TestType.MAIN.matchesFunction(testFooBarWidgets0), equalTo(false));
-      assertThat(TestType.GROUP.matchesFunction(testFooBarWidgets0), equalTo(false));
-      assertThat(TestType.SINGLE.matchesFunction(testFooBarWidgets0), equalTo(true));
+      final PsiElement testFooBarWidgets0 = getTestCall("testFooBarWidgets", "test foobar widgets 0");
+      assertThat(TestType.GROUP.findCorrespondingCall(testFooBarWidgets0), not(equalTo(null)));
+      assertThat(TestType.SINGLE.findCorrespondingCall(testFooBarWidgets0), not(equalTo(null)));
     });
   }
 
   @Test
   public void shouldMatchTest1() throws Exception {
     run(() -> {
-      final DartCallExpression test1 = getTestCall("test", "test 1");
-      assertThat(TestType.MAIN.matchesFunction(test1), equalTo(false));
-      assertThat(TestType.GROUP.matchesFunction(test1), equalTo(false));
-      assertThat(TestType.SINGLE.matchesFunction(test1), equalTo(true));
+      final PsiElement test1 = getTestCall("test", "test 1");
+      assertThat(TestType.GROUP.findCorrespondingCall(test1), equalTo(null));
+      assertThat(TestType.SINGLE.findCorrespondingCall(test1), not(equalTo(null)));
     });
   }
 
   @Test
   public void shouldNotMatchTestingWidgets() throws Exception {
     run(() -> {
-      final DartCallExpression testingWidgets = getTestCall("testingWidgets", "does not test widgets");
-      assertThat(TestType.MAIN.matchesFunction(testingWidgets), equalTo(false));
-      assertThat(TestType.GROUP.matchesFunction(testingWidgets), equalTo(false));
-      assertThat(TestType.SINGLE.matchesFunction(testingWidgets), equalTo(false));
+      final PsiElement testingWidgets = getTestCall("testingWidgets", "does not test widgets");
+      assertThat(TestType.GROUP.findCorrespondingCall(testingWidgets), equalTo(null));
+      assertThat(TestType.SINGLE.findCorrespondingCall(testingWidgets), equalTo(null));
     });
   }
 
   @NotNull
-  private DartCallExpression getMainCall() {
+  private PsiElement getMainCall() {
     // Set up fake source code.
     final PsiElement mainIdentifier = setUpDartElement(
       fileContents, "main", LeafPsiElement.class);
     assertThat(mainIdentifier, not(equalTo(null)));
 
-    final DartCallExpression main = DartSyntax.findEnclosingFunctionCall(mainIdentifier, "main");
-    assertThat(main, not(equalTo(null)));
-
-    return main;
+    return mainIdentifier;
   }
 
 
   @NotNull
-  private DartCallExpression getGroupCall() {
+  private PsiElement getGroupCall() {
     // Set up fake source code.
     final PsiElement groupIdentifier = setUpDartElement(
       fileContents, "group 0", LeafPsiElement.class);
+    assertThat(groupIdentifier, not(equalTo(null)));
 
-    final DartCallExpression group = DartSyntax.findEnclosingFunctionCall(groupIdentifier, "group");
-    assertThat(group, not(equalTo(null)));
-
-    return group;
+    return groupIdentifier;
   }
 
   /**
@@ -151,15 +120,12 @@ public class TestTypeTest extends AbstractDartElementTest {
    * @return
    */
   @NotNull
-  private DartCallExpression getTestCall(String functionName, String testName) {
+  private PsiElement getTestCall(String functionName, String testName) {
     // Set up fake source code.
     final PsiElement testIdentifier = setUpDartElement(
       fileContents, testName, LeafPsiElement.class);
     assertThat(testIdentifier, not(equalTo(null)));
 
-    final DartCallExpression test = DartSyntax.findEnclosingFunctionCall(testIdentifier, functionName);
-    assertThat(test, not(equalTo(null)));
-
-    return test;
+    return testIdentifier;
   }
 }

--- a/testSrc/unit/io/flutter/run/common/TestTypeTest.java
+++ b/testSrc/unit/io/flutter/run/common/TestTypeTest.java
@@ -41,10 +41,17 @@ public class TestTypeTest extends AbstractDartElementTest {
   @Test
   public void shouldMatchMain() throws Exception {
     run(() -> {
+<<<<<<< Updated upstream
       final DartCallExpression mainCall = getMainCall();
       assertThat(TestType.MAIN.matchesFunction(mainCall), equalTo(true));
       assertThat(TestType.GROUP.matchesFunction(mainCall), equalTo(false));
       assertThat(TestType.SINGLE.matchesFunction(mainCall), equalTo(false));
+=======
+      final PsiElement mainCall = getMainCall();
+      assertThat(TestType.MAIN.findCorrespondingCall(mainCall), equalTo(true));
+      assertThat(TestType.GROUP.findCorrespondingCall(mainCall), equalTo(false));
+      assertThat(TestType.SINGLE.findCorrespondingCall(mainCall), equalTo(false));
+>>>>>>> Stashed changes
     });
   }
 


### PR DESCRIPTION
Add support for detecting test call sites matching `test([A-Z][A-Za-z0-9]*)?Widgets`, eg test patterns that start with `test`, are followed by a capital letter and the rest of a target name, then end with Widgets.

Justification: some g3 customers are introducing their own shims on top of `testWidgets()`.  Message me for additional context here.