### PR TITLE
more work to support running Flutter web apps

### DIFF
--- a/src/io/flutter/FlutterUtils.java
+++ b/src/io/flutter/FlutterUtils.java
@@ -340,8 +340,8 @@ public class FlutterUtils {
    */
   public static boolean declaresFlutterWeb(@NotNull final VirtualFile pubspec) {
     // It uses Flutter if it contains:
-    //dependencies:
-    //  flutter_web: any
+    // dependencies:
+    //   flutter_web:
 
     try {
       final Map<String, Object> yamlMap = readPubspecFileToMap(pubspec);

--- a/src/io/flutter/actions/ReloadFlutterApp.java
+++ b/src/io/flutter/actions/ReloadFlutterApp.java
@@ -51,4 +51,14 @@ public class ReloadFlutterApp extends FlutterAppAction {
       FlutterReloadManager.getInstance(project).saveAllAndReload(getApp(), FlutterConstants.RELOAD_REASON_MANUAL);
     }
   }
+
+  // Override to disable the hot reload action when running flutter web apps.
+  @Override
+  public void update(@NotNull AnActionEvent e) {
+    super.update(e);
+
+    if (!getApp().appSupportsHotReload()) {
+      e.getPresentation().setEnabled(false);
+    }
+  }
 }

--- a/src/io/flutter/console/FlutterConsoleFilter.java
+++ b/src/io/flutter/console/FlutterConsoleFilter.java
@@ -76,9 +76,14 @@ public class FlutterConsoleFilter implements Filter {
   @VisibleForTesting
   @Nullable
   public VirtualFile fileAtPath(@NotNull String pathPart) {
-
     // "lib/main.dart:6"
     pathPart = pathPart.split(":")[0];
+
+    // We require the pathPart reference to be a file reference, otherwise we'd match things like
+    // "Build: Running build completed, took 191ms".
+    if (pathPart.indexOf('.') == -1) {
+      return null;
+    }
 
     final VirtualFile[] roots = ModuleRootManager.getInstance(module).getContentRoots();
     for (VirtualFile root : roots) {

--- a/src/io/flutter/devtools/DevToolsManager.java
+++ b/src/io/flutter/devtools/DevToolsManager.java
@@ -106,16 +106,16 @@ public class DevToolsManager {
   }
 
   public void openBrowser() {
-    openBrowserImpl(-1);
+    openBrowserImpl(null);
   }
 
-  public void openBrowserAndConnect(int port) {
-    openBrowserImpl(port);
+  public void openBrowserAndConnect(String uri) {
+    openBrowserImpl(uri);
   }
 
-  private void openBrowserImpl(int port) {
+  private void openBrowserImpl(String uri) {
     if (devToolsInstance != null) {
-      devToolsInstance.openBrowserAndConnect(port);
+      devToolsInstance.openBrowserAndConnect(uri);
       return;
     }
 
@@ -133,7 +133,7 @@ public class DevToolsManager {
     DevToolsInstance.startServer(project, sdk, pubRoots.get(0), instance -> {
       devToolsInstance = instance;
 
-      devToolsInstance.openBrowserAndConnect(port);
+      devToolsInstance.openBrowserAndConnect(uri);
     }, instance -> {
       // Listen for closing, null out the devToolsInstance.
       devToolsInstance = null;
@@ -209,13 +209,14 @@ class DevToolsInstance {
     this.devtoolsPort = devtoolsPort;
   }
 
-  public void openBrowserAndConnect(int serviceProtocolPort) {
-    if (serviceProtocolPort == -1) {
+  public void openBrowserAndConnect(String serviceProtocolUri) {
+    if (serviceProtocolUri == null) {
       BrowserLauncher.getInstance().browse("http://" + devtoolsHost + ":" + devtoolsPort + "/?hide=debugger&", null);
     }
     else {
+      // TODO: do we need to url encode uri?
       BrowserLauncher.getInstance().browse(
-        "http://" + devtoolsHost + ":" + devtoolsPort + "/?hide=debugger&port=" + serviceProtocolPort,
+        "http://" + devtoolsHost + ":" + devtoolsPort + "/?hide=debugger&uri=" + serviceProtocolUri,
         null
       );
     }

--- a/src/io/flutter/devtools/DevToolsManager.java
+++ b/src/io/flutter/devtools/DevToolsManager.java
@@ -216,17 +216,15 @@ class DevToolsInstance {
       BrowserLauncher.getInstance().browse("http://" + devtoolsHost + ":" + devtoolsPort + "/?hide=debugger&", null);
     }
     else {
-      String urlParam = serviceProtocolUri;
       try {
-        urlParam = URLEncoder.encode(serviceProtocolUri, "UTF-8");
+        final String urlParam = URLEncoder.encode(serviceProtocolUri, "UTF-8");
+        BrowserLauncher.getInstance().browse(
+          "http://" + devtoolsHost + ":" + devtoolsPort + "/?hide=debugger&uri=" + urlParam,
+          null
+        );
       }
       catch (UnsupportedEncodingException ignored) {
       }
-
-      BrowserLauncher.getInstance().browse(
-        "http://" + devtoolsHost + ":" + devtoolsPort + "/?hide=debugger&uri=" + urlParam,
-        null
-      );
     }
   }
 }

--- a/src/io/flutter/devtools/DevToolsManager.java
+++ b/src/io/flutter/devtools/DevToolsManager.java
@@ -26,6 +26,8 @@ import io.flutter.sdk.FlutterSdk;
 import io.flutter.utils.JsonUtils;
 import org.jetbrains.annotations.NotNull;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
@@ -214,9 +216,15 @@ class DevToolsInstance {
       BrowserLauncher.getInstance().browse("http://" + devtoolsHost + ":" + devtoolsPort + "/?hide=debugger&", null);
     }
     else {
-      // TODO: do we need to url encode uri?
+      String urlParam = serviceProtocolUri;
+      try {
+        urlParam = URLEncoder.encode(serviceProtocolUri, "UTF-8");
+      }
+      catch (UnsupportedEncodingException ignored) {
+      }
+
       BrowserLauncher.getInstance().browse(
-        "http://" + devtoolsHost + ":" + devtoolsPort + "/?hide=debugger&uri=" + serviceProtocolUri,
+        "http://" + devtoolsHost + ":" + devtoolsPort + "/?hide=debugger&uri=" + urlParam,
         null
       );
     }

--- a/src/io/flutter/inspector/DiagnosticsNode.java
+++ b/src/io/flutter/inspector/DiagnosticsNode.java
@@ -9,13 +9,14 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
+import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.xdebugger.XSourcePosition;
 import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService;
-import io.flutter.server.vmService.frame.DartVmServiceValue;
 import io.flutter.run.daemon.FlutterApp;
+import io.flutter.server.vmService.frame.DartVmServiceValue;
 import io.flutter.utils.CustomIconMaker;
 import io.flutter.utils.JsonUtils;
 import org.apache.commons.lang.StringUtils;
@@ -49,6 +50,8 @@ import java.util.function.BiConsumer;
  * also available via the getValue() method.
  */
 public class DiagnosticsNode {
+  private static final Logger LOG = Logger.getInstance(DiagnosticsNode.class);
+
   private static final CustomIconMaker iconMaker = new CustomIconMaker();
   private final FlutterApp app;
 
@@ -104,7 +107,8 @@ public class DiagnosticsNode {
       final InspectorService.ObjectGroup service = inspectorService.getNow(null);
       // If the service isn't created yet it can't have been disposed.
       return service != null && service.isDisposed();
-    } catch (Exception e) {
+    }
+    catch (Exception e) {
       // If the service can't be acquired then it is disposed.
       return false;
     }
@@ -638,12 +642,13 @@ public class DiagnosticsNode {
         final JsonArray jsonArray = json.get("children").getAsJsonArray();
         final ArrayList<DiagnosticsNode> nodes = new ArrayList<>();
         for (JsonElement element : jsonArray) {
-          DiagnosticsNode child = new DiagnosticsNode(element.getAsJsonObject(), inspectorService,  app,false, parent);
+          DiagnosticsNode child = new DiagnosticsNode(element.getAsJsonObject(), inspectorService, app, false, parent);
           child.setParent(this);
           nodes.add(child);
         }
         children = CompletableFuture.completedFuture(nodes);
-      } else  if (hasChildren()) {
+      }
+      else if (hasChildren()) {
         children = inspectorService.thenComposeAsync((service) -> {
           if (service == null) {
             return null;
@@ -720,12 +725,12 @@ public class DiagnosticsNode {
   @NotNull
   public CompletableFuture<String> getPropertyDoc() {
     if (propertyDocFuture == null) {
-      propertyDocFuture = createPropertyDocFurure();
+      propertyDocFuture = createPropertyDocFuture();
     }
     return propertyDocFuture;
   }
 
-  private CompletableFuture<String> createPropertyDocFurure() {
+  private CompletableFuture<String> createPropertyDocFuture() {
     final DiagnosticsNode parent = getParent();
     if (parent != null) {
       return inspectorService.thenComposeAsync((service) -> service.toDartVmServiceValueForSourceLocation(parent.getValueRef())
@@ -734,23 +739,26 @@ public class DiagnosticsNode {
             return CompletableFuture.completedFuture(null);
           }
           return inspectorService.getNow(null).getPropertyLocation(vmValue.getInstanceRef(), getName())
-          .thenApplyAsync((XSourcePosition sourcePosition) -> {
-            if (sourcePosition != null) {
-              final VirtualFile file = sourcePosition.getFile();
-              final int offset = sourcePosition.getOffset();
+            .thenApplyAsync((XSourcePosition sourcePosition) -> {
+              if (sourcePosition != null) {
+                final VirtualFile file = sourcePosition.getFile();
+                final int offset = sourcePosition.getOffset();
 
-              final Project project = getProject(file);
-              if (project != null) {
-                final List<HoverInformation> hovers =
-                  DartAnalysisServerService.getInstance(project).analysis_getHover(file, offset);
-                if (!hovers.isEmpty()) {
-                  return hovers.get(0).getDartdoc();
+                final Project project = getProject(file);
+                if (project != null) {
+                  final List<HoverInformation> hovers =
+                    DartAnalysisServerService.getInstance(project).analysis_getHover(file, offset);
+                  if (!hovers.isEmpty()) {
+                    return hovers.get(0).getDartdoc();
+                  }
                 }
               }
-            }
-            return "Unable to find property source";
-          });
-        }));
+              return "Unable to find property source";
+            });
+        })).exceptionally(t -> {
+        LOG.info("ignoring exception from toObjectForSourceLocation: " + t.toString());
+        return null;
+      });
     }
 
     return CompletableFuture.completedFuture("Unable to find property source");
@@ -834,7 +842,8 @@ public class DiagnosticsNode {
         }
         group.safeWhenComplete(future, action);
       });
-    } catch (Exception e) {
+    }
+    catch (Exception e) {
       // Nothing to do if the service can't be acquired.
     }
   }

--- a/src/io/flutter/inspector/DiagnosticsNode.java
+++ b/src/io/flutter/inspector/DiagnosticsNode.java
@@ -843,7 +843,7 @@ public class DiagnosticsNode {
         group.safeWhenComplete(future, action);
       });
     }
-    catch (Exception e) {
+    catch (Exception ignored) {
       // Nothing to do if the service can't be acquired.
     }
   }

--- a/src/io/flutter/inspector/InspectorService.java
+++ b/src/io/flutter/inspector/InspectorService.java
@@ -59,7 +59,7 @@ public class InspectorService implements Disposable {
                                                            @NotNull FlutterDebugProcess debugProcess,
                                                            @NotNull VmService vmService) {
     assert app.getVMServiceManager() != null;
-    Set<String> inspectorLibraryNames = new HashSet<>();
+    final Set<String> inspectorLibraryNames = new HashSet<>();
     inspectorLibraryNames.add("package:flutter/src/widgets/widget_inspector.dart");
     inspectorLibraryNames.add("package:flutter_web/src/widgets/widget_inspector.dart");
     final EvalOnDartLibrary inspectorLibrary = new EvalOnDartLibrary(

--- a/src/io/flutter/run/OpenDevToolsAction.java
+++ b/src/io/flutter/run/OpenDevToolsAction.java
@@ -15,8 +15,6 @@ import io.flutter.devtools.DevToolsManager;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.concurrent.CompletableFuture;
 
 public class OpenDevToolsAction extends DumbAwareAction {
@@ -70,22 +68,12 @@ public class OpenDevToolsAction extends DumbAwareAction {
         return;
       }
 
-      final URL url;
-      try {
-        url = new URL(urlString);
-      }
-      catch (MalformedURLException e) {
-        return;
-      }
-
-      final int port = url.getPort();
-
       if (devToolsManager.hasInstalledDevTools()) {
-        devToolsManager.openBrowserAndConnect(port);
+        devToolsManager.openBrowserAndConnect(urlString);
       }
       else {
         final CompletableFuture<Boolean> result = devToolsManager.installDevTools();
-        result.thenAccept(o -> devToolsManager.openBrowserAndConnect(port));
+        result.thenAccept(o -> devToolsManager.openBrowserAndConnect(urlString));
       }
     }
   }

--- a/src/io/flutter/run/SdkAttachConfig.java
+++ b/src/io/flutter/run/SdkAttachConfig.java
@@ -71,22 +71,22 @@ public class SdkAttachConfig extends SdkRunConfig {
       throw new ExecutionException(e);
     }
 
-    SdkFields launchFields = getFields();
-    MainFile mainFile = MainFile.verify(launchFields.getFilePath(), env.getProject()).get();
-    Project project = env.getProject();
-    RunMode mode = RunMode.fromEnv(env);
-    Module module = ModuleUtilCore.findModuleForFile(mainFile.getFile(), env.getProject());
-    LaunchState.CreateAppCallback createAppCallback = (device) -> {
+    final SdkFields launchFields = getFields();
+    final MainFile mainFile = MainFile.verify(launchFields.getFilePath(), env.getProject()).get();
+    final Project project = env.getProject();
+    final RunMode mode = RunMode.fromEnv(env);
+    final Module module = ModuleUtilCore.findModuleForFile(mainFile.getFile(), env.getProject());
+    final LaunchState.CreateAppCallback createAppCallback = (@Nullable FlutterDevice device) -> {
       if (device == null) return null;
 
-      GeneralCommandLine command = getCommand(env, device);
+      final GeneralCommandLine command = getCommand(env, device);
 
-      FlutterApp app = FlutterApp.start(env, project, module, mode, device, command,
+      final FlutterApp app = FlutterApp.start(env, project, module, mode, device, command,
                                         StringUtil.capitalize(mode.mode()) + "App",
-                                        "StopApp");
+                                              "StopApp");
 
       // Stop the app if the Flutter SDK changes.
-      FlutterSdkManager.Listener sdkListener = new FlutterSdkManager.Listener() {
+      final FlutterSdkManager.Listener sdkListener = new FlutterSdkManager.Listener() {
         @Override
         public void flutterSdkRemoved() {
           app.shutdownAsync();
@@ -98,7 +98,7 @@ public class SdkAttachConfig extends SdkRunConfig {
       return app;
     };
 
-    LaunchState launcher = new AttachState(env, mainFile.getAppDir(), mainFile.getFile(), this, createAppCallback);
+    final LaunchState launcher = new AttachState(env, mainFile.getAppDir(), mainFile.getFile(), this, createAppCallback);
     addConsoleFilters(launcher, env, mainFile, module);
     return launcher;
   }
@@ -110,12 +110,12 @@ public class SdkAttachConfig extends SdkRunConfig {
   }
 
   private void checkRunnable(@NotNull Project project) throws RuntimeConfigurationError {
-    DartSdk sdk = DartPlugin.getDartSdk(project);
+    final DartSdk sdk = DartPlugin.getDartSdk(project);
     if (sdk == null) {
       throw new RuntimeConfigurationError(FlutterBundle.message("dart.sdk.is.not.configured"),
                                           () -> DartConfigurable.openDartSettings(project));
     }
-    MainFile.Result main = MainFile.verify(getFields().getFilePath(), project);
+    final MainFile.Result main = MainFile.verify(getFields().getFilePath(), project);
     if (!main.canLaunch()) {
       throw new RuntimeConfigurationError(main.getError());
     }

--- a/src/io/flutter/run/bazel/BazelRunConfig.java
+++ b/src/io/flutter/run/bazel/BazelRunConfig.java
@@ -25,6 +25,7 @@ import io.flutter.run.daemon.FlutterDevice;
 import io.flutter.run.daemon.RunMode;
 import org.jdom.Element;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class BazelRunConfig extends RunConfigurationBase
   implements RunConfigurationWithSuppressedDefaultRunAction, LaunchState.RunConfig {
@@ -71,7 +72,7 @@ public class BazelRunConfig extends RunConfigurationBase
     final RunMode mode = RunMode.fromEnv(env);
     final Module module = ModuleUtil.findModuleForFile(workspaceRoot, env.getProject());
 
-    final LaunchState.CreateAppCallback createAppCallback = (device) -> {
+    final LaunchState.CreateAppCallback createAppCallback = (@Nullable FlutterDevice device) -> {
       if (device == null) return null;
 
       final GeneralCommandLine command = getCommand(env, device);

--- a/src/io/flutter/run/daemon/DaemonApi.java
+++ b/src/io/flutter/run/daemon/DaemonApi.java
@@ -313,8 +313,6 @@ public class DaemonApi {
   public static class RestartResult {
     private int code;
     private String message;
-    private String hintMessage;
-    private String hintId;
 
     public boolean ok() {
       return code == 0;
@@ -326,18 +324,6 @@ public class DaemonApi {
 
     public String getMessage() {
       return message;
-    }
-
-    public String getHintMessage() {
-      return hintMessage;
-    }
-
-    public String getHintId() {
-      return hintId;
-    }
-
-    public boolean isRestartRecommended() {
-      return "restartRecommended".equals(hintId);
     }
 
     @Override

--- a/src/io/flutter/run/daemon/DaemonEvent.java
+++ b/src/io/flutter/run/daemon/DaemonEvent.java
@@ -56,10 +56,12 @@ abstract class DaemonEvent {
   static DaemonEvent create(@NotNull String eventName, @NotNull JsonObject params) {
     try {
       switch (eventName) {
+        case "daemon.log":
+          return GSON.fromJson(params, DaemonLog.class);
         case "daemon.logMessage":
-          return GSON.fromJson(params, LogMessage.class);
+          return GSON.fromJson(params, DaemonLogMessage.class);
         case "daemon.showMessage":
-          return GSON.fromJson(params, ShowMessage.class);
+          return GSON.fromJson(params, DaemonShowMessage.class);
         case "app.start":
           return GSON.fromJson(params, AppStarting.class);
         case "app.debugPort":
@@ -108,10 +110,13 @@ abstract class DaemonEvent {
 
     // daemon domain
 
-    default void onDaemonLogMessage(LogMessage event) {
+    default void onDaemonLog(DaemonLog event) {
     }
 
-    default void onDaemonShowMessage(ShowMessage event) {
+    default void onDaemonLogMessage(DaemonLogMessage event) {
+    }
+
+    default void onDaemonShowMessage(DaemonShowMessage event) {
     }
 
     // app domain
@@ -149,7 +154,18 @@ abstract class DaemonEvent {
   // daemon domain
 
   @SuppressWarnings("unused")
-  static class LogMessage extends DaemonEvent {
+  static class DaemonLog extends DaemonEvent {
+    // "event":"daemon.log"
+    String log;
+    boolean error;
+
+    void accept(Listener listener) {
+      listener.onDaemonLog(this);
+    }
+  }
+
+  @SuppressWarnings("unused")
+  static class DaemonLogMessage extends DaemonEvent {
     // "event":"daemon.logMessage"
     String level;
     String message;
@@ -161,7 +177,7 @@ abstract class DaemonEvent {
   }
 
   @SuppressWarnings("unused")
-  static class ShowMessage extends DaemonEvent {
+  static class DaemonShowMessage extends DaemonEvent {
     // "event":"daemon.showMessage"
     String level;
     String title;

--- a/src/io/flutter/run/daemon/DeviceDaemon.java
+++ b/src/io/flutter/run/daemon/DeviceDaemon.java
@@ -140,10 +140,11 @@ class DeviceDaemon {
 
     try {
       final String path = FlutterSdkUtil.pathToFlutterTool(sdk.getHomePath());
-      ImmutableList<String> list;
+      final ImmutableList<String> list;
       if (FlutterUtils.isIntegrationTestingMode()) {
         list = ImmutableList.of("--show-test-device", "daemon");
-      } else {
+      }
+      else {
         list = ImmutableList.of("daemon");
       }
       return new Command(sdk.getHomePath(), path, list, androidHome);
@@ -319,12 +320,12 @@ class DeviceDaemon {
     // daemon domain
 
     @Override
-    public void onDaemonLogMessage(@NotNull DaemonEvent.LogMessage message) {
+    public void onDaemonLogMessage(@NotNull DaemonEvent.DaemonLogMessage message) {
       LOG.info("flutter device daemon #" + daemonId + ": " + message.message);
     }
 
     @Override
-    public void onDaemonShowMessage(@NotNull DaemonEvent.ShowMessage event) {
+    public void onDaemonShowMessage(@NotNull DaemonEvent.DaemonShowMessage event) {
       if ("error".equals(event.level)) {
         FlutterMessages.showError(event.title, event.message);
       }

--- a/src/io/flutter/run/daemon/FlutterApp.java
+++ b/src/io/flutter/run/daemon/FlutterApp.java
@@ -605,6 +605,7 @@ public class FlutterApp {
            !debugProcess.getSession().isStopped();
   }
 
+  @Nullable
   public FlutterDevice device() {
     return myDevice;
   }
@@ -754,7 +755,7 @@ class FlutterAppDaemonEventListener implements DaemonEvent.Listener {
     if (console == null) return;
     if (message.log != null) {
       console.print(message.log + "\n", message.error ? ConsoleViewContentType.ERROR_OUTPUT : ConsoleViewContentType.NORMAL_OUTPUT);
-    }    
+    }
   }
 
   @Override

--- a/src/io/flutter/run/daemon/FlutterApp.java
+++ b/src/io/flutter/run/daemon/FlutterApp.java
@@ -68,7 +68,8 @@ public class FlutterApp {
   private final @NotNull Project myProject;
   private final @Nullable Module myModule;
   private final @NotNull RunMode myMode;
-  // TODO(github.com/flutter/flutter-intellij/issues/3293) myDevice is not-null for all run configurations except flutter web configurations
+  // TODO(jwren): myDevice is not-null for all run configurations except flutter web configurations
+  // See https://github.com/flutter/flutter-intellij/issues/3293.
   private final @Nullable FlutterDevice myDevice;
   private final @NotNull ProcessHandler myProcessHandler;
   private final @NotNull ExecutionEnvironment myExecutionEnvironment;
@@ -79,6 +80,8 @@ public class FlutterApp {
   private @Nullable String myWsUrl;
   private @Nullable String myBaseUri;
   private @Nullable ConsoleView myConsole;
+
+  private boolean isFlutterWeb = false;
 
   /**
    * The command with which the app was launched.
@@ -300,6 +303,19 @@ public class FlutterApp {
   @NotNull
   public ObservatoryConnector getConnector() {
     return myConnector;
+  }
+
+  public void setIsFlutterWeb(boolean value) {
+    isFlutterWeb = value;
+  }
+
+  public boolean getIsFlutterWeb() {
+    return isFlutterWeb;
+  }
+
+  @SuppressWarnings("BooleanMethodIsAlwaysInverted")
+  public boolean appSupportsHotReload() {
+    return !isFlutterWeb;
   }
 
   public State getState() {
@@ -593,13 +609,9 @@ public class FlutterApp {
     return myDevice;
   }
 
+  @Nullable
   public String deviceId() {
-    return myDevice != null ? myDevice.deviceId() : "";
-  }
-
-  // TODO this should be a temporary hack until there is some mocked out "browser" device
-  public boolean isWebDev() {
-    return myDevice == null;
+    return myDevice != null ? myDevice.deviceId() : null;
   }
 
   public void setFlutterDebugProcess(FlutterDebugProcess flutterDebugProcess) {
@@ -737,7 +749,16 @@ class FlutterAppDaemonEventListener implements DaemonEvent.Listener {
   // daemon domain
 
   @Override
-  public void onDaemonLogMessage(@NotNull DaemonEvent.LogMessage message) {
+  public void onDaemonLog(@NotNull DaemonEvent.DaemonLog message) {
+    final ConsoleView console = app.getConsole();
+    if (console == null) return;
+    if (message.log != null) {
+      console.print(message.log + "\n", message.error ? ConsoleViewContentType.ERROR_OUTPUT : ConsoleViewContentType.NORMAL_OUTPUT);
+    }    
+  }
+
+  @Override
+  public void onDaemonLogMessage(@NotNull DaemonEvent.DaemonLogMessage message) {
     LOG.info("flutter app: " + message.message);
   }
 

--- a/src/io/flutter/sdk/FlutterCommand.java
+++ b/src/io/flutter/sdk/FlutterCommand.java
@@ -37,39 +37,24 @@ public class FlutterCommand {
     Arrays.asList(Type.PACKAGES_GET, Type.PACKAGES_UPGRADE, Type.UPGRADE));
 
   @NotNull
-  private final FlutterSdk sdk;
+  protected final FlutterSdk sdk;
 
   @Nullable
-  private final VirtualFile workDir;
+  protected final VirtualFile workDir;
 
   @NotNull
   private final Type type;
 
   @NotNull
-  private final List<String> args;
-
-  // TODO(https://github.com/flutter/flutter-intellij/issues/3348) This is a temporary "<pub-cache>/bin/webdev" that can be provided to test
-  //  some webdev directly.
-  @Nullable
-  private final String localWebDevExe = "webdev";
-
-  private final boolean isFlutterWeb;
+  protected final List<String> args;
 
   /**
    * @see FlutterSdk for methods to create specific commands.
    */
   FlutterCommand(@NotNull FlutterSdk sdk, @Nullable VirtualFile workDir, @NotNull Type type, String... args) {
-    this(sdk, workDir, type, false, args);
-  }
-
-  /**
-   * @see FlutterSdk for methods to create specific commands.
-   */
-  FlutterCommand(@NotNull FlutterSdk sdk, @Nullable VirtualFile workDir, @NotNull Type type, boolean isFlutterWeb, String... args) {
     this.sdk = sdk;
     this.workDir = workDir;
     this.type = type;
-    this.isFlutterWeb = isFlutterWeb;
     this.args = ImmutableList.copyOf(args);
   }
 
@@ -260,54 +245,20 @@ public class FlutterCommand {
   public GeneralCommandLine createGeneralCommandLine(@Nullable Project project) {
     final GeneralCommandLine line = new GeneralCommandLine();
     line.setCharset(CharsetToolkit.UTF8_CHARSET);
-    if (isFlutterWeb) {
-      if (workDir != null) {
-        line.setWorkDirectory(workDir.getPath());
-      }
-      if (localWebDevExe != null || !localWebDevExe.isEmpty()) {
-        line.setExePath(localWebDevExe);
-        line.addParameters("daemon");
-        if (args.contains("--debug")) {
-          line.addParameters("--debug");
-        }
-        if (args.contains("--hot-reload")) {
-          line.addParameters("--hot-reload");
-        }
-      }
-      else {
-        line.setExePath(FileUtil.toSystemDependentName(sdk.getHomePath() + "/bin/" + FlutterSdkUtil.flutterScriptName()));
-        line.addParameters(args);
-      }
+    line.withEnvironment(FlutterSdkUtil.FLUTTER_HOST_ENV, FlutterSdkUtil.getFlutterHostEnvValue());
+    final String androidHome = IntelliJAndroidSdk.chooseAndroidHome(project, false);
+    if (androidHome != null) {
+      line.withEnvironment("ANDROID_HOME", androidHome);
     }
-    else {
-      line.withEnvironment(FlutterSdkUtil.FLUTTER_HOST_ENV, FlutterSdkUtil.getFlutterHostEnvValue());
-      final String androidHome = IntelliJAndroidSdk.chooseAndroidHome(project, false);
-      if (androidHome != null) {
-        line.withEnvironment("ANDROID_HOME", androidHome);
-      }
-      line.setExePath(FileUtil.toSystemDependentName(sdk.getHomePath() + "/bin/" + FlutterSdkUtil.flutterScriptName()));
-      if (workDir != null) {
-        line.setWorkDirectory(workDir.getPath());
-      }
-      if (!isDoctorCommand()) {
-        line.addParameter("--no-color");
-      }
-      line.addParameters(type.subCommand);
-      line.addParameters(args);
-    }
-    return line;
-  }
-
-  @NotNull
-  public GeneralCommandLine createFlutterWebCommandLine(@Nullable Project project) {
-    final GeneralCommandLine line = new GeneralCommandLine();
-    line.setCharset(CharsetToolkit.UTF8_CHARSET);
+    line.setExePath(FileUtil.toSystemDependentName(sdk.getHomePath() + "/bin/" + FlutterSdkUtil.flutterScriptName()));
     if (workDir != null) {
       line.setWorkDirectory(workDir.getPath());
     }
+    if (!isDoctorCommand()) {
+      line.addParameter("--no-color");
+    }
     line.addParameters(type.subCommand);
     line.addParameters(args);
-
     return line;
   }
 
@@ -327,6 +278,7 @@ public class FlutterCommand {
     PACKAGES_UPGRADE("Flutter packages upgrade", "packages", "upgrade"),
     PACKAGES_PUB("Flutter packages pub", "packages", "pub"),
     RUN("Flutter run", "run"),
+    FLUTTER_WEB_RUN("Flutter Web run", "flutter_web_run"),
     UPGRADE("Flutter upgrade", "upgrade"),
     VERSION("Flutter version", "--version"),
     TEST("Flutter test", "test");

--- a/src/io/flutter/sdk/FlutterSdk.java
+++ b/src/io/flutter/sdk/FlutterSdk.java
@@ -270,16 +270,14 @@ public class FlutterSdk {
   }
 
   public FlutterCommand flutterRunWeb(@NotNull PubRoot root, @NotNull RunMode mode) {
-    // flutter packages pub global run webdev serve [--debug] [--hot-reload]
-    final List<String> args = new ArrayList<>();
-    args.add("global");
-    args.add("run");
-    args.add("webdev");
-    args.add("daemon");
-    // TODO(https://github.com/flutter/flutter-intellij/issues/3349) After debug is supported by webdev, this should be modified to check
-    //  for debug and add any additional needed flags:
-    //  i.e. if (mode == RunMode.DEBUG) { args.add("--debug"); }
-    return new FlutterCommand(this, root.getRoot(), FlutterCommand.Type.PACKAGES_PUB, true, args.toArray(new String[]{ }));
+    // TODO(devoncarew): We need to provision the webdev cli here.
+
+    // TODO(jwren): After debugging is supported by webdev, this should be modified to check for debug and add
+    // any additional needed flags: i.e. if (mode == RunMode.DEBUG) { args.add("--debug"); }
+    // See https://github.com/flutter/flutter-intellij/issues/3349.
+
+    // flutter packages pub global run webdev daemon
+    return new FlutterWebCommand(this, root.getRoot(), FlutterCommand.Type.FLUTTER_WEB_RUN, new String[]{ });
   }
 
   public FlutterCommand flutterRunOnTester(@NotNull PubRoot root, @NotNull String mainPath) {

--- a/src/io/flutter/sdk/FlutterWebCommand.java
+++ b/src/io/flutter/sdk/FlutterWebCommand.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.sdk;
+
+import com.intellij.execution.configurations.GeneralCommandLine;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.io.FileUtil;
+import com.intellij.openapi.vfs.CharsetToolkit;
+import com.intellij.openapi.vfs.VirtualFile;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * This subclasses FlutterCommand specifically to override the command line creation behavior for
+ * Flutter Web run commands.
+ */
+public class FlutterWebCommand extends FlutterCommand {
+  public FlutterWebCommand(@NotNull FlutterSdk sdk, @Nullable VirtualFile workDir, @NotNull FlutterCommand.Type type, String... args) {
+    super(sdk, workDir, type, args);
+  }
+
+  @NotNull
+  public GeneralCommandLine createGeneralCommandLine(@Nullable Project project) {
+    final GeneralCommandLine line = new GeneralCommandLine();
+    line.setCharset(CharsetToolkit.UTF8_CHARSET);
+    if (workDir != null) {
+      line.setWorkDirectory(workDir.getPath());
+    }
+    line.setExePath(FileUtil.toSystemDependentName(sdk.getHomePath() + "/bin/" + FlutterSdkUtil.flutterScriptName()));
+    // flutter packages pub
+    line.addParameters(Type.PACKAGES_PUB.subCommand);
+    // TODO(devoncarew): We need to provision webdev locally.
+    line.addParameters("global", "run", "webdev", "daemon");
+    line.addParameters(args);
+    return line;
+  }
+}

--- a/src/io/flutter/server/vmService/DartVmServiceDebugProcess.java
+++ b/src/io/flutter/server/vmService/DartVmServiceDebugProcess.java
@@ -39,7 +39,6 @@ import gnu.trove.TIntObjectHashMap;
 import io.flutter.FlutterBundle;
 import io.flutter.FlutterUtils;
 import io.flutter.ObservatoryConnector;
-import io.flutter.run.FlutterDebugProcess;
 import io.flutter.run.FlutterLaunchMode;
 import io.flutter.server.vmService.frame.DartVmServiceEvaluator;
 import io.flutter.server.vmService.frame.DartVmServiceStackFrame;
@@ -249,25 +248,20 @@ public class DartVmServiceDebugProcess extends XDebugProcess {
         return;
       }
 
-      // "Flutter run" has given us a websocket; we can assume it's ready immediately,
-      // because "flutter run" has already connected to it.
+      // "flutter run" has given us a websocket; we can assume it's ready immediately, because
+      // "flutter run" has already connected to it.
       final VmService vmService;
       final VmOpenSourceLocationListener vmOpenSourceLocationListener;
-      // TODO(github.com/dart-lang/webdev/issues/233) The following check disables the WebSocket connection for all FlutterWeb run
-      //  configurations, for some reason the WebSocket port can't be connected to, see listed issue above.
-      if (this instanceof FlutterDebugProcess && (!((FlutterDebugProcess)this).getApp().isWebDev())) {
-        try {
-          vmService = VmService.connect(url);
-          vmOpenSourceLocationListener = VmOpenSourceLocationListener.connect(url);
-        }
-        catch (IOException | RuntimeException e) {
-          onConnectFailed("Failed to connect to the VM observatory service at: " + url + "\n"
-                          + e.toString() + "\n" +
-                          formatStackTraces(e));
-          return;
-        }
-        onConnectSucceeded(vmService, vmOpenSourceLocationListener);
+      try {
+        vmService = VmService.connect(url);
+        vmOpenSourceLocationListener = VmOpenSourceLocationListener.connect(url);
       }
+      catch (IOException | RuntimeException e) {
+        onConnectFailed("Failed to connect to the VM observatory service at: " + url + "\n"
+                        + e.toString() + "\n" + formatStackTraces(e));
+        return;
+      }
+      onConnectSucceeded(vmService, vmOpenSourceLocationListener);
     });
   }
 

--- a/src/io/flutter/view/FlutterPerfView.java
+++ b/src/io/flutter/view/FlutterPerfView.java
@@ -98,7 +98,6 @@ public class FlutterPerfView implements Disposable {
   }
 
   void debugActive(@NotNull FlutterViewMessages.FlutterDebugEvent event) {
-
     final FlutterApp app = event.app;
     final ToolWindowManager toolWindowManager = ToolWindowManager.getInstance(myProject);
     if (!(toolWindowManager instanceof ToolWindowManagerEx)) {

--- a/src/io/flutter/view/FlutterPerfView.java
+++ b/src/io/flutter/view/FlutterPerfView.java
@@ -163,13 +163,21 @@ public class FlutterPerfView implements Disposable {
     final JBRunnerTabs runnerTabs = new JBRunnerTabs(myProject, ActionManager.getInstance(), null, this);
     runnerTabs.setSelectionChangeHandler(this::onTabSelectionChange);
 
-    final List<FlutterDevice> existingDevices = new ArrayList<>();
-    for (FlutterApp otherApp : perAppViewState.keySet()) {
-      existingDevices.add(otherApp.device());
+    final String tabName;
+    final FlutterDevice device = app.device();
+    if (device == null) {
+      tabName = app.getProject().getName();
+    }
+    else {
+      final List<FlutterDevice> existingDevices = new ArrayList<>();
+      for (FlutterApp otherApp : perAppViewState.keySet()) {
+        existingDevices.add(otherApp.device());
+      }
+      tabName = device.getUniqueName(existingDevices);
     }
 
     final JPanel tabContainer = new JPanel(new BorderLayout());
-    final Content content = contentManager.getFactory().createContent(null, app.device().getUniqueName(existingDevices), false);
+    final Content content = contentManager.getFactory().createContent(null, tabName, false);
     tabContainer.add(runnerTabs.getComponent(), BorderLayout.CENTER);
     content.setComponent(tabContainer);
     content.putUserData(ToolWindow.SHOW_CONTENT_ICON, Boolean.TRUE);

--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -384,25 +384,17 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
   public void debugActive(@NotNull FlutterViewMessages.FlutterDebugEvent event) {
     final FlutterApp app = event.app;
 
-    System.out.println("FlutterView.debugActive()");
-
     if (app.getMode().isProfiling() || app.getLaunchMode().isProfiling()) {
       ApplicationManager.getApplication().invokeLater(() -> debugActiveHelper(app, null));
     }
     else {
-      System.out.println("FlutterView.whenCompleteUiThread()");
-
       whenCompleteUiThread(
         InspectorService.create(app, app.getFlutterDebugProcess(), app.getVmService()),
         (InspectorService inspectorService, Throwable throwable) -> {
-          System.out.println("FlutterView InspectorService.create()");
-
           if (throwable != null) {
             FlutterUtils.warn(LOG, throwable);
             return;
           }
-
-          System.out.println("FlutterView debugActiveHelper()");
 
           debugActiveHelper(app, inspectorService);
         });

--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -64,8 +64,6 @@ import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 import java.awt.*;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.List;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
@@ -386,17 +384,26 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
   public void debugActive(@NotNull FlutterViewMessages.FlutterDebugEvent event) {
     final FlutterApp app = event.app;
 
+    System.out.println("FlutterView.debugActive()");
+
     if (app.getMode().isProfiling() || app.getLaunchMode().isProfiling()) {
       ApplicationManager.getApplication().invokeLater(() -> debugActiveHelper(app, null));
     }
     else {
+      System.out.println("FlutterView.whenCompleteUiThread()");
+
       whenCompleteUiThread(
         InspectorService.create(app, app.getFlutterDebugProcess(), app.getVmService()),
         (InspectorService inspectorService, Throwable throwable) -> {
+          System.out.println("FlutterView InspectorService.create()");
+
           if (throwable != null) {
             FlutterUtils.warn(LOG, throwable);
             return;
           }
+
+          System.out.println("FlutterView debugActiveHelper()");
+
           debugActiveHelper(app, inspectorService);
         });
     }
@@ -613,24 +620,14 @@ class FlutterViewDevToolsAction extends FlutterViewAction {
         return;
       }
 
-      final URL url;
-      try {
-        url = new URL(urlString);
-      }
-      catch (MalformedURLException e) {
-        return;
-      }
-
-      final int port = url.getPort();
-
       final DevToolsManager devToolsManager = DevToolsManager.getInstance(app.getProject());
 
       if (devToolsManager.hasInstalledDevTools()) {
-        devToolsManager.openBrowserAndConnect(port);
+        devToolsManager.openBrowserAndConnect(urlString);
       }
       else {
         final CompletableFuture<Boolean> result = devToolsManager.installDevTools();
-        result.thenAccept(o -> devToolsManager.openBrowserAndConnect(port));
+        result.thenAccept(o -> devToolsManager.openBrowserAndConnect(urlString));
       }
     }
   }

--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -216,12 +216,22 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
     final SimpleToolWindowPanel toolWindowPanel = new SimpleToolWindowPanel(true);
     final JBRunnerTabs runnerTabs = new JBRunnerTabs(myProject, ActionManager.getInstance(), null, this);
     runnerTabs.setSelectionChangeHandler(this::onTabSelectionChange);
-    final List<FlutterDevice> existingDevices = new ArrayList<>();
-    for (FlutterApp otherApp : perAppViewState.keySet()) {
-      existingDevices.add(otherApp.device());
-    }
     final JPanel tabContainer = new JPanel(new BorderLayout());
-    final Content content = contentManager.getFactory().createContent(null, app.device().getUniqueName(existingDevices), false);
+
+    final String tabName;
+    final FlutterDevice device = app.device();
+    if (device == null) {
+      tabName = app.getProject().getName();
+    }
+    else {
+      final List<FlutterDevice> existingDevices = new ArrayList<>();
+      for (FlutterApp otherApp : perAppViewState.keySet()) {
+        existingDevices.add(otherApp.device());
+      }
+      tabName = device.getUniqueName(existingDevices);
+    }
+
+    final Content content = contentManager.getFactory().createContent(null, tabName, false);
     tabContainer.add(runnerTabs.getComponent(), BorderLayout.CENTER);
     content.setComponent(tabContainer);
     content.putUserData(ToolWindow.SHOW_CONTENT_ICON, Boolean.TRUE);

--- a/testSrc/unit/io/flutter/run/daemon/DaemonEventTest.java
+++ b/testSrc/unit/io/flutter/run/daemon/DaemonEventTest.java
@@ -33,12 +33,12 @@ public class DaemonEventTest {
       // daemon domain
 
       @Override
-      public void onDaemonLogMessage(DaemonEvent.LogMessage event) {
+      public void onDaemonLogMessage(DaemonEvent.DaemonLogMessage event) {
         logEvent(event, event.level, event.message, event.stackTrace);
       }
 
       @Override
-      public void onDaemonShowMessage(DaemonEvent.ShowMessage event) {
+      public void onDaemonShowMessage(DaemonEvent.DaemonShowMessage event) {
         logEvent(event, event.level, event.title, event.message);
       }
 

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/VmServiceBase.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/VmServiceBase.java
@@ -96,8 +96,6 @@ abstract class VmServiceBase implements VmServiceConst {
 
       @Override
       public void onOpen() {
-        System.out.println("VmServiceBase.onOpen()");
-
         vmService.connectionOpened();
 
         Logging.getLogger().logInformation("VM connection open: " + url);
@@ -352,8 +350,6 @@ abstract class VmServiceBase implements VmServiceConst {
   }
 
   public void connectionOpened() {
-    System.out.println("VmServiceBase.connectionOpened()");
-
     for (VmServiceListener listener : vmListeners) {
       try {
         listener.connectionOpened();

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/VmServiceBase.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/VmServiceBase.java
@@ -55,7 +55,8 @@ abstract class VmServiceBase implements VmServiceConst {
     URI uri;
     try {
       uri = new URI(url);
-    } catch (URISyntaxException e) {
+    }
+    catch (URISyntaxException e) {
       throw new IOException("Invalid URL: " + url, e);
     }
     String wsScheme = uri.getScheme();
@@ -67,7 +68,8 @@ abstract class VmServiceBase implements VmServiceConst {
     WebSocket webSocket;
     try {
       webSocket = new WebSocket(uri);
-    } catch (WebSocketException e) {
+    }
+    catch (WebSocketException e) {
       throw new IOException("Failed to create websocket: " + url, e);
     }
     final VmService vmService = new VmService();
@@ -86,13 +88,16 @@ abstract class VmServiceBase implements VmServiceConst {
         Logging.getLogger().logInformation("VM message: " + message.getText());
         try {
           vmService.processMessage(message.getText());
-        } catch (Exception e) {
+        }
+        catch (Exception e) {
           Logging.getLogger().logError(e.getMessage(), e);
         }
       }
 
       @Override
       public void onOpen() {
+        System.out.println("VmServiceBase.onOpen()");
+
         vmService.connectionOpened();
 
         Logging.getLogger().logInformation("VM connection open: " + url);
@@ -111,9 +116,11 @@ abstract class VmServiceBase implements VmServiceConst {
     //noinspection TryWithIdenticalCatches
     try {
       webSocket.connect();
-    } catch (WebSocketException e) {
+    }
+    catch (WebSocketException e) {
       throw new IOException("Failed to connect: " + url, e);
-    } catch (ArrayIndexOutOfBoundsException e) {
+    }
+    catch (ArrayIndexOutOfBoundsException e) {
       // The weberknecht can occasionally throw an array index exception if a connect terminates on initial connect
       // (de.roderick.weberknecht.WebSocket.connect, WebSocket.java:126).
       throw new IOException("Failed to connect: " + url, e);
@@ -127,7 +134,7 @@ abstract class VmServiceBase implements VmServiceConst {
       @Override
       public void onError(RPCError error) {
         String msg = "Failed to determine protocol version: " + error.getCode() + "\n  message: "
-            + error.getMessage() + "\n  details: " + error.getDetails();
+                     + error.getMessage() + "\n  details: " + error.getDetails();
         Logging.getLogger().logInformation(msg);
         errMsg[0] = msg;
       }
@@ -139,11 +146,12 @@ abstract class VmServiceBase implements VmServiceConst {
         if (major != VmService.versionMajor || minor != VmService.versionMinor) {
           if (major == 2 || major == 3) {
             Logging.getLogger().logInformation(
-                "Difference in protocol version: client=" + VmService.versionMajor + "."
-                    + VmService.versionMinor + " vm=" + major + "." + minor);
-          } else {
+              "Difference in protocol version: client=" + VmService.versionMajor + "."
+              + VmService.versionMinor + " vm=" + major + "." + minor);
+          }
+          else {
             String msg = "Incompatible protocol version: client=" + VmService.versionMajor + "."
-                + VmService.versionMinor + " vm=" + major + "." + minor;
+                         + VmService.versionMinor + " vm=" + major + "." + minor;
             Logging.getLogger().logError(msg);
             errMsg[0] = msg;
           }
@@ -158,7 +166,8 @@ abstract class VmServiceBase implements VmServiceConst {
       if (errMsg[0] != null) {
         throw new IOException(errMsg[0]);
       }
-    } catch (InterruptedException e) {
+    }
+    catch (InterruptedException e) {
       throw new RuntimeException("Interrupted while waiting for response", e);
     }
 
@@ -254,8 +263,9 @@ abstract class VmServiceBase implements VmServiceConst {
       @Override
       public void received(Obj response) {
         if (response instanceof Instance) {
-          consumer.received((Instance) response);
-        } else {
+          consumer.received((Instance)response);
+        }
+        else {
           onError(RPCError.unexpected("Instance", response));
         }
       }
@@ -281,8 +291,9 @@ abstract class VmServiceBase implements VmServiceConst {
       @Override
       public void received(Obj response) {
         if (response instanceof Library) {
-          consumer.received((Library) response);
-        } else {
+          consumer.received((Library)response);
+        }
+        else {
           onError(RPCError.unexpected("Library", response));
         }
       }
@@ -341,10 +352,13 @@ abstract class VmServiceBase implements VmServiceConst {
   }
 
   public void connectionOpened() {
+    System.out.println("VmServiceBase.connectionOpened()");
+
     for (VmServiceListener listener : vmListeners) {
       try {
         listener.connectionOpened();
-      } catch (Exception e) {
+      }
+      catch (Exception e) {
         Logging.getLogger().logError("Exception notifying listener", e);
       }
     }
@@ -354,7 +368,8 @@ abstract class VmServiceBase implements VmServiceConst {
     for (VmServiceListener listener : vmListeners) {
       try {
         listener.received(streamId, event);
-      } catch (Exception e) {
+      }
+      catch (Exception e) {
         Logging.getLogger().logError("Exception processing event: " + streamId + ", " + event.getJson(), e);
       }
     }
@@ -364,7 +379,8 @@ abstract class VmServiceBase implements VmServiceConst {
     for (VmServiceListener listener : vmListeners) {
       try {
         listener.connectionClosed();
-      } catch (Exception e) {
+      }
+      catch (Exception e) {
         Logging.getLogger().logError("Exception notifying listener", e);
       }
     }
@@ -395,8 +411,9 @@ abstract class VmServiceBase implements VmServiceConst {
     // Decode the JSON
     JsonObject json;
     try {
-      json = (JsonObject) new JsonParser().parse(jsonText);
-    } catch (Exception e) {
+      json = (JsonObject)new JsonParser().parse(jsonText);
+    }
+    catch (Exception e) {
       Logging.getLogger().logError("Parse message failed: " + jsonText, e);
       return;
     }
@@ -416,12 +433,15 @@ abstract class VmServiceBase implements VmServiceConst {
       }
       if (json.has("id")) {
         processRequest(json);
-      } else {
+      }
+      else {
         processNotification(json);
       }
-    } else if (json.has("result") || json.has("error")) {
+    }
+    else if (json.has("result") || json.has("error")) {
       processResponse(json);
-    } else {
+    }
+    else {
       Logging.getLogger().logError("Malformed message");
     }
   }
@@ -434,7 +454,8 @@ abstract class VmServiceBase implements VmServiceConst {
     String id;
     try {
       id = json.get(ID).getAsString();
-    } catch (Exception e) {
+    }
+    catch (Exception e) {
       final String message = "Request malformed " + ID;
       Logging.getLogger().logError(message, e);
       final JsonObject error = new JsonObject();
@@ -450,7 +471,8 @@ abstract class VmServiceBase implements VmServiceConst {
     String method;
     try {
       method = json.get(METHOD).getAsString();
-    } catch (Exception e) {
+    }
+    catch (Exception e) {
       final String message = "Request malformed " + METHOD;
       Logging.getLogger().logError(message, e);
       final JsonObject error = new JsonObject();
@@ -464,7 +486,8 @@ abstract class VmServiceBase implements VmServiceConst {
     JsonObject params;
     try {
       params = json.get(PARAMS).getAsJsonObject();
-    } catch (Exception e) {
+    }
+    catch (Exception e) {
       final String message = "Request malformed " + METHOD;
       Logging.getLogger().logError(message, e);
       final JsonObject error = new JsonObject();
@@ -505,7 +528,8 @@ abstract class VmServiceBase implements VmServiceConst {
           requestSink.add(response);
         }
       });
-    } catch (Exception e) {
+    }
+    catch (Exception e) {
       final String message = "Internal Server Error";
       Logging.getLogger().logError(message, e);
       final JsonObject error = new JsonObject();
@@ -517,28 +541,30 @@ abstract class VmServiceBase implements VmServiceConst {
   }
 
   private static final RemoteServiceCompleter ignoreCallback =
-      new RemoteServiceCompleter() {
-        public void result(JsonObject result) {
-          // ignore
-        }
+    new RemoteServiceCompleter() {
+      public void result(JsonObject result) {
+        // ignore
+      }
 
-        public void error(int code, String message, JsonObject data) {
-          // ignore
-        }
-      };
+      public void error(int code, String message, JsonObject data) {
+        // ignore
+      }
+    };
 
   void processNotification(JsonObject json) {
     String method;
     try {
       method = json.get(METHOD).getAsString();
-    } catch (Exception e) {
+    }
+    catch (Exception e) {
       Logging.getLogger().logError("Request malformed " + METHOD, e);
       return;
     }
     JsonObject params;
     try {
       params = json.get(PARAMS).getAsJsonObject();
-    } catch (Exception e) {
+    }
+    catch (Exception e) {
       Logging.getLogger().logError("Event missing " + PARAMS, e);
       return;
     }
@@ -546,19 +572,22 @@ abstract class VmServiceBase implements VmServiceConst {
       String streamId;
       try {
         streamId = params.get(STREAM_ID).getAsString();
-      } catch (Exception e) {
+      }
+      catch (Exception e) {
         Logging.getLogger().logError("Event missing " + STREAM_ID, e);
         return;
       }
       Event event;
       try {
         event = new Event(params.get(EVENT).getAsJsonObject());
-      } catch (Exception e) {
+      }
+      catch (Exception e) {
         Logging.getLogger().logError("Event missing " + EVENT, e);
         return;
       }
       forwardEvent(streamId, event);
-    } else {
+    }
+    else {
       if (!remoteServiceRunners.containsKey(method)) {
         Logging.getLogger().logError("Unknown service " + method);
         return;
@@ -567,7 +596,8 @@ abstract class VmServiceBase implements VmServiceConst {
       final RemoteServiceRunner runner = remoteServiceRunners.get(method);
       try {
         runner.run(params, ignoreCallback);
-      } catch (Exception e) {
+      }
+      catch (Exception e) {
         Logging.getLogger().logError("Internal Server Error", e);
       }
     }
@@ -584,7 +614,8 @@ abstract class VmServiceBase implements VmServiceConst {
     String id;
     try {
       id = idElem.getAsString();
-    } catch (Exception e) {
+    }
+    catch (Exception e) {
       Logging.getLogger().logError("Response missing " + ID, e);
       return;
     }
@@ -600,14 +631,16 @@ abstract class VmServiceBase implements VmServiceConst {
       JsonObject result;
       try {
         result = resultElem.getAsJsonObject();
-      } catch (Exception e) {
+      }
+      catch (Exception e) {
         Logging.getLogger().logError("Response has invalid " + RESULT, e);
         return;
       }
       String responseType;
       try {
         responseType = result.get(TYPE).getAsString();
-      } catch (Exception e) {
+      }
+      catch (Exception e) {
         Logging.getLogger().logError("Response missing " + TYPE, e);
         return;
       }
@@ -621,7 +654,8 @@ abstract class VmServiceBase implements VmServiceConst {
       JsonObject error;
       try {
         error = resultElem.getAsJsonObject();
-      } catch (Exception e) {
+      }
+      catch (Exception e) {
         Logging.getLogger().logError("Response has invalid " + RESULT, e);
         return;
       }


### PR DESCRIPTION
Various work in support of https://github.com/flutter/flutter-intellij/issues/3293:
- ensure that the hot reload action is disabled for flutter web app runs
- disable hot reload on save for flutter web app runs
- fix a bug where some text (like `"Build: Running build completed, took 191ms"`) was erroneously hyperlinked to in the run console
- change to connecting to service protocol apps via urls (not ports)
- remove no longer used 'restart recommended...' text
- fix an issue where a device was being associated with a flutter web launch; this would cause the iOS simulator to be brought to the front when launching flutter web apps
- fix an issue where already running flutter web apps weren't reloaded when the run button was hit
- add support for a new `daemon.log` event, to better support showing output from running flutter web apps
- refactor the initial flutter web support - add a new `FlutterCommand.FLUTTER_WEB_RUN` command

Things that are not yet supported:
- there's a race condition - which we generally lose - which means that the inspector is not aware of running flutter web apps
- we do not yet provision webdev locally for users (we rely on a manually pub globally activated version existing)

Both of the above issues will need to be resolved for flutter web support (not necessarily in this PR).