### PR TITLE
Fix ArrayIndexOutOfBounds for target platform selector.

### DIFF
--- a/src/io/flutter/view/TogglePlatformAction.java
+++ b/src/io/flutter/view/TogglePlatformAction.java
@@ -55,8 +55,13 @@ class TogglePlatformAction extends ToolbarComboBoxAction {
       }
 
       final int platformIndex = extensionDescription.getValues().indexOf(selectedPlatform.name());
-      System.out.println("Unknown platform: " + selectedPlatform.name());
-      selectorText = platformIndex == -1 ? "Platform: Unknown" : (String)extensionDescription.getTooltips().get(platformIndex);
+      try {
+        selectorText = (String)extensionDescription.getTooltips().get(platformIndex);
+      }
+      catch (ArrayIndexOutOfBoundsException ex) {
+        selectorText = "Platform: Unknown";
+        System.out.println("Unknown platform: " + selectedPlatform.name());
+      }
     }
 
     e.getPresentation().setText(selectorText);

--- a/src/io/flutter/view/TogglePlatformAction.java
+++ b/src/io/flutter/view/TogglePlatformAction.java
@@ -55,7 +55,8 @@ class TogglePlatformAction extends ToolbarComboBoxAction {
       }
 
       final int platformIndex = extensionDescription.getValues().indexOf(selectedPlatform.name());
-      selectorText = (String)extensionDescription.getTooltips().get(platformIndex);
+      System.out.println("Unknown platform: " + selectedPlatform.name());
+      selectorText = platformIndex == -1 ? "Platform: Unknown" : (String)extensionDescription.getTooltips().get(platformIndex);
     }
 
     e.getPresentation().setText(selectorText);

--- a/src/io/flutter/view/TogglePlatformAction.java
+++ b/src/io/flutter/view/TogglePlatformAction.java
@@ -55,12 +55,12 @@ class TogglePlatformAction extends ToolbarComboBoxAction {
       }
 
       final int platformIndex = extensionDescription.getValues().indexOf(selectedPlatform.name());
-      try {
-        selectorText = (String)extensionDescription.getTooltips().get(platformIndex);
-      }
-      catch (ArrayIndexOutOfBoundsException ex) {
+      if (platformIndex == -1) {
         selectorText = "Platform: Unknown";
         System.out.println("Unknown platform: " + selectedPlatform.name());
+      }
+      else {
+        selectorText = (String)extensionDescription.getTooltips().get(platformIndex);
       }
     }
 


### PR DESCRIPTION
Added a print so that we can catch cases where we are getting an unknown platform target.

Fixes https://github.com/flutter/flutter-intellij/issues/3771.