### PR TITLE
Update for AS canary 10

### DIFF
--- a/flutter-studio/src/io/flutter/FlutterStudioStartupActivity.java
+++ b/flutter-studio/src/io/flutter/FlutterStudioStartupActivity.java
@@ -26,7 +26,6 @@ public class FlutterStudioStartupActivity implements StartupActivity {
     // The IntelliJ version of this action spawns a new process for Android Studio.
     // Since we're already running Android Studio we want to simply open the project in the current process.
     replaceAction("flutter.androidstudio.open", new OpenAndroidModule());
-    replaceAction("ShowProjectStructureSettings", new FlutterShowStructureSettingsAction());
     // Unset this flag for all projects, mainly to ease the upgrade from 3.0.1 to 3.1.
     // TODO(messick) Delete once 3.0.x has 0 7DA's.
     FlutterProjectCreator.disableUserConfig(project);

--- a/resources/META-INF/studio-contribs.xml
+++ b/resources/META-INF/studio-contribs.xml
@@ -50,6 +50,11 @@
             icon="AllIcons.Debugger.AttachToProcess">
     </action>
 
+    <action id="ShowProjectStructureSettings"
+            class="io.flutter.actions.FlutterShowStructureSettingsAction"
+            project-type="io.flutter"
+            icon="AllIcons.General.ProjectStructure"/>
+
   </actions>
 
 </idea-plugin>

--- a/resources/META-INF/studio-contribs_template.xml
+++ b/resources/META-INF/studio-contribs_template.xml
@@ -48,6 +48,11 @@
             icon="AllIcons.Debugger.AttachToProcess">
     </action>
 
+    <action id="ShowProjectStructureSettings"
+            class="io.flutter.actions.FlutterShowStructureSettingsAction"
+            project-type="io.flutter"
+            icon="AllIcons.General.ProjectStructure"/>
+
   </actions>
 
 </idea-plugin>

--- a/src/io/flutter/ProjectOpenActivity.java
+++ b/src/io/flutter/ProjectOpenActivity.java
@@ -13,6 +13,8 @@ import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectType;
+import com.intellij.openapi.project.ProjectTypeService;
 import com.intellij.openapi.startup.StartupActivity;
 import com.intellij.openapi.ui.Messages;
 import icons.FlutterIcons;
@@ -28,6 +30,7 @@ import org.jetbrains.annotations.NotNull;
  * @see FlutterInitializer for actions that run later.
  */
 public class ProjectOpenActivity implements StartupActivity, DumbAware {
+  public static final ProjectType FLUTTER_PROJECT_TYPE = new ProjectType("io.flutter");
   private static final Logger LOG = Logger.getInstance(ProjectOpenActivity.class);
 
   @Override
@@ -46,6 +49,9 @@ public class ProjectOpenActivity implements StartupActivity, DumbAware {
       if (!pubRoot.hasUpToDatePackages()) {
         Notifications.Bus.notify(new PackagesOutOfDateNotification(project, pubRoot));
       }
+    }
+    if (ProjectTypeService.getProjectType(project) == null) {
+      ProjectTypeService.setProjectType(project, FLUTTER_PROJECT_TYPE);
     }
   }
 

--- a/src/io/flutter/ProjectOpenActivity.java
+++ b/src/io/flutter/ProjectOpenActivity.java
@@ -50,7 +50,7 @@ public class ProjectOpenActivity implements StartupActivity, DumbAware {
         Notifications.Bus.notify(new PackagesOutOfDateNotification(project, pubRoot));
       }
     }
-    if (ProjectTypeService.getProjectType(project) == null) {
+    if (!FLUTTER_PROJECT_TYPE.equals(ProjectTypeService.getProjectType(project))) {
       ProjectTypeService.setProjectType(project, FLUTTER_PROJECT_TYPE);
     }
   }

--- a/tool/plugin/test/plugin_test.dart
+++ b/tool/plugin/test/plugin_test.dart
@@ -38,7 +38,6 @@ void main() {
               'android-studio',
               'android-studio',
               'android-studio',
-              'android-studio',
               'ideaIC',
             ]));
       });
@@ -55,7 +54,6 @@ void main() {
               'android-studio',
               'android-studio',
               'android-studio',
-              'android-studio',
               'ideaIC',
             ]));
       });
@@ -69,7 +67,6 @@ void main() {
         expect(
             specs.map((spec) => spec.ideaProduct).toList(),
             orderedEquals([
-              'android-studio',
               'android-studio',
               'android-studio',
               'android-studio',
@@ -151,7 +148,6 @@ void main() {
           cmd.paths.map((p) => p.substring(p.indexOf('releases'))),
           orderedEquals([
             'releases/release_19/3.3.2/flutter-intellij.zip',
-            'releases/release_19/2018.3/flutter-intellij.zip',
             'releases/release_19/3.4/flutter-intellij.zip',
             'releases/release_19/3.5/flutter-intellij.zip',
             'releases/release_19/2019.2/flutter-intellij.zip',


### PR DESCRIPTION
- Define a project type for Flutter projects
- Set it when a project is first opened (handles `flutter create ...`)
  - In Android Studio the default project type is "Android"
  - In IntelliJ the default is null
- Use it via a chameleon action, defined by XML,  to choose the proper Project Structure dialog
- Remove the hack that replaced the original with the custom action

@pq