### PR TITLE
Add IDE query param to DevTools url.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,8 @@ idea {
 
 dependencies {
   testCompile("io.kotlintest:kotlintest:2.0.7")
+  testCompile "org.powermock:powermock-api-mockito2:2.0.0"
+  testCompile "org.powermock:powermock-module-junit4:2.0.0"
 }
 
 /* Need to swizzle source and resource paths to match standard or buildPlugin does nothing. */

--- a/flutter-intellij.iml
+++ b/flutter-intellij.iml
@@ -60,5 +60,7 @@
     </orderEntry>
     <orderEntry type="library" name="Dart SDK" level="project" />
     <orderEntry type="library" name="Dart Packages" level="project" />
+    <orderEntry type="library" name="org.powermock:powermock-api-mockito2:2.0.0" level="project" />
+    <orderEntry type="library" name="org.powermock:powermock-module-junit4:2.0.0" level="project" />
   </component>
 </module>

--- a/src/io/flutter/devtools/DevToolsManager.java
+++ b/src/io/flutter/devtools/DevToolsManager.java
@@ -23,6 +23,7 @@ import com.intellij.openapi.util.Key;
 import com.intellij.openapi.vfs.VirtualFile;
 import io.flutter.bazel.Workspace;
 import io.flutter.console.FlutterConsoles;
+import io.flutter.FlutterUtils;
 import io.flutter.pub.PubRoot;
 import io.flutter.pub.PubRoots;
 import io.flutter.sdk.FlutterCommand;
@@ -224,8 +225,12 @@ class DevToolsInstance {
   }
 
   public void openBrowserAndConnect(String serviceProtocolUri, String page) {
+    final String ideParam = "ide=" + (FlutterUtils.isAndroidStudio() ? "AndroidStudio&" : "IntelliJ&");
     if (serviceProtocolUri == null) {
-      BrowserLauncher.getInstance().browse("http://" + devtoolsHost + ":" + devtoolsPort + "/?hide=debugger&", null);
+      BrowserLauncher.getInstance().browse(
+        "http://" + devtoolsHost + ":" + devtoolsPort + "/?" + ideParam,
+        null
+      );
     }
     else {
       try {
@@ -233,7 +238,7 @@ class DevToolsInstance {
         final String pageParam = page == null ? "" : ("#" + page);
 
         BrowserLauncher.getInstance().browse(
-          "http://" + devtoolsHost + ":" + devtoolsPort + "/?uri=" + urlParam + pageParam,
+          "http://" + devtoolsHost + ":" + devtoolsPort + "/?" + ideParam + "uri=" + urlParam + pageParam,
           null
         );
       }

--- a/src/io/flutter/devtools/DevToolsManager.java
+++ b/src/io/flutter/devtools/DevToolsManager.java
@@ -20,22 +20,15 @@ import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.progress.Task;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Key;
-import com.intellij.openapi.vfs.VirtualFile;
-import io.flutter.bazel.Workspace;
 import io.flutter.console.FlutterConsoles;
-import io.flutter.FlutterUtils;
 import io.flutter.pub.PubRoot;
 import io.flutter.pub.PubRoots;
 import io.flutter.sdk.FlutterCommand;
 import io.flutter.sdk.FlutterSdk;
-import io.flutter.settings.FlutterSettings;
 import io.flutter.utils.JsonUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
-import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -225,26 +218,10 @@ class DevToolsInstance {
   }
 
   public void openBrowserAndConnect(String serviceProtocolUri, String page) {
-    final String ideParam = "ide=" + (FlutterUtils.isAndroidStudio() ? "AndroidStudio&" : "IntelliJ&");
-    if (serviceProtocolUri == null) {
-      BrowserLauncher.getInstance().browse(
-        "http://" + devtoolsHost + ":" + devtoolsPort + "/?" + ideParam,
-        null
-      );
-    }
-    else {
-      try {
-        final String urlParam = URLEncoder.encode(serviceProtocolUri, "UTF-8");
-        final String pageParam = page == null ? "" : ("#" + page);
-
-        BrowserLauncher.getInstance().browse(
-          "http://" + devtoolsHost + ":" + devtoolsPort + "/?" + ideParam + "uri=" + urlParam + pageParam,
-          null
-        );
-      }
-      catch (UnsupportedEncodingException ignored) {
-      }
-    }
+    BrowserLauncher.getInstance().browse(
+      DevToolsUtils.generateDevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page),
+      null
+    );
   }
 }
 

--- a/src/io/flutter/devtools/DevToolsUtils.java
+++ b/src/io/flutter/devtools/DevToolsUtils.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.devtools;
+
+import io.flutter.FlutterUtils;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.ArrayList;
+import java.util.List;
+
+public class DevToolsUtils {
+  public static String generateDevToolsUrl(
+    String devtoolsHost,
+    int devtoolsPort,
+    String serviceProtocolUri,
+    String page
+  ) {
+    final List<String> params = new ArrayList<>();
+
+    params.add("ide=" + (FlutterUtils.isAndroidStudio() ? "AndroidStudio" : "IntelliJ"));
+
+    if (serviceProtocolUri != null) {
+      try {
+        final String urlParam = URLEncoder.encode(serviceProtocolUri, "UTF-8");
+        final String pageParam = page == null ? "" : ("#" + page);
+        params.add("uri=" + urlParam + pageParam);
+      }
+      catch (UnsupportedEncodingException ignored) {
+      }
+    }
+    return "http://" + devtoolsHost + ":" + devtoolsPort + "/?" + String.join("&", params);
+  }
+}

--- a/src/io/flutter/devtools/DevToolsUtils.java
+++ b/src/io/flutter/devtools/DevToolsUtils.java
@@ -5,7 +5,7 @@
  */
 package io.flutter.devtools;
 
-import io.flutter.FlutterUtils;
+import io.flutter.sdk.FlutterSdkUtil;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
@@ -21,7 +21,7 @@ public class DevToolsUtils {
   ) {
     final List<String> params = new ArrayList<>();
 
-    params.add("ide=" + (FlutterUtils.isAndroidStudio() ? "AndroidStudio" : "IntelliJ"));
+    params.add("ide=" + FlutterSdkUtil.getFlutterHostEnvValue());
 
     if (serviceProtocolUri != null) {
       try {

--- a/testSrc/unit/io/flutter/devtools/DevToolsUtilsTest.java
+++ b/testSrc/unit/io/flutter/devtools/DevToolsUtilsTest.java
@@ -5,7 +5,7 @@
  */
 package io.flutter.devtools;
 
-import io.flutter.FlutterUtils;
+import io.flutter.sdk.FlutterSdkUtil;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.mockito.PowerMockito;
@@ -16,7 +16,7 @@ import static io.flutter.devtools.DevToolsUtils.generateDevToolsUrl;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest(FlutterUtils.class)
+@PrepareForTest(FlutterSdkUtil.class)
 public class DevToolsUtilsTest {
   @Test
   public void validDevToolsUrl() {
@@ -25,18 +25,20 @@ public class DevToolsUtilsTest {
     final String serviceProtocolUri = "http://127.0.0.1:50224/WTFTYus3IPU=/";
     final String page = "timeline";
 
+    PowerMockito.mockStatic(FlutterSdkUtil.class);
+    PowerMockito.when(FlutterSdkUtil.getFlutterHostEnvValue()).thenReturn("IntelliJ-IDEA");
+
     assertEquals(
-      generateDevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page),
-      "http://127.0.0.1:9100/?ide=IntelliJ&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F#timeline"
+      "http://127.0.0.1:9100/?ide=IntelliJ-IDEA&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F#timeline",
+      generateDevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page)
     );
 
     assertEquals(
-      generateDevToolsUrl(devtoolsHost, devtoolsPort, null, null),
-      "http://127.0.0.1:9100/?ide=IntelliJ"
+      "http://127.0.0.1:9100/?ide=IntelliJ-IDEA",
+      generateDevToolsUrl(devtoolsHost, devtoolsPort, null, null)
     );
 
-    PowerMockito.mockStatic(FlutterUtils.class);
-    PowerMockito.when(FlutterUtils.isAndroidStudio()).thenReturn(true);
+    PowerMockito.when(FlutterSdkUtil.getFlutterHostEnvValue()).thenReturn("AndroidStudio");
 
     assertEquals(
       generateDevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page),

--- a/testSrc/unit/io/flutter/devtools/DevToolsUtilsTest.java
+++ b/testSrc/unit/io/flutter/devtools/DevToolsUtilsTest.java
@@ -38,7 +38,7 @@ public class DevToolsUtilsTest {
       generateDevToolsUrl(devtoolsHost, devtoolsPort, null, null)
     );
 
-    PowerMockito.when(FlutterSdkUtil.getFlutterHostEnvValue()).thenReturn("AndroidStudio");
+    PowerMockito.when(FlutterSdkUtil.getFlutterHostEnvValue()).thenReturn("Android-Studio");
 
     assertEquals(
       generateDevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page),

--- a/testSrc/unit/io/flutter/devtools/DevToolsUtilsTest.java
+++ b/testSrc/unit/io/flutter/devtools/DevToolsUtilsTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.devtools;
+
+import io.flutter.FlutterUtils;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static io.flutter.devtools.DevToolsUtils.generateDevToolsUrl;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(FlutterUtils.class)
+public class DevToolsUtilsTest {
+  @Test
+  public void validDevToolsUrl() {
+    final String devtoolsHost = "127.0.0.1";
+    final int devtoolsPort = 9100;
+    final String serviceProtocolUri = "http://127.0.0.1:50224/WTFTYus3IPU=/";
+    final String page = "timeline";
+
+    assertEquals(
+      generateDevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page),
+      "http://127.0.0.1:9100/?ide=IntelliJ&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F#timeline"
+    );
+
+    assertEquals(
+      generateDevToolsUrl(devtoolsHost, devtoolsPort, null, null),
+      "http://127.0.0.1:9100/?ide=IntelliJ"
+    );
+
+    PowerMockito.mockStatic(FlutterUtils.class);
+    PowerMockito.when(FlutterUtils.isAndroidStudio()).thenReturn(true);
+
+    assertEquals(
+      generateDevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page),
+      "http://127.0.0.1:9100/?ide=AndroidStudio&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F#timeline"
+    );
+  }
+}

--- a/tool/plugin/lib/plugin.dart
+++ b/tool/plugin/lib/plugin.dart
@@ -1102,7 +1102,7 @@ class TestCommand extends ProductCommand {
   Future<int> doit() async {
     final javaHome = Platform.environment['JAVA_HOME'];
     if (javaHome == null) {
-      log('JAVA_HOME environment variable net set - this is needed by gradle.');
+      log('JAVA_HOME environment variable not set - this is needed by gradle.');
       return 1;
     }
 


### PR DESCRIPTION
Adds "ide=IntelliJ" or "ide=AndroidStudio" to the DevTools url upon launch. Fixes https://github.com/flutter/flutter-intellij/issues/3591.

Also removed the `hide=debugger` param from the `serviceProtocolUrl == null` case to be consistent with what we do when the vm service uri is not null (the else path in this if statement). Discussion for this [here](https://github.com/flutter/devtools/issues/731). 
@jacob314 @terry @DanTup