### PR TITLE
Perf view

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 language: java
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 install: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,15 @@ branches:
   only:
     - master
 
+services:
+  - xvfb
+
+before_install:
+  - sudo apt-get update
+  - sudo apt-get install ant
+  - echo $(ant -version)
+
 before_script:
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
-  - sleep 3 # give xvfb some time to start
   - git clone --depth 1 https://github.com/flutter/flutter.git ../flutter
   - export PATH="$PATH":`pwd`/../flutter/bin:`pwd`/../flutter/bin/cache/dart-sdk/bin
   - flutter config --no-analytics

--- a/.travis_template.yml
+++ b/.travis_template.yml
@@ -1,7 +1,7 @@
 language: java
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 install: true
 

--- a/.travis_template.yml
+++ b/.travis_template.yml
@@ -9,10 +9,15 @@ branches:
   only:
     - master
 
+services:
+  - xvfb
+
+before_install:
+  - sudo apt-get update
+  - sudo apt-get install ant
+  - echo $(ant -version)
+
 before_script:
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
-  - sleep 3 # give xvfb some time to start
   - git clone --depth 1 https://github.com/flutter/flutter.git ../flutter
   - export PATH="$PATH":`pwd`/../flutter/bin:`pwd`/../flutter/bin/cache/dart-sdk/bin
   - flutter config --no-analytics

--- a/flutter-gui-tests/README.md
+++ b/flutter-gui-tests/README.md
@@ -38,9 +38,9 @@ This is likely to be needed if a new version of IntelliJ is downloaded automatic
 On a Mac, you must grant permission to control your computer to the JVM. Open System Preferences then select
 Security & Privacy. Unlock it and click the + button. Navigate to the JVM used to run the integration tests
 and add it to the list. One way to find the JVM is to run the tests, let it hang, and search the output of
-`ps xa` for LATEST_EAP. If that points to a JVM in a .gradle directory (which the Mac will not allow you to
+`ps xa` for LATEST-EAP. If that points to a JVM in a .gradle directory (which the Mac will not allow you to
 navigate to) you can hard link to it in some random directory then add that file.
 
 If you get errors from Gradle sync failing try using Java 11 instead of Java 8 in the project that manages
-the test plugin. For example, create an IntelliJ platform plugin SDK in Priject Structure and point its base
+the test plugin. For example, create an IntelliJ platform plugin SDK in Project Structure and point its base
 SDK to a Java 11 installation. Then set that as the default SDK for the project.

--- a/flutter-gui-tests/README.md
+++ b/flutter-gui-tests/README.md
@@ -34,3 +34,13 @@ If you want to test recent changes be sure to repeat Step 1 in Usage so you are 
 
 If the buildPlugin task fails, check for a new version of the Gradle plugin with id org.jetbrains.intellij.
 This is likely to be needed if a new version of IntelliJ is downloaded automatically.
+
+On a Mac, you must grant permission to control your computer to the JVM. Open System Preferences then select
+Security & Privacy. Unlock it and click the + button. Navigate to the JVM used to run the integration tests
+and add it to the list. One way to find the JVM is to run the tests, let it hang, and search the output of
+`ps xa` for LATEST_EAP. If that points to a JVM in a .gradle directory (which the Mac will not allow you to
+navigate to) you can hard link to it in some random directory then add that file.
+
+If you get errors from Gradle sync failing try using Java 11 instead of Java 8 in the project that manages
+the test plugin. For example, create an IntelliJ platform plugin SDK in Priject Structure and point its base
+SDK to a Java 11 installation. Then set that as the default SDK for the project.

--- a/flutter-gui-tests/build.gradle
+++ b/flutter-gui-tests/build.gradle
@@ -17,8 +17,6 @@ repositories {
 dependencies {
   compile "org.jetbrains.kotlin:kotlin-reflect"
   testCompile group: 'junit', name: 'junit', version: '4.12'
-  //testCompile fileTree(include: ['*.jar'], dir: '../releases/release_master/2019.1')
-  //testImplementation fileTree(include: ['*.jar'], dir: '../releases/release_master/2019.1')
 }
 
 sourceSets {

--- a/flutter-gui-tests/build.gradle
+++ b/flutter-gui-tests/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id 'org.jetbrains.intellij' version '0.4.5'
+  id "org.jetbrains.intellij" version "0.4.9"
   id 'org.jetbrains.kotlin.jvm' version '1.3.21'
 }
 
@@ -17,8 +17,8 @@ repositories {
 dependencies {
   compile "org.jetbrains.kotlin:kotlin-reflect"
   testCompile group: 'junit', name: 'junit', version: '4.12'
-  testCompile fileTree(include: ['*.jar'], dir: '../releases/release_master/2019.1')
-  testImplementation fileTree(include: ['*.jar'], dir: '../releases/release_master/2019.1')
+  //testCompile fileTree(include: ['*.jar'], dir: '../releases/release_master/2019.1')
+  //testImplementation fileTree(include: ['*.jar'], dir: '../releases/release_master/2019.1')
 }
 
 sourceSets {

--- a/flutter-gui-tests/testSrc/io/flutter/tests/gui/InspectorTest.kt
+++ b/flutter-gui-tests/testSrc/io/flutter/tests/gui/InspectorTest.kt
@@ -16,6 +16,7 @@ import com.intellij.testGuiFramework.impl.GuiTestCase
 import com.intellij.testGuiFramework.launcher.ide.CommunityIde
 import com.intellij.testGuiFramework.util.step
 import io.flutter.tests.gui.fixtures.flutterInspectorFixture
+import org.fest.swing.exception.ComponentLookupException
 import org.fest.swing.fixture.JTreeRowFixture
 import org.fest.swing.timing.Condition
 import org.fest.swing.timing.Pause.pause
@@ -39,16 +40,19 @@ class InspectorTest : GuiTestCase() {
       expect(true) { detailsTree.selection() == null }
 
       step("Details selection synced with main tree") {
-        inspectorTree.selectRow(2, expand = true)
+        inspectorTree.selectRow(2, reexpand = true)
+        //inspectorTree.selectRow(2, expand = true)
         expect("[[root], MyApp, MaterialApp, MyHomePage]") { inspectorTree.selectionSync().toString() }
         expect("[MyHomePage]") { detailsTree.selectionSync().toString() }
-        inspectorTree.selectRow(10, expand = true)
+        inspectorTree.selectRow(10, reexpand = true)
+        //inspectorTree.selectRow(10, expand = true)
         expect("[[root], MyApp, MaterialApp, MyHomePage, Scaffold, FloatingActionButton]") {
           inspectorTree.selectionSync().toString()
         }
         val string = detailsTree.selectionSync().toString()
+        println("DEBUG $string")
         expect(true) {
-          string.startsWith("[MyHomePage,") && string.endsWith("FloatingActionButton]")
+          string.startsWith("[FloatingActionButton]")
         }
       }
 
@@ -129,13 +133,24 @@ class InspectorTest : GuiTestCase() {
 
   fun IdeFrameFixture.launchFlutterApp() {
     step("Launch Flutter app") {
-      findRunApplicationButton().click()
+      tryFindRunAppButton().click()
       val runner = runner()
       pause(object : Condition("Start app") {
         override fun test(): Boolean {
           return runner.isExecutionInProgress
         }
       }, Timeouts.seconds30)
+    }
+  }
+
+  private fun IdeFrameFixture.tryFindRunAppButton(): ActionButtonFixture {
+    while (true) {
+      try {
+        return findRunApplicationButton()
+      }
+      catch (ex: ComponentLookupException) {
+        pause()
+      }
     }
   }
 

--- a/flutter-gui-tests/testSrc/io/flutter/tests/gui/InspectorTest.kt
+++ b/flutter-gui-tests/testSrc/io/flutter/tests/gui/InspectorTest.kt
@@ -41,16 +41,13 @@ class InspectorTest : GuiTestCase() {
 
       step("Details selection synced with main tree") {
         inspectorTree.selectRow(2, reexpand = true)
-        //inspectorTree.selectRow(2, expand = true)
         expect("[[root], MyApp, MaterialApp, MyHomePage]") { inspectorTree.selectionSync().toString() }
         expect("[MyHomePage]") { detailsTree.selectionSync().toString() }
         inspectorTree.selectRow(10, reexpand = true)
-        //inspectorTree.selectRow(10, expand = true)
         expect("[[root], MyApp, MaterialApp, MyHomePage, Scaffold, FloatingActionButton]") {
           inspectorTree.selectionSync().toString()
         }
         val string = detailsTree.selectionSync().toString()
-        println("DEBUG $string")
         expect(true) {
           string.startsWith("[FloatingActionButton]")
         }

--- a/flutter-gui-tests/testSrc/io/flutter/tests/gui/InspectorTest.kt
+++ b/flutter-gui-tests/testSrc/io/flutter/tests/gui/InspectorTest.kt
@@ -128,35 +128,8 @@ class InspectorTest : GuiTestCase() {
     }
   }
 
-  fun IdeFrameFixture.launchFlutterApp() {
-    step("Launch Flutter app") {
-      tryFindRunAppButton().click()
-      val runner = runner()
-      pause(object : Condition("Start app") {
-        override fun test(): Boolean {
-          return runner.isExecutionInProgress
-        }
-      }, Timeouts.seconds30)
-    }
-  }
-
-  private fun IdeFrameFixture.tryFindRunAppButton(): ActionButtonFixture {
-    while (true) {
-      try {
-        return findRunApplicationButton()
-      }
-      catch (ex: ComponentLookupException) {
-        pause()
-      }
-    }
-  }
-
   private fun findHotReloadButton(): ActionButtonFixture {
     return findActionButtonByClassName("ReloadFlutterAppRetarget")
-  }
-
-  private fun IdeFrameFixture.runner(): ExecutionToolWindowFixture.ContentFixture {
-    return runToolWindow.findContent("main.dart")
   }
 
   private fun findActionButtonByActionId(actionId: String): ActionButtonFixture {

--- a/flutter-gui-tests/testSrc/io/flutter/tests/gui/InspectorTest.kt
+++ b/flutter-gui-tests/testSrc/io/flutter/tests/gui/InspectorTest.kt
@@ -8,15 +8,12 @@ package io.flutter.tests.gui
 
 import com.intellij.openapi.util.SystemInfo.isMac
 import com.intellij.testGuiFramework.fixtures.ActionButtonFixture
-import com.intellij.testGuiFramework.fixtures.ExecutionToolWindowFixture
-import com.intellij.testGuiFramework.fixtures.IdeFrameFixture
 import com.intellij.testGuiFramework.framework.RunWithIde
 import com.intellij.testGuiFramework.framework.Timeouts
 import com.intellij.testGuiFramework.impl.GuiTestCase
 import com.intellij.testGuiFramework.launcher.ide.CommunityIde
 import com.intellij.testGuiFramework.util.step
 import io.flutter.tests.gui.fixtures.flutterInspectorFixture
-import org.fest.swing.exception.ComponentLookupException
 import org.fest.swing.fixture.JTreeRowFixture
 import org.fest.swing.timing.Condition
 import org.fest.swing.timing.Pause.pause

--- a/flutter-gui-tests/testSrc/io/flutter/tests/gui/PerfTest.kt
+++ b/flutter-gui-tests/testSrc/io/flutter/tests/gui/PerfTest.kt
@@ -6,6 +6,7 @@
 
 package io.flutter.tests.gui
 
+import com.intellij.testGuiFramework.fixtures.ActionButtonFixture
 import com.intellij.testGuiFramework.fixtures.ExecutionToolWindowFixture
 import com.intellij.testGuiFramework.fixtures.IdeFrameFixture
 import com.intellij.testGuiFramework.framework.RunWithIde
@@ -14,8 +15,10 @@ import com.intellij.testGuiFramework.impl.GuiTestCase
 import com.intellij.testGuiFramework.launcher.ide.CommunityIde
 import com.intellij.testGuiFramework.util.step
 import io.flutter.tests.gui.fixtures.flutterPerfFixture
+import org.fest.swing.exception.ComponentLookupException
 import org.fest.swing.timing.Condition
 import org.fest.swing.timing.Pause
+import org.fest.swing.timing.Pause.pause
 import org.junit.Test
 
 @RunWithIde(CommunityIde::class)
@@ -28,19 +31,34 @@ class PerfTest : GuiTestCase() {
       launchFlutterApp()
       val inspector = flutterPerfFixture(this)
       inspector.populate()
+
+      pause()
+
+      runner().stop()
     }
   }
 
   // TODO Share with InspectorTest
   fun IdeFrameFixture.launchFlutterApp() {
     step("Launch Flutter app") {
-      findRunApplicationButton().click()
+      tryFindRunAppButton().click()
       val runner = runner()
       Pause.pause(object : Condition("Start app") {
         override fun test(): Boolean {
           return runner.isExecutionInProgress
         }
       }, Timeouts.seconds30)
+    }
+  }
+
+  private fun IdeFrameFixture.tryFindRunAppButton(): ActionButtonFixture {
+    while (true) {
+      try {
+        return findRunApplicationButton()
+      }
+      catch (ex: ComponentLookupException) {
+        Pause.pause()
+      }
     }
   }
 

--- a/flutter-gui-tests/testSrc/io/flutter/tests/gui/PerfTest.kt
+++ b/flutter-gui-tests/testSrc/io/flutter/tests/gui/PerfTest.kt
@@ -6,18 +6,10 @@
 
 package io.flutter.tests.gui
 
-import com.intellij.testGuiFramework.fixtures.ActionButtonFixture
-import com.intellij.testGuiFramework.fixtures.ExecutionToolWindowFixture
-import com.intellij.testGuiFramework.fixtures.IdeFrameFixture
 import com.intellij.testGuiFramework.framework.RunWithIde
-import com.intellij.testGuiFramework.framework.Timeouts
 import com.intellij.testGuiFramework.impl.GuiTestCase
 import com.intellij.testGuiFramework.launcher.ide.CommunityIde
-import com.intellij.testGuiFramework.util.step
 import io.flutter.tests.gui.fixtures.flutterPerfFixture
-import org.fest.swing.exception.ComponentLookupException
-import org.fest.swing.timing.Condition
-import org.fest.swing.timing.Pause
 import org.fest.swing.timing.Pause.pause
 import org.junit.Test
 

--- a/flutter-gui-tests/testSrc/io/flutter/tests/gui/ProjectCreator.kt
+++ b/flutter-gui-tests/testSrc/io/flutter/tests/gui/ProjectCreator.kt
@@ -104,8 +104,6 @@ class ProjectCreator(guiTestCase: GuiTestCase) : TestUtilsClass(guiTestCase) {
       step("Create project $projectName") {
         welcomeFrame {
           this.actionLink(name = "Create New Project").click()
-//          GuiTestUtilKt.waitProgressDialogUntilGone(
-//            robot = robot(), progressTitle = "Loading Templates", timeoutToAppear = Timeouts.seconds02)
           dialog("New Project") {
             jList("Flutter").clickItem("Flutter")
             button("Next").click()

--- a/flutter-gui-tests/testSrc/io/flutter/tests/gui/ProjectCreator.kt
+++ b/flutter-gui-tests/testSrc/io/flutter/tests/gui/ProjectCreator.kt
@@ -20,6 +20,7 @@ import com.intellij.util.UriUtil
 import com.intellij.util.io.URLUtil
 import io.flutter.tests.gui.fixtures.FlutterMessagesToolWindowFixture
 import org.fest.swing.exception.WaitTimedOutError
+import org.fest.swing.timing.Pause.pause
 import java.io.BufferedOutputStream
 import java.io.File
 import java.io.FileOutputStream
@@ -58,7 +59,8 @@ class ProjectCreator(guiTestCase: GuiTestCase) : TestUtilsClass(guiTestCase) {
             }
           }
         }
-        openMainInProject()
+        openMainInProject(wait = true)
+        pause()
       }
       projectPath
     }
@@ -102,8 +104,8 @@ class ProjectCreator(guiTestCase: GuiTestCase) : TestUtilsClass(guiTestCase) {
       step("Create project $projectName") {
         welcomeFrame {
           this.actionLink(name = "Create New Project").click()
-          GuiTestUtilKt.waitProgressDialogUntilGone(
-            robot = robot(), progressTitle = "Loading Templates", timeoutToAppear = Timeouts.seconds02)
+//          GuiTestUtilKt.waitProgressDialogUntilGone(
+//            robot = robot(), progressTitle = "Loading Templates", timeoutToAppear = Timeouts.seconds02)
           dialog("New Project") {
             jList("Flutter").clickItem("Flutter")
             button("Next").click()

--- a/flutter-gui-tests/testSrc/io/flutter/tests/gui/ProjectCreator.kt
+++ b/flutter-gui-tests/testSrc/io/flutter/tests/gui/ProjectCreator.kt
@@ -110,7 +110,7 @@ class ProjectCreator(guiTestCase: GuiTestCase) : TestUtilsClass(guiTestCase) {
             typeText(projectName)
             button("Finish").click()
             GuiTestUtilKt.waitProgressDialogUntilGone(
-                robot = robot(), progressTitle = "Creating Flutter Project", timeoutToAppear = Timeouts.seconds03)
+              robot = robot(), progressTitle = "Creating Flutter Project", timeoutToAppear = Timeouts.seconds03)
           }
         }
         waitForFirstIndexing()

--- a/flutter-gui-tests/testSrc/io/flutter/tests/gui/ProjectCreator.kt
+++ b/flutter-gui-tests/testSrc/io/flutter/tests/gui/ProjectCreator.kt
@@ -112,7 +112,7 @@ class ProjectCreator(guiTestCase: GuiTestCase) : TestUtilsClass(guiTestCase) {
             typeText(projectName)
             button("Finish").click()
             GuiTestUtilKt.waitProgressDialogUntilGone(
-              robot = robot(), progressTitle = "Creating Flutter Project", timeoutToAppear = Timeouts.seconds03)
+                robot = robot(), progressTitle = "Creating Flutter Project", timeoutToAppear = Timeouts.seconds03)
           }
         }
         waitForFirstIndexing()

--- a/flutter-gui-tests/testSrc/io/flutter/tests/gui/TestSuite.kt
+++ b/flutter-gui-tests/testSrc/io/flutter/tests/gui/TestSuite.kt
@@ -15,6 +15,5 @@ import org.junit.runners.Suite
 // The log file is at flutter-gui-tests/build/idea-sandbox/system/log/idea.log
 // The test report is at flutter-gui-tests/build/reports/tests/test/index.html
 @RunWith(GuiTestSuiteRunner::class)
-//@Suite.SuiteClasses(SmokeTest::class, InspectorTest::class, PerfTest::class)
-@Suite.SuiteClasses(PerfTest::class)
+@Suite.SuiteClasses(SmokeTest::class, InspectorTest::class, PerfTest::class)
 class TestSuite : GuiTestSuite()

--- a/flutter-gui-tests/testSrc/io/flutter/tests/gui/TestSuite.kt
+++ b/flutter-gui-tests/testSrc/io/flutter/tests/gui/TestSuite.kt
@@ -15,5 +15,6 @@ import org.junit.runners.Suite
 // The log file is at flutter-gui-tests/build/idea-sandbox/system/log/idea.log
 // The test report is at flutter-gui-tests/build/reports/tests/test/index.html
 @RunWith(GuiTestSuiteRunner::class)
-@Suite.SuiteClasses(SmokeTest::class, InspectorTest::class, PerfTest::class)
+@Suite.SuiteClasses(InspectorTest::class)
+//@Suite.SuiteClasses(SmokeTest::class, InspectorTest::class, PerfTest::class)
 class TestSuite : GuiTestSuite()

--- a/flutter-gui-tests/testSrc/io/flutter/tests/gui/TestSuite.kt
+++ b/flutter-gui-tests/testSrc/io/flutter/tests/gui/TestSuite.kt
@@ -15,5 +15,6 @@ import org.junit.runners.Suite
 // The log file is at flutter-gui-tests/build/idea-sandbox/system/log/idea.log
 // The test report is at flutter-gui-tests/build/reports/tests/test/index.html
 @RunWith(GuiTestSuiteRunner::class)
-@Suite.SuiteClasses(SmokeTest::class, InspectorTest::class)
+//@Suite.SuiteClasses(SmokeTest::class, InspectorTest::class, PerfTest::class)
+@Suite.SuiteClasses(PerfTest::class)
 class TestSuite : GuiTestSuite()

--- a/flutter-gui-tests/testSrc/io/flutter/tests/gui/Utils.kt
+++ b/flutter-gui-tests/testSrc/io/flutter/tests/gui/Utils.kt
@@ -9,32 +9,35 @@ package io.flutter.tests.gui
 import com.intellij.testGuiFramework.fixtures.ActionButtonFixture
 import com.intellij.testGuiFramework.fixtures.ExecutionToolWindowFixture
 import com.intellij.testGuiFramework.fixtures.IdeFrameFixture
-import com.intellij.testGuiFramework.framework.RunWithIde
 import com.intellij.testGuiFramework.framework.Timeouts
-import com.intellij.testGuiFramework.impl.GuiTestCase
-import com.intellij.testGuiFramework.launcher.ide.CommunityIde
 import com.intellij.testGuiFramework.util.step
-import io.flutter.tests.gui.fixtures.flutterPerfFixture
 import org.fest.swing.exception.ComponentLookupException
 import org.fest.swing.timing.Condition
 import org.fest.swing.timing.Pause
-import org.fest.swing.timing.Pause.pause
-import org.junit.Test
 
-@RunWithIde(CommunityIde::class)
-class PerfTest : GuiTestCase() {
+fun IdeFrameFixture.launchFlutterApp() {
+  step("Launch Flutter app") {
+    tryFindRunAppButton().click()
+    val runner = runner()
+    Pause.pause(object : Condition("Start app") {
+      override fun test(): Boolean {
+        return runner.isExecutionInProgress
+      }
+    }, Timeouts.seconds30)
+  }
+}
 
-  @Test
-  fun widgetTree() {
-    ProjectCreator.importProject()
-    ideFrame {
-      launchFlutterApp()
-      val inspector = flutterPerfFixture(this)
-      inspector.populate()
-
-      pause()
-
-      runner().stop()
+fun IdeFrameFixture.tryFindRunAppButton(): ActionButtonFixture {
+  while (true) {
+    try {
+      return findRunApplicationButton()
+    }
+    catch (ex: ComponentLookupException) {
+      Pause.pause()
     }
   }
+}
+
+fun IdeFrameFixture.runner(): ExecutionToolWindowFixture.ContentFixture {
+  return runToolWindow.findContent("main.dart")
 }

--- a/flutter-gui-tests/testSrc/io/flutter/tests/gui/fixtures/FlutterInspectorFixture.kt
+++ b/flutter-gui-tests/testSrc/io/flutter/tests/gui/fixtures/FlutterInspectorFixture.kt
@@ -142,11 +142,13 @@ class FlutterInspectorFixture(project: Project, robot: Robot, private val ideFra
       return JTreeFixture(ideFrame.robot(), inspectorTree)
     }
 
-    fun selectRow(number: Int, expand: Boolean = true) {
+    fun selectRow(number: Int, reexpand: Boolean = true) {
       waitForContent()
       treeFixture().clickRow(number) // This should not collapse the tree, but it does.
-      if (expand) {
+      if (reexpand) {
+        pause()
         treeFixture().expandRow(number) // TODO(messick) Remove when selection preserves tree expansion.
+        pause()
       }
     }
 

--- a/flutter-gui-tests/testSrc/io/flutter/tests/gui/fixtures/FlutterInspectorFixture.kt
+++ b/flutter-gui-tests/testSrc/io/flutter/tests/gui/fixtures/FlutterInspectorFixture.kt
@@ -6,18 +6,13 @@
 
 package io.flutter.tests.gui.fixtures
 
-import com.intellij.execution.ui.layout.impl.JBRunnerTabs
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Ref
 import com.intellij.testGuiFramework.fixtures.IdeFrameFixture
-import com.intellij.testGuiFramework.fixtures.JComponentFixture
 import com.intellij.testGuiFramework.fixtures.ToolWindowFixture
 import com.intellij.testGuiFramework.framework.Timeouts
-import com.intellij.testGuiFramework.impl.GuiRobotHolder.robot
 import com.intellij.testGuiFramework.matcher.ClassNameMatcher
 import com.intellij.testGuiFramework.util.step
-import com.intellij.ui.tabs.TabInfo
-import com.intellij.ui.tabs.newImpl.TabLabel
 import io.flutter.inspector.InspectorService
 import io.flutter.inspector.InspectorTree
 import io.flutter.view.InspectorPanel

--- a/flutter-gui-tests/testSrc/io/flutter/tests/gui/fixtures/FlutterInspectorFixture.kt
+++ b/flutter-gui-tests/testSrc/io/flutter/tests/gui/fixtures/FlutterInspectorFixture.kt
@@ -54,20 +54,13 @@ class FlutterInspectorFixture(project: Project, robot: Robot, private val ideFra
   }
 
   fun widgetsFixture(): InspectorPanelFixture {
-    showTab(0)
+    showTab(0, contents)
     return inspectorPanel(InspectorService.FlutterTreeType.widget)
   }
 
   fun renderTreeFixture(): InspectorPanelFixture {
-    showTab(1)
+    showTab(1, contents)
     return inspectorPanel(InspectorService.FlutterTreeType.renderObject)
-  }
-
-  private fun showTab(index: Int) {
-    val tabs: JBRunnerTabs = contents[0].component.components[0] as JBRunnerTabs
-    val info: TabInfo = tabs.getTabAt(index)
-    val label = tabs.getTabLabel(info)
-    TabLabelFixture(robot, label).click()
   }
 
   private fun finder(): ComponentFinder {
@@ -105,7 +98,7 @@ class FlutterInspectorFixture(project: Project, robot: Robot, private val ideFra
   inner class InspectorPanelFixture(val inspectorPanel: InspectorPanel, val type: InspectorService.FlutterTreeType) {
 
     fun show() {
-      showTab(tabIndex())
+      showTab(tabIndex(), contents)
     }
 
     private fun tabIndex(): Int {
@@ -178,7 +171,3 @@ class FlutterInspectorFixture(project: Project, robot: Robot, private val ideFra
     }
   }
 }
-
-// A clickable fixture for the three tabs in the inspector: Widgets, Render Tree, and Performance.
-class TabLabelFixture(robot: Robot, target: TabLabel)
-  : JComponentFixture<TabLabelFixture, TabLabel>(TabLabelFixture::class.java, robot, target)

--- a/flutter-gui-tests/testSrc/io/flutter/tests/gui/fixtures/FlutterMessagesToolWindowFixture.kt
+++ b/flutter-gui-tests/testSrc/io/flutter/tests/gui/fixtures/FlutterMessagesToolWindowFixture.kt
@@ -44,15 +44,15 @@ class FlutterMessagesToolWindowFixture(project: Project, robot: Robot) : ToolWin
 
     private fun doFindMessage(matcher: String, timeout: Timeout): ConsoleViewImpl {
       return GuiTestUtil.waitUntilFound(robot(), myContent.component,
-                                        object : GenericTypeMatcher<ConsoleViewImpl>(ConsoleViewImpl::class.java) {
-                                          override fun isMatching(panel: ConsoleViewImpl): Boolean {
-                                            if (panel.javaClass.name.startsWith(ConsoleViewImpl::class.java.name) && panel.isShowing) {
-                                              val doc = panel.editor.document
-                                              return (doc.text.contains(matcher))
-                                            }
-                                            return false
-                                          }
-                                        }, timeout)
+          object : GenericTypeMatcher<ConsoleViewImpl>(ConsoleViewImpl::class.java) {
+            override fun isMatching(panel: ConsoleViewImpl): Boolean {
+              if (panel.javaClass.name.startsWith(ConsoleViewImpl::class.java.name) && panel.isShowing) {
+                val doc = panel.editor.document
+                return (doc.text.contains(matcher))
+              }
+              return false
+            }
+          }, timeout)
     }
 
   }

--- a/flutter-gui-tests/testSrc/io/flutter/tests/gui/fixtures/FlutterMessagesToolWindowFixture.kt
+++ b/flutter-gui-tests/testSrc/io/flutter/tests/gui/fixtures/FlutterMessagesToolWindowFixture.kt
@@ -44,15 +44,15 @@ class FlutterMessagesToolWindowFixture(project: Project, robot: Robot) : ToolWin
 
     private fun doFindMessage(matcher: String, timeout: Timeout): ConsoleViewImpl {
       return GuiTestUtil.waitUntilFound(robot(), myContent.component,
-          object : GenericTypeMatcher<ConsoleViewImpl>(ConsoleViewImpl::class.java) {
-            override fun isMatching(panel: ConsoleViewImpl): Boolean {
-              if (panel.javaClass.name.startsWith(ConsoleViewImpl::class.java.name) && panel.isShowing) {
-                val doc = panel.editor.document
-                return (doc.text.contains(matcher))
-              }
-              return false
-            }
-          }, timeout)
+                                        object : GenericTypeMatcher<ConsoleViewImpl>(ConsoleViewImpl::class.java) {
+                                          override fun isMatching(panel: ConsoleViewImpl): Boolean {
+                                            if (panel.javaClass.name.startsWith(ConsoleViewImpl::class.java.name) && panel.isShowing) {
+                                              val doc = panel.editor.document
+                                              return (doc.text.contains(matcher))
+                                            }
+                                            return false
+                                          }
+                                        }, timeout)
     }
 
   }

--- a/flutter-gui-tests/testSrc/io/flutter/tests/gui/fixtures/FlutterPerfFixture.kt
+++ b/flutter-gui-tests/testSrc/io/flutter/tests/gui/fixtures/FlutterPerfFixture.kt
@@ -6,11 +6,14 @@
 
 package io.flutter.tests.gui.fixtures
 
+import com.intellij.execution.ui.layout.impl.JBRunnerTabs
 import com.intellij.openapi.project.Project
 import com.intellij.testGuiFramework.fixtures.IdeFrameFixture
 import com.intellij.testGuiFramework.fixtures.ToolWindowFixture
 import com.intellij.testGuiFramework.framework.Timeouts
+import com.intellij.testGuiFramework.impl.GuiRobotHolder
 import com.intellij.testGuiFramework.util.step
+import com.intellij.ui.tabs.TabInfo
 import org.fest.swing.core.Robot
 import org.fest.swing.timing.Condition
 import org.fest.swing.timing.Pause
@@ -36,10 +39,12 @@ class FlutterPerfFixture(project: Project, robot: Robot, private val ideFrame: I
   }
 
   fun memoryTabFixture(): MemoryTabFixture {
+    showTab(0, contents)
     return MemoryTabFixture();
   }
 
   fun perfTabFixture(): PerfTabFixture {
+    showTab(1, contents)
     return PerfTabFixture();
   }
 

--- a/flutter-gui-tests/testSrc/io/flutter/tests/gui/fixtures/FlutterPerfFixture.kt
+++ b/flutter-gui-tests/testSrc/io/flutter/tests/gui/fixtures/FlutterPerfFixture.kt
@@ -6,14 +6,11 @@
 
 package io.flutter.tests.gui.fixtures
 
-import com.intellij.execution.ui.layout.impl.JBRunnerTabs
 import com.intellij.openapi.project.Project
 import com.intellij.testGuiFramework.fixtures.IdeFrameFixture
 import com.intellij.testGuiFramework.fixtures.ToolWindowFixture
 import com.intellij.testGuiFramework.framework.Timeouts
-import com.intellij.testGuiFramework.impl.GuiRobotHolder
 import com.intellij.testGuiFramework.util.step
-import com.intellij.ui.tabs.TabInfo
 import org.fest.swing.core.Robot
 import org.fest.swing.timing.Condition
 import org.fest.swing.timing.Pause
@@ -40,19 +37,15 @@ class FlutterPerfFixture(project: Project, robot: Robot, private val ideFrame: I
 
   fun memoryTabFixture(): MemoryTabFixture {
     showTab(0, contents)
-    return MemoryTabFixture();
+    return MemoryTabFixture()
   }
 
   fun perfTabFixture(): PerfTabFixture {
     showTab(1, contents)
-    return PerfTabFixture();
+    return PerfTabFixture()
   }
 
-  inner class MemoryTabFixture {
+  inner class MemoryTabFixture
 
-  }
-
-  inner class PerfTabFixture {
-
-  }
+  inner class PerfTabFixture
 }

--- a/flutter-gui-tests/testSrc/io/flutter/tests/gui/fixtures/Utils.kt
+++ b/flutter-gui-tests/testSrc/io/flutter/tests/gui/fixtures/Utils.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+package io.flutter.tests.gui.fixtures
+
+import com.intellij.execution.ui.layout.impl.JBRunnerTabs
+import com.intellij.testGuiFramework.fixtures.JComponentFixture
+import com.intellij.testGuiFramework.impl.GuiRobotHolder
+import com.intellij.ui.content.Content
+import com.intellij.ui.tabs.TabInfo
+import com.intellij.ui.tabs.newImpl.TabLabel
+import org.fest.swing.core.Robot
+
+fun showTab(index: Int, contents: Array<Content>) {
+  val tabs: JBRunnerTabs = contents[0].component.components[0] as JBRunnerTabs
+  val info: TabInfo = tabs.getTabAt(index)
+  val label = tabs.getTabLabel(info)
+  TabLabelFixture(GuiRobotHolder.robot, label).click()
+}
+
+// A clickable fixture for the three tabs in the inspector: Widgets, Render Tree, and Performance.
+class TabLabelFixture(robot: Robot, target: TabLabel)
+  : JComponentFixture<TabLabelFixture, TabLabel>(TabLabelFixture::class.java, robot, target)


### PR DESCRIPTION
More clean up of integration tests. They were super flakey, and not usable for a while. This makes it so the tests pass almost always. The random `pause()` calls are not ideal and I'm looking for a way to be more deterministic.

@jacob314 @devoncarew 