### PR TITLE
Fix problems discovered during testing M40

### DIFF
--- a/flutter-studio/src/io/flutter/FlutterStudioStartupActivity.java
+++ b/flutter-studio/src/io/flutter/FlutterStudioStartupActivity.java
@@ -58,9 +58,6 @@ public class FlutterStudioStartupActivity implements StartupActivity {
       return;
     }
 
-    // The IntelliJ version of this action spawns a new process for Android Studio.
-    // Since we're already running Android Studio we want to simply open the project in the current process.
-    replaceAction("flutter.androidstudio.open", new OpenAndroidModule());
     // Unset this flag for all projects, mainly to ease the upgrade from 3.0.1 to 3.1.
     // TODO(messick) Delete once 3.0.x has 0 7DA's.
     FlutterProjectCreator.disableUserConfig(project);
@@ -112,17 +109,5 @@ public class FlutterStudioStartupActivity implements StartupActivity {
       public void sourceGenerationFinished(@NotNull Project project) {
       }
     };
-  }
-
-  public static void replaceAction(@NotNull String actionId, @NotNull AnAction newAction) {
-    ActionManager actionManager = ActionManager.getInstance();
-    AnAction oldAction = actionManager.getAction(actionId);
-    if (oldAction != null) {
-      newAction.getTemplatePresentation().setIcon(oldAction.getTemplatePresentation().getIcon());
-      newAction.getTemplatePresentation().setText(oldAction.getTemplatePresentation().getTextWithMnemonic(), true);
-      newAction.getTemplatePresentation().setDescription(oldAction.getTemplatePresentation().getDescription());
-      actionManager.unregisterAction(actionId);
-    }
-    actionManager.registerAction(actionId, newAction);
   }
 }

--- a/src/io/flutter/actions/FlutterExternalIdeActionGroup.java
+++ b/src/io/flutter/actions/FlutterExternalIdeActionGroup.java
@@ -24,7 +24,7 @@ import org.jetbrains.annotations.Nullable;
 
 public class FlutterExternalIdeActionGroup extends DefaultActionGroup {
   private static boolean isExternalIdeFile(AnActionEvent e) {
-    final VirtualFile file = CommonDataKeys.VIRTUAL_FILE.getData(e.getDataContext());
+    VirtualFile file = e.getData(CommonDataKeys.VIRTUAL_FILE);
     if (file == null || !file.exists()) {
       return false;
     }
@@ -32,7 +32,7 @@ public class FlutterExternalIdeActionGroup extends DefaultActionGroup {
     final Project project = e.getProject();
     assert (project != null);
     return
-      FlutterModuleUtils.isInFlutterAndroidModule(project, file) ||
+      isWithinAndroidDirectory(file, project) ||
       isProjectDirectory(file, project) ||
       isWithinIOsDirectory(file, project) ||
       FlutterUtils.isXcodeProjectFileName(file.getName()) || OpenInAndroidStudioAction.isProjectFileName(file.getName());

--- a/src/io/flutter/actions/OpenInAndroidStudioAction.java
+++ b/src/io/flutter/actions/OpenInAndroidStudioAction.java
@@ -20,6 +20,7 @@ import com.intellij.openapi.util.SystemInfo;
 import com.intellij.openapi.vfs.VirtualFile;
 import io.flutter.FlutterBundle;
 import io.flutter.FlutterMessages;
+import io.flutter.FlutterUtils;
 import io.flutter.pub.PubRoot;
 import io.flutter.pub.PubRoots;
 import io.flutter.sdk.FlutterSdk;
@@ -41,6 +42,16 @@ public class OpenInAndroidStudioAction extends AnAction {
 
   @Override
   public void actionPerformed(AnActionEvent event) {
+    if (FlutterUtils.isAndroidStudio()) {
+      try {
+        //noinspection unchecked
+        Class<OpenInAndroidStudioAction> opener = (Class<OpenInAndroidStudioAction>)Class.forName("io.flutter.actions.OpenAndroidModule");
+        opener.newInstance().actionPerformed(event);
+        return;
+      }
+      catch (ClassNotFoundException | IllegalAccessException | InstantiationException ignored) {
+      }
+    }
     final String androidStudioPath = findAndroidStudio(event.getProject());
     if (androidStudioPath == null) {
       FlutterMessages.showError("Unable to locate Android Studio",

--- a/src/io/flutter/utils/AndroidUtils.java
+++ b/src/io/flutter/utils/AndroidUtils.java
@@ -14,11 +14,6 @@ import com.android.tools.idea.gradle.dsl.parser.BuildModelContext;
 import com.android.tools.idea.gradle.dsl.parser.elements.GradleDslElement;
 import com.android.tools.idea.gradle.dsl.parser.elements.GradleDslLiteral;
 import com.android.tools.idea.gradle.dsl.parser.files.GradleSettingsFile;
-import com.android.tools.idea.gradle.project.build.BuildContext;
-import com.android.tools.idea.gradle.project.build.BuildStatus;
-import com.android.tools.idea.gradle.project.build.GradleBuildListener;
-import com.android.tools.idea.gradle.project.build.GradleBuildState;
-import com.android.tools.idea.gradle.project.sync.GradleSyncListener;
 import com.android.tools.idea.gradle.project.sync.GradleSyncState;
 import com.android.tools.idea.gradle.util.GradleUtil;
 import com.intellij.lang.java.JavaParserDefinition;
@@ -212,28 +207,30 @@ public class AndroidUtils {
 
   public static void addGradleListeners(@NotNull Project project) {
     if (!FlutterUtils.isAndroidStudio()) {
-      GradleSyncState.subscribe(project, new GradleSyncListener() {
-        @Override
-        public void syncSucceeded(@NotNull Project project) {
-          checkDartSupport(project);
-          if (isCoeditTransformedProject(project)) {
-            return;
-          }
-          enableCoeditIfAddToAppDetected(project);
-        }
-      });
-      GradleBuildState.subscribe(project, new GradleBuildListener.Adapter() {
-        @Override
-        public void buildFinished(@NotNull BuildStatus status, @Nullable BuildContext context) {
-          checkDartSupport(project);
-          if (isCoeditTransformedProject(project)) {
-            return;
-          }
-          if (status == BuildStatus.SUCCESS && context != null && context.getGradleTasks().contains(":flutter:generateDebugSources")) {
-            enableCoeditIfAddToAppDetected(project);
-          }
-        }
-      });
+      // We're not supporting Gradle integration with IntelliJ currently, so these are disabled for now.
+      // TODO(messick): Support Gradle in IntelliJ for add-to-app.
+      //GradleSyncState.subscribe(project, new GradleSyncListener() {
+      //  @Override
+      //  public void syncSucceeded(@NotNull Project project) {
+      //    checkDartSupport(project);
+      //    if (isCoeditTransformedProject(project)) {
+      //      return;
+      //    }
+      //    enableCoeditIfAddToAppDetected(project);
+      //  }
+      //});
+      //GradleBuildState.subscribe(project, new GradleBuildListener.Adapter() {
+      //  @Override
+      //  public void buildFinished(@NotNull BuildStatus status, @Nullable BuildContext context) {
+      //    checkDartSupport(project);
+      //    if (isCoeditTransformedProject(project)) {
+      //      return;
+      //    }
+      //    if (status == BuildStatus.SUCCESS && context != null && context.getGradleTasks().contains(":flutter:generateDebugSources")) {
+      //      enableCoeditIfAddToAppDetected(project);
+      //    }
+      //  }
+      //});
     }
   }
 

--- a/src/io/flutter/utils/FlutterModuleUtils.java
+++ b/src/io/flutter/utils/FlutterModuleUtils.java
@@ -27,6 +27,7 @@ import com.intellij.ui.EditorNotifications;
 import com.intellij.util.PlatformUtils;
 import com.jetbrains.lang.dart.sdk.DartSdk;
 import io.flutter.FlutterUtils;
+import io.flutter.actions.FlutterBuildActionGroup;
 import io.flutter.bazel.Workspace;
 import io.flutter.bazel.WorkspaceCache;
 import io.flutter.dart.DartPlugin;
@@ -326,19 +327,15 @@ public class FlutterModuleUtils {
     }
 
     // Validate that the pubspec references flutter.
-    return FlutterModuleUtils.declaresFlutter(module);
+    return declaresFlutter(module);
   }
 
   public static boolean isInFlutterAndroidModule(@NotNull Project project, @NotNull VirtualFile file) {
-    Module[] modules = ModuleManager.getInstance(project).getModules();
-    for (Module module : modules) {
-      // contains() should be fast since it uses the index.
-      boolean isModuleFile = module.getModuleContentScope().contains(file);
-      if (isModuleFile) {
-        for (Facet facet : FacetManager.getInstance(module).getAllFacets()) {
-          if ("Android".equals(facet.getName())) {
-            return declaresFlutter(project);
-          }
+    Module module = FlutterBuildActionGroup.findFlutterModule(project, file);
+    if (module != null) {
+      for (Facet facet : FacetManager.getInstance(module).getAllFacets()) {
+        if ("Android".equals(facet.getName())) {
+          return declaresFlutter(project);
         }
       }
     }


### PR DESCRIPTION
In IntelliJ, project creation was throwing an error because Android Studio classes were not found. The code block doing that has been disabled for now; it needs to be updated with the proper Gradle hooks when the next phase of add-to-app for IntelliJ commences.

The `Open in Android Studio` menu was flakey. Sometimes it did not appear; other times it was disabled. It has been changed to work all the time (I hope). Instead of relying on dynamic replacement of the action object, we now check at runtime and use the Android Studio one when needed. (I tried using chameleon actions here but could not get that to work, possibly due to action references in plugin.xml.)