### PR TITLE
use getThrowableText() from IdeaLoggingEvents

### DIFF
--- a/src/io/flutter/FlutterErrorReportSubmitter.java
+++ b/src/io/flutter/FlutterErrorReportSubmitter.java
@@ -61,7 +61,9 @@ public class FlutterErrorReportSubmitter extends ErrorReportSubmitter {
       return;
     }
 
-    String stackTrace = null, errorMessage = null;
+    String stackTrace = null;
+    String errorMessage = null;
+
     for (IdeaLoggingEvent event : events) {
       String stackTraceText = event.getThrowableText();
       if (stackTraceText.startsWith(COMPLETION_EXCEPTION_PREFIX)) {
@@ -163,8 +165,6 @@ public class FlutterErrorReportSubmitter extends ErrorReportSubmitter {
           builder.append(event.getThrowableText().trim()).append("\n");
           builder.append("```\n");
           builder.append("\n");
-
-          FlutterInitializer.getAnalytics().sendException(event.getThrowable(), false);
         }
       }
     }
@@ -179,12 +179,15 @@ public class FlutterErrorReportSubmitter extends ErrorReportSubmitter {
       builder.append("\n");
     }
 
+    for (IdeaLoggingEvent event : events) {
+      FlutterInitializer.getAnalytics().sendException(event.getThrowableText(), false);
+    }
+
     final String text = builder.toString().trim() + "\n";
 
     // Create scratch file.
     final ScratchRootType scratchRoot = ScratchRootType.getInstance();
-    final VirtualFile file = scratchRoot.createScratchFile(
-      project, "bug-report.md", Language.ANY, text);
+    final VirtualFile file = scratchRoot.createScratchFile(project, "bug-report.md", Language.ANY, text);
 
     if (file == null) {
       fail(consumer);

--- a/src/io/flutter/analytics/Analytics.java
+++ b/src/io/flutter/analytics/Analytics.java
@@ -107,17 +107,17 @@ public class Analytics {
   /**
    * Note: we never send the exception's message here - that can potentially contain PII.
    */
-  @SuppressWarnings("SameParameterValue")
   public void sendException(Throwable throwable, boolean isFatal) {
     final StringWriter stringWriter = new StringWriter();
     final PrintWriter printWriter = new PrintWriter(stringWriter);
 
-    printWriter.println(throwable.getClass().getName() + ":");
-    for (StackTraceElement element : throwable.getStackTrace()) {
-      printWriter.println(element.toString());
-    }
+    throwable.printStackTrace(printWriter);
 
-    String description = stringWriter.toString().trim();
+    sendException(stringWriter.toString().trim(), isFatal);
+  }
+
+  public void sendException(String throwableText, boolean isFatal) {
+    String description = throwableText;
     description = description.replaceAll("com.intellij.openapi.", "c.i.o.");
     description = description.replaceAll("com.intellij.", "c.i.");
     if (description.length() > maxExceptionLength) {

--- a/testSrc/unit/io/flutter/analytics/AnalyticsTest.java
+++ b/testSrc/unit/io/flutter/analytics/AnalyticsTest.java
@@ -28,31 +28,31 @@ public class AnalyticsTest {
   }
 
   @Test
-  public void testSendScreenView() throws Exception {
+  public void testSendScreenView() {
     analytics.sendScreenView("testAnalyticsPage");
     assertEquals(1, transport.sentValues.size());
   }
 
   @Test
-  public void testSendEvent() throws Exception {
+  public void testSendEvent() {
     analytics.sendEvent("flutter", "doctor");
     assertEquals(1, transport.sentValues.size());
   }
 
   @Test
-  public void testSendTiming() throws Exception {
+  public void testSendTiming() {
     analytics.sendTiming("perf", "reloadTime", 100);
     assertEquals(1, transport.sentValues.size());
   }
 
   @Test
-  public void testSendException() throws Exception {
+  public void testSendException() {
     analytics.sendException(new UnsupportedOperationException("test operation"), true);
     assertEquals(1, transport.sentValues.size());
   }
 
   @Test
-  public void testOptOutDoesntSend() throws Exception {
+  public void testOptOutDoesntSend() {
     analytics.setCanSend(false);
     analytics.sendScreenView("testAnalyticsPage");
     assertEquals(0, transport.sentValues.size());


### PR DESCRIPTION
- use getThrowableText() from IdeaLoggingEvents

At some point, the `Throwable` reported from IdeaLoggingEvents became a synthetic throwable: `IdeaReportingEvent$TextBasedThrowable`. In order to get the stack trace, we need to call `getThrowableText()` on it.

We should also plan to move to a more featureful crash reporting mechanism. With the current mechanism, we're not able to log crash exception names or messages, only traces.
