### PR TITLE
Resolve load conflict for beta

### DIFF
--- a/product-matrix.json
+++ b/product-matrix.json
@@ -20,11 +20,11 @@
       "ideaVersion": "191.5585527",
       "dartPluginVersion": "191.7221",
       "sinceBuild": "191.6707",
-      "untilBuild": "191.7141.44.35.*"
+      "untilBuild": "191.7141.44.*"
     },
     {
-      "comments": "Android Studio 3.6 canary 1",
-      "name": "Android Studio 3.6 canary 1",
+      "comments": "Android Studio 3.6 canary 2",
+      "name": "Android Studio 3.6 canary 2",
       "version": "3.6",
       "ideaProduct": "android-studio",
       "ideaVersion": "191.5595896",


### PR DESCRIPTION
The AS beta release wasn't showing up in the plugin manager.

@pq @devoncarew 