### PR TITLE
change the inspector tool window to not only show when an app is running

### DIFF
--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -89,9 +89,6 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
   protected final EventStream<Boolean> highlightNodesShownInBothTrees =
     new EventStream<>(FlutterViewState.HIGHLIGHT_NODES_SHOWN_IN_BOTH_TREES_DEFAULT);
 
-
-  private boolean previouslyVisible = false;
-
   @NotNull
   private final FlutterViewState state = new FlutterViewState();
 
@@ -425,12 +422,6 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
           if (perAppViewState.isEmpty()) {
             // No more applications are running.
             updateForEmptyContent(toolWindow);
-            if (toolWindow.isAvailable()) {
-              // Store whether the tool window was visible before we decided to close it
-              // because it had no content.
-              previouslyVisible = toolWindow.isVisible();
-              toolWindow.setAvailable(false, null);
-            }
           }
         });
       }
@@ -557,7 +548,7 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
       return;
     }
 
-    if (FlutterSettings.getInstance().isOpenInspectorOnAppLaunch() || previouslyVisible) {
+    if (FlutterSettings.getInstance().isOpenInspectorOnAppLaunch()) {
       flutterToolWindow.show(null);
     }
   }

--- a/src/io/flutter/view/FlutterViewFactory.java
+++ b/src/io/flutter/view/FlutterViewFactory.java
@@ -23,7 +23,7 @@ public class FlutterViewFactory implements ToolWindowFactory, DumbAware {
 
   @Override
   public void init(ToolWindow window) {
-    window.setAvailable(false, null);
+    window.setAvailable(true, null);
   }
 
   private static void initFlutterView(@NotNull Project project, FlutterViewMessages.FlutterDebugEvent event) {


### PR DESCRIPTION
- change the inspector tool window to not only show when an app is running

This addresses an issue where, when the inspector view closed when an app closes, it closes the right tool window sidebar. This would also hide the Flutter Outline view - that's not desirable as there are already enough discoverability issues with the sidebar views.

When the Inspector is open and there's no application running, the content says 'No running applications'.