### PR TITLE
Add an option to turn off closing labels in Dart source code when UI guides are on.

### DIFF
--- a/src/io/flutter/editor/WidgetIndentsHighlightingPassFactory.java
+++ b/src/io/flutter/editor/WidgetIndentsHighlightingPassFactory.java
@@ -26,6 +26,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
+import com.jetbrains.lang.dart.analyzer.DartClosingLabelManager;
 import io.flutter.FlutterUtils;
 import io.flutter.dart.FlutterDartAnalysisServer;
 import io.flutter.dart.FlutterOutlineListener;
@@ -61,12 +62,14 @@ public class WidgetIndentsHighlightingPassFactory implements TextEditorHighlight
   // from the FlutterSettings class.
   private boolean isShowMultipleChildrenGuides;
   private boolean isShowBuildMethodGuides;
+  private boolean isDisableDartClosingLabels;
 
   private final FlutterSettings.Listener settingsListener = () -> {
     final FlutterSettings settings = FlutterSettings.getInstance();
     // Skip if none of the settings that impact Widget Idents were changed.
     if (isShowBuildMethodGuides == settings.isShowBuildMethodGuides() &&
-        isShowMultipleChildrenGuides == settings.isShowMultipleChildrenGuides()) {
+        isShowMultipleChildrenGuides == settings.isShowMultipleChildrenGuides() &&
+        isDisableDartClosingLabels == settings.isDisableDartClosingLabels()) {
       // Change doesn't matter for us.
       return;
     }
@@ -205,6 +208,14 @@ public class WidgetIndentsHighlightingPassFactory implements TextEditorHighlight
     if (isShowBuildMethodGuides != settings.isShowBuildMethodGuides()) {
       isShowBuildMethodGuides = settings.isShowBuildMethodGuides();
       updateActiveEditors();
+      if (settings.isDisableDartClosingLabels()) {
+        DartClosingLabelManager.getInstance().setShowClosingLabels(!isShowBuildMethodGuides);
+      }
+    }
+    if (settings.isShowBuildMethodGuides() && isDisableDartClosingLabels != settings.isDisableDartClosingLabels()) {
+      isDisableDartClosingLabels = settings.isDisableDartClosingLabels();
+      DartClosingLabelManager.getInstance().setShowClosingLabels(!isDisableDartClosingLabels);
+
     }
     isShowMultipleChildrenGuides = settings.isShowMultipleChildrenGuides() && isShowBuildMethodGuides;
   }

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.form
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.form
@@ -144,7 +144,7 @@
           </component>
         </children>
       </grid>
-      <grid id="32490" layout-manager="GridLayoutManager" row-count="5" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="32490" layout-manager="GridLayoutManager" row-count="6" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -179,9 +179,17 @@
               <toolTipText value="When this option is checked lines are drawn on the scrollbar indicating where build methods are."/>
             </properties>
           </component>
+          <component id="23423483" class="javax.swing.JCheckBox" binding="myDisableDartClosingLabels">
+            <constraints>
+              <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="2" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Turn off closing labels in Dart source code when UI guides are on"/>
+            </properties>
+          </component>
           <component id="a0dd8" class="javax.swing.JCheckBox" binding="myFormatCodeOnSaveCheckBox" default-binding="true">
             <constraints>
-              <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text resource-bundle="io/flutter/FlutterBundle" key="settings.format.code.on.save"/>
@@ -190,7 +198,7 @@
           </component>
           <component id="8bd46" class="javax.swing.JCheckBox" binding="myOrganizeImportsOnSaveCheckBox" default-binding="true">
             <constraints>
-              <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="2" use-parent-layout="false"/>
+              <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="2" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text resource-bundle="io/flutter/FlutterBundle" key="settings.organize.imports.on.save"/>

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.form
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.form
@@ -184,7 +184,7 @@
               <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="2" use-parent-layout="false"/>
             </constraints>
             <properties>
-              <text value="Turn off closing labels in Dart source code when UI guides are on"/>
+              <text value="Hide closing labels in Dart source code when UI guides are on"/>
             </properties>
           </component>
           <component id="a0dd8" class="javax.swing.JCheckBox" binding="myFormatCodeOnSaveCheckBox" default-binding="true">

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.java
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.java
@@ -69,6 +69,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
   private JCheckBox myShowBuildMethodGuides;
   private JCheckBox myShowMultipleChildrenGuides;
   private JCheckBox myShowBuildMethodsOnScrollbar;
+  private JCheckBox myDisableDartClosingLabels;
 
   private final @NotNull Project myProject;
 
@@ -117,6 +118,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     myShowBuildMethodGuides.addChangeListener((e) -> {
       myShowMultipleChildrenGuides.setEnabled(myShowBuildMethodGuides.isSelected());
       myShowBuildMethodsOnScrollbar.setEnabled(myShowBuildMethodGuides.isSelected());
+      myDisableDartClosingLabels.setEnabled(myShowBuildMethodGuides.isSelected());
     });
 
     mySyncAndroidLibrariesCheckBox.setVisible(FlutterUtils.isAndroidStudio());
@@ -190,6 +192,9 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     if (settings.isShowBuildMethodsOnScrollbar() != myShowBuildMethodsOnScrollbar.isSelected()) {
       return true;
     }
+    if (settings.isDisableDartClosingLabels() != myDisableDartClosingLabels.isSelected()) {
+      return true;
+    }
 
     if (settings.useFlutterLogView() != myUseLogViewCheckBox.isSelected()) {
       return true;
@@ -246,6 +251,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     settings.setShowBuildMethodGuides(myShowBuildMethodGuides.isSelected());
     settings.setShowMultipleChildrenGuides(myShowMultipleChildrenGuides.isSelected());
     settings.setShowBuildMethodsOnScrollbar(myShowBuildMethodsOnScrollbar.isSelected());
+    settings.setDisableDartClosingLabels(myDisableDartClosingLabels.isSelected());
     settings.setUseFlutterLogView(myUseLogViewCheckBox.isSelected());
     settings.setOpenInspectorOnAppLaunch(myOpenInspectorOnAppLaunchCheckBox.isSelected());
     settings.setDisableTrackWidgetCreation(myDisableTrackWidgetCreationCheckBox.isSelected());
@@ -280,6 +286,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     myShowBuildMethodGuides.setSelected(settings.isShowBuildMethodGuides());
     myShowMultipleChildrenGuides.setSelected(settings.isShowMultipleChildrenGuides());
     myShowBuildMethodsOnScrollbar.setSelected(settings.isShowBuildMethodsOnScrollbar());
+    myDisableDartClosingLabels.setSelected(settings.isDisableDartClosingLabels());
 
     myUseLogViewCheckBox.setSelected(settings.useFlutterLogView());
     myOpenInspectorOnAppLaunchCheckBox.setSelected(settings.isOpenInspectorOnAppLaunch());
@@ -299,6 +306,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     // same class handles all these cases.
     myShowMultipleChildrenGuides.setEnabled(myShowBuildMethodGuides.isSelected());
     myShowBuildMethodsOnScrollbar.setEnabled(myShowBuildMethodGuides.isSelected());
+    myDisableDartClosingLabels.setEnabled(myShowBuildMethodGuides.isSelected());
   }
 
   private void onVersionChanged() {

--- a/src/io/flutter/settings/FlutterSettings.java
+++ b/src/io/flutter/settings/FlutterSettings.java
@@ -38,6 +38,7 @@ public class FlutterSettings {
   private static final String showBuildMethodGuidesKey = "io.flutter.editor.showBuildMethodGuides";
   private static final String showMultipleChildrenGuidesKey = "io.flutter.editor.showMultipleChildrenGuides";
   private static final String showBuildMethodsOnScrollbarKey = "io.flutter.editor.showBuildMethodsOnScrollbarKey";
+  private static final String disableDartClosingLabelsKey = "io.flutter.editor.disableDartClosingLabelsKey";
 
   public static FlutterSettings getInstance() {
     return ServiceManager.getService(FlutterSettings.class);
@@ -100,6 +101,10 @@ public class FlutterSettings {
     }
     if (isShowBuildMethodsOnScrollbar()) {
       analytics.sendEvent("settings", afterLastPeriod(showBuildMethodsOnScrollbarKey));
+    }
+    if (!isDisableDartClosingLabels()) {
+      // The default value is true so only send the event if the setting was turned off.
+      analytics.sendEvent("settings", afterLastPeriod(disableDartClosingLabelsKey + "_off"));
     }
 
     if (useFlutterLogView()) {
@@ -269,6 +274,17 @@ public class FlutterSettings {
 
     fireEvent();
   }
+
+  public boolean isDisableDartClosingLabels() {
+    return getPropertiesComponent().getBoolean(disableDartClosingLabelsKey, true);
+  }
+
+  public void setDisableDartClosingLabels(boolean value) {
+    getPropertiesComponent().setValue(disableDartClosingLabelsKey, value, true);
+
+    fireEvent();
+  }
+
 
   public boolean isShowMultipleChildrenGuides() {
     return getPropertiesComponent().getBoolean(showMultipleChildrenGuidesKey, false);


### PR DESCRIPTION
The option is enabled by default as UI Guides serve a lot of the same purpose as the closing tags.

We have analytics for when users turn the closing labels back on so we will be able to see how many users actually want both options at the same time. With very large build methods it could definitely make sense to want both options.

Settings dialog with one additional option:
When "Turn off closing labels in Dart source code when UI guides are on" is checked, checking the "UI Guides" checkbox toggles the closing labels checkbox in the separate settings panel. When the box is unchecked, checking the UI Guides checkbox has no impact.
<img width="581" alt="Screen Shot 2019-04-30 at 6 32 07 PM" src="https://user-images.githubusercontent.com/1226812/57002719-4cc80280-6b76-11e9-9b67-a893514d18e8.png">
