### PR TITLE
Enable structured errors by default.

### DIFF
--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.form
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.form
@@ -98,7 +98,7 @@
           </component>
         </children>
       </grid>
-      <grid id="919ec" layout-manager="GridLayoutManager" row-count="4" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="919ec" layout-manager="GridLayoutManager" row-count="5" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -139,6 +139,14 @@
             <properties>
               <text resource-bundle="io/flutter/FlutterBundle" key="settings.hot.reload.with.error"/>
               <toolTipText value="Hot reload changes into running Flutter apps even if there are analysis errors"/>
+            </properties>
+          </component>
+          <component id="b1533" class="javax.swing.JCheckBox" binding="myShowStructuredErrors">
+            <constraints>
+              <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Show structured errors for Flutter framework issues"/>
             </properties>
           </component>
         </children>
@@ -234,7 +242,7 @@
           </component>
         </children>
       </grid>
-      <grid id="23e52" layout-manager="GridLayoutManager" row-count="4" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="23e52" layout-manager="GridLayoutManager" row-count="3" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -252,7 +260,7 @@
           </component>
           <component id="1f6f8" class="javax.swing.JCheckBox" binding="myUseLogViewCheckBox">
             <constraints>
-              <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text resource-bundle="io/flutter/FlutterBundle" key="settings.experimental.flutter.logging.view"/>
@@ -260,19 +268,11 @@
           </component>
           <component id="33088" class="javax.swing.JCheckBox" binding="mySyncAndroidLibrariesCheckBox">
             <constraints>
-              <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text resource-bundle="io/flutter/FlutterBundle" key="settings.enable.android.gradle.sync"/>
               <toolTipText value="Provides advanced editing capabilities for Java and Kotlin code. Uses Gradle to find Android libraries then links them into the Flutter project."/>
-            </properties>
-          </component>
-          <component id="b1533" class="javax.swing.JCheckBox" binding="myShowStructuredErrors">
-            <constraints>
-              <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <text value="Show structured errors for Flutter framework issues"/>
             </properties>
           </component>
         </children>

--- a/src/io/flutter/settings/FlutterSettings.java
+++ b/src/io/flutter/settings/FlutterSettings.java
@@ -210,11 +210,11 @@ public class FlutterSettings {
   }
 
   public boolean isShowStructuredErrors() {
-    return getPropertiesComponent().getBoolean(showStructuredErrors, false);
+    return getPropertiesComponent().getBoolean(showStructuredErrors, true);
   }
 
   public void setShowStructuredErrors(boolean value) {
-    getPropertiesComponent().setValue(showStructuredErrors, value, false);
+    getPropertiesComponent().setValue(showStructuredErrors, value, true);
 
     fireEvent();
   }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1226812/63886358-259c0900-c98f-11e9-87dc-ff2b01fc0fcf.png)

Fixes https://github.com/flutter/flutter-intellij/issues/3808