### PR TITLE
fix a dart2 type issue

### DIFF
--- a/tool/plugin/lib/plugin.dart
+++ b/tool/plugin/lib/plugin.dart
@@ -97,8 +97,9 @@ List<File> findJars(String path) {
   final dir = new Directory(path);
   return dir
       .listSync(recursive: true, followLinks: false)
-      .where((e) => e.path.endsWith('.jar'))
-      .toList();
+      .where((e) => e is File && e.path.endsWith('.jar'))
+      .toList()
+      .cast<File>();
 }
 
 List<String> findJavaFiles(String path) {
@@ -573,7 +574,7 @@ class BuildCommand extends ProductCommand {
       } finally {
         // Restore sources.
         files.forEach((file, src) {
-          log('Reestoring ${file.path}');
+          log('Restoring ${file.path}');
           file.writeAsStringSync(src);
         });
 


### PR DESCRIPTION
- fix a dart2 type issue
- fix https://github.com/flutter/flutter-intellij/issues/3282

There are then follow-on issues running the command - I believe it's regressed:

```
  testSrc/integration/io/flutter/testing/FlutterTestUtils.java:18: error: cannot find symbol
  import io.flutter.dart.DartPlugin;
                        ^
    symbol:   class DartPlugin
    location: package io.flutter.dart
```

Likely the compile paths are not longer up-to-date?

We should either fix the command, if we'd like to use it, and run it continuously on travis, or remove it.


@stevemessick @DaveShuckerow 