### PR TITLE
remove extra console whitespace

### DIFF
--- a/src/io/flutter/utils/StdoutJsonParser.java
+++ b/src/io/flutter/utils/StdoutJsonParser.java
@@ -20,6 +20,7 @@ public class StdoutJsonParser {
   private final StringBuilder buffer = new StringBuilder();
   private boolean bufferIsJson = false;
   private final List<String> lines = new ArrayList<>();
+  private boolean eatNextEol = false;
 
   /**
    * Write new output to this [StdoutJsonParser].
@@ -27,6 +28,15 @@ public class StdoutJsonParser {
   public void appendOutput(String string) {
     for (int i = 0; i < string.length(); ++i) {
       final char c = string.charAt(i);
+
+      if (eatNextEol) {
+        eatNextEol = false;
+
+        if (c == '\n') {
+          continue;
+        }
+      }
+
       buffer.append(c);
 
       if (!bufferIsJson && buffer.length() == 2 && buffer.charAt(0) == '[' && c == '{') {
@@ -46,6 +56,7 @@ public class StdoutJsonParser {
       flushLine();
     }
     else if (buffer.toString().endsWith("}]")) {
+      eatNextEol = true;
       flushLine();
     }
   }


### PR DESCRIPTION
- remove extra console whitespace

A minor follow up to https://github.com/flutter/flutter-intellij/pull/3658 - make sure we don't emit too many eol's (we shouldn't show the eols after a daemon output line).
