### PR TITLE
add in a preference to toggle closing labels

### DIFF
--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.form
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.form
@@ -144,7 +144,7 @@
           </component>
         </children>
       </grid>
-      <grid id="32490" layout-manager="GridLayoutManager" row-count="5" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="32490" layout-manager="GridLayoutManager" row-count="6" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -181,7 +181,7 @@
           </component>
           <component id="a0dd8" class="javax.swing.JCheckBox" binding="myFormatCodeOnSaveCheckBox" default-binding="true">
             <constraints>
-              <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text resource-bundle="io/flutter/FlutterBundle" key="settings.format.code.on.save"/>
@@ -190,11 +190,19 @@
           </component>
           <component id="8bd46" class="javax.swing.JCheckBox" binding="myOrganizeImportsOnSaveCheckBox" default-binding="true">
             <constraints>
-              <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="2" use-parent-layout="false"/>
+              <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="2" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text resource-bundle="io/flutter/FlutterBundle" key="settings.organize.imports.on.save"/>
               <toolTipText value="On save, organize imports for changed Dart files."/>
+            </properties>
+          </component>
+          <component id="92f7c" class="javax.swing.JCheckBox" binding="myShowClosingLabelsInCheckBox" default-binding="true">
+            <constraints>
+              <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Show closing labels in Dart source code"/>
             </properties>
           </component>
         </children>

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.form
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.form
@@ -197,7 +197,7 @@
               <toolTipText value="On save, organize imports for changed Dart files."/>
             </properties>
           </component>
-          <component id="92f7c" class="javax.swing.JCheckBox" binding="myShowClosingLabelsInCheckBox" default-binding="true">
+          <component id="92f7c" class="javax.swing.JCheckBox" binding="myShowClosingLabels" default-binding="true">
             <constraints>
               <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.java
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.java
@@ -67,6 +67,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
   private JCheckBox myShowBuildMethodGuides;
   private JCheckBox myShowMultipleChildrenGuides;
   private JCheckBox myShowBuildMethodsOnScrollbar;
+  private JCheckBox myShowClosingLabelsInCheckBox;
 
   private final @NotNull Project myProject;
 
@@ -184,8 +185,11 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     if (settings.isShowMultipleChildrenGuides() != myShowMultipleChildrenGuides.isSelected()) {
       return true;
     }
-
     if (settings.isShowBuildMethodsOnScrollbar() != myShowBuildMethodsOnScrollbar.isSelected()) {
+      return true;
+    }
+
+    if (settings.isShowClosingLabels() != myShowClosingLabelsInCheckBox.isSelected()) {
       return true;
     }
 
@@ -243,6 +247,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     settings.setShowBuildMethodGuides(myShowBuildMethodGuides.isSelected());
     settings.setShowMultipleChildrenGuides(myShowMultipleChildrenGuides.isSelected());
     settings.setShowBuildMethodsOnScrollbar(myShowBuildMethodsOnScrollbar.isSelected());
+    settings.setShowClosingLabels(myShowClosingLabelsInCheckBox.isSelected());
     settings.setUseFlutterLogView(myUseLogViewCheckBox.isSelected());
     settings.setOpenInspectorOnAppLaunch(myOpenInspectorOnAppLaunchCheckBox.isSelected());
     settings.setDisableTrackWidgetCreation(myDisableTrackWidgetCreationCheckBox.isSelected());
@@ -282,6 +287,8 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     myShowBuildMethodGuides.setSelected(settings.isShowBuildMethodGuides());
     myShowMultipleChildrenGuides.setSelected(settings.isShowMultipleChildrenGuides());
     myShowBuildMethodsOnScrollbar.setSelected(settings.isShowBuildMethodsOnScrollbar());
+
+    myShowClosingLabelsInCheckBox.setSelected(settings.isShowClosingLabels());
 
     myUseLogViewCheckBox.setSelected(settings.useFlutterLogView());
     myOpenInspectorOnAppLaunchCheckBox.setSelected(settings.isOpenInspectorOnAppLaunch());

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.java
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.java
@@ -67,7 +67,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
   private JCheckBox myShowBuildMethodGuides;
   private JCheckBox myShowMultipleChildrenGuides;
   private JCheckBox myShowBuildMethodsOnScrollbar;
-  private JCheckBox myShowClosingLabelsInCheckBox;
+  private JCheckBox myShowClosingLabels;
 
   private final @NotNull Project myProject;
 
@@ -189,7 +189,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
       return true;
     }
 
-    if (settings.isShowClosingLabels() != myShowClosingLabelsInCheckBox.isSelected()) {
+    if (settings.isShowClosingLabels() != myShowClosingLabels.isSelected()) {
       return true;
     }
 
@@ -247,7 +247,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     settings.setShowBuildMethodGuides(myShowBuildMethodGuides.isSelected());
     settings.setShowMultipleChildrenGuides(myShowMultipleChildrenGuides.isSelected());
     settings.setShowBuildMethodsOnScrollbar(myShowBuildMethodsOnScrollbar.isSelected());
-    settings.setShowClosingLabels(myShowClosingLabelsInCheckBox.isSelected());
+    settings.setShowClosingLabels(myShowClosingLabels.isSelected());
     settings.setUseFlutterLogView(myUseLogViewCheckBox.isSelected());
     settings.setOpenInspectorOnAppLaunch(myOpenInspectorOnAppLaunchCheckBox.isSelected());
     settings.setDisableTrackWidgetCreation(myDisableTrackWidgetCreationCheckBox.isSelected());
@@ -288,7 +288,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     myShowMultipleChildrenGuides.setSelected(settings.isShowMultipleChildrenGuides());
     myShowBuildMethodsOnScrollbar.setSelected(settings.isShowBuildMethodsOnScrollbar());
 
-    myShowClosingLabelsInCheckBox.setSelected(settings.isShowClosingLabels());
+    myShowClosingLabels.setSelected(settings.isShowClosingLabels());
 
     myUseLogViewCheckBox.setSelected(settings.useFlutterLogView());
     myOpenInspectorOnAppLaunchCheckBox.setSelected(settings.isOpenInspectorOnAppLaunch());

--- a/src/io/flutter/settings/FlutterSettings.java
+++ b/src/io/flutter/settings/FlutterSettings.java
@@ -10,6 +10,7 @@ import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.registry.Registry;
 import com.intellij.util.EventDispatcher;
+import com.jetbrains.lang.dart.analyzer.DartClosingLabelManager;
 import io.flutter.analytics.Analytics;
 import io.flutter.sdk.FlutterSdk;
 
@@ -255,6 +256,14 @@ public class FlutterSettings {
     getPropertiesComponent().setValue(showBuildMethodsOnScrollbarKey, value, false);
 
     fireEvent();
+  }
+
+  public boolean isShowClosingLabels() {
+    return DartClosingLabelManager.getInstance().getShowClosingLabels();
+  }
+
+  public void setShowClosingLabels(boolean value) {
+    DartClosingLabelManager.getInstance().setShowClosingLabels(value);
   }
 
   public boolean isShowMultipleChildrenGuides() {


### PR DESCRIPTION
- add a preference to toggle closing labels (duplicate the existing one from the Dart plugin, but expose it in the Flutter prefs UI)
- fix https://github.com/flutter/flutter-intellij/issues/3526

<img width="372" alt="Screen Shot 2019-05-28 at 3 29 59 PM" src="https://user-images.githubusercontent.com/1269969/58516631-7c5e3080-815d-11e9-9b52-56118728f3a9.png">
