### PR TITLE
disables samples until creation issue is fixed

### DIFF
--- a/src/io/flutter/samples/FlutterSampleManager.java
+++ b/src/io/flutter/samples/FlutterSampleManager.java
@@ -33,10 +33,13 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
 public class FlutterSampleManager {
+  // See https://github.com/flutter/flutter-intellij/issues/3330.
+  private static final boolean DISABLE_SAMPLES = true;
 
   private static final String SNIPPETS_REMOTE_INDEX_URL = "https://docs.flutter.io/snippets/index.json";
 
@@ -45,6 +48,10 @@ public class FlutterSampleManager {
   private static List<FlutterSample> SAMPLES;
 
   public static List<FlutterSample> getSamples() {
+    if (DISABLE_SAMPLES) {
+      return Collections.emptyList();
+    }
+
     if (SAMPLES == null) {
       // When we're reading from the repo and the file may be changing, consider a fresh read on each access.
       SAMPLES = loadSamples();
@@ -57,7 +64,7 @@ public class FlutterSampleManager {
     final StringBuilder contents = new StringBuilder();
     final byte[] bytes = new byte[1024];
     int bytesRead;
-    while((bytesRead = in.read(bytes)) != -1) {
+    while ((bytesRead = in.read(bytes)) != -1) {
       contents.append(new String(bytes, 0, bytesRead));
     }
 

--- a/src/io/flutter/samples/FlutterSampleNotificationProvider.java
+++ b/src/io/flutter/samples/FlutterSampleNotificationProvider.java
@@ -22,9 +22,6 @@ import java.util.Collections;
 import java.util.List;
 
 public class FlutterSampleNotificationProvider extends EditorNotifications.Provider<JPanel> implements DumbAware {
-  // See https://github.com/flutter/flutter-intellij/issues/3330.
-  private static final boolean DISABLE_SAMPLES = true;
-
   private static final Key<JPanel> KEY = Key.create("flutter.sample");
 
   @NotNull private final Project project;
@@ -51,10 +48,6 @@ public class FlutterSampleNotificationProvider extends EditorNotifications.Provi
   }
 
   private List<FlutterSample> getSamplesForFile(@NotNull VirtualFile file) {
-    if (DISABLE_SAMPLES) {
-      return Collections.emptyList();
-    }
-
     final FlutterSdk sdk = getSdk();
     if (sdk == null) {
       return Collections.emptyList();

--- a/src/io/flutter/samples/FlutterSampleNotificationProvider.java
+++ b/src/io/flutter/samples/FlutterSampleNotificationProvider.java
@@ -22,6 +22,9 @@ import java.util.Collections;
 import java.util.List;
 
 public class FlutterSampleNotificationProvider extends EditorNotifications.Provider<JPanel> implements DumbAware {
+  // See https://github.com/flutter/flutter-intellij/issues/3330.
+  private static final boolean DISABLE_SAMPLES = true;
+
   private static final Key<JPanel> KEY = Key.create("flutter.sample");
 
   @NotNull private final Project project;
@@ -48,6 +51,10 @@ public class FlutterSampleNotificationProvider extends EditorNotifications.Provi
   }
 
   private List<FlutterSample> getSamplesForFile(@NotNull VirtualFile file) {
+    if (DISABLE_SAMPLES) {
+      return Collections.emptyList();
+    }
+
     final FlutterSdk sdk = getSdk();
     if (sdk == null) {
       return Collections.emptyList();


### PR DESCRIPTION
- disables samples until creation issue is fixed

see https://github.com/flutter/flutter-intellij/issues/3330

From my understanding of the issue, the data about avialable samples we have in the flutter-intellij repo is out of date with the actual samples in the flutter/flutter repo.

@pq @stevemessick @jacob314 