### PR TITLE
fix an NPE in DocumentFileLocationMapper.java

### DIFF
--- a/src/io/flutter/perf/FileLocationMapper.java
+++ b/src/io/flutter/perf/FileLocationMapper.java
@@ -6,16 +6,19 @@
 package io.flutter.perf;
 
 import com.intellij.openapi.util.TextRange;
+import org.jetbrains.annotations.Nullable;
 
 /**
- * Mapper from a line column offset to a range of text associated with the
- * identifier at an offset.
- *
- * For example, if there is a constructor call at the specified line and offset
- * then the name of the constructor called should be returned.
+ * Mapper from a line column offset to a range of text associated with the identifier at an
+ * offset.
+ * <p>
+ * For example, if there is a constructor call at the specified line and offset then the
+ * name of the constructor called should be returned.
  */
 public interface FileLocationMapper {
+  @Nullable
   TextRange getIdentifierRange(int line, int column);
 
-  String getText(TextRange textRange);
+  @Nullable
+  String getText(@Nullable TextRange textRange);
 }

--- a/src/io/flutter/perf/FlutterWidgetPerf.java
+++ b/src/io/flutter/perf/FlutterWidgetPerf.java
@@ -183,8 +183,10 @@ public class FlutterWidgetPerf implements Disposable, WidgetPerfListener {
               final int line = entries.get(i + 1).getAsInt();
               final int column = entries.get(i + 2).getAsInt();
               final TextRange textRange = locationMapper.getIdentifierRange(line, column);
-              final String name = locationMapper.getText(textRange);
-              assert (name != null);
+              String name = locationMapper.getText(textRange);
+              if (name == null) {
+                name = "";
+              }
               final Location location = new Location(path, line, column, id, textRange, name);
 
               final Location existingLocation = knownLocationIds.get(id);


### PR DESCRIPTION
- fix an NPE in DocumentFileLocationMapper.java (seen via crash reporting)

```
io.flutter.perf.DocumentFileLocationMapper.getText(), DocumentFileLocationMapper.java:98
io.flutter.perf.FlutterWidgetPerf.lambda$onWidgetPerfEvent$2(), FlutterWidgetPerf.java:184
com.intellij.openapi.application.impl.ApplicationImpl.runReadAction(), ApplicationImpl.java:946
io.flutter.perf.FlutterWidgetPerf.onWidgetPerfEvent(), FlutterWidgetPerf.java:225
io.flutter.perf.VmServiceWidgetPerfProvider.onWidgetPerfEvent(), VmServiceWidgetPerfProvider.java:93
io.flutter.perf.VmServiceWidgetPerfProvider.onVmServiceReceived(), VmServiceWidgetPerfProvider.java:182
```

The NPE was https://github.com/flutter/flutter-intellij/compare/master...devoncarew:fix_npe_23?expand=1#diff-d56ac0069855b6e0d47e1ae6fbe88902L98 - I believe `document` must have been null.

@jacob314 