### PR TITLE
show service protocol logging events in the console view

### DIFF
--- a/src/io/flutter/logging/FlutterConsoleLogManager.java
+++ b/src/io/flutter/logging/FlutterConsoleLogManager.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2019 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+package io.flutter.logging;
+
+import com.intellij.execution.ui.ConsoleView;
+import com.intellij.execution.ui.ConsoleViewContentType;
+import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.ui.SimpleTextAttributes;
+import com.intellij.util.concurrency.QueueProcessor;
+import io.flutter.run.daemon.FlutterApp;
+import io.flutter.vmService.ServiceExtensions;
+import io.flutter.vmService.VmServiceConsumers;
+import org.dartlang.vm.service.element.*;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.concurrent.CountDownLatch;
+
+public class FlutterConsoleLogManager {
+  private static final boolean SHOW_STRUCTURED_ERRORS = false;
+
+  private static final ConsoleViewContentType SUBTLE_CONTENT_TYPE =
+    new ConsoleViewContentType("subtle", SimpleTextAttributes.GRAY_ATTRIBUTES.toTextAttributes());
+
+  private static QueueProcessor<Runnable> queue;
+
+  @NotNull final FlutterApp app;
+
+  public FlutterConsoleLogManager(@NotNull FlutterApp app) {
+    this.app = app;
+
+    if (queue == null) {
+      queue = QueueProcessor.createRunnableQueueProcessor();
+    }
+
+    if (SHOW_STRUCTURED_ERRORS) {
+      // Calling this will override the default Flutter stdout error display.
+      app.hasServiceExtension(ServiceExtensions.toggleShowStructuredErrors.getExtension(), (present) -> {
+        if (present) {
+          app.callBooleanExtension(ServiceExtensions.toggleShowStructuredErrors.getExtension(), true);
+        }
+      });
+    }
+  }
+
+  public void handleFlutterErrorEvent(@NotNull Event event) {
+    if (SHOW_STRUCTURED_ERRORS) {
+      assert app.getConsole() != null;
+
+      // TODO(devoncarew): Pretty print the error (using the available console syling attributes).
+      app.getConsole().print(
+        event.getExtensionData().getJson().toString() + "\n",
+        new ConsoleViewContentType("subtle", SimpleTextAttributes.GRAY_ATTRIBUTES.toTextAttributes()));
+    }
+  }
+
+  public void handleLoggingEvent(@NotNull Event event) {
+    queue.add(() -> processEvent(event));
+  }
+
+  private void processEvent(@NotNull Event event) {
+    final LogRecord logRecord = event.getLogRecord();
+
+    @NotNull final InstanceRef message = logRecord.getMessage();
+    @NotNull final InstanceRef loggerName = logRecord.getLoggerName();
+
+    // TODO(devoncarew): Handle truncated 'message' values.
+    final String name = loggerName.getValueAsString().isEmpty() ? "log" : loggerName.getValueAsString();
+    final String prefix = "[" + name + "] ";
+    final String output = prefix + stringValueFromStringRef(message) + "\n";
+
+    assert app.getConsole() != null;
+    final ConsoleView console = app.getConsole();
+
+    console.print(prefix, SUBTLE_CONTENT_TYPE);
+    console.print(message.getValueAsString() + "\n", ConsoleViewContentType.NORMAL_OUTPUT);
+
+    // TODO(devoncarew): Handle json in the error payload.
+
+    @NotNull final InstanceRef error = logRecord.getError();
+    @NotNull final InstanceRef stackTrace = logRecord.getStackTrace();
+
+    // TODO(devoncarew): Add an 'isNull' method to InstanceRef.
+    if (error.getKind() != InstanceKind.Null) {
+      final String padding = StringUtil.repeat(" ", prefix.length());
+
+      if (error.getKind() == InstanceKind.String) {
+        // TODO(devoncarew): Handle cases where the string value is truncated.
+        console.print(padding + stringValueFromStringRef(error) + "\n", ConsoleViewContentType.ERROR_OUTPUT);
+      }
+      else {
+        final CountDownLatch latch = new CountDownLatch(1);
+
+        final IsolateRef isolateRef = event.getIsolate();
+        app.getFlutterDebugProcess().getVmServiceWrapper().callToString(
+          isolateRef.getId(), error.getId(),
+          new VmServiceConsumers.InvokeConsumerWrapper() {
+            @Override
+            public void received(InstanceRef response) {
+              console.print(padding + stringValueFromStringRef(response) + "\n",
+                            ConsoleViewContentType.ERROR_OUTPUT);
+              latch.countDown();
+            }
+
+            @Override
+            public void noGoodResult() {
+              console.print(padding + error.getClassRef().getName() + " " + error.getId() + "\n",
+                            ConsoleViewContentType.ERROR_OUTPUT);
+              latch.countDown();
+            }
+          });
+
+        try {
+          latch.await();
+        }
+        catch (InterruptedException ignored) {
+        }
+      }
+    }
+
+    if (stackTrace.getKind() != InstanceKind.Null) {
+      final String padding = StringUtil.repeat(" ", prefix.length());
+      final String out = stackTrace.getValueAsString().trim();
+
+      console.print(
+        padding + out.replaceAll("\n", "\n" + padding) + "\n",
+        ConsoleViewContentType.ERROR_OUTPUT);
+    }
+  }
+
+  private void printStackTraceToConsole(
+    @NotNull ConsoleView console, String padding, @NotNull InstanceRef stackTrace) {
+    if (stackTrace.getKind() == InstanceKind.Null) return;
+
+    final String out = stackTrace.getValueAsString();
+    console.print(
+      padding + out.replaceAll("\n", "\n" + padding),
+      ConsoleViewContentType.ERROR_OUTPUT);
+  }
+
+  private String stringValueFromStringRef(InstanceRef ref) {
+    return ref.getValueAsStringIsTruncated() ? ref.getValueAsString() + "..." : ref.getValueAsString();
+  }
+}

--- a/src/io/flutter/run/LaunchState.java
+++ b/src/io/flutter/run/LaunchState.java
@@ -103,7 +103,7 @@ public class LaunchState extends CommandLineState {
   @Override
   @Nullable
   protected ConsoleView createConsole(@NotNull final Executor executor) throws ExecutionException {
-    if (FlutterLog.isLoggingEnabled()) {
+    if (FlutterLog.useFlutterLogView()) {
       final FlutterApp app = FlutterApp.fromEnv(getEnvironment());
       assert app != null;
       return new FlutterLogView(app);
@@ -190,7 +190,6 @@ public class LaunchState extends CommandLineState {
     // Checks if this is a pub-based project.
     // TODO(djshuckerow): Refactor out pub-specific logic and provide bazel support.
     if (SdkRunConfig.class.isAssignableFrom(runConfig.getClass())) {
-
       final String filePath = ((SdkRunConfig)runConfig).getFields().getFilePath();
 
       if (filePath != null) {

--- a/src/io/flutter/run/daemon/FlutterApp.java
+++ b/src/io/flutter/run/daemon/FlutterApp.java
@@ -31,6 +31,7 @@ import com.intellij.util.concurrency.AppExecutorUtil;
 import io.flutter.FlutterInitializer;
 import io.flutter.FlutterUtils;
 import io.flutter.ObservatoryConnector;
+import io.flutter.logging.FlutterConsoleLogManager;
 import io.flutter.logging.FlutterLog;
 import io.flutter.pub.PubRoot;
 import io.flutter.pub.PubRoots;
@@ -82,6 +83,7 @@ public class FlutterApp {
   private @Nullable String myWsUrl;
   private @Nullable String myBaseUri;
   private @Nullable ConsoleView myConsole;
+  private FlutterConsoleLogManager myFlutterConsoleLogManager;
 
   private boolean isFlutterWeb = false;
 
@@ -647,6 +649,9 @@ public class FlutterApp {
     });
 
     listenersDispatcher.getMulticaster().notifyVmServiceAvailable(vmService);
+
+    // Init the app's FlutterConsoleLogManager.
+    getFlutterConsoleLogManager();
   }
 
   @Nullable
@@ -675,6 +680,13 @@ public class FlutterApp {
   @Nullable
   public Module getModule() {
     return myModule;
+  }
+
+  public FlutterConsoleLogManager getFlutterConsoleLogManager() {
+    if (myFlutterConsoleLogManager == null) {
+      myFlutterConsoleLogManager = new FlutterConsoleLogManager(this);
+    }
+    return myFlutterConsoleLogManager;
   }
 
   @Override

--- a/src/io/flutter/vmService/ServiceExtensions.java
+++ b/src/io/flutter/vmService/ServiceExtensions.java
@@ -76,6 +76,14 @@ public class ServiceExtensions {
       "Disable Select Widget Mode",
       "Enable Select Widget Mode");
 
+  public static final ToggleableServiceExtensionDescription<Boolean> toggleShowStructuredErrors =
+    new ToggleableServiceExtensionDescription<>(
+      "ext.flutter.inspector.structuredErrors",
+      true,
+      false,
+      "Disable Showing Structured Errors",
+      "Show Structured Errors");
+
   public static final ToggleableServiceExtensionDescription<Boolean> trackRebuildWidgets =
     new ToggleableServiceExtensionDescription<>(
       "ext.flutter.inspector.trackRebuildDirtyWidgets",
@@ -113,6 +121,7 @@ public class ServiceExtensions {
     slowAnimations,
     togglePlatformMode,
     toggleSelectWidgetMode,
+    toggleShowStructuredErrors,
     trackRebuildWidgets,
     trackRepaintWidgets);
 

--- a/src/io/flutter/vmService/VMServiceManager.java
+++ b/src/io/flutter/vmService/VMServiceManager.java
@@ -27,6 +27,9 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
 public class VMServiceManager implements FlutterApp.FlutterAppListener {
+  // TODO(devoncarew): Remove on or after approx. Oct 1 2019.
+  public static final String LOGGING_STREAM_ID_OLD = "_Logging";
+
   @NotNull private final FlutterApp app;
   @NotNull private final HeapMonitor heapMonitor;
   @NotNull private final FlutterFramesMonitor flutterFramesMonitor;
@@ -49,7 +52,7 @@ public class VMServiceManager implements FlutterApp.FlutterAppListener {
    * Temporarily stores service extensions that we need to add. We should not add extensions until the first frame event
    * has been received [firstFrameEventReceived].
    */
-  private List<String> pendingServiceExtensions = new ArrayList<>();
+  private final List<String> pendingServiceExtensions = new ArrayList<>();
 
   public VMServiceManager(@NotNull FlutterApp app, @NotNull VmService vmService) {
     this.app = app;
@@ -61,10 +64,14 @@ public class VMServiceManager implements FlutterApp.FlutterAppListener {
     this.polledCount = 0;
     flutterIsolateRefStream = new EventStream<>();
 
-    // The VM Service depends on events from the Extension event stream to
-    // determine when Flutter.Frame events are fired.
-    // Without the call to listen, events from the stream will not be sent.
+    // The VM Service depends on events from the Extension event stream to determine when Flutter.Frame
+    // events are fired. Without the call to listen, events from the stream will not be sent.
     vmService.streamListen(VmService.EXTENSION_STREAM_ID, VmServiceConsumers.EMPTY_SUCCESS_CONSUMER);
+
+    vmService.streamListen(LOGGING_STREAM_ID_OLD, VmServiceConsumers.EMPTY_SUCCESS_CONSUMER);
+    vmService.streamListen(VmService.LOGGING_STREAM_ID, VmServiceConsumers.EMPTY_SUCCESS_CONSUMER);
+
+    vmService.streamListen(VmService.GC_STREAM_ID, VmServiceConsumers.EMPTY_SUCCESS_CONSUMER);
 
     vmService.addVmServiceListener(new VmServiceListenerAdapter() {
       @Override
@@ -137,9 +144,9 @@ public class VMServiceManager implements FlutterApp.FlutterAppListener {
       );
       flutterLibrary.eval("WidgetsBinding.instance.debugDidSendFirstFrameEvent", null, null).whenCompleteAsync((v, e) -> {
         // If there is an error we assume the first frame has been received.
-        boolean didSendFirstFrameEvent = e == null ||
-                                         v == null ||
-                                         Objects.equals(v.getValueAsString(), "true");
+        final boolean didSendFirstFrameEvent = e == null ||
+                                               v == null ||
+                                               Objects.equals(v.getValueAsString(), "true");
         if (didSendFirstFrameEvent) {
           onFrameEventReceived();
         }
@@ -257,11 +264,17 @@ public class VMServiceManager implements FlutterApp.FlutterAppListener {
             final boolean enabled = value.equals(extension.getEnabledValue());
             setServiceExtensionState(name, enabled, value);
           }
+          break;
+        case "Flutter.Error":
+          app.getFlutterConsoleLogManager().handleFlutterErrorEvent(event);
+          break;
       }
     }
-
-    if (event.getKind() == EventKind.ServiceExtensionAdded) {
+    else if (event.getKind() == EventKind.ServiceExtensionAdded) {
       maybeAddServiceExtension(event.getExtensionRPC());
+    }
+    else if (StringUtil.equals(streamId, VmService.LOGGING_STREAM_ID) || StringUtil.equals(streamId, LOGGING_STREAM_ID_OLD)) {
+      app.getFlutterConsoleLogManager().handleLoggingEvent(event);
     }
 
     // Check to see if there's a new Flutter isolate.
@@ -446,7 +459,7 @@ public class VMServiceManager implements FlutterApp.FlutterAppListener {
 
   public @NotNull
   StreamSubscription<Boolean> hasServiceExtension(String name, Consumer<Boolean> onData) {
-    EventStream<Boolean> stream = getStream(name, serviceExtensions);
+    final EventStream<Boolean> stream = getStream(name, serviceExtensions);
     return stream.listen(onData, true);
   }
 
@@ -483,7 +496,7 @@ public class VMServiceManager implements FlutterApp.FlutterAppListener {
   }
 
   public void setServiceExtensionState(String name, boolean enabled, Object value) {
-    EventStream<ServiceExtensionState> stream = getServiceExtensionState(name);
+    final EventStream<ServiceExtensionState> stream = getServiceExtensionState(name);
     stream.setValue(new ServiceExtensionState(enabled, value));
   }
 

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/VmServiceBase.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/VmServiceBase.java
@@ -43,20 +43,17 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 @SuppressWarnings({"unused", "WeakerAccess"})
 abstract class VmServiceBase implements VmServiceConst {
-
   /**
    * Connect to the VM observatory service via the specified URI
    *
    * @return an API object for interacting with the VM service (not {@code null}).
    */
   public static VmService connect(final String url) throws IOException {
-
     // Validate URL
     URI uri;
     try {
       uri = new URI(url);
-    }
-    catch (URISyntaxException e) {
+    } catch (URISyntaxException e) {
       throw new IOException("Invalid URL: " + url, e);
     }
     String wsScheme = uri.getScheme();
@@ -68,8 +65,7 @@ abstract class VmServiceBase implements VmServiceConst {
     WebSocket webSocket;
     try {
       webSocket = new WebSocket(uri);
-    }
-    catch (WebSocketException e) {
+    } catch (WebSocketException e) {
       throw new IOException("Failed to create websocket: " + url, e);
     }
     final VmService vmService = new VmService();
@@ -88,8 +84,7 @@ abstract class VmServiceBase implements VmServiceConst {
         Logging.getLogger().logInformation("VM message: " + message.getText());
         try {
           vmService.processMessage(message.getText());
-        }
-        catch (Exception e) {
+        } catch (Exception e) {
           Logging.getLogger().logError(e.getMessage(), e);
         }
       }
@@ -114,11 +109,9 @@ abstract class VmServiceBase implements VmServiceConst {
     //noinspection TryWithIdenticalCatches
     try {
       webSocket.connect();
-    }
-    catch (WebSocketException e) {
+    } catch (WebSocketException e) {
       throw new IOException("Failed to connect: " + url, e);
-    }
-    catch (ArrayIndexOutOfBoundsException e) {
+    } catch (ArrayIndexOutOfBoundsException e) {
       // The weberknecht can occasionally throw an array index exception if a connect terminates on initial connect
       // (de.roderick.weberknecht.WebSocket.connect, WebSocket.java:126).
       throw new IOException("Failed to connect: " + url, e);
@@ -132,7 +125,7 @@ abstract class VmServiceBase implements VmServiceConst {
       @Override
       public void onError(RPCError error) {
         String msg = "Failed to determine protocol version: " + error.getCode() + "\n  message: "
-                     + error.getMessage() + "\n  details: " + error.getDetails();
+            + error.getMessage() + "\n  details: " + error.getDetails();
         Logging.getLogger().logInformation(msg);
         errMsg[0] = msg;
       }
@@ -144,12 +137,11 @@ abstract class VmServiceBase implements VmServiceConst {
         if (major != VmService.versionMajor || minor != VmService.versionMinor) {
           if (major == 2 || major == 3) {
             Logging.getLogger().logInformation(
-              "Difference in protocol version: client=" + VmService.versionMajor + "."
-              + VmService.versionMinor + " vm=" + major + "." + minor);
-          }
-          else {
+                "Difference in protocol version: client=" + VmService.versionMajor + "."
+                    + VmService.versionMinor + " vm=" + major + "." + minor);
+          } else {
             String msg = "Incompatible protocol version: client=" + VmService.versionMajor + "."
-                         + VmService.versionMinor + " vm=" + major + "." + minor;
+                + VmService.versionMinor + " vm=" + major + "." + minor;
             Logging.getLogger().logError(msg);
             errMsg[0] = msg;
           }
@@ -164,8 +156,7 @@ abstract class VmServiceBase implements VmServiceConst {
       if (errMsg[0] != null) {
         throw new IOException(errMsg[0]);
       }
-    }
-    catch (InterruptedException e) {
+    } catch (InterruptedException e) {
       throw new RuntimeException("Interrupted while waiting for response", e);
     }
 
@@ -176,7 +167,10 @@ abstract class VmServiceBase implements VmServiceConst {
    * Connect to the VM observatory service on the given local port.
    *
    * @return an API object for interacting with the VM service (not {@code null}).
+   *
+   * @deprecated prefer the Url based constructor {@link VmServiceBase#connect}
    */
+  @Deprecated
   public static VmService localConnect(int port) throws IOException {
     return connect("ws://localhost:" + port + "/ws");
   }
@@ -261,9 +255,8 @@ abstract class VmServiceBase implements VmServiceConst {
       @Override
       public void received(Obj response) {
         if (response instanceof Instance) {
-          consumer.received((Instance)response);
-        }
-        else {
+          consumer.received((Instance) response);
+        } else {
           onError(RPCError.unexpected("Instance", response));
         }
       }
@@ -289,9 +282,8 @@ abstract class VmServiceBase implements VmServiceConst {
       @Override
       public void received(Obj response) {
         if (response instanceof Library) {
-          consumer.received((Library)response);
-        }
-        else {
+          consumer.received((Library) response);
+        } else {
           onError(RPCError.unexpected("Library", response));
         }
       }
@@ -350,33 +342,30 @@ abstract class VmServiceBase implements VmServiceConst {
   }
 
   public void connectionOpened() {
-    for (VmServiceListener listener : vmListeners) {
+    for (VmServiceListener listener : new ArrayList<>(vmListeners)) {
       try {
         listener.connectionOpened();
-      }
-      catch (Exception e) {
+      } catch (Exception e) {
         Logging.getLogger().logError("Exception notifying listener", e);
       }
     }
   }
 
   private void forwardEvent(String streamId, Event event) {
-    for (VmServiceListener listener : vmListeners) {
+    for (VmServiceListener listener : new ArrayList<>(vmListeners)) {
       try {
         listener.received(streamId, event);
-      }
-      catch (Exception e) {
+      } catch (Exception e) {
         Logging.getLogger().logError("Exception processing event: " + streamId + ", " + event.getJson(), e);
       }
     }
   }
 
   public void connectionClosed() {
-    for (VmServiceListener listener : vmListeners) {
+    for (VmServiceListener listener : new ArrayList<>(vmListeners)) {
       try {
         listener.connectionClosed();
-      }
-      catch (Exception e) {
+      } catch (Exception e) {
         Logging.getLogger().logError("Exception notifying listener", e);
       }
     }
@@ -407,9 +396,8 @@ abstract class VmServiceBase implements VmServiceConst {
     // Decode the JSON
     JsonObject json;
     try {
-      json = (JsonObject)new JsonParser().parse(jsonText);
-    }
-    catch (Exception e) {
+      json = (JsonObject) new JsonParser().parse(jsonText);
+    } catch (Exception e) {
       Logging.getLogger().logError("Parse message failed: " + jsonText, e);
       return;
     }
@@ -429,15 +417,12 @@ abstract class VmServiceBase implements VmServiceConst {
       }
       if (json.has("id")) {
         processRequest(json);
-      }
-      else {
+      } else {
         processNotification(json);
       }
-    }
-    else if (json.has("result") || json.has("error")) {
+    } else if (json.has("result") || json.has("error")) {
       processResponse(json);
-    }
-    else {
+    } else {
       Logging.getLogger().logError("Malformed message");
     }
   }
@@ -450,8 +435,7 @@ abstract class VmServiceBase implements VmServiceConst {
     String id;
     try {
       id = json.get(ID).getAsString();
-    }
-    catch (Exception e) {
+    } catch (Exception e) {
       final String message = "Request malformed " + ID;
       Logging.getLogger().logError(message, e);
       final JsonObject error = new JsonObject();
@@ -467,8 +451,7 @@ abstract class VmServiceBase implements VmServiceConst {
     String method;
     try {
       method = json.get(METHOD).getAsString();
-    }
-    catch (Exception e) {
+    } catch (Exception e) {
       final String message = "Request malformed " + METHOD;
       Logging.getLogger().logError(message, e);
       final JsonObject error = new JsonObject();
@@ -482,8 +465,7 @@ abstract class VmServiceBase implements VmServiceConst {
     JsonObject params;
     try {
       params = json.get(PARAMS).getAsJsonObject();
-    }
-    catch (Exception e) {
+    } catch (Exception e) {
       final String message = "Request malformed " + METHOD;
       Logging.getLogger().logError(message, e);
       final JsonObject error = new JsonObject();
@@ -524,8 +506,7 @@ abstract class VmServiceBase implements VmServiceConst {
           requestSink.add(response);
         }
       });
-    }
-    catch (Exception e) {
+    } catch (Exception e) {
       final String message = "Internal Server Error";
       Logging.getLogger().logError(message, e);
       final JsonObject error = new JsonObject();
@@ -537,30 +518,28 @@ abstract class VmServiceBase implements VmServiceConst {
   }
 
   private static final RemoteServiceCompleter ignoreCallback =
-    new RemoteServiceCompleter() {
-      public void result(JsonObject result) {
-        // ignore
-      }
+      new RemoteServiceCompleter() {
+        public void result(JsonObject result) {
+          // ignore
+        }
 
-      public void error(int code, String message, JsonObject data) {
-        // ignore
-      }
-    };
+        public void error(int code, String message, JsonObject data) {
+          // ignore
+        }
+      };
 
   void processNotification(JsonObject json) {
     String method;
     try {
       method = json.get(METHOD).getAsString();
-    }
-    catch (Exception e) {
+    } catch (Exception e) {
       Logging.getLogger().logError("Request malformed " + METHOD, e);
       return;
     }
     JsonObject params;
     try {
       params = json.get(PARAMS).getAsJsonObject();
-    }
-    catch (Exception e) {
+    } catch (Exception e) {
       Logging.getLogger().logError("Event missing " + PARAMS, e);
       return;
     }
@@ -568,22 +547,19 @@ abstract class VmServiceBase implements VmServiceConst {
       String streamId;
       try {
         streamId = params.get(STREAM_ID).getAsString();
-      }
-      catch (Exception e) {
+      } catch (Exception e) {
         Logging.getLogger().logError("Event missing " + STREAM_ID, e);
         return;
       }
       Event event;
       try {
         event = new Event(params.get(EVENT).getAsJsonObject());
-      }
-      catch (Exception e) {
+      } catch (Exception e) {
         Logging.getLogger().logError("Event missing " + EVENT, e);
         return;
       }
       forwardEvent(streamId, event);
-    }
-    else {
+    } else {
       if (!remoteServiceRunners.containsKey(method)) {
         Logging.getLogger().logError("Unknown service " + method);
         return;
@@ -592,8 +568,7 @@ abstract class VmServiceBase implements VmServiceConst {
       final RemoteServiceRunner runner = remoteServiceRunners.get(method);
       try {
         runner.run(params, ignoreCallback);
-      }
-      catch (Exception e) {
+      } catch (Exception e) {
         Logging.getLogger().logError("Internal Server Error", e);
       }
     }
@@ -610,8 +585,7 @@ abstract class VmServiceBase implements VmServiceConst {
     String id;
     try {
       id = idElem.getAsString();
-    }
-    catch (Exception e) {
+    } catch (Exception e) {
       Logging.getLogger().logError("Response missing " + ID, e);
       return;
     }
@@ -627,16 +601,14 @@ abstract class VmServiceBase implements VmServiceConst {
       JsonObject result;
       try {
         result = resultElem.getAsJsonObject();
-      }
-      catch (Exception e) {
+      } catch (Exception e) {
         Logging.getLogger().logError("Response has invalid " + RESULT, e);
         return;
       }
       String responseType;
       try {
         responseType = result.get(TYPE).getAsString();
-      }
-      catch (Exception e) {
+      } catch (Exception e) {
         Logging.getLogger().logError("Response missing " + TYPE, e);
         return;
       }
@@ -650,8 +622,7 @@ abstract class VmServiceBase implements VmServiceConst {
       JsonObject error;
       try {
         error = resultElem.getAsJsonObject();
-      }
-      catch (Exception e) {
+      } catch (Exception e) {
         Logging.getLogger().logError("Response has invalid " + RESULT, e);
         return;
       }

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/consumer/GetMemoryUsageConsumer.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/consumer/GetMemoryUsageConsumer.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2015, the Dart project authors.
+ *
+ * Licensed under the Eclipse Public License v1.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.dartlang.vm.service.consumer;
+
+// This is a generated file.
+
+import org.dartlang.vm.service.element.MemoryUsage;
+import org.dartlang.vm.service.element.Sentinel;
+
+@SuppressWarnings({"WeakerAccess", "unused"})
+public interface GetMemoryUsageConsumer extends Consumer {
+
+  void received(MemoryUsage response);
+
+  void received(Sentinel response);
+}

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/consumer/InstanceSetConsumer.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/consumer/InstanceSetConsumer.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2015, the Dart project authors.
+ *
+ * Licensed under the Eclipse Public License v1.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.dartlang.vm.service.consumer;
+
+// This is a generated file.
+
+import org.dartlang.vm.service.element.InstanceSet;
+
+@SuppressWarnings({"WeakerAccess", "unused"})
+public interface InstanceSetConsumer extends Consumer {
+
+  void received(InstanceSet response);
+}

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/consumer/TimelineConsumer.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/consumer/TimelineConsumer.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2015, the Dart project authors.
+ *
+ * Licensed under the Eclipse Public License v1.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.dartlang.vm.service.consumer;
+
+// This is a generated file.
+
+import org.dartlang.vm.service.element.Timeline;
+
+@SuppressWarnings({"WeakerAccess", "unused"})
+public interface TimelineConsumer extends Consumer {
+
+  void received(Timeline response);
+}

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/consumer/TimelineFlagsConsumer.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/consumer/TimelineFlagsConsumer.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2015, the Dart project authors.
+ *
+ * Licensed under the Eclipse Public License v1.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.dartlang.vm.service.consumer;
+
+// This is a generated file.
+
+import org.dartlang.vm.service.element.TimelineFlags;
+
+@SuppressWarnings({"WeakerAccess", "unused"})
+public interface TimelineFlagsConsumer extends Consumer {
+
+  void received(TimelineFlags response);
+}

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/element/AllocationProfile.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/element/AllocationProfile.java
@@ -25,10 +25,31 @@ public class AllocationProfile extends Response {
     super(json);
   }
 
-  public String getDateLastServiceGC() {
-    return json.get("dateLastServiceGC").getAsString();
+  /**
+   * The timestamp of the last accumulator reset.
+   *
+   * If the accumulators have not been reset, this field is not present.
+   *
+   * Can return <code>null</code>.
+   */
+  public int getDateLastAccumulatorReset() {
+    return json.get("dateLastAccumulatorReset") == null ? -1 : json.get("dateLastAccumulatorReset").getAsInt();
   }
 
+  /**
+   * The timestamp of the last manually triggered GC.
+   *
+   * If a GC has not been triggered manually, this field is not present.
+   *
+   * Can return <code>null</code>.
+   */
+  public int getDateLastServiceGC() {
+    return json.get("dateLastServiceGC") == null ? -1 : json.get("dateLastServiceGC").getAsInt();
+  }
+
+  /**
+   * Allocation information for all class types.
+   */
   public ElementList<ClassHeapStats> getMembers() {
     return new ElementList<ClassHeapStats>(json.get("members").getAsJsonArray()) {
       @Override
@@ -36,5 +57,12 @@ public class AllocationProfile extends Response {
         return new ClassHeapStats(array.get(index).getAsJsonObject());
       }
     };
+  }
+
+  /**
+   * Information about memory usage for the isolate.
+   */
+  public MemoryUsage getMemoryUsage() {
+    return new MemoryUsage((JsonObject) json.get("memoryUsage"));
   }
 }

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/element/ClassHeapStats.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/element/ClassHeapStats.java
@@ -25,8 +25,40 @@ public class ClassHeapStats extends Response {
     super(json);
   }
 
+  /**
+   * The number of bytes allocated for instances of class since the accumulator was last reset.
+   */
+  public int getAccumulatedSize() {
+    return json.get("accumulatedSize") == null ? -1 : json.get("accumulatedSize").getAsInt();
+  }
+
+  /**
+   * The number of bytes currently allocated for instances of class.
+   */
+  public int getBytesCurrent() {
+    return json.get("bytesCurrent") == null ? -1 : json.get("bytesCurrent").getAsInt();
+  }
+
+  /**
+   * The class for which this memory information is associated.
+   */
   public ClassRef getClassRef() {
     return new ClassRef((JsonObject) json.get("class"));
+  }
+
+  /**
+   * The number of instances of class which have been allocated since the accumulator was last
+   * reset.
+   */
+  public int getInstancesAccumulated() {
+    return json.get("instancesAccumulated") == null ? -1 : json.get("instancesAccumulated").getAsInt();
+  }
+
+  /**
+   * The number of instances of class which are currently alive.
+   */
+  public int getInstancesCurrent() {
+    return json.get("instancesCurrent") == null ? -1 : json.get("instancesCurrent").getAsInt();
   }
 
   public List<Integer> getNew() {

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/element/Event.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/element/Event.java
@@ -159,6 +159,17 @@ public class Event extends Response {
   }
 
   /**
+   * LogRecord data.
+   *
+   * This is provided for the Logging event.
+   *
+   * Can return <code>null</code>.
+   */
+  public LogRecord getLogRecord() {
+    return json.get("logRecord") == null ? null : new LogRecord((JsonObject) json.get("logRecord"));
+  }
+
+  /**
    * The RPC method that should be used to invoke the service.
    *
    * This is provided for the event kinds:

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/element/EventKind.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/element/EventKind.java
@@ -79,6 +79,11 @@ public enum EventKind {
   IsolateUpdate,
 
   /**
+   * Event from dart:developer.log.
+   */
+  Logging,
+
+  /**
    * Indicates an isolate is not yet runnable. Only appears in an Isolate's pauseEvent. Never sent
    * over a stream.
    */

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/element/InstanceSet.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/element/InstanceSet.java
@@ -15,36 +15,35 @@ package org.dartlang.vm.service.element;
 
 // This is a generated file.
 
+import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 
 /**
- * {@link IsolateRef} is a reference to an {@link Isolate} object.
+ * See getInstances.
  */
 @SuppressWarnings({"WeakerAccess", "unused"})
-public class IsolateRef extends Response {
+public class InstanceSet extends Response {
 
-  public IsolateRef(JsonObject json) {
+  public InstanceSet(JsonObject json) {
     super(json);
   }
 
   /**
-   * The id which is passed to the getIsolate RPC to load this isolate.
+   * An array of instances of the requested type.
    */
-  public String getId() {
-    return json.get("id").getAsString();
+  public ElementList<ObjRef> getInstances() {
+    return new ElementList<ObjRef>(json.get("instances").getAsJsonArray()) {
+      @Override
+      protected ObjRef basicGet(JsonArray array, int index) {
+        return new ObjRef(array.get(index).getAsJsonObject());
+      }
+    };
   }
 
   /**
-   * A name identifying this isolate. Not guaranteed to be unique.
+   * The number of instances of the requested type currently allocated.
    */
-  public String getName() {
-    return json.get("name").getAsString();
-  }
-
-  /**
-   * A numeric id for this isolate, represented as a string. Unique.
-   */
-  public String getNumber() {
-    return json.get("number").getAsString();
+  public int getTotalCount() {
+    return json.get("totalCount") == null ? -1 : json.get("totalCount").getAsInt();
   }
 }

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/element/Isolate.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/element/Isolate.java
@@ -73,16 +73,6 @@ public class Isolate extends Response {
   }
 
   /**
-   * Provided and set to true if the id of an Object is fixed. If true, the id of an Object is
-   * guaranteed not to change or expire. The object may, however, still be _Collected_.
-   *
-   * Can return <code>null</code>.
-   */
-  public boolean getFixedId() {
-    return json.get("fixedId") == null ? false : json.get("fixedId").getAsBoolean();
-  }
-
-  /**
    * The id which is passed to the getIsolate RPC to reload this isolate.
    */
   public String getId() {

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/element/LogRecord.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/element/LogRecord.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2015, the Dart project authors.
+ *
+ * Licensed under the Eclipse Public License v1.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.dartlang.vm.service.element;
+
+// This is a generated file.
+
+import com.google.gson.JsonObject;
+
+@SuppressWarnings({"WeakerAccess", "unused"})
+public class LogRecord extends Response {
+
+  public LogRecord(JsonObject json) {
+    super(json);
+  }
+
+  /**
+   * An error object associated with this log event.
+   */
+  public InstanceRef getError() {
+    return new InstanceRef((JsonObject) json.get("error"));
+  }
+
+  /**
+   * The severity level (a value between 0 and 2000).
+   *
+   * See the package:logging `Level` class for an overview of the possible values.
+   */
+  public int getLevel() {
+    return json.get("level") == null ? -1 : json.get("level").getAsInt();
+  }
+
+  /**
+   * The name of the source of the log message.
+   */
+  public InstanceRef getLoggerName() {
+    return new InstanceRef((JsonObject) json.get("loggerName"));
+  }
+
+  /**
+   * The log message.
+   */
+  public InstanceRef getMessage() {
+    return new InstanceRef((JsonObject) json.get("message"));
+  }
+
+  /**
+   * A monotonically increasing sequence number.
+   */
+  public int getSequenceNumber() {
+    return json.get("sequenceNumber") == null ? -1 : json.get("sequenceNumber").getAsInt();
+  }
+
+  /**
+   * A stack trace associated with this log event.
+   */
+  public InstanceRef getStackTrace() {
+    return new InstanceRef((JsonObject) json.get("stackTrace"));
+  }
+
+  /**
+   * The timestamp.
+   */
+  public int getTime() {
+    return json.get("time") == null ? -1 : json.get("time").getAsInt();
+  }
+
+  /**
+   * The zone where the log was emitted.
+   */
+  public InstanceRef getZone() {
+    return new InstanceRef((JsonObject) json.get("zone"));
+  }
+}

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/element/MemoryUsage.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/element/MemoryUsage.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2015, the Dart project authors.
+ *
+ * Licensed under the Eclipse Public License v1.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.dartlang.vm.service.element;
+
+// This is a generated file.
+
+import com.google.gson.JsonObject;
+
+/**
+ * An {@link MemoryUsage} object provides heap usage information for a specific isolate at a given
+ * point in time.
+ */
+@SuppressWarnings({"WeakerAccess", "unused"})
+public class MemoryUsage extends Response {
+
+  public MemoryUsage(JsonObject json) {
+    super(json);
+  }
+
+  /**
+   * The amount of non-Dart memory that is retained by Dart objects. For example, memory associated
+   * with Dart objects through APIs such as Dart_NewWeakPersistentHandle and
+   * Dart_NewExternalTypedData.  This usage is only as accurate as the values supplied to these
+   * APIs from the VM embedder or native extensions. This external memory applies GC pressure, but
+   * is separate from heapUsage and heapCapacity.
+   */
+  public int getExternalUsage() {
+    return json.get("externalUsage") == null ? -1 : json.get("externalUsage").getAsInt();
+  }
+
+  /**
+   * The total capacity of the heap in bytes. This is the amount of memory used by the Dart heap
+   * from the perspective of the operating system.
+   */
+  public int getHeapCapacity() {
+    return json.get("heapCapacity") == null ? -1 : json.get("heapCapacity").getAsInt();
+  }
+
+  /**
+   * The current heap memory usage in bytes. Heap usage is always less than or equal to the heap
+   * capacity.
+   */
+  public int getHeapUsage() {
+    return json.get("heapUsage") == null ? -1 : json.get("heapUsage").getAsInt();
+  }
+}

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/element/Script.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/element/Script.java
@@ -29,10 +29,24 @@ public class Script extends Obj {
   }
 
   /**
+   * Can return <code>null</code>.
+   */
+  public int getColumnOffset() {
+    return json.get("columnOffset") == null ? -1 : json.get("columnOffset").getAsInt();
+  }
+
+  /**
    * The library which owns this script.
    */
   public LibraryRef getLibrary() {
     return new LibraryRef((JsonObject) json.get("library"));
+  }
+
+  /**
+   * Can return <code>null</code>.
+   */
+  public int getLineOffset() {
+    return json.get("lineOffset") == null ? -1 : json.get("lineOffset").getAsInt();
   }
 
   /**

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/element/Timeline.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/element/Timeline.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2015, the Dart project authors.
+ *
+ * Licensed under the Eclipse Public License v1.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.dartlang.vm.service.element;
+
+// This is a generated file.
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+
+@SuppressWarnings({"WeakerAccess", "unused"})
+public class Timeline extends Response {
+
+  public Timeline(JsonObject json) {
+    super(json);
+  }
+
+  /**
+   * The duration of time covered by the timeline.
+   */
+  public int getTimeExtentMicros() {
+    return json.get("timeExtentMicros") == null ? -1 : json.get("timeExtentMicros").getAsInt();
+  }
+
+  /**
+   * The start of the period of time in which traceEvents were collected.
+   */
+  public int getTimeOriginMicros() {
+    return json.get("timeOriginMicros") == null ? -1 : json.get("timeOriginMicros").getAsInt();
+  }
+
+  /**
+   * A list of timeline events.
+   */
+  public ElementList<TimelineEvent> getTraceEvents() {
+    return new ElementList<TimelineEvent>(json.get("traceEvents").getAsJsonArray()) {
+      @Override
+      protected TimelineEvent basicGet(JsonArray array, int index) {
+        return new TimelineEvent(array.get(index).getAsJsonObject());
+      }
+    };
+  }
+}

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/element/TimelineFlags.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/element/TimelineFlags.java
@@ -16,35 +16,35 @@ package org.dartlang.vm.service.element;
 // This is a generated file.
 
 import com.google.gson.JsonObject;
+import java.util.List;
 
-/**
- * {@link IsolateRef} is a reference to an {@link Isolate} object.
- */
 @SuppressWarnings({"WeakerAccess", "unused"})
-public class IsolateRef extends Response {
+public class TimelineFlags extends Response {
 
-  public IsolateRef(JsonObject json) {
+  public TimelineFlags(JsonObject json) {
     super(json);
   }
 
   /**
-   * The id which is passed to the getIsolate RPC to load this isolate.
+   * The list of all available timeline streams.
    */
-  public String getId() {
-    return json.get("id").getAsString();
+  public List<String> getAvailableStreams() {
+    return getListString("availableStreams");
   }
 
   /**
-   * A name identifying this isolate. Not guaranteed to be unique.
+   * The list of timeline streams that are currently enabled.
    */
-  public String getName() {
-    return json.get("name").getAsString();
+  public List<String> getRecordedStreams() {
+    return getListString("recordedStreams");
   }
 
   /**
-   * A numeric id for this isolate, represented as a string. Unique.
+   * The name of the recorder currently in use. Recorder types include, but are not limited to:
+   * Callback, Endless, Fuchsia, Ring, Startup, and Systrace. Set to "null" if no recorder is
+   * currently set.
    */
-  public String getNumber() {
-    return json.get("number").getAsString();
+  public String getRecorderName() {
+    return json.get("recorderName").getAsString();
   }
 }


### PR DESCRIPTION
- upgrade the vm service library
- show service protocol logging events in the console view
- simplify and consolidate some code around 'Logging' events in the existing logging view
- fix https://github.com/flutter/flutter-intellij/issues/3421

This PR shows service protocol `'Logging'` events in the run and debug consoles. I bumped the vm service protocol library classes for this - done as a separate commit for easier reviewability.

There's a small bit of code in here related to `'Flutter.Error'` events; it's all disabled behind a compile time flag however.

<img width="910" alt="Screen Shot 2019-06-26 at 2 11 59 PM" src="https://user-images.githubusercontent.com/1269969/60215994-c0f0f080-981d-11e9-9661-6b4b29c918ab.png">
