### PR TITLE
Fix per SDK Stream<Uint8List> breaking changes

### DIFF
--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -46,7 +46,7 @@ colors() async {
   // Get color file from flutter.
   HttpClientRequest request = await new HttpClient().getUrl(Uri.parse(kUrl));
   HttpClientResponse response = await request.close();
-  List<String> data = await response.transform(utf8.decoder).toList();
+  List<String> data = await utf8.decoder.bind(response).toList();
 
   // Remove an import and define the Color class.
   String str = data.join('');

--- a/tool/icons/update_icons.dart
+++ b/tool/icons/update_icons.dart
@@ -39,7 +39,7 @@ void main() async {
 Future<String> downloadUrl(String url) async {
   HttpClientRequest request = await new HttpClient().getUrl(Uri.parse(url));
   HttpClientResponse response = await request.close();
-  List<String> data = await response.transform(utf8.decoder).toList();
+  List<String> data = await utf8.decoder.bind(response).toList();
   return data.join('');
 }
 

--- a/tool/plugin/lib/plugin.dart
+++ b/tool/plugin/lib/plugin.dart
@@ -131,9 +131,8 @@ Future<File> genPluginXml(BuildSpec spec, String destDir, String path) async {
   dest.writeln(
       "<!-- Do not edit; instead, modify ${p.basename(templatePath)}, and run './bin/plugin generate'. -->");
   dest.writeln();
-  await new File(p.join(rootPath, 'resources', templatePath))
-      .openRead()
-      .transform(utf8.decoder)
+  await utf8.decoder
+      .bind(new File(p.join(rootPath, 'resources', templatePath)).openRead())
       .transform(new LineSplitter())
       .forEach((l) => dest.writeln(substituteTemplateVariables(l, spec)));
   await dest.close();


### PR DESCRIPTION
This updates call sites with forward-compatible fixes for
a recent Dart SDK change that changed the following APIs
to be `Stream<Uint8List>` rather than `Stream<List<int>>`:

* HttpClientResponse
* File.openRead()

https://github.com/dart-lang/sdk/issues/36900