### PR TITLE
ui refactor of the settings dialog

### DIFF
--- a/src/io/flutter/FlutterBundle.properties
+++ b/src/io/flutter/FlutterBundle.properties
@@ -217,7 +217,7 @@ shout.level.title=Shout
 
 settings.try.out.features.still.under.development=Try out features still under development (a restart may be required)
 settings.show.preview.area=Show a live preview area in Flutter Outline
-settings.experimental.flutter.logging.view=Replace the Run and Debug console output with an experimental Flutter Logging view
+settings.experimental.flutter.logging.view=Replace the Run and Debug console output with a custom Flutter Logging view
 settings.enable.android.gradle.sync=Enable code completion, navigation, etc. for Java/Kotlin (requires restart to do Gradle build)
 settings.report.google.analytics=&Report usage information to Google Analytics
 settings.enable.verbose.logging=Enable &verbose logging
@@ -228,4 +228,4 @@ settings.open.inspector.on.launch=Open Flutter Inspector view on app launch
 settings.hot.reload.on.save=Perform hot reload on save
 settings.disable.tracking.widget.creation=Disable tracking widget creation locations
 settings.enable.bazel.test.runner=Enable new Bazel test runner
-settings.hot.reload.with.error=Perform hot reload even if there are analysis errors
+settings.hot.reload.with.error=Reload even if there are analysis errors

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.form
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.form
@@ -54,7 +54,7 @@
       <grid id="e885c" layout-manager="GridLayoutManager" row-count="3" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="etched" title="General"/>
@@ -86,6 +86,51 @@
             <properties>
               <text resource-bundle="io/flutter/FlutterBundle" key="settings.enable.verbose.logging"/>
               <toolTipText value="Enables verbose logging (this can be useful for diagnostic purposes)."/>
+            </properties>
+          </component>
+        </children>
+      </grid>
+      <grid id="919ec" layout-manager="GridLayoutManager" row-count="4" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+        <margin top="0" left="0" bottom="0" right="0"/>
+        <constraints>
+          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+        <border type="etched" title="App Execution"/>
+        <children>
+          <component id="356a" class="javax.swing.JCheckBox" binding="myOpenInspectorOnAppLaunchCheckBox">
+            <constraints>
+              <grid row="2" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text resource-bundle="io/flutter/FlutterBundle" key="settings.open.inspector.on.launch"/>
+            </properties>
+          </component>
+          <component id="87b06" class="javax.swing.JCheckBox" binding="myHotReloadOnSaveCheckBox">
+            <constraints>
+              <grid row="0" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text resource-bundle="io/flutter/FlutterBundle" key="settings.hot.reload.on.save"/>
+              <toolTipText value="On save, hot reload changes into running Flutter apps."/>
+            </properties>
+          </component>
+          <component id="6d6f0" class="javax.swing.JCheckBox" binding="myDisableTrackWidgetCreationCheckBox">
+            <constraints>
+              <grid row="3" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text resource-bundle="io/flutter/FlutterBundle" key="settings.disable.tracking.widget.creation"/>
+              <toolTipText value="Disabling this setting breaks advanced Flutter Inspector functionality and performance tools. Only disable if you are noticing unexpected behavior differences between apps run in debug and release build."/>
+            </properties>
+          </component>
+          <component id="ff6b2" class="javax.swing.JCheckBox" binding="myHotReloadIgnoreErrorCheckBox">
+            <constraints>
+              <grid row="1" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="2" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text resource-bundle="io/flutter/FlutterBundle" key="settings.hot.reload.with.error"/>
+              <toolTipText value="Hot reload changes into running Flutter apps even if there are analysis errors"/>
             </properties>
           </component>
         </children>
@@ -184,51 +229,6 @@
             <properties>
               <text resource-bundle="io/flutter/FlutterBundle" key="settings.enable.android.gradle.sync"/>
               <toolTipText value="Provides advanced editing capabilities for Java and Kotlin code. Uses Gradle to find Android libraries then links them into the Flutter project."/>
-            </properties>
-          </component>
-        </children>
-      </grid>
-      <grid id="919ec" layout-manager="GridLayoutManager" row-count="5" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
-        <margin top="0" left="0" bottom="0" right="0"/>
-        <constraints>
-          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties/>
-        <border type="etched" title="App Execution"/>
-        <children>
-          <component id="356a" class="javax.swing.JCheckBox" binding="myOpenInspectorOnAppLaunchCheckBox">
-            <constraints>
-              <grid row="2" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <text resource-bundle="io/flutter/FlutterBundle" key="settings.open.inspector.on.launch"/>
-            </properties>
-          </component>
-          <component id="87b06" class="javax.swing.JCheckBox" binding="myHotReloadOnSaveCheckBox">
-            <constraints>
-              <grid row="0" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <text resource-bundle="io/flutter/FlutterBundle" key="settings.hot.reload.on.save"/>
-              <toolTipText value="On save, hot reload changes into running Flutter apps."/>
-            </properties>
-          </component>
-          <component id="6d6f0" class="javax.swing.JCheckBox" binding="myDisableTrackWidgetCreationCheckBox">
-            <constraints>
-              <grid row="3" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <text resource-bundle="io/flutter/FlutterBundle" key="settings.disable.tracking.widget.creation"/>
-              <toolTipText value="Disabling this setting breaks advanced Flutter Inspector functionality and performance tools. Only disable if you are noticing unexpected behavior differences between apps run in debug and release build."/>
-            </properties>
-          </component>
-          <component id="ff6b2" class="javax.swing.JCheckBox" binding="myHotReloadIgnoreErrorCheckBox">
-            <constraints>
-              <grid row="1" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <text resource-bundle="io/flutter/FlutterBundle" key="settings.hot.reload.with.error"/>
-              <toolTipText value="Hot reload changes into running Flutter apps even if there are analysis errors"/>
             </properties>
           </component>
         </children>

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.form
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.form
@@ -93,7 +93,7 @@
               <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
-              <text value="Use Bazel instead of Pub by default"/>
+              <text value="Assume projects use Bazel for package management (instead of Pub)"/>
               <toolTipText value="When a project contains both Bazel and Pub sources, prefer Bazel instead of Pub."/>
             </properties>
           </component>

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.java
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.java
@@ -105,8 +105,10 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
       }
     });
 
-    myFormatCodeOnSaveCheckBox
-      .addChangeListener((e) -> myOrganizeImportsOnSaveCheckBox.setEnabled(myFormatCodeOnSaveCheckBox.isSelected()));
+    myHotReloadOnSaveCheckBox.addChangeListener(
+      (e) -> myHotReloadIgnoreErrorCheckBox.setEnabled(myHotReloadOnSaveCheckBox.isSelected()));
+    myFormatCodeOnSaveCheckBox.addChangeListener(
+      (e) -> myOrganizeImportsOnSaveCheckBox.setEnabled(myFormatCodeOnSaveCheckBox.isSelected()));
 
     // These options are only enabled if build method guides are enabled as the
     // same class handles all these cases.
@@ -277,6 +279,8 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     myDisableTrackWidgetCreationCheckBox.setSelected(settings.isDisableTrackWidgetCreation());
     myEnableVerboseLoggingCheckBox.setSelected(settings.isVerboseLogging());
     mySyncAndroidLibrariesCheckBox.setSelected(settings.isSyncingAndroidLibraries());
+
+    myHotReloadIgnoreErrorCheckBox.setEnabled(myHotReloadOnSaveCheckBox.isSelected());
 
     myOrganizeImportsOnSaveCheckBox.setEnabled(myFormatCodeOnSaveCheckBox.isSelected());
 


### PR DESCRIPTION
ui refactor of the settings dialog:
- re-order the sections (now: SDK, App Execution, Editor, Experimental)
- make the 'Reload with analysis errors' pref indented under the 'reload on save pref', and have it be enabled conditionally on that pref
- tweak the names of two of the settings

@jacob314 @DaveShuckerow 

<img width="771" alt="Screen Shot 2019-04-30 at 2 20 30 PM" src="https://user-images.githubusercontent.com/1269969/56995176-d87d6700-6b55-11e9-8268-a30ffed023dd.png">
