### PR TITLE
Defensively ensure all offsets are within the document length before calling getLineNumber.

### DIFF
--- a/src/io/flutter/editor/WidgetIndentsHighlightingPass.java
+++ b/src/io/flutter/editor/WidgetIndentsHighlightingPass.java
@@ -182,9 +182,10 @@ public class WidgetIndentsHighlightingPass {
 
       final int startOffset = highlighter.getStartOffset();
       final Document doc = highlighter.getDocument();
-      if (startOffset >= doc.getTextLength()) return;
+      final int textLength = doc.getTextLength();
+      if (startOffset >= textLength) return;
 
-      final int endOffset = highlighter.getEndOffset();
+      final int endOffset = min(highlighter.getEndOffset(), textLength);
 
       int off;
       int startLine = doc.getLineNumber(startOffset);
@@ -667,7 +668,7 @@ public class WidgetIndentsHighlightingPass {
   private OutlineLocation computeLocation(FlutterOutline node) {
     final int nodeOffset = getAnalysisService().getConvertedOffset(myFile, node.getOffset());
     assert (myDocument != null);
-    final int line = myDocument.getLineNumber(nodeOffset);
+    final int line = myDocument.getLineNumber(min(nodeOffset, myDocument.getTextLength()));
     final int lineStartOffset = myDocument.getLineStartOffset(line);
 
     final int column = nodeOffset - lineStartOffset;


### PR DESCRIPTION
There was one legitimate case where the regular indent guides could be a bit stale when we accessed them and a couple other cases where we are calling this just to be safe and avoid any other edge case bugs like.
https://github.com/flutter/flutter-intellij/issues/3443