### PR TITLE
init default settings for the run console text wrapping

### DIFF
--- a/src/io/flutter/FlutterInitializer.java
+++ b/src/io/flutter/FlutterInitializer.java
@@ -25,6 +25,7 @@ import io.flutter.analytics.ToolWindowTracker;
 import io.flutter.android.IntelliJAndroidSdk;
 import io.flutter.devtools.WebDevManager;
 import io.flutter.editor.FlutterSaveActionsManager;
+import io.flutter.logging.FlutterConsoleLogManager;
 import io.flutter.perf.FlutterWidgetPerfManager;
 import io.flutter.pub.PubRoot;
 import io.flutter.pub.PubRoots;
@@ -133,7 +134,7 @@ public class FlutterInitializer implements StartupActivity {
     }
 
     FlutterRunNotifications.init(project);
-    
+
     // Start the widget perf manager.
     FlutterWidgetPerfManager.init(project);
 
@@ -155,6 +156,9 @@ public class FlutterInitializer implements StartupActivity {
       Analytics.GROUP_DISPLAY_ID,
       NotificationDisplayType.STICKY_BALLOON,
       false);
+
+    // Set our preferred settings for the run console.
+    FlutterConsoleLogManager.initConsolePreferences();
 
     // Initialize analytics.
     final PropertiesComponent properties = PropertiesComponent.getInstance();

--- a/src/io/flutter/logging/FlutterConsoleLogManager.java
+++ b/src/io/flutter/logging/FlutterConsoleLogManager.java
@@ -11,7 +11,10 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.gson.*;
 import com.intellij.execution.ui.ConsoleView;
 import com.intellij.execution.ui.ConsoleViewContentType;
+import com.intellij.ide.util.PropertiesComponent;
 import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.editor.ex.EditorSettingsExternalizable;
+import com.intellij.openapi.editor.impl.softwrap.SoftWrapAppliancePlaces;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.ui.JBColor;
 import com.intellij.ui.SimpleTextAttributes;
@@ -59,6 +62,22 @@ public class FlutterConsoleLogManager {
 
   final private CompletableFuture<InspectorService.ObjectGroup> objectGroup;
   private static QueueProcessor<Runnable> queue;
+
+  /**
+   * Set our preferred settings for the run console.
+   */
+  public static void initConsolePreferences() {
+    final String consolePreferencesSet = "io.flutter.console.preferencesSet";
+
+    final PropertiesComponent properties = PropertiesComponent.getInstance();
+    if (!properties.getBoolean(consolePreferencesSet)) {
+      properties.setValue(consolePreferencesSet, true);
+
+      // Set our preferred default settings for console text wrapping.
+      final EditorSettingsExternalizable editorSettings = EditorSettingsExternalizable.getInstance();
+      editorSettings.setUseSoftWraps(true, SoftWrapAppliancePlaces.CONSOLE);
+    }
+  }
 
   @NotNull final VmService service;
   @NotNull final ConsoleView console;

--- a/src/io/flutter/logging/FlutterConsoleLogManager.java
+++ b/src/io/flutter/logging/FlutterConsoleLogManager.java
@@ -49,6 +49,8 @@ public class FlutterConsoleLogManager {
 
   public static final boolean SHOW_STRUCTURED_ERRORS = true;
 
+  private static final String consolePreferencesSetKey = "io.flutter.console.preferencesSet";
+
   private static final ConsoleViewContentType TITLE_CONTENT_TYPE =
     new ConsoleViewContentType("title",
                                new SimpleTextAttributes(
@@ -67,11 +69,9 @@ public class FlutterConsoleLogManager {
    * Set our preferred settings for the run console.
    */
   public static void initConsolePreferences() {
-    final String consolePreferencesSet = "io.flutter.console.preferencesSet";
-
     final PropertiesComponent properties = PropertiesComponent.getInstance();
-    if (!properties.getBoolean(consolePreferencesSet)) {
-      properties.setValue(consolePreferencesSet, true);
+    if (!properties.getBoolean(consolePreferencesSetKey)) {
+      properties.setValue(consolePreferencesSetKey, true);
 
       // Set our preferred default settings for console text wrapping.
       final EditorSettingsExternalizable editorSettings = EditorSettingsExternalizable.getInstance();


### PR DESCRIPTION
- init default settings for the run console text wrapping

`Flutter.Error` events will render better with text wrapping enabled for the Run and Debug consoles. We turn that setting on for the user (once).
