### PR TITLE
Swap order nodeChanged and nodeStructureChanged were called.

### DIFF
--- a/src/io/flutter/view/InspectorPanel.java
+++ b/src/io/flutter/view/InspectorPanel.java
@@ -939,8 +939,8 @@ public class InspectorPanel extends JPanel implements Disposable, InspectorServi
                   // TODO(jacobr): we are likely calling the wrong node structure changed APIs.
                   // For example, we should be getting these change notifications for free if we
                   // switched to call methods on the model object directly to manipulate the tree.
-                  model.nodeChanged(child);
                   model.nodeStructureChanged(child);
+                  model.nodeChanged(child);
                 }
                 model.reload(treeNode);
               }


### PR DESCRIPTION
This likely solves https://github.com/flutter/flutter-intellij/issues/3756
by avoiding an edge case where the node structure change needs to occur first
or else invalid cached data is present in the model.