### PR TITLE
address an instance of process execution on the EDT

### DIFF
--- a/src/io/flutter/ProjectOpenActivity.java
+++ b/src/io/flutter/ProjectOpenActivity.java
@@ -56,7 +56,9 @@ public class ProjectOpenActivity implements StartupActivity, DumbAware {
       return;
     }
 
-    ApplicationManager.getApplication().invokeLater(() -> sdk.queryFlutterConfig("android-studio-dir", false));
+    ApplicationManager.getApplication().executeOnPooledThread(() -> {
+      sdk.queryFlutterConfig("android-studio-dir", false);
+    });
 
     // If this project is intended as a bazel project, don't run the pub alerts.
     if (settings != null && settings.shouldUseBazel()) {


### PR DESCRIPTION
- address an instance of process execution on the EDT

Instead of `invokeLater()` - which runs the closure on the EDT - call `executeOnPooledThread()`.

@stevemessick 
