### PR TITLE
improve computeDefaultPresentation

### DIFF
--- a/src/io/flutter/vmService/frame/DartVmServiceValue.java
+++ b/src/io/flutter/vmService/frame/DartVmServiceValue.java
@@ -152,40 +152,9 @@ public class DartVmServiceValue extends XNamedValue {
 
     // computeDefaultPresentation is called internally here when no result is received.
     // The reason for this is that the async method used cannot be properly waited.
-    computeDebugPresentation(node);
+    computeDefaultPresentation(node);
 
     // todo handle other special kinds: Type, TypeParameter, Pattern, may be some others as well
-  }
-
-  private void computeDebugPresentation(final XValueNode node) {
-    myDebugProcess.getVmServiceWrapper()
-      .evaluateInTargetContext(myIsolateId, myInstanceRef.getId(), "toStringDeep()", new VmServiceConsumers.EvaluateConsumerWrapper() {
-        @Override
-        public void received(final InstanceRef toStringInstanceRef) {
-          // TODO: Get actual DiagnosticsNode object instead of calling toStringDeep here.
-          if (toStringInstanceRef.getKind() == InstanceKind.String) {
-            String content = toStringInstanceRef.getValueAsString();
-            int firstLineBreak = content.indexOf('\n');
-            String summary = firstLineBreak < 0 ? content : content.substring(0, firstLineBreak);
-            node.setPresentation(getIcon(), myInstanceRef.getClassRef().getName(), summary, true);
-            if (toStringInstanceRef.getValueAsStringIsTruncated()) {
-              addFullStringValueEvaluator(node, toStringInstanceRef);
-            }
-            else if (firstLineBreak >= 0) {
-              // Multi-line content. Display a View link to reveal full content.
-              node.setFullValueEvaluator(new ImmediateFullValueEvaluator("...View", content));
-            }
-          }
-          else {
-            noGoodResult();
-          }
-        }
-
-        @Override
-        public void noGoodResult() {
-          computeDefaultPresentation(node);
-        }
-      });
   }
 
   private Icon getIcon() {
@@ -320,27 +289,48 @@ public class DartVmServiceValue extends XNamedValue {
   }
 
   private void computeDefaultPresentation(@NotNull final XValueNode node) {
+    final String typeName = myInstanceRef.getClassRef().getName();
+
+    // Check if the string value is populated.
+    if (myInstanceRef.getValueAsString() != null && !myInstanceRef.getValueAsStringIsTruncated()) {
+      node.setPresentation(getIcon(), typeName, myInstanceRef.getValueAsString(), true);
+      return;
+    }
+
     myDebugProcess.getVmServiceWrapper().callToString(myIsolateId, myInstanceRef.getId(), new VmServiceConsumers.InvokeConsumerWrapper() {
       @Override
       public void received(final InstanceRef toStringInstanceRef) {
         if (toStringInstanceRef.getKind() == InstanceKind.String) {
-          final String string = toStringInstanceRef.getValueAsString();
-          // default toString() implementation returns "Instance of 'ClassName'" - no interest to show
-          if (string.equals("Instance of '" + myInstanceRef.getClassRef().getName() + "'")) {
-            noGoodResult();
+          final String value = toStringInstanceRef.getValueAsString();
+          // We don't need to show the default implementation of toString() ("Instance of ...").
+          if (value.startsWith("Instance of ")) {
+            node.setPresentation(getIcon(), typeName, "", true);
           }
           else {
-            node.setPresentation(getIcon(), myInstanceRef.getClassRef().getName(), string, true);
+            node.setPresentation(getIcon(), typeName, value, true);
           }
         }
         else {
-          noGoodResult(); // unlikely possible
+          preesentationFallback(node);
         }
       }
 
       @Override
       public void noGoodResult() {
-        node.setPresentation(getIcon(), myInstanceRef.getClassRef().getName(), "", true);
+        preesentationFallback(node);
+      }
+
+      private void preesentationFallback(@NotNull final XValueNode node) {
+        if (myInstanceRef.getValueAsString() != null) {
+          node.setPresentation(
+            getIcon(),
+            typeName,
+            myInstanceRef.getValueAsString() + (myInstanceRef.getValueAsStringIsTruncated() ? "..." : ""),
+            true);
+        }
+        else {
+          node.setPresentation(getIcon(), typeName, "", true);
+        }
       }
     });
   }


### PR DESCRIPTION
- improve `computeDefaultPresentation()` in the debugger

When calculating the presentation to use for variables in the debugger, only call `toString()` on a VM object if we don't already have the full toString value locally. This aids in debugging flutter web apps, as `package:dwds` does not yet support the `invoke()` service protocol call (https://github.com/dart-lang/webdev/issues/591).
