### PR TITLE
address some issues with blocking the EDT thread in 2019.2

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -915,6 +915,7 @@
     <directoryProjectGenerator implementation="io.flutter.module.FlutterSmallIDEProjectGenerator"/>
 
     <projectService serviceImplementation="io.flutter.sdk.FlutterSdkManager"/>
+    <projectService serviceImplementation="io.flutter.sdk.AndroidEmulatorManager"/>
 
     <applicationService serviceInterface="io.flutter.settings.FlutterSettings"
                         serviceImplementation="io.flutter.settings.FlutterSettings"

--- a/resources/META-INF/plugin_template.xml
+++ b/resources/META-INF/plugin_template.xml
@@ -234,6 +234,7 @@
     <directoryProjectGenerator implementation="io.flutter.module.FlutterSmallIDEProjectGenerator"/>
 
     <projectService serviceImplementation="io.flutter.sdk.FlutterSdkManager"/>
+    <projectService serviceImplementation="io.flutter.sdk.AndroidEmulatorManager"/>
 
     <applicationService serviceInterface="io.flutter.settings.FlutterSettings"
                         serviceImplementation="io.flutter.settings.FlutterSettings"

--- a/src/io/flutter/actions/DeviceSelectorAction.java
+++ b/src/io/flutter/actions/DeviceSelectorAction.java
@@ -17,6 +17,7 @@ import io.flutter.FlutterBundle;
 import io.flutter.FlutterUtils;
 import io.flutter.run.FlutterDevice;
 import io.flutter.run.daemon.DeviceService;
+import io.flutter.sdk.AndroidEmulatorManager;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -65,6 +66,10 @@ public class DeviceSelectorAction extends ComboBoxAction implements DumbAware {
       Disposer.register(project, () -> knownProjects.remove(project));
 
       DeviceService.getInstance(project).addListener(() -> update(project, e.getPresentation()));
+
+      // Listen for android device changes, and rebuild the menu if necessary.
+      AndroidEmulatorManager.getInstance(project).addListener(() -> update(project, e.getPresentation()));
+
       update(project, e.getPresentation());
     }
   }
@@ -97,10 +102,10 @@ public class DeviceSelectorAction extends ComboBoxAction implements DumbAware {
   private void updateActions(@NotNull Project project, Presentation presentation) {
     actions.clear();
 
-    final DeviceService service = DeviceService.getInstance(project);
+    final DeviceService deviceService = DeviceService.getInstance(project);
 
-    final FlutterDevice selectedDevice = service.getSelectedDevice();
-    final Collection<FlutterDevice> devices = service.getConnectedDevices();
+    final FlutterDevice selectedDevice = deviceService.getSelectedDevice();
+    final Collection<FlutterDevice> devices = deviceService.getConnectedDevices();
 
     selectedDeviceAction = null;
 
@@ -143,15 +148,17 @@ public class DeviceSelectorAction extends ComboBoxAction implements DumbAware {
     }
 
     if (devices.isEmpty()) {
-      final boolean isLoading = service.getStatus() == DeviceService.State.LOADING;
+      final boolean isLoading = deviceService.getStatus() == DeviceService.State.LOADING;
       if (isLoading) {
         presentation.setText(FlutterBundle.message("devicelist.loading"));
       }
       else {
+        //noinspection DialogTitleCapitalization
         presentation.setText("<no devices>");
       }
     }
     else if (selectedDevice == null) {
+      //noinspection DialogTitleCapitalization
       presentation.setText("<no device selected>");
     }
   }

--- a/src/io/flutter/actions/OpenEmulatorAction.java
+++ b/src/io/flutter/actions/OpenEmulatorAction.java
@@ -9,23 +9,25 @@ import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.project.Project;
 import io.flutter.android.AndroidEmulator;
-import io.flutter.android.AndroidSdk;
+import io.flutter.sdk.AndroidEmulatorManager;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Collections;
 import java.util.List;
 
 import static java.util.stream.Collectors.toList;
 
 public class OpenEmulatorAction extends AnAction {
+  /**
+   * Retrieve a list of {@link OpenEmulatorAction}s.
+   *
+   * This list of based of of cached information from the {@link AndroidEmulatorManager}. Callers who
+   * wanted notifications for updates should listen the {@link AndroidEmulatorManager}for changes
+   * to the list of emulators.
+   */
   public static List<OpenEmulatorAction> getEmulatorActions(Project project) {
-    final AndroidSdk sdk = AndroidSdk.createFromProject(project);
-    if (sdk == null) {
-      return Collections.emptyList();
-    }
+    final AndroidEmulatorManager emulatorManager = AndroidEmulatorManager.getInstance(project);
 
-    final List<AndroidEmulator> emulators = sdk.getEmulators();
-    emulators.sort((emulator1, emulator2) -> emulator1.getName().compareToIgnoreCase(emulator2.getName()));
+    final List<AndroidEmulator> emulators = emulatorManager.getCachedEmulators();
     return emulators.stream().map(OpenEmulatorAction::new).collect(toList());
   }
 

--- a/src/io/flutter/actions/OpenEmulatorAction.java
+++ b/src/io/flutter/actions/OpenEmulatorAction.java
@@ -19,9 +19,9 @@ import static java.util.stream.Collectors.toList;
 public class OpenEmulatorAction extends AnAction {
   /**
    * Retrieve a list of {@link OpenEmulatorAction}s.
-   *
-   * This list of based of of cached information from the {@link AndroidEmulatorManager}. Callers who
-   * wanted notifications for updates should listen the {@link AndroidEmulatorManager}for changes
+   * <p>
+   * This list is based off of cached information from the {@link AndroidEmulatorManager} class. Callers
+   * who wanted notifications for updates should listen the {@link AndroidEmulatorManager} for changes
    * to the list of emulators.
    */
   public static List<OpenEmulatorAction> getEmulatorActions(Project project) {

--- a/src/io/flutter/actions/OpenSimulatorAction.java
+++ b/src/io/flutter/actions/OpenSimulatorAction.java
@@ -14,6 +14,7 @@ public class OpenSimulatorAction extends AnAction {
   final boolean enabled;
 
   public OpenSimulatorAction(boolean enabled) {
+    //noinspection DialogTitleCapitalization
     super("Open iOS Simulator");
 
     this.enabled = enabled;
@@ -26,15 +27,15 @@ public class OpenSimulatorAction extends AnAction {
 
   @Override
   public void actionPerformed(@NotNull AnActionEvent event) {
-    // Check to see if the simulator is already running.
-    // If it is, and we're here, that means there are no running devices and we want
-    // to issue an extra call to start (w/ `-n`) to load a new simulator.
-    if (XcodeUtils.isSimulatorRunning()) {
-      if (XcodeUtils.openSimulator("-n") != 0) {
-        // No point in trying if we errored.
-        return;
-      }
-    }
+    // Check to see if the simulator is already running. If it is, and we're here, that means there are
+    // no running devices and we want to issue an extra call to start (w/ `-n`) to load a new simulator.
+    // TODO(devoncarew): Determine if we need to support this code path.
+    //if (XcodeUtils.isSimulatorRunning()) {
+    //  if (XcodeUtils.openSimulator("-n") != 0) {
+    //    // No point in trying if we errored.
+    //    return;
+    //  }
+    //}
 
     XcodeUtils.openSimulator();
   }

--- a/src/io/flutter/android/AndroidEmulator.java
+++ b/src/io/flutter/android/AndroidEmulator.java
@@ -79,12 +79,7 @@ public class AndroidEmulator {
 
   @Override
   public boolean equals(Object obj) {
-    if (!(obj instanceof AndroidEmulator)) {
-      return false;
-    }
-
-    final AndroidEmulator other = (AndroidEmulator)obj;
-    return other.id.equals(id);
+    return obj instanceof AndroidEmulator && ((AndroidEmulator)obj).id.equals(id);
   }
 
   @Override

--- a/src/io/flutter/android/AndroidEmulator.java
+++ b/src/io/flutter/android/AndroidEmulator.java
@@ -76,4 +76,19 @@ public class AndroidEmulator {
       FlutterMessages.showError("Error Opening Emulator", e.toString());
     }
   }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof AndroidEmulator)) {
+      return false;
+    }
+
+    final AndroidEmulator other = (AndroidEmulator)obj;
+    return other.id.equals(id);
+  }
+
+  @Override
+  public int hashCode() {
+    return id.hashCode();
+  }
 }

--- a/src/io/flutter/android/AndroidSdk.java
+++ b/src/io/flutter/android/AndroidSdk.java
@@ -101,8 +101,8 @@ public class AndroidSdk {
       });
       process.startNotify();
 
-      // We wait a maximum of 2000ms.
-      if (!process.waitFor(2000)) {
+      // We wait a maximum of 10s.
+      if (!process.waitFor(10000)) {
         return Collections.emptyList();
       }
 

--- a/src/io/flutter/run/daemon/DeviceService.java
+++ b/src/io/flutter/run/daemon/DeviceService.java
@@ -19,6 +19,7 @@ import io.flutter.FlutterMessages;
 import io.flutter.FlutterUtils;
 import io.flutter.bazel.WorkspaceCache;
 import io.flutter.run.FlutterDevice;
+import io.flutter.sdk.AndroidEmulatorManager;
 import io.flutter.sdk.FlutterSdkManager;
 import io.flutter.utils.Refreshable;
 import org.jetbrains.annotations.NotNull;
@@ -220,6 +221,10 @@ public class DeviceService {
     if (request.isCancelled()) {
       return previous;
     }
+
+    // When starting the device daemon, also refresh the list of AndroidEmulators.
+    final AndroidEmulatorManager emulatorManager = AndroidEmulatorManager.getInstance(project);
+    emulatorManager.refresh();
 
     try {
       return nextCommand.start(request::isCancelled, this::refreshDeviceSelection, this::daemonStopped);

--- a/src/io/flutter/sdk/AndroidEmulatorManager.java
+++ b/src/io/flutter/sdk/AndroidEmulatorManager.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2019 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.sdk;
+
+import com.google.common.collect.ImmutableSet;
+import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.project.Project;
+import com.intellij.util.concurrency.AppExecutorUtil;
+import io.flutter.FlutterUtils;
+import io.flutter.android.AndroidEmulator;
+import io.flutter.android.AndroidSdk;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * This class manages the list of known Android eumlators, and handles refreshing the list as well
+ * as notifying interested parties when the list changes.
+ */
+public class AndroidEmulatorManager {
+  private static final Logger LOG = Logger.getInstance(AndroidEmulatorManager.class);
+
+  @NotNull
+  public static AndroidEmulatorManager getInstance(@NotNull Project project) {
+    return ServiceManager.getService(project, AndroidEmulatorManager.class);
+  }
+
+  private final @NotNull Project project;
+  private final AtomicReference<ImmutableSet<Runnable>> listeners = new AtomicReference<>(ImmutableSet.of());
+
+  private List<AndroidEmulator> cachedEmulators = new ArrayList<>();
+
+  private AndroidEmulatorManager(@NotNull Project project) {
+    this.project = project;
+  }
+
+  public void addListener(@NotNull Runnable callback) {
+    listeners.updateAndGet((old) -> {
+      final List<Runnable> changed = new ArrayList<>(old);
+      changed.add(callback);
+      return ImmutableSet.copyOf(changed);
+    });
+  }
+
+  private CompletableFuture<List<AndroidEmulator>> inProgressRefresh;
+
+  public CompletableFuture<List<AndroidEmulator>> refresh() {
+    // We don't need to refresh if one is in progress.
+    synchronized (this) {
+      if (inProgressRefresh != null) {
+        return inProgressRefresh;
+      }
+    }
+
+    final CompletableFuture<List<AndroidEmulator>> future = new CompletableFuture<>();
+
+    synchronized (this) {
+      inProgressRefresh = future;
+    }
+
+    AppExecutorUtil.getAppExecutorService().submit(() -> {
+      final AndroidSdk sdk = AndroidSdk.createFromProject(project);
+      if (sdk == null) {
+        future.complete(Collections.emptyList());
+      }
+      else {
+        final List<AndroidEmulator> emulators = sdk.getEmulators();
+        emulators.sort((emulator1, emulator2) -> emulator1.getName().compareToIgnoreCase(emulator2.getName()));
+        future.complete(emulators);
+      }
+    });
+
+    future.thenAccept(emulators -> {
+      fireChangeEvent(emulators, cachedEmulators);
+
+      synchronized (this) {
+        inProgressRefresh = null;
+      }
+    });
+
+    return future;
+  }
+
+  public List<AndroidEmulator> getCachedEmulators() {
+    return cachedEmulators;
+  }
+
+  private void fireChangeEvent(final List<AndroidEmulator> newEmulators, final List<AndroidEmulator> oldEmulators) {
+    if (project.isDisposed()) return;
+
+    // Don't fire if the list of devices is unchanged.
+    if (cachedEmulators.equals(newEmulators)) {
+      return;
+    }
+
+    cachedEmulators = newEmulators;
+
+    for (Runnable listener : listeners.get()) {
+      try {
+        listener.run();
+      }
+      catch (Exception e) {
+        FlutterUtils.warn(LOG, "AndroidEmulatorManager listener threw an exception", e);
+      }
+    }
+  }
+}

--- a/src/io/flutter/utils/SystemUtils.java
+++ b/src/io/flutter/utils/SystemUtils.java
@@ -9,8 +9,12 @@ import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configurations.GeneralCommandLine;
 import com.intellij.execution.process.*;
 import com.intellij.execution.util.ExecUtil;
+import com.intellij.openapi.util.Comparing;
 import com.intellij.openapi.util.Key;
 import com.intellij.openapi.util.SystemInfo;
+import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.openapi.vfs.VfsUtilCore;
+import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.util.concurrency.AppExecutorUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -80,5 +84,50 @@ public class SystemUtils {
     });
 
     return future;
+  }
+
+  /**
+   * Copied from VfsUtilCore because we need to build for 2017.3 (see below, @since).
+   * TODO(anyone): Delete this method after 2017.3 is no longer supported (i.e. when AS 3.2 is stable).
+   * <p>
+   * Returns the relative path from one virtual file to another.
+   * If {@code src} is a file, the path is calculated from its parent directory.
+   *
+   * @param src           the file or directory, from which the path is built
+   * @param dst           the file or directory, to which the path is built
+   * @param separatorChar the separator for the path components
+   * @return the relative path, or {@code null} if the files have no common ancestor
+   * @since 2018.1
+   */
+  @Nullable
+  public static String findRelativePath(@NotNull VirtualFile src, @NotNull VirtualFile dst, char separatorChar) {
+    if (!src.getFileSystem().equals(dst.getFileSystem())) {
+      return null;
+    }
+
+    if (!src.isDirectory()) {
+      src = src.getParent();
+      if (src == null) return null;
+    }
+
+    final VirtualFile commonAncestor = VfsUtilCore.getCommonAncestor(src, dst);
+    if (commonAncestor == null) return null;
+
+    final StringBuilder buffer = new StringBuilder();
+
+    if (!Comparing.equal(src, commonAncestor)) {
+      while (!Comparing.equal(src, commonAncestor)) {
+        buffer.append("..").append(separatorChar);
+        src = src.getParent();
+      }
+    }
+
+    buffer.append(VfsUtilCore.getRelativePath(dst, commonAncestor, separatorChar));
+
+    if (StringUtil.endsWithChar(buffer, separatorChar)) {
+      buffer.setLength(buffer.length() - 1);
+    }
+
+    return buffer.toString();
   }
 }

--- a/src/io/flutter/utils/SystemUtils.java
+++ b/src/io/flutter/utils/SystemUtils.java
@@ -7,18 +7,15 @@ package io.flutter.utils;
 
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configurations.GeneralCommandLine;
-import com.intellij.execution.process.OSProcessHandler;
-import com.intellij.execution.process.ProcessAdapter;
-import com.intellij.execution.process.ProcessEvent;
-import com.intellij.execution.process.ProcessOutputTypes;
-import com.intellij.openapi.util.Comparing;
+import com.intellij.execution.process.*;
+import com.intellij.execution.util.ExecUtil;
 import com.intellij.openapi.util.Key;
 import com.intellij.openapi.util.SystemInfo;
-import com.intellij.openapi.util.text.StringUtil;
-import com.intellij.openapi.vfs.VfsUtilCore;
-import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.util.concurrency.AppExecutorUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.concurrent.CompletableFuture;
 
 public class SystemUtils {
   /**
@@ -65,47 +62,23 @@ public class SystemUtils {
   }
 
   /**
-   * Copied from VfsUtilCore because we need to build for 2017.3 (see below, @since).
-   * TODO(anyone): Delete this method after 2017.3 is no longer supported (i.e. when AS 3.2 is stable).
-   *
-   * Returns the relative path from one virtual file to another.
-   * If {@code src} is a file, the path is calculated from its parent directory.
-   *
-   * @param src           the file or directory, from which the path is built
-   * @param dst           the file or directory, to which the path is built
-   * @param separatorChar the separator for the path components
-   * @return the relative path, or {@code null} if the files have no common ancestor
-   * @since 2018.1
+   * Execute the given command line, and return the process output as one result in a future.
+   * <p>
+   * This is a non-blocking equivalient to {@link ExecUtil#execAndGetOutput(GeneralCommandLine)}.
    */
-  @Nullable
-  public static String findRelativePath(@NotNull VirtualFile src, @NotNull VirtualFile dst, char separatorChar) {
-    if (!src.getFileSystem().equals(dst.getFileSystem())) {
-      return null;
-    }
+  public static CompletableFuture<ProcessOutput> execAndGetOutput(GeneralCommandLine cmd) {
+    final CompletableFuture<ProcessOutput> future = new CompletableFuture<>();
 
-    if (!src.isDirectory()) {
-      src = src.getParent();
-      if (src == null) return null;
-    }
-
-    final VirtualFile commonAncestor = VfsUtilCore.getCommonAncestor(src, dst);
-    if (commonAncestor == null) return null;
-
-    final StringBuilder buffer = new StringBuilder();
-
-    if (!Comparing.equal(src, commonAncestor)) {
-      while (!Comparing.equal(src, commonAncestor)) {
-        buffer.append("..").append(separatorChar);
-        src = src.getParent();
+    AppExecutorUtil.getAppExecutorService().submit(() -> {
+      try {
+        final ProcessOutput output = ExecUtil.execAndGetOutput(cmd);
+        future.complete(output);
       }
-    }
+      catch (ExecutionException e) {
+        future.completeExceptionally(e);
+      }
+    });
 
-    buffer.append(VfsUtilCore.getRelativePath(dst, commonAncestor, separatorChar));
-
-    if (StringUtil.endsWithChar(buffer, separatorChar)) {
-      buffer.setLength(buffer.length() - 1);
-    }
-
-    return buffer.toString();
+    return future;
   }
 }


### PR DESCRIPTION
- address some issues with blocking the EDT thread in 2019.2
- fix https://github.com/flutter/flutter-intellij/issues/3697, fix https://github.com/flutter/flutter-intellij/issues/3696

2019.2 changed to complaining if we use a synchronous process execution library call from the EDT thread (and request to block for greater than 10ms).

Depending on whether we receive lots of user reports of this or not, we may choose to cherry-pick this into current stable. If we see few reports, we can assume that its not affecting users, and it can wait until the next stable (eta, ~1 week).

This does have the nice side benefit that the startup of the plugin is likely faster by 1-3 seconds.
