### PR TITLE
Make logic dealing with converting offsets more robust.

### DIFF
--- a/src/io/flutter/editor/OutlineLocation.java
+++ b/src/io/flutter/editor/OutlineLocation.java
@@ -61,7 +61,7 @@ public class OutlineLocation implements Comparable<OutlineLocation> {
     int column,
     int indent,
     VirtualFile file,
-    DartAnalysisServerService analysisService
+    WidgetIndentsHighlightingPass pass
   ) {
     this.line = line;
     this.column = column;
@@ -76,8 +76,8 @@ public class OutlineLocation implements Comparable<OutlineLocation> {
     assert (column >= indent);
     assert (line >= 0);
     this.indent = indent;
-    this.offset = analysisService.getConvertedOffset(file, node.getOffset());
-    this.endOffset = analysisService.getConvertedOffset(file, node.getOffset() + node.getLength());
+    this.offset = pass.getConvertedOffset(node);
+    this.endOffset = pass.getConvertedOffset(node.getOffset() + node.getLength());
   }
 
   public void dispose() {


### PR DESCRIPTION
Only use the converted offsets when the file and the converted
offsets disagree. This avoids bugs where we sometimes converted
offsets that shouldn't be converted on windows.

This fixes https://github.com/flutter/flutter-intellij/issues/3561