### PR TITLE
ignore errors from app.stop

### DIFF
--- a/src/io/flutter/run/daemon/FlutterApp.java
+++ b/src/io/flutter/run/daemon/FlutterApp.java
@@ -590,7 +590,7 @@ public class FlutterApp {
           // continue
         }
         catch (Exception e) {
-          FlutterUtils.warn(LOG, e);
+          // Ignore errors from app.stop.
           break;
         }
       }


### PR DESCRIPTION
- ignore errors from `app.stop`
- fix https://github.com/flutter/flutter-intellij/issues/3956

These are often reporting that the app is no longer running.
