### PR TITLE
detect whether the vm service connection supports the getMemoryUsage API

### DIFF
--- a/src/io/flutter/view/PerfMemoryTab.java
+++ b/src/io/flutter/view/PerfMemoryTab.java
@@ -59,10 +59,10 @@ public class PerfMemoryTab extends JBPanel implements InspectorTabPanel {
     }
 
     if (visible) {
-      app.getVMServiceManager().addPollingClient();
+      app.getVMServiceManager().getHeapMonitor().addPollingClient();
     }
     else {
-      app.getVMServiceManager().removePollingClient();
+      app.getVMServiceManager().getHeapMonitor().removePollingClient();
     }
   }
 }

--- a/src/io/flutter/vmService/HeapMonitor.java
+++ b/src/io/flutter/vmService/HeapMonitor.java
@@ -13,15 +13,12 @@ import org.dartlang.vm.service.element.*;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 
 public class HeapMonitor {
   private static final Logger LOG = Logger.getInstance(HeapMonitor.class);
 
-  private static final ScheduledExecutorService executor = Executors.newScheduledThreadPool(1);
+  private static final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
 
   private static final int POLL_PERIOD_IN_MS = 1000;
 
@@ -89,8 +86,6 @@ public class HeapMonitor {
 
   @NotNull private final VmServiceWrapper vmServiceWrapper;
 
-  private boolean isPolling;
-
   public HeapMonitor(@NotNull VmServiceWrapper vmServiceWrapper) {
     this.vmServiceWrapper = vmServiceWrapper;
   }
@@ -108,24 +103,23 @@ public class HeapMonitor {
   }
 
   public void start() {
-    isPolling = true;
-    pollingScheduler = executor.scheduleAtFixedRate(this::poll, 0, POLL_PERIOD_IN_MS, TimeUnit.MILLISECONDS);
+    pollingScheduler = executor.scheduleWithFixedDelay(this::poll, 100, POLL_PERIOD_IN_MS, TimeUnit.MILLISECONDS);
   }
 
-  public void pausePolling() {
-    isPolling = false;
+  private int pollingClients = 0;
+
+  public void addPollingClient() {
+    pollingClients++;
   }
 
-  public void resumePolling() {
-    isPolling = true;
+  public void removePollingClient() {
+    pollingClients--;
   }
 
   private void poll() {
-    if (!isPolling) {
-      return;
+    if (pollingClients > 0) {
+      collectMemoryUsage();
     }
-
-    collectMemoryUsage();
   }
 
   private void collectMemoryUsage() {
@@ -134,40 +128,48 @@ public class HeapMonitor {
       return;
     }
 
-    // Stash count so we can know when we've processed them all.
-    final int isolateCount = isolateRefs.size();
-
     final List<MemoryUsage> memoryUsage = new ArrayList<>();
+
+    final CountDownLatch latch = new CountDownLatch(isolateRefs.size());
 
     for (IsolateRef isolateRef : isolateRefs) {
       vmServiceWrapper.getVmService().getMemoryUsage(isolateRef.getId(), new GetMemoryUsageConsumer() {
-        private int errorCount = 0;
-
         @Override
         public void received(MemoryUsage usage) {
           memoryUsage.add(usage);
-
-          // Only update when we're done collecting from all isolates.
-          if ((memoryUsage.size() + errorCount) == isolateCount) {
-            notifyListeners(memoryUsage);
-          }
+          latch.countDown();
         }
 
         @Override
         public void received(Sentinel sentinel) {
-          errorCount++;
+          latch.countDown();
         }
 
         @Override
         public void onError(RPCError error) {
-          errorCount++;
+          // {"jsonrpc":"2.0","error":{"code":-32603,"message":"UnimplementedError..."}}
+          if (error.getCode() == -32603) {
+            handleMemoryApiNotSupported();
+          }
+
+          latch.countDown();
         }
       });
     }
+
+    try {
+      latch.await();
+    }
+    catch (InterruptedException ignored) {
+    }
+
+    if (pollingScheduler != null) {
+      heapListeners.forEach(listener -> listener.handleMemoryUsage(memoryUsage));
+    }
   }
 
-  private void notifyListeners(List<MemoryUsage> memoryUsage) {
-    heapListeners.forEach(listener -> listener.handleMemoryUsage(memoryUsage));
+  private void handleMemoryApiNotSupported() {
+    stop();
   }
 
   public void stop() {

--- a/src/io/flutter/vmService/HeapMonitor.java
+++ b/src/io/flutter/vmService/HeapMonitor.java
@@ -147,8 +147,12 @@ public class HeapMonitor {
 
         @Override
         public void onError(RPCError error) {
+          // TODO(devoncarew): Remove rpcInternalError once https://github.com/dart-lang/webdev/issues/781
+          // lands and rolls into flutter.
+          final int rpcInternalError = -32603;
+          final int rpcMethodNotFound = -32601;
           // {"jsonrpc":"2.0","error":{"code":-32603,"message":"UnimplementedError..."}}
-          if (error.getCode() == -32603) {
+          if (error.getCode() == rpcInternalError || error.getCode() == rpcMethodNotFound) {
             handleMemoryApiNotSupported();
           }
 

--- a/src/io/flutter/vmService/VmServiceWrapper.java
+++ b/src/io/flutter/vmService/VmServiceWrapper.java
@@ -173,7 +173,7 @@ public class VmServiceWrapper implements Disposable {
 
   public CompletableFuture<Isolate> getCachedIsolate(@NotNull final String isolateId) {
     return myIsolatesInfo.getCachedIsolate(isolateId, () -> {
-      CompletableFuture<Isolate> isolateFuture = new CompletableFuture<>();
+      final CompletableFuture<Isolate> isolateFuture = new CompletableFuture<>();
       getIsolate(isolateId, new GetIsolateConsumer() {
 
         @Override
@@ -229,7 +229,7 @@ public class VmServiceWrapper implements Disposable {
     final boolean newIsolate = myIsolatesInfo.addIsolate(isolateRef);
     // Just to make sure that the main isolate is not handled twice, both from handleDebuggerConnected() and DartVmServiceListener.received(PauseStart)
     if (newIsolate) {
-      XDebugSessionImpl session = (XDebugSessionImpl)myDebugProcess.getSession();
+      final XDebugSessionImpl session = (XDebugSessionImpl)myDebugProcess.getSession();
       ApplicationManager.getApplication().runReadAction(() -> {
         session.reset();
         session.initBreakpoints();
@@ -271,10 +271,10 @@ public class VmServiceWrapper implements Disposable {
     doSetBreakpointsForIsolate(myBreakpointHandler.getXBreakpoints(), isolateRef.getId(), () -> {
       myIsolatesInfo.setBreakpointsSet(isolateRef);
     });
-    FlutterApp app = FlutterApp.fromEnv(myDebugProcess.getExecutionEnvironment());
+    final FlutterApp app = FlutterApp.fromEnv(myDebugProcess.getExecutionEnvironment());
     // TODO(messick) Consider replacing this test with an assert; could interfere with setExceptionPauseMode().
     if (app != null) {
-      VMServiceManager service = app.getVMServiceManager();
+      final VMServiceManager service = app.getVMServiceManager();
       if (service != null) {
         service.addRegisteredExtensionRPCs(isolate, true);
       }


### PR DESCRIPTION
- detect whether the vm service connection supports the `getMemoryUsage` API
- cleanup code around memory polling to move more of the domain knowledge from `VMServiceManager` into `HeapMonitor`

Instead of polling the vm connection once a second for the device's memory usage, we use the error return code to detect whether that connection supports the `getMemoryUsage()` API (package:dwds doesn't currently support it). If it doesn't support the API we stop polling.
