### PR TITLE
Name the Bazel test config factories to match assumed names in g3

### DIFF
--- a/src/io/flutter/FlutterBundle.properties
+++ b/src/io/flutter/FlutterBundle.properties
@@ -61,6 +61,7 @@ runner.flutter.configuration.name=Flutter
 runner.flutter.bazel.configuration.description=Flutter Bazel run configuration
 runner.flutter.bazel.configuration.name=Flutter (Bazel)
 runner.flutter.bazel.test.configuration.name=Flutter Test (Bazel)
+runner.flutter.bazel.watch.test.configuration.name=Watch Flutter Test (Bazel)
 
 waiting.for.flutter=Waiting for debug connection...
 

--- a/src/io/flutter/run/bazel/FlutterBazelRunConfigurationType.java
+++ b/src/io/flutter/run/bazel/FlutterBazelRunConfigurationType.java
@@ -5,6 +5,7 @@
  */
 package io.flutter.run.bazel;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.intellij.execution.ExecutionBundle;
 import com.intellij.execution.configurations.ConfigurationFactory;
 import com.intellij.execution.configurations.ConfigurationTypeBase;
@@ -19,11 +20,13 @@ import io.flutter.utils.FlutterModuleUtils;
 import org.jetbrains.annotations.NotNull;
 
 public class FlutterBazelRunConfigurationType extends ConfigurationTypeBase {
+  @VisibleForTesting
+  final Factory factory = new Factory(this);
 
   public FlutterBazelRunConfigurationType() {
     super("FlutterBazelRunConfigurationType", FlutterBundle.message("runner.flutter.bazel.configuration.name"),
           FlutterBundle.message("runner.flutter.bazel.configuration.description"), FlutterIcons.BazelRun);
-    addFactory(new Factory(this));
+    addFactory(factory);
   }
 
   /**
@@ -34,7 +37,8 @@ public class FlutterBazelRunConfigurationType extends ConfigurationTypeBase {
            FlutterModuleUtils.isFlutterBazelProject(project);
   }
 
-  private static class Factory extends ConfigurationFactory {
+  @VisibleForTesting
+  static class Factory extends ConfigurationFactory {
     public Factory(FlutterBazelRunConfigurationType type) {
       super(type);
     }
@@ -77,6 +81,12 @@ public class FlutterBazelRunConfigurationType extends ConfigurationTypeBase {
     @Override
     public boolean isApplicable(@NotNull Project project) {
       return FlutterBazelRunConfigurationType.doShowBazelRunConfigurationForProject(project);
+    }
+
+    @Override
+    @NotNull
+    public String getId() {
+      return FlutterBundle.message("runner.flutter.bazel.configuration.name");
     }
   }
 }

--- a/src/io/flutter/run/bazelTest/FlutterBazelTestConfigurationType.java
+++ b/src/io/flutter/run/bazelTest/FlutterBazelTestConfigurationType.java
@@ -61,8 +61,9 @@ public class FlutterBazelTestConfigurationType extends ConfigurationTypeBase {
     }
 
     @Override
-    public @NotNull String getId() {
-      return "No Watch";
+    @NotNull
+    public String getId() {
+      return FlutterBundle.message("runner.flutter.bazel.test.configuration.name");
     }
   }
 
@@ -80,7 +81,8 @@ public class FlutterBazelTestConfigurationType extends ConfigurationTypeBase {
     public RunConfiguration createTemplateConfiguration(@NotNull Project project) {
       // This is always called first when loading a run config, even when it's a non-template config.
       // See RunManagerImpl.doCreateConfiguration
-      BazelTestConfig config = new BazelTestConfig(project, this, FlutterBundle.message("runner.flutter.bazel.test.configuration.name"));
+      BazelTestConfig config = new BazelTestConfig(
+        project, this, FlutterBundle.message("runner.flutter.bazel.watch.test.configuration.name"));
       config.setFields(new BazelTestFields(null, null, null, "--watch"));
       return config;
     }
@@ -97,7 +99,7 @@ public class FlutterBazelTestConfigurationType extends ConfigurationTypeBase {
 
     @Override
     public @NotNull String getId() {
-      return "Watch";
+      return FlutterBundle.message("runner.flutter.bazel.watch.test.configuration.name");
     }
   }
 }

--- a/testSrc/unit/io/flutter/run/bazel/BazelConfigurationFactoryTest.java
+++ b/testSrc/unit/io/flutter/run/bazel/BazelConfigurationFactoryTest.java
@@ -28,13 +28,13 @@ public class BazelConfigurationFactoryTest {
   public ProjectFixture projectFixture = Testing.makeEmptyModule();
 
   @Test
-  public void factoryIdAreCorrect() {
+  public void factoryIdIsCorrect() {
     // Bazel code assumes the id of the factory as a precondition.
     assertThat(type.factory.getId(), equalTo("Flutter (Bazel)"));
   }
 
   @Test
-  public void factoryConfigTypesMatch() {
+  public void factoryConfigTypeMatches() {
     assertThat(type.getId(), equalTo("FlutterBazelRunConfigurationType"));
   }
 }

--- a/testSrc/unit/io/flutter/run/bazel/BazelConfigurationFactoryTest.java
+++ b/testSrc/unit/io/flutter/run/bazel/BazelConfigurationFactoryTest.java
@@ -3,7 +3,7 @@
  * Use of this source code is governed by a BSD-style license that can be
  * found in the LICENSE file.
  */
-package io.flutter.run.bazelTest;
+package io.flutter.run.bazel;
 
 import io.flutter.testing.ProjectFixture;
 import io.flutter.testing.Testing;
@@ -13,15 +13,16 @@ import org.junit.Test;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 
+
 /**
- * Verify the behavior of bazel test configuration factories.
+ * Verify the behavior of bazel run configuration factories.
  *
  * <p>
  * These tests validate preconditions from Bazel IntelliJ plugin logic for how run configurations are saved to Piper.
  * If these tests fail, you may need to update some g3 code to prevent breaking g3 Bazel run configurations.
  */
-public class BazelTestConfigurationFactoryTest {
-  final FlutterBazelTestConfigurationType type = new FlutterBazelTestConfigurationType();
+public class BazelConfigurationFactoryTest {
+  final FlutterBazelRunConfigurationType type = new FlutterBazelRunConfigurationType();
 
   @Rule
   public ProjectFixture projectFixture = Testing.makeEmptyModule();
@@ -29,12 +30,11 @@ public class BazelTestConfigurationFactoryTest {
   @Test
   public void factoryIdAreCorrect() {
     // Bazel code assumes the id of the factory as a precondition.
-    assertThat(type.factory.getId(), equalTo("Flutter Test (Bazel)"));
-    assertThat(type.watchFactory.getId(), equalTo("Watch Flutter Test (Bazel)"));
+    assertThat(type.factory.getId(), equalTo("Flutter (Bazel)"));
   }
 
   @Test
   public void factoryConfigTypesMatch() {
-    assertThat(type.getId(), equalTo("FlutterBazelTestConfigurationType"));
+    assertThat(type.getId(), equalTo("FlutterBazelRunConfigurationType"));
   }
 }

--- a/testSrc/unit/io/flutter/run/bazelTest/BazelTestConfigurationFactoryTest.java
+++ b/testSrc/unit/io/flutter/run/bazelTest/BazelTestConfigurationFactoryTest.java
@@ -27,7 +27,7 @@ public class BazelTestConfigurationFactoryTest {
   public ProjectFixture projectFixture = Testing.makeEmptyModule();
 
   @Test
-  public void factoryIdAreCorrect() {
+  public void factoryIdsAreCorrect() {
     // Bazel code assumes the id of the factory as a precondition.
     assertThat(type.factory.getId(), equalTo("Flutter Test (Bazel)"));
     assertThat(type.watchFactory.getId(), equalTo("Watch Flutter Test (Bazel)"));

--- a/testSrc/unit/io/flutter/run/bazelTest/BazelTestConfigurationFactoryTest.java
+++ b/testSrc/unit/io/flutter/run/bazelTest/BazelTestConfigurationFactoryTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.run.bazelTest;
+
+import io.flutter.testing.ProjectFixture;
+import io.flutter.testing.Testing;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Verify the behavior of bazel test configuration factories.
+ *
+ * <p>
+ * These tests assume preconditions from Bazel IntelliJ plugin logic for how run configurations are saved to Piper.
+ */
+public class BazelTestConfigurationFactoryTest {
+  final FlutterBazelTestConfigurationType type = new FlutterBazelTestConfigurationType();
+
+  @Rule
+  public ProjectFixture projectFixture = Testing.makeEmptyModule();
+
+  @Test
+  public void normalFactoryIdIsCorrect() {
+    // Bazel code assumes the id of this factory as a precondition.
+    assertThat(type.factory.getId(), equalTo("Flutter Test (Bazel)"));
+  }
+
+  @Test
+  public void watchFactoryIdIsCorrect() {
+    // Bazel code assumes the id of this factory as a precondition.
+    assertThat(type.watchFactory.getId(), equalTo("Watch Flutter Test (Bazel)"));
+  }
+}


### PR DESCRIPTION
There is a regression currently where saved bazel test configurations aren't loading properly.

Add tests to prevent future regressions.