### PR TITLE
support showing desktop and web devices

### DIFF
--- a/src/io/flutter/FlutterBundle.properties
+++ b/src/io/flutter/FlutterBundle.properties
@@ -212,7 +212,7 @@ shout.level.title=Shout
 
 settings.try.out.features.still.under.development=Try out features still under development (a restart may be required)
 settings.experimental.flutter.logging.view=Replace the Run and Debug console output with a custom Flutter Logging view
-settings.enable.android.gradle.sync=Enable code completion, navigation, etc. for Java/Kotlin (requires restart to do Gradle build)
+settings.enable.android.gradle.sync=Enable code completion, navigation, etc. for Java / Kotlin (requires restart to do Gradle build)
 settings.report.google.analytics=&Report usage information to Google Analytics
 settings.enable.verbose.logging=Enable &verbose logging
 settings.format.code.on.save=Format code on save

--- a/src/io/flutter/actions/DeviceSelectorAction.java
+++ b/src/io/flutter/actions/DeviceSelectorAction.java
@@ -145,7 +145,7 @@ public class DeviceSelectorAction extends ComboBoxAction implements DumbAware {
 
           final Presentation template = action.getTemplatePresentation();
           presentation.setIcon(template.getIcon());
-          presentation.setText(deviceAction.deviceName());
+          presentation.setText(deviceAction.presentationName());
           presentation.setEnabled(true);
           return;
         }
@@ -192,8 +192,8 @@ public class DeviceSelectorAction extends ComboBoxAction implements DumbAware {
       this.device = device;
     }
 
-    public String deviceName() {
-      return device.deviceName();
+    public String presentationName() {
+      return device.presentationName();
     }
 
     @Override

--- a/src/io/flutter/actions/DeviceSelectorAction.java
+++ b/src/io/flutter/actions/DeviceSelectorAction.java
@@ -27,6 +27,8 @@ public class DeviceSelectorAction extends ComboBoxAction implements DumbAware {
   private final List<AnAction> actions = new ArrayList<>();
   private final List<Project> knownProjects = Collections.synchronizedList(new ArrayList<>());
 
+  private SelectDeviceAction selectedDeviceAction;
+
   @NotNull
   @Override
   protected DefaultActionGroup createPopupActionGroup(JComponent button) {
@@ -97,16 +99,23 @@ public class DeviceSelectorAction extends ComboBoxAction implements DumbAware {
 
     final DeviceService service = DeviceService.getInstance(project);
 
+    final FlutterDevice selectedDevice = service.getSelectedDevice();
     final Collection<FlutterDevice> devices = service.getConnectedDevices();
 
-    for (FlutterDevice device : devices) {
-      actions.add(new SelectDeviceAction(device, devices));
-    }
+    selectedDeviceAction = null;
 
-    if (actions.isEmpty()) {
-      final boolean isLoading = service.getStatus() == DeviceService.State.LOADING;
-      final String message = isLoading ? FlutterBundle.message("devicelist.loading") : FlutterBundle.message("devicelist.empty");
-      actions.add(new NoDevicesAction(message));
+    for (FlutterDevice device : devices) {
+      final SelectDeviceAction deviceAction = new SelectDeviceAction(device, devices);
+      actions.add(deviceAction);
+
+      if (Objects.equals(device, selectedDevice)) {
+        selectedDeviceAction = deviceAction;
+
+        final Presentation template = deviceAction.getTemplatePresentation();
+        presentation.setIcon(template.getIcon());
+        presentation.setText(deviceAction.presentationName());
+        presentation.setEnabled(true);
+      }
     }
 
     // Show the 'Open iOS Simulator' action.
@@ -133,54 +142,24 @@ public class DeviceSelectorAction extends ComboBoxAction implements DumbAware {
       actions.addAll(emulatorActions);
     }
 
-    selectedDeviceAction = null;
-
-    final FlutterDevice selectedDevice = service.getSelectedDevice();
-    for (AnAction action : actions) {
-      if (action instanceof SelectDeviceAction) {
-        final SelectDeviceAction deviceAction = (SelectDeviceAction)action;
-
-        if (Objects.equals(deviceAction.device, selectedDevice)) {
-          selectedDeviceAction = deviceAction;
-
-          final Presentation template = action.getTemplatePresentation();
-          presentation.setIcon(template.getIcon());
-          presentation.setText(deviceAction.presentationName());
-          presentation.setEnabled(true);
-          return;
-        }
+    if (devices.isEmpty()) {
+      final boolean isLoading = service.getStatus() == DeviceService.State.LOADING;
+      if (isLoading) {
+        presentation.setText(FlutterBundle.message("devicelist.loading"));
+      }
+      else {
+        presentation.setText("<no devices>");
       }
     }
-
-    if (devices.isEmpty()) {
-      presentation.setText("<no devices>");
-    }
-    else {
-      presentation.setText(null);
+    else if (selectedDevice == null) {
+      presentation.setText("<no device selected>");
     }
   }
-
-  private SelectDeviceAction selectedDeviceAction;
 
   // Show the current device as selected when the combo box menu opens.
   @Override
   protected Condition<AnAction> getPreselectCondition() {
     return action -> action == selectedDeviceAction;
-  }
-
-  // It's not clear if we need TransparentUpdate, but apparently it will make the UI refresh
-  // the display more often?
-  // See: https://intellij-support.jetbrains.com/hc/en-us/community/posts/206772825-How-to-enable-disable-action-in-runtime
-  private static class NoDevicesAction extends AnAction implements TransparentUpdate {
-    NoDevicesAction(String message) {
-      super(message, null, null);
-      getTemplatePresentation().setEnabled(false);
-    }
-
-    @Override
-    public void actionPerformed(AnActionEvent e) {
-      // No-op
-    }
   }
 
   private static class SelectDeviceAction extends AnAction {

--- a/src/io/flutter/run/daemon/DaemonEvent.java
+++ b/src/io/flutter/run/daemon/DaemonEvent.java
@@ -302,7 +302,11 @@ abstract class DaemonEvent {
     String id;
     String name;
     String platform;
-    boolean emulator;
+    Boolean emulator;
+
+    @Nullable String category;
+    @Nullable String platformType;
+    @Nullable Boolean ephemeral;
 
     void accept(Listener listener) {
       listener.onDeviceAdded(this);

--- a/src/io/flutter/run/daemon/DeviceDaemon.java
+++ b/src/io/flutter/run/daemon/DeviceDaemon.java
@@ -22,6 +22,7 @@ import io.flutter.bazel.Workspace;
 import io.flutter.bazel.WorkspaceCache;
 import io.flutter.sdk.FlutterSdk;
 import io.flutter.sdk.FlutterSdkUtil;
+import io.flutter.settings.FlutterSettings;
 import io.flutter.utils.FlutterModuleUtils;
 import io.flutter.utils.MostlySilentOsProcessHandler;
 import org.jetbrains.annotations.NotNull;
@@ -292,8 +293,10 @@ class DeviceDaemon {
       result.setCharset(CharsetToolkit.UTF8_CHARSET);
       result.setExePath(FileUtil.toSystemDependentName(command));
       result.withEnvironment(FlutterSdkUtil.FLUTTER_HOST_ENV, FlutterSdkUtil.getFlutterHostEnvValue());
-      result.withEnvironment("ENABLE_FLUTTER_DESKTOP", "true");
-      result.withEnvironment("FLUTTER_WEB", "true");
+      if (FlutterSettings.getInstance().isShowWebDesktopDevices()) {
+        result.withEnvironment("ENABLE_FLUTTER_DESKTOP", "true");
+        result.withEnvironment("FLUTTER_WEB", "true");
+      }
       if (androidHome != null) {
         result.withEnvironment("ANDROID_HOME", androidHome);
       }

--- a/src/io/flutter/run/daemon/DeviceDaemon.java
+++ b/src/io/flutter/run/daemon/DeviceDaemon.java
@@ -10,13 +10,11 @@ import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configurations.GeneralCommandLine;
-import com.intellij.execution.process.OSProcessHandler;
 import com.intellij.execution.process.ProcessHandler;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.vfs.CharsetToolkit;
-import com.intellij.util.io.BaseOutputReader;
 import io.flutter.FlutterMessages;
 import io.flutter.FlutterUtils;
 import io.flutter.android.IntelliJAndroidSdk;
@@ -294,6 +292,8 @@ class DeviceDaemon {
       result.setCharset(CharsetToolkit.UTF8_CHARSET);
       result.setExePath(FileUtil.toSystemDependentName(command));
       result.withEnvironment(FlutterSdkUtil.FLUTTER_HOST_ENV, FlutterSdkUtil.getFlutterHostEnvValue());
+      result.withEnvironment("ENABLE_FLUTTER_DESKTOP", "true");
+      result.withEnvironment("FLUTTER_WEB", "true");
       if (androidHome != null) {
         result.withEnvironment("ANDROID_HOME", androidHome);
       }
@@ -373,7 +373,10 @@ class DeviceDaemon {
       final FlutterDevice newDevice = new FlutterDevice(event.id,
                                                         event.name == null ? event.id : event.name,
                                                         event.platform,
-                                                        event.emulator);
+                                                        event.emulator,
+                                                        event.category,
+                                                        event.platformType,
+                                                        event.ephemeral);
       devices.updateAndGet((old) -> addDevice(old.stream(), newDevice));
       deviceChanged.run();
     }

--- a/src/io/flutter/run/daemon/DeviceSelection.java
+++ b/src/io/flutter/run/daemon/DeviceSelection.java
@@ -26,11 +26,13 @@ class DeviceSelection {
     this.selection = selected;
   }
 
-  @NotNull ImmutableList<FlutterDevice> getDevices() {
+  @NotNull
+  ImmutableList<FlutterDevice> getDevices() {
     return devices;
   }
 
-  @Nullable FlutterDevice getSelection() {
+  @Nullable
+  FlutterDevice getSelection() {
     return selection;
   }
 
@@ -41,9 +43,11 @@ class DeviceSelection {
   DeviceSelection withDevices(@NotNull List<FlutterDevice> newDevices) {
     final String selectedId = selection == null ? null : selection.deviceId();
     final Optional<FlutterDevice> selectedDevice = findById(newDevices, selectedId);
-    // If there's no selected device, default to the first one in the list.
-    final FlutterDevice selectionOrDefault = selectedDevice.orElse(newDevices.size() > 0 ? newDevices.get(0) : null);
-    return new DeviceSelection(ImmutableList.copyOf(newDevices), selectionOrDefault);
+
+    // If there's no selected device, default the first ephemoral one in the list.
+    final FlutterDevice firstEphemoral =
+      newDevices.stream().filter(FlutterDevice::ephemeral).findFirst().orElse(null);
+    return new DeviceSelection(ImmutableList.copyOf(newDevices), firstEphemoral);
   }
 
   /**

--- a/src/io/flutter/run/daemon/FlutterDevice.java
+++ b/src/io/flutter/run/daemon/FlutterDevice.java
@@ -18,11 +18,26 @@ public class FlutterDevice {
   private final @Nullable String myPlatform;
   private final boolean myEmulator;
 
+  private final @Nullable String myCategory;
+  private final @Nullable String myPlatformType;
+  private final boolean myEphemeral;
+
   public FlutterDevice(@NotNull String deviceId, @NotNull String deviceName, @Nullable String platform, boolean emulator) {
+    this(deviceId, deviceName, platform, emulator, null, null, null);
+  }
+
+  public FlutterDevice(
+    @NotNull String deviceId, @NotNull String deviceName, @Nullable String platform,
+    boolean emulator,
+    @Nullable String category, @Nullable String platformType, @Nullable Boolean ephemeral
+  ) {
     myDeviceId = deviceId;
     myDeviceName = deviceName;
     myPlatform = platform;
     myEmulator = emulator;
+    myCategory = category;
+    myPlatformType = platformType;
+    myEphemeral = ephemeral == null ? true : ephemeral;
   }
 
   @NotNull
@@ -42,6 +57,20 @@ public class FlutterDevice {
 
   public boolean emulator() {
     return myEmulator;
+  }
+
+  @Nullable
+  public String category() {
+    return myCategory;
+  }
+
+  @Nullable
+  public String platformType() {
+    return myPlatformType;
+  }
+
+  public boolean ephemeral() {
+    return myEphemeral;
   }
 
   public boolean isIOS() {
@@ -79,11 +108,11 @@ public class FlutterDevice {
       if (other == this) {
         continue;
       }
-      if (other.deviceName().equals(deviceName())) {
-        return deviceName() + " (" + deviceId() + ")";
+      if (other.presentationName().equals(presentationName())) {
+        return presentationName() + " (" + deviceId() + ")";
       }
     }
-    return deviceName();
+    return presentationName();
   }
 
   /**
@@ -102,5 +131,14 @@ public class FlutterDevice {
    */
   public static FlutterDevice getTester() {
     return new FlutterDevice("flutter-tester", "Flutter test device", null, false);
+  }
+
+  public String presentationName() {
+    if (category() != null) {
+      return deviceName() + " (" + category() + ")";
+    }
+    else {
+      return deviceName();
+    }
   }
 }

--- a/src/io/flutter/run/daemon/FlutterDevice.java
+++ b/src/io/flutter/run/daemon/FlutterDevice.java
@@ -59,6 +59,9 @@ public class FlutterDevice {
     return myEmulator;
   }
 
+  /**
+   * One of 'web', 'mobile', or 'desktop'.
+   */
   @Nullable
   public String category() {
     return myCategory;
@@ -69,6 +72,11 @@ public class FlutterDevice {
     return myPlatformType;
   }
 
+  /**
+   * Whether the device is persistent on the machine.
+   *
+   * Web and desktop devices are generally non-ephemeral; mobile devices are generally ephemeral
+   */
   public boolean ephemeral() {
     return myEphemeral;
   }

--- a/src/io/flutter/sdk/FlutterCommand.java
+++ b/src/io/flutter/sdk/FlutterCommand.java
@@ -21,6 +21,7 @@ import io.flutter.FlutterMessages;
 import io.flutter.android.IntelliJAndroidSdk;
 import io.flutter.console.FlutterConsoles;
 import io.flutter.dart.DartPlugin;
+import io.flutter.settings.FlutterSettings;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -246,8 +247,10 @@ public class FlutterCommand {
     final GeneralCommandLine line = new GeneralCommandLine();
     line.setCharset(CharsetToolkit.UTF8_CHARSET);
     line.withEnvironment(FlutterSdkUtil.FLUTTER_HOST_ENV, FlutterSdkUtil.getFlutterHostEnvValue());
-    line.withEnvironment("ENABLE_FLUTTER_DESKTOP", "true");
-    line.withEnvironment("FLUTTER_WEB", "true");
+    if (FlutterSettings.getInstance().isShowWebDesktopDevices()) {
+      line.withEnvironment("ENABLE_FLUTTER_DESKTOP", "true");
+      line.withEnvironment("FLUTTER_WEB", "true");
+    }
     final String androidHome = IntelliJAndroidSdk.chooseAndroidHome(project, false);
     if (androidHome != null) {
       line.withEnvironment("ANDROID_HOME", androidHome);

--- a/src/io/flutter/sdk/FlutterCommand.java
+++ b/src/io/flutter/sdk/FlutterCommand.java
@@ -246,6 +246,8 @@ public class FlutterCommand {
     final GeneralCommandLine line = new GeneralCommandLine();
     line.setCharset(CharsetToolkit.UTF8_CHARSET);
     line.withEnvironment(FlutterSdkUtil.FLUTTER_HOST_ENV, FlutterSdkUtil.getFlutterHostEnvValue());
+    line.withEnvironment("ENABLE_FLUTTER_DESKTOP", "true");
+    line.withEnvironment("FLUTTER_WEB", "true");
     final String androidHome = IntelliJAndroidSdk.chooseAndroidHome(project, false);
     if (androidHome != null) {
       line.withEnvironment("ANDROID_HOME", androidHome);

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.form
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.form
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="io.flutter.sdk.FlutterSettingsConfigurable">
-  <grid id="27dc6" binding="mainPanel" layout-manager="GridLayoutManager" row-count="7" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="mainPanel" layout-manager="GridLayoutManager" row-count="8" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="972" height="825"/>
     </constraints>
-    <properties/>
+    <properties>
+      <autoscrolls value="true"/>
+    </properties>
     <border type="none"/>
     <children>
       <grid id="7bd49" layout-manager="GridLayoutManager" row-count="2" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
@@ -204,45 +206,10 @@
           </component>
         </children>
       </grid>
-      <grid id="23e52" layout-manager="GridLayoutManager" row-count="3" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
-        <margin top="0" left="0" bottom="0" right="0"/>
-        <constraints>
-          <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties/>
-        <border type="etched" title="Experiments"/>
-        <children>
-          <component id="42d6c" class="javax.swing.JLabel">
-            <constraints>
-              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <text resource-bundle="io/flutter/FlutterBundle" key="settings.try.out.features.still.under.development"/>
-            </properties>
-          </component>
-          <component id="1f6f8" class="javax.swing.JCheckBox" binding="myUseLogViewCheckBox">
-            <constraints>
-              <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <text resource-bundle="io/flutter/FlutterBundle" key="settings.experimental.flutter.logging.view"/>
-            </properties>
-          </component>
-          <component id="33088" class="javax.swing.JCheckBox" binding="mySyncAndroidLibrariesCheckBox">
-            <constraints>
-              <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <text resource-bundle="io/flutter/FlutterBundle" key="settings.enable.android.gradle.sync"/>
-              <toolTipText value="Provides advanced editing capabilities for Java and Kotlin code. Uses Gradle to find Android libraries then links them into the Flutter project."/>
-            </properties>
-          </component>
-        </children>
-      </grid>
       <grid id="a6e3b" binding="myBazelOptionsSection" layout-manager="GridLayoutManager" row-count="2" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="etched" title="Bazel"/>
@@ -266,6 +233,58 @@
             </properties>
           </component>
         </children>
+      </grid>
+      <grid id="23e52" layout-manager="GridLayoutManager" row-count="4" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+        <margin top="0" left="0" bottom="0" right="0"/>
+        <constraints>
+          <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+        <border type="etched" title="Experiments"/>
+        <children>
+          <component id="42d6c" class="javax.swing.JLabel">
+            <constraints>
+              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text resource-bundle="io/flutter/FlutterBundle" key="settings.try.out.features.still.under.development"/>
+            </properties>
+          </component>
+          <component id="1f6f8" class="javax.swing.JCheckBox" binding="myUseLogViewCheckBox">
+            <constraints>
+              <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text resource-bundle="io/flutter/FlutterBundle" key="settings.experimental.flutter.logging.view"/>
+            </properties>
+          </component>
+          <component id="33088" class="javax.swing.JCheckBox" binding="mySyncAndroidLibrariesCheckBox">
+            <constraints>
+              <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text resource-bundle="io/flutter/FlutterBundle" key="settings.enable.android.gradle.sync"/>
+              <toolTipText value="Provides advanced editing capabilities for Java and Kotlin code. Uses Gradle to find Android libraries then links them into the Flutter project."/>
+            </properties>
+          </component>
+          <component id="67d4f" class="javax.swing.JCheckBox" binding="myShowWebDevicesCheckBox">
+            <constraints>
+              <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Show web and desktop devices in the device selector (available on Flutter's master, dev, and beta channels)"/>
+            </properties>
+          </component>
+        </children>
+      </grid>
+      <grid id="3bf2f" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+        <margin top="0" left="0" bottom="0" right="0"/>
+        <constraints>
+          <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="7" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+        <border type="none"/>
+        <children/>
       </grid>
     </children>
   </grid>

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.java
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.java
@@ -63,6 +63,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
   private JCheckBox myFormatCodeOnSaveCheckBox;
   private JCheckBox myOrganizeImportsOnSaveCheckBox;
   private JCheckBox myDisableTrackWidgetCreationCheckBox;
+  private JCheckBox myShowWebDevicesCheckBox;
   private JCheckBox myUseLogViewCheckBox;
   private JCheckBox mySyncAndroidLibrariesCheckBox;
 
@@ -211,6 +212,9 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
       return true;
     }
 
+    if (settings.isShowWebDesktopDevices() != myShowWebDevicesCheckBox.isSelected()) {
+      return true;
+    }
     if (settings.useFlutterLogView() != myUseLogViewCheckBox.isSelected()) {
       return true;
     }
@@ -270,6 +274,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     settings.setShowMultipleChildrenGuides(myShowMultipleChildrenGuides.isSelected());
     settings.setShowBuildMethodsOnScrollbar(myShowBuildMethodsOnScrollbar.isSelected());
     settings.setShowClosingLabels(myShowClosingLabels.isSelected());
+    settings.setShowWebDesktopDevices(myShowWebDevicesCheckBox.isSelected());
     settings.setUseFlutterLogView(myUseLogViewCheckBox.isSelected());
     settings.setOpenInspectorOnAppLaunch(myOpenInspectorOnAppLaunchCheckBox.isSelected());
     settings.setDisableTrackWidgetCreation(myDisableTrackWidgetCreationCheckBox.isSelected());
@@ -313,6 +318,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
 
     myShowClosingLabels.setSelected(settings.isShowClosingLabels());
 
+    myShowWebDevicesCheckBox.setSelected(settings.isShowWebDesktopDevices());
     myUseLogViewCheckBox.setSelected(settings.useFlutterLogView());
     myOpenInspectorOnAppLaunchCheckBox.setSelected(settings.isOpenInspectorOnAppLaunch());
     myDisableTrackWidgetCreationCheckBox.setSelected(settings.isDisableTrackWidgetCreation());

--- a/src/io/flutter/settings/FlutterSettings.java
+++ b/src/io/flutter/settings/FlutterSettings.java
@@ -27,6 +27,7 @@ public class FlutterSettings {
   private static final String syncAndroidLibrariesKey = "io.flutter.syncAndroidLibraries";
   private static final String disableTrackWidgetCreationKey = "io.flutter.disableTrackWidgetCreation";
   private static final String useFlutterLogView = "io.flutter.useLogView";
+  private static final String showWebDesktopDevices = "io.flutter.showWebDesktopDevices";
 
   /**
    * The Dart plugin uses this registry key to avoid bazel users getting their settings overridden on projects that include a
@@ -109,6 +110,9 @@ public class FlutterSettings {
       analytics.sendEvent("settings", afterLastPeriod(showBuildMethodsOnScrollbarKey));
     }
 
+    if (isShowWebDesktopDevices()) {
+      analytics.sendEvent("settings", afterLastPeriod(showWebDesktopDevices));
+    }
     if (useFlutterLogView()) {
       analytics.sendEvent("settings", afterLastPeriod(useFlutterLogView));
     }
@@ -201,6 +205,16 @@ public class FlutterSettings {
 
   public void setSyncingAndroidLibraries(boolean value) {
     getPropertiesComponent().setValue(syncAndroidLibrariesKey, value, false);
+
+    fireEvent();
+  }
+
+  public boolean isShowWebDesktopDevices() {
+    return getPropertiesComponent().getBoolean(showWebDesktopDevices, false);
+  }
+
+  public void setShowWebDesktopDevices(boolean value) {
+    getPropertiesComponent().setValue(showWebDesktopDevices, value, false);
 
     fireEvent();
   }

--- a/testSrc/unit/io/flutter/run/daemon/DaemonEventTest.java
+++ b/testSrc/unit/io/flutter/run/daemon/DaemonEventTest.java
@@ -88,7 +88,7 @@ public class DaemonEventTest {
 
       @Override
       public void onDeviceAdded(DaemonEvent.DeviceAdded event) {
-        logEvent(event, event.id, event.name, event.platform);
+        logEvent(event, event.id, event.name, event.platform, event.category);
       }
 
       @Override
@@ -173,8 +173,8 @@ public class DaemonEventTest {
 
   @Test
   public void canReceiveDeviceAdded() {
-    send("device.added", curly("id:9000", "name:\"Banana Jr\"", "platform:\"feet\""));
-    checkLog("DeviceAdded: 9000, Banana Jr, feet");
+    send("device.added", curly("id:9000", "name:\"Banana Jr\"", "platform:\"feet\"", "category:\"mobile\""));
+    checkLog("DeviceAdded: 9000, Banana Jr, feet, mobile");
   }
 
   @Test


### PR DESCRIPTION
- show web and desktop devices in the device selector
- add a user preference to enable showing the above devices
- fix https://github.com/flutter/flutter-intellij/issues/3508

Note that running with those devices won’t work unless the projects have been created with the rightt support (flutter web, or desktop).

<img width="765" alt="Screen Shot 2019-06-25 at 8 03 22 AM" src="https://user-images.githubusercontent.com/1269969/60109753-c49e4d80-971f-11e9-9c9d-df1613ab846f.png">

<img width="318" alt="Screen Shot 2019-06-24 at 4 24 48 PM" src="https://user-images.githubusercontent.com/1269969/60109622-87d25680-971f-11e9-9341-b14bdc65d78d.png">
