### PR TITLE
don't disable closing labels as part of UI Guides

### DIFF
--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.form
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.form
@@ -9,7 +9,7 @@
     <border type="none"/>
     <children>
       <grid id="7bd49" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
-        <margin top="0" left="0" bottom="0" right="0"/>
+        <margin top="0" left="2" bottom="1" right="0"/>
         <constraints>
           <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
@@ -144,7 +144,7 @@
           </component>
         </children>
       </grid>
-      <grid id="32490" layout-manager="GridLayoutManager" row-count="6" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="32490" layout-manager="GridLayoutManager" row-count="5" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -157,7 +157,7 @@
               <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
-              <text value="UI Guides"/>
+              <text value="Show UI Guides for build methods"/>
               <toolTipText value="Visualize the widget tree structure from the outline view directly in build methods."/>
             </properties>
           </component>
@@ -179,17 +179,9 @@
               <toolTipText value="When this option is checked lines are drawn on the scrollbar indicating where build methods are."/>
             </properties>
           </component>
-          <component id="23423483" class="javax.swing.JCheckBox" binding="myDisableDartClosingLabels">
-            <constraints>
-              <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="2" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <text value="Hide closing labels in Dart source code when UI guides are on"/>
-            </properties>
-          </component>
           <component id="a0dd8" class="javax.swing.JCheckBox" binding="myFormatCodeOnSaveCheckBox" default-binding="true">
             <constraints>
-              <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text resource-bundle="io/flutter/FlutterBundle" key="settings.format.code.on.save"/>
@@ -198,7 +190,7 @@
           </component>
           <component id="8bd46" class="javax.swing.JCheckBox" binding="myOrganizeImportsOnSaveCheckBox" default-binding="true">
             <constraints>
-              <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="2" use-parent-layout="false"/>
+              <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="2" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text resource-bundle="io/flutter/FlutterBundle" key="settings.organize.imports.on.save"/>

--- a/src/io/flutter/settings/FlutterSettings.java
+++ b/src/io/flutter/settings/FlutterSettings.java
@@ -37,7 +37,6 @@ public class FlutterSettings {
   private static final String showBuildMethodGuidesKey = "io.flutter.editor.showBuildMethodGuides";
   private static final String showMultipleChildrenGuidesKey = "io.flutter.editor.showMultipleChildrenGuides";
   private static final String showBuildMethodsOnScrollbarKey = "io.flutter.editor.showBuildMethodsOnScrollbarKey";
-  private static final String disableDartClosingLabelsKey = "io.flutter.editor.disableDartClosingLabelsKey";
 
   public static FlutterSettings getInstance() {
     return ServiceManager.getService(FlutterSettings.class);
@@ -98,10 +97,6 @@ public class FlutterSettings {
     if (isShowBuildMethodsOnScrollbar()) {
       analytics.sendEvent("settings", afterLastPeriod(showBuildMethodsOnScrollbarKey));
     }
-    if (!isDisableDartClosingLabels()) {
-      // The default value is true so only send the event if the setting was turned off.
-      analytics.sendEvent("settings", afterLastPeriod(disableDartClosingLabelsKey + "_off"));
-    }
 
     if (useFlutterLogView()) {
       analytics.sendEvent("settings", afterLastPeriod(useFlutterLogView));
@@ -143,6 +138,7 @@ public class FlutterSettings {
 
   public void setDisableTrackWidgetCreation(boolean value) {
     getPropertiesComponent().setValue(disableTrackWidgetCreationKey, value, false);
+
     fireEvent();
   }
 
@@ -260,17 +256,6 @@ public class FlutterSettings {
 
     fireEvent();
   }
-
-  public boolean isDisableDartClosingLabels() {
-    return getPropertiesComponent().getBoolean(disableDartClosingLabelsKey, true);
-  }
-
-  public void setDisableDartClosingLabels(boolean value) {
-    getPropertiesComponent().setValue(disableDartClosingLabelsKey, value, true);
-
-    fireEvent();
-  }
-
 
   public boolean isShowMultipleChildrenGuides() {
     return getPropertiesComponent().getBoolean(showMultipleChildrenGuidesKey, false);


### PR DESCRIPTION
- don't disable closing labels as part of UI Guides
- fix https://github.com/flutter/flutter-intellij/issues/3502
- rename the 'UI Guides' pref to 'Show UI Guides for build methods'
- add a small bit of padding to the left of some preference items
- fix an issue where we would request info from `flutter --version` twice in a very brief time, and the text in the preference page would often show `waiting for another flutter to release the lock`

