### PR TITLE
address an NPE

### DIFF
--- a/src/io/flutter/dart/DartSyntax.java
+++ b/src/io/flutter/dart/DartSyntax.java
@@ -132,7 +132,7 @@ public class DartSyntax {
    */
   public static boolean isCallToFunctionMatching(@NotNull DartCallExpression element, @NotNull Pattern functionRegex) {
     final String name = getCalledFunctionName(element);
-    return functionRegex.matcher(name).matches();
+    return name != null && functionRegex.matcher(name).matches();
   }
 
   /**


### PR DESCRIPTION
- address an NPE

```
    class_name: "io.flutter.dart.DartSyntax",
    method_name: "isCallToFunctionMatching",
    filename: "DartSyntax.java",
    line_number: 135
```
