### PR TITLE
fix an issue with some daemon json output appearing in the console

### DIFF
--- a/flutter-studio/src/io/flutter/module/FlutterModuleImporter.java
+++ b/flutter-studio/src/io/flutter/module/FlutterModuleImporter.java
@@ -52,7 +52,7 @@ public class FlutterModuleImporter {
     assert (myModel.project().get().isPresent());
     Project androidProject = myModel.project().get().get();
     VirtualFile projectRoot = androidProject.getBaseDir();
-    myRelativePath = io.flutter.utils.System.findRelativePath(projectRoot.getParent(), moduleRoot, File.separatorChar);
+    myRelativePath = io.flutter.utils.SystemUtils.findRelativePath(projectRoot.getParent(), moduleRoot, File.separatorChar);
     if (myRelativePath == null) {
       showHowToEditDialog();
       return;

--- a/src/io/flutter/run/daemon/DaemonConsoleView.java
+++ b/src/io/flutter/run/daemon/DaemonConsoleView.java
@@ -85,7 +85,6 @@ public class DaemonConsoleView extends ConsoleViewImpl {
         if (FlutterSettings.getInstance().isVerboseLogging()) {
           LOG.info(line.trim());
         }
-        return;
       }
       else {
         // We're seeing a spurious newline before some launches; this removes any single newline that occurred

--- a/src/io/flutter/sdk/FlutterSdkUtil.java
+++ b/src/io/flutter/sdk/FlutterSdkUtil.java
@@ -28,7 +28,7 @@ import io.flutter.dart.DartPlugin;
 import io.flutter.pub.PubRoot;
 import io.flutter.pub.PubRoots;
 import io.flutter.utils.FlutterModuleUtils;
-import io.flutter.utils.System;
+import io.flutter.utils.SystemUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -300,7 +300,7 @@ public class FlutterSdkUtil {
    */
   @Nullable
   public static String locateSdkFromPath() {
-    final String flutterBinPath = System.which("flutter");
+    final String flutterBinPath = SystemUtils.which("flutter");
     if (flutterBinPath == null) {
       return null;
     }

--- a/src/io/flutter/utils/StdoutJsonParser.java
+++ b/src/io/flutter/utils/StdoutJsonParser.java
@@ -32,7 +32,7 @@ public class StdoutJsonParser {
       if (!bufferIsJson && buffer.length() == 2 && buffer.charAt(0) == '[' && c == '{') {
         bufferIsJson = true;
       }
-      else if (bufferIsJson && c == ']' && possiblyTerminatesJson(string, i, buffer)) {
+      else if (bufferIsJson && c == ']' && possiblyTerminatesJson(buffer, string, i)) {
         flushLine();
       }
 
@@ -41,25 +41,27 @@ public class StdoutJsonParser {
       }
     }
 
-    // Eagerly flush if we are not within JSON so regular log text is written
-    // as soon as possible.
+    // Eagerly flush if we are not within JSON so regular log text is written as soon as possible.
     if (!bufferIsJson) {
+      flushLine();
+    }
+    else if (buffer.toString().endsWith("}]")) {
       flushLine();
     }
   }
 
-  private boolean possiblyTerminatesJson(String string, int stringIndex, StringBuilder output) {
+  private boolean possiblyTerminatesJson(StringBuilder output, String input, int inputIndex) {
     // This is an approximate approach to look for json message terminations inside of strings -
     // where the normally terminating eol gets separated from the json.
 
-    if (output.length() < 2 || stringIndex + 1 >= string.length()) {
+    if (output.length() < 2 || inputIndex + 1 >= input.length()) {
       return false;
     }
 
     // Look for '}', ']', and a letter
     final char prev = output.charAt(output.length() - 2);
     final char current = output.charAt(output.length() - 1);
-    final char next = string.charAt(stringIndex + 1);
+    final char next = input.charAt(inputIndex + 1);
 
     return prev == '}' && current == ']' && Character.isAlphabetic(next);
   }

--- a/src/io/flutter/utils/SystemUtils.java
+++ b/src/io/flutter/utils/SystemUtils.java
@@ -20,7 +20,7 @@ import com.intellij.openapi.vfs.VirtualFile;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public class System {
+public class SystemUtils {
   /**
    * Locate a given command-line tool given its name.
    */
@@ -88,10 +88,10 @@ public class System {
       if (src == null) return null;
     }
 
-    VirtualFile commonAncestor = VfsUtilCore.getCommonAncestor(src, dst);
+    final VirtualFile commonAncestor = VfsUtilCore.getCommonAncestor(src, dst);
     if (commonAncestor == null) return null;
 
-    StringBuilder buffer = new StringBuilder();
+    final StringBuilder buffer = new StringBuilder();
 
     if (!Comparing.equal(src, commonAncestor)) {
       while (!Comparing.equal(src, commonAncestor)) {

--- a/testSrc/unit/io/flutter/utils/StdoutJsonParserTest.java
+++ b/testSrc/unit/io/flutter/utils/StdoutJsonParserTest.java
@@ -86,9 +86,8 @@ public class StdoutJsonParserTest {
     final StdoutJsonParser parser = new StdoutJsonParser();
     parser.appendOutput("hello\n");
     parser.appendOutput("there\n");
-    parser.appendOutput("[{'foo':");
-    parser.appendOutput("[{'bar':'baz'}]");
-    // The JSON has not yet terminated with an \n.
+    parser.appendOutput("[{'bar':'baz'");
+    // The JSON has not yet terminated with a '}]' sequence.
 
     assertArrayEquals(
       "validating parser results",


### PR DESCRIPTION
- fix an issue with some daemon json output appearing in the console
- unrelated, rename a `System` class to `SystemUtils` so it doesn't have the same name as `java.lang.System`

```
[{"event":"app.progress","params":{"appId":"3afb1f88-db66-490d-bce7-f30050cb5d2a","id":"7","progressId":"hot.reload","message":"Performing hot reload..."}}]Performing hot reload...
```
