### PR TITLE
Enable devtools launching from Bazel

### DIFF
--- a/src/io/flutter/bazel/PluginConfig.java
+++ b/src/io/flutter/bazel/PluginConfig.java
@@ -15,6 +15,7 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.util.Computable;
 import com.intellij.openapi.vfs.VirtualFile;
 import io.flutter.FlutterUtils;
+import org.dartlang.vm.service.element.Obj;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -52,6 +53,16 @@ public class PluginConfig {
   @Nullable
   String getTestScript() {
     return fields.testScript;
+  }
+
+  @Nullable
+  String getSdkHome() {
+    return fields.sdkHome;
+  }
+
+  @Nullable
+  String getVersionFile() {
+    return fields.versionFile;
   }
 
   @Override
@@ -93,7 +104,8 @@ public class PluginConfig {
         return null;
       }
       catch (PatternSyntaxException e) {
-        FlutterUtils.warn(LOG, "Flutter plugin failed to parse directory pattern (" + e.getPattern() + ") in config file at " + file.getPath());
+        FlutterUtils
+          .warn(LOG, "Flutter plugin failed to parse directory pattern (" + e.getPattern() + ") in config file at " + file.getPath());
         return null;
       }
     };
@@ -106,13 +118,17 @@ public class PluginConfig {
     @Nullable String daemonScript,
     @Nullable String doctorScript,
     @Nullable String launchScript,
-    @Nullable String testScript
+    @Nullable String testScript,
+    @Nullable String sdkHome,
+    @Nullable String versionFile
   ) {
     final Fields fields = new Fields(
       daemonScript,
       doctorScript,
       launchScript,
-      testScript
+      testScript,
+      sdkHome,
+      versionFile
     );
     return new PluginConfig(fields);
   }
@@ -146,17 +162,31 @@ public class PluginConfig {
     @SerializedName("testScript")
     private String testScript;
 
+    /**
+     * The directory containing the SDK tools.
+     */
+    @SerializedName("sdkHome")
+    private String sdkHome;
+
+    /**
+     * The file containing the Flutter version.
+     */
+    @SerializedName("versionFile")
+    private String versionFile;
+
     Fields() {
     }
 
     /**
      * Convenience constructor that takes all
      */
-    Fields(String daemonScript, String doctorScript, String launchScript, String testScript) {
+    Fields(String daemonScript, String doctorScript, String launchScript, String testScript, String sdkHome, String versionFile) {
       this.daemonScript = daemonScript;
       this.doctorScript = doctorScript;
       this.launchScript = launchScript;
       this.testScript = testScript;
+      this.sdkHome = sdkHome;
+      this.versionFile = versionFile;
     }
 
     @Override
@@ -166,12 +196,14 @@ public class PluginConfig {
       return Objects.equal(daemonScript, other.daemonScript)
              && Objects.equal(doctorScript, other.doctorScript)
              && Objects.equal(launchScript, other.launchScript)
-             && Objects.equal(testScript, other.testScript);
+             && Objects.equal(testScript, other.testScript)
+             && Objects.equal(sdkHome, other.sdkHome)
+             && Objects.equal(versionFile, other.versionFile);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hashCode(daemonScript, doctorScript, launchScript, testScript);
+      return Objects.hashCode(daemonScript, doctorScript, launchScript, testScript, sdkHome, versionFile);
     }
   }
 

--- a/src/io/flutter/bazel/Workspace.java
+++ b/src/io/flutter/bazel/Workspace.java
@@ -37,7 +37,7 @@ public class Workspace {
   @Nullable private final String daemonScript;
   @Nullable private final String doctorScript;
   @Nullable private final String testScript;
-  @Nullable private final String sdkHomePath;
+  @Nullable private final String sdkHome;
   @Nullable private final String versionFile;
 
   private Workspace(@NotNull VirtualFile root,
@@ -45,14 +45,14 @@ public class Workspace {
                     @Nullable String daemonScript,
                     @Nullable String doctorScript,
                     @Nullable String testScript,
-                    @Nullable String sdkHomePath,
+                    @Nullable String sdkHome,
                     @Nullable String versionFile) {
     this.root = root;
     this.config = config;
     this.daemonScript = daemonScript;
     this.doctorScript = doctorScript;
     this.testScript = testScript;
-    this.sdkHomePath = sdkHomePath;
+    this.sdkHome = sdkHome;
     this.versionFile = versionFile;
   }
 
@@ -141,8 +141,8 @@ public class Workspace {
    * Returns the directory that contains the flutter SDK commands, or null if not configured.
    */
   @Nullable
-  public String getSdkHomePath() {
-    return sdkHomePath;
+  public String getSdkHome() {
+    return sdkHome;
   }
 
   /**
@@ -211,11 +211,11 @@ public class Workspace {
 
     final String testScript = config == null ? null : getScriptFromPath(root, readonlyPath, config.getTestScript());
 
-    final String sdkHomePath = config == null ? null : getScriptFromPath(root, readonlyPath, config.getSdkHome());
+    final String sdkHome = config == null ? null : getScriptFromPath(root, readonlyPath, config.getSdkHome());
 
     final String versionFile = config == null ? null : getScriptFromPath(root, readonlyPath, config.getVersionFile());
 
-    return new Workspace(root, config, daemonScript, doctorScript, testScript, sdkHomePath, versionFile);
+    return new Workspace(root, config, daemonScript, doctorScript, testScript, sdkHome, versionFile);
   }
 
   @VisibleForTesting

--- a/src/io/flutter/bazel/Workspace.java
+++ b/src/io/flutter/bazel/Workspace.java
@@ -37,17 +37,23 @@ public class Workspace {
   @Nullable private final String daemonScript;
   @Nullable private final String doctorScript;
   @Nullable private final String testScript;
+  @Nullable private final String sdkHomePath;
+  @Nullable private final String versionFile;
 
   private Workspace(@NotNull VirtualFile root,
                     @Nullable PluginConfig config,
                     @Nullable String daemonScript,
                     @Nullable String doctorScript,
-                    @Nullable String testScript) {
+                    @Nullable String testScript,
+                    @Nullable String sdkHomePath,
+                    @Nullable String versionFile) {
     this.root = root;
     this.config = config;
     this.daemonScript = daemonScript;
     this.doctorScript = doctorScript;
     this.testScript = testScript;
+    this.sdkHomePath = sdkHomePath;
+    this.versionFile = versionFile;
   }
 
   /**
@@ -132,6 +138,22 @@ public class Workspace {
   }
 
   /**
+   * Returns the directory that contains the flutter SDK commands, or null if not configured.
+   */
+  @Nullable
+  public String getSdkHomePath() {
+    return sdkHomePath;
+  }
+
+  /**
+   * Returns the file for the in-use version of Flutter, or null if not configured.
+   */
+  @Nullable
+  public String getVersionFile() {
+    return versionFile;
+  }
+
+  /**
    * Returns true if the plugin config was loaded.
    */
   public boolean hasPluginConfig() {
@@ -189,7 +211,11 @@ public class Workspace {
 
     final String testScript = config == null ? null : getScriptFromPath(root, readonlyPath, config.getTestScript());
 
-    return new Workspace(root, config, daemonScript, doctorScript, testScript);
+    final String sdkHomePath = config == null ? null : getScriptFromPath(root, readonlyPath, config.getSdkHome());
+
+    final String versionFile = config == null ? null : getScriptFromPath(root, readonlyPath, config.getVersionFile());
+
+    return new Workspace(root, config, daemonScript, doctorScript, testScript, sdkHomePath, versionFile);
   }
 
   @VisibleForTesting
@@ -199,7 +225,9 @@ public class Workspace {
       pluginConfig,
       pluginConfig.getDaemonScript(),
       pluginConfig.getDoctorScript(),
-      pluginConfig.getTestScript()
+      pluginConfig.getTestScript(),
+      pluginConfig.getSdkHome(),
+      pluginConfig.getVersionFile()
     );
   }
 

--- a/src/io/flutter/devtools/DevToolsManager.java
+++ b/src/io/flutter/devtools/DevToolsManager.java
@@ -30,6 +30,7 @@ import io.flutter.sdk.FlutterSdk;
 import io.flutter.settings.FlutterSettings;
 import io.flutter.utils.JsonUtils;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
@@ -65,8 +66,9 @@ public class DevToolsManager {
     }
 
     final CompletableFuture<Boolean> result = new CompletableFuture<>();
-    // We don't need a pubroot to call pub global.
-    final FlutterCommand command = sdk.flutterPackagesPub(null, "global", "activate", "devtools");
+    // TODO(https://github.com/flutter/flutter/issues/33324): We shouldn't need a pubroot to call pub global.
+    @Nullable final PubRoot pubRoot = PubRoots.forProject(project).stream().findFirst().orElse(null);
+    final FlutterCommand command = sdk.flutterPackagesPub(pubRoot, "global", "activate", "devtools");
 
     final ProgressManager progressManager = ProgressManager.getInstance();
     progressManager.run(new Task.Backgroundable(project, "Installing DevTools...", true) {
@@ -162,8 +164,9 @@ class DevToolsInstance {
     Callback<DevToolsInstance> onSuccess,
     Callback<DevToolsInstance> onClose
   ) {
-    // We don't need a pubroot to call pub global.
-    final FlutterCommand command = sdk.flutterPackagesPub(null, "global", "run", "devtools", "--machine", "--port=0");
+    // TODO(https://github.com/flutter/flutter/issues/33324): We shouldn't need a pubroot to call pub global.
+    @Nullable final PubRoot pubRoot = PubRoots.forProject(project).stream().findFirst().orElse(null);
+    final FlutterCommand command = sdk.flutterPackagesPub(pubRoot, "global", "run", "devtools", "--machine", "--port=0");
 
     // TODO(devoncarew): Refactor this so that we don't use the console to display output - this steals
     // focus away from the Run (or Debug) view.

--- a/src/io/flutter/devtools/DevToolsManager.java
+++ b/src/io/flutter/devtools/DevToolsManager.java
@@ -59,8 +59,7 @@ public class DevToolsManager {
   }
 
   public CompletableFuture<Boolean> installDevTools() {
-    final FlutterSdk sdk =
-      FlutterSettings.getInstance().shouldUseBazel() ? FlutterSdk.forBazel(project) : FlutterSdk.getFlutterSdk(project);
+    final FlutterSdk sdk = FlutterSdk.forPubOrBazel(project);
     if (sdk == null) {
       return createCompletedFuture(false);
     }
@@ -133,8 +132,7 @@ public class DevToolsManager {
       return;
     }
 
-    final FlutterSdk sdk =
-      FlutterSettings.getInstance().shouldUseBazel() ? FlutterSdk.forBazel(project) : FlutterSdk.getFlutterSdk(project);
+    final FlutterSdk sdk = FlutterSdk.forPubOrBazel(project);
     if (sdk == null) {
       return;
     }

--- a/src/io/flutter/devtools/DevToolsManager.java
+++ b/src/io/flutter/devtools/DevToolsManager.java
@@ -59,26 +59,15 @@ public class DevToolsManager {
   }
 
   public CompletableFuture<Boolean> installDevTools() {
-    final FlutterSdk sdk = FlutterSettings.getInstance().shouldUseBazel() ? FlutterSdk.forBazel(project) : FlutterSdk.getFlutterSdk(project);
+    final FlutterSdk sdk =
+      FlutterSettings.getInstance().shouldUseBazel() ? FlutterSdk.forBazel(project) : FlutterSdk.getFlutterSdk(project);
     if (sdk == null) {
-        return createCompletedFuture(false);
+      return createCompletedFuture(false);
     }
 
-    VirtualFile pubRoot = null;
-    if (FlutterSettings.getInstance().shouldUseBazel()) {
-      final Workspace workspace = Workspace.load(project);
-      if ( workspace != null) {
-        pubRoot = workspace.getRoot();
-      }
-    } else {
-      final List<PubRoot> pubRoots = PubRoots.forProject(project);
-      if (pubRoots.isEmpty()) {
-        return createCompletedFuture(false);
-      }
-      pubRoot = pubRoots.get(0).getRoot();
-    }
     final CompletableFuture<Boolean> result = new CompletableFuture<>();
-    final FlutterCommand command = sdk.flutterPackagesPub(pubRoot, "global", "activate", "devtools");
+    // We don't need a pubroot to call pub global.
+    final FlutterCommand command = sdk.flutterPackagesPub(null, "global", "activate", "devtools");
 
     final ProgressManager progressManager = ProgressManager.getInstance();
     progressManager.run(new Task.Backgroundable(project, "Installing DevTools...", true) {
@@ -144,27 +133,14 @@ public class DevToolsManager {
       return;
     }
 
-    final FlutterSdk sdk = FlutterSettings.getInstance().shouldUseBazel() ? FlutterSdk.forBazel(project) : FlutterSdk.getFlutterSdk(project);
+    final FlutterSdk sdk =
+      FlutterSettings.getInstance().shouldUseBazel() ? FlutterSdk.forBazel(project) : FlutterSdk.getFlutterSdk(project);
     if (sdk == null) {
       return;
     }
 
-    VirtualFile pubRoot  = null;
-    if (FlutterSettings.getInstance().shouldUseBazel()) {
-      final Workspace workspace = Workspace.load(project);
-      if ( workspace != null) {
-        pubRoot = workspace.getRoot();
-      }
-    } else {
-      final List<PubRoot> pubRoots = PubRoots.forProject(project);
-      if (pubRoots.isEmpty()) {
-        return;
-      }
-      pubRoot = pubRoots.get(0).getRoot();
-    }
-
     // start the server
-    DevToolsInstance.startServer(project, sdk, pubRoot, instance -> {
+    DevToolsInstance.startServer(project, sdk, instance -> {
       devToolsInstance = instance;
 
       devToolsInstance.openBrowserAndConnect(uri, page);
@@ -185,11 +161,11 @@ class DevToolsInstance {
   public static void startServer(
     Project project,
     FlutterSdk sdk,
-    VirtualFile pubRoot,
     Callback<DevToolsInstance> onSuccess,
     Callback<DevToolsInstance> onClose
   ) {
-    final FlutterCommand command = sdk.flutterPackagesPub(pubRoot, "global", "run", "devtools", "--machine", "--port=0");
+    // We don't need a pubroot to call pub global.
+    final FlutterCommand command = sdk.flutterPackagesPub(null, "global", "run", "devtools", "--machine", "--port=0");
 
     // TODO(devoncarew): Refactor this so that we don't use the console to display output - this steals
     // focus away from the Run (or Debug) view.

--- a/src/io/flutter/sdk/FlutterCommand.java
+++ b/src/io/flutter/sdk/FlutterCommand.java
@@ -254,7 +254,7 @@ public class FlutterCommand {
     if (workDir != null) {
       line.setWorkDirectory(workDir.getPath());
     }
-    if (!isDoctorCommand()) {
+    if (!isDoctorCommand() && !(sdk instanceof FlutterSdk.BazelSdk)) {
       line.addParameter("--no-color");
     }
     line.addParameters(type.subCommand);
@@ -277,7 +277,7 @@ public class FlutterCommand {
     MAKE_HOST_APP_EDITABLE("Flutter make-host-app-editable", "make-host-app-editable"),
     PACKAGES_GET("Flutter packages get", "packages", "get"),
     PACKAGES_UPGRADE("Flutter packages upgrade", "packages", "upgrade"),
-    PACKAGES_PUB("Flutter packages pub", "packages", "pub"),
+    PACKAGES_PUB("Flutter packages pub", "pub"),
     RUN("Flutter run", "run"),
     FLUTTER_WEB_RUN("Flutter Web run", "flutter_web_run"),
     UPGRADE("Flutter upgrade", "upgrade"),

--- a/src/io/flutter/sdk/FlutterCommand.java
+++ b/src/io/flutter/sdk/FlutterCommand.java
@@ -254,13 +254,16 @@ public class FlutterCommand {
     if (workDir != null) {
       line.setWorkDirectory(workDir.getPath());
     }
-    // The Bazel version of the Flutter SDK doesn't know how to handle the no-color flag.
-    if (!(sdk instanceof FlutterSdk.BazelSdk)) {
+    if (!isDoctorCommand() && !(sdk instanceof FlutterSdk.BazelSdk)) {
       line.addParameter("--no-color");
     }
     line.addParameters(type.subCommand);
     line.addParameters(args);
     return line;
+  }
+
+  private boolean isDoctorCommand() {
+    return type == Type.DOCTOR;
   }
 
   enum Type {

--- a/src/io/flutter/sdk/FlutterCommand.java
+++ b/src/io/flutter/sdk/FlutterCommand.java
@@ -254,16 +254,13 @@ public class FlutterCommand {
     if (workDir != null) {
       line.setWorkDirectory(workDir.getPath());
     }
-    if (!isDoctorCommand() && !(sdk instanceof FlutterSdk.BazelSdk)) {
+    // The Bazel version of the Flutter SDK doesn't know how to handle the no-color flag.
+    if (!(sdk instanceof FlutterSdk.BazelSdk)) {
       line.addParameter("--no-color");
     }
     line.addParameters(type.subCommand);
     line.addParameters(args);
     return line;
-  }
-
-  private boolean isDoctorCommand() {
-    return type == Type.DOCTOR;
   }
 
   enum Type {

--- a/src/io/flutter/sdk/FlutterCommand.java
+++ b/src/io/flutter/sdk/FlutterCommand.java
@@ -277,7 +277,7 @@ public class FlutterCommand {
     MAKE_HOST_APP_EDITABLE("Flutter make-host-app-editable", "make-host-app-editable"),
     PACKAGES_GET("Flutter packages get", "packages", "get"),
     PACKAGES_UPGRADE("Flutter packages upgrade", "packages", "upgrade"),
-    PACKAGES_PUB("Flutter packages pub", "pub"),
+    PACKAGES_PUB("Flutter packages pub", "packages", "pub"),
     RUN("Flutter run", "run"),
     FLUTTER_WEB_RUN("Flutter Web run", "flutter_web_run"),
     UPGRADE("Flutter upgrade", "upgrade"),

--- a/src/io/flutter/sdk/FlutterSdk.java
+++ b/src/io/flutter/sdk/FlutterSdk.java
@@ -89,6 +89,14 @@ public class FlutterSdk {
     return projectSdkCache.computeIfAbsent(cacheKey, s -> forPath(sdkPath));
   }
 
+  /**
+   * Return the FlutterSdk for a project in a Bazel workspace.
+   * <p>
+   * Returns null if we are not in a bazel project.
+   * <p>
+   * NOTE that the Bazel FlutterSdk does not have the same features defined as the normal SDK.
+   * Only use this if you are sure you know what you are doing.
+   */
   public static FlutterSdk forBazel(@NotNull final Project project) {
     // If this is not a bazel project, return null.
     final Workspace workspace = Workspace.load(project);
@@ -96,6 +104,17 @@ public class FlutterSdk {
       return null;
     }
     return new BazelSdk(project, workspace);
+  }
+
+  /**
+   * Return the FlutterSdk for a project, using a pub or bazel-based SDK as appropriate.
+   * <p>
+   * NOTE that the Bazel FlutterSdk does not have the same features defined as the normal SDK.
+   * Only use this if you are sure you know what you are doing.
+   */
+  @Nullable
+  public static FlutterSdk forPubOrBazel(@NotNull final Project project) {
+    return FlutterSettings.getInstance().shouldUseBazel() ? FlutterSdk.forBazel(project) : FlutterSdk.getFlutterSdk(project);
   }
 
   /**

--- a/src/io/flutter/sdk/FlutterSdk.java
+++ b/src/io/flutter/sdk/FlutterSdk.java
@@ -194,10 +194,6 @@ public class FlutterSdk {
     return new FlutterCommand(this, root == null ? null : root.getRoot(), FlutterCommand.Type.PACKAGES_PUB, args);
   }
 
-  public FlutterCommand flutterPackagesPub(@Nullable VirtualFile root, String... args) {
-    return new FlutterCommand(this, root == null ? null : root, FlutterCommand.Type.PACKAGES_PUB, args);
-  }
-
   public FlutterCommand flutterMakeHostAppEditable(@NotNull PubRoot root) {
     return new FlutterCommand(this, root.getRoot(), FlutterCommand.Type.MAKE_HOST_APP_EDITABLE);
   }

--- a/src/io/flutter/sdk/FlutterSdk.java
+++ b/src/io/flutter/sdk/FlutterSdk.java
@@ -613,7 +613,7 @@ public class FlutterSdk {
       super(
         Objects.requireNonNull(
           workspace.getRoot().findFileByRelativePath(
-            Objects.requireNonNull(workspace.getSdkHomePath())
+            Objects.requireNonNull(workspace.getSdkHome())
           )
         ),
         FlutterSdkVersion.readFromFile(

--- a/src/io/flutter/sdk/FlutterSdk.java
+++ b/src/io/flutter/sdk/FlutterSdk.java
@@ -611,9 +611,18 @@ public class FlutterSdk {
 
     private BazelSdk(@NotNull Project project, @NotNull Workspace workspace) {
       super(
-        Objects.requireNonNull(workspace.getRoot().findFileByRelativePath("mobile/flutter/tools/ide/gflutter")),
-        FlutterSdkVersion
-          .readFromSdk(Objects.requireNonNull(workspace.getRoot().findFileByRelativePath("mobile/flutter/tools/ide/gflutter")))
+        Objects.requireNonNull(
+          workspace.getRoot().findFileByRelativePath(
+            Objects.requireNonNull(workspace.getSdkHomePath())
+          )
+        ),
+        FlutterSdkVersion.readFromFile(
+          Objects.requireNonNull(
+            workspace.getRoot().findFileByRelativePath(
+              Objects.requireNonNull(workspace.getVersionFile())
+            )
+          )
+        )
       );
       this.workspace = workspace;
       this.project = project;

--- a/src/io/flutter/sdk/FlutterSdkVersion.java
+++ b/src/io/flutter/sdk/FlutterSdkVersion.java
@@ -41,6 +41,11 @@ public class FlutterSdkVersion {
   public static FlutterSdkVersion readFromSdk(@NotNull VirtualFile sdkHome) {
     final VirtualFile file = sdkHome.findChild("version");
 
+    return readFromFile(file);
+  }
+
+  @NotNull
+  public static FlutterSdkVersion readFromFile(@Nullable VirtualFile file) {
     if (file == null) {
       return MIN_SUPPORTED_SDK;
     }

--- a/testSrc/unit/io/flutter/bazel/FakeWorkspaceFactory.java
+++ b/testSrc/unit/io/flutter/bazel/FakeWorkspaceFactory.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2019 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.bazel;
+
+import com.intellij.mock.MockVirtualFileSystem;
+import com.intellij.openapi.util.Pair;
+import io.flutter.bazel.PluginConfig;
+import io.flutter.bazel.Workspace;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class FakeWorkspaceFactory {
+  /**
+   * Creates a {@code Workspace} for testing and a {@code MockVirtualFileSystem} with the expected Flutter script files.
+   */
+  @NotNull
+  public static Pair.NonNull<MockVirtualFileSystem, Workspace> createWorkspaceAndFilesystem(
+    @Nullable String daemonScript,
+    @Nullable String doctorScript,
+    @Nullable String launchScript,
+    @Nullable String testScript,
+    @Nullable String sdkHome,
+    @Nullable String versionFile
+  ) {
+    MockVirtualFileSystem fs = new MockVirtualFileSystem();
+    fs.file("/workspace/WORKSPACE", "");
+    if (daemonScript != null) {
+      fs.file("/workspace/" + daemonScript, "");
+    }
+    if (doctorScript != null) {
+      fs.file("/workspace/" + doctorScript, "");
+    }
+    if (launchScript != null) {
+      fs.file("/workspace/" + launchScript, "");
+    }
+    if (testScript != null) {
+      fs.file("/workspace/" + testScript, "");
+    }
+    if (sdkHome != null) {
+      fs.file("/workspace/" + sdkHome, "");
+    }
+    if (versionFile != null) {
+      fs.file("/workspace/" + versionFile, "");
+    }
+    return Pair.createNonNull(
+      fs,
+      Workspace.forTest(
+        fs.findFileByPath("/workspace/"),
+        PluginConfig.forTest(
+          daemonScript,
+          doctorScript,
+          launchScript,
+          testScript,
+          sdkHome,
+          versionFile
+        )
+      )
+    );
+  }
+
+  /**
+   * Creates a {@code Workspace} for testing and a {@code MockVirtualFileSystem} with the expected Flutter script files.
+   * <p>
+   * Uses default values for all fields.
+   */
+  @NotNull
+  public static Pair.NonNull<MockVirtualFileSystem, Workspace> createWorkspaceAndFilesystem() {
+    return createWorkspaceAndFilesystem(
+      "scripts/flutter-daemon.sh",
+      "scripts/flutter-doctor.sh",
+      "scripts/bazel-run.sh",
+      "scripts/flutter-test.sh",
+      "scripts/",
+      "flutter-version"
+    );
+  }
+}

--- a/testSrc/unit/io/flutter/run/bazel/LaunchCommandsTest.java
+++ b/testSrc/unit/io/flutter/run/bazel/LaunchCommandsTest.java
@@ -9,8 +9,9 @@ import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configurations.GeneralCommandLine;
 import com.intellij.mock.MockVirtualFileSystem;
 import com.intellij.openapi.project.Project;
-import io.flutter.bazel.PluginConfig;
+import com.intellij.openapi.util.Pair;
 import io.flutter.bazel.Workspace;
+import io.flutter.bazel.FakeWorkspaceFactory;
 import io.flutter.run.daemon.FlutterDevice;
 import io.flutter.run.daemon.RunMode;
 import io.flutter.testing.ProjectFixture;
@@ -373,53 +374,35 @@ public class LaunchCommandsTest {
    * Fake bazel fields that doesn't depend on the Dart SDK.
    */
   private static class FakeBazelFields extends BazelFields {
-    MockVirtualFileSystem fs = new MockVirtualFileSystem();
+    MockVirtualFileSystem fs;
     final Workspace fakeWorkspace;
 
     FakeBazelFields(@NotNull BazelFields template,
-                        @Nullable String daemonScript,
-                        @Nullable String doctorScript,
-                        @Nullable String launchScript,
-                        @Nullable String testScript) {
+                    @Nullable String daemonScript,
+                    @Nullable String doctorScript,
+                    @Nullable String launchScript,
+                    @Nullable String testScript,
+                    @Nullable String sdkHome,
+                    @Nullable String versionFile) {
       super(template);
-      fs.file("/workspace/WORKSPACE", "");
-      if (daemonScript != null) {
-        fs.file("/workspace/" + daemonScript, "");
-      }
-      if (doctorScript != null) {
-        fs.file("/workspace/" + doctorScript, "");
-      }
-      if (launchScript != null) {
-        fs.file("/workspace/" + launchScript, "");
-      }
-      if (testScript!= null) {
-        fs.file("/workspace/" + testScript, "");
-      }
-      fakeWorkspace = Workspace.forTest(
-        fs.findFileByPath("/workspace/"),
-        PluginConfig.forTest(
-          daemonScript,
-          doctorScript,
-          launchScript,
-          testScript
-        )
-      );
+      Pair.NonNull<MockVirtualFileSystem, Workspace> pair = FakeWorkspaceFactory
+        .createWorkspaceAndFilesystem(daemonScript, doctorScript, launchScript, testScript, sdkHome, versionFile);
+      fs = pair.first;
+      fakeWorkspace = pair.second;
     }
 
     FakeBazelFields(@NotNull BazelFields template) {
-      this(
-        template,
-        "scripts/flutter-daemon.sh",
-        "scripts/flutter-doctor.sh",
-        "scripts/bazel-run.sh",
-        "scripts/flutter-test.sh"
-      );
-
+      super(template);
+      Pair.NonNull<MockVirtualFileSystem, Workspace> pair = FakeWorkspaceFactory
+        .createWorkspaceAndFilesystem();
+      fs = pair.first;
+      fakeWorkspace = pair.second;
     }
 
 
     @Override
-    void checkRunnable(@NotNull Project project) {}
+    void checkRunnable(@NotNull Project project) {
+    }
 
     @Nullable
     @Override

--- a/testSrc/unit/io/flutter/run/bazelTest/BazelTestConfigProducerTest.java
+++ b/testSrc/unit/io/flutter/run/bazelTest/BazelTestConfigProducerTest.java
@@ -142,7 +142,7 @@ public class BazelTestConfigProducerTest extends AbstractDartElementTest {
       fs.file("/workspace/WORKSPACE", "");
       fakeWorkspace = Workspace.forTest(
         fs.findFileByPath("/workspace/"),
-        PluginConfig.forTest("", "", "", "")
+        PluginConfig.forTest("", "", "", "", "", "")
       );
       this.hasWorkspace = hasWorkspace;
       this.hasValidTestFile = hasValidTestFile;

--- a/testSrc/unit/io/flutter/run/bazelTest/LaunchCommandsTest.java
+++ b/testSrc/unit/io/flutter/run/bazelTest/LaunchCommandsTest.java
@@ -10,7 +10,8 @@ import com.intellij.execution.configurations.GeneralCommandLine;
 import com.intellij.execution.configurations.RuntimeConfigurationError;
 import com.intellij.mock.MockVirtualFileSystem;
 import com.intellij.openapi.project.Project;
-import io.flutter.bazel.PluginConfig;
+import com.intellij.openapi.util.Pair;
+import io.flutter.bazel.FakeWorkspaceFactory;
 import io.flutter.bazel.Workspace;
 import io.flutter.run.daemon.RunMode;
 import io.flutter.testing.ProjectFixture;
@@ -122,6 +123,8 @@ public class LaunchCommandsTest {
       "scripts/daemon.sh",
       "scripts/doctor.sh",
       "scripts/launch.sh",
+      null,
+      null,
       null
     );
     final GeneralCommandLine launchCommand = fields.getLaunchCommand(projectFixture.getProject(), RunMode.RUN);
@@ -139,6 +142,8 @@ public class LaunchCommandsTest {
       "scripts/daemon.sh",
       "scripts/doctor.sh",
       "scripts/launch.sh",
+      null,
+      null,
       null
     );
     final GeneralCommandLine launchCommand = fields.getLaunchCommand(projectFixture.getProject(), RunMode.DEBUG);
@@ -158,6 +163,8 @@ public class LaunchCommandsTest {
       "scripts/daemon.sh",
       "scripts/doctor.sh",
       "scripts/launch.sh",
+      null,
+      null,
       null
     );
     boolean didThrow = false;
@@ -177,6 +184,8 @@ public class LaunchCommandsTest {
       "scripts/daemon.sh",
       "scripts/doctor.sh",
       "scripts/launch.sh",
+      null,
+      null,
       null
     );
     boolean didThrow = false;
@@ -213,6 +222,8 @@ public class LaunchCommandsTest {
       "scripts/daemon.sh",
       "scripts/doctor.sh",
       "scripts/launch.sh",
+      null,
+      null,
       null
     );
     final GeneralCommandLine launchCommand = fields.getLaunchCommand(projectFixture.getProject(), RunMode.RUN);
@@ -240,47 +251,28 @@ public class LaunchCommandsTest {
    */
   private static class FakeBazelTestFields extends BazelTestFields {
 
-    final MockVirtualFileSystem fs = new MockVirtualFileSystem();
+    final MockVirtualFileSystem fs;
     final Workspace fakeWorkspace;
 
     FakeBazelTestFields(@NotNull BazelTestFields template,
                         @Nullable String daemonScript,
                         @Nullable String doctorScript,
                         @Nullable String launchScript,
-                        @Nullable String testScript) {
+                        @Nullable String testScript,
+                        @Nullable String sdkHome,
+                        @Nullable String versionFile) {
       super(template);
-      fs.file("/workspace/WORKSPACE", "");
-      if (daemonScript != null) {
-        fs.file("/workspace/" + daemonScript, "");
-      }
-      if (doctorScript != null) {
-        fs.file("/workspace/" + doctorScript, "");
-      }
-      if (launchScript != null) {
-        fs.file("/workspace/" + launchScript, "");
-      }
-      if (testScript != null) {
-        fs.file("/workspace/" + testScript, "");
-      }
-      fakeWorkspace = Workspace.forTest(
-        fs.findFileByPath("/workspace/"),
-        PluginConfig.forTest(
-          daemonScript,
-          doctorScript,
-          launchScript,
-          testScript
-        )
-      );
+      final Pair.NonNull<MockVirtualFileSystem, Workspace> pair = FakeWorkspaceFactory
+        .createWorkspaceAndFilesystem(daemonScript, doctorScript, launchScript, testScript, sdkHome, versionFile);
+      fs = pair.first;
+      fakeWorkspace = pair.second;
     }
 
     FakeBazelTestFields(@NotNull BazelTestFields template) {
-      this(
-        template,
-        "scripts/flutter-daemon.sh",
-        "scripts/flutter-doctor.sh",
-        "scripts/bazel-run.sh",
-        "scripts/flutter-test.sh"
-      );
+      super(template);
+      final Pair.NonNull<MockVirtualFileSystem, Workspace> pair = FakeWorkspaceFactory.createWorkspaceAndFilesystem();
+      fs = pair.first;
+      fakeWorkspace = pair.second;
     }
 
     @Override


### PR DESCRIPTION
Involves setting up a Bazel-compatible FlutterSDK and delegating to it.

Because the Bazel SDK does not surface the same behavior as the pub-based SDK, I made this an explicit step that we have to take when it is necessary.