### PR TITLE
Cache values that cause Edt-sync warnings

### DIFF
--- a/flutter-intellij-community.iml
+++ b/flutter-intellij-community.iml
@@ -16,6 +16,7 @@
       <excludeFolder url="file://$MODULE_DIR$/artifacts" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
       <excludeFolder url="file://$MODULE_DIR$/src/main" />
+      <excludeFolder url="file://$MODULE_DIR$/testData/sample_tests/.dart_tool" />
       <excludeFolder url="file://$MODULE_DIR$/testData/sample_tests/.pub" />
       <excludeFolder url="file://$MODULE_DIR$/testData/sample_tests/build" />
       <excludeFolder url="file://$MODULE_DIR$/tool/icon_generator/.dart_tool" />

--- a/src/io/flutter/ProjectOpenActivity.java
+++ b/src/io/flutter/ProjectOpenActivity.java
@@ -10,6 +10,7 @@ import com.intellij.notification.NotificationType;
 import com.intellij.notification.Notifications;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.Project;
@@ -55,8 +56,7 @@ public class ProjectOpenActivity implements StartupActivity, DumbAware {
       return;
     }
 
-    sdk.queryFlutterConfig("android-sdk", false);
-    sdk.queryFlutterConfig("android-studio-dir", false);
+    ApplicationManager.getApplication().invokeLater(() -> sdk.queryFlutterConfig("android-studio-dir", false));
 
     // If this project is intended as a bazel project, don't run the pub alerts.
     if (settings != null && settings.shouldUseBazel()) {

--- a/src/io/flutter/ProjectOpenActivity.java
+++ b/src/io/flutter/ProjectOpenActivity.java
@@ -55,6 +55,9 @@ public class ProjectOpenActivity implements StartupActivity, DumbAware {
       return;
     }
 
+    sdk.queryFlutterConfig("android-sdk", false);
+    sdk.queryFlutterConfig("android-studio-dir", false);
+
     // If this project is intended as a bazel project, don't run the pub alerts.
     if (settings != null && settings.shouldUseBazel()) {
       return;

--- a/src/io/flutter/actions/OpenInAndroidStudioAction.java
+++ b/src/io/flutter/actions/OpenInAndroidStudioAction.java
@@ -198,7 +198,10 @@ public class OpenInAndroidStudioAction extends AnAction {
 
     final FlutterSdk flutterSdk = FlutterSdk.getFlutterSdk(project);
     if (flutterSdk != null) {
-      String androidSdkLocation = flutterSdk.queryFlutterConfig("android-studio-dir", false);
+      String androidSdkLocation = flutterSdk.queryFlutterConfig("android-studio-dir", true);
+      if (androidSdkLocation!= null && !new File(androidSdkLocation).exists()) {
+        androidSdkLocation = flutterSdk.queryFlutterConfig("android-studio-dir", false);
+      }
       if (androidSdkLocation != null) {
         if (androidSdkLocation.contains("/Android Studio 2")) {
           Messages.showErrorDialog(FlutterBundle.message("old.android.studio.message", File.separator),


### PR DESCRIPTION
Finding Android Studio can cause a warning about synchronous execution on EDT. This will (probably) fix that. It needs more testing and should be queued for M40.