### PR TITLE
Make Dart constructor calls pop out in light mode. 

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -909,6 +909,7 @@
     <projectStructureDetector implementation="io.flutter.project.FlutterProjectStructureDetector"/>
     <colorSettingsPage implementation="io.flutter.logging.FlutterLogColorPage"/>
     <additionalTextAttributes scheme="Default" file="colorSchemes/FlutterLogColorSchemeDefault.xml"/>
+    <additionalTextAttributes scheme="Default" file="colorSchemes/FlutterCodeColorSchemeDefault.xml"/>
     <search.optionContributor implementation="io.flutter.sdk.FlutterSearchableOptionContributor"/>
   </extensions>
 

--- a/resources/META-INF/plugin_template.xml
+++ b/resources/META-INF/plugin_template.xml
@@ -298,6 +298,7 @@
     <projectStructureDetector implementation="io.flutter.project.FlutterProjectStructureDetector"/>
     <colorSettingsPage implementation="io.flutter.logging.FlutterLogColorPage"/>
     <additionalTextAttributes scheme="Default" file="colorSchemes/FlutterLogColorSchemeDefault.xml"/>
+    <additionalTextAttributes scheme="Default" file="colorSchemes/FlutterCodeColorSchemeDefault.xml"/>
     <search.optionContributor implementation="io.flutter.sdk.FlutterSearchableOptionContributor"/>
   </extensions>
 

--- a/resources/colorSchemes/FlutterCodeColorSchemeDefault.xml
+++ b/resources/colorSchemes/FlutterCodeColorSchemeDefault.xml
@@ -23,7 +23,7 @@
   -->
   <option name="DART_CONSTRUCTOR">
     <value>
-      <option name="FOREGROUND" value="#76B4F0"/>
+      <option name="FOREGROUND" value="#2196f3"/>
     </value>
   </option>
 </list>

--- a/resources/colorSchemes/FlutterCodeColorSchemeDefault.xml
+++ b/resources/colorSchemes/FlutterCodeColorSchemeDefault.xml
@@ -1,0 +1,29 @@
+<?xml version='1.0'?>
+<!--
+  ~ Copyright 2019 The Chromium Authors. All rights reserved.
+  ~ Use of this source code is governed by a BSD-style license that can be
+  ~ found in the LICENSE file.
+  -->
+
+<list>
+  <!--<option name="TEMPLATE_CONFIG_NAME">-->
+  <!--<value>-->
+  <!--<option name="FOREGROUND" value="008000"/>-->
+  <!--<option name="BACKGROUND" value="e3fcff"/>-->
+  <!--<option name="FONT_TYPE" value="1"/>-->
+  <!--</value>-->
+  <!--</option>-->
+
+  <!--
+  Customizations to the regular Dart color scheme to make Flutter UI as code
+  more readable.
+
+  All tweaks added here need to be acceptable for regular Dart code as they
+  will apply to all Dart code not just Flutter code.
+  -->
+  <option name="DART_CONSTRUCTOR">
+    <value>
+      <option name="FOREGROUND" value="#76B4F0"/>
+    </value>
+  </option>
+</list>


### PR DESCRIPTION
Constructors are already nicely visible in Darkula mode.

Having this separate color style format will be handy for future additional UI as Code related
color tweaks. Here are screenshots of what this looks like in action. The Dark theme isn't
impacted but the light theme is.

<img width="633" alt="Screen Shot 2019-03-27 at 3 53 15 PM" src="https://user-images.githubusercontent.com/1226812/55118187-b7cf7680-50aa-11e9-8b77-6b006cd2e80f.png">
<img width="643" alt="Screen Shot 2019-03-27 at 3 53 40 PM" src="https://user-images.githubusercontent.com/1226812/55118191-baca6700-50aa-11e9-84e4-869394360141.png">
