### PR TITLE
Add inspector dependency to test

### DIFF
--- a/flutter-gui-tests/build.gradle
+++ b/flutter-gui-tests/build.gradle
@@ -10,13 +10,16 @@ repositories {
   mavenLocal()
   mavenCentral()
   jcenter()
+  // unpack flutter-intellij.zip and rename the jar file to io.flutter.jar in this directory
+  flatDir dirs: ['../releases/release_master/2019.1']
 }
 
 dependencies {
   compile "org.jetbrains.kotlin:kotlin-reflect"
   testCompile group: 'junit', name: 'junit', version: '4.12'
+  testCompile fileTree(include: ['*.jar'], dir: '../releases/release_master/2019.1')
+  testImplementation fileTree(include: ['*.jar'], dir: '../releases/release_master/2019.1')
 }
-
 
 sourceSets {
   main {
@@ -32,7 +35,7 @@ sourceSets {
 }
 
 intellij {
-  plugins 'com.intellij.testGuiFramework:0.9.44.1@nightly', 'Dart:191.5849.16'
+  plugins 'com.intellij.testGuiFramework:0.9.44.1@nightly', 'Dart:191.5849.16', 'io.flutter:SNAPSHOT'
   if (System.getProperty("idea.gui.test.alternativeIdePath") != null) {
     alternativeIdePath System.getProperty("idea.gui.test.alternativeIdePath")
   }
@@ -59,20 +62,12 @@ task testsJar(type: Jar, dependsOn: classes) {
 }
 
 prepareSandbox {
-  def zipFile = file("$projectDir/../flutter-intellij.zip")
-  from zipTree(zipFile)
-  into 'flutter-intellij'
-
   from(testsJar) {
     into "$pluginName/lib"
   }
 }
 
 prepareTestingSandbox {
-  def zipFile = file("$projectDir/../flutter-intellij.zip")
-  from zipTree(zipFile)
-  into 'flutter-intellij'
-
   from(testsJar) {
     into "$pluginName/lib"
   }

--- a/flutter-gui-tests/res/META-INF/plugin.xml
+++ b/flutter-gui-tests/res/META-INF/plugin.xml
@@ -8,6 +8,7 @@
     &lt;em&gt;Do not distribute this plugin with Flutter&lt;/em&gt;
   </description>
   <depends optional="true">com.intellij.testGuiFramework</depends>
+  <depends>io.flutter</depends>
   <vendor>flutter.io</vendor>
   <extensions defaultExtensionNs="com.intellij"/>
   <actions/>

--- a/flutter-gui-tests/testSrc/io/flutter/tests/gui/InspectorTest.kt
+++ b/flutter-gui-tests/testSrc/io/flutter/tests/gui/InspectorTest.kt
@@ -7,6 +7,7 @@
 package io.flutter.tests.gui
 
 import com.intellij.testGuiFramework.fixtures.ActionButtonFixture
+import com.intellij.testGuiFramework.fixtures.ExecutionToolWindowFixture
 import com.intellij.testGuiFramework.fixtures.IdeFrameFixture
 import com.intellij.testGuiFramework.framework.RunWithIde
 import com.intellij.testGuiFramework.framework.Timeouts
@@ -32,18 +33,28 @@ class InspectorTest : GuiTestCase() {
   fun importSimpleProject() {
     ProjectCreator.importProject()
     ideFrame {
-      findRunApplicationButton().click()
-      val runner = runToolWindow.findContent("main.dart")
-      pause(object : Condition("Start app") {
-        override fun test(): Boolean {
-          return runner.isExecutionInProgress
-        }
-      }, Timeouts.seconds10)
-      val inspector = flutterInspectorFixture()
-      inspector.activate()
-      pause(1000)
-      runner.stop()
+      launchFlutterApp()
+      val inspector = flutterInspectorFixture(this)
+      inspector.populate()
+      val widgetTree = inspector.widgetTreeFixture()
+      println("DEBUG")
+      println(widgetTree)
+      runner().stop()
     }
+  }
+
+  private fun IdeFrameFixture.runner(): ExecutionToolWindowFixture.ContentFixture {
+    return runToolWindow.findContent("main.dart")
+  }
+
+  fun IdeFrameFixture.launchFlutterApp() {
+    findRunApplicationButton().click()
+    val runner = runner()
+    pause(object : Condition("Start app") {
+      override fun test(): Boolean {
+        return runner.isExecutionInProgress
+      }
+    }, Timeouts.seconds10)
   }
 
   fun IdeFrameFixture.selectSimulator() {
@@ -83,8 +94,8 @@ class InspectorTest : GuiTestCase() {
     return button!!
   }
 
-  fun IdeFrameFixture.flutterInspectorFixture(): FlutterInspectorFixture {
-    return FlutterInspectorFixture(project, robot())
+  fun IdeFrameFixture.flutterInspectorFixture(ideFrame: IdeFrameFixture): FlutterInspectorFixture {
+    return FlutterInspectorFixture(project, robot(), ideFrame)
   }
 
 }

--- a/flutter-gui-tests/testSrc/io/flutter/tests/gui/fixtures/FlutterInspectorFixture.kt
+++ b/flutter-gui-tests/testSrc/io/flutter/tests/gui/fixtures/FlutterInspectorFixture.kt
@@ -7,7 +7,62 @@
 package io.flutter.tests.gui.fixtures
 
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Ref
+import com.intellij.testGuiFramework.fixtures.IdeFrameFixture
 import com.intellij.testGuiFramework.fixtures.ToolWindowFixture
+import com.intellij.testGuiFramework.framework.Timeouts
+import com.intellij.testGuiFramework.matcher.ClassNameMatcher
+import io.flutter.inspector.InspectorService
+import io.flutter.view.InspectorPanel
+import junit.framework.Assert.assertNotNull
 import org.fest.swing.core.Robot
+import org.fest.swing.timing.Condition
+import org.fest.swing.timing.Pause
+import org.fest.swing.timing.Pause.pause
+import javax.swing.JPanel
 
-class FlutterInspectorFixture(project: Project, robot: Robot) : ToolWindowFixture("Flutter Inspector", project, robot)
+class FlutterInspectorFixture(project: Project, robot: Robot, private val ideFrame: IdeFrameFixture) : ToolWindowFixture(
+    "Flutter Inspector", project, robot) {
+
+  fun populate() {
+    activate()
+    Pause.pause(object : Condition("Initialize inspector") {
+      override fun test(): Boolean {
+        return contents[0].displayName != null
+      }
+    }, Timeouts.seconds30)
+  }
+
+  fun widgetTreeFixture(): InspectorPanelFixture {
+    return inspectorPanel(InspectorService.FlutterTreeType.widget)
+  }
+
+  fun renderTreeFixture(): InspectorPanelFixture {
+    return inspectorPanel(InspectorService.FlutterTreeType.renderObject)
+  }
+
+  private fun inspectorPanel(type: InspectorService.FlutterTreeType): InspectorPanelFixture {
+    val inspectorPanelRef = Ref<InspectorPanel>()
+
+    pause(object : Condition("Inspector with type '$type' shows up") {
+      override fun test(): Boolean {
+        val inspectorPanel = findInspectorPanel(type)
+        inspectorPanelRef.set(inspectorPanel)
+        return inspectorPanel != null
+      }
+    }, Timeouts.seconds10)
+
+    val notificationPanel = inspectorPanelRef.get()
+    assertNotNull(notificationPanel)
+    return InspectorPanelFixture(notificationPanel)
+  }
+
+  private fun findInspectorPanel(type: InspectorService.FlutterTreeType): InspectorPanel? {
+    val panels = ideFrame.robot().finder().findAll(contents[0].component, ClassNameMatcher.forClass("io.flutter.view.InspectorPanel", JPanel::class.java))
+    return panels.firstOrNull { (it as InspectorPanel).treeType == type } as InspectorPanel
+  }
+
+  inner class InspectorPanelFixture(val inspectorPanel: InspectorPanel) {
+
+  }
+}

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -10,7 +10,7 @@
   </description>
   <!--suppress PluginXmlValidity -->
   <vendor url="https://github.com/flutter/flutter-intellij">flutter.io</vendor>
-
+  <version>SNAPSHOT</version>
   <category>Custom Languages</category>
   
   <idea-version since-build="182.5107.16" until-build="192.SNAPSHOT"/>

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -10,9 +10,9 @@
   </description>
   <!--suppress PluginXmlValidity -->
   <vendor url="https://github.com/flutter/flutter-intellij">flutter.io</vendor>
-  <version>SNAPSHOT</version>
+
   <category>Custom Languages</category>
-  
+  <version>SNAPSHOT</version>
   <idea-version since-build="182.5107.16" until-build="192.SNAPSHOT"/>
 
   <depends>Dart</depends>

--- a/tool/plugin/lib/plugin.dart
+++ b/tool/plugin/lib/plugin.dart
@@ -275,7 +275,7 @@ String substituteTemplateVariables(String line, BuildSpec spec) {
         return spec.untilBuild;
       case 'VERSION':
         return spec.release == null
-            ? ''
+            ? '<version>SNAPSHOT</version>'
             : '<version>${spec.release}.${++pluginCount}</version>';
       case 'CHANGELOG':
         return spec.changeLog;


### PR DESCRIPTION
@pq @devoncarew 

With these changes the integration test now is able to work with classes defined by the Flutter plugin.
- Refactor InspectorTest
- Add functionality to FlutterInspectorFixture and allow it to refer to plugin classes
- Change plugin architecture to use the Flutter plugin as a plugin (to enable above)
- Change plugin tool to create a valid plugin for testing (needs version tag)

There is a manual set-up step that is documented in build.gradle. It would be easy to add to the plugin tool, or just use a shell script.