### PR TITLE
Treat FlutterApp as a long-running process

### DIFF
--- a/src/io/flutter/run/daemon/DeviceDaemon.java
+++ b/src/io/flutter/run/daemon/DeviceDaemon.java
@@ -25,6 +25,7 @@ import io.flutter.bazel.WorkspaceCache;
 import io.flutter.sdk.FlutterSdk;
 import io.flutter.sdk.FlutterSdkUtil;
 import io.flutter.utils.FlutterModuleUtils;
+import io.flutter.utils.MostlySilentOsProcessHandler;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -203,17 +204,8 @@ class DeviceDaemon {
                        Consumer<String> processStopped) throws ExecutionException {
       final int daemonId = nextDaemonId.incrementAndGet();
       LOG.info("starting Flutter device daemon #" + daemonId + ": " + toString());
-      final ProcessHandler process = new OSProcessHandler(toCommandLine()) {
-        /**
-         * Return BaseOutputReader.Options.forMostlySilentProcess() in order to reduce cpu usage
-         * of the device daemon process (this also address a log message in the IntelliJ log).
-         */
-        @NotNull
-        @Override
-        protected BaseOutputReader.Options readerOptions() {
-          return BaseOutputReader.Options.forMostlySilentProcess();
-        }
-      };
+      // The mostly silent process handler reduces CPU usage of the daemon process.
+      final ProcessHandler process = new MostlySilentOsProcessHandler(toCommandLine());
 
       boolean succeeded = false;
       try {

--- a/src/io/flutter/run/daemon/FlutterApp.java
+++ b/src/io/flutter/run/daemon/FlutterApp.java
@@ -41,6 +41,7 @@ import io.flutter.run.FlutterLaunchMode;
 import io.flutter.server.vmService.ServiceExtensions;
 import io.flutter.server.vmService.VMServiceManager;
 import io.flutter.settings.FlutterSettings;
+import io.flutter.utils.MostlySilentOsProcessHandler;
 import io.flutter.utils.ProgressHelper;
 import io.flutter.utils.StreamSubscription;
 import io.flutter.utils.VmServiceListenerAdapter;
@@ -250,17 +251,7 @@ public class FlutterApp {
     LOG.info(analyticsStart + " " + project.getName() + " (" + mode.mode() + ")");
     LOG.info(command.toString());
 
-    final ProcessHandler process = new OSProcessHandler(command) {
-      /**
-       * Return BaseOutputReader.Options.forMostlySilentProcess() in order to reduce cpu usage
-       * of the device daemon process (this also address a log message in the IntelliJ log).
-       */
-      @NotNull
-      @Override
-      protected BaseOutputReader.Options readerOptions() {
-        return BaseOutputReader.Options.forMostlySilentProcess();
-      }
-    };
+    final ProcessHandler process = new MostlySilentOsProcessHandler(command);
     Disposer.register(project, process::destroyProcess);
 
     // Send analytics for the start and stop events.

--- a/src/io/flutter/run/daemon/FlutterApp.java
+++ b/src/io/flutter/run/daemon/FlutterApp.java
@@ -29,6 +29,7 @@ import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.util.EventDispatcher;
 import com.intellij.util.concurrency.AppExecutorUtil;
+import com.intellij.util.io.BaseOutputReader;
 import io.flutter.FlutterInitializer;
 import io.flutter.FlutterUtils;
 import io.flutter.ObservatoryConnector;
@@ -249,7 +250,17 @@ public class FlutterApp {
     LOG.info(analyticsStart + " " + project.getName() + " (" + mode.mode() + ")");
     LOG.info(command.toString());
 
-    final ProcessHandler process = new OSProcessHandler(command);
+    final ProcessHandler process = new OSProcessHandler(command) {
+      /**
+       * Return BaseOutputReader.Options.forMostlySilentProcess() in order to reduce cpu usage
+       * of the device daemon process (this also address a log message in the IntelliJ log).
+       */
+      @NotNull
+      @Override
+      protected BaseOutputReader.Options readerOptions() {
+        return BaseOutputReader.Options.forMostlySilentProcess();
+      }
+    };
     Disposer.register(project, process::destroyProcess);
 
     // Send analytics for the start and stop events.

--- a/src/io/flutter/utils/MostlySilentOsProcessHandler.java
+++ b/src/io/flutter/utils/MostlySilentOsProcessHandler.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.utils;
+
+import com.intellij.execution.ExecutionException;
+import com.intellij.execution.configurations.GeneralCommandLine;
+import com.intellij.execution.process.OSProcessHandler;
+import com.intellij.util.io.BaseOutputReader;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * An {@link OSProcessHandler} that uses {@code BaseOutputReader.Options.forMostlySilentProcess()}
+ * in order to reduce cpu usage of the process it runs.
+ *
+ * <p>
+ * This also addresses a log message in the IntelliJ log.
+ */
+public class MostlySilentOsProcessHandler extends OSProcessHandler {
+  public MostlySilentOsProcessHandler(@NotNull GeneralCommandLine commandLine)
+    throws ExecutionException {
+    super(commandLine);
+  }
+
+  @NotNull
+  @Override
+  protected BaseOutputReader.Options readerOptions() {
+    return BaseOutputReader.Options.forMostlySilentProcess();
+  }
+}

--- a/src/io/flutter/utils/MostlySilentOsProcessHandler.java
+++ b/src/io/flutter/utils/MostlySilentOsProcessHandler.java
@@ -7,16 +7,27 @@ package io.flutter.utils;
 
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configurations.GeneralCommandLine;
+import com.intellij.execution.process.BaseOSProcessHandler;
 import com.intellij.execution.process.OSProcessHandler;
 import com.intellij.util.io.BaseOutputReader;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * An {@link OSProcessHandler} that uses {@code BaseOutputReader.Options.forMostlySilentProcess()}
+ * An {@link OSProcessHandler} that uses {@code BaseOutputReader.Options.forMostlySilentProcess}
  * in order to reduce cpu usage of the process it runs.
  *
  * <p>
- * This also addresses a log message in the IntelliJ log.
+ * This works by defaulting to a non-blocking process polling mode instead of a blocking mode.
+ * The default can be overriden by setting the following registry flags:
+ * <ul>
+ *   <li> "output.reader.blocking.mode.for.mostly.silent.processes" = false
+ *   <li> "output.reader.blocking.mode" = true
+ * </ul>
+ *
+ * <p>
+ * Note that long-running processes that don't use these options may log a warning in message
+ * in the IntelliJ log.  See {@link BaseOSProcessHandler}'s {@code SimpleOutputReader.beforeSleeping}
+ * for more information.
  */
 public class MostlySilentOsProcessHandler extends OSProcessHandler {
   public MostlySilentOsProcessHandler(@NotNull GeneralCommandLine commandLine)


### PR DESCRIPTION
- switch it to a mostly silent process
- refactor the mostly silent process handler into a shared util

Justification: Flutter apps that take a long time to start up in debug mode (for example, they have native logic that they invoke before the Flutter app itself starts) can make IntelliJ upset.