### PR TITLE
throttle logger updates

### DIFF
--- a/src/io/flutter/logging/FlutterLogView.java
+++ b/src/io/flutter/logging/FlutterLogView.java
@@ -517,7 +517,7 @@ public class FlutterLogView extends JPanel implements ConsoleView, DataProvider,
 
   private final Gson gsonHelper = new GsonBuilder().setPrettyPrinting().create();
   boolean isPinned;
-  // Auto-scroll defautls to on.
+  // Auto-scroll defaults to on.
   boolean prePinAutoScroll = true;
 
   public FlutterLogView(@NotNull FlutterApp app) {
@@ -750,7 +750,7 @@ public class FlutterLogView extends JPanel implements ConsoleView, DataProvider,
     final boolean isError = entry.getKind() == FlutterLogEntry.Kind.FLUTTER_ERROR;
     logTree.append(entry, isError && !isPinned);
 
-    if (isError & !isPinned) {
+    if (isError && !isPinned) {
       prePinAutoScroll = logModel.autoScrollToEnd;
       scrollToEndAction.disableIfNeeded();
       isPinned = true;
@@ -759,6 +759,7 @@ public class FlutterLogView extends JPanel implements ConsoleView, DataProvider,
 
   @Override
   public void onEntryContentChange() {
+    // Called when truncated text values are returned.
     logModel.uiExec(logModel::update, 10);
   }
 


### PR DESCRIPTION
Fixes: #3219.

* puts logging view updates on a throttled timer (updates limited to once per 100ms)
* simplifies append
* unifies UI exec calls and adds guards

Show's liveness using a version of @jaumard's stress test.

![logging_perf](https://user-images.githubusercontent.com/67586/54234553-8791b080-44cc-11e9-8282-6961c1149712.gif)

(Previously this would have hung the UI.)

/cc @stevemessick @jacob314 