### PR TITLE
update the flutter error display

### DIFF
--- a/src/io/flutter/logging/FlutterConsoleLogManager.java
+++ b/src/io/flutter/logging/FlutterConsoleLogManager.java
@@ -173,7 +173,7 @@ public class FlutterConsoleLogManager {
       }
     }
 
-    console.print(StringUtil.repeat(errorSeparatorChar, errorSeparatorLength) + "\n\n", TITLE_CONTENT_TYPE);
+    console.print(StringUtil.repeat(errorSeparatorChar, errorSeparatorLength) + "\n", TITLE_CONTENT_TYPE);
   }
 
   private void printTerseNodeProperty(ConsoleView console, String indent, DiagnosticsNode property) {
@@ -256,7 +256,11 @@ public class FlutterConsoleLogManager {
     console.print(description + "\n", contentType);
 
     if (property.hasInlineProperties()) {
-      final String childIndent = getChildIndent(indent, property);
+      String childIndent = getChildIndent(indent, property);
+      if (property.getStyle() == DiagnosticsTreeStyle.shallow && !indent.startsWith("...")) {
+        // Render properties of shallow nodes as collapesed.
+        childIndent = "...  " + indent;
+      }
       for (DiagnosticsNode childProperty : property.getInlineProperties()) {
         printDiagnosticsNodeProperty(console, childIndent, childProperty, contentType, isInChild);
       }


### PR DESCRIPTION
- update the flutter error display wrt the header and footer ansi chars
- fix https://github.com/flutter/flutter-intellij/issues/3680

We output a header and footer string that are >= 100 chars long, with the error message centered 1/3 of the way on the header line.

cc @DanTup for the VS Code work

Here is the current display from the 3 error messages generated by the `flutter_error_studies` app:

<img width="982" alt="Screen Shot 2019-07-18 at 9 55 32 AM" src="https://user-images.githubusercontent.com/1269969/61476849-c3d59180-a942-11e9-9e38-801ea8a23054.png">

<img width="887" alt="Screen Shot 2019-07-18 at 9 55 41 AM" src="https://user-images.githubusercontent.com/1269969/61476858-cd5ef980-a942-11e9-917a-8deb236bdcd6.png">

<img width="944" alt="Screen Shot 2019-07-18 at 9 55 52 AM" src="https://user-images.githubusercontent.com/1269969/61476868-d2bc4400-a942-11e9-97c0-07dcbde9f316.png">

