### PR TITLE
Add AndroidX option to new project wizards

### DIFF
--- a/flutter-studio/src/io/flutter/project/FlutterProjectCreator.java
+++ b/flutter-studio/src/io/flutter/project/FlutterProjectCreator.java
@@ -206,6 +206,7 @@ public class FlutterProjectCreator {
     return new FlutterCreateAdditionalSettings.Builder()
       .setDescription(myModel.description().get().isEmpty() ? null : myModel.description().get())
       .setType(myModel.projectType().getValue())
+      .setAndroidX(myModel.isGeneratingAndroidX())
       .setOrg(myModel.packageName().get().isEmpty() ? null : reversedOrgFromPackage(myModel.packageName().get()))
       .setKotlin(isNotModule() && myModel.useKotlin().get() ? true : null)
       .setSwift(isNotModule() && myModel.useSwift().get() ? true : null)

--- a/flutter-studio/src/io/flutter/project/FlutterProjectModel.java
+++ b/flutter-studio/src/io/flutter/project/FlutterProjectModel.java
@@ -32,7 +32,7 @@ public class FlutterProjectModel extends WizardModel {
   private static final String PROPERTIES_DOMAIN_KEY = "FLUTTER_COMPANY_DOMAIN";
   private static final String PROPERTIES_KOTLIN_SUPPORT_KEY = "FLUTTER_PROJECT_KOTLIN_SUPPORT";
   private static final String PROPERTIES_SWIFT_SUPPORT_KEY = "FLUTTER_PROJECT_SWIFT_SUPPORT";
-  private static final String PROPERTIES_ANDROIDX_SUPPORT_KEY = "FLUTTER_PROJECT_SWIFT_SUPPORT";
+  private static final String PROPERTIES_ANDROIDX_SUPPORT_KEY = "FLUTTER_PROJECT_ANDROIDX_SUPPORT";
 
   @NotNull final private OptionalValueProperty<FlutterProjectType> myProjectType = new OptionalValueProperty<>();
   @NotNull final private StringProperty myFlutterSdk = new StringValueProperty();

--- a/flutter-studio/src/io/flutter/project/FlutterProjectModel.java
+++ b/flutter-studio/src/io/flutter/project/FlutterProjectModel.java
@@ -13,7 +13,9 @@ import com.android.tools.idea.observable.core.StringValueProperty;
 import com.android.tools.idea.wizard.model.WizardModel;
 import com.intellij.ide.util.PropertiesComponent;
 import com.intellij.openapi.project.Project;
+import io.flutter.FlutterUtils;
 import io.flutter.module.FlutterProjectType;
+import io.flutter.sdk.FlutterSdk;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -30,6 +32,7 @@ public class FlutterProjectModel extends WizardModel {
   private static final String PROPERTIES_DOMAIN_KEY = "FLUTTER_COMPANY_DOMAIN";
   private static final String PROPERTIES_KOTLIN_SUPPORT_KEY = "FLUTTER_PROJECT_KOTLIN_SUPPORT";
   private static final String PROPERTIES_SWIFT_SUPPORT_KEY = "FLUTTER_PROJECT_SWIFT_SUPPORT";
+  private static final String PROPERTIES_ANDROIDX_SUPPORT_KEY = "FLUTTER_PROJECT_SWIFT_SUPPORT";
 
   @NotNull final private OptionalValueProperty<FlutterProjectType> myProjectType = new OptionalValueProperty<>();
   @NotNull final private StringProperty myFlutterSdk = new StringValueProperty();
@@ -42,6 +45,7 @@ public class FlutterProjectModel extends WizardModel {
   @NotNull final private BoolValueProperty mySwift = new BoolValueProperty();
   @NotNull final private OptionalProperty<Project> myProject = new OptionalValueProperty<>();
   @NotNull final private BoolValueProperty myIsOfflineSelected = new BoolValueProperty();
+  @NotNull final private BoolValueProperty myAndroidX = new BoolValueProperty();
 
   public FlutterProjectModel(@NotNull FlutterProjectType type) {
     myProjectType.set(new OptionalValueProperty<>(type));
@@ -61,6 +65,9 @@ public class FlutterProjectModel extends WizardModel {
 
     mySwift.set(getInitialSwiftSupport());
     mySwift.addListener(() -> setInitialSwiftSupport(mySwift.get()));
+
+    myAndroidX.set(getInitialAndroidxSupport());
+    myAndroidX.addListener(() -> setInitialAndroidxSupport(myAndroidX.get()));
   }
 
   @NotNull
@@ -101,6 +108,19 @@ public class FlutterProjectModel extends WizardModel {
   @NotNull
   public BoolValueProperty useSwift() {
     return mySwift;
+  }
+
+  @NotNull
+  public BoolValueProperty useAndroidX() {
+    return myAndroidX;
+  }
+
+  public boolean isGeneratingAndroidX() {
+    if (project().getValueOrNull() == null) {
+      return useAndroidX().get() && FlutterSdk.forPath(flutterSdk().get()).getVersion().isAndroidxSupported();
+    } else {
+      return FlutterUtils.isAndroidxProject(project().getValue());
+    }
   }
 
   @NotNull
@@ -163,5 +183,14 @@ public class FlutterProjectModel extends WizardModel {
 
   private static void setInitialSwiftSupport(boolean isSupported) {
     PropertiesComponent.getInstance().setValue(PROPERTIES_SWIFT_SUPPORT_KEY, isSupported);
+  }
+
+  private static boolean getInitialAndroidxSupport() {
+    return !PropertiesComponent.getInstance().isValueSet(PROPERTIES_ANDROIDX_SUPPORT_KEY) ||
+           Boolean.parseBoolean(PropertiesComponent.getInstance().getValue(PROPERTIES_ANDROIDX_SUPPORT_KEY));
+  }
+
+  private static void setInitialAndroidxSupport(boolean isSupported) {
+    PropertiesComponent.getInstance().setValue(PROPERTIES_ANDROIDX_SUPPORT_KEY, isSupported);
   }
 }

--- a/flutter-studio/src/io/flutter/project/FlutterSettingsStep.form
+++ b/flutter-studio/src/io/flutter/project/FlutterSettingsStep.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="io.flutter.project.FlutterSettingsStep">
-  <grid id="27dc6" binding="myRootPanel" layout-manager="GridLayoutManager" row-count="13" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="myRootPanel" layout-manager="GridLayoutManager" row-count="16" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="500" height="452"/>
@@ -20,12 +20,12 @@
       </component>
       <vspacer id="85806">
         <constraints>
-          <grid row="12" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="15" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
       <component id="3d5fb" class="javax.swing.JLabel" binding="myLanguageLabel">
         <constraints>
-          <grid row="9" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="12" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <font style="1"/>
@@ -72,7 +72,7 @@
       </vspacer>
       <component id="533e3" class="javax.swing.JCheckBox" binding="myKotlinCheckBox">
         <constraints>
-          <grid row="10" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="13" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Kotlin"/>
@@ -81,7 +81,7 @@
       </component>
       <component id="15a79" class="javax.swing.JCheckBox" binding="mySwiftCheckBox">
         <constraints>
-          <grid row="11" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="14" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Swift"/>
@@ -112,6 +112,30 @@
           <text value="Applications and plugins need to generate platform-specific code"/>
         </properties>
       </component>
+      <component id="5bff0" class="com.intellij.ui.components.JBLabel" binding="myAndroidXLabel">
+        <constraints>
+          <grid row="9" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <font style="1"/>
+          <text value="AndroidX"/>
+        </properties>
+      </component>
+      <component id="f10cb" class="javax.swing.JCheckBox" binding="myUseAndroidxCheckBox">
+        <constraints>
+          <grid row="10" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="Use androidx.* artifacts"/>
+        </properties>
+      </component>
+      <vspacer id="5a8f6">
+        <constraints>
+          <grid row="11" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
+            <preferred-size width="-1" height="16"/>
+          </grid>
+        </constraints>
+      </vspacer>
     </children>
   </grid>
 </form>

--- a/flutter-studio/src/io/flutter/project/FlutterSettingsStep.java
+++ b/flutter-studio/src/io/flutter/project/FlutterSettingsStep.java
@@ -26,7 +26,6 @@ import com.intellij.ui.components.JBLabel;
 import com.intellij.ui.components.JBLayeredPane;
 import com.intellij.ui.components.JBScrollPane;
 import io.flutter.FlutterBundle;
-import io.flutter.FlutterUtils;
 import io.flutter.sdk.FlutterSdk;
 import java.awt.Container;
 import java.awt.event.FocusAdapter;

--- a/flutter-studio/src/io/flutter/project/FlutterSettingsStep.java
+++ b/flutter-studio/src/io/flutter/project/FlutterSettingsStep.java
@@ -21,9 +21,13 @@ import com.android.tools.idea.ui.wizard.StudioWizardStepPanel;
 import com.android.tools.idea.wizard.model.ModelWizard;
 import com.android.tools.idea.wizard.model.ModelWizardStep;
 import com.intellij.openapi.application.ApplicationInfo;
+import com.intellij.openapi.project.Project;
+import com.intellij.ui.components.JBLabel;
 import com.intellij.ui.components.JBLayeredPane;
 import com.intellij.ui.components.JBScrollPane;
 import io.flutter.FlutterBundle;
+import io.flutter.FlutterUtils;
+import io.flutter.sdk.FlutterSdk;
 import java.awt.Container;
 import java.awt.event.FocusAdapter;
 import java.awt.event.FocusEvent;
@@ -54,6 +58,8 @@ public class FlutterSettingsStep extends ModelWizardStep<FlutterProjectModel> {
   private JCheckBox myKotlinCheckBox;
   private JCheckBox mySwiftCheckBox;
   private JLabel myLanguageLabel;
+  private JCheckBox myUseAndroidxCheckBox;
+  private JBLabel myAndroidXLabel;
   private boolean hasEntered = false;
   private FocusListener focusListener;
 
@@ -144,13 +150,23 @@ public class FlutterSettingsStep extends ModelWizardStep<FlutterProjectModel> {
       myLanguageLabel.setVisible(false);
       myKotlinCheckBox.setVisible(false);
       mySwiftCheckBox.setVisible(false);
+      myAndroidXLabel.setVisible(false);
+      myUseAndroidxCheckBox.setVisible(false);
     }
     else {
+      Project project = getModel().project().getValueOrNull();
+      FlutterSdk sdk = FlutterSdk.forPath(getModel().flutterSdk().get());
+      boolean enableAndroidX = project == null && sdk != null && sdk.getVersion().isAndroidxSupported();
       myLanguageLabel.setVisible(true);
       myKotlinCheckBox.setVisible(true);
       mySwiftCheckBox.setVisible(true);
+      myAndroidXLabel.setVisible(enableAndroidX);
+      myUseAndroidxCheckBox.setVisible(enableAndroidX);
       myBindings.bindTwoWay(new SelectedProperty(myKotlinCheckBox), getModel().useKotlin());
       myBindings.bindTwoWay(new SelectedProperty(mySwiftCheckBox), getModel().useSwift());
+      if (enableAndroidX) {
+        myBindings.bindTwoWay(new SelectedProperty(myUseAndroidxCheckBox), getModel().useAndroidX());
+      }
     }
     hasEntered = true;
   }

--- a/src/io/flutter/module/settings/FlutterCreateAdditionalSettingsFields.java
+++ b/src/io/flutter/module/settings/FlutterCreateAdditionalSettingsFields.java
@@ -44,7 +44,7 @@ public class FlutterCreateAdditionalSettingsFields {
     projectTypeForm.addListener(e -> {
       if (e.getStateChange() == ItemEvent.SELECTED) {
         settings.setType(projectTypeForm.getType());
-        projectTypeForm.adjustAndroidX(project);
+        projectTypeForm.computeAndroidXAvailability(project);
         changeVisibility(projectTypeForm.getType() != FlutterProjectType.PACKAGE);
       }
     });
@@ -119,6 +119,7 @@ public class FlutterCreateAdditionalSettingsFields {
     return new FlutterCreateAdditionalSettings.Builder()
       .setDescription(!descriptionField.getText().trim().isEmpty() ? descriptionField.getText().trim() : null)
       .setType(projectTypeForm.getType())
+      // Packages are pure Dart code, no iOS or Android modules.
       .setAndroidX(projectTypeForm.getType() != FlutterProjectType.PACKAGE && projectTypeForm.getAndroidxCheckbox().isSelected())
       .setKotlin(androidLanguageRadios.isRadio2Selected() ? true : null)
       .setOrg(!orgField.getText().trim().isEmpty() ? orgField.getText().trim() : null)
@@ -132,6 +133,6 @@ public class FlutterCreateAdditionalSettingsFields {
   }
 
   public void update() {
-    projectTypeForm.adjustAndroidX(project);
+    projectTypeForm.computeAndroidXAvailability(project);
   }
 }

--- a/src/io/flutter/module/settings/FlutterCreateAdditionalSettingsFields.java
+++ b/src/io/flutter/module/settings/FlutterCreateAdditionalSettingsFields.java
@@ -6,9 +6,7 @@
 package io.flutter.module.settings;
 
 import com.intellij.ide.util.projectWizard.SettingsStep;
-import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.roots.ModifiableRootModel;
 import com.intellij.ui.DocumentAdapter;
 import com.intellij.util.PlatformUtils;
 import com.intellij.util.ui.UIUtil;
@@ -16,13 +14,11 @@ import io.flutter.FlutterBundle;
 import io.flutter.module.FlutterProjectType;
 import io.flutter.sdk.FlutterCreateAdditionalSettings;
 import io.flutter.sdk.FlutterSdk;
-import java.util.function.Function;
-import java.util.function.Supplier;
-import org.jetbrains.annotations.NotNull;
-
-import javax.swing.*;
-import javax.swing.event.DocumentEvent;
 import java.awt.event.ItemEvent;
+import java.util.function.Supplier;
+import javax.swing.JTextField;
+import javax.swing.event.DocumentEvent;
+import org.jetbrains.annotations.NotNull;
 
 public class FlutterCreateAdditionalSettingsFields {
   private final FlutterCreateAdditionalSettings settings;

--- a/src/io/flutter/module/settings/ProjectType.form
+++ b/src/io/flutter/module/settings/ProjectType.form
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="io.flutter.module.settings.ProjectType">
-  <grid id="27dc6" binding="projectTypePanel" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="projectTypePanel" layout-manager="GridLayoutManager" row-count="2" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="102" height="400"/>
+      <xy x="20" y="20" width="297" height="400"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -21,6 +21,19 @@
           <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
+      <component id="29199" class="javax.swing.JCheckBox" binding="androidxCheckbox" custom-create="true">
+        <constraints>
+          <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="1" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="Use AndroidX artifacts"/>
+        </properties>
+      </component>
+      <hspacer id="54647">
+        <constraints>
+          <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+      </hspacer>
     </children>
   </grid>
 </form>

--- a/src/io/flutter/module/settings/ProjectType.java
+++ b/src/io/flutter/module/settings/ProjectType.java
@@ -5,10 +5,16 @@
  */
 package io.flutter.module.settings;
 
+import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.ComboBox;
 import io.flutter.FlutterBundle;
+import io.flutter.FlutterUtils;
 import io.flutter.module.FlutterProjectType;
 import io.flutter.sdk.FlutterSdk;
+import java.awt.event.FocusAdapter;
+import java.awt.event.FocusEvent;
+import java.util.function.Function;
+import java.util.function.Supplier;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -19,14 +25,13 @@ import java.util.EnumSet;
 import java.util.List;
 
 public class ProjectType {
-  // TODO(pq): replace w/ simple EnumComboBoxModel when add-to-app is complete and we no longer need to filter out MODULE types.
-  private static final class ProjectTypeComboBoxModel extends AbstractListModel<FlutterProjectType>
+  private final class ProjectTypeComboBoxModel extends AbstractListModel<FlutterProjectType>
     implements ComboBoxModel<FlutterProjectType> {
     private final List<FlutterProjectType> myList = new ArrayList<>(EnumSet.allOf(FlutterProjectType.class));
     private FlutterProjectType mySelected;
 
-    public ProjectTypeComboBoxModel() {
-      // Remove MODULE type until add-to-app is complete.
+    private ProjectTypeComboBoxModel() {
+      // TODO Remove this filter in 2019Q4, assuming add-to-app is complete then.
       if (System.getProperty("flutter.experimental.modules", null) == null) {
         myList.remove(FlutterProjectType.MODULE);
         myList.remove(FlutterProjectType.IMPORT);
@@ -55,19 +60,23 @@ public class ProjectType {
     }
 
     public void setSelectedItem(FlutterProjectType item) {
+      cacheState();
       mySelected = item;
       fireContentsChanged(this, 0, getSize());
     }
   }
 
-  @Nullable
-  private FlutterSdk sdk;
+  private Supplier<? extends FlutterSdk> getSdk;
 
   private JPanel projectTypePanel;
   private ComboBox projectTypeCombo;
+  private JCheckBox androidxCheckbox;
+  private boolean androidxCheckboxSet = false;
+  private boolean androidxCheckboxValue = false;
 
-  public ProjectType(@Nullable FlutterSdk sdk) {
-    this.sdk = sdk;
+  public ProjectType(@Nullable Supplier<? extends FlutterSdk> getSdk) {
+    this.getSdk = getSdk;
+    adjustAndroidX();
   }
 
   @SuppressWarnings("unused")
@@ -80,11 +89,17 @@ public class ProjectType {
     //noinspection unchecked
     projectTypeCombo.setModel(new ProjectTypeComboBoxModel());
     projectTypeCombo.setToolTipText(FlutterBundle.message("flutter.module.create.settings.type.tip"));
+    androidxCheckbox = new JCheckBox();
   }
 
   @NotNull
   public JComponent getComponent() {
     return projectTypePanel;
+  }
+
+  @NotNull
+  public JCheckBox getAndroidxCheckbox() {
+    return androidxCheckbox;
   }
 
   public FlutterProjectType getType() {
@@ -95,11 +110,50 @@ public class ProjectType {
     return projectTypeCombo;
   }
 
-  public void setSdk(@NotNull FlutterSdk sdk) {
-    this.sdk = sdk;
+  public void setSdk(@NotNull Supplier<? extends FlutterSdk> sdk) {
+    this.getSdk = sdk;
+    adjustAndroidX();
   }
 
   public void addListener(ItemListener listener) {
     projectTypeCombo.addItemListener(listener);
+  }
+
+  public void cacheState() {
+    if (getType() != FlutterProjectType.PACKAGE) {
+      androidxCheckboxValue = androidxCheckbox.isSelected();
+    }
+  }
+
+  public void adjustAndroidX(@Nullable Project project) {
+    if (project != null) {
+      androidxCheckbox.setVisible(false);
+      androidxCheckbox.setSelected(FlutterUtils.isAndroidxProject(project));
+    }
+    adjustAndroidX();
+  }
+
+  public void adjustAndroidX() {
+    if (!androidxCheckbox.isVisible()) {
+      return;
+    }
+    assert getSdk != null;
+    if (getSdk.get().getVersion().isAndroidxSupported() && getType() != FlutterProjectType.PACKAGE) {
+      // It would be nice to save and restore the selection based on current state when the Prev/Next buttons
+      // are used. The wizard doesn't provide navigation hooks to do that. This does the right thing when
+      // switching project types.
+      if (!androidxCheckboxSet) {
+        androidxCheckbox.setSelected(true);
+        androidxCheckboxSet = true;
+        androidxCheckboxValue = true;
+      } else {
+        androidxCheckbox.setSelected(androidxCheckboxValue);
+      }
+      androidxCheckbox.setEnabled(true);
+    } else {
+      androidxCheckboxValue = androidxCheckbox.isSelected();
+      androidxCheckbox.setSelected(false);
+      androidxCheckbox.setEnabled(false);
+    }
   }
 }

--- a/src/io/flutter/module/settings/ProjectType.java
+++ b/src/io/flutter/module/settings/ProjectType.java
@@ -11,18 +11,18 @@ import io.flutter.FlutterBundle;
 import io.flutter.FlutterUtils;
 import io.flutter.module.FlutterProjectType;
 import io.flutter.sdk.FlutterSdk;
-import java.awt.event.FocusAdapter;
-import java.awt.event.FocusEvent;
-import java.util.function.Function;
-import java.util.function.Supplier;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-
-import javax.swing.*;
 import java.awt.event.ItemListener;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.function.Supplier;
+import javax.swing.AbstractListModel;
+import javax.swing.ComboBoxModel;
+import javax.swing.JCheckBox;
+import javax.swing.JComponent;
+import javax.swing.JPanel;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class ProjectType {
   private final class ProjectTypeComboBoxModel extends AbstractListModel<FlutterProjectType>
@@ -146,11 +146,13 @@ public class ProjectType {
         androidxCheckbox.setSelected(true);
         androidxCheckboxSet = true;
         androidxCheckboxValue = true;
-      } else {
+      }
+      else {
         androidxCheckbox.setSelected(androidxCheckboxValue);
       }
       androidxCheckbox.setEnabled(true);
-    } else {
+    }
+    else {
       androidxCheckboxValue = androidxCheckbox.isSelected();
       androidxCheckbox.setSelected(false);
       androidxCheckbox.setEnabled(false);

--- a/src/io/flutter/module/settings/ProjectType.java
+++ b/src/io/flutter/module/settings/ProjectType.java
@@ -31,7 +31,7 @@ public class ProjectType {
     private FlutterProjectType mySelected;
 
     private ProjectTypeComboBoxModel() {
-      // TODO Remove this filter in 2019Q4, assuming add-to-app is complete then.
+      // TODO(messick) Remove this filter in 2019Q4, assuming add-to-app is complete then.
       if (System.getProperty("flutter.experimental.modules", null) == null) {
         myList.remove(FlutterProjectType.MODULE);
         myList.remove(FlutterProjectType.IMPORT);
@@ -76,7 +76,7 @@ public class ProjectType {
 
   public ProjectType(@Nullable Supplier<? extends FlutterSdk> getSdk) {
     this.getSdk = getSdk;
-    adjustAndroidX();
+    computeAndroidXAvailability();
   }
 
   @SuppressWarnings("unused")
@@ -112,7 +112,7 @@ public class ProjectType {
 
   public void setSdk(@NotNull Supplier<? extends FlutterSdk> sdk) {
     this.getSdk = sdk;
-    adjustAndroidX();
+    computeAndroidXAvailability();
   }
 
   public void addListener(ItemListener listener) {
@@ -125,15 +125,15 @@ public class ProjectType {
     }
   }
 
-  public void adjustAndroidX(@Nullable Project project) {
+  public void computeAndroidXAvailability(@Nullable Project project) {
     if (project != null) {
       androidxCheckbox.setVisible(false);
       androidxCheckbox.setSelected(FlutterUtils.isAndroidxProject(project));
     }
-    adjustAndroidX();
+    computeAndroidXAvailability();
   }
 
-  public void adjustAndroidX() {
+  private void computeAndroidXAvailability() {
     if (!androidxCheckbox.isVisible()) {
       return;
     }

--- a/src/io/flutter/sdk/FlutterCreateAdditionalSettings.java
+++ b/src/io/flutter/sdk/FlutterCreateAdditionalSettings.java
@@ -28,6 +28,7 @@ public class FlutterCreateAdditionalSettings {
   private Boolean kotlin;
   @Nullable
   private Boolean offlineMode;
+  private boolean isAndroidX;
 
   public FlutterCreateAdditionalSettings() {
     type = FlutterProjectType.APP;
@@ -41,7 +42,8 @@ public class FlutterCreateAdditionalSettings {
                                           @Nullable String org,
                                           @Nullable Boolean swift,
                                           @Nullable Boolean kotlin,
-                                          @Nullable Boolean offlineMode) {
+                                          @Nullable Boolean offlineMode,
+                                          boolean isAndroidX) {
     this.includeDriverTest = includeDriverTest;
     this.type = type;
     this.description = description;
@@ -49,6 +51,7 @@ public class FlutterCreateAdditionalSettings {
     this.swift = swift;
     this.kotlin = kotlin;
     this.offlineMode = offlineMode;
+    this.isAndroidX = isAndroidX;
   }
 
   public void setType(@Nullable FlutterProjectType value) {
@@ -108,6 +111,11 @@ public class FlutterCreateAdditionalSettings {
       args.add("kotlin");
     }
 
+    if (isAndroidX) {
+      // TODO(messick): Remove the AndroidX UI components when AS 3.6 becomes the stable version. By then AndroidX should always be used.
+      args.add("--androidx");
+    }
+
     return args;
   }
 
@@ -147,6 +155,7 @@ public class FlutterCreateAdditionalSettings {
     private Boolean offlineMode;
     @Nullable
     private FlutterSample sampleContent;
+    private boolean isAndroidX;
 
     public Builder() {
     }
@@ -191,8 +200,13 @@ public class FlutterCreateAdditionalSettings {
       return this;
     }
 
+    public Builder setAndroidX(boolean selected) {
+      this.isAndroidX = selected;
+      return this;
+    }
+
     public FlutterCreateAdditionalSettings build() {
-      return new FlutterCreateAdditionalSettings(includeDriverTest, type, description, org, swift, kotlin, offlineMode);
+      return new FlutterCreateAdditionalSettings(includeDriverTest, type, description, org, swift, kotlin, offlineMode, isAndroidX);
     }
   }
 }

--- a/src/io/flutter/sdk/FlutterSdkVersion.java
+++ b/src/io/flutter/sdk/FlutterSdkVersion.java
@@ -29,6 +29,11 @@ public class FlutterSdkVersion {
    */
   private static final FlutterSdkVersion MIN_SAFE_TRACK_WIDGET_CREATION_SDK = new FlutterSdkVersion("0.10.2");
 
+  /**
+   * The version of the stable channel that suppoorts --androidx in the create command.
+   */
+  private static final FlutterSdkVersion MIN_ANDROIDX_SDK = new FlutterSdkVersion("1.7.8");
+
   @Nullable
   private final Version version;
 
@@ -87,6 +92,11 @@ public class FlutterSdkVersion {
   public boolean isTrackWidgetCreationRecommended() {
     assert (MIN_SAFE_TRACK_WIDGET_CREATION_SDK.version != null);
     return version != null && version.compareTo(MIN_SAFE_TRACK_WIDGET_CREATION_SDK.version) >= 0;
+  }
+
+  public boolean isAndroidxSupported() {
+    assert (MIN_ANDROIDX_SDK.version != null);
+    return version != null && version.compareTo(MIN_ANDROIDX_SDK.version) >= 0;
   }
 
   public boolean flutterTestSupportsMachineMode() {

--- a/src/io/flutter/sdk/FlutterSdkVersion.java
+++ b/src/io/flutter/sdk/FlutterSdkVersion.java
@@ -9,11 +9,10 @@ package io.flutter.sdk;
 import com.google.common.annotations.VisibleForTesting;
 import com.intellij.openapi.util.Version;
 import com.intellij.openapi.vfs.VirtualFile;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class FlutterSdkVersion {
   /**
@@ -23,7 +22,7 @@ public class FlutterSdkVersion {
 
   /**
    * The minimum version we suggest people use to enable track-widget-creation.
-   *
+   * <p>
    * Before this version there were issues if you ran the app from the command
    * line without the flag after running
    */
@@ -95,7 +94,7 @@ public class FlutterSdkVersion {
   }
 
   public boolean isAndroidxSupported() {
-    assert (MIN_ANDROIDX_SDK.version != null);
+    //noinspection ConstantConditions
     return version != null && version.compareTo(MIN_ANDROIDX_SDK.version) >= 0;
   }
 

--- a/testSrc/unit/io/flutter/android/AndroidxTest.java
+++ b/testSrc/unit/io/flutter/android/AndroidxTest.java
@@ -38,6 +38,11 @@ public class AndroidxTest {
     "android.useAndroidX=true\n" +
     "android.enableJetifier=true";
 
+  private static final String NON_STANDARD_PROPERTIES =
+    "# comment\n" +
+    "android.useAndroidX=\\\n" +
+    "  true\n";
+
   @Rule
   public final ProjectFixture fixture = Testing.makeEmptyModule();
 
@@ -107,6 +112,13 @@ public class AndroidxTest {
     assertFalse(result);
   }
 
+  @Test
+  public void userEditsAreValid() {
+    createTestHarness("android", FlutterProjectType.APP, NON_STANDARD_PROPERTIES);
+    boolean result = FlutterUtils.isAndroidxProject(fixture.getProject());
+    assertTrue(result);
+  }
+
   private void createTestHarness(@NotNull String androidPath, @Nullable FlutterProjectType type, @NotNull String propertiesContent) {
     @SystemIndependent String basePath = fixture.getProject().getBasePath();
     VirtualFile projectDir = LocalFileSystem.getInstance().findFileByPath(basePath);
@@ -150,7 +162,7 @@ public class AndroidxTest {
             }
           }
           catch (IOException x) {
-            System.out.println(x.getMessage());
+            fail(x.getMessage());
           }
         });
       });

--- a/testSrc/unit/io/flutter/android/AndroidxTest.java
+++ b/testSrc/unit/io/flutter/android/AndroidxTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright  2019 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.android;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VirtualFile;
+import io.flutter.FlutterUtils;
+import io.flutter.module.FlutterProjectType;
+import io.flutter.testing.ProjectFixture;
+import io.flutter.testing.Testing;
+import java.io.BufferedOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.SystemIndependent;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class AndroidxTest {
+
+  private static final String ANDROID_PROPERTIES =
+    "org.gradle.jvmargs=-Xmx1536M\n";
+
+  private static final String ANDROIDX_PROPERTIES =
+    "org.gradle.jvmargs=-Xmx1536M\n" +
+    "\n" +
+    "android.useAndroidX=true\n" +
+    "android.enableJetifier=true";
+
+  @Rule
+  public final ProjectFixture fixture = Testing.makeEmptyModule();
+
+  @Test
+  public void androidOldAppRecognized() {
+    createTestHarness("android", null, ANDROID_PROPERTIES);
+    assertFalse(FlutterUtils.isAndroidxProject(fixture.getProject()));
+  }
+
+  @Test
+  public void androidxOldAppRecognized() throws Exception {
+    createTestHarness("android", null, ANDROIDX_PROPERTIES);
+    assertTrue(FlutterUtils.isAndroidxProject(fixture.getProject()));
+  }
+
+  @Test
+  public void androidxOldModuleRecognized() throws Exception {
+    createTestHarness(".android", null, ANDROIDX_PROPERTIES);
+    assertTrue(FlutterUtils.isAndroidxProject(fixture.getProject()));
+  }
+
+  @Test
+  public void androidOldPluginRecognized() {
+    createTestHarness("example/android", null, ANDROID_PROPERTIES);
+    assertFalse(FlutterUtils.isAndroidxProject(fixture.getProject()));
+  }
+
+  @Test
+  public void androidxOldPluginRecognized() throws Exception {
+    createTestHarness("example/android", null, ANDROIDX_PROPERTIES);
+    assertTrue(FlutterUtils.isAndroidxProject(fixture.getProject()));
+  }
+
+  @Test
+  public void androidAppRecognized() {
+    createTestHarness("android", FlutterProjectType.APP, ANDROID_PROPERTIES);
+    assertFalse(FlutterUtils.isAndroidxProject(fixture.getProject()));
+  }
+
+  @Test
+  public void androidxAppRecognized() throws Exception {
+    createTestHarness("android", FlutterProjectType.APP, ANDROIDX_PROPERTIES);
+    assertTrue(FlutterUtils.isAndroidxProject(fixture.getProject()));
+  }
+
+  @Test
+  public void androidxModuleRecognized() throws Exception {
+    createTestHarness(".android", FlutterProjectType.MODULE, ANDROIDX_PROPERTIES);
+    assertTrue(FlutterUtils.isAndroidxProject(fixture.getProject()));
+  }
+
+  @Test
+  public void androidPluginRecognized() {
+    createTestHarness("example/android", FlutterProjectType.PLUGIN, ANDROID_PROPERTIES);
+    assertFalse(FlutterUtils.isAndroidxProject(fixture.getProject()));
+  }
+
+  @Test
+  public void androidxPluginRecognized() throws Exception {
+    createTestHarness("example/android", FlutterProjectType.PLUGIN, ANDROIDX_PROPERTIES);
+    assertTrue(FlutterUtils.isAndroidxProject(fixture.getProject()));
+  }
+
+  @Test
+  public void packageRecognized() {
+    boolean result = FlutterUtils.isAndroidxProject(fixture.getProject());
+    assertFalse(result);
+  }
+
+  private void createTestHarness(@NotNull String androidPath, @Nullable FlutterProjectType type, @NotNull String propertiesContent) {
+    @SystemIndependent String basePath = fixture.getProject().getBasePath();
+    VirtualFile projectDir = LocalFileSystem.getInstance().findFileByPath(basePath);
+    try {
+      Testing.runOnDispatchThread(() -> {
+        ApplicationManager.getApplication().runWriteAction(() -> {
+          try {
+            if (type != null) {
+              VirtualFile metadataFile = projectDir.createChildData(this, ".metadata");
+              String metadataContent = "project_type: ";
+              switch (type) {
+                case APP:
+                  metadataContent += "app\n";
+                  break;
+                case MODULE:
+                  metadataContent += "module\n";
+                  break;
+                case PACKAGE:
+                  metadataContent += "package\n";
+                  break;
+                case PLUGIN:
+                  metadataContent += "plugin\n";
+                  break;
+                case IMPORT:
+                  fail();
+                  break;
+              }
+              try (OutputStream out = new BufferedOutputStream(metadataFile.getOutputStream(this))) {
+                out.write(metadataContent.getBytes(StandardCharsets.UTF_8));
+              }
+            }
+            String[] dirs = androidPath.split("/");
+            VirtualFile androidDir = projectDir;
+            for (String dir : dirs) {
+              androidDir = androidDir.createChildDirectory(this, dir);
+            }
+            assertNotEquals(androidDir, projectDir);
+            VirtualFile propertiesFile = androidDir.createChildData(this, "gradle.properties");
+            try (OutputStream out = new BufferedOutputStream(propertiesFile.getOutputStream(this))) {
+              out.write(propertiesContent.getBytes(StandardCharsets.UTF_8));
+            }
+          }
+          catch (IOException x) {
+            System.out.println(x.getMessage());
+          }
+        });
+      });
+    }
+    catch (Exception e) {
+      fail(e.getMessage());
+    }
+  }
+}

--- a/testSrc/unit/io/flutter/android/AndroidxTest.java
+++ b/testSrc/unit/io/flutter/android/AndroidxTest.java
@@ -48,13 +48,13 @@ public class AndroidxTest {
   }
 
   @Test
-  public void androidxOldAppRecognized() throws Exception {
+  public void androidxOldAppRecognized() {
     createTestHarness("android", null, ANDROIDX_PROPERTIES);
     assertTrue(FlutterUtils.isAndroidxProject(fixture.getProject()));
   }
 
   @Test
-  public void androidxOldModuleRecognized() throws Exception {
+  public void androidxOldModuleRecognized() {
     createTestHarness(".android", null, ANDROIDX_PROPERTIES);
     assertTrue(FlutterUtils.isAndroidxProject(fixture.getProject()));
   }
@@ -66,7 +66,7 @@ public class AndroidxTest {
   }
 
   @Test
-  public void androidxOldPluginRecognized() throws Exception {
+  public void androidxOldPluginRecognized() {
     createTestHarness("example/android", null, ANDROIDX_PROPERTIES);
     assertTrue(FlutterUtils.isAndroidxProject(fixture.getProject()));
   }
@@ -78,13 +78,13 @@ public class AndroidxTest {
   }
 
   @Test
-  public void androidxAppRecognized() throws Exception {
+  public void androidxAppRecognized() {
     createTestHarness("android", FlutterProjectType.APP, ANDROIDX_PROPERTIES);
     assertTrue(FlutterUtils.isAndroidxProject(fixture.getProject()));
   }
 
   @Test
-  public void androidxModuleRecognized() throws Exception {
+  public void androidxModuleRecognized() {
     createTestHarness(".android", FlutterProjectType.MODULE, ANDROIDX_PROPERTIES);
     assertTrue(FlutterUtils.isAndroidxProject(fixture.getProject()));
   }
@@ -96,7 +96,7 @@ public class AndroidxTest {
   }
 
   @Test
-  public void androidxPluginRecognized() throws Exception {
+  public void androidxPluginRecognized() {
     createTestHarness("example/android", FlutterProjectType.PLUGIN, ANDROIDX_PROPERTIES);
     assertTrue(FlutterUtils.isAndroidxProject(fixture.getProject()));
   }


### PR DESCRIPTION
@devoncarew 

Adds UI and logic to support creating projects (and modules) that use AndroidX. Note that modules are created in the style of their host project, so there is no new UI for modules.

Fixes #3616

IntelliJ:
<img width="918" alt="Screen Shot 2019-07-26 at 1 48 02 PM" src="https://user-images.githubusercontent.com/8518285/61980652-3a5e3900-afac-11e9-9ca7-037168f4550e.png">

Android Studio:
<img width="1012" alt="Screen Shot 2019-07-26 at 1 49 06 PM" src="https://user-images.githubusercontent.com/8518285/61980672-4518ce00-afac-11e9-90ed-1ee8142a06c1.png">
