### PR TITLE
Make Perf and Inspector views only display when a Flutter app is being debugged.

### DIFF
--- a/src/io/flutter/view/FlutterPerfView.java
+++ b/src/io/flutter/view/FlutterPerfView.java
@@ -85,13 +85,6 @@ public class FlutterPerfView implements Disposable {
       //noinspection UnnecessaryReturnStatement
       return;
     }
-
-    if (toolWindow.isAvailable()) {
-      // Store whether the tool window was visible before we decided to close it
-      // because it had no content.
-      previouslyVisible = toolWindow.isVisible();
-      toolWindow.setAvailable(false, null);
-    }
   }
 
   private void updateToolWindowVisibility(ToolWindow toolWindow) {
@@ -152,6 +145,12 @@ public class FlutterPerfView implements Disposable {
           if (perAppViewState.isEmpty()) {
             // No more applications are running.
             updateForEmptyContent(toolWindow);
+            if (toolWindow.isAvailable()) {
+              // Store whether the tool window was visible before we decided to close it
+              // because it had no content.
+              previouslyVisible = toolWindow.isVisible();
+              toolWindow.setAvailable(false, null);
+            }
           }
         });
       }

--- a/src/io/flutter/view/FlutterPerfViewFactory.java
+++ b/src/io/flutter/view/FlutterPerfViewFactory.java
@@ -15,6 +15,11 @@ import com.intellij.openapi.wm.ToolWindowFactory;
 import org.jetbrains.annotations.NotNull;
 
 public class FlutterPerfViewFactory implements ToolWindowFactory, DumbAware {
+  @Override
+  public void init(ToolWindow window) {
+    window.setAvailable(false, null);
+  }
+
   public static void init(@NotNull Project project) {
     project.getMessageBus().connect().subscribe(
       FlutterViewMessages.FLUTTER_DEBUG_TOPIC, (event) -> initPerfView(project, event)

--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -462,6 +462,12 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
           if (perAppViewState.isEmpty()) {
             // No more applications are running.
             updateForEmptyContent(toolWindow);
+            if (toolWindow.isAvailable()) {
+              // Store whether the tool window was visible before we decided to close it
+              // because it had no content.
+              previouslyVisible = toolWindow.isVisible();
+              toolWindow.setAvailable(false, null);
+            }
           }
         });
       }
@@ -501,13 +507,6 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
     panel.add(label, BorderLayout.CENTER);
     emptyContent = contentManager.getFactory().createContent(panel, null, false);
     contentManager.addContent(emptyContent);
-
-    if (toolWindow.isAvailable()) {
-      // Store whether the tool window was visible before we decided to close it
-      // because it had no content.
-      previouslyVisible = toolWindow.isVisible();
-      toolWindow.setAvailable(false, null);
-    }
   }
 
   private static void listenForRenderTreeActivations(@NotNull ToolWindow toolWindow) {

--- a/src/io/flutter/view/FlutterViewFactory.java
+++ b/src/io/flutter/view/FlutterViewFactory.java
@@ -21,6 +21,11 @@ public class FlutterViewFactory implements ToolWindowFactory, DumbAware {
     );
   }
 
+  @Override
+  public void init(ToolWindow window) {
+    window.setAvailable(false, null);
+  }
+
   private static void initFlutterView(@NotNull Project project, FlutterViewMessages.FlutterDebugEvent event) {
     ApplicationManager.getApplication().invokeLater(() -> {
       final FlutterView flutterView = ServiceManager.getService(project, FlutterView.class);


### PR DESCRIPTION
If the views were open and the flutter app is closed and then reopened,
the views are also automatically reopened.
Consistent with before, neither view is opened by default unless the users
opts to.

This fixes.
https://github.com/flutter/flutter-intellij/issues/3096

![smaller_demo](https://user-images.githubusercontent.com/1226812/55102208-24cf1600-5083-11e9-84fe-a90a3980d48a.gif)
