### PR TITLE
Issue 3615. Fix message for 'Remove widget'.

### DIFF
--- a/src/io/flutter/preview/PreviewView.java
+++ b/src/io/flutter/preview/PreviewView.java
@@ -174,7 +174,7 @@ public class PreviewView implements PersistentStateComponent<PreviewViewState>, 
     actionContainer = new QuickAssistAction("dart.assist.flutter.wrap.container", FlutterIcons.Container, "Wrap with Container");
     actionMoveUp = new QuickAssistAction("dart.assist.flutter.move.up", FlutterIcons.Up, "Move widget up");
     actionMoveDown = new QuickAssistAction("dart.assist.flutter.move.down", FlutterIcons.Down, "Move widget down");
-    actionRemove = new QuickAssistAction("dart.assist.flutter.removeWidget", FlutterIcons.RemoveWidget, "Remove widget");
+    actionRemove = new QuickAssistAction("dart.assist.flutter.removeWidget", FlutterIcons.RemoveWidget, "Replace widget with its children");
     actionExtractMethod = new ExtractMethodAction();
     actionExtractWidget = new ExtractWidgetAction();
   }


### PR DESCRIPTION
Ideally we should use `id` for matching Quick Assists and actions.
I think we postponed because at that time IDs were added only recently.

fix https://github.com/flutter/flutter-intellij/issues/3615