### PR TITLE
simplify the sample creation workflow

### DIFF
--- a/flutter-studio/src/io/flutter/project/FlutterProjectCreator.java
+++ b/flutter-studio/src/io/flutter/project/FlutterProjectCreator.java
@@ -210,7 +210,6 @@ public class FlutterProjectCreator {
       .setKotlin(isNotModule() && myModel.useKotlin().get() ? true : null)
       .setSwift(isNotModule() && myModel.useSwift().get() ? true : null)
       .setOffline(myModel.isOfflineSelected().get())
-      .setSampleContent(myModel.getSample())
       .build();
   }
 

--- a/flutter-studio/src/io/flutter/project/FlutterProjectModel.java
+++ b/flutter-studio/src/io/flutter/project/FlutterProjectModel.java
@@ -14,7 +14,6 @@ import com.android.tools.idea.wizard.model.WizardModel;
 import com.intellij.ide.util.PropertiesComponent;
 import com.intellij.openapi.project.Project;
 import io.flutter.module.FlutterProjectType;
-import io.flutter.samples.FlutterSample;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -43,7 +42,6 @@ public class FlutterProjectModel extends WizardModel {
   @NotNull final private BoolValueProperty mySwift = new BoolValueProperty();
   @NotNull final private OptionalProperty<Project> myProject = new OptionalValueProperty<>();
   @NotNull final private BoolValueProperty myIsOfflineSelected = new BoolValueProperty();
-  private FlutterSample mySelectedSample;
 
   public FlutterProjectModel(@NotNull FlutterProjectType type) {
     myProjectType.set(new OptionalValueProperty<>(type));
@@ -63,15 +61,6 @@ public class FlutterProjectModel extends WizardModel {
 
     mySwift.set(getInitialSwiftSupport());
     mySwift.addListener(() -> setInitialSwiftSupport(mySwift.get()));
-  }
-
-  public void setSample(@Nullable FlutterSample sample) {
-    mySelectedSample = sample;
-  }
-
-  @Nullable
-  public FlutterSample getSample() {
-    return mySelectedSample;
   }
 
   @NotNull

--- a/flutter-studio/src/io/flutter/project/FlutterSettingsStep.form
+++ b/flutter-studio/src/io/flutter/project/FlutterSettingsStep.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="io.flutter.project.FlutterSettingsStep">
-  <grid id="27dc6" binding="myRootPanel" layout-manager="GridLayoutManager" row-count="14" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="myRootPanel" layout-manager="GridLayoutManager" row-count="13" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="500" height="452"/>
@@ -20,12 +20,12 @@
       </component>
       <vspacer id="85806">
         <constraints>
-          <grid row="13" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="12" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
       <component id="3d5fb" class="javax.swing.JLabel" binding="myLanguageLabel">
         <constraints>
-          <grid row="10" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="9" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <font style="1"/>
@@ -72,7 +72,7 @@
       </vspacer>
       <component id="533e3" class="javax.swing.JCheckBox" binding="myKotlinCheckBox">
         <constraints>
-          <grid row="11" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="10" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Kotlin"/>
@@ -81,7 +81,7 @@
       </component>
       <component id="15a79" class="javax.swing.JCheckBox" binding="mySwiftCheckBox">
         <constraints>
-          <grid row="12" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="11" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Swift"/>
@@ -112,42 +112,6 @@
           <text value="Applications and plugins need to generate platform-specific code"/>
         </properties>
       </component>
-      <grid id="a336f" binding="mySamplePanel" layout-manager="GridLayoutManager" row-count="3" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
-        <margin top="0" left="0" bottom="0" right="0"/>
-        <constraints>
-          <grid row="9" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties/>
-        <border type="none"/>
-        <children>
-          <component id="fe85" class="javax.swing.JLabel">
-            <constraints>
-              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <font style="1"/>
-              <text value="Sample Application"/>
-            </properties>
-          </component>
-          <hspacer id="c6bbb">
-            <constraints>
-              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
-            </constraints>
-          </hspacer>
-          <nested-form id="4869f" form-file="io/flutter/module/settings/ProjectType.form" binding="myProjectTypeForm">
-            <constraints>
-              <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
-            </constraints>
-          </nested-form>
-          <vspacer id="d5f9">
-            <constraints>
-              <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
-                <preferred-size width="-1" height="16"/>
-              </grid>
-            </constraints>
-          </vspacer>
-        </children>
-      </grid>
     </children>
   </grid>
 </form>

--- a/flutter-studio/src/io/flutter/project/FlutterSettingsStep.java
+++ b/flutter-studio/src/io/flutter/project/FlutterSettingsStep.java
@@ -57,7 +57,6 @@ public class FlutterSettingsStep extends ModelWizardStep<FlutterProjectModel> {
   private JCheckBox myKotlinCheckBox;
   private JCheckBox mySwiftCheckBox;
   private JLabel myLanguageLabel;
-  private JPanel mySamplePanel;
   private ProjectType myProjectTypeForm;
   private boolean hasEntered = false;
   private FocusListener focusListener;
@@ -165,7 +164,6 @@ public class FlutterSettingsStep extends ModelWizardStep<FlutterProjectModel> {
         myProjectTypeForm.setSdk(sdk);
       }
     }
-    mySamplePanel.setVisible(projectType == FlutterProjectType.APP);
     myProjectTypeForm.getProjectTypeCombo().setSelectedItem(projectType);
     myProjectTypeForm.getProjectTypeCombo().setVisible(false);
     hasEntered = true;
@@ -173,6 +171,6 @@ public class FlutterSettingsStep extends ModelWizardStep<FlutterProjectModel> {
 
   @Override
   protected void onProceeding() {
-    getModel().setSample(myProjectTypeForm.getSample());
+
   }
 }

--- a/src/io/flutter/module/settings/FlutterCreateAdditionalSettingsFields.java
+++ b/src/io/flutter/module/settings/FlutterCreateAdditionalSettingsFields.java
@@ -27,6 +27,7 @@ public class FlutterCreateAdditionalSettingsFields {
   private final RadiosForm iosLanguageRadios;
   private final ProjectType projectTypeForm;
   private final FlutterCreateParams createParams;
+
   public FlutterCreateAdditionalSettingsFields() {
     this(new FlutterCreateAdditionalSettings(), null);
   }
@@ -37,7 +38,6 @@ public class FlutterCreateAdditionalSettingsFields {
     projectTypeForm = new ProjectType(sdk);
     projectTypeForm.addListener(e -> {
       settings.setType(projectTypeForm.getType());
-      settings.setSampleContent(projectTypeForm.getSample());
       changeVisibility(projectTypeForm.getType() != FlutterProjectType.PACKAGE);
     });
 
@@ -114,7 +114,6 @@ public class FlutterCreateAdditionalSettingsFields {
       .setKotlin(androidLanguageRadios.isRadio2Selected() ? true : null)
       .setOrg(!orgField.getText().trim().isEmpty() ? orgField.getText().trim() : null)
       .setSwift(iosLanguageRadios.isRadio2Selected() ? true : null)
-      .setSampleContent(projectTypeForm.getSample())
       .setOffline(createParams.isOfflineSelected())
       .build();
   }

--- a/src/io/flutter/module/settings/ProjectType.form
+++ b/src/io/flutter/module/settings/ProjectType.form
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="io.flutter.module.settings.ProjectType">
-  <grid id="27dc6" binding="projectTypePanel" layout-manager="GridLayoutManager" row-count="2" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="projectTypePanel" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="400" height="400"/>
+      <xy x="20" y="20" width="102" height="400"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -21,20 +21,6 @@
           <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
-      <component id="ffd7" class="com.intellij.openapi.ui.ComboBox" binding="snippetSelectorCombo" custom-create="true">
-        <constraints>
-          <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties/>
-      </component>
-      <component id="5527c" class="javax.swing.JCheckBox" binding="generateSampleContentCheckBox" custom-create="true" default-binding="true">
-        <constraints>
-          <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <text value="generate s&amp;ample content:"/>
-        </properties>
-      </component>
     </children>
   </grid>
 </form>

--- a/src/io/flutter/module/settings/ProjectType.java
+++ b/src/io/flutter/module/settings/ProjectType.java
@@ -6,20 +6,15 @@
 package io.flutter.module.settings;
 
 import com.intellij.openapi.ui.ComboBox;
-import com.intellij.ui.ColoredListCellRenderer;
-import com.intellij.ui.SimpleTextAttributes;
 import io.flutter.FlutterBundle;
 import io.flutter.module.FlutterProjectType;
-import io.flutter.samples.FlutterSample;
 import io.flutter.sdk.FlutterSdk;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
-import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 
@@ -65,66 +60,11 @@ public class ProjectType {
     }
   }
 
-  private static final class FlutterSampleComboBoxModel extends AbstractListModel<FlutterSample>
-    implements ComboBoxModel<FlutterSample> {
-    private final List<FlutterSample> myList;
-    private FlutterSample mySelected;
-
-    public FlutterSampleComboBoxModel() {
-      this(null);
-    }
-
-    public FlutterSampleComboBoxModel(@Nullable FlutterSdk sdk) {
-      myList = sdk == null ? Collections.emptyList() : sdk.getSamples();
-      mySelected = myList.isEmpty() ? null : myList.get(0);
-    }
-
-    @Override
-    public int getSize() {
-      return myList.size();
-    }
-
-    @Override
-    public FlutterSample getElementAt(int index) {
-      return myList.isEmpty() ? null : myList.get(index);
-    }
-
-    @Override
-    public void setSelectedItem(Object item) {
-      setSelectedItem((FlutterSample)item);
-    }
-
-    @Override
-    public FlutterSample getSelectedItem() {
-      return mySelected;
-    }
-
-    public void setSelectedItem(FlutterSample item) {
-      mySelected = item;
-      fireContentsChanged(this, 0, getSize());
-    }
-  }
-
-  private class FlutterSampleCellRenderer extends ColoredListCellRenderer<FlutterSample> {
-    @Override
-    protected void customizeCellRenderer(@NotNull JList<? extends FlutterSample> list,
-                                         @Nullable FlutterSample sample,
-                                         int index,
-                                         boolean selected,
-                                         boolean hasFocus) {
-      final SimpleTextAttributes style =
-        snippetSelectorCombo.isEnabled() ? SimpleTextAttributes.REGULAR_ATTRIBUTES : SimpleTextAttributes.GRAY_ATTRIBUTES;
-      append(sample == null ? "" : sample.getDisplayLabel(), style);
-    }
-  }
-
   @Nullable
   private FlutterSdk sdk;
 
   private JPanel projectTypePanel;
   private ComboBox projectTypeCombo;
-  private ComboBox<FlutterSample> snippetSelectorCombo;
-  private JCheckBox generateSampleContentCheckBox;
 
   public ProjectType(@Nullable FlutterSdk sdk) {
     this.sdk = sdk;
@@ -140,24 +80,6 @@ public class ProjectType {
     //noinspection unchecked
     projectTypeCombo.setModel(new ProjectTypeComboBoxModel());
     projectTypeCombo.setToolTipText(FlutterBundle.message("flutter.module.create.settings.type.tip"));
-    projectTypeCombo.addItemListener(e -> {
-      final boolean appType = getType() == FlutterProjectType.APP;
-      if (!appType) {
-        // Make sure sample generation is de-selected in non-app contexts.
-        generateSampleContentCheckBox.setSelected(false);
-      }
-      generateSampleContentCheckBox.setEnabled(appType);
-    });
-
-    snippetSelectorCombo = new ComboBox<>();
-    snippetSelectorCombo.setModel(new FlutterSampleComboBoxModel(sdk));
-    snippetSelectorCombo.setRenderer(new FlutterSampleCellRenderer());
-    snippetSelectorCombo.setToolTipText(FlutterBundle.message("flutter.module.create.settings.sample.tip"));
-    snippetSelectorCombo.setEnabled(false);
-
-    generateSampleContentCheckBox = new JCheckBox();
-    generateSampleContentCheckBox.setText(FlutterBundle.message("flutter.module.create.settings.sample.text"));
-    generateSampleContentCheckBox.addItemListener(e -> snippetSelectorCombo.setEnabled(e.getStateChange() == ItemEvent.SELECTED));
   }
 
   @NotNull
@@ -169,22 +91,15 @@ public class ProjectType {
     return (FlutterProjectType)projectTypeCombo.getSelectedItem();
   }
 
-  public FlutterSample getSample() {
-    return generateSampleContentCheckBox.isVisible() && generateSampleContentCheckBox.isSelected() ? (FlutterSample)snippetSelectorCombo
-      .getSelectedItem() : null;
-  }
-
   public ComboBox getProjectTypeCombo() {
     return projectTypeCombo;
   }
 
   public void setSdk(@NotNull FlutterSdk sdk) {
     this.sdk = sdk;
-    snippetSelectorCombo.setModel(new FlutterSampleComboBoxModel(sdk));
   }
 
   public void addListener(ItemListener listener) {
     projectTypeCombo.addItemListener(listener);
-    snippetSelectorCombo.addItemListener(listener);
   }
 }

--- a/src/io/flutter/samples/FlutterSampleManager.java
+++ b/src/io/flutter/samples/FlutterSampleManager.java
@@ -42,10 +42,6 @@ import java.nio.file.Files;
 import java.util.*;
 
 public class FlutterSampleManager {
-  // TODO(pq): remove after testing.
-  // See https://github.com/flutter/flutter-intellij/issues/3330.
-  private static final boolean DISABLE_SAMPLES = false;
-
   private static final long SAMPLE_LISTING_PROCESS_TIMEOUT_IN_MS = 30000L;
 
   private static final String SNIPPETS_REMOTE_INDEX_URL = "https://docs.flutter.io/snippets/index.json";
@@ -61,10 +57,6 @@ public class FlutterSampleManager {
   }
 
   public List<FlutterSample> getSamples() {
-    if (DISABLE_SAMPLES) {
-      return Collections.emptyList();
-    }
-
     if (flutterSamples != null) {
       return flutterSamples;
     }
@@ -79,8 +71,9 @@ public class FlutterSampleManager {
     final Task.Backgroundable task = new Task.Backgroundable(null, "Initializing Flutter Sample Listing", true) {
       OSProcessHandler process;
       boolean isRunning;
+
       public void run(@NotNull ProgressIndicator indicator) {
-        synchronized(this) {
+        synchronized (this) {
           if (isRunning) {
             return;
           }
@@ -249,7 +242,6 @@ public class FlutterSampleManager {
         // TODO(pq): handle event.getExitCode().
       }
     };
-
 
     final PubRoot root =
       FlutterModuleBuilder.runFlutterCreateWithProgress(baseDir, sdk, project, outputListener, getCreateSettings(sample));

--- a/src/io/flutter/samples/FlutterSampleNotificationProvider.java
+++ b/src/io/flutter/samples/FlutterSampleNotificationProvider.java
@@ -67,4 +67,3 @@ public class FlutterSampleNotificationProvider extends EditorNotifications.Provi
     return samples;
   }
 }
-

--- a/src/io/flutter/sdk/FlutterCreateAdditionalSettings.java
+++ b/src/io/flutter/sdk/FlutterCreateAdditionalSettings.java
@@ -28,8 +28,6 @@ public class FlutterCreateAdditionalSettings {
   private Boolean kotlin;
   @Nullable
   private Boolean offlineMode;
-  @Nullable
-  private FlutterSample sampleContent;
 
   public FlutterCreateAdditionalSettings() {
     type = FlutterProjectType.APP;
@@ -43,7 +41,6 @@ public class FlutterCreateAdditionalSettings {
                                           @Nullable String org,
                                           @Nullable Boolean swift,
                                           @Nullable Boolean kotlin,
-                                          @Nullable FlutterSample sampleContent,
                                           @Nullable Boolean offlineMode) {
     this.includeDriverTest = includeDriverTest;
     this.type = type;
@@ -51,7 +48,6 @@ public class FlutterCreateAdditionalSettings {
     this.org = org;
     this.swift = swift;
     this.kotlin = kotlin;
-    this.sampleContent = sampleContent;
     this.offlineMode = offlineMode;
   }
 
@@ -74,15 +70,6 @@ public class FlutterCreateAdditionalSettings {
 
   public void setKotlin(boolean value) {
     kotlin = value;
-  }
-
-  @Nullable
-  public FlutterSample getSampleContent() {
-    return sampleContent;
-  }
-
-  public void setSampleContent(@Nullable FlutterSample sampleContent) {
-    this.sampleContent = sampleContent;
   }
 
   public List<String> getArgs() {
@@ -119,11 +106,6 @@ public class FlutterCreateAdditionalSettings {
     if (Boolean.TRUE.equals(kotlin)) {
       args.add("--android-language");
       args.add("kotlin");
-    }
-
-    if (sampleContent != null) {
-      args.add("--sample");
-      args.add(sampleContent.getId());
     }
 
     return args;
@@ -210,7 +192,7 @@ public class FlutterCreateAdditionalSettings {
     }
 
     public FlutterCreateAdditionalSettings build() {
-      return new FlutterCreateAdditionalSettings(includeDriverTest, type, description, org, swift, kotlin, sampleContent, offlineMode);
+      return new FlutterCreateAdditionalSettings(includeDriverTest, type, description, org, swift, kotlin, offlineMode);
     }
   }
 }

--- a/src/io/flutter/sdk/FlutterSdk.java
+++ b/src/io/flutter/sdk/FlutterSdk.java
@@ -406,17 +406,6 @@ public class FlutterSdk {
   @Nullable
   public PubRoot createFiles(@NotNull VirtualFile baseDir, @Nullable Module module, @Nullable ProcessListener listener,
                              @Nullable FlutterCreateAdditionalSettings additionalSettings) {
-    // Sample projects overwrite project directory contents which causes the Android Support plugin to get confused.
-    // (See: https://github.com/flutter/flutter-intellij/issues/3120).
-    // As a work-around, we remove sample basedir project directory contents proactively.
-    if (additionalSettings != null && additionalSettings.getSampleContent() != null) {
-      for (VirtualFile f : baseDir.getChildren()) {
-        final File file = VfsUtilCore.virtualToIoFile(f);
-        FileUtil.delete(file);
-      }
-      baseDir.refresh(false, true);
-    }
-
     final Process process;
     if (module == null) {
       process = flutterCreate(baseDir, additionalSettings).start(null, listener);


### PR DESCRIPTION
- simplify the sample creation workflow
- this PR removes the ability to create the dartdoc defined samples from the project wizards
- some work towards https://github.com/flutter/flutter-intellij/issues/3562

After this PR, users can continue to create sample projects via the in-line editor contributions. I think this better matches the flow of how we expect this to be used - when looking at specific widgets, rather than ahead of time, when considering creating a new project.

<img width="927" alt="Screen Shot 2019-06-24 at 9 23 54 AM" src="https://user-images.githubusercontent.com/1269969/60035491-cf92a880-9661-11e9-8085-627c0affd1af.png">

@pq
