### PR TITLE
Fix errors in AS 3.5 beta 1

### DIFF
--- a/flutter-studio/src/io/flutter/actions/FlutterNewProjectAction.java
+++ b/flutter-studio/src/io/flutter/actions/FlutterNewProjectAction.java
@@ -9,14 +9,22 @@ package io.flutter.actions;
 import com.android.tools.idea.ui.wizard.StudioWizardDialogBuilder;
 import com.android.tools.idea.wizard.model.ModelWizard;
 import com.android.tools.idea.wizard.model.ModelWizardDialog;
+import com.intellij.icons.AllIcons;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.DumbAware;
+import com.intellij.openapi.wm.impl.welcomeScreen.NewWelcomeScreen;
+import com.intellij.ui.LayeredIcon;
+import com.intellij.ui.OffsetIcon;
+import com.intellij.ui.SizedIcon;
+import icons.FlutterIcons;
 import io.flutter.module.FlutterProjectType;
 import io.flutter.project.ChoseProjectTypeStep;
 import io.flutter.project.FlutterProjectModel;
 import java.util.NoSuchElementException;
+import javax.swing.Icon;
+import javax.swing.SwingConstants;
 import org.jetbrains.annotations.NotNull;
 
 public class FlutterNewProjectAction extends AnAction implements DumbAware {
@@ -32,7 +40,10 @@ public class FlutterNewProjectAction extends AnAction implements DumbAware {
 
   @Override
   public void update(@NotNull AnActionEvent e) {
-    // This can be used to change the icon on the welcome screen, if needed.
+    if (NewWelcomeScreen.isNewWelcomeScreen(e)) {
+      e.getPresentation().setIcon(getFlutterDecoratedIcon());
+      e.getPresentation().setText("Start a new Flutter project");
+    }
   }
 
   @Override
@@ -50,5 +61,15 @@ public class FlutterNewProjectAction extends AnAction implements DumbAware {
     catch (NoSuchElementException ex) {
       // This happens if no Flutter SDK is installed and the user cancels the FlutterProjectStep.
     }
+  }
+
+  Icon getFlutterDecoratedIcon() {
+    Icon icon = AllIcons.Welcome.CreateNewProject;
+    Icon badgeIcon = new OffsetIcon(0, FlutterIcons.Flutter_badge).scale(0.666f);
+
+    LayeredIcon decorated = new LayeredIcon(2);
+    decorated.setIcon(badgeIcon, 0, 7, 7);
+    decorated.setIcon(icon, 1, 0, 0);
+    return decorated;
   }
 }

--- a/flutter-studio/src/io/flutter/android/AndroidModuleLibraryManager.java
+++ b/flutter-studio/src/io/flutter/android/AndroidModuleLibraryManager.java
@@ -210,7 +210,7 @@ public class AndroidModuleLibraryManager extends AbstractLibraryManager<AndroidM
       @SuppressWarnings("override")
       public void syncTaskCreated(@NotNull Project project, @NotNull GradleSyncInvoker.Request request) {}
 
-      @Override
+      // TODO(messick) Remove when 3.6 is stable.
       public void syncStarted(@NotNull Project project, boolean skipped, boolean sourceGenerationRequested) {}
 
       @Override

--- a/flutter-studio/src/io/flutter/project/FlutterSettingsStep.form
+++ b/flutter-studio/src/io/flutter/project/FlutterSettingsStep.form
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="io.flutter.project.FlutterSettingsStep">
-  <grid id="27dc6" binding="myPanel" layout-manager="GridLayoutManager" row-count="14" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
-    <margin top="0" left="5" bottom="0" right="5"/>
+  <grid id="27dc6" binding="myRootPanel" layout-manager="GridLayoutManager" row-count="14" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+    <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="500" height="452"/>
     </constraints>
     <properties/>
     <border type="none"/>
     <children>
-      <component id="a0d4c" class="javax.swing.JLabel">
+      <component id="29b06" class="com.intellij.ui.components.JBLabel">
         <constraints>
           <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
@@ -33,7 +33,7 @@
           <text value="Platform channel language"/>
         </properties>
       </component>
-      <component id="a3bbd" class="javax.swing.JLabel">
+      <component id="ab6e5" class="com.intellij.ui.components.JBLabel">
         <constraints>
           <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
@@ -88,7 +88,7 @@
           <toolTipText value="Objective-C support will be included"/>
         </properties>
       </component>
-      <component id="92255" class="javax.swing.JLabel">
+      <component id="f7960" class="com.intellij.ui.components.JBLabel">
         <constraints>
           <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
@@ -104,7 +104,7 @@
           </grid>
         </constraints>
       </vspacer>
-      <component id="9cfa6" class="javax.swing.JLabel">
+      <component id="dedae" class="com.intellij.ui.components.JBLabel">
         <constraints>
           <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>

--- a/resources/META-INF/studio-contribs.xml
+++ b/resources/META-INF/studio-contribs.xml
@@ -28,11 +28,10 @@
     <action id="flutter.NewProject" class="io.flutter.actions.FlutterNewProjectAction"
             text="New Flutter Project..."
             description="Create a new Flutter project">
-      <add-to-group group-id="NewProjectOrModuleGroup" anchor="after" relative-to-action="NewProject"/>
+      <add-to-group group-id="JavaNewProjectOrModuleGroup" anchor="after" relative-to-action="NewProject"/>
     </action>
 
-    <!-- The icon isn't being used here, but the same syntax works for menu items -->
-    <!-- We can't change it in a StartupActivity because those don't run until a project is opened -->
+    <!-- The icon isn't being used here, but it is set by the action -->
     <action id="flutter.NewProject.welcome" class="io.flutter.actions.FlutterNewProjectAction"
             text="Start a new Flutter project"
             icon="FlutterIcons.Flutter"

--- a/resources/META-INF/studio-contribs_template.xml
+++ b/resources/META-INF/studio-contribs_template.xml
@@ -26,11 +26,10 @@
     <action id="flutter.NewProject" class="io.flutter.actions.FlutterNewProjectAction"
             text="New Flutter Project..."
             description="Create a new Flutter project">
-      <add-to-group group-id="NewProjectOrModuleGroup" anchor="after" relative-to-action="NewProject"/>
+      <add-to-group group-id="JavaNewProjectOrModuleGroup" anchor="after" relative-to-action="NewProject"/>
     </action>
 
-    <!-- The icon isn't being used here, but the same syntax works for menu items -->
-    <!-- We can't change it in a StartupActivity because those don't run until a project is opened -->
+    <!-- The icon isn't being used here, but it is set by the action -->
     <action id="flutter.NewProject.welcome" class="io.flutter.actions.FlutterNewProjectAction"
             text="Start a new Flutter project"
             icon="FlutterIcons.Flutter"


### PR DESCRIPTION
This fixes a number of problems that surfaced with Android Studio 3.5 beta 1.

1. The third page of the new project wizard is visible now.
2. The File menu has _New Flutter Project_ next to _New Project_ again.
3. The Welcome screen has the proper label for creating Flutter projects.
4. The Welcome screen has a spiffy new icon for Flutter.
5. The plugin tool allows resource files to be editing during the build (for # 2).

Here's the new icon, in context:
<img width="322" alt="Screen Shot 2019-05-10 at 3 40 13 PM" src="https://user-images.githubusercontent.com/8518285/57560185-02930e00-733a-11e9-99f3-25b7cd96d7f9.png">

Fixes #3473 

@pq @devoncarew 