### PR TITLE
fix an NPE in FlutterIconProvider.java

### DIFF
--- a/src/io/flutter/project/FlutterIconProvider.java
+++ b/src/io/flutter/project/FlutterIconProvider.java
@@ -62,7 +62,7 @@ public class FlutterIconProvider extends IconProvider {
     if (element instanceof DartFile) {
       final DartFile dartFile = (DartFile)element;
       final VirtualFile file = dartFile.getVirtualFile();
-      if (!file.isInLocalFileSystem()) return null;
+      if (file == null || !file.isInLocalFileSystem()) return null;
 
       // Use a simple naming convention heuristic to identify test files.
       // TODO(pq): consider pushing up to the Dart Plugin.


### PR DESCRIPTION
- fix an NPE in FlutterIconProvider.java

```
java.lang.NullPointerException
	at io.flutter.project.FlutterIconProvider.getIcon(FlutterIconProvider.java:65)
	at com.intellij.util.PsiIconUtil.getProvidersIcon(PsiIconUtil.java:17)
	at com.intellij.psi.impl.ElementBase.doComputeIconNow(ElementBase.java:101)
	at com.intellij.psi.impl.ElementBase.lambda$computeIconNow$2(ElementBase.java:97)
	at com.intellij.util.AstLoadingFilter.disallowTreeLoading(AstLoadingFilter.java:127)
	at com.intellij.util.AstLoadingFilter.disallowTreeLoading(AstLoadingFilter.java:116)
```
