### PR TITLE
address a setPreferredFocusableComponent() warning in the IntelliJ log

### DIFF
--- a/src/io/flutter/preview/PreviewView.java
+++ b/src/io/flutter/preview/PreviewView.java
@@ -286,6 +286,7 @@ public class PreviewView implements PersistentStateComponent<PreviewViewState>, 
 
     scrollPane = ScrollPaneFactory.createScrollPane(tree);
     windowPanel.setContent(scrollPane);
+    content.setPreferredFocusableComponent(tree);
 
     contentManager.addContent(content);
     contentManager.setSelectedContent(content);


### PR DESCRIPTION
- address a setPreferredFocusableComponent() warning in the IntelliJ log

> WARN - j.openapi.wm.impl.IdeFrameImpl - Set preferredFocusableComponent in 'null' content in Flutter Outline tool window to avoid focus-related problems.
