### PR TITLE
Add target platform selector for togglePlatform service extension.

### DIFF
--- a/src/io/flutter/run/daemon/FlutterApp.java
+++ b/src/io/flutter/run/daemon/FlutterApp.java
@@ -428,7 +428,7 @@ public class FlutterApp {
     return future;
   }
 
-  public CompletableFuture<Boolean> togglePlatform() {
+  public CompletableFuture<String> togglePlatform() {
     if (myAppId == null) {
       FlutterUtils.warn(LOG, "cannot invoke togglePlatform on Flutter app because app id is not set");
       return CompletableFuture.completedFuture(null);
@@ -437,22 +437,22 @@ public class FlutterApp {
     final CompletableFuture<JsonObject> result = callServiceExtension(ServiceExtensions.togglePlatformMode.getExtension());
     return result.thenApply(obj -> {
       //noinspection CodeBlock2Expr
-      return obj != null && "android".equals(obj.get("value").getAsString());
+      return obj.get("value").getAsString();
     });
   }
 
-  public CompletableFuture<Boolean> togglePlatform(boolean showAndroid) {
+  public CompletableFuture<String> togglePlatform(String platform) {
     if (myAppId == null) {
       FlutterUtils.warn(LOG, "cannot invoke togglePlatform on Flutter app because app id is not set");
       return CompletableFuture.completedFuture(null);
     }
 
     final Map<String, Object> params = new HashMap<>();
-    params.put("value", showAndroid ? "android" : "iOS");
+    params.put("value", platform);
     return callServiceExtension(ServiceExtensions.togglePlatformMode.getExtension(), params)
       .thenApply(obj -> {
         //noinspection CodeBlock2Expr
-        return obj != null && "android".equals(obj.get("value").getAsString());
+        return obj != null ? obj.get("value").getAsString() : null;
       });
   }
 

--- a/src/io/flutter/view/FlutterPerfView.java
+++ b/src/io/flutter/view/FlutterPerfView.java
@@ -234,12 +234,13 @@ public class FlutterPerfView implements Disposable {
                                            Disposable parentDisposable) {
     final DefaultActionGroup toolbarGroup = new DefaultActionGroup();
     toolbarGroup.add(registerAction(new PerformanceOverlayAction(app)));
-    toolbarGroup.add(registerAction(new TogglePlatformAction(app)));
     toolbarGroup.addSeparator();
     toolbarGroup.add(registerAction(new DebugPaintAction(app)));
     toolbarGroup.add(registerAction(new ShowPaintBaselinesAction(app, true)));
     toolbarGroup.addSeparator();
     toolbarGroup.add(registerAction(new TimeDilationAction(app, true)));
+    toolbarGroup.addSeparator();
+    toolbarGroup.add(new TogglePlatformAction(getOrCreateStateForApp(app), app));
 
     return toolbarGroup;
   }
@@ -360,11 +361,7 @@ public class FlutterPerfView implements Disposable {
     return perAppViewState.computeIfAbsent(app, k -> new PerfViewAppState());
   }
 
-  private static class PerfViewAppState {
-    @Nullable Content content;
+  private static class PerfViewAppState extends AppState {
     @Nullable Disposable disposable;
-    JBRunnerTabs tabs;
-    // TODO(devoncarew): We never query flutterViewActions.
-    ArrayList<FlutterViewAction> flutterViewActions = new ArrayList<>();
   }
 }

--- a/src/io/flutter/view/TogglePlatformAction.java
+++ b/src/io/flutter/view/TogglePlatformAction.java
@@ -5,12 +5,10 @@
  */
 package io.flutter.view;
 
-import com.intellij.execution.ui.ConsoleViewContentType;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.DefaultActionGroup;
 import com.intellij.openapi.actionSystem.Toggleable;
-import io.flutter.FlutterBundle;
 import io.flutter.run.daemon.FlutterApp;
 import io.flutter.utils.StreamSubscription;
 import io.flutter.vmService.ServiceExtensionState;
@@ -19,20 +17,23 @@ import io.flutter.vmService.ServiceExtensionDescription;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
-import java.util.List;
 
 class TogglePlatformAction extends ToolbarComboBoxAction {
   private static final ServiceExtensionDescription extensionDescription = ServiceExtensions.togglePlatformMode;
   private final @NotNull FlutterApp app;
+  private final @NotNull AppState appState;
   private final DefaultActionGroup myActionGroup;
+  private final FlutterViewAction fuchsiaAction;
 
   private PlatformTarget selectedPlatform;
 
   public TogglePlatformAction(@NotNull AppState appState, @NotNull FlutterApp app) {
     super();
     this.app = app;
+    this.appState = appState;
     setSmallVariant(false);
     myActionGroup = createPopupActionGroup(appState, app);
+    fuchsiaAction = new PlatformTargetAction(app, PlatformTarget.fuchsia);
   }
 
   @NotNull
@@ -49,6 +50,10 @@ class TogglePlatformAction extends ToolbarComboBoxAction {
 
     String selectorText = "Platform:";
     if (selectedPlatform != null) {
+      if (selectedPlatform == PlatformTarget.fuchsia && !appState.flutterViewActions.contains(fuchsiaAction)) {
+        myActionGroup.add(appState.registerAction(fuchsiaAction));
+      }
+
       final int platformIndex = extensionDescription.getValues().indexOf(selectedPlatform.name());
       selectorText = (String)extensionDescription.getTooltips().get(platformIndex);
     }
@@ -62,7 +67,6 @@ class TogglePlatformAction extends ToolbarComboBoxAction {
     final DefaultActionGroup group = new DefaultActionGroup();
     group.add(appState.registerAction(new PlatformTargetAction(app, PlatformTarget.android)));
     group.add(appState.registerAction(new PlatformTargetAction(app, PlatformTarget.iOS)));
-    group.add(appState.registerAction(new PlatformTargetAction(app, PlatformTarget.fuchsia)));
     return group;
   }
 }

--- a/src/io/flutter/vmService/ServiceExtensionDescription.java
+++ b/src/io/flutter/vmService/ServiceExtensionDescription.java
@@ -5,16 +5,16 @@
  */
 package io.flutter.vmService;
 
-import java.util.ArrayList;
+import java.util.List;
 
 public class ServiceExtensionDescription<T> {
   private final String extension;
   private final String description;
-  private final ArrayList<T> values;
-  private final ArrayList<String> tooltips;
+  private final List<T> values;
+  private final List<String> tooltips;
 
   public ServiceExtensionDescription(
-    String extension, String description, ArrayList<T> values, ArrayList<String> tooltips) {
+    String extension, String description, List<T> values, List<String> tooltips) {
     this.extension = extension;
     this.description = description;
     this.values = values;
@@ -29,11 +29,15 @@ public class ServiceExtensionDescription<T> {
     return description;
   }
 
-  public ArrayList<T> getValues() {
+  public List<T> getValues() {
     return values;
   }
 
-  public ArrayList<String> getTooltips() {
+  public List<String> getTooltips() {
     return tooltips;
+  }
+
+  public Class getValueClass() {
+    return values.get(0).getClass();
   }
 }

--- a/src/io/flutter/vmService/ServiceExtensionDescription.java
+++ b/src/io/flutter/vmService/ServiceExtensionDescription.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.vmService;
+
+import java.util.ArrayList;
+
+public class ServiceExtensionDescription<T> {
+  private final String extension;
+  private final String description;
+  private final ArrayList<T> values;
+  private final ArrayList<String> tooltips;
+
+  public ServiceExtensionDescription(
+    String extension, String description, ArrayList<T> values, ArrayList<String> tooltips) {
+    this.extension = extension;
+    this.description = description;
+    this.values = values;
+    this.tooltips = tooltips;
+  }
+
+  public String getExtension() {
+    return extension;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public ArrayList<T> getValues() {
+    return values;
+  }
+
+  public ArrayList<String> getTooltips() {
+    return tooltips;
+  }
+}

--- a/src/io/flutter/vmService/ServiceExtensions.java
+++ b/src/io/flutter/vmService/ServiceExtensions.java
@@ -5,6 +5,7 @@
  */
 package io.flutter.vmService;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -15,6 +16,7 @@ public class ServiceExtensions {
   public static final ToggleableServiceExtensionDescription<Boolean> debugAllowBanner =
     new ToggleableServiceExtensionDescription<>(
       "ext.flutter.debugAllowBanner",
+      "Debug Banner",
       true,
       false,
       "Hide Debug Mode Banner",
@@ -23,6 +25,7 @@ public class ServiceExtensions {
   public static final ToggleableServiceExtensionDescription<Boolean> debugPaint =
     new ToggleableServiceExtensionDescription<>(
       "ext.flutter.debugPaint",
+      "Debug Paint",
       true,
       false,
       "Hide Debug Paint",
@@ -31,6 +34,7 @@ public class ServiceExtensions {
   public static final ToggleableServiceExtensionDescription<Boolean> debugPaintBaselines =
     new ToggleableServiceExtensionDescription<>(
       "ext.flutter.debugPaintBaselinesEnabled",
+      "Paint Baselines",
       true,
       false,
       "Hide Paint Baselines",
@@ -39,6 +43,7 @@ public class ServiceExtensions {
   public static final ToggleableServiceExtensionDescription<Boolean> performanceOverlay =
     new ToggleableServiceExtensionDescription<>(
       "ext.flutter.showPerformanceOverlay",
+      "Performance Overlay",
       true,
       false,
       "Hide Performance Overlay",
@@ -47,6 +52,7 @@ public class ServiceExtensions {
   public static final ToggleableServiceExtensionDescription<Boolean> repaintRainbow =
     new ToggleableServiceExtensionDescription<>(
       "ext.flutter.repaintRainbow",
+      "Repaint Rainbow",
       true,
       false,
       "Hide Repaint Rainbow",
@@ -55,22 +61,23 @@ public class ServiceExtensions {
   public static final ToggleableServiceExtensionDescription<Double> slowAnimations =
     new ToggleableServiceExtensionDescription<>(
       "ext.flutter.timeDilation",
+      "Slow Animations",
       5.0,
       1.0,
       "Disable Slow Animations",
       "Enable Slow Animations");
 
-  public static final ToggleableServiceExtensionDescription<String> togglePlatformMode =
-    new ToggleableServiceExtensionDescription<>(
+  public static final ServiceExtensionDescription<String> togglePlatformMode =
+    new ServiceExtensionDescription<>(
       "ext.flutter.platformOverride",
-      "iOS",
-      "android",
-      "Toggle Platform",
-      "Toggle Platform");
+      "Override Target Platform",
+      new ArrayList<>(Arrays.asList("iOS", "android", "fuchsia")),
+      new ArrayList<>(Arrays.asList("Platform: iOS", "Platform: Android", "Platform: Fuchsia")));
 
   public static final ToggleableServiceExtensionDescription<Boolean> toggleSelectWidgetMode =
     new ToggleableServiceExtensionDescription<>(
       "ext.flutter.inspector.show",
+      "Select Widget Mode",
       true,
       false,
       "Disable Select Widget Mode",
@@ -79,6 +86,7 @@ public class ServiceExtensions {
   public static final ToggleableServiceExtensionDescription<Boolean> toggleShowStructuredErrors =
     new ToggleableServiceExtensionDescription<>(
       "ext.flutter.inspector.structuredErrors",
+      "Structured Errors",
       true,
       false,
       "Disable Showing Structured Errors",
@@ -87,6 +95,7 @@ public class ServiceExtensions {
   public static final ToggleableServiceExtensionDescription<Boolean> trackRebuildWidgets =
     new ToggleableServiceExtensionDescription<>(
       "ext.flutter.inspector.trackRebuildDirtyWidgets",
+      "Track Widget Rebuilds",
       true,
       false,
       "Do Not Track Widget Rebuilds",
@@ -95,6 +104,7 @@ public class ServiceExtensions {
   public static final ToggleableServiceExtensionDescription<Boolean> trackRepaintWidgets =
     new ToggleableServiceExtensionDescription<>(
       "ext.flutter.inspector.trackRepaintWidgets",
+      "Track Widget Repaints",
       true,
       false,
       "Do Not Track Widget Repaints",
@@ -112,7 +122,7 @@ public class ServiceExtensions {
   public static final String loggingChannels = "ext.flutter.logs.loggingChannels";
   public static final String designerRender = "ext.flutter.designer.render";
 
-  static final List<ToggleableServiceExtensionDescription> toggleableExtensionDescriptions = Arrays.asList(
+  static final List<ServiceExtensionDescription> toggleableExtensionDescriptions = Arrays.asList(
     debugAllowBanner,
     debugPaint,
     debugPaintBaselines,
@@ -125,9 +135,9 @@ public class ServiceExtensions {
     trackRebuildWidgets,
     trackRepaintWidgets);
 
-  public static final Map<String, ToggleableServiceExtensionDescription> toggleableExtensionsWhitelist =
+  public static final Map<String, ServiceExtensionDescription> toggleableExtensionsWhitelist =
     toggleableExtensionDescriptions.stream().collect(
       Collectors.toMap(
-        ToggleableServiceExtensionDescription::getExtension,
+        ServiceExtensionDescription::getExtension,
         extensionDescription -> extensionDescription));
 }

--- a/src/io/flutter/vmService/ServiceExtensions.java
+++ b/src/io/flutter/vmService/ServiceExtensions.java
@@ -5,7 +5,6 @@
  */
 package io.flutter.vmService;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -71,8 +70,8 @@ public class ServiceExtensions {
     new ServiceExtensionDescription<>(
       "ext.flutter.platformOverride",
       "Override Target Platform",
-      new ArrayList<>(Arrays.asList("iOS", "android", "fuchsia")),
-      new ArrayList<>(Arrays.asList("Platform: iOS", "Platform: Android", "Platform: Fuchsia")));
+      Arrays.asList("iOS", "android", "fuchsia"),
+      Arrays.asList("Platform: iOS", "Platform: Android", "Platform: Fuchsia"));
 
   public static final ToggleableServiceExtensionDescription<Boolean> toggleSelectWidgetMode =
     new ToggleableServiceExtensionDescription<>(

--- a/src/io/flutter/vmService/ToggleableServiceExtensionDescription.java
+++ b/src/io/flutter/vmService/ToggleableServiceExtensionDescription.java
@@ -5,39 +5,44 @@
  */
 package io.flutter.vmService;
 
-public class ToggleableServiceExtensionDescription<T> {
-  private final String extension;
-  private final T enabledValue;
-  private final T disabledValue;
-  private final String enabledText;
-  private final String disabledText;
+import java.util.ArrayList;
+import java.util.Arrays;
 
+public class ToggleableServiceExtensionDescription<T> extends ServiceExtensionDescription {
   public ToggleableServiceExtensionDescription(
-    String extension, T enabledValue, T disabledValue, String enabledText, String disabledText) {
-    this.extension = extension;
-    this.enabledValue = enabledValue;
-    this.disabledValue = disabledValue;
-    this.enabledText = enabledText;
-    this.disabledText = disabledText;
+    String extension,
+    String description,
+    T enabledValue,
+    T disabledValue,
+    String enabledText,
+    String disabledText
+  ) {
+    super(extension,
+          description,
+          new ArrayList<>(Arrays.asList(enabledValue, disabledValue)),
+          new ArrayList<>(Arrays.asList(enabledText, disabledText)));
   }
 
-  public String getExtension() {
-    return extension;
-  }
+  static int enabledIndex = 0;
+  static int disabledIndex = 1;
 
   public T getEnabledValue() {
-    return enabledValue;
+    @SuppressWarnings("unchecked") final ArrayList<T> values = (ArrayList<T>)super.getValues();
+    return values.get(enabledIndex);
   }
 
   public T getDisabledValue() {
-    return disabledValue;
+    @SuppressWarnings("unchecked") final ArrayList<T> values = (ArrayList<T>)super.getValues();
+    return values.get(disabledIndex);
   }
 
   public String getEnabledText() {
-    return enabledText;
+    @SuppressWarnings("unchecked") final ArrayList<String> tooltips = (ArrayList<String>)super.getTooltips();
+    return tooltips.get(enabledIndex);
   }
 
   public String getDisabledText() {
-    return disabledText;
+    @SuppressWarnings("unchecked") final ArrayList<String> values = (ArrayList<String>)super.getTooltips();
+    return values.get(disabledIndex);
   }
 }

--- a/src/io/flutter/vmService/ToggleableServiceExtensionDescription.java
+++ b/src/io/flutter/vmService/ToggleableServiceExtensionDescription.java
@@ -5,8 +5,8 @@
  */
 package io.flutter.vmService;
 
-import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 public class ToggleableServiceExtensionDescription<T> extends ServiceExtensionDescription {
   public ToggleableServiceExtensionDescription(
@@ -19,30 +19,30 @@ public class ToggleableServiceExtensionDescription<T> extends ServiceExtensionDe
   ) {
     super(extension,
           description,
-          new ArrayList<>(Arrays.asList(enabledValue, disabledValue)),
-          new ArrayList<>(Arrays.asList(enabledText, disabledText)));
+          Arrays.asList(enabledValue, disabledValue),
+          Arrays.asList(enabledText, disabledText));
   }
 
   static int enabledIndex = 0;
   static int disabledIndex = 1;
 
   public T getEnabledValue() {
-    @SuppressWarnings("unchecked") final ArrayList<T> values = (ArrayList<T>)super.getValues();
+    @SuppressWarnings("unchecked") final List<T> values = super.getValues();
     return values.get(enabledIndex);
   }
 
   public T getDisabledValue() {
-    @SuppressWarnings("unchecked") final ArrayList<T> values = (ArrayList<T>)super.getValues();
+    @SuppressWarnings("unchecked") final List<T> values = super.getValues();
     return values.get(disabledIndex);
   }
 
   public String getEnabledText() {
-    @SuppressWarnings("unchecked") final ArrayList<String> tooltips = (ArrayList<String>)super.getTooltips();
+    @SuppressWarnings("unchecked") final List<String> tooltips = super.getTooltips();
     return tooltips.get(enabledIndex);
   }
 
   public String getDisabledText() {
-    @SuppressWarnings("unchecked") final ArrayList<String> values = (ArrayList<String>)super.getTooltips();
-    return values.get(disabledIndex);
+    @SuppressWarnings("unchecked") final List<String> tooltips = super.getTooltips();
+    return tooltips.get(disabledIndex);
   }
 }

--- a/src/io/flutter/vmService/VMServiceManager.java
+++ b/src/io/flutter/vmService/VMServiceManager.java
@@ -308,13 +308,13 @@ public class VMServiceManager implements FlutterApp.FlutterAppListener {
   }
 
   private Object getExtensionValueFromEventJson(String name, String valueFromJson) {
-    final Object sampleValue =
-      ServiceExtensions.toggleableExtensionsWhitelist.get(name).getValues().get(0);
+    final Class valueClass =
+      ServiceExtensions.toggleableExtensionsWhitelist.get(name).getValueClass();
 
-    if (sampleValue instanceof Boolean) {
+    if (valueClass == Boolean.class) {
       return valueFromJson.equals("true");
     }
-    else if (sampleValue instanceof Double) {
+    else if (valueClass == Double.class) {
       return Double.valueOf(valueFromJson);
     }
     else {
@@ -375,22 +375,22 @@ public class VMServiceManager implements FlutterApp.FlutterAppListener {
     if (!ServiceExtensions.toggleableExtensionsWhitelist.containsKey(name)) {
       return;
     }
-    final Object sampleValue =
-      ServiceExtensions.toggleableExtensionsWhitelist.get(name).getValues().get(0);
+    final Class valueClass =
+      ServiceExtensions.toggleableExtensionsWhitelist.get(name).getValueClass();
 
     final CompletableFuture<JsonObject> response = app.callServiceExtension(name);
     response.thenApply(obj -> {
       Object value = null;
       if (obj != null) {
-        if (sampleValue instanceof Boolean) {
+        if (valueClass == Boolean.class) {
           value = obj.get("enabled").getAsString().equals("true");
           maybeRestoreExtension(name, value);
         }
-        else if (sampleValue instanceof String) {
+        else if (valueClass == String.class) {
           value = obj.get("value").getAsString();
           maybeRestoreExtension(name, value);
         }
-        else if (sampleValue instanceof Double) {
+        else if (valueClass == Double.class) {
           value = Double.parseDouble(obj.get("value").getAsString());
           maybeRestoreExtension(name, value);
         }

--- a/src/io/flutter/vmService/VMServiceManager.java
+++ b/src/io/flutter/vmService/VMServiceManager.java
@@ -258,11 +258,16 @@ public class VMServiceManager implements FlutterApp.FlutterAppListener {
           final String name = extensionData.get("extension").getAsString();
           final String valueFromJson = extensionData.get("value").getAsString();
 
-          final ToggleableServiceExtensionDescription extension = ServiceExtensions.toggleableExtensionsWhitelist.get(name);
+          final ServiceExtensionDescription extension = ServiceExtensions.toggleableExtensionsWhitelist.get(name);
           if (extension != null) {
             final Object value = getExtensionValueFromEventJson(name, valueFromJson);
-            final boolean enabled = value.equals(extension.getEnabledValue());
-            setServiceExtensionState(name, enabled, value);
+            if (extension instanceof ToggleableServiceExtensionDescription) {
+              final ToggleableServiceExtensionDescription toggleableExtension = (ToggleableServiceExtensionDescription)extension;
+              setServiceExtensionState(name, value.equals(toggleableExtension.getEnabledValue()), value);
+            }
+            else {
+              setServiceExtensionState(name, true, value);
+            }
           }
           break;
         case "Flutter.Error":
@@ -303,13 +308,13 @@ public class VMServiceManager implements FlutterApp.FlutterAppListener {
   }
 
   private Object getExtensionValueFromEventJson(String name, String valueFromJson) {
-    final Object enabledValue =
-      ServiceExtensions.toggleableExtensionsWhitelist.get(name).getEnabledValue();
+    final Object sampleValue =
+      ServiceExtensions.toggleableExtensionsWhitelist.get(name).getValues().get(0);
 
-    if (enabledValue instanceof Boolean) {
+    if (sampleValue instanceof Boolean) {
       return valueFromJson.equals("true");
     }
-    else if (enabledValue instanceof Double) {
+    else if (sampleValue instanceof Double) {
       return Double.valueOf(valueFromJson);
     }
     else {
@@ -370,22 +375,22 @@ public class VMServiceManager implements FlutterApp.FlutterAppListener {
     if (!ServiceExtensions.toggleableExtensionsWhitelist.containsKey(name)) {
       return;
     }
-    final Object enabledValue =
-      ServiceExtensions.toggleableExtensionsWhitelist.get(name).getEnabledValue();
+    final Object sampleValue =
+      ServiceExtensions.toggleableExtensionsWhitelist.get(name).getValues().get(0);
 
     final CompletableFuture<JsonObject> response = app.callServiceExtension(name);
     response.thenApply(obj -> {
       Object value = null;
       if (obj != null) {
-        if (enabledValue instanceof Boolean) {
+        if (sampleValue instanceof Boolean) {
           value = obj.get("enabled").getAsString().equals("true");
           maybeRestoreExtension(name, value);
         }
-        else if (enabledValue instanceof String) {
+        else if (sampleValue instanceof String) {
           value = obj.get("value").getAsString();
           maybeRestoreExtension(name, value);
         }
-        else if (enabledValue instanceof Double) {
+        else if (sampleValue instanceof Double) {
           value = Double.parseDouble(obj.get("value").getAsString());
           maybeRestoreExtension(name, value);
         }
@@ -395,7 +400,14 @@ public class VMServiceManager implements FlutterApp.FlutterAppListener {
   }
 
   private void maybeRestoreExtension(String name, Object value) {
-    if (value.equals(ServiceExtensions.toggleableExtensionsWhitelist.get(name).getEnabledValue())) {
+    if (ServiceExtensions.toggleableExtensionsWhitelist.get(name) instanceof ToggleableServiceExtensionDescription) {
+      final ToggleableServiceExtensionDescription extensionDescription =
+        (ToggleableServiceExtensionDescription)ServiceExtensions.toggleableExtensionsWhitelist.get(name);
+      if (value.equals(extensionDescription.getEnabledValue())) {
+        setServiceExtensionState(name, true, value);
+      }
+    }
+    else {
       setServiceExtensionState(name, true, value);
     }
   }


### PR DESCRIPTION
Removes the toggle platform button from the service extension button bars (Inspector View and Performance View), and replaces it with a dropdown selector. We now include Fuchsia as an option and can add additional platforms in the future.

![Screen Shot 2019-07-23 at 8 42 36 AM](https://user-images.githubusercontent.com/43759233/61726092-e3473280-ad25-11e9-94a2-732044e7f885.png)
![Screen Shot 2019-07-23 at 8 42 49 AM](https://user-images.githubusercontent.com/43759233/61726099-e6422300-ad25-11e9-8568-15f5dd823124.png)

Confirmed that states stay synchronized between IntelliJ and DevTools.
Matching CL from DevTools is here: https://github.com/flutter/devtools/pull/783.

cc: @sfshaza2 in case this changes any docs or screenshots.