### PR TITLE
fix the offset of console hyperlink detection

### DIFF
--- a/src/io/flutter/console/FlutterConsoleFilter.java
+++ b/src/io/flutter/console/FlutterConsoleFilter.java
@@ -125,7 +125,7 @@ public class FlutterConsoleFilter implements Filter {
         pathPart = parts[1];
         file = fileAtPath(pathPart);
         if (file != null) {
-          lineStart = line.indexOf(pathPart);
+          lineStart = entireLength - line.length() + line.indexOf(pathPart);
           highlightLength = pathPart.length();
         }
       }


### PR DESCRIPTION
- fix the offset of console hyperlink detection

This would show up when there was text printed before the line being hyperlinked.