### PR TITLE
Run unit tests on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,4 +26,11 @@ script: ./tool/travis.sh
 
 # Testing product matrix; the values are generated from product-matrix.json.
 env:
+  - DART_BOT=true
+  - CHECK_BOT=true
   - UNIT_TEST_BOT = true
+  - IDEA_VERSION=3.4.1
+  - IDEA_VERSION=3.5
+  - IDEA_VERSION=3.6
+  - IDEA_VERSION=2019.1.3
+  - IDEA_VERSION=2019.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ script: ./tool/travis.sh
 env:
   - DART_BOT=true
   - CHECK_BOT=true
-  - UNIT_TEST_BOT=true
+  - UNIT_TEST_BOT = true
   - IDEA_VERSION=3.4.1
   - IDEA_VERSION=3.5
   - IDEA_VERSION=3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ script: ./tool/travis.sh
 env:
   - DART_BOT=true
   - CHECK_BOT=true
-  - UNIT_TEST_BOT = true
+  - UNIT_TEST_BOT=true
   - IDEA_VERSION=3.4.1
   - IDEA_VERSION=3.5
   - IDEA_VERSION=3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,10 +26,4 @@ script: ./tool/travis.sh
 
 # Testing product matrix; the values are generated from product-matrix.json.
 env:
-  - DART_BOT=true
-  - CHECK_BOT=true
-  - IDEA_VERSION=3.4.1
-  - IDEA_VERSION=3.5
-  - IDEA_VERSION=3.6
-  - IDEA_VERSION=2019.1.3
-  - IDEA_VERSION=2019.2
+  - UNIT_TEST_BOT = true

--- a/.travis_template.yml
+++ b/.travis_template.yml
@@ -26,4 +26,4 @@ script: ./tool/travis.sh
 env:
   - DART_BOT=true
   - CHECK_BOT=true
-  - UNIT_TEST_BOT = true
+  - UNIT_TEST_BOT=true

--- a/.travis_template.yml
+++ b/.travis_template.yml
@@ -26,3 +26,4 @@ script: ./tool/travis.sh
 env:
   - DART_BOT=true
   - CHECK_BOT=true
+  - UNIT_TEST_BOT = true

--- a/build.gradle
+++ b/build.gradle
@@ -83,9 +83,9 @@ sourceSets {
 }
 
 test {
-  exclude "io/flutter/run/bazelTest/LaunchCommandsTest.class"
-  exclude "io/flutter/utils/EventStreamTest.class"
-  ignoreFailures false
+//  exclude "io/flutter/run/bazelTest/LaunchCommandsTest.class"
+//  exclude "io/flutter/utils/EventStreamTest.class"
+  ignoreFailures true
 }
 
 /* This fails in a way that suggests internal version skew at JetBrains. */

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -42,7 +42,7 @@ elif [ "$CHECK_BOT" = true ] ; then
 elif [ "$UNIT_TEST_BOT" = true ] ; then
   # Run unit tests without failing the build.
   set +e
-  ./gradlew -d -s test
+  ./gradlew -s test
   return 0
 
 else

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -8,6 +8,7 @@
 set -e
 
 # Echo build info.
+echo "UNIT_TEST_BOT = $UNIT_TEST_BOT"
 echo $FLUTTER_SDK
 flutter --version
 
@@ -42,7 +43,9 @@ elif [ "$CHECK_BOT" = true ] ; then
 elif [ "$UNIT_TEST_BOT" = true ] ; then
   # Run unit tests without failing the build.
   set +e
+  echo "TRACE: Starting unit tests with Gradle"
   ./gradlew -s test
+  echo "TRACE: Finished unit tests with Gradle"
   return 0
 
 else

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -43,7 +43,7 @@ elif [ "$UNIT_TEST_BOT" = true ] ; then
   # Run unit tests without failing the build.
   set +e
   ./gradlew -s test
-  return 0
+  exit 0
 
 else
   # Run some validations on the repo code.

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -8,7 +8,6 @@
 set -e
 
 # Echo build info.
-echo "UNIT_TEST_BOT = $UNIT_TEST_BOT"
 echo $FLUTTER_SDK
 flutter --version
 
@@ -43,9 +42,7 @@ elif [ "$CHECK_BOT" = true ] ; then
 elif [ "$UNIT_TEST_BOT" = true ] ; then
   # Run unit tests without failing the build.
   set +e
-  echo "TRACE: Starting unit tests with Gradle"
   ./gradlew -s test
-  echo "TRACE: Finished unit tests with Gradle"
   return 0
 
 else

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -22,7 +22,7 @@ if [ "$DART_BOT" = true ] ; then
   pub global activate tuneup
   pub global run tuneup
 
-  # ensure that the edits have been applied to template files (and they're target
+  # ensure that the edits have been applied to template files (and their target
   # files have been regenerated)
   ./bin/plugin generate
 

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -39,6 +39,12 @@ elif [ "$CHECK_BOT" = true ] ; then
   # Check plugin-referenced urls for liveness.
   dart tool/grind.dart check-urls
 
+elif [ "$UNIT_TEST_BOT" = true ] ; then
+  # Run unit tests without failing the build.
+  set +e
+  ./gradlew -d -s test
+  return 0
+
 else
   # Run some validations on the repo code.
   ./bin/plugin lint


### PR DESCRIPTION
There are too many failing tests to allow the build to fail due to failed tests. We''ll need to get those fixed first.

To find the failing tests, go to the travis build log, select the third job (UNIT_TEST_BOT) and scroll through for redness. We may want to improve reporting, but that's probably going to be a Q3 task.

To run the tests locally, open a terminal and cd to your plugin project directory. Then do:
```bash
export JAVA_HOME=<path-to-java-home>
./gradlew test
```

@devoncarew @pq @jacob314 @DaveShuckerow @terrylucas @kenzieschmoll 