### PR TITLE
limit the amount of time we wait for a graceful app shutdown

### DIFF
--- a/src/io/flutter/run/daemon/FlutterApp.java
+++ b/src/io/flutter/run/daemon/FlutterApp.java
@@ -734,7 +734,10 @@ class FlutterAppDaemonEventListener implements DaemonEvent.Listener {
     // Shutdown must be sync so that we prevent the processTerminated() event from being delivered
     // until a graceful shutdown has been tried.
     try {
-      app.shutdownAsync().get();
+      app.shutdownAsync().get(100, TimeUnit.MILLISECONDS);
+    }
+    catch (TimeoutException e) {
+      LOG.info("app shutdown took longer than 100ms");
     }
     catch (Exception e) {
       FlutterUtils.warn(LOG, "exception while shutting down Flutter App", e);


### PR DESCRIPTION
- limit the amount of time we wait for a graceful app shutdown
- fix https://github.com/flutter/flutter-intellij/issues/3319

Only block on the UI thread for a brief period when asking for a graceful shutdown when terminating flutter app runs.