### PR TITLE
Wait Device Daemon connected to prevent race condition in devices list

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -11,3 +11,4 @@ Alexander Zolotov <goldifit@gmail.com>
 QuangSon <quangson91@gmail.com>
 ChangJoo Park <pcjpcj2@gmail.com>
 Amol Grover <frextrite@gmail.com>
+Jeremy Judeaux <jeremy.judeaux@volune.net>

--- a/src/io/flutter/run/daemon/DaemonApi.java
+++ b/src/io/flutter/run/daemon/DaemonApi.java
@@ -101,7 +101,7 @@ public class DaemonApi {
     return send("app.callServiceExtension", new AppServiceExtension(appId, methodName, params));
   }
 
-  CompletableFuture enableDeviceEvents() {
+  CompletableFuture<Void> enableDeviceEvents() {
     return send("device.enable", null);
   }
 

--- a/src/io/flutter/run/daemon/DaemonEvent.java
+++ b/src/io/flutter/run/daemon/DaemonEvent.java
@@ -56,6 +56,8 @@ abstract class DaemonEvent {
   static DaemonEvent create(@NotNull String eventName, @NotNull JsonObject params) {
     try {
       switch (eventName) {
+        case "daemon.connected":
+          return GSON.fromJson(params, DaemonConnected.class);
         case "daemon.log":
           return GSON.fromJson(params, DaemonLog.class);
         case "daemon.logMessage":
@@ -110,6 +112,9 @@ abstract class DaemonEvent {
 
     // daemon domain
 
+    default void onDaemonConnected(DaemonConnected event) {
+    }
+
     default void onDaemonLog(DaemonLog event) {
     }
 
@@ -152,6 +157,17 @@ abstract class DaemonEvent {
   }
 
   // daemon domain
+
+  @SuppressWarnings("unused")
+  static class DaemonConnected extends DaemonEvent {
+    // "event":"daemon.log"
+    String version;
+    long pid;
+
+    void accept(Listener listener) {
+      listener.onDaemonConnected(this);
+    }
+  }
 
   @SuppressWarnings("unused")
   static class DaemonLog extends DaemonEvent {


### PR DESCRIPTION
## Issue description

The devices list was keeping showing "Loading..." in Android Studio.
Windows 10, Android Studio `3.5.1`, Flutter `1.9.1+hotfix.5`, flutter-intellij `4.2.2`

May be related to #3892

## Fix

Flutter-doctor is able to detect the devices. Android Studio logs showed that AS didn't receive the "device.enable" command response. Just putting some breakpoints were solving the issue, identifying a race condition (sending the command too early).

The fix waits for the "daemon.connected" before sending any commands.

## Test

I was not able to correctly build the plugin. The version I built showed the fix is working, but other stuff were broken. It may be caused by me using the "master" version of the plugin in AS 3.5.1, or by bad project/dependencies configuration.