### PR TITLE
pass in disableBreakpoints

### DIFF
--- a/src/io/flutter/logging/FlutterConsoleLogManager.java
+++ b/src/io/flutter/logging/FlutterConsoleLogManager.java
@@ -375,6 +375,7 @@ public class FlutterConsoleLogManager {
         service.invoke(
           isolateRef.getId(), error.getId(),
           "toString", Collections.emptyList(),
+          true,
           new VmServiceConsumers.InvokeConsumerWrapper() {
             @Override
             public void received(InstanceRef response) {

--- a/src/io/flutter/vmService/VmServiceWrapper.java
+++ b/src/io/flutter/vmService/VmServiceWrapper.java
@@ -582,6 +582,6 @@ public class VmServiceWrapper implements Disposable {
   public void callToString(@NotNull final String isolateId,
                            @NotNull final String targetId,
                            @NotNull final InvokeConsumer callback) {
-    addRequest(() -> myVmService.invoke(isolateId, targetId, "toString", Collections.emptyList(), callback));
+    addRequest(() -> myVmService.invoke(isolateId, targetId, "toString", Collections.emptyList(), true, callback));
   }
 }


### PR DESCRIPTION
- pass in the `disableBreakpoints: true` option in places where we eval code

(note: not necessarily for landing for the current release)
