### PR TITLE
Guard against null sdk

### DIFF
--- a/src/io/flutter/module/settings/ProjectType.java
+++ b/src/io/flutter/module/settings/ProjectType.java
@@ -138,7 +138,8 @@ public class ProjectType {
       return;
     }
     assert getSdk != null;
-    if (getSdk.get().getVersion().isAndroidxSupported() && getType() != FlutterProjectType.PACKAGE) {
+    FlutterSdk sdk = getSdk.get();
+    if (sdk != null && sdk.getVersion().isAndroidxSupported() && getType() != FlutterProjectType.PACKAGE) {
       // It would be nice to save and restore the selection based on current state when the Prev/Next buttons
       // are used. The wizard doesn't provide navigation hooks to do that. This does the right thing when
       // switching project types.


### PR DESCRIPTION
It is possible for the Flutter SDK to be not set when the first project is created. This change allows the wizard to operate.