### PR TITLE
remove support for file path breakpoints; handle multiple vm breakpoints better

### DIFF
--- a/src/io/flutter/run/FlutterPositionMapper.java
+++ b/src/io/flutter/run/FlutterPositionMapper.java
@@ -43,11 +43,12 @@ import java.util.Set;
  * <p>
  * Used when setting breakpoints, stepping through code, and so on while debugging.
  */
-public class PositionMapper implements DartVmServiceDebugProcess.PositionMapper {
+public class FlutterPositionMapper implements DartVmServiceDebugProcess.PositionMapper {
+  private static final Logger LOG = Logger.getInstance(FlutterPositionMapper.class);
+
   @NotNull
   private final Project project;
 
-  // TODO(skybrian) for Bazel this should be a list of source roots.
   /**
    * The directory containing the Flutter application's source code.
    * <p>
@@ -95,10 +96,10 @@ public class PositionMapper implements DartVmServiceDebugProcess.PositionMapper 
    */
   private final Map<String, ObservatoryFile.Cache> fileCache = new THashMap<>();
 
-  public PositionMapper(@NotNull Project project,
-                        @NotNull VirtualFile sourceRoot,
-                        @NotNull DartUrlResolver resolver,
-                        @Nullable Analyzer analyzer) {
+  public FlutterPositionMapper(@NotNull Project project,
+                               @NotNull VirtualFile sourceRoot,
+                               @NotNull DartUrlResolver resolver,
+                               @Nullable Analyzer analyzer) {
 
     this.project = project;
     this.sourceRoot = sourceRoot;
@@ -195,9 +196,6 @@ public class PositionMapper implements DartVmServiceDebugProcess.PositionMapper 
       results.add(uriByIde);
       results.add(threeSlashize(new File(file.getPath()).toURI().toString()));
     }
-
-    // straight path - used by some VM embedders
-    results.add(file.getPath());
 
     // package: (if applicable)
     if (analyzer != null) {
@@ -348,8 +346,6 @@ public class PositionMapper implements DartVmServiceDebugProcess.PositionMapper 
       analyzer.close();
     }
   }
-
-  private static final Logger LOG = Logger.getInstance(PositionMapper.class);
 
   /**
    * Wraps a Dart analysis server and execution id for doing URI resolution for a particular Flutter app.

--- a/src/io/flutter/run/LaunchState.java
+++ b/src/io/flutter/run/LaunchState.java
@@ -227,7 +227,7 @@ public class LaunchState extends CommandLineState {
     throws ExecutionException {
 
     final DartUrlResolver resolver = DartUrlResolver.getInstance(env.getProject(), sourceLocation);
-    final PositionMapper mapper = createPositionMapper(env, app, resolver);
+    final FlutterPositionMapper mapper = createPositionMapper(env, app, resolver);
 
     final XDebuggerManager manager = XDebuggerManager.getInstance(env.getProject());
     final XDebugSession session = manager.startSession(env, new XDebugProcessStarter() {
@@ -246,12 +246,12 @@ public class LaunchState extends CommandLineState {
   }
 
   @NotNull
-  private PositionMapper createPositionMapper(@NotNull ExecutionEnvironment env,
-                                              @NotNull FlutterApp app,
-                                              @NotNull DartUrlResolver resolver) {
-    final PositionMapper.Analyzer analyzer;
+  private FlutterPositionMapper createPositionMapper(@NotNull ExecutionEnvironment env,
+                                                     @NotNull FlutterApp app,
+                                                     @NotNull DartUrlResolver resolver) {
+    final FlutterPositionMapper.Analyzer analyzer;
     if (app.getMode() == RunMode.DEBUG) {
-      analyzer = PositionMapper.Analyzer.create(env.getProject(), sourceLocation);
+      analyzer = FlutterPositionMapper.Analyzer.create(env.getProject(), sourceLocation);
     }
     else {
       analyzer = null; // Don't need analysis server just to run.
@@ -262,7 +262,7 @@ public class LaunchState extends CommandLineState {
     final VirtualFile pubspec = resolver.getPubspecYamlFile();
     final VirtualFile sourceRoot = pubspec != null ? pubspec.getParent() : workDir;
 
-    return new PositionMapper(env.getProject(), sourceRoot, resolver, analyzer);
+    return new FlutterPositionMapper(env.getProject(), sourceRoot, resolver, analyzer);
   }
 
   @NotNull

--- a/src/io/flutter/run/bazelTest/BazelTestRunner.java
+++ b/src/io/flutter/run/bazelTest/BazelTestRunner.java
@@ -34,7 +34,7 @@ import com.jetbrains.lang.dart.sdk.DartSdkLibUtil;
 import com.jetbrains.lang.dart.util.DartUrlResolver;
 import io.flutter.FlutterUtils;
 import io.flutter.ObservatoryConnector;
-import io.flutter.run.PositionMapper;
+import io.flutter.run.FlutterPositionMapper;
 import io.flutter.run.common.CommonTestConfigUtils;
 import io.flutter.run.test.FlutterTestRunner;
 import io.flutter.settings.FlutterSettings;
@@ -81,7 +81,7 @@ public class BazelTestRunner extends GenericProgramRunner {
 
     // Set up source file mapping.
     final DartUrlResolver resolver = DartUrlResolver.getInstance(env.getProject(), launcher.getTestFile());
-    final PositionMapper.Analyzer analyzer = PositionMapper.Analyzer.create(env.getProject(), launcher.getTestFile());
+    final FlutterPositionMapper.Analyzer analyzer = FlutterPositionMapper.Analyzer.create(env.getProject(), launcher.getTestFile());
 
     final BazelPositionMapper mapper =
       new BazelPositionMapper(env.getProject(), env.getProject().getBaseDir()/*this is different, incorrect?*/, resolver, analyzer,
@@ -240,7 +240,7 @@ public class BazelTestRunner extends GenericProgramRunner {
     }
   }
 
-  private static final class BazelPositionMapper extends PositionMapper {
+  private static final class BazelPositionMapper extends FlutterPositionMapper {
 
     @NotNull final Connector connector;
 

--- a/src/io/flutter/run/test/FlutterTestRunner.java
+++ b/src/io/flutter/run/test/FlutterTestRunner.java
@@ -24,7 +24,7 @@ import com.intellij.xdebugger.XDebuggerManager;
 import com.jetbrains.lang.dart.util.DartUrlResolver;
 import io.flutter.FlutterUtils;
 import io.flutter.ObservatoryConnector;
-import io.flutter.run.PositionMapper;
+import io.flutter.run.FlutterPositionMapper;
 import io.flutter.run.common.CommonTestConfigUtils;
 import io.flutter.sdk.FlutterSdk;
 import io.flutter.settings.FlutterSettings;
@@ -73,8 +73,8 @@ public class FlutterTestRunner extends GenericProgramRunner {
 
     // Set up source file mapping.
     final DartUrlResolver resolver = DartUrlResolver.getInstance(env.getProject(), launcher.getTestFileOrDir());
-    final PositionMapper.Analyzer analyzer = PositionMapper.Analyzer.create(env.getProject(), launcher.getTestFileOrDir());
-    final PositionMapper mapper = new PositionMapper(env.getProject(), launcher.getPubRoot().getRoot(), resolver, analyzer);
+    final FlutterPositionMapper.Analyzer analyzer = FlutterPositionMapper.Analyzer.create(env.getProject(), launcher.getTestFileOrDir());
+    final FlutterPositionMapper mapper = new FlutterPositionMapper(env.getProject(), launcher.getPubRoot().getRoot(), resolver, analyzer);
 
     // Create the debug session.
     final XDebuggerManager manager = XDebuggerManager.getInstance(env.getProject());

--- a/src/io/flutter/vmService/VmServiceConsumers.java
+++ b/src/io/flutter/vmService/VmServiceConsumers.java
@@ -1,10 +1,9 @@
 package io.flutter.vmService;
 
 import org.dartlang.vm.service.consumer.*;
-import org.dartlang.vm.service.element.ErrorRef;
-import org.dartlang.vm.service.element.RPCError;
-import org.dartlang.vm.service.element.Sentinel;
-import org.dartlang.vm.service.element.Success;
+import org.dartlang.vm.service.element.*;
+
+import java.util.List;
 
 public class VmServiceConsumers {
 
@@ -36,7 +35,9 @@ public class VmServiceConsumers {
     }
   }
 
-  public static abstract class BreakpointConsumerWrapper implements BreakpointConsumer {
+  public static abstract class BreakpointsConsumer {
+    abstract void received(List<Breakpoint> breakpointResponses, List<RPCError> errorResponses);
+
     abstract void sourcePositionNotApplicable();
   }
 

--- a/testSrc/unit/io/flutter/run/FlutterPositionMapperTest.java
+++ b/testSrc/unit/io/flutter/run/FlutterPositionMapperTest.java
@@ -36,7 +36,7 @@ import static org.junit.Assert.assertNotNull;
 /**
  * Verifies that we can map file locations.
  */
-public class PositionMapperTest {
+public class FlutterPositionMapperTest {
   private final FakeScriptProvider scripts = new FakeScriptProvider();
 
   @Rule
@@ -61,7 +61,7 @@ public class PositionMapperTest {
     final VirtualFile main = tmp.writeFile("root/lib/main.dart", "");
     final VirtualFile hello = tmp.writeFile("root/lib/hello.dart", "");
 
-    final PositionMapper mapper = setUpMapper(main, null);
+    final FlutterPositionMapper mapper = setUpMapper(main, null);
     mapper.onLibrariesDownloaded(ImmutableList.of(
       makeLibraryRef("some/stuff/to/ignore/lib/main.dart")
     ));
@@ -82,7 +82,7 @@ public class PositionMapperTest {
     final VirtualFile main = tmp.writeFile("root/lib/main.dart", "");
     final VirtualFile hello = tmp.writeFile("root/lib/hello.dart", "");
 
-    final PositionMapper mapper = setUpMapper(main, "remote:root");
+    final FlutterPositionMapper mapper = setUpMapper(main, "remote:root");
 
     scripts.addScript("1", "2", "remote:root/lib/hello.dart", ImmutableList.of(new Line(10, 123, 1)));
 
@@ -93,9 +93,9 @@ public class PositionMapperTest {
   }
 
   @NotNull
-  private PositionMapper setUpMapper(VirtualFile contextFile, String remoteBaseUri) {
+  private FlutterPositionMapper setUpMapper(VirtualFile contextFile, String remoteBaseUri) {
     final DartUrlResolver resolver = new DartUrlResolverImpl(fixture.getProject(), contextFile);
-    final PositionMapper mapper = new PositionMapper(fixture.getProject(), sourceRoot, resolver, null);
+    final FlutterPositionMapper mapper = new FlutterPositionMapper(fixture.getProject(), sourceRoot, resolver, null);
     mapper.onConnect(scripts, remoteBaseUri);
     return mapper;
   }


### PR DESCRIPTION
- remove support for file path breakpoints (continue to send in `file:`, `dart:`, and `package:` breakpoint uris); file paths are no longer used with the switch to the CFE
- handle multiple vm breakpoints better; register all successful vm breakpoints created from a user breakpoint; only convert the user breakpoint to a 'breakpointFailed' type if no vm breakpoints succeeded

Additional cleanup to the codebase while working in this area:
- renamed the `PositionMapper` class to `FlutterPositionMapper` to avoid a name conflict with an other `PositionMapper`

