### PR TITLE
Update installation for libraries

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,11 @@ file.
 * In the Project Structure dialog (`File | Project Structure`), select "Platform Settings > SDKs" click the "+" sign at the top "Add New SDK (Alt+Insert)" to configure an IntelliJ Platform Plugin SDK
   - point it to the directory of your downloaded IntelliJ Community Edition installation (e.g, `IntelliJ IDEA CE.app/Contents` or `~/idea-IC-183.4886.37`)
   - change the name to `IntelliJ IDEA Community Edition`
+* In the Project Structure dialog (`File | Project Structure`), select "Libraries" 
+  - click the "+" sign at the top "From maven..." to add libraries for PowerMock. Do this twice, for:
+    - powermock-module-junit4
+    - powermock-api-mockito2
+  - Use the 2.0.0 version, or whatever is current in `flutter-intellij.iml`
 * One-time Dart plugin install - first-time a new IDE is installed and run you will need to install the Dart plugin.  `Configure | Plugins` and install the Dart plugin, then restart the IDE
 * Open flutter-intellij project in IntelliJ (select and open the directory of the flutter-intellij repository). Build it using `Build` | `Make Project`
 * Try running the plugin; there is an existing launch config for "Flutter IntelliJ".


### PR DESCRIPTION
Unit tests can now use mockito through the PowerMock libraries. The instructions are updated to include installation of them.

You'll need to do this if you haven't already.

@kenzieschmoll @jacob314 @terrylucas @pq @devoncarew