### PR TITLE
work on supporting the flutter web inspector

### DIFF
--- a/src/io/flutter/inspector/EvalOnDartLibrary.java
+++ b/src/io/flutter/inspector/EvalOnDartLibrary.java
@@ -132,33 +132,31 @@ public class EvalOnDartLibrary implements Disposable {
   public CompletableFuture<InstanceRef> eval(String expression, Map<String, String> scope, InspectorService.ObjectGroup isAlive) {
     return addRequest(isAlive, () -> {
       final CompletableFuture<InstanceRef> future = new CompletableFuture<>();
-      libraryRef.thenAcceptAsync((LibraryRef ref) -> {
-        vmService.evaluate(
-          getIsolateId(), ref.getId(), expression,
-          scope, true,
-          new EvaluateConsumer() {
-            @Override
-            public void onError(RPCError error) {
-              future.completeExceptionally(new RuntimeException(error.getMessage()));
-            }
-
-            @Override
-            public void received(ErrorRef response) {
-              future.completeExceptionally(new RuntimeException(response.toString()));
-            }
-
-            @Override
-            public void received(InstanceRef response) {
-              future.complete(response);
-            }
-
-            @Override
-            public void received(Sentinel response) {
-              future.completeExceptionally(new RuntimeException(response.toString()));
-            }
+      libraryRef.thenAcceptAsync((LibraryRef ref) -> vmService.evaluate(
+        getIsolateId(), ref.getId(), expression,
+        scope, true,
+        new EvaluateConsumer() {
+          @Override
+          public void onError(RPCError error) {
+            future.completeExceptionally(new RuntimeException(error.getMessage()));
           }
-        );
-      });
+
+          @Override
+          public void received(ErrorRef response) {
+            future.completeExceptionally(new RuntimeException(response.toString()));
+          }
+
+          @Override
+          public void received(InstanceRef response) {
+            future.complete(response);
+          }
+
+          @Override
+          public void received(Sentinel response) {
+            future.completeExceptionally(new RuntimeException(response.toString()));
+          }
+        }
+      ));
       return future;
     });
   }
@@ -211,10 +209,6 @@ public class EvalOnDartLibrary implements Disposable {
 
   public CompletableFuture<Func> getFunc(FuncRef instance, InspectorService.ObjectGroup isAlive) {
     return getObjHelper(instance, isAlive);
-  }
-
-  public CompletableFuture<Instance> getInstance(CompletableFuture<InstanceRef> instanceFuture, InspectorService.ObjectGroup isAlive) {
-    return instanceFuture.thenComposeAsync((instance) -> getInstance(instance, isAlive));
   }
 
   private JsonObject convertMapToJsonObject(Map<String, String> map) {

--- a/src/io/flutter/inspector/InspectorService.java
+++ b/src/io/flutter/inspector/InspectorService.java
@@ -578,12 +578,20 @@ public class InspectorService implements Disposable {
      * Requires that the InstanceRef is really referring to a String that is valid JSON.
      */
     CompletableFuture<JsonElement> instanceRefToJson(InstanceRef instanceRef) {
-      return nullIfDisposed(() -> getInspectorLibrary().getInstance(instanceRef, this).thenApplyAsync((Instance instance) -> {
-        return nullValueIfDisposed(() -> {
-          final String json = instance.getValueAsString();
-          return new JsonParser().parse(json);
-        });
-      }));
+      if (instanceRef.getValueAsString() != null && !instanceRef.getValueAsStringIsTruncated()) {
+        // In some situations, the string may already be fully populated.
+        final JsonElement json = new JsonParser().parse(instanceRef.getValueAsString());
+        return CompletableFuture.completedFuture(json);
+      }
+      else {
+        // Otherwise, retrieve the full value of the string.
+        return nullIfDisposed(() -> getInspectorLibrary().getInstance(instanceRef, this).thenApplyAsync((Instance instance) -> {
+          return nullValueIfDisposed(() -> {
+            final String json = instance.getValueAsString();
+            return new JsonParser().parse(json);
+          });
+        }));
+      }
     }
 
     CompletableFuture<ArrayList<DiagnosticsNode>> parseDiagnosticsNodesObservatory(InstanceRef instanceRef, DiagnosticsNode parent) {


### PR DESCRIPTION
Work on supporting the flutter web inspector:
- move to no longer send inspector traffic over the daemon protocol - just use the vm service protocol (fix https://github.com/flutter/flutter-intellij/issues/3777; fix #3770)
- work around an issue with package:dwds involving the object id of strings; https://github.com/dart-lang/webdev/issues/575; done as a 2nd commit for easier reviewability

With this PR, the IntelliJ Inspector works with the unforked version of Flutter for web.
