### PR TITLE
don't invoke eval when shutting down

### DIFF
--- a/src/io/flutter/inspector/EvalOnDartLibrary.java
+++ b/src/io/flutter/inspector/EvalOnDartLibrary.java
@@ -69,6 +69,10 @@ public class EvalOnDartLibrary implements Disposable {
       return CompletableFuture.completedFuture(null);
     }
 
+    if (myRequestsScheduler.isDisposed()) {
+      return CompletableFuture.completedFuture(null);
+    }
+
     // Future that completes when the request has finished.
     final CompletableFuture<T> response = new CompletableFuture<>();
     // This is an optimization to avoid sending stale requests across the wire.


### PR DESCRIPTION
- don't invoke eval when shutting down

As follow-up to the resource leak PR, we can now occasionally try and invoke eval on an inspector that's been disposed. This PR prevents that.