### PR TITLE
remove the web/desktop user preference

### DIFF
--- a/src/io/flutter/run/daemon/DeviceDaemon.java
+++ b/src/io/flutter/run/daemon/DeviceDaemon.java
@@ -23,7 +23,6 @@ import io.flutter.bazel.WorkspaceCache;
 import io.flutter.run.FlutterDevice;
 import io.flutter.sdk.FlutterSdk;
 import io.flutter.sdk.FlutterSdkUtil;
-import io.flutter.settings.FlutterSettings;
 import io.flutter.utils.FlutterModuleUtils;
 import io.flutter.utils.MostlySilentOsProcessHandler;
 import org.jetbrains.annotations.NotNull;
@@ -294,10 +293,6 @@ class DeviceDaemon {
       result.setCharset(CharsetToolkit.UTF8_CHARSET);
       result.setExePath(FileUtil.toSystemDependentName(command));
       result.withEnvironment(FlutterSdkUtil.FLUTTER_HOST_ENV, FlutterSdkUtil.getFlutterHostEnvValue());
-      if (FlutterSettings.getInstance().isShowWebDesktopDevices()) {
-        result.withEnvironment("ENABLE_FLUTTER_DESKTOP", "true");
-        result.withEnvironment("FLUTTER_WEB", "true");
-      }
       if (androidHome != null) {
         result.withEnvironment("ANDROID_HOME", androidHome);
       }

--- a/src/io/flutter/sdk/FlutterCommand.java
+++ b/src/io/flutter/sdk/FlutterCommand.java
@@ -21,7 +21,6 @@ import io.flutter.FlutterMessages;
 import io.flutter.android.IntelliJAndroidSdk;
 import io.flutter.console.FlutterConsoles;
 import io.flutter.dart.DartPlugin;
-import io.flutter.settings.FlutterSettings;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -247,10 +246,6 @@ public class FlutterCommand {
     final GeneralCommandLine line = new GeneralCommandLine();
     line.setCharset(CharsetToolkit.UTF8_CHARSET);
     line.withEnvironment(FlutterSdkUtil.FLUTTER_HOST_ENV, FlutterSdkUtil.getFlutterHostEnvValue());
-    if (FlutterSettings.getInstance().isShowWebDesktopDevices()) {
-      line.withEnvironment("ENABLE_FLUTTER_DESKTOP", "true");
-      line.withEnvironment("FLUTTER_WEB", "true");
-    }
     final String androidHome = IntelliJAndroidSdk.chooseAndroidHome(project, false);
     if (androidHome != null) {
       line.withEnvironment("ANDROID_HOME", androidHome);

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.form
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.form
@@ -234,7 +234,7 @@
           </component>
         </children>
       </grid>
-      <grid id="23e52" layout-manager="GridLayoutManager" row-count="5" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="23e52" layout-manager="GridLayoutManager" row-count="4" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -252,7 +252,7 @@
           </component>
           <component id="1f6f8" class="javax.swing.JCheckBox" binding="myUseLogViewCheckBox">
             <constraints>
-              <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text resource-bundle="io/flutter/FlutterBundle" key="settings.experimental.flutter.logging.view"/>
@@ -260,24 +260,16 @@
           </component>
           <component id="33088" class="javax.swing.JCheckBox" binding="mySyncAndroidLibrariesCheckBox">
             <constraints>
-              <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text resource-bundle="io/flutter/FlutterBundle" key="settings.enable.android.gradle.sync"/>
               <toolTipText value="Provides advanced editing capabilities for Java and Kotlin code. Uses Gradle to find Android libraries then links them into the Flutter project."/>
             </properties>
           </component>
-          <component id="67d4f" class="javax.swing.JCheckBox" binding="myShowWebDevicesCheckBox">
-            <constraints>
-              <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <text value="Show web and desktop devices in the device selector (available on Flutter's master channel)"/>
-            </properties>
-          </component>
           <component id="b1533" class="javax.swing.JCheckBox" binding="myShowStructuredErrors">
             <constraints>
-              <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text value="Show structured errors for Flutter framework issues"/>

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.java
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.java
@@ -63,7 +63,6 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
   private JCheckBox myFormatCodeOnSaveCheckBox;
   private JCheckBox myOrganizeImportsOnSaveCheckBox;
   private JCheckBox myDisableTrackWidgetCreationCheckBox;
-  private JCheckBox myShowWebDevicesCheckBox;
   private JCheckBox myShowStructuredErrors;
   private JCheckBox myUseLogViewCheckBox;
   private JCheckBox mySyncAndroidLibrariesCheckBox;
@@ -213,9 +212,6 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
       return true;
     }
 
-    if (settings.isShowWebDesktopDevices() != myShowWebDevicesCheckBox.isSelected()) {
-      return true;
-    }
     if (settings.isShowStructuredErrors() != myShowStructuredErrors.isSelected()) {
       return true;
     }
@@ -278,7 +274,6 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     settings.setShowMultipleChildrenGuides(myShowMultipleChildrenGuides.isSelected());
     settings.setShowBuildMethodsOnScrollbar(myShowBuildMethodsOnScrollbar.isSelected());
     settings.setShowClosingLabels(myShowClosingLabels.isSelected());
-    settings.setShowWebDesktopDevices(myShowWebDevicesCheckBox.isSelected());
     settings.setUseFlutterLogView(myUseLogViewCheckBox.isSelected());
     settings.setShowStructuredErrors(myShowStructuredErrors.isSelected());
     settings.setOpenInspectorOnAppLaunch(myOpenInspectorOnAppLaunchCheckBox.isSelected());
@@ -323,7 +318,6 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
 
     myShowClosingLabels.setSelected(settings.isShowClosingLabels());
 
-    myShowWebDevicesCheckBox.setSelected(settings.isShowWebDesktopDevices());
     myUseLogViewCheckBox.setSelected(settings.useFlutterLogView());
     myShowStructuredErrors.setSelected(settings.isShowStructuredErrors());
     myOpenInspectorOnAppLaunchCheckBox.setSelected(settings.isOpenInspectorOnAppLaunch());

--- a/src/io/flutter/settings/FlutterSettings.java
+++ b/src/io/flutter/settings/FlutterSettings.java
@@ -27,7 +27,6 @@ public class FlutterSettings {
   private static final String syncAndroidLibrariesKey = "io.flutter.syncAndroidLibraries";
   private static final String disableTrackWidgetCreationKey = "io.flutter.disableTrackWidgetCreation";
   private static final String useFlutterLogView = "io.flutter.useLogView";
-  private static final String showWebDesktopDevices = "io.flutter.showWebDesktopDevices";
   private static final String showStructuredErrors = "io.flutter.showStructuredErrors";
 
   /**
@@ -111,9 +110,6 @@ public class FlutterSettings {
       analytics.sendEvent("settings", afterLastPeriod(showBuildMethodsOnScrollbarKey));
     }
 
-    if (isShowWebDesktopDevices()) {
-      analytics.sendEvent("settings", afterLastPeriod(showWebDesktopDevices));
-    }
     if (isShowStructuredErrors()) {
       analytics.sendEvent("settings", afterLastPeriod(showStructuredErrors));
     }
@@ -209,16 +205,6 @@ public class FlutterSettings {
 
   public void setSyncingAndroidLibraries(boolean value) {
     getPropertiesComponent().setValue(syncAndroidLibrariesKey, value, false);
-
-    fireEvent();
-  }
-
-  public boolean isShowWebDesktopDevices() {
-    return getPropertiesComponent().getBoolean(showWebDesktopDevices, false);
-  }
-
-  public void setShowWebDesktopDevices(boolean value) {
-    getPropertiesComponent().setValue(showWebDesktopDevices, value, false);
 
     fireEvent();
   }


### PR DESCRIPTION
- remove the web/desktop user preference

This had been enabled via passing in an environment variable. Now, the way to enable this is via the flutter command line tool. Specifically, for web:

```
flutter config --enable-web
```

That setting will take effect on the master and dev channels currently; the user will need to restart IntelliJ for the setting to take effect. We may want to mention the change in our release notes.

cc @jonahwilliams 
