### PR TITLE
address a compilation problem against 2019.2

### DIFF
--- a/src/io/flutter/utils/AndroidUtils.java
+++ b/src/io/flutter/utils/AndroidUtils.java
@@ -9,7 +9,6 @@ import static com.intellij.openapi.externalSystem.util.ExternalSystemApiUtil.get
 import static com.intellij.openapi.util.text.StringUtil.isNotEmpty;
 import static java.util.Objects.requireNonNull;
 
-import com.android.SdkConstants;
 import com.android.tools.idea.gradle.dsl.parser.BuildModelContext;
 import com.android.tools.idea.gradle.dsl.parser.elements.GradleDslElement;
 import com.android.tools.idea.gradle.dsl.parser.elements.GradleDslLiteral;
@@ -78,6 +77,7 @@ import org.jetbrains.plugins.gradle.util.GradleConstants;
 //import static com.google.wireless.android.sdk.stats.GradleSyncStats.Trigger.TRIGGER_PROJECT_MODIFIED;
 
 // based on: org.jetbrains.android.util.AndroidUtils
+@SuppressWarnings("LocalCanBeFinal")
 public class AndroidUtils {
 
   private static final Lexer JAVA_LEXER = JavaParserDefinition.createLexer(LanguageLevel.JDK_1_5);
@@ -632,4 +632,12 @@ public class AndroidUtils {
       }
     }
   }
+}
+
+class SdkConstants {
+  /** An SDK Project's build.gradle file */
+  public static final String FN_BUILD_GRADLE = "build.gradle";
+
+  /** An SDK Project's settings.gradle file */
+  public static final String FN_SETTINGS_GRADLE = "settings.gradle";
 }


### PR DESCRIPTION
- address a compilation problem against 2019.2

I wasn't able to compile locally against 2019.2; I'm not sure if user's would see this issue or not, but in-lining a small bit of the android `SdkConstants` seems low risk.

@stevemessick 