### PR TITLE
Hide DevTools debugger when launching from IntelliJ.

### DIFF
--- a/src/io/flutter/devtools/DevToolsManager.java
+++ b/src/io/flutter/devtools/DevToolsManager.java
@@ -211,11 +211,11 @@ class DevToolsInstance {
 
   public void openBrowserAndConnect(int serviceProtocolPort) {
     if (serviceProtocolPort == -1) {
-      BrowserLauncher.getInstance().browse("http://" + devtoolsHost + ":" + devtoolsPort + "/", null);
+      BrowserLauncher.getInstance().browse("http://" + devtoolsHost + ":" + devtoolsPort + "/?hide=debugger&", null);
     }
     else {
       BrowserLauncher.getInstance().browse(
-        "http://" + devtoolsHost + ":" + devtoolsPort + "/?port=" + serviceProtocolPort,
+        "http://" + devtoolsHost + ":" + devtoolsPort + "/?hide=debugger&port=" + serviceProtocolPort,
         null
       );
     }


### PR DESCRIPTION
Doing this the same way we do it in VSCode, via a query param. Fixes https://github.com/flutter/devtools/issues/383