### PR TITLE
working on 'Memory leak detected' warnings

### DIFF
--- a/src/io/flutter/utils/AsyncRateLimiter.java
+++ b/src/io/flutter/utils/AsyncRateLimiter.java
@@ -28,7 +28,9 @@ public class AsyncRateLimiter implements Disposable {
   private final RateLimiter rateLimiter;
   private final Alarm requestScheduler;
   private final Computable<CompletableFuture<?>> callback;
+
   private CompletableFuture<?> pendingRequest;
+
   /**
    * A request has been scheduled to run but is not yet pending.
    */
@@ -36,6 +38,7 @@ public class AsyncRateLimiter implements Disposable {
 
   public AsyncRateLimiter(double framesPerSecond, Computable<CompletableFuture<?>> callback) {
     this.callback = callback;
+
     rateLimiter = RateLimiter.create(framesPerSecond);
     requestScheduler = new Alarm(Alarm.ThreadToUse.POOLED_THREAD, this);
   }
@@ -93,5 +96,6 @@ public class AsyncRateLimiter implements Disposable {
 
   @Override
   public void dispose() {
+    requestScheduler.dispose();
   }
 }

--- a/src/io/flutter/view/InspectorPanel.java
+++ b/src/io/flutter/view/InspectorPanel.java
@@ -1182,11 +1182,10 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
   @Override
   public void dispose() {
     flutterIsolateSubscription.dispose();
+    refreshRateLimiter.dispose();
     // TODO(jacobr): actually implement.
     final InspectorService service = getInspectorService();
-    if (service != null) {
-      shutdownTree(false);
-    }
+    shutdownTree(false);
     // TODO(jacobr): verify subpanels are disposed as well.
   }
 
@@ -1197,7 +1196,7 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
     // TODO(jacobr): remove the following code once the
     // `setPubRootDirectories` method has been in two revs of the Flutter Alpha
     // channel. The feature is expected to have landed in the Flutter dev
-    // chanel on March 2, 2018.
+    // channel on March 2, 2018.
     final InspectorSourceLocation location = node.getCreationLocation();
     if (location == null) {
       return false;


### PR DESCRIPTION
- working on 'Memory leak detected' warnings

This is some code to investigate memory leak warnings in the IntelliJ log (note that this PR doesn't seem to fix any warnings). The warnings are:

```
2019-05-11 21:02:34,013 [ 557230]  ERROR - api.util.objectTree.ObjectTree - Memory leak detected: 'io.flutter.utils.AsyncRateLimiter@638202c' of class io.flutter.utils.AsyncRateLimiter
See the cause for the corresponding Disposer.register() stacktrace:
 
java.lang.RuntimeException: Memory leak detected: 'io.flutter.utils.AsyncRateLimiter@638202c' of class io.flutter.utils.AsyncRateLimiter
See the cause for the corresponding Disposer.register() stacktrace:

	at com.intellij.openapi.util.objectTree.ObjectTree.assertIsEmpty(ObjectTree.java:256)
	at com.intellij.openapi.util.Disposer.assertIsEmpty(Disposer.java:142)
	at com.intellij.openapi.util.Disposer.assertIsEmpty(Disposer.java:138)
	at com.intellij.openapi.application.impl.ApplicationImpl.disposeSelf(ApplicationImpl.java:251)
	at com.intellij.openapi.application.impl.ApplicationImpl.doExit(ApplicationImpl.java:815)
	at com.intellij.openapi.application.impl.ApplicationImpl.exit(ApplicationImpl.java:790)
	at com.intellij.openapi.application.impl.ApplicationImpl.exit(ApplicationImpl.java:779)
	at com.intellij.openapi.application.impl.ApplicationImpl.exit(ApplicationImpl.java:775)
	at com.intellij.openapi.application.impl.ApplicationImpl.exit(ApplicationImpl.java:742)
	at com.intellij.openapi.application.impl.ApplicationImpl.exit(ApplicationImpl.java:737)
	at com.intellij.ide.MacOSApplicationProvider$Worker.lambda$null$3(MacOSApplicationProvider.java:107)
	at com.intellij.ide.MacOSApplicationProvider$Worker.lambda$submit$7(MacOSApplicationProvider.java:177)
	at com.intellij.openapi.application.TransactionGuardImpl.runSyncTransaction(TransactionGuardImpl.java:88)
	at com.intellij.openapi.application.TransactionGuardImpl.lambda$pollQueueLater$0(TransactionGuardImpl.java:74)
	at com.intellij.openapi.application.impl.LaterInvocator$FlushQueue.doRun$$$capture(LaterInvocator.java:435)
	at com.intellij.openapi.application.impl.LaterInvocator$FlushQueue.doRun(LaterInvocator.java)
	at com.intellij.openapi.application.impl.LaterInvocator$FlushQueue.runNextEvent(LaterInvocator.java:419)
	at com.intellij.openapi.application.impl.LaterInvocator$FlushQueue.run(LaterInvocator.java:403)
	at java.awt.event.InvocationEvent.dispatch$$$capture(InvocationEvent.java:311)
	at java.awt.event.InvocationEvent.dispatch(InvocationEvent.java)
	at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:764)
	at java.awt.EventQueue.access$500(EventQueue.java:98)
	at java.awt.EventQueue$3.run(EventQueue.java:715)
	at java.awt.EventQueue$3.run(EventQueue.java:709)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:74)
	at java.awt.EventQueue.dispatchEvent(EventQueue.java:734)
	at com.intellij.ide.IdeEventQueue.defaultDispatchEvent(IdeEventQueue.java:729)
	at com.intellij.ide.IdeEventQueue._dispatchEvent(IdeEventQueue.java:678)
	at com.intellij.ide.IdeEventQueue.dispatchEvent(IdeEventQueue.java:373)
	at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:205)
	at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:116)
	at java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:105)
	at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
	at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:93)
	at java.awt.EventDispatchThread.run(EventDispatchThread.java:82)
Caused by: java.lang.Throwable
	at com.intellij.openapi.util.objectTree.ObjectNode.<init>(ObjectNode.java:54)
	at com.intellij.openapi.util.objectTree.ObjectTree.createNodeFor(ObjectTree.java:128)
	at com.intellij.openapi.util.objectTree.ObjectTree.register(ObjectTree.java:90)
	at com.intellij.openapi.util.Disposer.register(Disposer.java:97)
	at com.intellij.openapi.util.Disposer.register(Disposer.java:93)
	at com.intellij.util.Alarm.<init>(Alarm.java:137)
	at io.flutter.utils.AsyncRateLimiter.<init>(AsyncRateLimiter.java:43)
	at io.flutter.view.InspectorPanel.<init>(InspectorPanel.java:177)
	at io.flutter.view.InspectorPanel.<init>(InspectorPanel.java:147)
	at io.flutter.view.FlutterView.addInspectorPanel(FlutterView.java:333)
	at io.flutter.view.FlutterView.addInspectorViewContent(FlutterView.java:272)
	at io.flutter.view.FlutterView.debugActiveHelper(FlutterView.java:439)
	at io.flutter.view.FlutterView.lambda$debugActive$4(FlutterView.java:404)
	at io.flutter.utils.AsyncUtils.lambda$null$0(AsyncUtils.java:35)
	at com.intellij.openapi.application.TransactionGuardImpl$2.run(TransactionGuardImpl.java:315)
	... 22 more
```

```
2019-05-11 21:02:34,017 [ 557234]  ERROR - api.util.objectTree.ObjectTree - Memory leak detected: 'io.flutter.view.BoolServiceExtensionCheckbox@51e9b360' of class io.flutter.view.BoolServiceExtensionCheckbox
See the cause for the corresponding Disposer.register() stacktrace:
 
java.lang.RuntimeException: Memory leak detected: 'io.flutter.view.BoolServiceExtensionCheckbox@51e9b360' of class io.flutter.view.BoolServiceExtensionCheckbox
See the cause for the corresponding Disposer.register() stacktrace:

	at com.intellij.openapi.util.objectTree.ObjectTree.assertIsEmpty(ObjectTree.java:256)
	at com.intellij.openapi.util.Disposer.assertIsEmpty(Disposer.java:142)
	at com.intellij.openapi.util.Disposer.assertIsEmpty(Disposer.java:138)
	at com.intellij.openapi.application.impl.ApplicationImpl.disposeSelf(ApplicationImpl.java:251)
	at com.intellij.openapi.application.impl.ApplicationImpl.doExit(ApplicationImpl.java:815)
	at com.intellij.openapi.application.impl.ApplicationImpl.exit(ApplicationImpl.java:790)
	at com.intellij.openapi.application.impl.ApplicationImpl.exit(ApplicationImpl.java:779)
	at com.intellij.openapi.application.impl.ApplicationImpl.exit(ApplicationImpl.java:775)
	at com.intellij.openapi.application.impl.ApplicationImpl.exit(ApplicationImpl.java:742)
	at com.intellij.openapi.application.impl.ApplicationImpl.exit(ApplicationImpl.java:737)
	at com.intellij.ide.MacOSApplicationProvider$Worker.lambda$null$3(MacOSApplicationProvider.java:107)
	at com.intellij.ide.MacOSApplicationProvider$Worker.lambda$submit$7(MacOSApplicationProvider.java:177)
	at com.intellij.openapi.application.TransactionGuardImpl.runSyncTransaction(TransactionGuardImpl.java:88)
	at com.intellij.openapi.application.TransactionGuardImpl.lambda$pollQueueLater$0(TransactionGuardImpl.java:74)
	at com.intellij.openapi.application.impl.LaterInvocator$FlushQueue.doRun$$$capture(LaterInvocator.java:435)
	at com.intellij.openapi.application.impl.LaterInvocator$FlushQueue.doRun(LaterInvocator.java)
	at com.intellij.openapi.application.impl.LaterInvocator$FlushQueue.runNextEvent(LaterInvocator.java:419)
	at com.intellij.openapi.application.impl.LaterInvocator$FlushQueue.run(LaterInvocator.java:403)
	at java.awt.event.InvocationEvent.dispatch$$$capture(InvocationEvent.java:311)
	at java.awt.event.InvocationEvent.dispatch(InvocationEvent.java)
	at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:764)
	at java.awt.EventQueue.access$500(EventQueue.java:98)
	at java.awt.EventQueue$3.run(EventQueue.java:715)
	at java.awt.EventQueue$3.run(EventQueue.java:709)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:74)
	at java.awt.EventQueue.dispatchEvent(EventQueue.java:734)
	at com.intellij.ide.IdeEventQueue.defaultDispatchEvent(IdeEventQueue.java:729)
	at com.intellij.ide.IdeEventQueue._dispatchEvent(IdeEventQueue.java:678)
	at com.intellij.ide.IdeEventQueue.dispatchEvent(IdeEventQueue.java:373)
	at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:205)
	at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:116)
	at java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:105)
	at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
	at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:93)
	at java.awt.EventDispatchThread.run(EventDispatchThread.java:82)
Caused by: java.lang.Throwable
	at com.intellij.openapi.util.objectTree.ObjectNode.<init>(ObjectNode.java:54)
	at com.intellij.openapi.util.objectTree.ObjectTree.createNodeFor(ObjectTree.java:128)
	at com.intellij.openapi.util.objectTree.ObjectTree.register(ObjectTree.java:90)
	at com.intellij.openapi.util.Disposer.register(Disposer.java:97)
	at com.intellij.openapi.util.Disposer.register(Disposer.java:93)
	at io.flutter.server.vmService.VMServiceManager.hasServiceExtension(VMServiceManager.java:504)
	at io.flutter.run.daemon.FlutterApp.hasServiceExtension(FlutterApp.java:506)
	at io.flutter.view.BoolServiceExtensionCheckbox.<init>(BoolServiceExtensionCheckbox.java:37)
	at io.flutter.view.PerfFPSTab.<init>(PerfFPSTab.java:48)
	at io.flutter.view.FlutterPerfView.addFPSTab(FlutterPerfView.java:258)
	at io.flutter.view.FlutterPerfView.addPerformanceViewContent(FlutterPerfView.java:217)
	at io.flutter.view.FlutterPerfView.debugActive(FlutterPerfView.java:108)
	at io.flutter.view.FlutterPerfViewFactory.lambda$initPerfView$1(FlutterPerfViewFactory.java:32)
	at com.intellij.openapi.application.TransactionGuardImpl$2.run(TransactionGuardImpl.java:315)
	... 22 more
```

```
2019-05-11 21:02:34,018 [ 557235]  ERROR - api.util.objectTree.ObjectTree - Memory leak detected: 'io.flutter.inspector.EvalOnDartLibrary@2dd0b47e' of class io.flutter.inspector.EvalOnDartLibrary
See the cause for the corresponding Disposer.register() stacktrace:
 
java.lang.RuntimeException: Memory leak detected: 'io.flutter.inspector.EvalOnDartLibrary@2dd0b47e' of class io.flutter.inspector.EvalOnDartLibrary
See the cause for the corresponding Disposer.register() stacktrace:

	at com.intellij.openapi.util.objectTree.ObjectTree.assertIsEmpty(ObjectTree.java:256)
	at com.intellij.openapi.util.Disposer.assertIsEmpty(Disposer.java:142)
	at com.intellij.openapi.util.Disposer.assertIsEmpty(Disposer.java:138)
	at com.intellij.openapi.application.impl.ApplicationImpl.disposeSelf(ApplicationImpl.java:251)
	at com.intellij.openapi.application.impl.ApplicationImpl.doExit(ApplicationImpl.java:815)
	at com.intellij.openapi.application.impl.ApplicationImpl.exit(ApplicationImpl.java:790)
	at com.intellij.openapi.application.impl.ApplicationImpl.exit(ApplicationImpl.java:779)
	at com.intellij.openapi.application.impl.ApplicationImpl.exit(ApplicationImpl.java:775)
	at com.intellij.openapi.application.impl.ApplicationImpl.exit(ApplicationImpl.java:742)
	at com.intellij.openapi.application.impl.ApplicationImpl.exit(ApplicationImpl.java:737)
	at com.intellij.ide.MacOSApplicationProvider$Worker.lambda$null$3(MacOSApplicationProvider.java:107)
	at com.intellij.ide.MacOSApplicationProvider$Worker.lambda$submit$7(MacOSApplicationProvider.java:177)
	at com.intellij.openapi.application.TransactionGuardImpl.runSyncTransaction(TransactionGuardImpl.java:88)
	at com.intellij.openapi.application.TransactionGuardImpl.lambda$pollQueueLater$0(TransactionGuardImpl.java:74)
	at com.intellij.openapi.application.impl.LaterInvocator$FlushQueue.doRun$$$capture(LaterInvocator.java:435)
	at com.intellij.openapi.application.impl.LaterInvocator$FlushQueue.doRun(LaterInvocator.java)
	at com.intellij.openapi.application.impl.LaterInvocator$FlushQueue.runNextEvent(LaterInvocator.java:419)
	at com.intellij.openapi.application.impl.LaterInvocator$FlushQueue.run(LaterInvocator.java:403)
	at java.awt.event.InvocationEvent.dispatch$$$capture(InvocationEvent.java:311)
	at java.awt.event.InvocationEvent.dispatch(InvocationEvent.java)
	at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:764)
	at java.awt.EventQueue.access$500(EventQueue.java:98)
	at java.awt.EventQueue$3.run(EventQueue.java:715)
	at java.awt.EventQueue$3.run(EventQueue.java:709)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:74)
	at java.awt.EventQueue.dispatchEvent(EventQueue.java:734)
	at com.intellij.ide.IdeEventQueue.defaultDispatchEvent(IdeEventQueue.java:729)
	at com.intellij.ide.IdeEventQueue._dispatchEvent(IdeEventQueue.java:678)
	at com.intellij.ide.IdeEventQueue.dispatchEvent(IdeEventQueue.java:373)
	at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:205)
	at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:116)
	at java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:105)
	at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
	at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:93)
	at java.awt.EventDispatchThread.run(EventDispatchThread.java:82)
Caused by: java.lang.Throwable
	at com.intellij.openapi.util.objectTree.ObjectNode.<init>(ObjectNode.java:54)
	at com.intellij.openapi.util.objectTree.ObjectTree.createNodeFor(ObjectTree.java:128)
	at com.intellij.openapi.util.objectTree.ObjectTree.register(ObjectTree.java:90)
	at com.intellij.openapi.util.Disposer.register(Disposer.java:97)
	at com.intellij.openapi.util.Disposer.register(Disposer.java:93)
	at com.intellij.util.Alarm.<init>(Alarm.java:137)
	at io.flutter.inspector.EvalOnDartLibrary.<init>(EvalOnDartLibrary.java:108)
	at io.flutter.inspector.InspectorService.create(InspectorService.java:68)
	at io.flutter.view.FlutterView.debugActive(FlutterView.java:397)
	at io.flutter.view.FlutterViewFactory.lambda$initFlutterView$1(FlutterViewFactory.java:32)
	at com.intellij.openapi.application.TransactionGuardImpl$2.run(TransactionGuardImpl.java:315)
	... 22 more
```
