### PR TITLE
guard against null project basedir

### DIFF
--- a/src/io/flutter/editor/NativeEditorNotificationProvider.java
+++ b/src/io/flutter/editor/NativeEditorNotificationProvider.java
@@ -76,7 +76,8 @@ public class NativeEditorNotificationProvider extends EditorNotifications.Provid
     }
   }
 
-  private static VirtualFile findRootDir(@NotNull VirtualFile file, VirtualFile projectDir) {
+  @Nullable
+  private static VirtualFile findRootDir(@NotNull VirtualFile file, @Nullable VirtualFile projectDir) {
     if (projectDir == null) {
       return null;
     }

--- a/src/io/flutter/editor/NativeEditorNotificationProvider.java
+++ b/src/io/flutter/editor/NativeEditorNotificationProvider.java
@@ -77,6 +77,9 @@ public class NativeEditorNotificationProvider extends EditorNotifications.Provid
   }
 
   private static VirtualFile findRootDir(@NotNull VirtualFile file, VirtualFile projectDir) {
+    if (projectDir == null) {
+      return null;
+    }
     // Return the top-most parent of file that is a child of the project directory.
     VirtualFile parent = file.getParent();
     if (projectDir.equals(parent)) {


### PR DESCRIPTION
Fixes: #3514.

(Still trying to figure out why the basedir would be `null` but crashing on banner creation isn't good regardless 😬)

/cc @stevemessick @devoncarew 