### PR TITLE
Integration test update

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,10 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel>
-      <module name="flutter-gui-tests.main" target="1.8" />
-      <module name="flutter-gui-tests.test" target="1.8" />
-    </bytecodeTargetLevel>
     <resourceExtensions />
     <wildcardResourcePatterns>
       <entry name="!?*.java" />
@@ -22,5 +18,9 @@
         <processorPath useClasspath="true" />
       </profile>
     </annotationProcessing>
+    <bytecodeTargetLevel>
+      <module name="flutter-gui-tests.main" target="11" />
+      <module name="flutter-gui-tests.test" target="11" />
+    </bytecodeTargetLevel>
   </component>
 </project>

--- a/flutter-gui-tests/build.gradle
+++ b/flutter-gui-tests/build.gradle
@@ -36,7 +36,7 @@ sourceSets {
 
 intellij {
   // Check versions at https://plugins.jetbrains.com/plugin/11114-test-gui-framework/
-  plugins 'com.intellij.testGuiFramework:0.9.44.1@nightly', 'Dart:192.4488.21', 'io.flutter:SNAPSHOT'
+  plugins 'com.intellij.testGuiFramework:0.9.44.1@nightly', 'Dart:192.4787.16', 'io.flutter:SNAPSHOT'
   if (System.getProperty("idea.gui.test.alternativeIdePath") != null) {
     alternativeIdePath System.getProperty("idea.gui.test.alternativeIdePath")
   }

--- a/flutter-gui-tests/build.gradle
+++ b/flutter-gui-tests/build.gradle
@@ -95,5 +95,6 @@ test {
                                              (it.key as String) != "jb.vmOptionsFile"
   }
   sysProps.put("idea.gui.tests.gradle.runner", true) //Use Gradle Launcher to run GUI tests
+  //sysProps.put("idea.debug.mode", true) // Add to enable debugging with breakpoints
   systemProperties sysProps
 }

--- a/flutter-gui-tests/testSrc/io/flutter/tests/gui/PerfTest.kt
+++ b/flutter-gui-tests/testSrc/io/flutter/tests/gui/PerfTest.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+package io.flutter.tests.gui
+
+import com.intellij.testGuiFramework.fixtures.ExecutionToolWindowFixture
+import com.intellij.testGuiFramework.fixtures.IdeFrameFixture
+import com.intellij.testGuiFramework.framework.RunWithIde
+import com.intellij.testGuiFramework.framework.Timeouts
+import com.intellij.testGuiFramework.impl.GuiTestCase
+import com.intellij.testGuiFramework.launcher.ide.CommunityIde
+import com.intellij.testGuiFramework.util.step
+import io.flutter.tests.gui.fixtures.flutterPerfFixture
+import org.fest.swing.timing.Condition
+import org.fest.swing.timing.Pause
+import org.junit.Test
+
+@RunWithIde(CommunityIde::class)
+class PerfTest : GuiTestCase() {
+
+  @Test
+  fun widgetTree() {
+    ProjectCreator.importProject()
+    ideFrame {
+      launchFlutterApp()
+      val inspector = flutterPerfFixture(this)
+      inspector.populate()
+    }
+  }
+
+  // TODO Share with InspectorTest
+  fun IdeFrameFixture.launchFlutterApp() {
+    step("Launch Flutter app") {
+      findRunApplicationButton().click()
+      val runner = runner()
+      Pause.pause(object : Condition("Start app") {
+        override fun test(): Boolean {
+          return runner.isExecutionInProgress
+        }
+      }, Timeouts.seconds30)
+    }
+  }
+
+  // TODO Share with InspectorTest
+  private fun IdeFrameFixture.runner(): ExecutionToolWindowFixture.ContentFixture {
+    return runToolWindow.findContent("main.dart")
+  }
+}

--- a/flutter-gui-tests/testSrc/io/flutter/tests/gui/fixtures/FlutterPerfFixture.kt
+++ b/flutter-gui-tests/testSrc/io/flutter/tests/gui/fixtures/FlutterPerfFixture.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+package io.flutter.tests.gui.fixtures
+
+import com.intellij.openapi.project.Project
+import com.intellij.testGuiFramework.fixtures.IdeFrameFixture
+import com.intellij.testGuiFramework.fixtures.ToolWindowFixture
+import com.intellij.testGuiFramework.framework.Timeouts
+import com.intellij.testGuiFramework.util.step
+import org.fest.swing.core.Robot
+import org.fest.swing.timing.Condition
+import org.fest.swing.timing.Pause
+
+fun IdeFrameFixture.flutterPerfFixture(ideFrame: IdeFrameFixture): FlutterPerfFixture {
+  return FlutterPerfFixture(project, robot(), ideFrame)
+}
+
+// A fixture for the Performance top-level view.
+class FlutterPerfFixture(project: Project, robot: Robot, private val ideFrame: IdeFrameFixture)
+  : ToolWindowFixture("Flutter Performance", project, robot) {
+
+  fun populate() {
+    step("Populate perf view") {
+      activate()
+      selectedContent
+      Pause.pause(object : Condition("Initialize perf") {
+        override fun test(): Boolean {
+          return contents[0].displayName != null
+        }
+      }, Timeouts.seconds30)
+    }
+  }
+
+  fun memoryTabFixture(): MemoryTabFixture {
+    return MemoryTabFixture();
+  }
+
+  fun perfTabFixture(): PerfTabFixture {
+    return PerfTabFixture();
+  }
+
+  inner class MemoryTabFixture {
+
+  }
+
+  inner class PerfTabFixture {
+
+  }
+}

--- a/flutter-intellij.iml
+++ b/flutter-intellij.iml
@@ -60,6 +60,5 @@
     </orderEntry>
     <orderEntry type="library" name="Dart SDK" level="project" />
     <orderEntry type="library" name="Dart Packages" level="project" />
-    <orderEntry type="library" name="netty-codec-http" level="project" />
   </component>
 </module>

--- a/product-matrix.json
+++ b/product-matrix.json
@@ -20,7 +20,7 @@
       "ideaVersion": "191.5585527",
       "dartPluginVersion": "191.7221",
       "sinceBuild": "191.6707",
-      "untilBuild": "191.7141.44.*"
+      "untilBuild": "191.7479.31.*"
     },
     {
       "comments": "Android Studio 3.6 canary 2",


### PR DESCRIPTION
Various things relating to integration tests. With this, we have a stable platform from which real work can get done.

- Inspector tests pass.
- Perf tests started but not working yet.
- Use Java 11 for flutter-gui-tests module to keep Gradle sync working.
- Update build numbers for 2019.2.
- Clean up module definition.

The Java 11 bit is surprisingly important and hard to track down. Gradle sync just fails with Java 8, and there are a whole bunch of comments about that on the net. Lots of cargo-cult techniques to fix it; I tried them all, and sometimes they did work. Switching to Java 11 just eliminated the problem. You can get Java 11 bundled with IntelliJ 2019.2 EAP.

@jacob314 @devoncarew 