### PR TITLE
Add flag to skip the dart analyzer error check before a hot reload

### DIFF
--- a/src/io/flutter/FlutterBundle.properties
+++ b/src/io/flutter/FlutterBundle.properties
@@ -228,4 +228,4 @@ settings.open.inspector.on.launch=Open Flutter Inspector view on app launch
 settings.hot.reload.on.save=Perform hot reload on save
 settings.disable.tracking.widget.creation=Disable tracking widget creation locations
 settings.enable.bazel.test.runner=Enable new Bazel test runner
-settings.hot.reload.with.error=Perform hot reload even if there are analysis errors in the project
+settings.hot.reload.with.error=Perform hot reload even if there are analysis errors

--- a/src/io/flutter/FlutterBundle.properties
+++ b/src/io/flutter/FlutterBundle.properties
@@ -228,3 +228,4 @@ settings.open.inspector.on.launch=Open Flutter Inspector view on app launch
 settings.hot.reload.on.save=Perform hot reload on save
 settings.disable.tracking.widget.creation=Disable tracking widget creation locations
 settings.enable.bazel.test.runner=Enable new Bazel test runner
+settings.hot.reload.with.error=Perform hot reload even if there are analysis errors in the project

--- a/src/io/flutter/run/FlutterReloadManager.java
+++ b/src/io/flutter/run/FlutterReloadManager.java
@@ -190,6 +190,16 @@ public class FlutterReloadManager {
         return;
       }
 
+      // If the analysis server detects any errors in the project, it will not perform a hot reload.
+      // This can cause hot reload to stop working needlessly when, eg, there is an analysis error in a test file.
+      // The reloadWithError option in settings is a workaround.
+      if (hasErrors(app.getProject(), app.getModule(), editor.getDocument()) && !mySettings.isReloadWithError()) {
+        handlingSave.set(false);
+
+        showAnalysisNotification("Reload not performed", "Analysis issues found", true);
+
+        return;
+      }
       final Notification notification = showRunNotification(app, null, "Reloading…", false);
       final long startTime = System.currentTimeMillis();
 

--- a/src/io/flutter/run/FlutterReloadManager.java
+++ b/src/io/flutter/run/FlutterReloadManager.java
@@ -193,6 +193,7 @@ public class FlutterReloadManager {
       // If the analysis server detects any errors in the project, it will not perform a hot reload.
       // This can cause hot reload to stop working needlessly when, eg, there is an analysis error in a test file.
       // The reloadWithError option in settings is a workaround.
+      // See https://github.com/flutter/flutter/issues/27618 for the high-level goal.
       if (hasErrors(app.getProject(), app.getModule(), editor.getDocument()) && !mySettings.isReloadWithError()) {
         handlingSave.set(false);
 

--- a/src/io/flutter/run/FlutterReloadManager.java
+++ b/src/io/flutter/run/FlutterReloadManager.java
@@ -190,14 +190,6 @@ public class FlutterReloadManager {
         return;
       }
 
-      if (hasErrors(app.getProject(), app.getModule(), editor.getDocument())) {
-        handlingSave.set(false);
-
-        showAnalysisNotification("Reload not performed", "Analysis issues found", true);
-
-        return;
-      }
-
       final Notification notification = showRunNotification(app, null, "Reloading…", false);
       final long startTime = System.currentTimeMillis();
 

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.form
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.form
@@ -209,7 +209,7 @@
             </constraints>
             <properties>
               <text resource-bundle="io/flutter/FlutterBundle" key="settings.hot.reload.with.error"/>
-              <toolTipText value="Hot reload changes into running Flutter apps even with analysis errors."/>
+              <toolTipText value="Hot reload changes into running Flutter apps even if there are analysis errors"/>
             </properties>
           </component>
         </children>

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.form
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.form
@@ -160,7 +160,7 @@
           </component>
         </children>
       </grid>
-      <grid id="919ec" layout-manager="GridLayoutManager" row-count="4" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="919ec" layout-manager="GridLayoutManager" row-count="5" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -170,7 +170,7 @@
         <children>
           <component id="356a" class="javax.swing.JCheckBox" binding="myOpenInspectorOnAppLaunchCheckBox">
             <constraints>
-              <grid row="1" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="2" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text resource-bundle="io/flutter/FlutterBundle" key="settings.open.inspector.on.launch"/>
@@ -187,7 +187,7 @@
           </component>
           <component id="6d6f0" class="javax.swing.JCheckBox" binding="myDisableTrackWidgetCreationCheckBox">
             <constraints>
-              <grid row="2" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="3" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text resource-bundle="io/flutter/FlutterBundle" key="settings.disable.tracking.widget.creation"/>
@@ -196,11 +196,20 @@
           </component>
           <component id="6d6f0" class="javax.swing.JCheckBox" binding="myLegacyTrackWidgetCreationCheckBox">
             <constraints>
-              <grid row="3" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="4" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text value="Run applications with --track-widget-creation (always enabled for Flutter v0.10.2 and later)"/>
               <toolTipText value="Allows the Flutter Inspector to track source locations where widgets are created. This setting is required for advanced Flutter Inspector functionality and performance tools."/>
+            </properties>
+          </component>
+          <component id="ff6b2" class="javax.swing.JCheckBox" binding="myHotReloadIgnoreErrorCheckBox">
+            <constraints>
+              <grid row="1" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text resource-bundle="io/flutter/FlutterBundle" key="settings.hot.reload.with.error"/>
+              <toolTipText value="Hot reload changes into running Flutter apps even with analysis errors."/>
             </properties>
           </component>
         </children>

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.java
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.java
@@ -27,7 +27,6 @@ import io.flutter.FlutterBundle;
 import io.flutter.FlutterConstants;
 import io.flutter.FlutterInitializer;
 import io.flutter.FlutterUtils;
-import io.flutter.bazel.Workspace;
 import io.flutter.settings.FlutterSettings;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
@@ -53,6 +52,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
   private JCheckBox myReportUsageInformationCheckBox;
   private JLabel myPrivacyPolicy;
   private JCheckBox myHotReloadOnSaveCheckBox;
+  private JCheckBox myHotReloadIgnoreErrorCheckBox;
   private JCheckBox myEnableVerboseLoggingCheckBox;
   private JCheckBox myOpenInspectorOnAppLaunchCheckBox;
   private JCheckBox myFormatCodeOnSaveCheckBox;
@@ -64,6 +64,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
   private JCheckBox myUseLogViewCheckBox;
   private JCheckBox mySyncAndroidLibrariesCheckBox;
   private JCheckBox myDisableMemoryProfilerCheckBox;
+
   private final @NotNull Project myProject;
 
   FlutterSettingsConfigurable(@NotNull Project project) {
@@ -147,6 +148,11 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
       return true;
     }
 
+    if (settings.isReloadWithError() != myHotReloadIgnoreErrorCheckBox.isSelected()) {
+      return true;
+    }
+
+
     if (settings.isFormatCodeOnSave() != myFormatCodeOnSaveCheckBox.isSelected()) {
       return true;
     }
@@ -209,6 +215,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
 
     final FlutterSettings settings = FlutterSettings.getInstance();
     settings.setReloadOnSave(myHotReloadOnSaveCheckBox.isSelected());
+    settings.setReloadWithError(myHotReloadIgnoreErrorCheckBox.isSelected());
     settings.setFormatCodeOnSave(myFormatCodeOnSaveCheckBox.isSelected());
     settings.setOrganizeImportsOnSaveKey(myOrganizeImportsOnSaveCheckBox.isSelected());
     settings.setShowPreviewArea(myShowPreviewAreaCheckBox.isSelected());
@@ -239,6 +246,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
 
     final FlutterSettings settings = FlutterSettings.getInstance();
     myHotReloadOnSaveCheckBox.setSelected(settings.isReloadOnSave());
+    myHotReloadIgnoreErrorCheckBox.setSelected(settings.isReloadWithError());
     myFormatCodeOnSaveCheckBox.setSelected(settings.isFormatCodeOnSave());
     myOrganizeImportsOnSaveCheckBox.setSelected(settings.isOrganizeImportsOnSaveKey());
     myShowPreviewAreaCheckBox.setSelected(settings.isShowPreviewArea());

--- a/src/io/flutter/settings/FlutterSettings.java
+++ b/src/io/flutter/settings/FlutterSettings.java
@@ -12,9 +12,7 @@ import com.intellij.openapi.util.registry.Registry;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.util.EventDispatcher;
 import io.flutter.analytics.Analytics;
-import io.flutter.bazel.Workspace;
 import io.flutter.sdk.FlutterSdk;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.EventListener;
@@ -22,6 +20,7 @@ import java.util.List;
 
 public class FlutterSettings {
   private static final String reloadOnSaveKey = "io.flutter.reloadOnSave";
+  private static final String reloadWithErrorKey = "io.flutter.reloadWithError";
   private static final String openInspectorOnAppLaunchKey = "io.flutter.openInspectorOnAppLaunch";
   private static final String verboseLoggingKey = "io.flutter.verboseLogging";
   private static final String formatCodeOnSaveKey = "io.flutter.formatCodeOnSave";
@@ -61,6 +60,9 @@ public class FlutterSettings {
 
     if (isReloadOnSave()) {
       analytics.sendEvent("settings", afterLastPeriod(reloadOnSaveKey));
+    }
+    if (isReloadWithError()) {
+      analytics.sendEvent("settings", afterLastPeriod(reloadWithErrorKey));
     }
     if (isOpenInspectorOnAppLaunch()) {
       analytics.sendEvent("settings", afterLastPeriod(openInspectorOnAppLaunchKey));
@@ -105,6 +107,10 @@ public class FlutterSettings {
     return getPropertiesComponent().getBoolean(reloadOnSaveKey, true);
   }
 
+  public boolean isReloadWithError() {
+    return getPropertiesComponent().getBoolean(reloadWithErrorKey, false);
+  }
+
   // TODO(jacobr): remove after 0.10.2 is the default.
   public boolean isLegacyTrackWidgetCreation() {
     return getPropertiesComponent().getBoolean(legacyTrackWidgetCreationKey, false);
@@ -137,6 +143,12 @@ public class FlutterSettings {
 
   public void setReloadOnSave(boolean value) {
     getPropertiesComponent().setValue(reloadOnSaveKey, value, true);
+
+    fireEvent();
+  }
+
+  public void setReloadWithError(boolean value) {
+    getPropertiesComponent().setValue(reloadWithErrorKey, value, false);
 
     fireEvent();
   }


### PR DESCRIPTION
Currently, if the analysis server detects any errors in the project, it will not perform a hot reload.
This can cause hot reload to stop working needlessly when, eg, there is an analysis error in a test file.
 
Take two on #3181.