### PR TITLE
address several warnings in the IntelliJ log about leaked resources

### DIFF
--- a/src/io/flutter/inspector/EvalOnDartLibrary.java
+++ b/src/io/flutter/inspector/EvalOnDartLibrary.java
@@ -29,6 +29,8 @@ import java.util.function.Supplier;
  * Invoke methods from a specified Dart library using the observatory protocol.
  */
 public class EvalOnDartLibrary implements Disposable {
+  private static final Logger LOG = Logger.getInstance(EvalOnDartLibrary.class);
+
   private final StreamSubscription<IsolateRef> subscription;
   private String isolateId;
   private final VmService vmService;
@@ -36,7 +38,6 @@ public class EvalOnDartLibrary implements Disposable {
   private final Set<String> libraryNames;
   CompletableFuture<LibraryRef> libraryRef;
   private final Alarm myRequestsScheduler;
-  private static final Logger LOG = Logger.getInstance(EvalOnDartLibrary.class);
 
   /**
    * For robustness we ensure at most one pending request is issued at a time.
@@ -124,7 +125,6 @@ public class EvalOnDartLibrary implements Disposable {
   }
 
   public void dispose() {
-    myRequestsScheduler.dispose();
     subscription.dispose();
     // TODO(jacobr): complete all pending futures as cancelled?
   }

--- a/src/io/flutter/logging/FlutterConsoleLogManager.java
+++ b/src/io/flutter/logging/FlutterConsoleLogManager.java
@@ -14,6 +14,7 @@ import com.intellij.ide.util.PropertiesComponent;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.ex.EditorSettingsExternalizable;
 import com.intellij.openapi.editor.impl.softwrap.SoftWrapAppliancePlaces;
+import com.intellij.openapi.util.Disposer;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.ui.SimpleTextAttributes;
 import com.intellij.util.concurrency.QueueProcessor;
@@ -83,6 +84,11 @@ public class FlutterConsoleLogManager {
 
     assert (app.getFlutterDebugProcess() != null);
     objectGroup = InspectorService.createGroup(app, app.getFlutterDebugProcess(), app.getVmService(), "console-group");
+    objectGroup.whenCompleteAsync((group, error) -> {
+      if (group != null) {
+        Disposer.register(app, group.getInspectorService());
+      }
+    });
 
     if (queue == null) {
       queue = QueueProcessor.createRunnableQueueProcessor();

--- a/src/io/flutter/perf/FlutterWidgetPerf.java
+++ b/src/io/flutter/perf/FlutterWidgetPerf.java
@@ -17,6 +17,7 @@ import com.intellij.openapi.Disposable;
 import com.intellij.openapi.application.Application;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.fileEditor.TextEditor;
+import com.intellij.openapi.util.Disposer;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.util.ui.EdtInvocationManager;
@@ -430,7 +431,7 @@ public class FlutterWidgetPerf implements Disposable, WidgetPerfListener {
       if (!editor.isValid() || (newEditors != null && !newEditors.contains(editor))) {
         final EditorPerfModel editorPerfDecorations = editorDecorations.get(editor);
         editors.remove();
-        editorPerfDecorations.dispose();
+        Disposer.dispose(editorPerfDecorations);
       }
     }
   }
@@ -452,11 +453,11 @@ public class FlutterWidgetPerf implements Disposable, WidgetPerfListener {
     if (uiAnimationTimer.isRunning()) {
       uiAnimationTimer.stop();
     }
-    perfProvider.dispose();
+    Disposer.dispose(perfProvider);
 
     clearModels();
     for (EditorPerfModel decorations : editorDecorations.values()) {
-      decorations.dispose();
+      Disposer.dispose(decorations);
     }
     editorDecorations.clear();
     perfListeners.clear();

--- a/src/io/flutter/perf/VmServiceWidgetPerfProvider.java
+++ b/src/io/flutter/perf/VmServiceWidgetPerfProvider.java
@@ -7,6 +7,7 @@ package io.flutter.perf;
 
 import com.google.gson.JsonObject;
 import com.intellij.openapi.fileEditor.FileEditor;
+import com.intellij.openapi.util.Disposer;
 import com.intellij.openapi.util.text.StringUtil;
 import io.flutter.inspector.DiagnosticsNode;
 import io.flutter.inspector.InspectorService;
@@ -141,6 +142,9 @@ public class VmServiceWidgetPerfProvider implements WidgetPerfProvider {
     });
 
     inspectorService = InspectorService.create(app, app.getFlutterDebugProcess(), app.getVmService());
+    inspectorService.whenCompleteAsync((service, throwable) -> {
+      Disposer.register(this, service);
+    });
 
     requestRepaint(When.soon);
   }

--- a/src/io/flutter/run/daemon/FlutterApp.java
+++ b/src/io/flutter/run/daemon/FlutterApp.java
@@ -64,7 +64,7 @@ import java.util.function.Consumer;
 /**
  * A running Flutter app.
  */
-public class FlutterApp {
+public class FlutterApp implements Disposable {
   private static final Logger LOG = Logger.getInstance(FlutterApp.class);
   private static final Key<FlutterApp> FLUTTER_APP_KEY = new Key<>("FLUTTER_APP_KEY");
 
@@ -283,6 +283,8 @@ public class FlutterApp {
           reloadfraction = (int)Math.round(fraction);
         }
         FlutterInitializer.getAnalytics().sendEventMetric("workflow", "reloadFraction", reloadfraction);
+
+        Disposer.dispose(app);
       }
     });
 
@@ -746,6 +748,10 @@ public class FlutterApp {
   }
 
   public enum State {STARTING, STARTED, RELOADING, RESTARTING, TERMINATING, TERMINATED}
+
+  @Override
+  public void dispose() {
+  }
 }
 
 /**

--- a/src/io/flutter/utils/AsyncRateLimiter.java
+++ b/src/io/flutter/utils/AsyncRateLimiter.java
@@ -71,7 +71,7 @@ public class AsyncRateLimiter implements Disposable {
       requestScheduler.addRequest(() -> {
         rateLimiter.acquire();
 
-        Runnable doRun = () -> {
+        final Runnable doRun = () -> {
           requestScheduledButNotStarted = false;
           performRequest();
         };

--- a/src/io/flutter/view/BoolServiceExtensionCheckbox.java
+++ b/src/io/flutter/view/BoolServiceExtensionCheckbox.java
@@ -6,6 +6,7 @@
 package io.flutter.view;
 
 import com.intellij.openapi.Disposable;
+import com.intellij.openapi.util.Disposer;
 import com.intellij.ui.components.JBCheckBox;
 import io.flutter.run.daemon.FlutterApp;
 import io.flutter.utils.StreamSubscription;
@@ -33,8 +34,8 @@ public class BoolServiceExtensionCheckbox implements Disposable {
     checkbox = new JBCheckBox(extensionDescription.getDisabledText());
     checkbox.setHorizontalAlignment(JLabel.LEFT);
     checkbox.setToolTipText(tooltip);
-    assert(app.getVMServiceManager() != null);
-    app.hasServiceExtension(extensionDescription.getExtension(), checkbox::setEnabled, this);
+    assert (app.getVMServiceManager() != null);
+    app.hasServiceExtension(extensionDescription.getExtension(), checkbox::setEnabled, app);
 
     checkbox.addActionListener((l) -> {
       final boolean newValue = checkbox.isSelected();
@@ -62,7 +63,7 @@ public class BoolServiceExtensionCheckbox implements Disposable {
   @Override
   public void dispose() {
     if (currentValueSubscription != null) {
-      currentValueSubscription.dispose();
+      Disposer.dispose(currentValueSubscription);
       currentValueSubscription = null;
     }
   }

--- a/src/io/flutter/view/FlutterPerfView.java
+++ b/src/io/flutter/view/FlutterPerfView.java
@@ -126,7 +126,7 @@ public class FlutterPerfView implements Disposable {
               contentManager.removeContent(state.content, true);
             }
             if (state.disposable != null) {
-              state.disposable.dispose();
+              Disposer.dispose(state.disposable);
             }
           }
           if (perAppViewState.isEmpty()) {

--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -75,6 +75,12 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
   private static class PerAppState extends AppState {
     ArrayList<InspectorPanel> inspectorPanels = new ArrayList<>();
     boolean sendRestartNotificationOnNextFrame = false;
+
+    public void dispose() {
+      for (InspectorPanel panel : inspectorPanels) {
+        Disposer.dispose(panel);
+      }
+    }
   }
 
   private Content emptyContent;
@@ -415,12 +421,19 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
       @Override
       public void connectionClosed() {
         ApplicationManager.getApplication().invokeLater(() -> {
+          if (inspectorService != null) {
+            Disposer.dispose(inspectorService);
+          }
+
           if (toolWindow.isDisposed()) return;
           final ContentManager contentManager = toolWindow.getContentManager();
           onAppChanged(app);
           final PerAppState state = perAppViewState.remove(app);
-          if (state != null && state.content != null) {
-            contentManager.removeContent(state.content, true);
+          if (state != null) {
+            if (state.content != null) {
+              contentManager.removeContent(state.content, true);
+            }
+            state.dispose();
           }
           if (perAppViewState.isEmpty()) {
             // No more applications are running.

--- a/src/io/flutter/vmService/VMServiceManager.java
+++ b/src/io/flutter/vmService/VMServiceManager.java
@@ -168,6 +168,8 @@ public class VMServiceManager implements FlutterApp.FlutterAppListener, Disposab
         if (didSendFirstFrameEvent) {
           onFrameEventReceived();
         }
+        // TODO(devoncarew): This can cause a issue with early disposable of the library.
+        //Disposer.dispose(flutterLibrary);
       });
     }
     if (isolate.getExtensionRPCs() != null) {


### PR DESCRIPTION
- address several warnings in the IntelliJ log about leaked resources

It looks like the pattern for using the IntelliJ auto dispose mechanism is to register the disposal via `Disposer.register(parent, child)`, and then actually do the dispose using `Disposer.dispose()` (and not by calling `dispose()` on the object directly).
