### PR TITLE
make the area for the flutter version smaller

### DIFF
--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.form
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.form
@@ -8,7 +8,7 @@
     <properties/>
     <border type="none"/>
     <children>
-      <grid id="7bd49" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="7bd49" layout-manager="GridLayoutManager" row-count="2" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="2" bottom="1" right="0"/>
         <constraints>
           <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -35,18 +35,24 @@
           </component>
           <component id="83a87" class="com.intellij.ui.ComboboxWithBrowseButton" binding="mySdkCombo" custom-create="true">
             <constraints>
-              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+              <grid row="0" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties/>
           </component>
           <component id="6278f" class="com.intellij.ui.components.JBLabel" binding="myVersionLabel">
             <constraints>
-              <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false">
-                <preferred-size width="-1" height="80"/>
-              </grid>
+              <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="7" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
-              <text value="&lt;html&gt;placeholder for&lt;br/&gt;version details&lt;br/&gt;(this text is not visible at runtime)&lt;/html&gt;"/>
+              <text value="placeholder for version details"/>
+            </properties>
+          </component>
+          <component id="3285c" class="com.intellij.openapi.ui.FixedSizeButton" binding="myCopyButton">
+            <constraints>
+              <grid row="1" column="2" row-span="1" col-span="1" vsize-policy="3" hsize-policy="1" anchor="0" fill="0" indent="1" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <toolTipText value="Copy to Clipboard"/>
             </properties>
           </component>
         </children>

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.java
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.java
@@ -335,6 +335,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
   private void onVersionChanged() {
     final FlutterSdk sdk = FlutterSdk.forPath(getSdkPathText());
     if (sdk == null) {
+      // Clear the label out with a non-empty string, so that the layout doesn't give this element 0 height.
       myVersionLabel.setText(" ");
       fullVersionString = null;
       return;

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.java
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.java
@@ -8,14 +8,17 @@ package io.flutter.sdk;
 import com.intellij.execution.process.ProcessOutput;
 import com.intellij.ide.actions.ShowSettingsUtilImpl;
 import com.intellij.ide.browsers.BrowserLauncher;
+import com.intellij.openapi.actionSystem.ActionToolbar;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory;
+import com.intellij.openapi.ide.CopyPasteManager;
 import com.intellij.openapi.options.ConfigurationException;
 import com.intellij.openapi.options.SearchableConfigurable;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.ComboBox;
+import com.intellij.openapi.ui.FixedSizeButton;
 import com.intellij.openapi.ui.TextComponentAccessor;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.util.io.FileUtilRt;
@@ -23,12 +26,12 @@ import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.ui.ComboboxWithBrowseButton;
 import com.intellij.ui.DocumentAdapter;
 import com.intellij.ui.components.JBLabel;
+import com.intellij.util.PlatformIcons;
 import io.flutter.FlutterBundle;
 import io.flutter.FlutterConstants;
 import io.flutter.FlutterInitializer;
 import io.flutter.FlutterUtils;
 import io.flutter.settings.FlutterSettings;
-import io.flutter.utils.FlutterModuleUtils;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -36,6 +39,7 @@ import org.jetbrains.annotations.Nullable;
 import javax.swing.*;
 import javax.swing.event.DocumentEvent;
 import javax.swing.text.JTextComponent;
+import java.awt.datatransfer.StringSelection;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.net.URI;
@@ -72,22 +76,32 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
   private JCheckBox myShowMultipleChildrenGuides;
   private JCheckBox myShowBuildMethodsOnScrollbar;
   private JCheckBox myShowClosingLabels;
+  private FixedSizeButton myCopyButton;
 
   private final @NotNull Project myProject;
 
   private boolean ignoringSdkChanges = false;
+
+  private String fullVersionString;
 
   FlutterSettingsConfigurable(@NotNull Project project) {
     this.myProject = project;
 
     init();
 
-    myVersionLabel.setText("");
-    myVersionLabel.setCopyable(true);
+    myVersionLabel.setText(" ");
   }
 
   private void init() {
     mySdkCombo.getComboBox().setEditable(true);
+
+    myCopyButton.setSize(ActionToolbar.DEFAULT_MINIMUM_BUTTON_SIZE);
+    myCopyButton.setIcon(PlatformIcons.COPY_ICON);
+    myCopyButton.addActionListener(e -> {
+      if (fullVersionString != null) {
+        CopyPasteManager.getInstance().setContents(new StringSelection(fullVersionString));
+      }
+    });
 
     final JTextComponent sdkEditor = (JTextComponent)mySdkCombo.getComboBox().getEditor().getEditorComponent();
     sdkEditor.getDocument().addDocumentListener(new DocumentAdapter() {
@@ -321,7 +335,8 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
   private void onVersionChanged() {
     final FlutterSdk sdk = FlutterSdk.forPath(getSdkPathText());
     if (sdk == null) {
-      myVersionLabel.setText("");
+      myVersionLabel.setText(" ");
+      fullVersionString = null;
       return;
     }
 
@@ -331,9 +346,12 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     myDisableTrackWidgetCreationCheckBox.setVisible(trackWidgetCreationRecommended);
 
     sdk.flutterVersion().start((ProcessOutput output) -> {
-      final String stdout = output.getStdout();
-      final String htmlText = "<html>" + StringUtil.replace(StringUtil.escapeXml(stdout.trim()), "\n", "<br/>") + "</html>";
-      ApplicationManager.getApplication().invokeLater(() -> updateVersionTextIfCurrent(sdk, htmlText), modalityState);
+      final String fullVersionText = output.getStdout();
+      fullVersionString = fullVersionText;
+
+      final String[] lines = StringUtil.splitByLines(fullVersionText);
+      final String singleLineVersion = lines.length > 0 ? lines[0] : "";
+      ApplicationManager.getApplication().invokeLater(() -> updateVersionTextIfCurrent(sdk, singleLineVersion), modalityState);
     }, null);
   }
 
@@ -345,7 +363,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
   private void updateVersionTextIfCurrent(@NotNull FlutterSdk sdk, @NotNull String value) {
     final FlutterSdk current = FlutterSdk.forPath(getSdkPathText());
     if (current == null) {
-      myVersionLabel.setText("");
+      myVersionLabel.setText(" ");
     }
     else {
       myVersionLabel.setText(value);


### PR DESCRIPTION
- reduce the screen area we use to display the Flutter version in the preferences view. We've added several new preferences recently - this change will make it less likely for the Flutter preference page to need to scroll.
- also, add a 'copy tp clipboard' button for the version text

<img width="765" alt="Screen Shot 2019-06-21 at 1 08 19 PM" src="https://user-images.githubusercontent.com/1269969/59951487-efda2180-942d-11e9-9415-4dc294b193dd.png">
