### PR TITLE
guard against null json heap entries

### DIFF
--- a/src/io/flutter/inspector/HeapState.java
+++ b/src/io/flutter/inspector/HeapState.java
@@ -15,6 +15,7 @@
  */
 package io.flutter.inspector;
 
+import com.google.gson.JsonElement;
 import io.flutter.vmService.HeapMonitor;
 import org.dartlang.vm.service.element.IsolateRef;
 import org.dartlang.vm.service.element.VM;
@@ -110,7 +111,8 @@ public class HeapState implements HeapMonitor.HeapListener {
       }
     }
 
-    rssBytes = vm.getJson().get("_currentRSS").getAsInt();
+    final JsonElement rss = vm.getJson().get("_currentRSS");
+    rssBytes = rss != null ? rss.getAsInt() : 0;
     heapMaxInBytes = total;
 
     addSample(new HeapMonitor.HeapSample(current, external, false));

--- a/src/io/flutter/vmService/HeapMonitor.java
+++ b/src/io/flutter/vmService/HeapMonitor.java
@@ -15,10 +15,7 @@ import org.dartlang.vm.service.consumer.VMConsumer;
 import org.dartlang.vm.service.element.*;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -52,11 +49,13 @@ public class HeapMonitor {
     }
 
     JsonObject getAsJsonObject(String memberName) {
-      return json.get(memberName).getAsJsonObject();
+      final JsonElement element = json.get(memberName);
+      return element != null ? element.getAsJsonObject() : null;
     }
 
     Set<Map.Entry<String, JsonElement>> getEntries(String memberName) {
-      return getAsJsonObject(memberName).entrySet();
+      final JsonObject object = getAsJsonObject(memberName);
+      return object != null ? object.entrySet() : Collections.emptySet();
     }
   }
 


### PR DESCRIPTION
Handle null JSON entries more gracefully.  This happens, for example, if we ask an Isolate for it's heap data (as for a web app in https://github.com/flutter/flutter-intellij/issues/3590) and there isn't any.

/cc @devoncarew 