### PR TITLE
Fix test to match class docs

### DIFF
--- a/testSrc/unit/io/flutter/utils/AsyncRateLimiterTest.java
+++ b/testSrc/unit/io/flutter/utils/AsyncRateLimiterTest.java
@@ -103,7 +103,7 @@ public class AsyncRateLimiterTest {
 
     // First event should occur immediately so don't count it.
     final double requestsPerSecond = (expectedEvents - 1) / (delta * 0.001);
-    assertTrue("Requests per second less than limit. Actual: " + requestsPerSecond, requestsPerSecond < TEST_FRAMES_PER_SECOND);
+    assertTrue("Requests per second less than limit. Actual: " + requestsPerSecond, requestsPerSecond <= TEST_FRAMES_PER_SECOND);
     // We use a large delta so that tests run under load do not result in flakes.
     assertTrue("Requests per second within 3 fps of rate limit:", requestsPerSecond + 3.0 > TEST_FRAMES_PER_SECOND);
   }

--- a/testSrc/unit/io/flutter/utils/AsyncRateLimiterTest.java
+++ b/testSrc/unit/io/flutter/utils/AsyncRateLimiterTest.java
@@ -103,7 +103,7 @@ public class AsyncRateLimiterTest {
 
     // First event should occur immediately so don't count it.
     final double requestsPerSecond = (expectedEvents - 1) / (delta * 0.001);
-    assertTrue("Requests per second less than limit. Actual: " + requestsPerSecond, requestsPerSecond <= TEST_FRAMES_PER_SECOND);
+    assertTrue("Requests per second does not exceed limit. Actual: " + requestsPerSecond, requestsPerSecond <= TEST_FRAMES_PER_SECOND);
     // We use a large delta so that tests run under load do not result in flakes.
     assertTrue("Requests per second within 3 fps of rate limit:", requestsPerSecond + 3.0 > TEST_FRAMES_PER_SECOND);
   }


### PR DESCRIPTION
From the class docs:
```java
 * Rate limiter that issues requests asynchronously on the ui thread
 * ensuring framesPerSecond rate is not exceeded and that no more than 1
 * request is issued at a time.
```
The test would fail with `requestsPerSecond` at 10, which is what the rate limited was told to not exceed. So, change `<` to `<=` to make the test not flakey.