### PR TITLE
remove use of some deprecated calls

### DIFF
--- a/src/io/flutter/editor/FlutterSaveActionsManager.java
+++ b/src/io/flutter/editor/FlutterSaveActionsManager.java
@@ -12,7 +12,7 @@ import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
-import com.intellij.openapi.fileEditor.FileDocumentManagerAdapter;
+import com.intellij.openapi.fileEditor.FileDocumentManagerListener;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleUtil;
 import com.intellij.openapi.project.Project;
@@ -62,7 +62,7 @@ public class FlutterSaveActionsManager {
 
     final MessageBus bus = project.getMessageBus();
     final MessageBusConnection connection = bus.connect();
-    connection.subscribe(AppTopics.FILE_DOCUMENT_SYNC, new FileDocumentManagerAdapter() {
+    connection.subscribe(AppTopics.FILE_DOCUMENT_SYNC, new FileDocumentManagerListener() {
       @Override
       public void beforeDocumentSaving(@NotNull Document document) {
         handleBeforeDocumentSaving(document);
@@ -108,13 +108,13 @@ public class FlutterSaveActionsManager {
       return;
     }
 
-    DartAnalysisServerService.getInstance(myProject).serverReadyForRequest(myProject);
-
-    if (settings.isOrganizeImportsOnSaveKey()) {
-      performOrganizeThenFormat(document, file);
-    }
-    else {
-      performFormat(document, file, false);
+    if (DartAnalysisServerService.getInstance(myProject).serverReadyForRequest(myProject)) {
+      if (settings.isOrganizeImportsOnSave()) {
+        performOrganizeThenFormat(document, file);
+      }
+      else {
+        performFormat(document, file, false);
+      }
     }
   }
 

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.form
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.form
@@ -108,7 +108,7 @@
         <children>
           <component id="356a" class="javax.swing.JCheckBox" binding="myOpenInspectorOnAppLaunchCheckBox">
             <constraints>
-              <grid row="2" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="3" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text resource-bundle="io/flutter/FlutterBundle" key="settings.open.inspector.on.launch"/>
@@ -125,7 +125,7 @@
           </component>
           <component id="6d6f0" class="javax.swing.JCheckBox" binding="myDisableTrackWidgetCreationCheckBox">
             <constraints>
-              <grid row="3" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="4" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text resource-bundle="io/flutter/FlutterBundle" key="settings.disable.tracking.widget.creation"/>
@@ -143,7 +143,7 @@
           </component>
           <component id="b1533" class="javax.swing.JCheckBox" binding="myShowStructuredErrors">
             <constraints>
-              <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text value="Show structured errors for Flutter framework issues"/>

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.java
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.java
@@ -194,7 +194,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
       return true;
     }
 
-    if (settings.isOrganizeImportsOnSaveKey() != myOrganizeImportsOnSaveCheckBox.isSelected()) {
+    if (settings.isOrganizeImportsOnSave() != myOrganizeImportsOnSaveCheckBox.isSelected()) {
       return true;
     }
 
@@ -268,7 +268,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     settings.setReloadOnSave(myHotReloadOnSaveCheckBox.isSelected());
     settings.setReloadWithError(myHotReloadIgnoreErrorCheckBox.isSelected());
     settings.setFormatCodeOnSave(myFormatCodeOnSaveCheckBox.isSelected());
-    settings.setOrganizeImportsOnSaveKey(myOrganizeImportsOnSaveCheckBox.isSelected());
+    settings.setOrganizeImportsOnSave(myOrganizeImportsOnSaveCheckBox.isSelected());
 
     settings.setShowBuildMethodGuides(myShowBuildMethodGuides.isSelected());
     settings.setShowMultipleChildrenGuides(myShowMultipleChildrenGuides.isSelected());
@@ -310,7 +310,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     myHotReloadOnSaveCheckBox.setSelected(settings.isReloadOnSave());
     myHotReloadIgnoreErrorCheckBox.setSelected(settings.isReloadWithError());
     myFormatCodeOnSaveCheckBox.setSelected(settings.isFormatCodeOnSave());
-    myOrganizeImportsOnSaveCheckBox.setSelected(settings.isOrganizeImportsOnSaveKey());
+    myOrganizeImportsOnSaveCheckBox.setSelected(settings.isOrganizeImportsOnSave());
 
     myShowBuildMethodGuides.setSelected(settings.isShowBuildMethodGuides());
     myShowMultipleChildrenGuides.setSelected(settings.isShowMultipleChildrenGuides());

--- a/src/io/flutter/settings/FlutterSettings.java
+++ b/src/io/flutter/settings/FlutterSettings.java
@@ -85,7 +85,7 @@ public class FlutterSettings {
     if (isFormatCodeOnSave()) {
       analytics.sendEvent("settings", afterLastPeriod(formatCodeOnSaveKey));
 
-      if (isOrganizeImportsOnSaveKey()) {
+      if (isOrganizeImportsOnSave()) {
         analytics.sendEvent("settings", afterLastPeriod(organizeImportsOnSaveKey));
       }
     }
@@ -179,11 +179,11 @@ public class FlutterSettings {
     fireEvent();
   }
 
-  public boolean isOrganizeImportsOnSaveKey() {
+  public boolean isOrganizeImportsOnSave() {
     return getPropertiesComponent().getBoolean(organizeImportsOnSaveKey, false);
   }
 
-  public void setOrganizeImportsOnSaveKey(boolean value) {
+  public void setOrganizeImportsOnSave(boolean value) {
     getPropertiesComponent().setValue(organizeImportsOnSaveKey, value, false);
 
     fireEvent();


### PR DESCRIPTION
- remove use of some deprecated calls in `FlutterSaveActionsManager.java `
- fix the name for the `isOrganizeImportsOnSaveKey()` method; => `isOrganizeImportsOnSave()`
- move the `myShowStructuredErrors` setting up a bit in the preference page, so that the enabled by default settings show before the disabled by default ones

<img width="387" alt="Screen Shot 2019-09-16 at 9 25 18 AM" src="https://user-images.githubusercontent.com/1269969/64975503-055fbb80-d864-11e9-9051-d648761a5f87.png">

