### PR TITLE
Add focus manager to JBRunnerTabs constructor call

### DIFF
--- a/src/io/flutter/view/FlutterPerfView.java
+++ b/src/io/flutter/view/FlutterPerfView.java
@@ -17,6 +17,7 @@ import com.intellij.openapi.ui.SimpleToolWindowPanel;
 import com.intellij.openapi.util.ActionCallback;
 import com.intellij.openapi.util.ActiveRunnable;
 import com.intellij.openapi.util.Disposer;
+import com.intellij.openapi.wm.IdeFocusManager;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowManager;
 import com.intellij.openapi.wm.ex.ToolWindowManagerEx;
@@ -141,7 +142,7 @@ public class FlutterPerfView implements Disposable {
   private void addPerformanceViewContent(FlutterApp app, ToolWindow toolWindow) {
     final ContentManager contentManager = toolWindow.getContentManager();
     final SimpleToolWindowPanel toolWindowPanel = new SimpleToolWindowPanel(true);
-    final JBRunnerTabs runnerTabs = new JBRunnerTabs(myProject, ActionManager.getInstance(), null, this);
+    final JBRunnerTabs runnerTabs = new JBRunnerTabs(myProject, ActionManager.getInstance(), IdeFocusManager.getInstance(myProject), this);
     runnerTabs.setSelectionChangeHandler(this::onTabSelectionChange);
 
     final String tabName;

--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -25,6 +25,7 @@ import com.intellij.openapi.util.ActionCallback;
 import com.intellij.openapi.util.ActiveRunnable;
 import com.intellij.openapi.util.Disposer;
 import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.openapi.wm.IdeFocusManager;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowManager;
 import com.intellij.openapi.wm.ex.ToolWindowEx;
@@ -214,7 +215,7 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
   private void addInspectorViewContent(FlutterApp app, @Nullable InspectorService inspectorService, ToolWindow toolWindow) {
     final ContentManager contentManager = toolWindow.getContentManager();
     final SimpleToolWindowPanel toolWindowPanel = new SimpleToolWindowPanel(true);
-    final JBRunnerTabs runnerTabs = new JBRunnerTabs(myProject, ActionManager.getInstance(), null, this);
+    final JBRunnerTabs runnerTabs = new JBRunnerTabs(myProject, ActionManager.getInstance(), IdeFocusManager.getInstance(myProject), this);
     runnerTabs.setSelectionChangeHandler(this::onTabSelectionChange);
     final JPanel tabContainer = new JPanel(new BorderLayout());
 


### PR DESCRIPTION
@jacob314 @terrylucas 

IJ 2019.2 EAP has a new implementation of editor tabs. It requires a focus manager. This shouldn't affect builds for older versions, where that arg was nullable.

This changes makes the integration tests work again.

In 2019.2 EAP we get this exception when run without these changes:
```java
java.lang.IllegalArgumentException: Parameter specified as non-null is null: method com.intellij.ui.tabs.newImpl.SameHeightTabs.<init>, parameter focusManager
	at com.intellij.ui.tabs.newImpl.SameHeightTabs.<init>(SameHeightTabs.kt)
	at com.intellij.execution.ui.layout.impl.JBRunnerTabs.<init>(JBRunnerTabs.java:40)
	at io.flutter.view.FlutterView.addInspectorViewContent(FlutterView.java:218)
	at io.flutter.view.FlutterView.debugActiveHelper(FlutterView.java:440)
```