### PR TITLE
Detect when integrations tests are running

### DIFF
--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,7 +1,0 @@
-<component name="InspectionProjectProfileManager">
-  <settings>
-    <option name="PROJECT_PROFILE" value="Project Default" />
-    <option name="USE_PROJECT_PROFILE" value="true" />
-    <version value="1.0" />
-  </settings>
-</component>

--- a/src/io/flutter/FlutterUtils.java
+++ b/src/io/flutter/FlutterUtils.java
@@ -150,6 +150,10 @@ public class FlutterUtils {
     return relativePath != null && (relativePath.startsWith("test/"));
   }
 
+  public static boolean isIntegrationTestingMode() {
+    return System.getProperty("idea.required.plugins.id", "").equals("io.flutter.tests.gui.flutter-gui-tests");
+  }
+
   @Nullable
   public static VirtualFile getRealVirtualFile(@Nullable PsiFile psiFile) {
     return psiFile != null ? psiFile.getOriginalFile().getVirtualFile() : null;

--- a/src/io/flutter/run/daemon/DeviceDaemon.java
+++ b/src/io/flutter/run/daemon/DeviceDaemon.java
@@ -140,7 +140,13 @@ class DeviceDaemon {
 
     try {
       final String path = FlutterSdkUtil.pathToFlutterTool(sdk.getHomePath());
-      return new Command(sdk.getHomePath(), path, ImmutableList.of("daemon"), androidHome);
+      ImmutableList<String> list;
+      if (FlutterUtils.isIntegrationTestingMode()) {
+        list = ImmutableList.of("--show-test-device", "daemon");
+      } else {
+        list = ImmutableList.of("daemon");
+      }
+      return new Command(sdk.getHomePath(), path, list, androidHome);
     }
     catch (ExecutionException e) {
       FlutterUtils.warn(LOG, "Unable to calculate command to watch Flutter devices", e);


### PR DESCRIPTION
@devoncarew @pq 

The testing device shows in the device list when integrations tests are running but not otherwise.

I don't know why profiles_settings.xml gets deleted but 2019.1 has been doing that every time it gets focus. I've been ignoring that change, but it slipped in this time and the file might as well go away.