### PR TITLE
remove a no longer used 'PROJECTSYSTEM' case switch

### DIFF
--- a/tool/plugin/lib/plugin.dart
+++ b/tool/plugin/lib/plugin.dart
@@ -287,12 +287,6 @@ String substituteTemplateVariables(String line, BuildSpec spec) {
         return spec.isSynthetic
             ? 'com.intellij.modules.androidstudio'
             : 'com.android.tools.apk';
-      case 'PROJECTSYSTEM':
-        // Temporary work-around for 3.0 vs 3.1 AS incompatibility.
-        // TODO(messick) Delete this when we are SURE we do not need to build version < 3.1
-        return spec.version == '3.1'
-            ? '<projectsystem implementation="io.flutter.project.FlutterProjectSystemProvider"/>'
-            : '';
       default:
         throw 'unknown template variable: $name';
     }
@@ -1106,7 +1100,7 @@ class TestCommand extends ProductCommand {
     for (var spec in specs) {
       await spec.artifacts.provision();
 
-      //TODO(messick) Finish the implementation of TestCommand.
+      // TODO(messick) Finish the implementation of TestCommand.
       separator('Compiling test sources');
 
       var jars = []


### PR DESCRIPTION
- remove a no longer used 'PROJECTSYSTEM' case switch

@stevemessick; it looks like this is no longer necessary (and I verified that we can build the releases after this change)