### PR TITLE
add more info to eval() exceptions

### DIFF
--- a/src/io/flutter/inspector/EvalException.java
+++ b/src/io/flutter/inspector/EvalException.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.inspector;
+
+/**
+ * An exception that can occur from calls to eval() from the Inspector codebase.
+ */
+public class EvalException extends Exception {
+  public final String expression;
+  public final String errorCode;
+  public final String errorMessage;
+
+  public EvalException(String expression, String errorCode, String errorMessage) {
+    this.expression = expression;
+    this.errorCode = errorCode;
+    this.errorMessage = errorMessage;
+  }
+
+  @Override
+  public String toString() {
+    return "expression=" + expression + ",errorCode=" + errorCode + ",errorMessage=" + errorMessage;
+  }
+}

--- a/src/io/flutter/inspector/EvalOnDartLibrary.java
+++ b/src/io/flutter/inspector/EvalOnDartLibrary.java
@@ -138,12 +138,14 @@ public class EvalOnDartLibrary implements Disposable {
         new EvaluateConsumer() {
           @Override
           public void onError(RPCError error) {
-            future.completeExceptionally(new RuntimeException(error.getMessage()));
+            future.completeExceptionally(
+              new EvalException(expression, Integer.toString(error.getCode()), error.getMessage()));
           }
 
           @Override
           public void received(ErrorRef response) {
-            future.completeExceptionally(new RuntimeException(response.toString()));
+            future.completeExceptionally(
+              new EvalException(expression, response.getKind().name(), response.getMessage()));
           }
 
           @Override
@@ -153,7 +155,8 @@ public class EvalOnDartLibrary implements Disposable {
 
           @Override
           public void received(Sentinel response) {
-            future.completeExceptionally(new RuntimeException(response.toString()));
+            future.completeExceptionally(
+              new EvalException(expression, "Sentinel", response.getValueAsString()));
           }
         }
       ));


### PR DESCRIPTION
- add more info to eval() exceptions

We see a fair amount of CompletionExceptions coming from the inspector eval. Many of them have the message 'Server error'; this PR adds more info to the failures, so we can identify in what cases they occur, and better know where to handle the  CompletionException in the inspector codebase.

```
java.util.concurrent.CompletionException: java.lang.RuntimeException: Server error
  java.util.concurrent.CompletableFuture.encodeThrowable(), CompletableFuture.java:292
  java.util.concurrent.CompletableFuture.completeThrowable(), CompletableFuture.java:308
  java.util.concurrent.CompletableFuture.uniApply(), CompletableFuture.java:593
  java.util.concurrent.CompletableFuture$UniApply.tryFire(), CompletableFuture.java:577
  java.util.concurrent.CompletableFuture.postComplete(), CompletableFuture.java:474
  java.util.concurrent.CompletableFuture.completeExceptionally(), CompletableFuture.java:1977
  io.flutter.inspector.EvalOnDartLibrary.lambda$null$0(), EvalOnDartLibrary.java:82
  java.util.concurrent.CompletableFuture.uniWhenComplete(), CompletableFuture.java:760
  java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(), CompletableFuture.java:736
  java.util.concurrent.CompletableFuture$Completion.exec(), CompletableFuture.java:443
  java.util.concurrent.ForkJoinTask.doExec(), ForkJoinTask.java:289
  java.util.concurrent.ForkJoinPool$WorkQueue.runTask(), ForkJoinPool.java:1056
  java.util.concurrent.ForkJoinPool.runWorker(), ForkJoinPool.java:1692
  java.util.concurrent.ForkJoinWorkerThread.run(), ForkJoinWorkerThread.java:157
```

cc @jacob314 
