### PR TITLE
update how we manipulate the service protocol url

### DIFF
--- a/src/io/flutter/run/OpenDevToolsAction.java
+++ b/src/io/flutter/run/OpenDevToolsAction.java
@@ -55,7 +55,6 @@ public class OpenDevToolsAction extends DumbAwareAction {
 
     final DevToolsManager devToolsManager = DevToolsManager.getInstance(event.getProject());
 
-
     if (myConnector == null) {
       if (devToolsManager.hasInstalledDevTools()) {
         devToolsManager.openBrowser();

--- a/src/io/flutter/run/bazelTest/BazelTestRunner.java
+++ b/src/io/flutter/run/bazelTest/BazelTestRunner.java
@@ -24,6 +24,7 @@ import com.intellij.openapi.roots.ContentEntry;
 import com.intellij.openapi.roots.ModuleRootManager;
 import com.intellij.openapi.util.Computable;
 import com.intellij.openapi.util.Key;
+import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.xdebugger.XDebugProcess;
@@ -150,10 +151,11 @@ public class BazelTestRunner extends GenericProgramRunner {
     @Nullable
     @Override
     public String getWebSocketUrl() {
-      if (observatoryUri == null || !observatoryUri.startsWith("http:") || !observatoryUri.endsWith("/")) {
+      if (observatoryUri == null || !observatoryUri.startsWith("http:")) {
         return null;
       }
-      return observatoryUri.replace("http:", "ws:") + "ws";
+      final String wsUrl = observatoryUri.replaceFirst("http:", "ws:");
+      return StringUtil.trimTrailing(wsUrl, '/') + "/ws";
     }
 
     @Nullable

--- a/src/io/flutter/run/bazelTest/BazelTestRunner.java
+++ b/src/io/flutter/run/bazelTest/BazelTestRunner.java
@@ -24,7 +24,6 @@ import com.intellij.openapi.roots.ContentEntry;
 import com.intellij.openapi.roots.ModuleRootManager;
 import com.intellij.openapi.util.Computable;
 import com.intellij.openapi.util.Key;
-import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.xdebugger.XDebugProcess;
@@ -36,6 +35,7 @@ import com.jetbrains.lang.dart.sdk.DartSdkLibUtil;
 import com.jetbrains.lang.dart.util.DartUrlResolver;
 import io.flutter.FlutterUtils;
 import io.flutter.run.PositionMapper;
+import io.flutter.run.common.CommonTestConfigUtils;
 import io.flutter.run.test.FlutterTestRunner;
 import io.flutter.settings.FlutterSettings;
 import io.flutter.utils.StdoutJsonParser;
@@ -154,8 +154,7 @@ public class BazelTestRunner extends GenericProgramRunner {
       if (observatoryUri == null || !observatoryUri.startsWith("http:")) {
         return null;
       }
-      final String wsUrl = observatoryUri.replaceFirst("http:", "ws:");
-      return StringUtil.trimTrailing(wsUrl, '/') + "/ws";
+      return CommonTestConfigUtils.convertHttpServiceProtocolToWs(observatoryUri);
     }
 
     @Nullable

--- a/src/io/flutter/run/common/CommonTestConfigUtils.java
+++ b/src/io/flutter/run/common/CommonTestConfigUtils.java
@@ -6,6 +6,7 @@
 package io.flutter.run.common;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.search.PsiElementProcessor;
 import com.intellij.psi.util.PsiTreeUtil;
@@ -33,6 +34,11 @@ public abstract class CommonTestConfigUtils {
   public static final Pattern WIDGET_TEST_REGEX = Pattern.compile("test([A-Z][A-Za-z0-9_$]*)?Widgets");
 
   public abstract TestType asTestCall(@NotNull PsiElement element);
+
+  public static String convertHttpServiceProtocolToWs(String url) {
+    return StringUtil.trimTrailing(
+      url.replaceFirst("http:", "ws:"), '/') + "/ws";
+  }
 
   @VisibleForTesting
   public boolean isMainFunctionDeclarationWithTests(@NotNull PsiElement element) {

--- a/src/io/flutter/run/daemon/DaemonEvent.java
+++ b/src/io/flutter/run/daemon/DaemonEvent.java
@@ -195,7 +195,7 @@ abstract class DaemonEvent {
   static class AppDebugPort extends DaemonEvent {
     // "event":"app.eventDebugPort"
     String appId;
-    // port seems to be deprecated
+    // <code>port</code> is deprecated; prefer using <code>wsUri</code>.
     // int port;
     String wsUri;
     String baseUri;
@@ -261,7 +261,8 @@ abstract class DaemonEvent {
     void accept(Listener listener) {
       if (isStarting()) {
         listener.onAppProgressStarting(this);
-      } else {
+      }
+      else {
         listener.onAppProgressFinished(this);
       }
     }

--- a/src/io/flutter/run/test/FlutterTestRunner.java
+++ b/src/io/flutter/run/test/FlutterTestRunner.java
@@ -17,7 +17,6 @@ import com.intellij.execution.runners.GenericProgramRunner;
 import com.intellij.execution.ui.RunContentDescriptor;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.util.Key;
-import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.xdebugger.XDebugProcess;
 import com.intellij.xdebugger.XDebugProcessStarter;
 import com.intellij.xdebugger.XDebugSession;
@@ -26,6 +25,7 @@ import com.jetbrains.lang.dart.ide.runner.ObservatoryConnector;
 import com.jetbrains.lang.dart.util.DartUrlResolver;
 import io.flutter.FlutterUtils;
 import io.flutter.run.PositionMapper;
+import io.flutter.run.common.CommonTestConfigUtils;
 import io.flutter.sdk.FlutterSdk;
 import io.flutter.settings.FlutterSettings;
 import io.flutter.utils.StdoutJsonParser;
@@ -136,8 +136,7 @@ public class FlutterTestRunner extends GenericProgramRunner {
       if (observatoryUri == null || !observatoryUri.startsWith("http:")) {
         return null;
       }
-      final String wsUrl = observatoryUri.replaceFirst("http:", "ws:");
-      return StringUtil.trimTrailing(wsUrl, '/') + "/ws";
+      return CommonTestConfigUtils.convertHttpServiceProtocolToWs(observatoryUri);
     }
 
     @Nullable

--- a/src/io/flutter/run/test/FlutterTestRunner.java
+++ b/src/io/flutter/run/test/FlutterTestRunner.java
@@ -17,6 +17,7 @@ import com.intellij.execution.runners.GenericProgramRunner;
 import com.intellij.execution.ui.RunContentDescriptor;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.util.Key;
+import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.xdebugger.XDebugProcess;
 import com.intellij.xdebugger.XDebugProcessStarter;
 import com.intellij.xdebugger.XDebugSession;
@@ -132,10 +133,11 @@ public class FlutterTestRunner extends GenericProgramRunner {
     @Nullable
     @Override
     public String getWebSocketUrl() {
-      if (observatoryUri == null || !observatoryUri.startsWith("http:") || !observatoryUri.endsWith("/")) {
+      if (observatoryUri == null || !observatoryUri.startsWith("http:")) {
         return null;
       }
-      return observatoryUri.replace("http:", "ws:") + "ws";
+      final String wsUrl = observatoryUri.replaceFirst("http:", "ws:");
+      return StringUtil.trimTrailing(wsUrl, '/') + "/ws";
     }
 
     @Nullable

--- a/src/io/flutter/run/test/TestConfigUtils.java
+++ b/src/io/flutter/run/test/TestConfigUtils.java
@@ -15,6 +15,7 @@ import org.jetbrains.annotations.Nullable;
 
 public class TestConfigUtils extends CommonTestConfigUtils {
   private static TestConfigUtils instance;
+
   public static TestConfigUtils getInstance() {
     if (instance == null) {
       instance = new TestConfigUtils();
@@ -22,7 +23,8 @@ public class TestConfigUtils extends CommonTestConfigUtils {
     return instance;
   }
 
-  private TestConfigUtils() {}
+  private TestConfigUtils() {
+  }
 
   @Nullable
   @Override

--- a/src/io/flutter/server/vmService/DartVmServiceDebugProcess.java
+++ b/src/io/flutter/server/vmService/DartVmServiceDebugProcess.java
@@ -18,7 +18,6 @@ import com.intellij.openapi.util.Disposer;
 import com.intellij.openapi.util.Key;
 import com.intellij.openapi.util.Pair;
 import com.intellij.openapi.util.SystemInfo;
-import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.wm.WindowManager;
 import com.intellij.testFramework.LightVirtualFile;
@@ -68,21 +67,15 @@ public class DartVmServiceDebugProcess extends XDebugProcess {
 
   @Nullable private final ExecutionResult myExecutionResult;
   @NotNull private final DartUrlResolver myDartUrlResolver;
-  @NotNull private final String myDebuggingHost;
-  private final int myObservatoryPort;
   @NotNull private final XBreakpointHandler[] myBreakpointHandlers;
   private final IsolatesInfo myIsolatesInfo;
   @NotNull private final Map<String, CompletableFuture<Object>> mySuspendedIsolateIds = Collections.synchronizedMap(new HashMap<>());
   private final Map<String, LightVirtualFile> myScriptIdToContentMap = new THashMap<>();
-  private final Map<String, TIntObjectHashMap<Pair<Integer, Integer>>> myScriptIdToLinesAndColumnsMap =
-    new THashMap<>();
-  private final int myTimeout;
+  private final Map<String, TIntObjectHashMap<Pair<Integer, Integer>>> myScriptIdToLinesAndColumnsMap = new THashMap<>();
   @Nullable private final VirtualFile myCurrentWorkingDirectory;
   @NotNull private final ObservatoryConnector myConnector;
-  @NotNull
-  private final ExecutionEnvironment executionEnvironment;
-  @NotNull
-  private final PositionMapper mapper;
+  @NotNull private final ExecutionEnvironment executionEnvironment;
+  @NotNull private final PositionMapper mapper;
   @Nullable protected String myRemoteProjectRootUri;
   private boolean myVmConnected = false;
   @NotNull private final OpenDartObservatoryUrlAction myOpenObservatoryAction =
@@ -99,11 +92,8 @@ public class DartVmServiceDebugProcess extends XDebugProcess {
                                    @NotNull final PositionMapper mapper) {
     super(session);
 
-    myDebuggingHost = "localhost";
-    myObservatoryPort = 0;
     myExecutionResult = executionResult;
     myDartUrlResolver = dartUrlResolver;
-    myTimeout = 0;
     myCurrentWorkingDirectory = null;
 
     myIsolatesInfo = new IsolatesInfo();
@@ -117,7 +107,7 @@ public class DartVmServiceDebugProcess extends XDebugProcess {
       @Override
       public void sessionPaused() {
         // This can be removed if XFramesView starts popping the project window to the top of the z-axis stack.
-        Project project = getSession().getProject();
+        final Project project = getSession().getProject();
         focusProject(project);
         stackFrameChanged();
       }
@@ -290,12 +280,6 @@ public class DartVmServiceDebugProcess extends XDebugProcess {
     myVmConnected = true;
   }
 
-  @NotNull
-  @Deprecated // returns incorrect URL for Dart SDK 1.22+ because returned URL doesn't contain auth token
-  private String getObservatoryUrl(@NotNull final String scheme, @Nullable final String path) {
-    return scheme + "://" + myDebuggingHost + ":" + myObservatoryPort + StringUtil.notNullize(path);
-  }
-
   @Override
   protected ProcessHandler doGetProcessHandler() {
     return myExecutionResult == null ? super.doGetProcessHandler() : myExecutionResult.getProcessHandler();
@@ -391,7 +375,7 @@ public class DartVmServiceDebugProcess extends XDebugProcess {
 
   public void isolateSuspended(@NotNull final IsolateRef isolateRef) {
     final String id = isolateRef.getId();
-    assert(!mySuspendedIsolateIds.containsKey(id));
+    assert (!mySuspendedIsolateIds.containsKey(id));
     if (!mySuspendedIsolateIds.containsKey(id)) {
       mySuspendedIsolateIds.put(id, new CompletableFuture<>());
     }
@@ -406,10 +390,10 @@ public class DartVmServiceDebugProcess extends XDebugProcess {
     if (future == null) {
       // Isolate wasn't actually suspended.
       return CompletableFuture.completedFuture(null);
-    } else {
+    }
+    else {
       return future;
     }
-
   }
 
   public boolean isIsolateAlive(@NotNull final String isolateId) {

--- a/testSrc/integration/io/flutter/testing/FlutterTestUtils.java
+++ b/testSrc/integration/io/flutter/testing/FlutterTestUtils.java
@@ -25,7 +25,6 @@ import java.io.File;
 import java.util.Collections;
 
 public class FlutterTestUtils {
-
   public static final String BASE_TEST_DATA_PATH = findTestDataPath();
   public static final String SDK_HOME_PATH = BASE_TEST_DATA_PATH + "/sdk";
 


### PR DESCRIPTION
- update how we manipulate the service protocol url
- this is in prep for handling urls in the form `http://xxx:yyy/token/` (and `ws://xxx:yyy/token/ws`)
- fix https://github.com/flutter/flutter-intellij/issues/3341
