### PR TITLE
convert an error to a warning

### DIFF
--- a/src/io/flutter/run/daemon/DeviceDaemon.java
+++ b/src/io/flutter/run/daemon/DeviceDaemon.java
@@ -236,7 +236,8 @@ class DeviceDaemon {
             }
             else {
               // IntelliJ will show a generic failure message the first time we log this error.
-              LOG.error(failureMessage);
+              LOG.warn(failureMessage);
+
               // The second time we log this error, we'll show a customized message to alert the user to the specific problem.
               if (attempts == DeviceDaemon.RESTART_ATTEMPTS_BEFORE_WARNING + 1) {
                 // Show a message in the UI when we reach the warning threshold.


### PR DESCRIPTION
- convert an error to a warning

We were logging this issue as an error, which is user visible. Instead we now log as a warning, and reply on the existing user notification on `DeviceDaemon.RESTART_ATTEMPTS_BEFORE_WARNING + 1` attempts.

