### PR TITLE
Partial revert of "Remove netty and gnu.trove imports (#3623)"

### DIFF
--- a/src/io/flutter/inspections/FlutterDependencyInspection.java
+++ b/src/io/flutter/inspections/FlutterDependencyInspection.java
@@ -15,6 +15,7 @@ import com.intellij.openapi.roots.ProjectRootManager;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
 import com.jetbrains.lang.dart.psi.DartFile;
+import gnu.trove.THashSet;
 import io.flutter.FlutterBundle;
 import io.flutter.FlutterUtils;
 import io.flutter.dart.DartPlugin;
@@ -25,11 +26,10 @@ import io.flutter.utils.FlutterModuleUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.HashSet;
 import java.util.Set;
 
 public class FlutterDependencyInspection extends LocalInspectionTool {
-  private final Set<String> myIgnoredPubspecPaths = new HashSet<>(); // remember for the current session only, do not serialize
+  private final Set<String> myIgnoredPubspecPaths = new THashSet<>(); // remember for the current session only, do not serialize
 
   @Nullable
   @Override

--- a/src/io/flutter/inspector/TreeScrollAnimator.java
+++ b/src/io/flutter/inspector/TreeScrollAnimator.java
@@ -7,6 +7,7 @@ package io.flutter.inspector;
 
 import com.intellij.openapi.Disposable;
 import com.intellij.ui.components.JBScrollBar;
+import gnu.trove.THashSet;
 import io.flutter.utils.animation.Curve;
 import io.flutter.utils.animation.Curves;
 
@@ -16,7 +17,6 @@ import javax.swing.tree.TreePath;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -456,7 +456,7 @@ public class TreeScrollAnimator implements Disposable {
       return;
     }
 
-    this.targets = new HashSet<>(targets);
+    this.targets = new THashSet<>(targets);
 
     final long currentTime = System.currentTimeMillis();
 

--- a/src/io/flutter/logging/FlutterLogView.java
+++ b/src/io/flutter/logging/FlutterLogView.java
@@ -53,8 +53,8 @@ import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.MouseEvent;
-import java.util.*;
 import java.util.List;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static com.intellij.openapi.editor.markup.EffectType.*;
@@ -71,7 +71,7 @@ public class FlutterLogView extends JPanel implements ConsoleView, DataProvider,
   private static final float DATA_PANEL_SPLITTER_PROPORTION_DEFAULT = 0.60f;
 
   @NotNull
-  private static final Map<Level, TextAttributesKey> LOG_LEVEL_TEXT_ATTRIBUTES_KEY_MAP;
+  private static final Map<FlutterLog.Level, TextAttributesKey> LOG_LEVEL_TEXT_ATTRIBUTES_KEY_MAP;
   @NotNull
   private static final Map<EffectType, Integer> EFFECT_TYPE_TEXT_STYLE_MAP;
   @NotNull

--- a/src/io/flutter/run/ObservatoryFile.java
+++ b/src/io/flutter/run/ObservatoryFile.java
@@ -11,12 +11,13 @@ import com.intellij.util.PathUtil;
 import com.intellij.xdebugger.XDebuggerUtil;
 import com.intellij.xdebugger.XSourcePosition;
 import com.jetbrains.lang.dart.DartFileType;
+import gnu.trove.THashMap;
+import gnu.trove.TIntObjectHashMap;
 import io.flutter.vmService.DartVmServiceDebugProcess;
 import org.dartlang.vm.service.element.Script;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -35,7 +36,7 @@ class ObservatoryFile {
    * Maps an observatory token id to its line and column.
    */
   @Nullable
-  private final Map<Integer, Position> positionMap;
+  private final TIntObjectHashMap<Position> positionMap;
 
   /**
    * User-visible source code downloaded from Observatory.
@@ -91,8 +92,8 @@ class ObservatoryFile {
    * <p>See <a href="https://github.com/dart-lang/vm_service_drivers/blob/master/dart/tool/service.md#scrip">docs</a>.
    */
   @NotNull
-  private static Map<Integer, Position> createPositionMap(@NotNull final List<List<Integer>> table) {
-    final Map<Integer, Position> result = new HashMap<>();
+  private static TIntObjectHashMap<Position> createPositionMap(@NotNull final List<List<Integer>> table) {
+    final TIntObjectHashMap<Position> result = new TIntObjectHashMap<>();
 
     for (List<Integer> line : table) {
       // Each line consists of a line number followed by (tokenId, columnNumber) pairs.
@@ -139,7 +140,7 @@ class ObservatoryFile {
      * A cache containing each file downloaded from Observatory. The key is a script id.
      * Each version of a file is stored as a separate entry.
      */
-    private final Map<String, ObservatoryFile> versions = new HashMap<>();
+    private final Map<String, ObservatoryFile> versions = new THashMap<>();
 
     Cache(@NotNull String isolateId, @NotNull DartVmServiceDebugProcess.ScriptProvider provider) {
       this.isolateId = isolateId;

--- a/src/io/flutter/run/PositionMapper.java
+++ b/src/io/flutter/run/PositionMapper.java
@@ -22,6 +22,7 @@ import com.intellij.xdebugger.XSourcePosition;
 import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService;
 import com.jetbrains.lang.dart.util.DartResolveUtil;
 import com.jetbrains.lang.dart.util.DartUrlResolver;
+import gnu.trove.THashMap;
 import io.flutter.FlutterUtils;
 import io.flutter.dart.DartPlugin;
 import io.flutter.vmService.DartVmServiceDebugProcess;
@@ -32,7 +33,10 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
-import java.util.*;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Converts positions between Dart files in Observatory and local Dart files.
@@ -89,7 +93,7 @@ public class PositionMapper implements DartVmServiceDebugProcess.PositionMapper 
   /**
    * A cache containing each file version downloaded from Observatory. The key is an isolate id.
    */
-  private final Map<String, ObservatoryFile.Cache> fileCache = new HashMap<>();
+  private final Map<String, ObservatoryFile.Cache> fileCache = new THashMap<>();
 
   public PositionMapper(@NotNull Project project,
                         @NotNull VirtualFile sourceRoot,

--- a/src/io/flutter/test/DartTestEventsConverterZ.java
+++ b/src/io/flutter/test/DartTestEventsConverterZ.java
@@ -11,6 +11,7 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.util.PathUtil;
 import com.jetbrains.lang.dart.ide.runner.util.DartTestLocationProvider;
 import com.jetbrains.lang.dart.util.DartUrlResolver;
+import gnu.trove.TIntLongHashMap;
 import jetbrains.buildServer.messages.serviceMessages.ServiceMessageVisitor;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -90,7 +91,7 @@ public class DartTestEventsConverterZ extends OutputToGeneralTestEventsConverter
   private String myLocation;
   private Key myCurrentOutputType;
   private ServiceMessageVisitor myCurrentVisitor;
-  private Map<Integer, Long> myTestIdToTimestamp;
+  private TIntLongHashMap myTestIdToTimestamp;
   private Map<Integer, Test> myTestData;
   private Map<Integer, Group> myGroupData;
   private Map<Integer, Suite> mySuiteData;
@@ -101,7 +102,7 @@ public class DartTestEventsConverterZ extends OutputToGeneralTestEventsConverter
                                   @NotNull final DartUrlResolver urlResolver) {
     super(testFrameworkName, consoleProperties);
     myUrlResolver = urlResolver;
-    myTestIdToTimestamp = new HashMap<>();
+    myTestIdToTimestamp = new TIntLongHashMap();
     myTestData = new HashMap<>();
     myGroupData = new HashMap<>();
     mySuiteData = new HashMap<>();

--- a/src/io/flutter/view/WidgetPerfTable.java
+++ b/src/io/flutter/view/WidgetPerfTable.java
@@ -20,6 +20,7 @@ import com.intellij.ui.treeStructure.treetable.TreeTable;
 import com.intellij.util.PathUtil;
 import com.intellij.util.ui.ColumnInfo;
 import com.intellij.xdebugger.XSourcePosition;
+import gnu.trove.TIntArrayList;
 import io.flutter.inspector.InspectorActions;
 import io.flutter.inspector.InspectorService;
 import io.flutter.inspector.InspectorTree;
@@ -286,8 +287,8 @@ class WidgetPerfTable extends TreeTable implements DataProvider, PerfModel {
       }
       final boolean previouslyEmpty = root.getChildCount() == 0;
       int childIndex = 0;
-      final ArrayList<Integer> indicesChanged = new ArrayList<>();
-      final ArrayList<Integer> indicesInserted = new ArrayList<>();
+      final TIntArrayList indicesChanged = new TIntArrayList();
+      final TIntArrayList indicesInserted = new TIntArrayList();
       for (SlidingWindowStatsSummary entry : entries) {
         if (entry.getLocation().equals(lastSelectedLocation)) {
           selectionIndex = childIndex;
@@ -309,7 +310,7 @@ class WidgetPerfTable extends TreeTable implements DataProvider, PerfModel {
       }
       final int endChildIndex = childIndex;
       final ArrayList<TreeNode> nodesRemoved = new ArrayList<>();
-      final ArrayList<Integer> indicesRemoved = new ArrayList<>();
+      final TIntArrayList indicesRemoved = new TIntArrayList();
       // Gather nodes to remove.
       for (int j = endChildIndex; j < root.getChildCount(); j++) {
         nodesRemoved.add(root.getChildAt(j));
@@ -329,13 +330,13 @@ class WidgetPerfTable extends TreeTable implements DataProvider, PerfModel {
       else {
         // Report events for all the changes made to the table.
         if (indicesChanged.size() > 0) {
-          model.nodesChanged(root, toIntArray(indicesChanged));
+          model.nodesChanged(root, indicesChanged.toNativeArray());
         }
         if (indicesInserted.size() > 0) {
-          model.nodesWereInserted(root, toIntArray(indicesInserted));
+          model.nodesWereInserted(root, indicesInserted.toNativeArray());
         }
         if (indicesRemoved.size() > 0) {
-          model.nodesWereRemoved(root, toIntArray(indicesRemoved), nodesRemoved.toArray());
+          model.nodesWereRemoved(root, indicesRemoved.toNativeArray(), nodesRemoved.toArray());
         }
       }
 
@@ -347,14 +348,6 @@ class WidgetPerfTable extends TreeTable implements DataProvider, PerfModel {
         getSelectionModel().clearSelection();
       }
     }
-  }
-
-  private int[] toIntArray(ArrayList<Integer> list) {
-    final int[] indices = new int[list.size()];
-    for (int i = 0; i < list.size(); i++) {
-      indices[i] = list.get(i);
-    }
-    return indices;
   }
 
   private boolean statsChanged(ArrayList<SlidingWindowStatsSummary> previous, ArrayList<SlidingWindowStatsSummary> current) {

--- a/src/io/flutter/vmService/DartVmServiceBreakpointHandler.java
+++ b/src/io/flutter/vmService/DartVmServiceBreakpointHandler.java
@@ -17,6 +17,8 @@ import com.intellij.xdebugger.breakpoints.XBreakpointHandler;
 import com.intellij.xdebugger.breakpoints.XBreakpointProperties;
 import com.intellij.xdebugger.breakpoints.XLineBreakpoint;
 import com.jetbrains.lang.dart.ide.runner.DartLineBreakpointType;
+import gnu.trove.THashMap;
+import gnu.trove.THashSet;
 import org.dartlang.vm.service.element.Breakpoint;
 import org.jetbrains.annotations.NotNull;
 
@@ -27,9 +29,9 @@ import static com.intellij.icons.AllIcons.Debugger.Db_invalid_breakpoint;
 public class DartVmServiceBreakpointHandler extends XBreakpointHandler<XLineBreakpoint<XBreakpointProperties>> {
 
   private final DartVmServiceDebugProcess myDebugProcess;
-  private final Set<XLineBreakpoint<XBreakpointProperties>> myXBreakpoints = new HashSet<>();
-  private final Map<String, IsolateBreakpointInfo> myIsolateInfo = new HashMap<>();
-  private final Map<String, XLineBreakpoint<XBreakpointProperties>> myVmBreakpointIdToXBreakpointMap = new HashMap<>();
+  private final Set<XLineBreakpoint<XBreakpointProperties>> myXBreakpoints = new THashSet<>();
+  private final Map<String, IsolateBreakpointInfo> myIsolateInfo = new THashMap<>();
+  private final Map<String, XLineBreakpoint<XBreakpointProperties>> myVmBreakpointIdToXBreakpointMap = new THashMap<>();
 
   public DartVmServiceBreakpointHandler(@NotNull final DartVmServiceDebugProcess debugProcess) {
     super(DartLineBreakpointType.class);
@@ -119,7 +121,7 @@ class IsolateBreakpointInfo {
   private final String myIsolateId;
   private final DartVmServiceDebugProcess myDebugProcess;
   private final List<String> myTemporaryVmBreakpointIds = new ArrayList<>();
-  private final Map<XLineBreakpoint<XBreakpointProperties>, Set<String>> myXBreakpointToVmBreakpointIdsMap = new HashMap<>();
+  private final Map<XLineBreakpoint<XBreakpointProperties>, Set<String>> myXBreakpointToVmBreakpointIdsMap = new THashMap<>();
 
   IsolateBreakpointInfo(@NotNull String isolateId, @NotNull DartVmServiceDebugProcess debugProcess) {
     this.myIsolateId = isolateId;

--- a/src/io/flutter/vmService/DartVmServiceDebugProcess.java
+++ b/src/io/flutter/vmService/DartVmServiceDebugProcess.java
@@ -33,6 +33,8 @@ import com.jetbrains.lang.dart.ide.runner.actions.DartPopFrameAction;
 import com.jetbrains.lang.dart.ide.runner.base.DartDebuggerEditorsProvider;
 import com.jetbrains.lang.dart.ide.runner.server.OpenDartObservatoryUrlAction;
 import com.jetbrains.lang.dart.util.DartUrlResolver;
+import gnu.trove.THashMap;
+import gnu.trove.TIntObjectHashMap;
 import io.flutter.FlutterBundle;
 import io.flutter.FlutterUtils;
 import io.flutter.ObservatoryConnector;
@@ -67,8 +69,8 @@ public class DartVmServiceDebugProcess extends XDebugProcess {
   @NotNull private final XBreakpointHandler[] myBreakpointHandlers;
   private final IsolatesInfo myIsolatesInfo;
   @NotNull private final Map<String, CompletableFuture<Object>> mySuspendedIsolateIds = Collections.synchronizedMap(new HashMap<>());
-  private final Map<String, LightVirtualFile> myScriptIdToContentMap = new HashMap<>();
-  private final Map<String, Map<Integer, Pair<Integer, Integer>>> myScriptIdToLinesAndColumnsMap = new HashMap<>();
+  private final Map<String, LightVirtualFile> myScriptIdToContentMap = new THashMap<>();
+  private final Map<String, TIntObjectHashMap<Pair<Integer, Integer>>> myScriptIdToLinesAndColumnsMap = new THashMap<>();
   @Nullable private final VirtualFile myCurrentWorkingDirectory;
   @NotNull private final ObservatoryConnector myConnector;
   @NotNull private final ExecutionEnvironment executionEnvironment;
@@ -619,10 +621,10 @@ public class DartVmServiceDebugProcess extends XDebugProcess {
   }
 
   @NotNull
-  private static Map<Integer, Pair<Integer, Integer>> createTokenPosToLineAndColumnMap(@NotNull final List<List<Integer>> tokenPosTable) {
+  private static TIntObjectHashMap<Pair<Integer, Integer>> createTokenPosToLineAndColumnMap(@NotNull final List<List<Integer>> tokenPosTable) {
     // Each subarray consists of a line number followed by (tokenPos, columnNumber) pairs
     // see https://github.com/dart-lang/vm_service_drivers/blob/master/dart/tool/service.md#script
-    final Map<Integer, Pair<Integer, Integer>> result = new HashMap<>();
+    final TIntObjectHashMap<Pair<Integer, Integer>> result = new TIntObjectHashMap<>();
 
     for (List<Integer> lineAndPairs : tokenPosTable) {
       final Iterator<Integer> iterator = lineAndPairs.iterator();

--- a/src/io/flutter/vmService/IsolatesInfo.java
+++ b/src/io/flutter/vmService/IsolatesInfo.java
@@ -1,12 +1,12 @@
 package io.flutter.vmService;
 
+import gnu.trove.THashMap;
 import org.dartlang.vm.service.element.Isolate;
 import org.dartlang.vm.service.element.IsolateRef;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
@@ -50,7 +50,7 @@ public class IsolatesInfo {
     }
   }
 
-  private final Map<String, IsolateInfo> myIsolateIdToInfoMap = new HashMap<>();
+  private final Map<String, IsolateInfo> myIsolateIdToInfoMap = new THashMap<>();
 
   public synchronized boolean addIsolate(@NotNull final IsolateRef isolateRef) {
     if (myIsolateIdToInfoMap.containsKey(isolateRef.getId())) {

--- a/src/io/flutter/vmService/VMServiceManager.java
+++ b/src/io/flutter/vmService/VMServiceManager.java
@@ -9,6 +9,7 @@ import com.google.gson.JsonObject;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.util.Disposer;
 import com.intellij.openapi.util.text.StringUtil;
+import gnu.trove.THashMap;
 import io.flutter.inspector.EvalOnDartLibrary;
 import io.flutter.run.daemon.FlutterApp;
 import io.flutter.utils.EventStream;
@@ -32,13 +33,13 @@ public class VMServiceManager implements FlutterApp.FlutterAppListener {
   @NotNull private final FlutterApp app;
   @NotNull private final HeapMonitor heapMonitor;
   @NotNull private final FlutterFramesMonitor flutterFramesMonitor;
-  @NotNull private final Map<String, EventStream<Boolean>> serviceExtensions = new HashMap<>();
+  @NotNull private final Map<String, EventStream<Boolean>> serviceExtensions = new THashMap<>();
 
   /**
    * Boolean value applicable only for boolean service extensions indicating
    * whether the service extension is enabled or disabled.
    */
-  @NotNull private final Map<String, EventStream<ServiceExtensionState>> serviceExtensionState = new HashMap<>();
+  @NotNull private final Map<String, EventStream<ServiceExtensionState>> serviceExtensionState = new THashMap<>();
 
   private final EventStream<IsolateRef> flutterIsolateRefStream;
 

--- a/src/io/flutter/vmService/frame/DartVmServiceEvaluator.java
+++ b/src/io/flutter/vmService/frame/DartVmServiceEvaluator.java
@@ -21,6 +21,7 @@ import com.intellij.xdebugger.evaluation.XDebuggerEvaluator;
 import com.intellij.xdebugger.frame.XValue;
 import com.jetbrains.lang.dart.psi.*;
 import com.jetbrains.lang.dart.util.DartResolveUtil;
+import gnu.trove.THashSet;
 import io.flutter.vmService.DartVmServiceDebugProcess;
 import io.flutter.vmService.VmServiceWrapper;
 import org.dartlang.vm.service.consumer.GetObjectConsumer;
@@ -29,7 +30,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -161,7 +161,7 @@ public class DartVmServiceEvaluator extends XDebuggerEvaluator {
 
   private LibraryRef findMatchingLibrary(Isolate isolate, List<VirtualFile> libraryFiles) {
     if (libraryFiles != null && !libraryFiles.isEmpty()) {
-      final Set<String> uris = new HashSet<>();
+      final Set<String> uris = new THashSet<>();
 
       for (VirtualFile libraryFile : libraryFiles) {
         uris.addAll(myDebugProcess.getUrisForFile(libraryFile));

--- a/tool/plugin/lib/lint.dart
+++ b/tool/plugin/lib/lint.dart
@@ -74,7 +74,6 @@ class LintCommand extends Command {
   bool checkForBadImports() {
     final proscribedImports = [
       'com.android.annotations.NonNull',
-      'gnu.trove.',
       'io.netty.',
       'javax.annotation.Nullable',
       'org.apache.commons.lang3.StringUtils',


### PR DESCRIPTION
This reverts gnu.trove import removal from commit fb50615d6eaceac70830ead0c783be65a3673dc6.

The io.netty imports will remain proscribed after merging this.

Fixes #3647.