### PR TITLE
Add build actions

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -873,6 +873,22 @@
       <separator/>
       <add-to-group group-id="ProjectViewPopupMenu" relative-to-action="AddToFavorites" anchor="before"/>
     </group>
+    <group id="FlutterBuildActionGroup" class="io.flutter.actions.FlutterBuildActionGroup">
+      <separator/>
+      <group text="Flutter" popup="true">
+        <action id="flutter.build.aar" text="Build AAR" description="Building a Flutter module for Android add-to-app"
+                class="io.flutter.actions.FlutterBuildActionGroup$AAR"/>
+        <action id="flutter.build.apk" text="Build APK" description="Building a Flutter app for general distribution"
+                class="io.flutter.actions.FlutterBuildActionGroup$APK"/>
+        <!--suppress PluginXmlCapitalization -->
+        <action id="flutter.build.aab" text="Build App Bundle" description="Building a Flutter app for Google Play Store distribution"
+                class="io.flutter.actions.FlutterBuildActionGroup$AppBundle"/>
+        <!--suppress PluginXmlCapitalization -->
+        <action id="flutter.build.ios" text="Build iOS" description="Building a Flutter app for Apple App Store distribution"
+                class="io.flutter.actions.FlutterBuildActionGroup$Ios"/>
+      </group>
+      <add-to-group group-id="BuildMenu" anchor="first"/>
+    </group>
 
     <!-- main toolbar run actions -->
     <action id="AttachDebuggerAction"

--- a/resources/META-INF/plugin_template.xml
+++ b/resources/META-INF/plugin_template.xml
@@ -122,6 +122,22 @@
       <separator/>
       <add-to-group group-id="ProjectViewPopupMenu" relative-to-action="AddToFavorites" anchor="before"/>
     </group>
+    <group id="FlutterBuildActionGroup" class="io.flutter.actions.FlutterBuildActionGroup">
+      <separator/>
+      <group text="Flutter" popup="true">
+        <action id="flutter.build.aar" text="Build AAR" description="Building a Flutter module for Android add-to-app"
+                class="io.flutter.actions.FlutterBuildActionGroup$AAR"/>
+        <action id="flutter.build.apk" text="Build APK" description="Building a Flutter app for general distribution"
+                class="io.flutter.actions.FlutterBuildActionGroup$APK"/>
+        <!--suppress PluginXmlCapitalization -->
+        <action id="flutter.build.aab" text="Build App Bundle" description="Building a Flutter app for Google Play Store distribution"
+                class="io.flutter.actions.FlutterBuildActionGroup$AppBundle"/>
+        <!--suppress PluginXmlCapitalization -->
+        <action id="flutter.build.ios" text="Build iOS" description="Building a Flutter app for Apple App Store distribution"
+                class="io.flutter.actions.FlutterBuildActionGroup$Ios"/>
+      </group>
+      <add-to-group group-id="BuildMenu" anchor="first"/>
+    </group>
 
     <!-- main toolbar run actions -->
     <action id="AttachDebuggerAction"

--- a/src/io/flutter/ProjectOpenActivity.java
+++ b/src/io/flutter/ProjectOpenActivity.java
@@ -59,6 +59,9 @@ public class ProjectOpenActivity implements StartupActivity, DumbAware {
     ApplicationManager.getApplication().executeOnPooledThread(() -> {
       sdk.queryFlutterConfig("android-studio-dir", false);
     });
+    if (FlutterUtils.isAndroidStudio() && !FLUTTER_PROJECT_TYPE.equals(ProjectTypeService.getProjectType(project))) {
+      ProjectTypeService.setProjectType(project, FLUTTER_PROJECT_TYPE);
+    }
 
     // If this project is intended as a bazel project, don't run the pub alerts.
     if (settings != null && settings.shouldUseBazel()) {

--- a/src/io/flutter/actions/FlutterBuildActionGroup.java
+++ b/src/io/flutter/actions/FlutterBuildActionGroup.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.flutter.actions;
+
+import com.intellij.execution.process.OSProcessHandler;
+import com.intellij.execution.process.ProcessAdapter;
+import com.intellij.execution.process.ProcessEvent;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.CommonDataKeys;
+import com.intellij.openapi.actionSystem.DefaultActionGroup;
+import com.intellij.openapi.actionSystem.Presentation;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleUtilCore;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.ModuleRootManager;
+import com.intellij.openapi.vfs.VirtualFile;
+import io.flutter.FlutterMessages;
+import io.flutter.pub.PubRoot;
+import io.flutter.sdk.FlutterSdk;
+import io.flutter.utils.FlutterModuleUtils;
+import io.flutter.utils.ProgressHelper;
+import org.jetbrains.annotations.NotNull;
+
+public class FlutterBuildActionGroup extends DefaultActionGroup {
+
+  @Override
+  public void update(AnActionEvent event) {
+    final Presentation presentation = event.getPresentation();
+    final boolean enabled = isInFlutterModule(event);
+    presentation.setEnabled(enabled);
+    presentation.setVisible(enabled);
+  }
+
+  private static boolean isInFlutterModule(@NotNull AnActionEvent event) {
+    return findFlutterModule(event) != null;
+  }
+
+  private static Module findFlutterModule(@NotNull AnActionEvent event) {
+    Project project = event.getProject();
+    if (project == null) {
+      return null;
+    }
+    VirtualFile file = event.getData(CommonDataKeys.VIRTUAL_FILE);
+    if (file == null) {
+      return null;
+    }
+    return findFlutterModule(project, file);
+  }
+
+  public static Module findFlutterModule(@NotNull Project project, @NotNull VirtualFile file) {
+    Module module = ModuleUtilCore.findModuleForFile(file, project);
+    if (module == null) {
+      return null;
+    }
+    if (FlutterModuleUtils.declaresFlutter(module)) {
+      return module;
+    }
+    // We may get here if the file is in the Android module of a Flutter module project.
+    VirtualFile parent = ModuleRootManager.getInstance(module).getContentRoots()[0].getParent();
+    module = ModuleUtilCore.findModuleForFile(parent, project);
+    if (module == null) {
+      return null;
+    }
+    return FlutterModuleUtils.declaresFlutter(module) ? module : null;
+  }
+
+  abstract public static class FlutterBuildAction extends AnAction {
+
+    abstract protected String buildType();
+
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent event) {
+      final Presentation presentation = event.getPresentation();
+      Project project = event.getProject();
+      if (project == null) {
+        return;
+      }
+      FlutterSdk sdk = FlutterSdk.getFlutterSdk(project);
+      if (sdk == null) {
+        return;
+      }
+      PubRoot pubRoot = PubRoot.forEventWithRefresh(event);
+      if (pubRoot == null) {
+        return;
+      }
+      String buildType = buildType();
+      ProgressHelper progressHelper = new ProgressHelper(project);
+      progressHelper.start(presentation.getDescription());
+      OSProcessHandler processHandler = sdk.flutterBuild(pubRoot, buildType).startInConsole(project);
+      if (processHandler == null) {
+        progressHelper.done();
+      }
+      else {
+        processHandler.addProcessListener(new ProcessAdapter() {
+          @Override
+          public void processTerminated(@NotNull ProcessEvent event) {
+            progressHelper.done();
+            int exitCode = event.getExitCode();
+            if (exitCode != 0) {
+              FlutterMessages.showError("Error while building " + buildType, "`flutter build` returned: " + exitCode);
+            }
+          }
+        });
+      }
+    }
+  }
+
+  public static class AAR extends FlutterBuildAction {
+    @Override
+    protected String buildType() {
+      return "aar";
+    }
+  }
+
+  public static class APK extends FlutterBuildAction {
+    @Override
+    protected String buildType() {
+      return "apk";
+    }
+  }
+
+  public static class AppBundle extends FlutterBuildAction {
+    @Override
+    protected String buildType() {
+      return "appbundle";
+    }
+  }
+
+  public static class Ios extends FlutterBuildAction {
+    @Override
+    protected String buildType() {
+      return "ios";
+    }
+  }
+}

--- a/src/io/flutter/actions/FlutterBuildActionGroup.java
+++ b/src/io/flutter/actions/FlutterBuildActionGroup.java
@@ -1,17 +1,7 @@
 /*
- * Copyright (C) 2019 The Android Open Source Project
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright 2019 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
  */
 package io.flutter.actions;
 

--- a/src/io/flutter/utils/FlutterModuleUtils.java
+++ b/src/io/flutter/utils/FlutterModuleUtils.java
@@ -5,11 +5,19 @@
  */
 package io.flutter.utils;
 
+import static io.flutter.sdk.FlutterSdk.DART_SDK_SUFFIX;
+
 import com.intellij.execution.RunManager;
 import com.intellij.execution.RunnerAndConfigurationSettings;
+import com.intellij.facet.Facet;
+import com.intellij.facet.FacetManager;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.fileEditor.FileEditorManager;
-import com.intellij.openapi.module.*;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleManager;
+import com.intellij.openapi.module.ModuleType;
+import com.intellij.openapi.module.ModuleTypeManager;
+import com.intellij.openapi.module.ModuleUtilCore;
 import com.intellij.openapi.project.DumbService;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
@@ -29,12 +37,9 @@ import io.flutter.run.SdkFields;
 import io.flutter.run.SdkRunConfig;
 import io.flutter.sdk.FlutterSdk;
 import io.flutter.sdk.FlutterSdkUtil;
+import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
-import java.util.List;
-
-import static io.flutter.sdk.FlutterSdk.DART_SDK_SUFFIX;
 
 public class FlutterModuleUtils {
   public static final String DEPRECATED_FLUTTER_MODULE_TYPE_ID = "WEB_MODULE";
@@ -174,7 +179,7 @@ public class FlutterModuleUtils {
   @NotNull
   public static Module[] getModules(@NotNull Project project) {
     // A disposed project has no modules.
-    if (project.isDisposed()) return new Module[]{ };
+    if (project.isDisposed()) return new Module[]{};
 
     return ModuleManager.getInstance(project).getModules();
   }
@@ -322,6 +327,22 @@ public class FlutterModuleUtils {
 
     // Validate that the pubspec references flutter.
     return FlutterModuleUtils.declaresFlutter(module);
+  }
+
+  public static boolean isInFlutterAndroidModule(@NotNull Project project, @NotNull VirtualFile file) {
+    Module[] modules = ModuleManager.getInstance(project).getModules();
+    for (Module module : modules) {
+      // contains() should be fast since it uses the index.
+      boolean isModuleFile = module.getModuleContentScope().contains(file);
+      if (isModuleFile) {
+        for (Facet facet : FacetManager.getInstance(module).getAllFacets()) {
+          if ("Android".equals(facet.getName())) {
+            return declaresFlutter(project);
+          }
+        }
+      }
+    }
+    return false;
   }
 
   /**


### PR DESCRIPTION
This is needed for add-to-app integration (aar) and convenient for the others.

Also the `Flutter > Open in Android Studio` has been flakey for a while. I think this is due to recently-added timeouts in the event handling code. There's a change that should help improve performance of our `update()` method for that action, hopefully getting past the flakiness.