### PR TITLE
fix the changelog markdown translation

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -31,752 +31,750 @@
     <![CDATA[
 <h2>39.0</h2>
 <ul>
-  <li>Changed project creation to default to AndriodX deselected until it works for Flutter modules</li>
-  <li>Enabled structured errors by default</li>
-  <li>Fix #3731: Synchronous execution on EDT (#3823)</li>
-  <li>Make the new languages be default (#3819)</li>
-  <li>Don't call reload for the unforked flutter web impl (#3816)</li>
-  <li>Perform additional normalization on flutter error codes (#3813)</li>
-  <li>Fix an issue related to the error reporter (#3811)</li>
-  <li>Improve computeDefaultPresentation (#3803)</li>
-  <li>Convert an error to a warning (#3810)</li>
-  <li>Fix ArrayIndexOutOfBounds for target platform selector (#3809)</li>
-  <li>Flutter web inspector (#3792)</li>
-  <li>Rev to the latest vm service library (#3801)</li>
-  <li>Adapt to API changes in ASc6 (#3802)</li>
-  <li>Switch to using the VM Service directly instead of the Daemon protocol when invoking service extensions (#3790)</li>
-  <li>Update no-response.yml (#3789)</li>
-  <li>Upgrade the version of the dart plugin that we compile against (#3784)</li>
-  <li>Address a setPreferredFocusableComponent() warning in the IntelliJ log (#3783)</li>
-  <li>Fix a regression in the Flutter Outline view (#3782)</li>
-  <li>Cache the results of parsing the pubspec file (#3773)</li>
-  <li>Only parse analysis server events we're interested in (#3772)</li>
-  <li>Optimize FlutterUtils.isInTestDir (#3774)</li>
-  <li>Add platforms to testing matrix (#3768)</li>
-  <li>Make part of the dart code use implicit-casts false (#3762)</li>
+<li>Changed project creation to default to AndriodX deselected until it works for Flutter modules</li>
+<li>Enabled structured errors by default</li>
+<li>Fix #3731: Synchronous execution on EDT (#3823)</li>
+<li>Make the new languages be default (#3819)</li>
+<li>Don't call reload for the unforked flutter web impl (#3816)</li>
+<li>Perform additional normalization on flutter error codes (#3813)</li>
+<li>Fix an issue related to the error reporter (#3811)</li>
+<li>Improve computeDefaultPresentation (#3803)</li>
+<li>Convert an error to a warning (#3810)</li>
+<li>Fix ArrayIndexOutOfBounds for target platform selector (#3809)</li>
+<li>Flutter web inspector (#3792)</li>
+<li>Rev to the latest vm service library (#3801)</li>
+<li>Adapt to API changes in ASc6 (#3802)</li>
+<li>Switch to using the VM Service directly instead of the Daemon protocol when invoking service extensions (#3790)</li>
+<li>Update no-response.yml (#3789)</li>
+<li>Upgrade the version of the dart plugin that we compile against (#3784)</li>
+<li>Address a setPreferredFocusableComponent() warning in the IntelliJ log (#3783)</li>
+<li>Fix a regression in the Flutter Outline view (#3782)</li>
+<li>Cache the results of parsing the pubspec file (#3773)</li>
+<li>Only parse analysis server events we're interested in (#3772)</li>
+<li>Optimize FlutterUtils.isInTestDir (#3774)</li>
+<li>Add platforms to testing matrix (#3768)</li>
+<li>Make part of the dart code use implicit-casts false (#3762)</li>
 </ul>
 <h2>38.2</h2>
 <ul>
-  <li>Fix bug on Windows that prevented outlines from displaying</li>
-  <li>Restore the ability to run individual tests </li>
-  <li>Fix a couple other issues</li>
+<li>Fix bug on Windows that prevented outlines from displaying</li>
+<li>Restore the ability to run individual tests </li>
+<li>Fix a couple other issues</li>
 </ul>
 <h2>38.1</h2>
 <ul>
-  <li>Fix first-time installation issue</li>
+<li>Fix first-time installation issue</li>
 </ul>
 <h2>38.0</h2>
 <ul>
-  <li>Add AndroidX option to new project wizards (#3705)</li>
-  <li>Fix break due to Android Studio 3.6 API change (#3712)</li>
-  <li>Fix logger npe (#3711)</li>
-  <li>Integration test update (#3710)</li>
-  <li>Fix highlighting of project descriptions (#3709)</li>
-  <li>Re-enable tests on the bots (#3702)</li>
-  <li>Update the flutter error display (#3682)</li>
-  <li>Relabel 'samples'to 'widget samples' (#3701)</li>
-  <li>Address some issues with blocking the EDT thread in 2019.2 (#3700)</li>
-  <li>Remove the web/desktop user preference (#3698)</li>
-  <li>Fix the logging tests (#3699)</li>
-  <li>Use DAS test annotations to flag runnable tests (#3662)</li>
-  <li>Add short-lived prompt for Q3 user survey (#3691)</li>
-  <li>Add a user preference to opt-in to showing structured errors (#3692)</li>
-  <li>Add target platform selector for togglePlatform service extension (#3688)</li>
-  <li>Update the widgets.json catalog file (#3687)</li>
-  <li>Restore stack traces in generated error reports (#3685)</li>
-  <li>Make the event stream tests pass and re-enable them (#3684)</li>
-  <li>Init default settings for the run console text wrapping (#3661)</li>
-  <li>Send flutter.error analytics (#3659)</li>
-  <li>Remove extra console whitespace (#3660)</li>
-  <li>Fix an issue with some daemon json output appearing in the console (#3658)</li>
-  <li>Initial work on displaying Flutter.Error events (#3644)</li>
-  <li>Show truncated logging messages (#3641)</li>
-  <li>Name the Bazel test config factories to match assumed names in g3 (#3636)</li>
-  <li>Remove no longer used functionality related to restart warnings (#3645)</li>
-  <li>Fix per SDK Stream<Uint8List> breaking changes (#3640)</li>
-  <li>Fix New Pproject Wizard (#3631)</li>
-  <li>Adjust the text for the desktop/web device preference (#3629)</li>
-  <li>Issue 3615. Fix message for 'Remove widget' (#3622)</li>
-  <li>Support showing desktop and web devices (#3618)</li>
+<li>Add AndroidX option to new project wizards (#3705)</li>
+<li>Fix break due to Android Studio 3.6 API change (#3712)</li>
+<li>Fix logger npe (#3711)</li>
+<li>Integration test update (#3710)</li>
+<li>Fix highlighting of project descriptions (#3709)</li>
+<li>Re-enable tests on the bots (#3702)</li>
+<li>Update the flutter error display (#3682)</li>
+<li>Relabel 'samples'to 'widget samples' (#3701)</li>
+<li>Address some issues with blocking the EDT thread in 2019.2 (#3700)</li>
+<li>Remove the web/desktop user preference (#3698)</li>
+<li>Fix the logging tests (#3699)</li>
+<li>Use DAS test annotations to flag runnable tests (#3662)</li>
+<li>Add short-lived prompt for Q3 user survey (#3691)</li>
+<li>Add a user preference to opt-in to showing structured errors (#3692)</li>
+<li>Add target platform selector for togglePlatform service extension (#3688)</li>
+<li>Update the widgets.json catalog file (#3687)</li>
+<li>Restore stack traces in generated error reports (#3685)</li>
+<li>Make the event stream tests pass and re-enable them (#3684)</li>
+<li>Init default settings for the run console text wrapping (#3661)</li>
+<li>Send flutter.error analytics (#3659)</li>
+<li>Remove extra console whitespace (#3660)</li>
+<li>Fix an issue with some daemon json output appearing in the console (#3658)</li>
+<li>Initial work on displaying Flutter.Error events (#3644)</li>
+<li>Show truncated logging messages (#3641)</li>
+<li>Name the Bazel test config factories to match assumed names in g3 (#3636)</li>
+<li>Remove no longer used functionality related to restart warnings (#3645)</li>
+<li>Fix per SDK Stream<Uint8List> breaking changes (#3640)</li>
+<li>Fix New Pproject Wizard (#3631)</li>
+<li>Adjust the text for the desktop/web device preference (#3629)</li>
+<li>Issue 3615. Fix message for 'Remove widget' (#3622)</li>
+<li>Support showing desktop and web devices (#3618)</li>
 </ul>
 <h2>37.0</h2>
 <ul>
-  <li>Fix an offset issue with the UI guides code (#3574)</li>
-  <li>Add IDE query param to DevTools url. (#3592)</li>
-  <li>Treat FlutterApp as a long-running process (#3599)</li>
-  <li>Fix links for test URLs (#3600)</li>
+<li>Fix an offset issue with the UI guides code (#3574)</li>
+<li>Add IDE query param to DevTools url. (#3592)</li>
+<li>Treat FlutterApp as a long-running process (#3599)</li>
+<li>Fix links for test URLs (#3600)</li>
 </ul>
 <h2>36.0</h2>
 <ul>
-  <li>Add Gradle build script (#3529)</li>
-  <li>Update for new platform releases (#3527)</li>
-  <li>Add in a preference to toggle closing labels (#3528)</li>
-  <li>Don't disable closing labels as part of UI Guides (#3525)</li>
-  <li>Enable devtools launching from Bazel (#3511)</li>
-  <li>Guard against null project basedir (#3524)</li>
-  <li>Change DeviceDaemon to show a detailed error when it fails too many times. (#3513)</li>
-  <li>Add an inline run menu option to run or watch Bazel Flutter tests (#3507)</li>
-  <li>Make the save dialog refer to the save all action, not the save action (#3505)</li>
-  <li>Introduce an opt-in detailed test runner for Bazel tests (#3451)</li>
-  <li>Remove the android studio specific memory view (#3497)</li>
-  <li>Limit the amount of time we wait for a graceful app shutdown (#3490)</li>
-  <li>Mark the device daemon process as a background process (#3488)</li>
-  <li>Fix errors in AS 3.5 beta 1 (#3487)</li>
-  <li>Remove the preview view from the flutter outline view (#3481)</li>
-  <li>Remove a println in WidgetIndentsHighlightingPass.java (#3468)</li>
-  <li>Fix an npe from the FlutterErrorReportSubmitter.java class (#3469)</li>
-  <li>Handle notifications when a project has been disposed more gracefully. (#3472)</li>
-  <li>Fix two bugs for widget guide outlines. (#3470)</li>
+<li>Add Gradle build script (#3529)</li>
+<li>Update for new platform releases (#3527)</li>
+<li>Add in a preference to toggle closing labels (#3528)</li>
+<li>Don't disable closing labels as part of UI Guides (#3525)</li>
+<li>Enable devtools launching from Bazel (#3511)</li>
+<li>Guard against null project basedir (#3524)</li>
+<li>Change DeviceDaemon to show a detailed error when it fails too many times. (#3513)</li>
+<li>Add an inline run menu option to run or watch Bazel Flutter tests (#3507)</li>
+<li>Make the save dialog refer to the save all action, not the save action (#3505)</li>
+<li>Introduce an opt-in detailed test runner for Bazel tests (#3451)</li>
+<li>Remove the android studio specific memory view (#3497)</li>
+<li>Limit the amount of time we wait for a graceful app shutdown (#3490)</li>
+<li>Mark the device daemon process as a background process (#3488)</li>
+<li>Fix errors in AS 3.5 beta 1 (#3487)</li>
+<li>Remove the preview view from the flutter outline view (#3481)</li>
+<li>Remove a println in WidgetIndentsHighlightingPass.java (#3468)</li>
+<li>Fix an npe from the FlutterErrorReportSubmitter.java class (#3469)</li>
+<li>Handle notifications when a project has been disposed more gracefully. (#3472)</li>
+<li>Fix two bugs for widget guide outlines. (#3470)</li>
 </ul>
 <h2>35.1.3</h2>
 <ul>
-  <li>Support IntelliJ 2019.1.2 RC</li>
-  <li>Support Android Studio 3.5 beta 1</li>
-  <li>Bug fixes</li>
+<li>Support IntelliJ 2019.1.2 RC</li>
+<li>Support Android Studio 3.5 beta 1</li>
+<li>Bug fixes</li>
 </ul>
 <h2>35.1</h2>
 <ul>
-  <li>Add an option to hide closing labels in Dart source code when UI guides are on (#3438)</li>
-  <li>Create "Editor" section of Flutter Settings (#3434)</li>
-  <li>Support UI as Code Widget Guides (#3420)</li>
-  <li>Add checkbox to skip the dart analyzer error check before a hot reload (#3414)</li>
-  <li>Remove the option to disable the memory view from the settings (#3408)</li>
-  <li>Track API changes (#3427)</li>
+<li>Add an option to hide closing labels in Dart source code when UI guides are on (#3438)</li>
+<li>Create "Editor" section of Flutter Settings (#3434)</li>
+<li>Support UI as Code Widget Guides (#3420)</li>
+<li>Add checkbox to skip the dart analyzer error check before a hot reload (#3414)</li>
+<li>Remove the option to disable the memory view from the settings (#3408)</li>
+<li>Track API changes (#3427)</li>
 </ul>
 <h2>35.0</h2>
 <ul>
-  <li>Sample panel layout improvements (#3396)</li>
-  <li>Remove unneeded logging (#3394)</li>
-  <li>Java analysis lints cleanup (#3395)</li>
-  <li>Update subscriptions after analysis server restart (#3393)</li>
-  <li>Read sample index from flutter_tool call (#3379)</li>
-  <li>Update README (#3387)</li>
-  <li>Fix unit tests</li>
-  <li>Update build for canary 11 (#3380)</li>
-  <li>Integration test update (#3374)</li>
-  <li>Make the inspector easier to test (#3373)</li>
-  <li>Adjust build to make plugin for testing (#3366)</li>
-  <li>Address reported Java lints (#3356)</li>
-  <li>Adjust build for AS canary 10</li>
-  <li>Address an array index out of bounds (#3355)</li>
-  <li>Address an NPE (#3354)</li>
-  <li>Upgrade the service protocol library (#3353)</li>
-  <li>Address a number format exception (#3352)</li>
-  <li>Update how we manipulate the service protocol url (#3351)</li>
-  <li>Remove some uses of reflection (#3350)</li>
-  <li>Some initial work for FlutterWeb apps (#3342)</li>
-  <li>Fix an NPE when sample content generation is disabled (#3336)</li>
-  <li>Add inspector dependency to test (#3316)</li>
-  <li>Make Dart constructor calls pop out in light mode  (#3327)</li>
+<li>Sample panel layout improvements (#3396)</li>
+<li>Remove unneeded logging (#3394)</li>
+<li>Java analysis lints cleanup (#3395)</li>
+<li>Update subscriptions after analysis server restart (#3393)</li>
+<li>Read sample index from flutter_tool call (#3379)</li>
+<li>Update README (#3387)</li>
+<li>Fix unit tests</li>
+<li>Update build for canary 11 (#3380)</li>
+<li>Integration test update (#3374)</li>
+<li>Make the inspector easier to test (#3373)</li>
+<li>Adjust build to make plugin for testing (#3366)</li>
+<li>Address reported Java lints (#3356)</li>
+<li>Adjust build for AS canary 10</li>
+<li>Address an array index out of bounds (#3355)</li>
+<li>Address an NPE (#3354)</li>
+<li>Upgrade the service protocol library (#3353)</li>
+<li>Address a number format exception (#3352)</li>
+<li>Update how we manipulate the service protocol url (#3351)</li>
+<li>Remove some uses of reflection (#3350)</li>
+<li>Some initial work for FlutterWeb apps (#3342)</li>
+<li>Fix an NPE when sample content generation is disabled (#3336)</li>
+<li>Add inspector dependency to test (#3316)</li>
+<li>Make Dart constructor calls pop out in light mode  (#3327)</li>
 </ul>
 <h2>34.0</h2>
 <ul>
-  <li>Update build for Android Studio 3.3.2 and IntelliJ 2019.1 (#3321)</li>
-  <li>Fix issue preventing plugin from working in AS Canary 8 (#3321)</li>
-  <li>Provides a better display if the variable has a <code>toStringDeep()</code> method defined. (#3291)</li>
-  <li>Don't show a background square in the inspector summary tree. (#3326)</li>
-  <li>Make FlutterModuleUtils consistently robust to disposed projects. (#3323)</li>
-  <li>Fix NPE issue sometimes hit evaluating expressions. (#3324)</li>
-  <li>Fix widget names. (#3322)</li>
-  <li>Make Perf and Inspector views only display when a Flutter app is being debugged. (#3320)</li>
-  <li>Support the inspector for flutter_web libraries. (#3310)</li>
-  <li>Detect when integrations tests are running (#3308)</li>
-  <li>Add in support for reloading and restarting all running apps (#3268)</li>
-  <li>Log tree path selection fixes (#3302)</li>
-  <li>Throttle logger updates (#3280)</li>
-  <li>New method in FlutterUtils: declaresFlutterWeb, this method checks for dependencies: fluttler_web in a pubspec file. (#3275)</li>
-  <li>Update a comment in FlutterSaveActionsManager (#3277)</li>
-  <li>Remove the second parameter (the Project) from SdkFields constructor, it isn't used anymore. (#3261)</li>
-  <li>Add a comment to a recent change (#3267)</li>
-  <li>Fix a file handle leak (#3264)</li>
-  <li>Port inferPubRootDirectoryIfNeeded from devtools (#3242)</li>
-  <li>Add support for matching customized Widget tests. (#3249)</li>
-  <li>Hide DevTools debugger when launching from IntelliJ. (#3252)</li>
-  <li>Migrate to GearPlain (#3248)</li>
-  <li>Minor cleanup (#3247)</li>
-  <li>Inline sample index reading (#3245)</li>
-  <li>Make a newer daemon protocol field optional (#3230)</li>
-  <li>Link to the plugins readme file from the building instructions. (#3222)</li>
+<li>Update build for Android Studio 3.3.2 and IntelliJ 2019.1 (#3321)</li>
+<li>Fix issue preventing plugin from working in AS Canary 8 (#3321)</li>
+<li>Provides a better display if the variable has a <code>toStringDeep()</code> method defined. (#3291)</li>
+<li>Don't show a background square in the inspector summary tree. (#3326)</li>
+<li>Make FlutterModuleUtils consistently robust to disposed projects. (#3323)</li>
+<li>Fix NPE issue sometimes hit evaluating expressions. (#3324)</li>
+<li>Fix widget names. (#3322)</li>
+<li>Make Perf and Inspector views only display when a Flutter app is being debugged. (#3320)</li>
+<li>Support the inspector for flutter_web libraries. (#3310)</li>
+<li>Detect when integrations tests are running (#3308)</li>
+<li>Add in support for reloading and restarting all running apps (#3268)</li>
+<li>Log tree path selection fixes (#3302)</li>
+<li>Throttle logger updates (#3280)</li>
+<li>New method in FlutterUtils: declaresFlutterWeb, this method checks for dependencies: fluttler_web in a pubspec file. (#3275)</li>
+<li>Update a comment in FlutterSaveActionsManager (#3277)</li>
+<li>Remove the second parameter (the Project) from SdkFields constructor, it isn't used anymore. (#3261)</li>
+<li>Add a comment to a recent change (#3267)</li>
+<li>Fix a file handle leak (#3264)</li>
+<li>Port inferPubRootDirectoryIfNeeded from devtools (#3242)</li>
+<li>Add support for matching customized Widget tests. (#3249)</li>
+<li>Hide DevTools debugger when launching from IntelliJ. (#3252)</li>
+<li>Migrate to GearPlain (#3248)</li>
+<li>Minor cleanup (#3247)</li>
+<li>Inline sample index reading (#3245)</li>
+<li>Make a newer daemon protocol field optional (#3230)</li>
+<li>Link to the plugins readme file from the building instructions. (#3222)</li>
 </ul>
 <h2>33.3</h2>
 <ul>
-  <li>Fix an issue with an IllegalArgumentException when running Flutter apps</li>
+<li>Fix an issue with an IllegalArgumentException when running Flutter apps</li>
 </ul>
 <h2>33.2</h2>
 <ul>
-  <li>Support IntelliJ 2018.3.3</li>
+<li>Support IntelliJ 2018.3.3</li>
 </ul>
 <h2>33.1</h2>
 <ul>
-  <li>add menu and toolbar button to open Flutter DevTools</li>
-  <li>fix Gradle sync issue for Android Studio 3.3.1</li>
-  <li>fix highlighting of the Go link in sample banner</li>
+<li>add menu and toolbar button to open Flutter DevTools</li>
+<li>fix Gradle sync issue for Android Studio 3.3.1</li>
+<li>fix highlighting of the Go link in sample banner</li>
 </ul>
 <h2>33.0</h2>
 <ul>
-  <li>update build for Android Studio 3.3.1</li>
-  <li>reorder console filters so links work</li>
-  <li>more intelligently enable support for detaching from Flutter apps on exit</li>
-  <li>change the icon used for paint baselines</li>
-  <li>prevent bazel test run configurations from generating in a non-bazel workspace</li>
-  <li>support 2019.1 eap</li>
-  <li>mention 'Dart' in the plugin description</li>
-  <li>correct the bazel output for debugging bazel tests</li>
-  <li>simplify the bazel parameters we pass to Bazel Run configurations</li>
-  <li>pin flutter error events in the log</li>
-  <li>propagate node selections to inspector</li>
-  <li>link support for log data entries</li>
-  <li>fix category cell rendering</li>
-  <li>add sample creation banner</li>
-  <li>add sample apps to Android Studio New Project Wizard</li>
-  <li>update log entry data badge</li>
+<li>update build for Android Studio 3.3.1</li>
+<li>reorder console filters so links work</li>
+<li>more intelligently enable support for detaching from Flutter apps on exit</li>
+<li>change the icon used for paint baselines</li>
+<li>prevent bazel test run configurations from generating in a non-bazel workspace</li>
+<li>support 2019.1 eap</li>
+<li>mention 'Dart' in the plugin description</li>
+<li>correct the bazel output for debugging bazel tests</li>
+<li>simplify the bazel parameters we pass to Bazel Run configurations</li>
+<li>pin flutter error events in the log</li>
+<li>propagate node selections to inspector</li>
+<li>link support for log data entries</li>
+<li>fix category cell rendering</li>
+<li>add sample creation banner</li>
+<li>add sample apps to Android Studio New Project Wizard</li>
+<li>update log entry data badge</li>
 </ul>
 <h2>32.0</h2>
 <ul>
-  <li>address an NPE in FlutterWidgetPerfManager.java</li>
-  <li>added overlay renderered for GC, snapshot and memory reset events</li>
-  <li>consolidated all adt-ui API changes in FlutterStudioMonitorStageView</li>
-  <li>support for creating projects w/ sample content from the IDEA New Project Wizard</li>
-  <li>basic ansi color support for entries in the Flutter Logging View</li>
-  <li>restore log level combo to the Logging View</li>
-  <li>support to fill in truncated log entries</li>
-  <li>add keyboard shortcut for widget extraction</li>
-  <li>add debugPaint and debugAllowBanner icons</li>
-  <li>add repaint rainbow icon</li>
-  <li>handle cases where script.tokenPosTable is null</li>
-  <li>auto-hide details pane</li>
-  <li>guard against disposed when querying project type</li>
-  <li>fix an issue with escaped test names</li>
-  <li>refactor service extensions and set button text based on extension state</li>
-  <li>shorten message for debug mode perf disclaimer</li>
-  <li>listen for ServiceExtensionStateChanged events</li>
-  <li>restore service extension states from device on start and attach</li>
-  <li>don't use LOG.error()</li>
-  <li>refactor the Bazel Test configuration to support running tests on a single file or a single test</li>
-  <li>fix enabled/disabled text for service extensions</li>
-  <li>fix NPE in bazel config</li>
+<li>address an NPE in FlutterWidgetPerfManager.java</li>
+<li>added overlay renderered for GC, snapshot and memory reset events</li>
+<li>consolidated all adt-ui API changes in FlutterStudioMonitorStageView</li>
+<li>support for creating projects w/ sample content from the IDEA New Project Wizard</li>
+<li>basic ansi color support for entries in the Flutter Logging View</li>
+<li>restore log level combo to the Logging View</li>
+<li>support to fill in truncated log entries</li>
+<li>add keyboard shortcut for widget extraction</li>
+<li>add debugPaint and debugAllowBanner icons</li>
+<li>add repaint rainbow icon</li>
+<li>handle cases where script.tokenPosTable is null</li>
+<li>auto-hide details pane</li>
+<li>guard against disposed when querying project type</li>
+<li>fix an issue with escaped test names</li>
+<li>refactor service extensions and set button text based on extension state</li>
+<li>shorten message for debug mode perf disclaimer</li>
+<li>listen for ServiceExtensionStateChanged events</li>
+<li>restore service extension states from device on start and attach</li>
+<li>don't use LOG.error()</li>
+<li>refactor the Bazel Test configuration to support running tests on a single file or a single test</li>
+<li>fix enabled/disabled text for service extensions</li>
+<li>fix NPE in bazel config</li>
 </ul>
 <h2>31.3</h2>
 <ul>
-  <li>fix NPE in sdk installation (#2965)</li>
-  <li>fix NPE caused by internal inconsistency (#2963)</li>
+<li>fix NPE in sdk installation (#2965)</li>
+<li>fix NPE caused by internal inconsistency (#2963)</li>
 </ul>
 <h2>31.2</h2>
 <ul>
-  <li>show memory profiler legend with proper line chart color or line style</li>
-  <li>prevent the (IntelliJ) New Project wizard from completing when there is no Flutter SDK</li>
-  <li>fix a race condition causing unexpected conditions in attach</li>
-  <li>added control of RSS display to memory profiler</li>
-  <li>when running the flutter doctor command, use the -v flag</li>
-  <li>make attach use selected device</li>
+<li>show memory profiler legend with proper line chart color or line style</li>
+<li>prevent the (IntelliJ) New Project wizard from completing when there is no Flutter SDK</li>
+<li>fix a race condition causing unexpected conditions in attach</li>
+<li>added control of RSS display to memory profiler</li>
+<li>when running the flutter doctor command, use the -v flag</li>
+<li>make attach use selected device</li>
 </ul>
 <h2>31.1</h2>
 <ul>
-  <li>perf table polish and fix links to tip docs</li>
-  <li>fix Split Mode resize issue</li>
-  <li>rebuild stats wording tweaks</li>
+<li>perf table polish and fix links to tip docs</li>
+<li>fix Split Mode resize issue</li>
+<li>rebuild stats wording tweaks</li>
 </ul>
 <h2>31.0</h2>
 <ul>
-  <li>change FPS display to "Frame Rendering Time" and improve UI</li>
-  <li>reorganize inspector tools</li>
-  <li>better error reporting for Flutter runtime issues</li>
-  <li>fewer Flutter runtime issues</li>
-  <li>updated icons for Material and Cupertino</li>
-  <li>searchable preferences/settings</li>
-  <li>added refactoring to outline view: extract widget</li>
-  <li>new menu item to run 'flutter make-host-app-editable'</li>
-  <li>code cleanup and bug fixes</li>
+<li>change FPS display to "Frame Rendering Time" and improve UI</li>
+<li>reorganize inspector tools</li>
+<li>better error reporting for Flutter runtime issues</li>
+<li>fewer Flutter runtime issues</li>
+<li>updated icons for Material and Cupertino</li>
+<li>searchable preferences/settings</li>
+<li>added refactoring to outline view: extract widget</li>
+<li>new menu item to run 'flutter make-host-app-editable'</li>
+<li>code cleanup and bug fixes</li>
 </ul>
 <h2>30.0</h2>
 <ul>
-  <li>performance inspector changes</li>
-  <li>log view tweaks</li>
-  <li>memory profiler updates</li>
-  <li>support 'flutter attach' in the IDE (both IJ and AS)</li>
-  <li>support offline project creation in the AS wizard</li>
-  <li>code cleanup and bug fixes</li>
+<li>performance inspector changes</li>
+<li>log view tweaks</li>
+<li>memory profiler updates</li>
+<li>support 'flutter attach' in the IDE (both IJ and AS)</li>
+<li>support offline project creation in the AS wizard</li>
+<li>code cleanup and bug fixes</li>
 </ul>
 <h2>29.1</h2>
 <ul>
-  <li>address an issue with an NPE when debugging</li>
+<li>address an issue with an NPE when debugging</li>
 </ul>
 <h2>29.0</h2>
 <ul>
-  <li>add 'Wrap with Container' to preview</li>
-  <li>fix test navigation</li>
-  <li>clear log on restart</li>
-  <li>experimental memory profiler; enable in preferences</li>
-  <li>build for 2018.3 EAP</li>
-  <li>bug fixes</li>
+<li>add 'Wrap with Container' to preview</li>
+<li>fix test navigation</li>
+<li>clear log on restart</li>
+<li>experimental memory profiler; enable in preferences</li>
+<li>build for 2018.3 EAP</li>
+<li>bug fixes</li>
 </ul>
 <h2>28.0</h2>
 <ul>
-  <li>build for Android Studio 3.3 Canary and 3.2 Beta</li>
-  <li>add UI support for importing Flutter modules into Android apps</li>
-  <li>add more details to logging output</li>
-  <li>bug fixes</li>
+<li>build for Android Studio 3.3 Canary and 3.2 Beta</li>
+<li>add UI support for importing Flutter modules into Android apps</li>
+<li>add more details to logging output</li>
+<li>bug fixes</li>
 </ul>
 <h2>27.1</h2>
 <ul>
-  <li>change the preference for --track-widget-creation to default to off</li>
+<li>change the preference for --track-widget-creation to default to off</li>
 </ul>
 <h2>27.0</h2>
 <ul>
-  <li>add a setting to control syncing Android libraries</li>
-  <li>fixes related to evaluating expressions when not on a call frame</li>
-  <li>auto-disable scroll to end when the user manually scrolls the log up</li>
-  <li>add the "module" template to new-module and project wizards in Android Studio</li>
-  <li>improve copy / paste in the Logging View</li>
-  <li>some tweaks to the open in Android Studio functionality</li>
-  <li>validate android package names</li>
-  <li>add Android module libraries to Flutter projects</li>
-  <li>validate org in the project wizard</li>
-  <li>default log coloring to on and update logger defaults</li>
-  <li>fix log entry browser links</li>
-  <li>support hyperlinks in flutter console log</li>
-  <li>add InheritedWidget and Stateful Widget with Animation live templates</li>
-  <li>lower case the log level names</li>
+<li>add a setting to control syncing Android libraries</li>
+<li>fixes related to evaluating expressions when not on a call frame</li>
+<li>auto-disable scroll to end when the user manually scrolls the log up</li>
+<li>add the "module" template to new-module and project wizards in Android Studio</li>
+<li>improve copy / paste in the Logging View</li>
+<li>some tweaks to the open in Android Studio functionality</li>
+<li>validate android package names</li>
+<li>add Android module libraries to Flutter projects</li>
+<li>validate org in the project wizard</li>
+<li>default log coloring to on and update logger defaults</li>
+<li>fix log entry browser links</li>
+<li>support hyperlinks in flutter console log</li>
+<li>add InheritedWidget and Stateful Widget with Animation live templates</li>
+<li>lower case the log level names</li>
 </ul>
 <h2>26.0</h2>
 <ul>
-  <li>updates to support Android Studio 3.2 Beta</li>
-  <li>removes the Inspector's empty content message</li>
-  <li>support setting log color from flutter log settings page</li>
-  <li>support hiding/showing log categories (#2398)</li>
-  <li>add flutter log color settings page (#2394)</li>
-  <li>change the default for the open inspector setting</li>
-  <li>look for the emulator tool in the 'emulator/' directory first (#2383)</li>
-  <li>support filtering by log level (#2380)</li>
-  <li>fix the flutter log view while resizing (#2379)</li>
-  <li>log entry coloring (#2382)</li>
-  <li>log tree rendering refactor (#2381)</li>
-  <li>for BazelRunConfig launches, print the command-line to the console (#2368)</li>
-  <li>refactor the Flutter debugging client code (#2359)</li>
-  <li>support match case/regex filter in log view (#2350)</li>
-  <li>fix auto-scroll to catch up to fully rendered log tree (#2342)</li>
-  <li>use the log category name from the dart:developer event (#2339)</li>
-  <li>fix-up missing create project mnemonics (#2326)</li>
-  <li>handle reload errors (#2321)</li>
-  <li>fixes for the native editor banner</li>
+<li>updates to support Android Studio 3.2 Beta</li>
+<li>removes the Inspector's empty content message</li>
+<li>support setting log color from flutter log settings page</li>
+<li>support hiding/showing log categories (#2398)</li>
+<li>add flutter log color settings page (#2394)</li>
+<li>change the default for the open inspector setting</li>
+<li>look for the emulator tool in the 'emulator/' directory first (#2383)</li>
+<li>support filtering by log level (#2380)</li>
+<li>fix the flutter log view while resizing (#2379)</li>
+<li>log entry coloring (#2382)</li>
+<li>log tree rendering refactor (#2381)</li>
+<li>for BazelRunConfig launches, print the command-line to the console (#2368)</li>
+<li>refactor the Flutter debugging client code (#2359)</li>
+<li>support match case/regex filter in log view (#2350)</li>
+<li>fix auto-scroll to catch up to fully rendered log tree (#2342)</li>
+<li>use the log category name from the dart:developer event (#2339)</li>
+<li>fix-up missing create project mnemonics (#2326)</li>
+<li>handle reload errors (#2321)</li>
+<li>fixes for the native editor banner</li>
 </ul>
 <h2>25.0</h2>
 <ul>
-  <li>remove the user preference to disable --preview-dart-2</li>
-  <li>don't use 'new' for the stless, stfull, stanim templates</li>
-  <li>add support for IntelliJ 2018.2 EAP (#2270)</li>
-  <li>added a new (very experimental) logging view</li>
-  <li>update the extract widget refactoring visibility (#2251)</li>
-  <li>launch a simulator device if none is running (#2234)</li>
-  <li>improvements to the preview view on Windows (#2239)</li>
-  <li>open the selected file for editing when opening a new project (#2236)</li>
-  <li>open selected file when launching Android Studio (#2230)</li>
-  <li>add a command bar to editors that can open in a native-code editor (#2216)</li>
-  <li>rename full restart to hot restart (#2225)</li>
+<li>remove the user preference to disable --preview-dart-2</li>
+<li>don't use 'new' for the stless, stfull, stanim templates</li>
+<li>add support for IntelliJ 2018.2 EAP (#2270)</li>
+<li>added a new (very experimental) logging view</li>
+<li>update the extract widget refactoring visibility (#2251)</li>
+<li>launch a simulator device if none is running (#2234)</li>
+<li>improvements to the preview view on Windows (#2239)</li>
+<li>open the selected file for editing when opening a new project (#2236)</li>
+<li>open selected file when launching Android Studio (#2230)</li>
+<li>add a command bar to editors that can open in a native-code editor (#2216)</li>
+<li>rename full restart to hot restart (#2225)</li>
 </ul>
 <h2>24.2</h2>
 <ul>
-  <li>fix the --track-widget-creation flag implementation on Windows</li>
-  <li>fix for an exception in the Outline view on older Flutter SDKs</li>
+<li>fix the --track-widget-creation flag implementation on Windows</li>
+<li>fix for an exception in the Outline view on older Flutter SDKs</li>
 </ul>
 <h2>24.1</h2>
 <ul>
-  <li>update Flutter icons</li>
-  <li>fix an exception when the selection changes and the outline view isn't visible</li>
-  <li>fix for an issue with reload on save in profile runs</li>
-  <li>fix for a 2017.3 issue with a 'no running apps' message in the inspector</li>
+<li>update Flutter icons</li>
+<li>fix an exception when the selection changes and the outline view isn't visible</li>
+<li>fix for an issue with reload on save in profile runs</li>
+<li>fix for a 2017.3 issue with a 'no running apps' message in the inspector</li>
 </ul>
 <h2>24.0</h2>
 <ul>
-  <li><p>inspector: significant UI refactoring to show the tree in a master / details format</p></li>
-  <li><p>inspector: add a 'Performance' tab to the Inspector, to show application FPS and memory usage</p></li>
-  <li><p>inspector: fix issues turning --track-widget-creation on and off</p></li>
-  <li><p>inspector: handle apps with multiple isolates in the inspector</p></li>
-  <li><p>live preview: suggest 'Add forDesignTime() constructor' for widgets</p></li>
-  <li><p>live preview: make the preview area smaller if the widget is not renderable</p></li>
-  <li><p>live preview: fixes to make outline preview working on Windows</p></li>
-  <li><p>live preview: sort children outlines by their RenderObject.depth during preview</p></li>
-  <li><p>simplify how we recognize Flutter projects when using Bazel</p></li>
-  <li><p>fix the "Open in Android Studio" action to not show for the ios dir</p></li>
-  <li><p>add an option to create projects in “offline” mode</p></li>
-  <li><p>better support for using multiple Flutter modules per IntelliJ project</p></li>
-  <li><p>improvments to the "Open in XCode…" menu item</p></li>
-  <li><p>better support for importing Flutter projects</p></li>
-  <li><p>several fixes for issues with using resources that had been disposed</p></li>
-  <li><p>add local history labels on reloads and restarts</p></li>
-  <li><p>have the 'reloading...'' notification timeout after the reload completes</p></li>
-  <li><p>improved support of running in --profile mode</p></li>
-  <li><p>expose the new 'Extract Widget' refactoring</p></li>
+<li>inspector: significant UI refactoring to show the tree in a master / details format</li>
+<li>inspector: add a 'Performance' tab to the Inspector, to show application FPS and memory usage</li>
+<li>inspector: fix issues turning --track-widget-creation on and off</li>
+<li>inspector: handle apps with multiple isolates in the inspector</li>
+<li>live preview: suggest 'Add forDesignTime() constructor' for widgets</li>
+<li>live preview: make the preview area smaller if the widget is not renderable</li>
+<li>live preview: fixes to make outline preview working on Windows</li>
+<li>live preview: sort children outlines by their RenderObject.depth during preview</li>
+<li>simplify how we recognize Flutter projects when using Bazel</li>
+<li>fix the "Open in Android Studio" action to not show for the ios dir</li>
+<li>add an option to create projects in “offline” mode</li>
+<li>better support for using multiple Flutter modules per IntelliJ project</li>
+<li>improvments to the "Open in XCode…" menu item</li>
+<li>better support for importing Flutter projects</li>
+<li>several fixes for issues with using resources that had been disposed</li>
+<li>add local history labels on reloads and restarts</li>
+<li>have the 'reloading...'' notification timeout after the reload completes</li>
+<li>improved support of running in --profile mode</li>
+<li>expose the new 'Extract Widget' refactoring</li>
 </ul>
 <h2>23.2</h2>
 <ul>
-  <li>updated some Bazel breakpoint logic</li>
+<li>updated some Bazel breakpoint logic</li>
 </ul>
 <h2>23.1</h2>
 <ul>
-  <li>disabled an Android facet's ALLOW_USER_CONFIGURATION setting, to address a continuous indexing issue</li>
+<li>disabled an Android facet's ALLOW_USER_CONFIGURATION setting, to address a continuous indexing issue</li>
 </ul>
 <h2>23.0</h2>
 <ul>
-  <li>outline view: removed the experimental flag</li>
-  <li>outline view: filter the outline view to only show widgets by default</li>
-  <li>inspector: several stability and polish improvements</li>
-  <li>inspector: now supports inspecting multiple running apps at the same time</li>
-  <li>we now show material icons and colors in code completion (requires 2017.3 or AS 3.1)</li>
-  <li>running and debugging flutter test adding for Bazel launch configurations</li>
-  <li>added an 'Extract method' refactoring</li>
-  <li>the preview dart 2 flag can now accept the SDK default, be set to on, or set to off</li>
-  <li>Android Studio: we now support 3.1</li>
-  <li>Android Studio: fixed an issue where Android Studio was indexing frequently</li>
-  <li>experimental: added a live sparkline of the app's memory usage</li>
-  <li>experimental: added a live preview area in the Outline view</li>
-  <li>experimental: added the ability to format (and organize imports) on save</li>
+<li>outline view: removed the experimental flag</li>
+<li>outline view: filter the outline view to only show widgets by default</li>
+<li>inspector: several stability and polish improvements</li>
+<li>inspector: now supports inspecting multiple running apps at the same time</li>
+<li>we now show material icons and colors in code completion (requires 2017.3 or AS 3.1)</li>
+<li>running and debugging flutter test adding for Bazel launch configurations</li>
+<li>added an 'Extract method' refactoring</li>
+<li>the preview dart 2 flag can now accept the SDK default, be set to on, or set to off</li>
+<li>Android Studio: we now support 3.1</li>
+<li>Android Studio: fixed an issue where Android Studio was indexing frequently</li>
+<li>experimental: added a live sparkline of the app's memory usage</li>
+<li>experimental: added a live preview area in the Outline view</li>
+<li>experimental: added the ability to format (and organize imports) on save</li>
 </ul>
 <h2>22.2</h2>
 <ul>
-  <li>when installing the Flutter SDK, use the 'beta' channel instead of 'dev'</li>
+<li>when installing the Flutter SDK, use the 'beta' channel instead of 'dev'</li>
 </ul>
 <h2>22.1</h2>
 <ul>
-  <li>when installing the Flutter SDK, use the 'dev' channel instead of 'alpha'</li>
-  <li>fix an issue with the Flutter Outline view on Windows</li>
+<li>when installing the Flutter SDK, use the 'dev' channel instead of 'alpha'</li>
+<li>fix an issue with the Flutter Outline view on Windows</li>
 </ul>
-<h2>22.0</h2>
-<p>inspector view:</p><ul>
-  <li>support for multiple running applications</li>
-  <li>basic speed search for the Inspector Tree</li>
-  <li>restore flutter framework toggles after a restart</li>
-  <li>expose the observatory timeline view (the dashboard version) (#1744)</li>
-  <li>live update of property values triggered each time a flutter frame is drawn. (#1721)</li>
-  <li>enum property support and tweaks to property display. (#1695)</li>
-  <li>HD inspector Widgets (#1682)</li>
-  <li>restore inspector splitter position (#1676)</li>
-  <li>open the inspector view at app launch (#1670)</li>
-</ul>
-<p>outline view:</p><ul>
-  <li>rename 'Add widget padding' assist to 'Add padding' (#1771)</li>
-  <li>bind actions to move widget down/up. (#1768)</li>
-  <li>rename 'Replace with children' to 'Remove widget'. (#1764)</li>
-  <li>add action for 'Replace with children' assist. (#1759)</li>
-  <li>update messages for wrapping with Column/Row. (#1745)</li>
-  <li>add icons and actions for wrapping into Column and Row. (#1743)</li>
-  <li>show build() methods in bold (#1731)</li>
-  <li>associate the Center action with the corresponding Quick Assist. (#1726)</li>
-  <li>navigate from source to Preview view. (#1710)</li>
-  <li>add speed search to the Preview view. (#1696)</li>
-  <li>add basic Flutter Preview view. (#1678)</li>
-</ul>
-<p>platforms:</p><ul>
-  <li>support 2018.1 EAP</li>
-  <li>no longer build for 2017.2</li>
-</ul>
-<p>miscellaneous:</p><ul>
-  <li>fix for displaying the flutter icon for flutter modules</li>
-  <li>fix for issue 1772, Switch Bazel flag for launching apps (#1775)</li>
-  <li>add support for displaying flutter color shades in the editor ruler (#1770)</li>
-  <li>add a flag to enable --preview-dart-2 (#1709)</li>
-  <li>smarts to run <code>flutter build</code> before trying open Xcode (#1373). (#1694)</li>
-  <li>harden error reporting on iOS simulator start failures (#1647). (#1681)</li>
+<h2>22.0</h2>inspector view:<ul>
+<li>support for multiple running applications</li>
+<li>basic speed search for the Inspector Tree</li>
+<li>restore flutter framework toggles after a restart</li>
+<li>expose the observatory timeline view (the dashboard version) (#1744)</li>
+<li>live update of property values triggered each time a flutter frame is drawn. (#1721)</li>
+<li>enum property support and tweaks to property display. (#1695)</li>
+<li>HD inspector Widgets (#1682)</li>
+<li>restore inspector splitter position (#1676)</li>
+<li>open the inspector view at app launch (#1670)</li>
+</ul>outline view:<ul>
+<li>rename 'Add widget padding' assist to 'Add padding' (#1771)</li>
+<li>bind actions to move widget down/up. (#1768)</li>
+<li>rename 'Replace with children' to 'Remove widget'. (#1764)</li>
+<li>add action for 'Replace with children' assist. (#1759)</li>
+<li>update messages for wrapping with Column/Row. (#1745)</li>
+<li>add icons and actions for wrapping into Column and Row. (#1743)</li>
+<li>show build() methods in bold (#1731)</li>
+<li>associate the Center action with the corresponding Quick Assist. (#1726)</li>
+<li>navigate from source to Preview view. (#1710)</li>
+<li>add speed search to the Preview view. (#1696)</li>
+<li>add basic Flutter Preview view. (#1678)</li>
+</ul>platforms:<ul>
+<li>support 2018.1 EAP</li>
+<li>no longer build for 2017.2</li>
+</ul>miscellaneous:<ul>
+<li>fix for displaying the flutter icon for flutter modules</li>
+<li>fix for issue 1772, Switch Bazel flag for launching apps (#1775)</li>
+<li>add support for displaying flutter color shades in the editor ruler (#1770)</li>
+<li>add a flag to enable --preview-dart-2 (#1709)</li>
+<li>smarts to run <code>flutter build</code> before trying open Xcode (#1373). (#1694)</li>
+<li>harden error reporting on iOS simulator start failures (#1647). (#1681)</li>
 </ul>
 <h2>21.2</h2>
 <ul>
-  <li>Fix an NPE when the Flutter SDK version file contains the text 'unknown'</li>
+<li>Fix an NPE when the Flutter SDK version file contains the text 'unknown'</li>
 </ul>
 <h2>21.1</h2>
 <ul>
-  <li>Fix an NPE when reading the Flutter SDK version file</li>
+<li>Fix an NPE when reading the Flutter SDK version file</li>
 </ul>
 <h2>21.0</h2>
 <ul>
-  <li>select an existing config at launch</li>
-  <li>fix test discovery for plugin example tests</li>
-  <li>fix discovery of tests in example subdirs</li>
-  <li>improve pub root detection for flutter tests</li>
-  <li>actionable “restart” debugging console output</li>
-  <li>improve console hyperlinking for local files</li>
-  <li>fix run config autoselection for plugin projects</li>
-  <li>for non-bazel project configurations, don't show the FlutterBazelRunConfigurationType</li>
-  <li>update FlutterViewCondition to be bazel project aware</li>
-  <li>remove the preference for the Inspector view (it's now on by default)</li>
-  <li>rename the Flutter view to Flutter Inspector</li>
-  <li>clean up of the Flutter Inspector View icons</li>
-  <li>show color properties with a nice color swatch icons</li>
-  <li>add a notification for reloaded but not run elements</li>
-  <li>show flutter material icons in the inspector</li>
-  <li>for Bazel launch configurations, update the android_cpu architecture type from armeabi to armeabi-v7a</li>
+<li>select an existing config at launch</li>
+<li>fix test discovery for plugin example tests</li>
+<li>fix discovery of tests in example subdirs</li>
+<li>improve pub root detection for flutter tests</li>
+<li>actionable “restart” debugging console output</li>
+<li>improve console hyperlinking for local files</li>
+<li>fix run config autoselection for plugin projects</li>
+<li>for non-bazel project configurations, don't show the FlutterBazelRunConfigurationType</li>
+<li>update FlutterViewCondition to be bazel project aware</li>
+<li>remove the preference for the Inspector view (it's now on by default)</li>
+<li>rename the Flutter view to Flutter Inspector</li>
+<li>clean up of the Flutter Inspector View icons</li>
+<li>show color properties with a nice color swatch icons</li>
+<li>add a notification for reloaded but not run elements</li>
+<li>show flutter material icons in the inspector</li>
+<li>for Bazel launch configurations, update the android_cpu architecture type from armeabi to armeabi-v7a</li>
 </ul>
 <h2>20.0</h2>
 <ul>
-  <li>improved console filtering</li>
-  <li>improved unit test running support to allow running package:flutter tests</li>
-  <li>improved "Open with Xcode..." logic to work better for plugin projects</li>
-  <li>fixed project creation to properly respect custom creation options (such as target language)</li>
-  <li>fixed an NPE sometimes encountered when deleting projects</li>
+<li>improved console filtering</li>
+<li>improved unit test running support to allow running package:flutter tests</li>
+<li>improved "Open with Xcode..." logic to work better for plugin projects</li>
+<li>fixed project creation to properly respect custom creation options (such as target language)</li>
+<li>fixed an NPE sometimes encountered when deleting projects</li>
 </ul>
 <h2>19.1</h2>
 <ul>
-  <li>Bazel run configuration updates</li>
+<li>Bazel run configuration updates</li>
 </ul>
 <h2>19.0</h2>
 <ul>
-  <li>fixed an issue with reload when multiple project windows are open</li>
-  <li>fixed running Flutter tests in nested groups</li>
-  <li>fixed miscellaneous project wizard issues</li>
-  <li>fix to ensure we don't create Flutter library entries for non-Flutter projects</li>
-  <li>fixed project name validation in the new project creation wizard to be more performant</li>
-  <li>fixed project opening to only open main.dart if no other editors are open</li>
-  <li>fix to limit Flutter icon contributions to Flutter projects</li>
-  <li>reload on save updated to ignore errors in test files</li>
-  <li>IDEA EAP support</li>
-  <li>fix to give restarted apps focus on iOS</li>
-  <li>miscellaneous Android Studio support fixes</li>
-  <li>fixed check for Flutter tests to not mis-identify vanilla Dart tests</li>
-  <li>improved error reporting on project creation failures</li>
+<li>fixed an issue with reload when multiple project windows are open</li>
+<li>fixed running Flutter tests in nested groups</li>
+<li>fixed miscellaneous project wizard issues</li>
+<li>fix to ensure we don't create Flutter library entries for non-Flutter projects</li>
+<li>fixed project name validation in the new project creation wizard to be more performant</li>
+<li>fixed project opening to only open main.dart if no other editors are open</li>
+<li>fix to limit Flutter icon contributions to Flutter projects</li>
+<li>reload on save updated to ignore errors in test files</li>
+<li>IDEA EAP support</li>
+<li>fix to give restarted apps focus on iOS</li>
+<li>miscellaneous Android Studio support fixes</li>
+<li>fixed check for Flutter tests to not mis-identify vanilla Dart tests</li>
+<li>improved error reporting on project creation failures</li>
 </ul>
 <h2>18.4</h2>
 <ul>
-  <li>Revert to 18.1 to address an NPE in the FlutterInitializer class</li>
-  <li>fixed an issue where reload on save could not be disabled</li>
+<li>Revert to 18.1 to address an NPE in the FlutterInitializer class</li>
+<li>fixed an issue where reload on save could not be disabled</li>
 </ul>
 <h2>18.3</h2>
 <ul>
-  <li>fixed a build problem that prevented the Android Studio plugin from creating projects</li>
+<li>fixed a build problem that prevented the Android Studio plugin from creating projects</li>
 </ul>
 <h2>18.2</h2>
 <ul>
-  <li>fixed an issue where reload on save could not be disabled</li>
-  <li>fixed an exception that could occur on project creation</li>
+<li>fixed an issue where reload on save could not be disabled</li>
+<li>fixed an exception that could occur on project creation</li>
 </ul>
 <h2>18.1</h2>
 <ul>
-  <li>fixed hot reload issue when multiple project windows were open</li>
-  <li>fixed 'Open Observatory timeline' action</li>
+<li>fixed hot reload issue when multiple project windows were open</li>
+<li>fixed 'Open Observatory timeline' action</li>
 </ul>
 <h2>18.0</h2>
 <ul>
-  <li>Android Studio support</li>
-  <li>for flutter launches, support passing in a --flavor param</li>
-  <li>reload on save now on by default</li>
-  <li>improved and reorganized the Flutter view's toolbar</li>
-  <li>analysis toast provides a new hyperlink to open the analysis view</li>
-  <li>reloads disallowed while another reload is taking place</li>
-  <li>support to show referenced flutter plugin in the project view</li>
+<li>Android Studio support</li>
+<li>for flutter launches, support passing in a --flavor param</li>
+<li>reload on save now on by default</li>
+<li>improved and reorganized the Flutter view's toolbar</li>
+<li>analysis toast provides a new hyperlink to open the analysis view</li>
+<li>reloads disallowed while another reload is taking place</li>
+<li>support to show referenced flutter plugin in the project view</li>
 </ul>
 <h2>17.0</h2>
 <ul>
-  <li>improved new project wizard</li>
-  <li>improvements to the reload-on-save behavior</li>
-  <li>improved and reorganized the Flutter view's toolbar</li>
-  <li>fixes to the Flutter icon decorations in the editor ruler</li>
-  <li>fixes to group handling for widget tests</li>
-  <li>display a ballon toast if there are analysis issues when running apps</li>
-  <li>added a toggle inspect mode toolbar button</li>
-  <li>speed improvements to the device switcher pulldown</li>
+<li>improved new project wizard</li>
+<li>improvements to the reload-on-save behavior</li>
+<li>improved and reorganized the Flutter view's toolbar</li>
+<li>fixes to the Flutter icon decorations in the editor ruler</li>
+<li>fixes to group handling for widget tests</li>
+<li>display a ballon toast if there are analysis issues when running apps</li>
+<li>added a toggle inspect mode toolbar button</li>
+<li>speed improvements to the device switcher pulldown</li>
 </ul>
 <h2>16.0</h2>
 <ul>
-  <li>device list refresh fixes</li>
-  <li>support for flutter run in profile and release modes</li>
-  <li>support for reading the android sdk location from flutter tools</li>
-  <li>support for discovering and running Flutter widget tests</li>
-  <li>Flutter test console improvements</li>
-  <li>support for running flutter doctor in a Bazel workspace</li>
-  <li>test file icon annotations</li>
-  <li>support for locating a missing flutter SDK in .packages files</li>
-  <li>open emulator action sorting</li>
-  <li>test state icons for Flutter tests</li>
-  <li>editor line markers for Flutter tests</li>
-  <li>added a new restart daemon action</li>
-  <li>open emulator action sorting</li>
-  <li>run/debug button enablement improvements</li>
-  <li>fix to ensure the <code>Install SDK…</code> action is always visible</li>
-  <li>support for running a single Flutter test, by name</li>
-  <li>install creation progress UI fixes</li>
-  <li>project creation fixes for small IDEs</li>
-  <li>fixes to android emulator launching</li>
+<li>device list refresh fixes</li>
+<li>support for flutter run in profile and release modes</li>
+<li>support for reading the android sdk location from flutter tools</li>
+<li>support for discovering and running Flutter widget tests</li>
+<li>Flutter test console improvements</li>
+<li>support for running flutter doctor in a Bazel workspace</li>
+<li>test file icon annotations</li>
+<li>support for locating a missing flutter SDK in .packages files</li>
+<li>open emulator action sorting</li>
+<li>test state icons for Flutter tests</li>
+<li>editor line markers for Flutter tests</li>
+<li>added a new restart daemon action</li>
+<li>open emulator action sorting</li>
+<li>run/debug button enablement improvements</li>
+<li>fix to ensure the <code>Install SDK…</code> action is always visible</li>
+<li>support for running a single Flutter test, by name</li>
+<li>install creation progress UI fixes</li>
+<li>project creation fixes for small IDEs</li>
+<li>fixes to android emulator launching</li>
 </ul>
 <h2>15.2</h2>
 <ul>
-  <li>fix for an exception in the new project wizard in WebStorm (#1234)</li>
+<li>fix for an exception in the new project wizard in WebStorm (#1234)</li>
 </ul>
 <h2>15.1</h2>
 <ul>
-  <li>fix for a file watching related NPE on build systems using Bazel (#1191)</li>
+<li>fix for a file watching related NPE on build systems using Bazel (#1191)</li>
 </ul>
 <h2>15.0</h2>
 <ul>
-  <li>UI for starting android emulators from the device pull-down</li>
-  <li>workflow for installing a Flutter SDK from the New Flutter Project wizard</li>
-  <li>Flutter SDK configuration inspection improvements</li>
-  <li>improved error reporting on project creation failures</li>
-  <li>improved app reload feedback</li>
-  <li>Flutter View toolbar tweaks</li>
-  <li>initial support for running unit tests with <code>flutter test</code></li>
-  <li>new action to open iOS resources in Xcode</li>
+<li>UI for starting android emulators from the device pull-down</li>
+<li>workflow for installing a Flutter SDK from the New Flutter Project wizard</li>
+<li>Flutter SDK configuration inspection improvements</li>
+<li>improved error reporting on project creation failures</li>
+<li>improved app reload feedback</li>
+<li>Flutter View toolbar tweaks</li>
+<li>initial support for running unit tests with <code>flutter test</code></li>
+<li>new action to open iOS resources in Xcode</li>
 </ul>
 <h2>14.0</h2>
 <ul>
-  <li>user toggleable option to enable more verbose debug logging of Flutter app runs</li>
-  <li>fixes to the new Flutter Module workflow</li>
-  <li>improved console logging on Flutter app termination</li>
-  <li>improved error reporting on Observatory connection and Flutter View open failures</li>
-  <li>removed Flutter SDK settings from default projects</li>
-  <li>improved project name validation (to align with checks in <code>flutter create</code>)</li>
-  <li>console hyperlinks for Xcode resources</li>
-  <li>fix to inherit Android JDK setting when creating Flutter projects</li>
-  <li>fix to ensure Flutter console filtering is only applied to Flutter consoles</li>
-  <li>improved device daemon interop</li>
-  <li>improved SDK version checking</li>
+<li>user toggleable option to enable more verbose debug logging of Flutter app runs</li>
+<li>fixes to the new Flutter Module workflow</li>
+<li>improved console logging on Flutter app termination</li>
+<li>improved error reporting on Observatory connection and Flutter View open failures</li>
+<li>removed Flutter SDK settings from default projects</li>
+<li>improved project name validation (to align with checks in <code>flutter create</code>)</li>
+<li>console hyperlinks for Xcode resources</li>
+<li>fix to inherit Android JDK setting when creating Flutter projects</li>
+<li>fix to ensure Flutter console filtering is only applied to Flutter consoles</li>
+<li>improved device daemon interop</li>
+<li>improved SDK version checking</li>
 </ul>
 <h2>13.1</h2>
 <ul>
-  <li>project opening improvements</li>
-  <li>new action to open the Flutter view</li>
-  <li>module name validation on creation</li>
-  <li>fix to ensure all open files are saved to disk before running Flutter actions</li>
-  <li>improved progress reporting during calls to 'flutter create'</li>
-  <li>miscellaneous fixes and analytics improvements</li>
+<li>project opening improvements</li>
+<li>new action to open the Flutter view</li>
+<li>module name validation on creation</li>
+<li>fix to ensure all open files are saved to disk before running Flutter actions</li>
+<li>improved progress reporting during calls to 'flutter create'</li>
+<li>miscellaneous fixes and analytics improvements</li>
 </ul>
 <h2>13.0</h2>
 <ul>
-  <li>small IDE support improvements</li>
-  <li>android module enablement on project creation</li>
-  <li>project explorer icon customizations</li>
-  <li>support for Flutter drop frame debugging</li>
-  <li>hot reload UX improvements</li>
-  <li>Bazel run config refinements</li>
-  <li>support for toggling OS in the Flutter View</li>
-  <li>Flutter CLI interop fixes (proper env setup)</li>
-  <li>color icon improvements</li>
-  <li>bump to require 2017.1+</li>
+<li>small IDE support improvements</li>
+<li>android module enablement on project creation</li>
+<li>project explorer icon customizations</li>
+<li>support for Flutter drop frame debugging</li>
+<li>hot reload UX improvements</li>
+<li>Bazel run config refinements</li>
+<li>support for toggling OS in the Flutter View</li>
+<li>Flutter CLI interop fixes (proper env setup)</li>
+<li>color icon improvements</li>
+<li>bump to require 2017.1+</li>
 </ul>
 <h2>12.1</h2>
 <ul>
-  <li>fix an issue with enabling Dart support for modules from the Flutter settings page</li>
+<li>fix an issue with enabling Dart support for modules from the Flutter settings page</li>
 </ul>
 <h2>12.0</h2>
 <ul>
-  <li>support for IDEA <code>2017.1</code></li>
-  <li>new Flutter <code>stless</code>, <code>stful</code>, and <code>stanim</code> live templates</li>
-  <li>new assists for editing the widget hierarchy:<ul>
-  <li>move widget up or down</li>
-  <li>re-parent widget or list of widgets</li>
-  <li>convert <code>child:</code> keyword to <code>children:</code></li>
-</ul></li>
-  <li>support for specifying "Additional Args" to Flutter application launches</li>
-  <li>default run configuration creation on project open (when possible)</li>
-  <li>device menu improvements</li>
-  <li>miscellaneous bug fixes</li>
+<li>support for IDEA <code>2017.1</code></li>
+<li>new Flutter <code>stless</code>, <code>stful</code>, and <code>stanim</code> live templates</li>
+<li>new assists for editing the widget hierarchy:
+<ul>
+<li>move widget up or down</li>
+<li>re-parent widget or list of widgets</li>
+<li>convert <code>child:</code> keyword to <code>children:</code></li>
+</ul>
+</li>
+<li>support for specifying "Additional Args" to Flutter application launches</li>
+<li>default run configuration creation on project open (when possible)</li>
+<li>device menu improvements</li>
+<li>miscellaneous bug fixes</li>
 </ul>
 <h2>0.1.11.2</h2>
 <ul>
-  <li>fix an NPE in the Flutter View when launching an app</li>
+<li>fix an NPE in the Flutter View when launching an app</li>
 </ul>
 <h2>0.1.11.1</h2>
 <ul>
-  <li>fix to a use after dispose exception in the Flutter View</li>
+<li>fix to a use after dispose exception in the Flutter View</li>
 </ul>
 <h2>0.1.11</h2>
 <ul>
-  <li>Flutter tool window badging when active</li>
-  <li>iOS console output folding improvements</li>
-  <li>Flutter reload actions added to main "Run" menu</li>
-  <li>devices menu fixes</li>
-  <li>improved tooltips for pubspec editor notifications</li>
+<li>Flutter tool window badging when active</li>
+<li>iOS console output folding improvements</li>
+<li>Flutter reload actions added to main "Run" menu</li>
+<li>devices menu fixes</li>
+<li>improved tooltips for pubspec editor notifications</li>
 </ul>
 <h2>0.1.10</h2>
 <ul>
-  <li>fixes to pubspec timestamp checking</li>
-  <li>analytics events for run, debug, and process stop</li>
-  <li>fix to <code>flutter doctor</code> to better support multiple runs</li>
-  <li>fix to the reload action for apps launched from 'run'</li>
+<li>fixes to pubspec timestamp checking</li>
+<li>analytics events for run, debug, and process stop</li>
+<li>fix to <code>flutter doctor</code> to better support multiple runs</li>
+<li>fix to the reload action for apps launched from 'run'</li>
 </ul>
 <h2>0.1.9.1</h2>
 <ul>
-  <li>fix button enablement in the Flutter View</li>
-  <li>fix the reload action for apps launched from 'run'</li>
+<li>fix button enablement in the Flutter View</li>
+<li>fix the reload action for apps launched from 'run'</li>
 </ul>
 <h2>0.1.9</h2>
 <ul>
-  <li>added a 'Flutter' view to allow users to toggle Flutter framework debugging features while running</li>
-  <li>fixes to the visibility of the "Tools" menu</li>
-  <li>inspection to detect pubspec modifications (that may imply out of date package dependencies)</li>
-  <li>key bindings fixes</li>
-  <li>support for opening source folders as Flutter projects (using "Open...")</li>
-  <li>run and debug button enablement fixes</li>
-  <li>fix to bring iOS simulator to front on run/debug</li>
-  <li>fix to handle devfs breakpoints for projects without pubspecs</li>
+<li>added a 'Flutter' view to allow users to toggle Flutter framework debugging features while running</li>
+<li>fixes to the visibility of the "Tools" menu</li>
+<li>inspection to detect pubspec modifications (that may imply out of date package dependencies)</li>
+<li>key bindings fixes</li>
+<li>support for opening source folders as Flutter projects (using "Open...")</li>
+<li>run and debug button enablement fixes</li>
+<li>fix to bring iOS simulator to front on run/debug</li>
+<li>fix to handle devfs breakpoints for projects without pubspecs</li>
 </ul>
 <h2>0.1.8.1</h2>
 <ul>
-  <li>improve handling of breakpoints for the bazel launch config</li>
+<li>improve handling of breakpoints for the bazel launch config</li>
 </ul>
 <h2>0.1.8</h2>
 <ul>
-  <li>fixed race condition in console reporting on project creation</li>
-  <li>improved interaction between Flutter and Dart plugins during project creation (no more unnecessary nags to run pub)</li>
-  <li>improvements to version checking</li>
-  <li>settings UI refinements</li>
-  <li>new "Help > Flutter Plugin" top-level menu</li>
-  <li>added reload/restart actions in the main toolbar</li>
-  <li>improved console folding for iOS messages</li>
-  <li>fixed NPE in project creation</li>
+<li>fixed race condition in console reporting on project creation</li>
+<li>improved interaction between Flutter and Dart plugins during project creation (no more unnecessary nags to run pub)</li>
+<li>improvements to version checking</li>
+<li>settings UI refinements</li>
+<li>new "Help &gt; Flutter Plugin" top-level menu</li>
+<li>added reload/restart actions in the main toolbar</li>
+<li>improved console folding for iOS messages</li>
+<li>fixed NPE in project creation</li>
 </ul>
 <h2>0.1.7</h2>
 <ul>
-  <li>improved console output folding when running iOS apps</li>
-  <li>actions for Flutter package get and package update</li>
-  <li>a new top level Flutter menu (Tools>Flutter) with common Flutter actions</li>
-  <li>updated hot reload and restart icons</li>
-  <li>editor annotations showing Flutter colors and icons in the editor ruler</li>
-  <li>better console filtering (less noise)</li>
-  <li>improved detection of Flutter projects missing a Flutter module type</li>
+<li>improved console output folding when running iOS apps</li>
+<li>actions for Flutter package get and package update</li>
+<li>a new top level Flutter menu (Tools&gt;Flutter) with common Flutter actions</li>
+<li>updated hot reload and restart icons</li>
+<li>editor annotations showing Flutter colors and icons in the editor ruler</li>
+<li>better console filtering (less noise)</li>
+<li>improved detection of Flutter projects missing a Flutter module type</li>
 </ul>
 <h2>0.1.6</h2>
 <ul>
-  <li>reload and restart keybinding mapping fixes</li>
-  <li>new butter bar with actions for flutter.yaml files</li>
-  <li>"run" behavior re-designed to support reload</li>
-  <li>improved console output for reloading and restarting</li>
-  <li>miscellaneous fixes and stability improvements</li>
+<li>reload and restart keybinding mapping fixes</li>
+<li>new butter bar with actions for flutter.yaml files</li>
+<li>"run" behavior re-designed to support reload</li>
+<li>improved console output for reloading and restarting</li>
+<li>miscellaneous fixes and stability improvements</li>
 </ul>
 <h2>0.1.5</h2>
 <ul>
-  <li>console filtering for flutter run output</li>
-  <li>improved messaging for incomplete Flutter SDK configurations</li>
-  <li>support for new application events produced by Flutter tools</li>
-  <li>fixed duplicate service protocol console logging</li>
-  <li>Flutter run configuration cleanup</li>
-  <li>fixed NPE in showing progress from Flutter tools tasks</li>
-  <li>migration away from storing Flutter SDK location in an application library</li>
+<li>console filtering for flutter run output</li>
+<li>improved messaging for incomplete Flutter SDK configurations</li>
+<li>support for new application events produced by Flutter tools</li>
+<li>fixed duplicate service protocol console logging</li>
+<li>Flutter run configuration cleanup</li>
+<li>fixed NPE in showing progress from Flutter tools tasks</li>
+<li>migration away from storing Flutter SDK location in an application library</li>
 </ul>
 <h2>0.1.4.1</h2>
 <ul>
-  <li>removed an exception notification when we receive unknown events from the flutter tools</li>
+<li>removed an exception notification when we receive unknown events from the flutter tools</li>
 </ul>
 <h2>0.1.4</h2>
 <ul>
-  <li>first public release</li>
+<li>first public release</li>
 </ul>
 <h2>0.1.3</h2>
 <ul>
-  <li>notifications for projects that look like Flutter apps but do not have Flutter enabled</li>
-  <li>improved Flutter preference UI and SDK configuration</li>
-  <li>IDEA version constraints to ensure that the plugin cannot be installed in incompatible IDEA versions</li>
+<li>notifications for projects that look like Flutter apps but do not have Flutter enabled</li>
+<li>improved Flutter preference UI and SDK configuration</li>
+<li>IDEA version constraints to ensure that the plugin cannot be installed in incompatible IDEA versions</li>
 </ul>
 <h2>0.1.2</h2>
 <ul>
-  <li>fixed device selector filtering</li>
+<li>fixed device selector filtering</li>
 </ul>
 <h2>0.1.1</h2>
 <ul>
-  <li>removed second (redundant) "open observatory" button</li>
-  <li>filtering to ensure the Flutter device selector only appears for Flutter projects</li>
-  <li>fixed hangs on app re-runs</li>
+<li>removed second (redundant) "open observatory" button</li>
+<li>filtering to ensure the Flutter device selector only appears for Flutter projects</li>
+<li>fixed hangs on app re-runs</li>
 </ul>
 <h2>0.1.0</h2>
 <ul>
-  <li>initial alpha release</li>
+<li>initial alpha release</li>
 </ul>
 ]]>
   </change-notes>

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -32,34 +32,34 @@
 <h2>39.0</h2>
 <ul>
 <li>Changed project creation to default to AndriodX deselected until it works for Flutter modules</li>
-<li>Enabled structured errors by default</li>
-<li>Fix #3731: Synchronous execution on EDT (#3823)</li>
-<li>Make the new languages be default (#3819)</li>
-<li>Don't call reload for the unforked flutter web impl (#3816)</li>
-<li>Perform additional normalization on flutter error codes (#3813)</li>
-<li>Fix an issue related to the error reporter (#3811)</li>
-<li>Improve computeDefaultPresentation (#3803)</li>
-<li>Convert an error to a warning (#3810)</li>
-<li>Fix ArrayIndexOutOfBounds for target platform selector (#3809)</li>
-<li>Flutter web inspector (#3792)</li>
-<li>Rev to the latest vm service library (#3801)</li>
-<li>Adapt to API changes in ASc6 (#3802)</li>
-<li>Switch to using the VM Service directly instead of the Daemon protocol when invoking service extensions (#3790)</li>
-<li>Update no-response.yml (#3789)</li>
-<li>Upgrade the version of the dart plugin that we compile against (#3784)</li>
-<li>Address a setPreferredFocusableComponent() warning in the IntelliJ log (#3783)</li>
-<li>Fix a regression in the Flutter Outline view (#3782)</li>
-<li>Cache the results of parsing the pubspec file (#3773)</li>
-<li>Only parse analysis server events we're interested in (#3772)</li>
-<li>Optimize FlutterUtils.isInTestDir (#3774)</li>
-<li>Add platforms to testing matrix (#3768)</li>
-<li>Make part of the dart code use implicit-casts false (#3762)</li>
+  <li>Enabled structured errors by default</li>
+  <li>Fix #3731: Synchronous execution on EDT (#3823)</li>
+  <li>Make the new languages be default (#3819)</li>
+  <li>Don't call reload for the unforked flutter web impl (#3816)</li>
+  <li>Perform additional normalization on flutter error codes (#3813)</li>
+  <li>Fix an issue related to the error reporter (#3811)</li>
+  <li>Improve computeDefaultPresentation (#3803)</li>
+  <li>Convert an error to a warning (#3810)</li>
+  <li>Fix ArrayIndexOutOfBounds for target platform selector (#3809)</li>
+  <li>Flutter web inspector (#3792)</li>
+  <li>Rev to the latest vm service library (#3801)</li>
+  <li>Adapt to API changes in ASc6 (#3802)</li>
+  <li>Switch to using the VM Service directly instead of the Daemon protocol when invoking service extensions (#3790)</li>
+  <li>Update no-response.yml (#3789)</li>
+  <li>Upgrade the version of the dart plugin that we compile against (#3784)</li>
+  <li>Address a setPreferredFocusableComponent() warning in the IntelliJ log (#3783)</li>
+  <li>Fix a regression in the Flutter Outline view (#3782)</li>
+  <li>Cache the results of parsing the pubspec file (#3773)</li>
+  <li>Only parse analysis server events we're interested in (#3772)</li>
+  <li>Optimize FlutterUtils.isInTestDir (#3774)</li>
+  <li>Add platforms to testing matrix (#3768)</li>
+  <li>Make part of the dart code use implicit-casts false (#3762)</li>
 </ul>
 <h2>38.2</h2>
 <ul>
 <li>Fix bug on Windows that prevented outlines from displaying</li>
-<li>Restore the ability to run individual tests </li>
-<li>Fix a couple other issues</li>
+  <li>Restore the ability to run individual tests </li>
+  <li>Fix a couple other issues</li>
 </ul>
 <h2>38.1</h2>
 <ul>
@@ -68,135 +68,135 @@
 <h2>38.0</h2>
 <ul>
 <li>Add AndroidX option to new project wizards (#3705)</li>
-<li>Fix break due to Android Studio 3.6 API change (#3712)</li>
-<li>Fix logger npe (#3711)</li>
-<li>Integration test update (#3710)</li>
-<li>Fix highlighting of project descriptions (#3709)</li>
-<li>Re-enable tests on the bots (#3702)</li>
-<li>Update the flutter error display (#3682)</li>
-<li>Relabel 'samples'to 'widget samples' (#3701)</li>
-<li>Address some issues with blocking the EDT thread in 2019.2 (#3700)</li>
-<li>Remove the web/desktop user preference (#3698)</li>
-<li>Fix the logging tests (#3699)</li>
-<li>Use DAS test annotations to flag runnable tests (#3662)</li>
-<li>Add short-lived prompt for Q3 user survey (#3691)</li>
-<li>Add a user preference to opt-in to showing structured errors (#3692)</li>
-<li>Add target platform selector for togglePlatform service extension (#3688)</li>
-<li>Update the widgets.json catalog file (#3687)</li>
-<li>Restore stack traces in generated error reports (#3685)</li>
-<li>Make the event stream tests pass and re-enable them (#3684)</li>
-<li>Init default settings for the run console text wrapping (#3661)</li>
-<li>Send flutter.error analytics (#3659)</li>
-<li>Remove extra console whitespace (#3660)</li>
-<li>Fix an issue with some daemon json output appearing in the console (#3658)</li>
-<li>Initial work on displaying Flutter.Error events (#3644)</li>
-<li>Show truncated logging messages (#3641)</li>
-<li>Name the Bazel test config factories to match assumed names in g3 (#3636)</li>
-<li>Remove no longer used functionality related to restart warnings (#3645)</li>
-<li>Fix per SDK Stream<Uint8List> breaking changes (#3640)</li>
-<li>Fix New Pproject Wizard (#3631)</li>
-<li>Adjust the text for the desktop/web device preference (#3629)</li>
-<li>Issue 3615. Fix message for 'Remove widget' (#3622)</li>
-<li>Support showing desktop and web devices (#3618)</li>
+  <li>Fix break due to Android Studio 3.6 API change (#3712)</li>
+  <li>Fix logger npe (#3711)</li>
+  <li>Integration test update (#3710)</li>
+  <li>Fix highlighting of project descriptions (#3709)</li>
+  <li>Re-enable tests on the bots (#3702)</li>
+  <li>Update the flutter error display (#3682)</li>
+  <li>Relabel 'samples'to 'widget samples' (#3701)</li>
+  <li>Address some issues with blocking the EDT thread in 2019.2 (#3700)</li>
+  <li>Remove the web/desktop user preference (#3698)</li>
+  <li>Fix the logging tests (#3699)</li>
+  <li>Use DAS test annotations to flag runnable tests (#3662)</li>
+  <li>Add short-lived prompt for Q3 user survey (#3691)</li>
+  <li>Add a user preference to opt-in to showing structured errors (#3692)</li>
+  <li>Add target platform selector for togglePlatform service extension (#3688)</li>
+  <li>Update the widgets.json catalog file (#3687)</li>
+  <li>Restore stack traces in generated error reports (#3685)</li>
+  <li>Make the event stream tests pass and re-enable them (#3684)</li>
+  <li>Init default settings for the run console text wrapping (#3661)</li>
+  <li>Send flutter.error analytics (#3659)</li>
+  <li>Remove extra console whitespace (#3660)</li>
+  <li>Fix an issue with some daemon json output appearing in the console (#3658)</li>
+  <li>Initial work on displaying Flutter.Error events (#3644)</li>
+  <li>Show truncated logging messages (#3641)</li>
+  <li>Name the Bazel test config factories to match assumed names in g3 (#3636)</li>
+  <li>Remove no longer used functionality related to restart warnings (#3645)</li>
+  <li>Fix per SDK Stream<Uint8List> breaking changes (#3640)</li>
+  <li>Fix New Pproject Wizard (#3631)</li>
+  <li>Adjust the text for the desktop/web device preference (#3629)</li>
+  <li>Issue 3615. Fix message for 'Remove widget' (#3622)</li>
+  <li>Support showing desktop and web devices (#3618)</li>
 </ul>
 <h2>37.0</h2>
 <ul>
 <li>Fix an offset issue with the UI guides code (#3574)</li>
-<li>Add IDE query param to DevTools url. (#3592)</li>
-<li>Treat FlutterApp as a long-running process (#3599)</li>
-<li>Fix links for test URLs (#3600)</li>
+  <li>Add IDE query param to DevTools url. (#3592)</li>
+  <li>Treat FlutterApp as a long-running process (#3599)</li>
+  <li>Fix links for test URLs (#3600)</li>
 </ul>
 <h2>36.0</h2>
 <ul>
 <li>Add Gradle build script (#3529)</li>
-<li>Update for new platform releases (#3527)</li>
-<li>Add in a preference to toggle closing labels (#3528)</li>
-<li>Don't disable closing labels as part of UI Guides (#3525)</li>
-<li>Enable devtools launching from Bazel (#3511)</li>
-<li>Guard against null project basedir (#3524)</li>
-<li>Change DeviceDaemon to show a detailed error when it fails too many times. (#3513)</li>
-<li>Add an inline run menu option to run or watch Bazel Flutter tests (#3507)</li>
-<li>Make the save dialog refer to the save all action, not the save action (#3505)</li>
-<li>Introduce an opt-in detailed test runner for Bazel tests (#3451)</li>
-<li>Remove the android studio specific memory view (#3497)</li>
-<li>Limit the amount of time we wait for a graceful app shutdown (#3490)</li>
-<li>Mark the device daemon process as a background process (#3488)</li>
-<li>Fix errors in AS 3.5 beta 1 (#3487)</li>
-<li>Remove the preview view from the flutter outline view (#3481)</li>
-<li>Remove a println in WidgetIndentsHighlightingPass.java (#3468)</li>
-<li>Fix an npe from the FlutterErrorReportSubmitter.java class (#3469)</li>
-<li>Handle notifications when a project has been disposed more gracefully. (#3472)</li>
-<li>Fix two bugs for widget guide outlines. (#3470)</li>
+  <li>Update for new platform releases (#3527)</li>
+  <li>Add in a preference to toggle closing labels (#3528)</li>
+  <li>Don't disable closing labels as part of UI Guides (#3525)</li>
+  <li>Enable devtools launching from Bazel (#3511)</li>
+  <li>Guard against null project basedir (#3524)</li>
+  <li>Change DeviceDaemon to show a detailed error when it fails too many times. (#3513)</li>
+  <li>Add an inline run menu option to run or watch Bazel Flutter tests (#3507)</li>
+  <li>Make the save dialog refer to the save all action, not the save action (#3505)</li>
+  <li>Introduce an opt-in detailed test runner for Bazel tests (#3451)</li>
+  <li>Remove the android studio specific memory view (#3497)</li>
+  <li>Limit the amount of time we wait for a graceful app shutdown (#3490)</li>
+  <li>Mark the device daemon process as a background process (#3488)</li>
+  <li>Fix errors in AS 3.5 beta 1 (#3487)</li>
+  <li>Remove the preview view from the flutter outline view (#3481)</li>
+  <li>Remove a println in WidgetIndentsHighlightingPass.java (#3468)</li>
+  <li>Fix an npe from the FlutterErrorReportSubmitter.java class (#3469)</li>
+  <li>Handle notifications when a project has been disposed more gracefully. (#3472)</li>
+  <li>Fix two bugs for widget guide outlines. (#3470)</li>
 </ul>
 <h2>35.1.3</h2>
 <ul>
 <li>Support IntelliJ 2019.1.2 RC</li>
-<li>Support Android Studio 3.5 beta 1</li>
-<li>Bug fixes</li>
+  <li>Support Android Studio 3.5 beta 1</li>
+  <li>Bug fixes</li>
 </ul>
 <h2>35.1</h2>
 <ul>
 <li>Add an option to hide closing labels in Dart source code when UI guides are on (#3438)</li>
-<li>Create "Editor" section of Flutter Settings (#3434)</li>
-<li>Support UI as Code Widget Guides (#3420)</li>
-<li>Add checkbox to skip the dart analyzer error check before a hot reload (#3414)</li>
-<li>Remove the option to disable the memory view from the settings (#3408)</li>
-<li>Track API changes (#3427)</li>
+  <li>Create "Editor" section of Flutter Settings (#3434)</li>
+  <li>Support UI as Code Widget Guides (#3420)</li>
+  <li>Add checkbox to skip the dart analyzer error check before a hot reload (#3414)</li>
+  <li>Remove the option to disable the memory view from the settings (#3408)</li>
+  <li>Track API changes (#3427)</li>
 </ul>
 <h2>35.0</h2>
 <ul>
 <li>Sample panel layout improvements (#3396)</li>
-<li>Remove unneeded logging (#3394)</li>
-<li>Java analysis lints cleanup (#3395)</li>
-<li>Update subscriptions after analysis server restart (#3393)</li>
-<li>Read sample index from flutter_tool call (#3379)</li>
-<li>Update README (#3387)</li>
-<li>Fix unit tests</li>
-<li>Update build for canary 11 (#3380)</li>
-<li>Integration test update (#3374)</li>
-<li>Make the inspector easier to test (#3373)</li>
-<li>Adjust build to make plugin for testing (#3366)</li>
-<li>Address reported Java lints (#3356)</li>
-<li>Adjust build for AS canary 10</li>
-<li>Address an array index out of bounds (#3355)</li>
-<li>Address an NPE (#3354)</li>
-<li>Upgrade the service protocol library (#3353)</li>
-<li>Address a number format exception (#3352)</li>
-<li>Update how we manipulate the service protocol url (#3351)</li>
-<li>Remove some uses of reflection (#3350)</li>
-<li>Some initial work for FlutterWeb apps (#3342)</li>
-<li>Fix an NPE when sample content generation is disabled (#3336)</li>
-<li>Add inspector dependency to test (#3316)</li>
-<li>Make Dart constructor calls pop out in light mode  (#3327)</li>
+  <li>Remove unneeded logging (#3394)</li>
+  <li>Java analysis lints cleanup (#3395)</li>
+  <li>Update subscriptions after analysis server restart (#3393)</li>
+  <li>Read sample index from flutter_tool call (#3379)</li>
+  <li>Update README (#3387)</li>
+  <li>Fix unit tests</li>
+  <li>Update build for canary 11 (#3380)</li>
+  <li>Integration test update (#3374)</li>
+  <li>Make the inspector easier to test (#3373)</li>
+  <li>Adjust build to make plugin for testing (#3366)</li>
+  <li>Address reported Java lints (#3356)</li>
+  <li>Adjust build for AS canary 10</li>
+  <li>Address an array index out of bounds (#3355)</li>
+  <li>Address an NPE (#3354)</li>
+  <li>Upgrade the service protocol library (#3353)</li>
+  <li>Address a number format exception (#3352)</li>
+  <li>Update how we manipulate the service protocol url (#3351)</li>
+  <li>Remove some uses of reflection (#3350)</li>
+  <li>Some initial work for FlutterWeb apps (#3342)</li>
+  <li>Fix an NPE when sample content generation is disabled (#3336)</li>
+  <li>Add inspector dependency to test (#3316)</li>
+  <li>Make Dart constructor calls pop out in light mode  (#3327)</li>
 </ul>
 <h2>34.0</h2>
 <ul>
 <li>Update build for Android Studio 3.3.2 and IntelliJ 2019.1 (#3321)</li>
-<li>Fix issue preventing plugin from working in AS Canary 8 (#3321)</li>
-<li>Provides a better display if the variable has a <code>toStringDeep()</code> method defined. (#3291)</li>
-<li>Don't show a background square in the inspector summary tree. (#3326)</li>
-<li>Make FlutterModuleUtils consistently robust to disposed projects. (#3323)</li>
-<li>Fix NPE issue sometimes hit evaluating expressions. (#3324)</li>
-<li>Fix widget names. (#3322)</li>
-<li>Make Perf and Inspector views only display when a Flutter app is being debugged. (#3320)</li>
-<li>Support the inspector for flutter_web libraries. (#3310)</li>
-<li>Detect when integrations tests are running (#3308)</li>
-<li>Add in support for reloading and restarting all running apps (#3268)</li>
-<li>Log tree path selection fixes (#3302)</li>
-<li>Throttle logger updates (#3280)</li>
-<li>New method in FlutterUtils: declaresFlutterWeb, this method checks for dependencies: fluttler_web in a pubspec file. (#3275)</li>
-<li>Update a comment in FlutterSaveActionsManager (#3277)</li>
-<li>Remove the second parameter (the Project) from SdkFields constructor, it isn't used anymore. (#3261)</li>
-<li>Add a comment to a recent change (#3267)</li>
-<li>Fix a file handle leak (#3264)</li>
-<li>Port inferPubRootDirectoryIfNeeded from devtools (#3242)</li>
-<li>Add support for matching customized Widget tests. (#3249)</li>
-<li>Hide DevTools debugger when launching from IntelliJ. (#3252)</li>
-<li>Migrate to GearPlain (#3248)</li>
-<li>Minor cleanup (#3247)</li>
-<li>Inline sample index reading (#3245)</li>
-<li>Make a newer daemon protocol field optional (#3230)</li>
-<li>Link to the plugins readme file from the building instructions. (#3222)</li>
+  <li>Fix issue preventing plugin from working in AS Canary 8 (#3321)</li>
+  <li>Provides a better display if the variable has a <code>toStringDeep()</code> method defined. (#3291)</li>
+  <li>Don't show a background square in the inspector summary tree. (#3326)</li>
+  <li>Make FlutterModuleUtils consistently robust to disposed projects. (#3323)</li>
+  <li>Fix NPE issue sometimes hit evaluating expressions. (#3324)</li>
+  <li>Fix widget names. (#3322)</li>
+  <li>Make Perf and Inspector views only display when a Flutter app is being debugged. (#3320)</li>
+  <li>Support the inspector for flutter_web libraries. (#3310)</li>
+  <li>Detect when integrations tests are running (#3308)</li>
+  <li>Add in support for reloading and restarting all running apps (#3268)</li>
+  <li>Log tree path selection fixes (#3302)</li>
+  <li>Throttle logger updates (#3280)</li>
+  <li>New method in FlutterUtils: declaresFlutterWeb, this method checks for dependencies: fluttler_web in a pubspec file. (#3275)</li>
+  <li>Update a comment in FlutterSaveActionsManager (#3277)</li>
+  <li>Remove the second parameter (the Project) from SdkFields constructor, it isn't used anymore. (#3261)</li>
+  <li>Add a comment to a recent change (#3267)</li>
+  <li>Fix a file handle leak (#3264)</li>
+  <li>Port inferPubRootDirectoryIfNeeded from devtools (#3242)</li>
+  <li>Add support for matching customized Widget tests. (#3249)</li>
+  <li>Hide DevTools debugger when launching from IntelliJ. (#3252)</li>
+  <li>Migrate to GearPlain (#3248)</li>
+  <li>Minor cleanup (#3247)</li>
+  <li>Inline sample index reading (#3245)</li>
+  <li>Make a newer daemon protocol field optional (#3230)</li>
+  <li>Link to the plugins readme file from the building instructions. (#3222)</li>
 </ul>
 <h2>33.3</h2>
 <ul>
@@ -209,93 +209,93 @@
 <h2>33.1</h2>
 <ul>
 <li>add menu and toolbar button to open Flutter DevTools</li>
-<li>fix Gradle sync issue for Android Studio 3.3.1</li>
-<li>fix highlighting of the Go link in sample banner</li>
+  <li>fix Gradle sync issue for Android Studio 3.3.1</li>
+  <li>fix highlighting of the Go link in sample banner</li>
 </ul>
 <h2>33.0</h2>
 <ul>
 <li>update build for Android Studio 3.3.1</li>
-<li>reorder console filters so links work</li>
-<li>more intelligently enable support for detaching from Flutter apps on exit</li>
-<li>change the icon used for paint baselines</li>
-<li>prevent bazel test run configurations from generating in a non-bazel workspace</li>
-<li>support 2019.1 eap</li>
-<li>mention 'Dart' in the plugin description</li>
-<li>correct the bazel output for debugging bazel tests</li>
-<li>simplify the bazel parameters we pass to Bazel Run configurations</li>
-<li>pin flutter error events in the log</li>
-<li>propagate node selections to inspector</li>
-<li>link support for log data entries</li>
-<li>fix category cell rendering</li>
-<li>add sample creation banner</li>
-<li>add sample apps to Android Studio New Project Wizard</li>
-<li>update log entry data badge</li>
+  <li>reorder console filters so links work</li>
+  <li>more intelligently enable support for detaching from Flutter apps on exit</li>
+  <li>change the icon used for paint baselines</li>
+  <li>prevent bazel test run configurations from generating in a non-bazel workspace</li>
+  <li>support 2019.1 eap</li>
+  <li>mention 'Dart' in the plugin description</li>
+  <li>correct the bazel output for debugging bazel tests</li>
+  <li>simplify the bazel parameters we pass to Bazel Run configurations</li>
+  <li>pin flutter error events in the log</li>
+  <li>propagate node selections to inspector</li>
+  <li>link support for log data entries</li>
+  <li>fix category cell rendering</li>
+  <li>add sample creation banner</li>
+  <li>add sample apps to Android Studio New Project Wizard</li>
+  <li>update log entry data badge</li>
 </ul>
 <h2>32.0</h2>
 <ul>
 <li>address an NPE in FlutterWidgetPerfManager.java</li>
-<li>added overlay renderered for GC, snapshot and memory reset events</li>
-<li>consolidated all adt-ui API changes in FlutterStudioMonitorStageView</li>
-<li>support for creating projects w/ sample content from the IDEA New Project Wizard</li>
-<li>basic ansi color support for entries in the Flutter Logging View</li>
-<li>restore log level combo to the Logging View</li>
-<li>support to fill in truncated log entries</li>
-<li>add keyboard shortcut for widget extraction</li>
-<li>add debugPaint and debugAllowBanner icons</li>
-<li>add repaint rainbow icon</li>
-<li>handle cases where script.tokenPosTable is null</li>
-<li>auto-hide details pane</li>
-<li>guard against disposed when querying project type</li>
-<li>fix an issue with escaped test names</li>
-<li>refactor service extensions and set button text based on extension state</li>
-<li>shorten message for debug mode perf disclaimer</li>
-<li>listen for ServiceExtensionStateChanged events</li>
-<li>restore service extension states from device on start and attach</li>
-<li>don't use LOG.error()</li>
-<li>refactor the Bazel Test configuration to support running tests on a single file or a single test</li>
-<li>fix enabled/disabled text for service extensions</li>
-<li>fix NPE in bazel config</li>
+  <li>added overlay renderered for GC, snapshot and memory reset events</li>
+  <li>consolidated all adt-ui API changes in FlutterStudioMonitorStageView</li>
+  <li>support for creating projects w/ sample content from the IDEA New Project Wizard</li>
+  <li>basic ansi color support for entries in the Flutter Logging View</li>
+  <li>restore log level combo to the Logging View</li>
+  <li>support to fill in truncated log entries</li>
+  <li>add keyboard shortcut for widget extraction</li>
+  <li>add debugPaint and debugAllowBanner icons</li>
+  <li>add repaint rainbow icon</li>
+  <li>handle cases where script.tokenPosTable is null</li>
+  <li>auto-hide details pane</li>
+  <li>guard against disposed when querying project type</li>
+  <li>fix an issue with escaped test names</li>
+  <li>refactor service extensions and set button text based on extension state</li>
+  <li>shorten message for debug mode perf disclaimer</li>
+  <li>listen for ServiceExtensionStateChanged events</li>
+  <li>restore service extension states from device on start and attach</li>
+  <li>don't use LOG.error()</li>
+  <li>refactor the Bazel Test configuration to support running tests on a single file or a single test</li>
+  <li>fix enabled/disabled text for service extensions</li>
+  <li>fix NPE in bazel config</li>
 </ul>
 <h2>31.3</h2>
 <ul>
 <li>fix NPE in sdk installation (#2965)</li>
-<li>fix NPE caused by internal inconsistency (#2963)</li>
+  <li>fix NPE caused by internal inconsistency (#2963)</li>
 </ul>
 <h2>31.2</h2>
 <ul>
 <li>show memory profiler legend with proper line chart color or line style</li>
-<li>prevent the (IntelliJ) New Project wizard from completing when there is no Flutter SDK</li>
-<li>fix a race condition causing unexpected conditions in attach</li>
-<li>added control of RSS display to memory profiler</li>
-<li>when running the flutter doctor command, use the -v flag</li>
-<li>make attach use selected device</li>
+  <li>prevent the (IntelliJ) New Project wizard from completing when there is no Flutter SDK</li>
+  <li>fix a race condition causing unexpected conditions in attach</li>
+  <li>added control of RSS display to memory profiler</li>
+  <li>when running the flutter doctor command, use the -v flag</li>
+  <li>make attach use selected device</li>
 </ul>
 <h2>31.1</h2>
 <ul>
 <li>perf table polish and fix links to tip docs</li>
-<li>fix Split Mode resize issue</li>
-<li>rebuild stats wording tweaks</li>
+  <li>fix Split Mode resize issue</li>
+  <li>rebuild stats wording tweaks</li>
 </ul>
 <h2>31.0</h2>
 <ul>
 <li>change FPS display to "Frame Rendering Time" and improve UI</li>
-<li>reorganize inspector tools</li>
-<li>better error reporting for Flutter runtime issues</li>
-<li>fewer Flutter runtime issues</li>
-<li>updated icons for Material and Cupertino</li>
-<li>searchable preferences/settings</li>
-<li>added refactoring to outline view: extract widget</li>
-<li>new menu item to run 'flutter make-host-app-editable'</li>
-<li>code cleanup and bug fixes</li>
+  <li>reorganize inspector tools</li>
+  <li>better error reporting for Flutter runtime issues</li>
+  <li>fewer Flutter runtime issues</li>
+  <li>updated icons for Material and Cupertino</li>
+  <li>searchable preferences/settings</li>
+  <li>added refactoring to outline view: extract widget</li>
+  <li>new menu item to run 'flutter make-host-app-editable'</li>
+  <li>code cleanup and bug fixes</li>
 </ul>
 <h2>30.0</h2>
 <ul>
 <li>performance inspector changes</li>
-<li>log view tweaks</li>
-<li>memory profiler updates</li>
-<li>support 'flutter attach' in the IDE (both IJ and AS)</li>
-<li>support offline project creation in the AS wizard</li>
-<li>code cleanup and bug fixes</li>
+  <li>log view tweaks</li>
+  <li>memory profiler updates</li>
+  <li>support 'flutter attach' in the IDE (both IJ and AS)</li>
+  <li>support offline project creation in the AS wizard</li>
+  <li>code cleanup and bug fixes</li>
 </ul>
 <h2>29.1</h2>
 <ul>
@@ -304,18 +304,18 @@
 <h2>29.0</h2>
 <ul>
 <li>add 'Wrap with Container' to preview</li>
-<li>fix test navigation</li>
-<li>clear log on restart</li>
-<li>experimental memory profiler; enable in preferences</li>
-<li>build for 2018.3 EAP</li>
-<li>bug fixes</li>
+  <li>fix test navigation</li>
+  <li>clear log on restart</li>
+  <li>experimental memory profiler; enable in preferences</li>
+  <li>build for 2018.3 EAP</li>
+  <li>bug fixes</li>
 </ul>
 <h2>28.0</h2>
 <ul>
 <li>build for Android Studio 3.3 Canary and 3.2 Beta</li>
-<li>add UI support for importing Flutter modules into Android apps</li>
-<li>add more details to logging output</li>
-<li>bug fixes</li>
+  <li>add UI support for importing Flutter modules into Android apps</li>
+  <li>add more details to logging output</li>
+  <li>bug fixes</li>
 </ul>
 <h2>27.1</h2>
 <ul>
@@ -324,89 +324,89 @@
 <h2>27.0</h2>
 <ul>
 <li>add a setting to control syncing Android libraries</li>
-<li>fixes related to evaluating expressions when not on a call frame</li>
-<li>auto-disable scroll to end when the user manually scrolls the log up</li>
-<li>add the "module" template to new-module and project wizards in Android Studio</li>
-<li>improve copy / paste in the Logging View</li>
-<li>some tweaks to the open in Android Studio functionality</li>
-<li>validate android package names</li>
-<li>add Android module libraries to Flutter projects</li>
-<li>validate org in the project wizard</li>
-<li>default log coloring to on and update logger defaults</li>
-<li>fix log entry browser links</li>
-<li>support hyperlinks in flutter console log</li>
-<li>add InheritedWidget and Stateful Widget with Animation live templates</li>
-<li>lower case the log level names</li>
+  <li>fixes related to evaluating expressions when not on a call frame</li>
+  <li>auto-disable scroll to end when the user manually scrolls the log up</li>
+  <li>add the "module" template to new-module and project wizards in Android Studio</li>
+  <li>improve copy / paste in the Logging View</li>
+  <li>some tweaks to the open in Android Studio functionality</li>
+  <li>validate android package names</li>
+  <li>add Android module libraries to Flutter projects</li>
+  <li>validate org in the project wizard</li>
+  <li>default log coloring to on and update logger defaults</li>
+  <li>fix log entry browser links</li>
+  <li>support hyperlinks in flutter console log</li>
+  <li>add InheritedWidget and Stateful Widget with Animation live templates</li>
+  <li>lower case the log level names</li>
 </ul>
 <h2>26.0</h2>
 <ul>
 <li>updates to support Android Studio 3.2 Beta</li>
-<li>removes the Inspector's empty content message</li>
-<li>support setting log color from flutter log settings page</li>
-<li>support hiding/showing log categories (#2398)</li>
-<li>add flutter log color settings page (#2394)</li>
-<li>change the default for the open inspector setting</li>
-<li>look for the emulator tool in the 'emulator/' directory first (#2383)</li>
-<li>support filtering by log level (#2380)</li>
-<li>fix the flutter log view while resizing (#2379)</li>
-<li>log entry coloring (#2382)</li>
-<li>log tree rendering refactor (#2381)</li>
-<li>for BazelRunConfig launches, print the command-line to the console (#2368)</li>
-<li>refactor the Flutter debugging client code (#2359)</li>
-<li>support match case/regex filter in log view (#2350)</li>
-<li>fix auto-scroll to catch up to fully rendered log tree (#2342)</li>
-<li>use the log category name from the dart:developer event (#2339)</li>
-<li>fix-up missing create project mnemonics (#2326)</li>
-<li>handle reload errors (#2321)</li>
-<li>fixes for the native editor banner</li>
+  <li>removes the Inspector's empty content message</li>
+  <li>support setting log color from flutter log settings page</li>
+  <li>support hiding/showing log categories (#2398)</li>
+  <li>add flutter log color settings page (#2394)</li>
+  <li>change the default for the open inspector setting</li>
+  <li>look for the emulator tool in the 'emulator/' directory first (#2383)</li>
+  <li>support filtering by log level (#2380)</li>
+  <li>fix the flutter log view while resizing (#2379)</li>
+  <li>log entry coloring (#2382)</li>
+  <li>log tree rendering refactor (#2381)</li>
+  <li>for BazelRunConfig launches, print the command-line to the console (#2368)</li>
+  <li>refactor the Flutter debugging client code (#2359)</li>
+  <li>support match case/regex filter in log view (#2350)</li>
+  <li>fix auto-scroll to catch up to fully rendered log tree (#2342)</li>
+  <li>use the log category name from the dart:developer event (#2339)</li>
+  <li>fix-up missing create project mnemonics (#2326)</li>
+  <li>handle reload errors (#2321)</li>
+  <li>fixes for the native editor banner</li>
 </ul>
 <h2>25.0</h2>
 <ul>
 <li>remove the user preference to disable --preview-dart-2</li>
-<li>don't use 'new' for the stless, stfull, stanim templates</li>
-<li>add support for IntelliJ 2018.2 EAP (#2270)</li>
-<li>added a new (very experimental) logging view</li>
-<li>update the extract widget refactoring visibility (#2251)</li>
-<li>launch a simulator device if none is running (#2234)</li>
-<li>improvements to the preview view on Windows (#2239)</li>
-<li>open the selected file for editing when opening a new project (#2236)</li>
-<li>open selected file when launching Android Studio (#2230)</li>
-<li>add a command bar to editors that can open in a native-code editor (#2216)</li>
-<li>rename full restart to hot restart (#2225)</li>
+  <li>don't use 'new' for the stless, stfull, stanim templates</li>
+  <li>add support for IntelliJ 2018.2 EAP (#2270)</li>
+  <li>added a new (very experimental) logging view</li>
+  <li>update the extract widget refactoring visibility (#2251)</li>
+  <li>launch a simulator device if none is running (#2234)</li>
+  <li>improvements to the preview view on Windows (#2239)</li>
+  <li>open the selected file for editing when opening a new project (#2236)</li>
+  <li>open selected file when launching Android Studio (#2230)</li>
+  <li>add a command bar to editors that can open in a native-code editor (#2216)</li>
+  <li>rename full restart to hot restart (#2225)</li>
 </ul>
 <h2>24.2</h2>
 <ul>
 <li>fix the --track-widget-creation flag implementation on Windows</li>
-<li>fix for an exception in the Outline view on older Flutter SDKs</li>
+  <li>fix for an exception in the Outline view on older Flutter SDKs</li>
 </ul>
 <h2>24.1</h2>
 <ul>
 <li>update Flutter icons</li>
-<li>fix an exception when the selection changes and the outline view isn't visible</li>
-<li>fix for an issue with reload on save in profile runs</li>
-<li>fix for a 2017.3 issue with a 'no running apps' message in the inspector</li>
+  <li>fix an exception when the selection changes and the outline view isn't visible</li>
+  <li>fix for an issue with reload on save in profile runs</li>
+  <li>fix for a 2017.3 issue with a 'no running apps' message in the inspector</li>
 </ul>
 <h2>24.0</h2>
 <ul>
 <li>inspector: significant UI refactoring to show the tree in a master / details format</li>
-<li>inspector: add a 'Performance' tab to the Inspector, to show application FPS and memory usage</li>
-<li>inspector: fix issues turning --track-widget-creation on and off</li>
-<li>inspector: handle apps with multiple isolates in the inspector</li>
-<li>live preview: suggest 'Add forDesignTime() constructor' for widgets</li>
-<li>live preview: make the preview area smaller if the widget is not renderable</li>
-<li>live preview: fixes to make outline preview working on Windows</li>
-<li>live preview: sort children outlines by their RenderObject.depth during preview</li>
-<li>simplify how we recognize Flutter projects when using Bazel</li>
-<li>fix the "Open in Android Studio" action to not show for the ios dir</li>
-<li>add an option to create projects in “offline” mode</li>
-<li>better support for using multiple Flutter modules per IntelliJ project</li>
-<li>improvments to the "Open in XCode…" menu item</li>
-<li>better support for importing Flutter projects</li>
-<li>several fixes for issues with using resources that had been disposed</li>
-<li>add local history labels on reloads and restarts</li>
-<li>have the 'reloading...'' notification timeout after the reload completes</li>
-<li>improved support of running in --profile mode</li>
-<li>expose the new 'Extract Widget' refactoring</li>
+  <li>inspector: add a 'Performance' tab to the Inspector, to show application FPS and memory usage</li>
+  <li>inspector: fix issues turning --track-widget-creation on and off</li>
+  <li>inspector: handle apps with multiple isolates in the inspector</li>
+  <li>live preview: suggest 'Add forDesignTime() constructor' for widgets</li>
+  <li>live preview: make the preview area smaller if the widget is not renderable</li>
+  <li>live preview: fixes to make outline preview working on Windows</li>
+  <li>live preview: sort children outlines by their RenderObject.depth during preview</li>
+  <li>simplify how we recognize Flutter projects when using Bazel</li>
+  <li>fix the "Open in Android Studio" action to not show for the ios dir</li>
+  <li>add an option to create projects in “offline” mode</li>
+  <li>better support for using multiple Flutter modules per IntelliJ project</li>
+  <li>improvments to the "Open in XCode…" menu item</li>
+  <li>better support for importing Flutter projects</li>
+  <li>several fixes for issues with using resources that had been disposed</li>
+  <li>add local history labels on reloads and restarts</li>
+  <li>have the 'reloading...'' notification timeout after the reload completes</li>
+  <li>improved support of running in --profile mode</li>
+  <li>expose the new 'Extract Widget' refactoring</li>
 </ul>
 <h2>23.2</h2>
 <ul>
@@ -419,18 +419,18 @@
 <h2>23.0</h2>
 <ul>
 <li>outline view: removed the experimental flag</li>
-<li>outline view: filter the outline view to only show widgets by default</li>
-<li>inspector: several stability and polish improvements</li>
-<li>inspector: now supports inspecting multiple running apps at the same time</li>
-<li>we now show material icons and colors in code completion (requires 2017.3 or AS 3.1)</li>
-<li>running and debugging flutter test adding for Bazel launch configurations</li>
-<li>added an 'Extract method' refactoring</li>
-<li>the preview dart 2 flag can now accept the SDK default, be set to on, or set to off</li>
-<li>Android Studio: we now support 3.1</li>
-<li>Android Studio: fixed an issue where Android Studio was indexing frequently</li>
-<li>experimental: added a live sparkline of the app's memory usage</li>
-<li>experimental: added a live preview area in the Outline view</li>
-<li>experimental: added the ability to format (and organize imports) on save</li>
+  <li>outline view: filter the outline view to only show widgets by default</li>
+  <li>inspector: several stability and polish improvements</li>
+  <li>inspector: now supports inspecting multiple running apps at the same time</li>
+  <li>we now show material icons and colors in code completion (requires 2017.3 or AS 3.1)</li>
+  <li>running and debugging flutter test adding for Bazel launch configurations</li>
+  <li>added an 'Extract method' refactoring</li>
+  <li>the preview dart 2 flag can now accept the SDK default, be set to on, or set to off</li>
+  <li>Android Studio: we now support 3.1</li>
+  <li>Android Studio: fixed an issue where Android Studio was indexing frequently</li>
+  <li>experimental: added a live sparkline of the app's memory usage</li>
+  <li>experimental: added a live preview area in the Outline view</li>
+  <li>experimental: added the ability to format (and organize imports) on save</li>
 </ul>
 <h2>22.2</h2>
 <ul>
@@ -439,40 +439,40 @@
 <h2>22.1</h2>
 <ul>
 <li>when installing the Flutter SDK, use the 'dev' channel instead of 'alpha'</li>
-<li>fix an issue with the Flutter Outline view on Windows</li>
+  <li>fix an issue with the Flutter Outline view on Windows</li>
 </ul>
 <h2>22.0</h2>inspector view:<ul>
 <li>support for multiple running applications</li>
-<li>basic speed search for the Inspector Tree</li>
-<li>restore flutter framework toggles after a restart</li>
-<li>expose the observatory timeline view (the dashboard version) (#1744)</li>
-<li>live update of property values triggered each time a flutter frame is drawn. (#1721)</li>
-<li>enum property support and tweaks to property display. (#1695)</li>
-<li>HD inspector Widgets (#1682)</li>
-<li>restore inspector splitter position (#1676)</li>
-<li>open the inspector view at app launch (#1670)</li>
+  <li>basic speed search for the Inspector Tree</li>
+  <li>restore flutter framework toggles after a restart</li>
+  <li>expose the observatory timeline view (the dashboard version) (#1744)</li>
+  <li>live update of property values triggered each time a flutter frame is drawn. (#1721)</li>
+  <li>enum property support and tweaks to property display. (#1695)</li>
+  <li>HD inspector Widgets (#1682)</li>
+  <li>restore inspector splitter position (#1676)</li>
+  <li>open the inspector view at app launch (#1670)</li>
 </ul>outline view:<ul>
 <li>rename 'Add widget padding' assist to 'Add padding' (#1771)</li>
-<li>bind actions to move widget down/up. (#1768)</li>
-<li>rename 'Replace with children' to 'Remove widget'. (#1764)</li>
-<li>add action for 'Replace with children' assist. (#1759)</li>
-<li>update messages for wrapping with Column/Row. (#1745)</li>
-<li>add icons and actions for wrapping into Column and Row. (#1743)</li>
-<li>show build() methods in bold (#1731)</li>
-<li>associate the Center action with the corresponding Quick Assist. (#1726)</li>
-<li>navigate from source to Preview view. (#1710)</li>
-<li>add speed search to the Preview view. (#1696)</li>
-<li>add basic Flutter Preview view. (#1678)</li>
+  <li>bind actions to move widget down/up. (#1768)</li>
+  <li>rename 'Replace with children' to 'Remove widget'. (#1764)</li>
+  <li>add action for 'Replace with children' assist. (#1759)</li>
+  <li>update messages for wrapping with Column/Row. (#1745)</li>
+  <li>add icons and actions for wrapping into Column and Row. (#1743)</li>
+  <li>show build() methods in bold (#1731)</li>
+  <li>associate the Center action with the corresponding Quick Assist. (#1726)</li>
+  <li>navigate from source to Preview view. (#1710)</li>
+  <li>add speed search to the Preview view. (#1696)</li>
+  <li>add basic Flutter Preview view. (#1678)</li>
 </ul>platforms:<ul>
 <li>support 2018.1 EAP</li>
-<li>no longer build for 2017.2</li>
+  <li>no longer build for 2017.2</li>
 </ul>miscellaneous:<ul>
 <li>fix for displaying the flutter icon for flutter modules</li>
-<li>fix for issue 1772, Switch Bazel flag for launching apps (#1775)</li>
-<li>add support for displaying flutter color shades in the editor ruler (#1770)</li>
-<li>add a flag to enable --preview-dart-2 (#1709)</li>
-<li>smarts to run <code>flutter build</code> before trying open Xcode (#1373). (#1694)</li>
-<li>harden error reporting on iOS simulator start failures (#1647). (#1681)</li>
+  <li>fix for issue 1772, Switch Bazel flag for launching apps (#1775)</li>
+  <li>add support for displaying flutter color shades in the editor ruler (#1770)</li>
+  <li>add a flag to enable --preview-dart-2 (#1709)</li>
+  <li>smarts to run <code>flutter build</code> before trying open Xcode (#1373). (#1694)</li>
+  <li>harden error reporting on iOS simulator start failures (#1647). (#1681)</li>
 </ul>
 <h2>21.2</h2>
 <ul>
@@ -485,29 +485,29 @@
 <h2>21.0</h2>
 <ul>
 <li>select an existing config at launch</li>
-<li>fix test discovery for plugin example tests</li>
-<li>fix discovery of tests in example subdirs</li>
-<li>improve pub root detection for flutter tests</li>
-<li>actionable “restart” debugging console output</li>
-<li>improve console hyperlinking for local files</li>
-<li>fix run config autoselection for plugin projects</li>
-<li>for non-bazel project configurations, don't show the FlutterBazelRunConfigurationType</li>
-<li>update FlutterViewCondition to be bazel project aware</li>
-<li>remove the preference for the Inspector view (it's now on by default)</li>
-<li>rename the Flutter view to Flutter Inspector</li>
-<li>clean up of the Flutter Inspector View icons</li>
-<li>show color properties with a nice color swatch icons</li>
-<li>add a notification for reloaded but not run elements</li>
-<li>show flutter material icons in the inspector</li>
-<li>for Bazel launch configurations, update the android_cpu architecture type from armeabi to armeabi-v7a</li>
+  <li>fix test discovery for plugin example tests</li>
+  <li>fix discovery of tests in example subdirs</li>
+  <li>improve pub root detection for flutter tests</li>
+  <li>actionable “restart” debugging console output</li>
+  <li>improve console hyperlinking for local files</li>
+  <li>fix run config autoselection for plugin projects</li>
+  <li>for non-bazel project configurations, don't show the FlutterBazelRunConfigurationType</li>
+  <li>update FlutterViewCondition to be bazel project aware</li>
+  <li>remove the preference for the Inspector view (it's now on by default)</li>
+  <li>rename the Flutter view to Flutter Inspector</li>
+  <li>clean up of the Flutter Inspector View icons</li>
+  <li>show color properties with a nice color swatch icons</li>
+  <li>add a notification for reloaded but not run elements</li>
+  <li>show flutter material icons in the inspector</li>
+  <li>for Bazel launch configurations, update the android_cpu architecture type from armeabi to armeabi-v7a</li>
 </ul>
 <h2>20.0</h2>
 <ul>
 <li>improved console filtering</li>
-<li>improved unit test running support to allow running package:flutter tests</li>
-<li>improved "Open with Xcode..." logic to work better for plugin projects</li>
-<li>fixed project creation to properly respect custom creation options (such as target language)</li>
-<li>fixed an NPE sometimes encountered when deleting projects</li>
+  <li>improved unit test running support to allow running package:flutter tests</li>
+  <li>improved "Open with Xcode..." logic to work better for plugin projects</li>
+  <li>fixed project creation to properly respect custom creation options (such as target language)</li>
+  <li>fixed an NPE sometimes encountered when deleting projects</li>
 </ul>
 <h2>19.1</h2>
 <ul>
@@ -516,23 +516,23 @@
 <h2>19.0</h2>
 <ul>
 <li>fixed an issue with reload when multiple project windows are open</li>
-<li>fixed running Flutter tests in nested groups</li>
-<li>fixed miscellaneous project wizard issues</li>
-<li>fix to ensure we don't create Flutter library entries for non-Flutter projects</li>
-<li>fixed project name validation in the new project creation wizard to be more performant</li>
-<li>fixed project opening to only open main.dart if no other editors are open</li>
-<li>fix to limit Flutter icon contributions to Flutter projects</li>
-<li>reload on save updated to ignore errors in test files</li>
-<li>IDEA EAP support</li>
-<li>fix to give restarted apps focus on iOS</li>
-<li>miscellaneous Android Studio support fixes</li>
-<li>fixed check for Flutter tests to not mis-identify vanilla Dart tests</li>
-<li>improved error reporting on project creation failures</li>
+  <li>fixed running Flutter tests in nested groups</li>
+  <li>fixed miscellaneous project wizard issues</li>
+  <li>fix to ensure we don't create Flutter library entries for non-Flutter projects</li>
+  <li>fixed project name validation in the new project creation wizard to be more performant</li>
+  <li>fixed project opening to only open main.dart if no other editors are open</li>
+  <li>fix to limit Flutter icon contributions to Flutter projects</li>
+  <li>reload on save updated to ignore errors in test files</li>
+  <li>IDEA EAP support</li>
+  <li>fix to give restarted apps focus on iOS</li>
+  <li>miscellaneous Android Studio support fixes</li>
+  <li>fixed check for Flutter tests to not mis-identify vanilla Dart tests</li>
+  <li>improved error reporting on project creation failures</li>
 </ul>
 <h2>18.4</h2>
 <ul>
 <li>Revert to 18.1 to address an NPE in the FlutterInitializer class</li>
-<li>fixed an issue where reload on save could not be disabled</li>
+  <li>fixed an issue where reload on save could not be disabled</li>
 </ul>
 <h2>18.3</h2>
 <ul>
@@ -541,55 +541,55 @@
 <h2>18.2</h2>
 <ul>
 <li>fixed an issue where reload on save could not be disabled</li>
-<li>fixed an exception that could occur on project creation</li>
+  <li>fixed an exception that could occur on project creation</li>
 </ul>
 <h2>18.1</h2>
 <ul>
 <li>fixed hot reload issue when multiple project windows were open</li>
-<li>fixed 'Open Observatory timeline' action</li>
+  <li>fixed 'Open Observatory timeline' action</li>
 </ul>
 <h2>18.0</h2>
 <ul>
 <li>Android Studio support</li>
-<li>for flutter launches, support passing in a --flavor param</li>
-<li>reload on save now on by default</li>
-<li>improved and reorganized the Flutter view's toolbar</li>
-<li>analysis toast provides a new hyperlink to open the analysis view</li>
-<li>reloads disallowed while another reload is taking place</li>
-<li>support to show referenced flutter plugin in the project view</li>
+  <li>for flutter launches, support passing in a --flavor param</li>
+  <li>reload on save now on by default</li>
+  <li>improved and reorganized the Flutter view's toolbar</li>
+  <li>analysis toast provides a new hyperlink to open the analysis view</li>
+  <li>reloads disallowed while another reload is taking place</li>
+  <li>support to show referenced flutter plugin in the project view</li>
 </ul>
 <h2>17.0</h2>
 <ul>
 <li>improved new project wizard</li>
-<li>improvements to the reload-on-save behavior</li>
-<li>improved and reorganized the Flutter view's toolbar</li>
-<li>fixes to the Flutter icon decorations in the editor ruler</li>
-<li>fixes to group handling for widget tests</li>
-<li>display a ballon toast if there are analysis issues when running apps</li>
-<li>added a toggle inspect mode toolbar button</li>
-<li>speed improvements to the device switcher pulldown</li>
+  <li>improvements to the reload-on-save behavior</li>
+  <li>improved and reorganized the Flutter view's toolbar</li>
+  <li>fixes to the Flutter icon decorations in the editor ruler</li>
+  <li>fixes to group handling for widget tests</li>
+  <li>display a ballon toast if there are analysis issues when running apps</li>
+  <li>added a toggle inspect mode toolbar button</li>
+  <li>speed improvements to the device switcher pulldown</li>
 </ul>
 <h2>16.0</h2>
 <ul>
 <li>device list refresh fixes</li>
-<li>support for flutter run in profile and release modes</li>
-<li>support for reading the android sdk location from flutter tools</li>
-<li>support for discovering and running Flutter widget tests</li>
-<li>Flutter test console improvements</li>
-<li>support for running flutter doctor in a Bazel workspace</li>
-<li>test file icon annotations</li>
-<li>support for locating a missing flutter SDK in .packages files</li>
-<li>open emulator action sorting</li>
-<li>test state icons for Flutter tests</li>
-<li>editor line markers for Flutter tests</li>
-<li>added a new restart daemon action</li>
-<li>open emulator action sorting</li>
-<li>run/debug button enablement improvements</li>
-<li>fix to ensure the <code>Install SDK…</code> action is always visible</li>
-<li>support for running a single Flutter test, by name</li>
-<li>install creation progress UI fixes</li>
-<li>project creation fixes for small IDEs</li>
-<li>fixes to android emulator launching</li>
+  <li>support for flutter run in profile and release modes</li>
+  <li>support for reading the android sdk location from flutter tools</li>
+  <li>support for discovering and running Flutter widget tests</li>
+  <li>Flutter test console improvements</li>
+  <li>support for running flutter doctor in a Bazel workspace</li>
+  <li>test file icon annotations</li>
+  <li>support for locating a missing flutter SDK in .packages files</li>
+  <li>open emulator action sorting</li>
+  <li>test state icons for Flutter tests</li>
+  <li>editor line markers for Flutter tests</li>
+  <li>added a new restart daemon action</li>
+  <li>open emulator action sorting</li>
+  <li>run/debug button enablement improvements</li>
+  <li>fix to ensure the <code>Install SDK…</code> action is always visible</li>
+  <li>support for running a single Flutter test, by name</li>
+  <li>install creation progress UI fixes</li>
+  <li>project creation fixes for small IDEs</li>
+  <li>fixes to android emulator launching</li>
 </ul>
 <h2>15.2</h2>
 <ul>
@@ -602,49 +602,49 @@
 <h2>15.0</h2>
 <ul>
 <li>UI for starting android emulators from the device pull-down</li>
-<li>workflow for installing a Flutter SDK from the New Flutter Project wizard</li>
-<li>Flutter SDK configuration inspection improvements</li>
-<li>improved error reporting on project creation failures</li>
-<li>improved app reload feedback</li>
-<li>Flutter View toolbar tweaks</li>
-<li>initial support for running unit tests with <code>flutter test</code></li>
-<li>new action to open iOS resources in Xcode</li>
+  <li>workflow for installing a Flutter SDK from the New Flutter Project wizard</li>
+  <li>Flutter SDK configuration inspection improvements</li>
+  <li>improved error reporting on project creation failures</li>
+  <li>improved app reload feedback</li>
+  <li>Flutter View toolbar tweaks</li>
+  <li>initial support for running unit tests with <code>flutter test</code></li>
+  <li>new action to open iOS resources in Xcode</li>
 </ul>
 <h2>14.0</h2>
 <ul>
 <li>user toggleable option to enable more verbose debug logging of Flutter app runs</li>
-<li>fixes to the new Flutter Module workflow</li>
-<li>improved console logging on Flutter app termination</li>
-<li>improved error reporting on Observatory connection and Flutter View open failures</li>
-<li>removed Flutter SDK settings from default projects</li>
-<li>improved project name validation (to align with checks in <code>flutter create</code>)</li>
-<li>console hyperlinks for Xcode resources</li>
-<li>fix to inherit Android JDK setting when creating Flutter projects</li>
-<li>fix to ensure Flutter console filtering is only applied to Flutter consoles</li>
-<li>improved device daemon interop</li>
-<li>improved SDK version checking</li>
+  <li>fixes to the new Flutter Module workflow</li>
+  <li>improved console logging on Flutter app termination</li>
+  <li>improved error reporting on Observatory connection and Flutter View open failures</li>
+  <li>removed Flutter SDK settings from default projects</li>
+  <li>improved project name validation (to align with checks in <code>flutter create</code>)</li>
+  <li>console hyperlinks for Xcode resources</li>
+  <li>fix to inherit Android JDK setting when creating Flutter projects</li>
+  <li>fix to ensure Flutter console filtering is only applied to Flutter consoles</li>
+  <li>improved device daemon interop</li>
+  <li>improved SDK version checking</li>
 </ul>
 <h2>13.1</h2>
 <ul>
 <li>project opening improvements</li>
-<li>new action to open the Flutter view</li>
-<li>module name validation on creation</li>
-<li>fix to ensure all open files are saved to disk before running Flutter actions</li>
-<li>improved progress reporting during calls to 'flutter create'</li>
-<li>miscellaneous fixes and analytics improvements</li>
+  <li>new action to open the Flutter view</li>
+  <li>module name validation on creation</li>
+  <li>fix to ensure all open files are saved to disk before running Flutter actions</li>
+  <li>improved progress reporting during calls to 'flutter create'</li>
+  <li>miscellaneous fixes and analytics improvements</li>
 </ul>
 <h2>13.0</h2>
 <ul>
 <li>small IDE support improvements</li>
-<li>android module enablement on project creation</li>
-<li>project explorer icon customizations</li>
-<li>support for Flutter drop frame debugging</li>
-<li>hot reload UX improvements</li>
-<li>Bazel run config refinements</li>
-<li>support for toggling OS in the Flutter View</li>
-<li>Flutter CLI interop fixes (proper env setup)</li>
-<li>color icon improvements</li>
-<li>bump to require 2017.1+</li>
+  <li>android module enablement on project creation</li>
+  <li>project explorer icon customizations</li>
+  <li>support for Flutter drop frame debugging</li>
+  <li>hot reload UX improvements</li>
+  <li>Bazel run config refinements</li>
+  <li>support for toggling OS in the Flutter View</li>
+  <li>Flutter CLI interop fixes (proper env setup)</li>
+  <li>color icon improvements</li>
+  <li>bump to require 2017.1+</li>
 </ul>
 <h2>12.1</h2>
 <ul>
@@ -653,18 +653,18 @@
 <h2>12.0</h2>
 <ul>
 <li>support for IDEA <code>2017.1</code></li>
-<li>new Flutter <code>stless</code>, <code>stful</code>, and <code>stanim</code> live templates</li>
-<li>new assists for editing the widget hierarchy:
+  <li>new Flutter <code>stless</code>, <code>stful</code>, and <code>stanim</code> live templates</li>
+  <li>new assists for editing the widget hierarchy:
 <ul>
 <li>move widget up or down</li>
-<li>re-parent widget or list of widgets</li>
-<li>convert <code>child:</code> keyword to <code>children:</code></li>
+  <li>re-parent widget or list of widgets</li>
+  <li>convert <code>child:</code> keyword to <code>children:</code></li>
 </ul>
 </li>
-<li>support for specifying "Additional Args" to Flutter application launches</li>
-<li>default run configuration creation on project open (when possible)</li>
-<li>device menu improvements</li>
-<li>miscellaneous bug fixes</li>
+  <li>support for specifying "Additional Args" to Flutter application launches</li>
+  <li>default run configuration creation on project open (when possible)</li>
+  <li>device menu improvements</li>
+  <li>miscellaneous bug fixes</li>
 </ul>
 <h2>0.1.11.2</h2>
 <ul>
@@ -677,33 +677,33 @@
 <h2>0.1.11</h2>
 <ul>
 <li>Flutter tool window badging when active</li>
-<li>iOS console output folding improvements</li>
-<li>Flutter reload actions added to main "Run" menu</li>
-<li>devices menu fixes</li>
-<li>improved tooltips for pubspec editor notifications</li>
+  <li>iOS console output folding improvements</li>
+  <li>Flutter reload actions added to main "Run" menu</li>
+  <li>devices menu fixes</li>
+  <li>improved tooltips for pubspec editor notifications</li>
 </ul>
 <h2>0.1.10</h2>
 <ul>
 <li>fixes to pubspec timestamp checking</li>
-<li>analytics events for run, debug, and process stop</li>
-<li>fix to <code>flutter doctor</code> to better support multiple runs</li>
-<li>fix to the reload action for apps launched from 'run'</li>
+  <li>analytics events for run, debug, and process stop</li>
+  <li>fix to <code>flutter doctor</code> to better support multiple runs</li>
+  <li>fix to the reload action for apps launched from 'run'</li>
 </ul>
 <h2>0.1.9.1</h2>
 <ul>
 <li>fix button enablement in the Flutter View</li>
-<li>fix the reload action for apps launched from 'run'</li>
+  <li>fix the reload action for apps launched from 'run'</li>
 </ul>
 <h2>0.1.9</h2>
 <ul>
 <li>added a 'Flutter' view to allow users to toggle Flutter framework debugging features while running</li>
-<li>fixes to the visibility of the "Tools" menu</li>
-<li>inspection to detect pubspec modifications (that may imply out of date package dependencies)</li>
-<li>key bindings fixes</li>
-<li>support for opening source folders as Flutter projects (using "Open...")</li>
-<li>run and debug button enablement fixes</li>
-<li>fix to bring iOS simulator to front on run/debug</li>
-<li>fix to handle devfs breakpoints for projects without pubspecs</li>
+  <li>fixes to the visibility of the "Tools" menu</li>
+  <li>inspection to detect pubspec modifications (that may imply out of date package dependencies)</li>
+  <li>key bindings fixes</li>
+  <li>support for opening source folders as Flutter projects (using "Open...")</li>
+  <li>run and debug button enablement fixes</li>
+  <li>fix to bring iOS simulator to front on run/debug</li>
+  <li>fix to handle devfs breakpoints for projects without pubspecs</li>
 </ul>
 <h2>0.1.8.1</h2>
 <ul>
@@ -712,41 +712,41 @@
 <h2>0.1.8</h2>
 <ul>
 <li>fixed race condition in console reporting on project creation</li>
-<li>improved interaction between Flutter and Dart plugins during project creation (no more unnecessary nags to run pub)</li>
-<li>improvements to version checking</li>
-<li>settings UI refinements</li>
-<li>new "Help &gt; Flutter Plugin" top-level menu</li>
-<li>added reload/restart actions in the main toolbar</li>
-<li>improved console folding for iOS messages</li>
-<li>fixed NPE in project creation</li>
+  <li>improved interaction between Flutter and Dart plugins during project creation (no more unnecessary nags to run pub)</li>
+  <li>improvements to version checking</li>
+  <li>settings UI refinements</li>
+  <li>new "Help &gt; Flutter Plugin" top-level menu</li>
+  <li>added reload/restart actions in the main toolbar</li>
+  <li>improved console folding for iOS messages</li>
+  <li>fixed NPE in project creation</li>
 </ul>
 <h2>0.1.7</h2>
 <ul>
 <li>improved console output folding when running iOS apps</li>
-<li>actions for Flutter package get and package update</li>
-<li>a new top level Flutter menu (Tools&gt;Flutter) with common Flutter actions</li>
-<li>updated hot reload and restart icons</li>
-<li>editor annotations showing Flutter colors and icons in the editor ruler</li>
-<li>better console filtering (less noise)</li>
-<li>improved detection of Flutter projects missing a Flutter module type</li>
+  <li>actions for Flutter package get and package update</li>
+  <li>a new top level Flutter menu (Tools&gt;Flutter) with common Flutter actions</li>
+  <li>updated hot reload and restart icons</li>
+  <li>editor annotations showing Flutter colors and icons in the editor ruler</li>
+  <li>better console filtering (less noise)</li>
+  <li>improved detection of Flutter projects missing a Flutter module type</li>
 </ul>
 <h2>0.1.6</h2>
 <ul>
 <li>reload and restart keybinding mapping fixes</li>
-<li>new butter bar with actions for flutter.yaml files</li>
-<li>"run" behavior re-designed to support reload</li>
-<li>improved console output for reloading and restarting</li>
-<li>miscellaneous fixes and stability improvements</li>
+  <li>new butter bar with actions for flutter.yaml files</li>
+  <li>"run" behavior re-designed to support reload</li>
+  <li>improved console output for reloading and restarting</li>
+  <li>miscellaneous fixes and stability improvements</li>
 </ul>
 <h2>0.1.5</h2>
 <ul>
 <li>console filtering for flutter run output</li>
-<li>improved messaging for incomplete Flutter SDK configurations</li>
-<li>support for new application events produced by Flutter tools</li>
-<li>fixed duplicate service protocol console logging</li>
-<li>Flutter run configuration cleanup</li>
-<li>fixed NPE in showing progress from Flutter tools tasks</li>
-<li>migration away from storing Flutter SDK location in an application library</li>
+  <li>improved messaging for incomplete Flutter SDK configurations</li>
+  <li>support for new application events produced by Flutter tools</li>
+  <li>fixed duplicate service protocol console logging</li>
+  <li>Flutter run configuration cleanup</li>
+  <li>fixed NPE in showing progress from Flutter tools tasks</li>
+  <li>migration away from storing Flutter SDK location in an application library</li>
 </ul>
 <h2>0.1.4.1</h2>
 <ul>
@@ -759,8 +759,8 @@
 <h2>0.1.3</h2>
 <ul>
 <li>notifications for projects that look like Flutter apps but do not have Flutter enabled</li>
-<li>improved Flutter preference UI and SDK configuration</li>
-<li>IDEA version constraints to ensure that the plugin cannot be installed in incompatible IDEA versions</li>
+  <li>improved Flutter preference UI and SDK configuration</li>
+  <li>IDEA version constraints to ensure that the plugin cannot be installed in incompatible IDEA versions</li>
 </ul>
 <h2>0.1.2</h2>
 <ul>
@@ -769,8 +769,8 @@
 <h2>0.1.1</h2>
 <ul>
 <li>removed second (redundant) "open observatory" button</li>
-<li>filtering to ensure the Flutter device selector only appears for Flutter projects</li>
-<li>fixed hangs on app re-runs</li>
+  <li>filtering to ensure the Flutter device selector only appears for Flutter projects</li>
+  <li>fixed hangs on app re-runs</li>
 </ul>
 <h2>0.1.0</h2>
 <ul>

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -31,7 +31,7 @@
     <![CDATA[
 <h2>39.0</h2>
 <ul>
-<li>Changed project creation to default to AndriodX deselected until it works for Flutter modules</li>
+  <li>Changed project creation to default to AndriodX deselected until it works for Flutter modules</li>
   <li>Enabled structured errors by default</li>
   <li>Fix #3731: Synchronous execution on EDT (#3823)</li>
   <li>Make the new languages be default (#3819)</li>
@@ -57,17 +57,17 @@
 </ul>
 <h2>38.2</h2>
 <ul>
-<li>Fix bug on Windows that prevented outlines from displaying</li>
+  <li>Fix bug on Windows that prevented outlines from displaying</li>
   <li>Restore the ability to run individual tests </li>
   <li>Fix a couple other issues</li>
 </ul>
 <h2>38.1</h2>
 <ul>
-<li>Fix first-time installation issue</li>
+  <li>Fix first-time installation issue</li>
 </ul>
 <h2>38.0</h2>
 <ul>
-<li>Add AndroidX option to new project wizards (#3705)</li>
+  <li>Add AndroidX option to new project wizards (#3705)</li>
   <li>Fix break due to Android Studio 3.6 API change (#3712)</li>
   <li>Fix logger npe (#3711)</li>
   <li>Integration test update (#3710)</li>
@@ -101,14 +101,14 @@
 </ul>
 <h2>37.0</h2>
 <ul>
-<li>Fix an offset issue with the UI guides code (#3574)</li>
+  <li>Fix an offset issue with the UI guides code (#3574)</li>
   <li>Add IDE query param to DevTools url. (#3592)</li>
   <li>Treat FlutterApp as a long-running process (#3599)</li>
   <li>Fix links for test URLs (#3600)</li>
 </ul>
 <h2>36.0</h2>
 <ul>
-<li>Add Gradle build script (#3529)</li>
+  <li>Add Gradle build script (#3529)</li>
   <li>Update for new platform releases (#3527)</li>
   <li>Add in a preference to toggle closing labels (#3528)</li>
   <li>Don't disable closing labels as part of UI Guides (#3525)</li>
@@ -130,13 +130,13 @@
 </ul>
 <h2>35.1.3</h2>
 <ul>
-<li>Support IntelliJ 2019.1.2 RC</li>
+  <li>Support IntelliJ 2019.1.2 RC</li>
   <li>Support Android Studio 3.5 beta 1</li>
   <li>Bug fixes</li>
 </ul>
 <h2>35.1</h2>
 <ul>
-<li>Add an option to hide closing labels in Dart source code when UI guides are on (#3438)</li>
+  <li>Add an option to hide closing labels in Dart source code when UI guides are on (#3438)</li>
   <li>Create "Editor" section of Flutter Settings (#3434)</li>
   <li>Support UI as Code Widget Guides (#3420)</li>
   <li>Add checkbox to skip the dart analyzer error check before a hot reload (#3414)</li>
@@ -145,7 +145,7 @@
 </ul>
 <h2>35.0</h2>
 <ul>
-<li>Sample panel layout improvements (#3396)</li>
+  <li>Sample panel layout improvements (#3396)</li>
   <li>Remove unneeded logging (#3394)</li>
   <li>Java analysis lints cleanup (#3395)</li>
   <li>Update subscriptions after analysis server restart (#3393)</li>
@@ -171,7 +171,7 @@
 </ul>
 <h2>34.0</h2>
 <ul>
-<li>Update build for Android Studio 3.3.2 and IntelliJ 2019.1 (#3321)</li>
+  <li>Update build for Android Studio 3.3.2 and IntelliJ 2019.1 (#3321)</li>
   <li>Fix issue preventing plugin from working in AS Canary 8 (#3321)</li>
   <li>Provides a better display if the variable has a <code>toStringDeep()</code> method defined. (#3291)</li>
   <li>Don't show a background square in the inspector summary tree. (#3326)</li>
@@ -200,21 +200,21 @@
 </ul>
 <h2>33.3</h2>
 <ul>
-<li>Fix an issue with an IllegalArgumentException when running Flutter apps</li>
+  <li>Fix an issue with an IllegalArgumentException when running Flutter apps</li>
 </ul>
 <h2>33.2</h2>
 <ul>
-<li>Support IntelliJ 2018.3.3</li>
+  <li>Support IntelliJ 2018.3.3</li>
 </ul>
 <h2>33.1</h2>
 <ul>
-<li>add menu and toolbar button to open Flutter DevTools</li>
+  <li>add menu and toolbar button to open Flutter DevTools</li>
   <li>fix Gradle sync issue for Android Studio 3.3.1</li>
   <li>fix highlighting of the Go link in sample banner</li>
 </ul>
 <h2>33.0</h2>
 <ul>
-<li>update build for Android Studio 3.3.1</li>
+  <li>update build for Android Studio 3.3.1</li>
   <li>reorder console filters so links work</li>
   <li>more intelligently enable support for detaching from Flutter apps on exit</li>
   <li>change the icon used for paint baselines</li>
@@ -233,7 +233,7 @@
 </ul>
 <h2>32.0</h2>
 <ul>
-<li>address an NPE in FlutterWidgetPerfManager.java</li>
+  <li>address an NPE in FlutterWidgetPerfManager.java</li>
   <li>added overlay renderered for GC, snapshot and memory reset events</li>
   <li>consolidated all adt-ui API changes in FlutterStudioMonitorStageView</li>
   <li>support for creating projects w/ sample content from the IDEA New Project Wizard</li>
@@ -258,12 +258,12 @@
 </ul>
 <h2>31.3</h2>
 <ul>
-<li>fix NPE in sdk installation (#2965)</li>
+  <li>fix NPE in sdk installation (#2965)</li>
   <li>fix NPE caused by internal inconsistency (#2963)</li>
 </ul>
 <h2>31.2</h2>
 <ul>
-<li>show memory profiler legend with proper line chart color or line style</li>
+  <li>show memory profiler legend with proper line chart color or line style</li>
   <li>prevent the (IntelliJ) New Project wizard from completing when there is no Flutter SDK</li>
   <li>fix a race condition causing unexpected conditions in attach</li>
   <li>added control of RSS display to memory profiler</li>
@@ -272,13 +272,13 @@
 </ul>
 <h2>31.1</h2>
 <ul>
-<li>perf table polish and fix links to tip docs</li>
+  <li>perf table polish and fix links to tip docs</li>
   <li>fix Split Mode resize issue</li>
   <li>rebuild stats wording tweaks</li>
 </ul>
 <h2>31.0</h2>
 <ul>
-<li>change FPS display to "Frame Rendering Time" and improve UI</li>
+  <li>change FPS display to "Frame Rendering Time" and improve UI</li>
   <li>reorganize inspector tools</li>
   <li>better error reporting for Flutter runtime issues</li>
   <li>fewer Flutter runtime issues</li>
@@ -290,7 +290,7 @@
 </ul>
 <h2>30.0</h2>
 <ul>
-<li>performance inspector changes</li>
+  <li>performance inspector changes</li>
   <li>log view tweaks</li>
   <li>memory profiler updates</li>
   <li>support 'flutter attach' in the IDE (both IJ and AS)</li>
@@ -299,11 +299,11 @@
 </ul>
 <h2>29.1</h2>
 <ul>
-<li>address an issue with an NPE when debugging</li>
+  <li>address an issue with an NPE when debugging</li>
 </ul>
 <h2>29.0</h2>
 <ul>
-<li>add 'Wrap with Container' to preview</li>
+  <li>add 'Wrap with Container' to preview</li>
   <li>fix test navigation</li>
   <li>clear log on restart</li>
   <li>experimental memory profiler; enable in preferences</li>
@@ -312,18 +312,18 @@
 </ul>
 <h2>28.0</h2>
 <ul>
-<li>build for Android Studio 3.3 Canary and 3.2 Beta</li>
+  <li>build for Android Studio 3.3 Canary and 3.2 Beta</li>
   <li>add UI support for importing Flutter modules into Android apps</li>
   <li>add more details to logging output</li>
   <li>bug fixes</li>
 </ul>
 <h2>27.1</h2>
 <ul>
-<li>change the preference for --track-widget-creation to default to off</li>
+  <li>change the preference for --track-widget-creation to default to off</li>
 </ul>
 <h2>27.0</h2>
 <ul>
-<li>add a setting to control syncing Android libraries</li>
+  <li>add a setting to control syncing Android libraries</li>
   <li>fixes related to evaluating expressions when not on a call frame</li>
   <li>auto-disable scroll to end when the user manually scrolls the log up</li>
   <li>add the "module" template to new-module and project wizards in Android Studio</li>
@@ -340,7 +340,7 @@
 </ul>
 <h2>26.0</h2>
 <ul>
-<li>updates to support Android Studio 3.2 Beta</li>
+  <li>updates to support Android Studio 3.2 Beta</li>
   <li>removes the Inspector's empty content message</li>
   <li>support setting log color from flutter log settings page</li>
   <li>support hiding/showing log categories (#2398)</li>
@@ -362,7 +362,7 @@
 </ul>
 <h2>25.0</h2>
 <ul>
-<li>remove the user preference to disable --preview-dart-2</li>
+  <li>remove the user preference to disable --preview-dart-2</li>
   <li>don't use 'new' for the stless, stfull, stanim templates</li>
   <li>add support for IntelliJ 2018.2 EAP (#2270)</li>
   <li>added a new (very experimental) logging view</li>
@@ -376,19 +376,19 @@
 </ul>
 <h2>24.2</h2>
 <ul>
-<li>fix the --track-widget-creation flag implementation on Windows</li>
+  <li>fix the --track-widget-creation flag implementation on Windows</li>
   <li>fix for an exception in the Outline view on older Flutter SDKs</li>
 </ul>
 <h2>24.1</h2>
 <ul>
-<li>update Flutter icons</li>
+  <li>update Flutter icons</li>
   <li>fix an exception when the selection changes and the outline view isn't visible</li>
   <li>fix for an issue with reload on save in profile runs</li>
   <li>fix for a 2017.3 issue with a 'no running apps' message in the inspector</li>
 </ul>
 <h2>24.0</h2>
 <ul>
-<li>inspector: significant UI refactoring to show the tree in a master / details format</li>
+  <li>inspector: significant UI refactoring to show the tree in a master / details format</li>
   <li>inspector: add a 'Performance' tab to the Inspector, to show application FPS and memory usage</li>
   <li>inspector: fix issues turning --track-widget-creation on and off</li>
   <li>inspector: handle apps with multiple isolates in the inspector</li>
@@ -410,15 +410,15 @@
 </ul>
 <h2>23.2</h2>
 <ul>
-<li>updated some Bazel breakpoint logic</li>
+  <li>updated some Bazel breakpoint logic</li>
 </ul>
 <h2>23.1</h2>
 <ul>
-<li>disabled an Android facet's ALLOW_USER_CONFIGURATION setting, to address a continuous indexing issue</li>
+  <li>disabled an Android facet's ALLOW_USER_CONFIGURATION setting, to address a continuous indexing issue</li>
 </ul>
 <h2>23.0</h2>
 <ul>
-<li>outline view: removed the experimental flag</li>
+  <li>outline view: removed the experimental flag</li>
   <li>outline view: filter the outline view to only show widgets by default</li>
   <li>inspector: several stability and polish improvements</li>
   <li>inspector: now supports inspecting multiple running apps at the same time</li>
@@ -434,15 +434,15 @@
 </ul>
 <h2>22.2</h2>
 <ul>
-<li>when installing the Flutter SDK, use the 'beta' channel instead of 'dev'</li>
+  <li>when installing the Flutter SDK, use the 'beta' channel instead of 'dev'</li>
 </ul>
 <h2>22.1</h2>
 <ul>
-<li>when installing the Flutter SDK, use the 'dev' channel instead of 'alpha'</li>
+  <li>when installing the Flutter SDK, use the 'dev' channel instead of 'alpha'</li>
   <li>fix an issue with the Flutter Outline view on Windows</li>
 </ul>
 <h2>22.0</h2>inspector view:<ul>
-<li>support for multiple running applications</li>
+  <li>support for multiple running applications</li>
   <li>basic speed search for the Inspector Tree</li>
   <li>restore flutter framework toggles after a restart</li>
   <li>expose the observatory timeline view (the dashboard version) (#1744)</li>
@@ -452,7 +452,7 @@
   <li>restore inspector splitter position (#1676)</li>
   <li>open the inspector view at app launch (#1670)</li>
 </ul>outline view:<ul>
-<li>rename 'Add widget padding' assist to 'Add padding' (#1771)</li>
+  <li>rename 'Add widget padding' assist to 'Add padding' (#1771)</li>
   <li>bind actions to move widget down/up. (#1768)</li>
   <li>rename 'Replace with children' to 'Remove widget'. (#1764)</li>
   <li>add action for 'Replace with children' assist. (#1759)</li>
@@ -464,10 +464,10 @@
   <li>add speed search to the Preview view. (#1696)</li>
   <li>add basic Flutter Preview view. (#1678)</li>
 </ul>platforms:<ul>
-<li>support 2018.1 EAP</li>
+  <li>support 2018.1 EAP</li>
   <li>no longer build for 2017.2</li>
 </ul>miscellaneous:<ul>
-<li>fix for displaying the flutter icon for flutter modules</li>
+  <li>fix for displaying the flutter icon for flutter modules</li>
   <li>fix for issue 1772, Switch Bazel flag for launching apps (#1775)</li>
   <li>add support for displaying flutter color shades in the editor ruler (#1770)</li>
   <li>add a flag to enable --preview-dart-2 (#1709)</li>
@@ -476,15 +476,15 @@
 </ul>
 <h2>21.2</h2>
 <ul>
-<li>Fix an NPE when the Flutter SDK version file contains the text 'unknown'</li>
+  <li>Fix an NPE when the Flutter SDK version file contains the text 'unknown'</li>
 </ul>
 <h2>21.1</h2>
 <ul>
-<li>Fix an NPE when reading the Flutter SDK version file</li>
+  <li>Fix an NPE when reading the Flutter SDK version file</li>
 </ul>
 <h2>21.0</h2>
 <ul>
-<li>select an existing config at launch</li>
+  <li>select an existing config at launch</li>
   <li>fix test discovery for plugin example tests</li>
   <li>fix discovery of tests in example subdirs</li>
   <li>improve pub root detection for flutter tests</li>
@@ -503,7 +503,7 @@
 </ul>
 <h2>20.0</h2>
 <ul>
-<li>improved console filtering</li>
+  <li>improved console filtering</li>
   <li>improved unit test running support to allow running package:flutter tests</li>
   <li>improved "Open with Xcode..." logic to work better for plugin projects</li>
   <li>fixed project creation to properly respect custom creation options (such as target language)</li>
@@ -511,11 +511,11 @@
 </ul>
 <h2>19.1</h2>
 <ul>
-<li>Bazel run configuration updates</li>
+  <li>Bazel run configuration updates</li>
 </ul>
 <h2>19.0</h2>
 <ul>
-<li>fixed an issue with reload when multiple project windows are open</li>
+  <li>fixed an issue with reload when multiple project windows are open</li>
   <li>fixed running Flutter tests in nested groups</li>
   <li>fixed miscellaneous project wizard issues</li>
   <li>fix to ensure we don't create Flutter library entries for non-Flutter projects</li>
@@ -531,26 +531,26 @@
 </ul>
 <h2>18.4</h2>
 <ul>
-<li>Revert to 18.1 to address an NPE in the FlutterInitializer class</li>
+  <li>Revert to 18.1 to address an NPE in the FlutterInitializer class</li>
   <li>fixed an issue where reload on save could not be disabled</li>
 </ul>
 <h2>18.3</h2>
 <ul>
-<li>fixed a build problem that prevented the Android Studio plugin from creating projects</li>
+  <li>fixed a build problem that prevented the Android Studio plugin from creating projects</li>
 </ul>
 <h2>18.2</h2>
 <ul>
-<li>fixed an issue where reload on save could not be disabled</li>
+  <li>fixed an issue where reload on save could not be disabled</li>
   <li>fixed an exception that could occur on project creation</li>
 </ul>
 <h2>18.1</h2>
 <ul>
-<li>fixed hot reload issue when multiple project windows were open</li>
+  <li>fixed hot reload issue when multiple project windows were open</li>
   <li>fixed 'Open Observatory timeline' action</li>
 </ul>
 <h2>18.0</h2>
 <ul>
-<li>Android Studio support</li>
+  <li>Android Studio support</li>
   <li>for flutter launches, support passing in a --flavor param</li>
   <li>reload on save now on by default</li>
   <li>improved and reorganized the Flutter view's toolbar</li>
@@ -560,7 +560,7 @@
 </ul>
 <h2>17.0</h2>
 <ul>
-<li>improved new project wizard</li>
+  <li>improved new project wizard</li>
   <li>improvements to the reload-on-save behavior</li>
   <li>improved and reorganized the Flutter view's toolbar</li>
   <li>fixes to the Flutter icon decorations in the editor ruler</li>
@@ -571,7 +571,7 @@
 </ul>
 <h2>16.0</h2>
 <ul>
-<li>device list refresh fixes</li>
+  <li>device list refresh fixes</li>
   <li>support for flutter run in profile and release modes</li>
   <li>support for reading the android sdk location from flutter tools</li>
   <li>support for discovering and running Flutter widget tests</li>
@@ -593,15 +593,15 @@
 </ul>
 <h2>15.2</h2>
 <ul>
-<li>fix for an exception in the new project wizard in WebStorm (#1234)</li>
+  <li>fix for an exception in the new project wizard in WebStorm (#1234)</li>
 </ul>
 <h2>15.1</h2>
 <ul>
-<li>fix for a file watching related NPE on build systems using Bazel (#1191)</li>
+  <li>fix for a file watching related NPE on build systems using Bazel (#1191)</li>
 </ul>
 <h2>15.0</h2>
 <ul>
-<li>UI for starting android emulators from the device pull-down</li>
+  <li>UI for starting android emulators from the device pull-down</li>
   <li>workflow for installing a Flutter SDK from the New Flutter Project wizard</li>
   <li>Flutter SDK configuration inspection improvements</li>
   <li>improved error reporting on project creation failures</li>
@@ -612,7 +612,7 @@
 </ul>
 <h2>14.0</h2>
 <ul>
-<li>user toggleable option to enable more verbose debug logging of Flutter app runs</li>
+  <li>user toggleable option to enable more verbose debug logging of Flutter app runs</li>
   <li>fixes to the new Flutter Module workflow</li>
   <li>improved console logging on Flutter app termination</li>
   <li>improved error reporting on Observatory connection and Flutter View open failures</li>
@@ -626,7 +626,7 @@
 </ul>
 <h2>13.1</h2>
 <ul>
-<li>project opening improvements</li>
+  <li>project opening improvements</li>
   <li>new action to open the Flutter view</li>
   <li>module name validation on creation</li>
   <li>fix to ensure all open files are saved to disk before running Flutter actions</li>
@@ -635,7 +635,7 @@
 </ul>
 <h2>13.0</h2>
 <ul>
-<li>small IDE support improvements</li>
+  <li>small IDE support improvements</li>
   <li>android module enablement on project creation</li>
   <li>project explorer icon customizations</li>
   <li>support for Flutter drop frame debugging</li>
@@ -648,15 +648,15 @@
 </ul>
 <h2>12.1</h2>
 <ul>
-<li>fix an issue with enabling Dart support for modules from the Flutter settings page</li>
+  <li>fix an issue with enabling Dart support for modules from the Flutter settings page</li>
 </ul>
 <h2>12.0</h2>
 <ul>
-<li>support for IDEA <code>2017.1</code></li>
+  <li>support for IDEA <code>2017.1</code></li>
   <li>new Flutter <code>stless</code>, <code>stful</code>, and <code>stanim</code> live templates</li>
   <li>new assists for editing the widget hierarchy:
 <ul>
-<li>move widget up or down</li>
+  <li>move widget up or down</li>
   <li>re-parent widget or list of widgets</li>
   <li>convert <code>child:</code> keyword to <code>children:</code></li>
 </ul>
@@ -668,15 +668,15 @@
 </ul>
 <h2>0.1.11.2</h2>
 <ul>
-<li>fix an NPE in the Flutter View when launching an app</li>
+  <li>fix an NPE in the Flutter View when launching an app</li>
 </ul>
 <h2>0.1.11.1</h2>
 <ul>
-<li>fix to a use after dispose exception in the Flutter View</li>
+  <li>fix to a use after dispose exception in the Flutter View</li>
 </ul>
 <h2>0.1.11</h2>
 <ul>
-<li>Flutter tool window badging when active</li>
+  <li>Flutter tool window badging when active</li>
   <li>iOS console output folding improvements</li>
   <li>Flutter reload actions added to main "Run" menu</li>
   <li>devices menu fixes</li>
@@ -684,19 +684,19 @@
 </ul>
 <h2>0.1.10</h2>
 <ul>
-<li>fixes to pubspec timestamp checking</li>
+  <li>fixes to pubspec timestamp checking</li>
   <li>analytics events for run, debug, and process stop</li>
   <li>fix to <code>flutter doctor</code> to better support multiple runs</li>
   <li>fix to the reload action for apps launched from 'run'</li>
 </ul>
 <h2>0.1.9.1</h2>
 <ul>
-<li>fix button enablement in the Flutter View</li>
+  <li>fix button enablement in the Flutter View</li>
   <li>fix the reload action for apps launched from 'run'</li>
 </ul>
 <h2>0.1.9</h2>
 <ul>
-<li>added a 'Flutter' view to allow users to toggle Flutter framework debugging features while running</li>
+  <li>added a 'Flutter' view to allow users to toggle Flutter framework debugging features while running</li>
   <li>fixes to the visibility of the "Tools" menu</li>
   <li>inspection to detect pubspec modifications (that may imply out of date package dependencies)</li>
   <li>key bindings fixes</li>
@@ -707,11 +707,11 @@
 </ul>
 <h2>0.1.8.1</h2>
 <ul>
-<li>improve handling of breakpoints for the bazel launch config</li>
+  <li>improve handling of breakpoints for the bazel launch config</li>
 </ul>
 <h2>0.1.8</h2>
 <ul>
-<li>fixed race condition in console reporting on project creation</li>
+  <li>fixed race condition in console reporting on project creation</li>
   <li>improved interaction between Flutter and Dart plugins during project creation (no more unnecessary nags to run pub)</li>
   <li>improvements to version checking</li>
   <li>settings UI refinements</li>
@@ -722,7 +722,7 @@
 </ul>
 <h2>0.1.7</h2>
 <ul>
-<li>improved console output folding when running iOS apps</li>
+  <li>improved console output folding when running iOS apps</li>
   <li>actions for Flutter package get and package update</li>
   <li>a new top level Flutter menu (Tools&gt;Flutter) with common Flutter actions</li>
   <li>updated hot reload and restart icons</li>
@@ -732,7 +732,7 @@
 </ul>
 <h2>0.1.6</h2>
 <ul>
-<li>reload and restart keybinding mapping fixes</li>
+  <li>reload and restart keybinding mapping fixes</li>
   <li>new butter bar with actions for flutter.yaml files</li>
   <li>"run" behavior re-designed to support reload</li>
   <li>improved console output for reloading and restarting</li>
@@ -740,7 +740,7 @@
 </ul>
 <h2>0.1.5</h2>
 <ul>
-<li>console filtering for flutter run output</li>
+  <li>console filtering for flutter run output</li>
   <li>improved messaging for incomplete Flutter SDK configurations</li>
   <li>support for new application events produced by Flutter tools</li>
   <li>fixed duplicate service protocol console logging</li>
@@ -750,31 +750,31 @@
 </ul>
 <h2>0.1.4.1</h2>
 <ul>
-<li>removed an exception notification when we receive unknown events from the flutter tools</li>
+  <li>removed an exception notification when we receive unknown events from the flutter tools</li>
 </ul>
 <h2>0.1.4</h2>
 <ul>
-<li>first public release</li>
+  <li>first public release</li>
 </ul>
 <h2>0.1.3</h2>
 <ul>
-<li>notifications for projects that look like Flutter apps but do not have Flutter enabled</li>
+  <li>notifications for projects that look like Flutter apps but do not have Flutter enabled</li>
   <li>improved Flutter preference UI and SDK configuration</li>
   <li>IDEA version constraints to ensure that the plugin cannot be installed in incompatible IDEA versions</li>
 </ul>
 <h2>0.1.2</h2>
 <ul>
-<li>fixed device selector filtering</li>
+  <li>fixed device selector filtering</li>
 </ul>
 <h2>0.1.1</h2>
 <ul>
-<li>removed second (redundant) "open observatory" button</li>
+  <li>removed second (redundant) "open observatory" button</li>
   <li>filtering to ensure the Flutter device selector only appears for Flutter projects</li>
   <li>fixed hangs on app re-runs</li>
 </ul>
 <h2>0.1.0</h2>
 <ul>
-<li>initial alpha release</li>
+  <li>initial alpha release</li>
 </ul>
 ]]>
   </change-notes>

--- a/tool/plugin/lib/plugin.dart
+++ b/tool/plugin/lib/plugin.dart
@@ -892,7 +892,6 @@ class BuildSpec {
         .replaceAll('<ul>\n<li>', '<ul>\n  <li>')
         .replaceAll('</li>\n<li>', '</li>\n  <li>')
         .replaceAll('</li></ul>', '</li>\n</ul>')
-        //.replaceAll('<li>\n<p>', '<li><p>')
         .replaceAll('\n<p>', '')
         .replaceAll('<p>', '')
         .replaceAll('</p>\n', '')

--- a/tool/plugin/lib/plugin.dart
+++ b/tool/plugin/lib/plugin.dart
@@ -889,7 +889,7 @@ class BuildSpec {
     // paragraph tags.
     return html
         .replaceAll('</h2><ul>', '</h2>\n<ul>')
-        .replaceAll('<ul><li>', '<ul>\n  <li>')
+        .replaceAll('<ul>\n<li>', '<ul>\n  <li>')
         .replaceAll('</li>\n<li>', '</li>\n  <li>')
         .replaceAll('</li></ul>', '</li>\n</ul>')
         //.replaceAll('<li>\n<p>', '<li><p>')

--- a/tool/plugin/lib/plugin.dart
+++ b/tool/plugin/lib/plugin.dart
@@ -659,7 +659,8 @@ class BuildCommand extends ProductCommand {
         processedFile.writeAsStringSync(source);
       }
 
-      if (!spec.version.startsWith('2019.2') && ! spec.version.startsWith('3.6')) {
+      if (!spec.version.startsWith('2019.2') &&
+          !spec.version.startsWith('3.6')) {
         processedFile = File(
             'flutter-studio/src/io/flutter/android/AndroidModuleLibraryManager.java');
         source = processedFile.readAsStringSync();
@@ -883,12 +884,19 @@ class BuildSpec {
   String _parseChangelog() {
     var text = new File('CHANGELOG.md').readAsStringSync();
     var html = markdownToHtml(text);
+
+    // Translate our markdown based changelog into html; remove unwanted
+    // paragraph tags.
     return html
         .replaceAll('</h2><ul>', '</h2>\n<ul>')
         .replaceAll('<ul><li>', '<ul>\n  <li>')
         .replaceAll('</li><li>', '</li>\n  <li>')
         .replaceAll('</li></ul>', '</li>\n</ul>')
-        .replaceAll('<li>\n<p>', '<li><p>');
+        //.replaceAll('<li>\n<p>', '<li><p>')
+        .replaceAll('\n<p>', '')
+        .replaceAll('<p>', '')
+        .replaceAll('</p>\n', '')
+        .replaceAll('</p>', '');
   }
 
   String toString() {

--- a/tool/plugin/lib/plugin.dart
+++ b/tool/plugin/lib/plugin.dart
@@ -890,7 +890,7 @@ class BuildSpec {
     return html
         .replaceAll('</h2><ul>', '</h2>\n<ul>')
         .replaceAll('<ul><li>', '<ul>\n  <li>')
-        .replaceAll('</li><li>', '</li>\n  <li>')
+        .replaceAll('</li>\n<li>', '</li>\n  <li>')
         .replaceAll('</li></ul>', '</li>\n</ul>')
         //.replaceAll('<li>\n<p>', '<li><p>')
         .replaceAll('\n<p>', '')

--- a/tool/plugin/pubspec.yaml
+++ b/tool/plugin/pubspec.yaml
@@ -9,7 +9,7 @@ dependencies:
   args: ^1.0.0
   cli_util: ^0.1.0
   git: ^0.5.1
-  markdown: ^2.0.0
+  markdown: ^2.1.1
   path: ^1.6.2
 
 dev_dependencies:


### PR DESCRIPTION
- fix the changelog markdown translation

This was broken by the latest release of `package:markdown`.

@stevemessick 