### PR TITLE
Change AndroidX default to false

### DIFF
--- a/flutter-studio/src/io/flutter/project/FlutterProjectModel.java
+++ b/flutter-studio/src/io/flutter/project/FlutterProjectModel.java
@@ -186,6 +186,7 @@ public class FlutterProjectModel extends WizardModel {
   }
 
   private static boolean getInitialAndroidxSupport() {
+    // TODO(https://github.com/flutter/flutter/issues/23586) Change default to true after AndroidX is supported by Flutter.
     return PropertiesComponent.getInstance().getBoolean(PROPERTIES_ANDROIDX_SUPPORT_KEY, false);
   }
 

--- a/flutter-studio/src/io/flutter/project/FlutterProjectModel.java
+++ b/flutter-studio/src/io/flutter/project/FlutterProjectModel.java
@@ -186,7 +186,7 @@ public class FlutterProjectModel extends WizardModel {
   }
 
   private static boolean getInitialAndroidxSupport() {
-    return PropertiesComponent.getInstance().getBoolean(PROPERTIES_ANDROIDX_SUPPORT_KEY, true);
+    return PropertiesComponent.getInstance().getBoolean(PROPERTIES_ANDROIDX_SUPPORT_KEY, false);
   }
 
   private static void setInitialAndroidxSupport(boolean isSupported) {


### PR DESCRIPTION
AndroidX support is currently broken for Flutter modules so we shouldn't assume people want it by default.