### PR TITLE
address some performance issues with displaying test markers

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -1010,6 +1010,7 @@
                     serviceImplementation="io.flutter.bazel.WorkspaceCache"/>
     <projectService serviceInterface="io.flutter.logging.FlutterLogPreferences"
                     serviceImplementation="io.flutter.logging.FlutterLogPreferences"/>
+    <projectService serviceImplementation="io.flutter.pub.PubRootCache"/>
 
     <configurationType implementation="io.flutter.run.FlutterRunConfigurationType"/>
     <runConfigurationProducer implementation="io.flutter.run.FlutterRunConfigurationProducer"/>

--- a/resources/META-INF/plugin_template.xml
+++ b/resources/META-INF/plugin_template.xml
@@ -226,6 +226,7 @@
                     serviceImplementation="io.flutter.bazel.WorkspaceCache"/>
     <projectService serviceInterface="io.flutter.logging.FlutterLogPreferences"
                     serviceImplementation="io.flutter.logging.FlutterLogPreferences"/>
+    <projectService serviceImplementation="io.flutter.pub.PubRootCache"/>
 
     <configurationType implementation="io.flutter.run.FlutterRunConfigurationType"/>
     <runConfigurationProducer implementation="io.flutter.run.FlutterRunConfigurationProducer"/>

--- a/src/io/flutter/dart/DartSyntax.java
+++ b/src/io/flutter/dart/DartSyntax.java
@@ -161,7 +161,10 @@ public class DartSyntax {
    * @return true if the given element is a main declaration, false otherwise
    */
   public static boolean isMainFunctionDeclaration(@Nullable PsiElement element) {
-    if (!(element instanceof DartFunctionDeclarationWithBodyOrNative)) return false;
+    if (!(element instanceof DartFunctionDeclarationWithBodyOrNative)) {
+      return false;
+    }
+
     final String functionName = ((DartFunctionDeclarationWithBodyOrNative)element).getComponentName().getId().getText();
     return Objects.equals(functionName, "main");
   }

--- a/src/io/flutter/editor/ActiveEditorsOutlineService.java
+++ b/src/io/flutter/editor/ActiveEditorsOutlineService.java
@@ -42,7 +42,6 @@ import java.util.*;
  * </ul>
  */
 public class ActiveEditorsOutlineService implements Disposable {
-
   private final Project project;
   private final FlutterDartAnalysisServer analysisServer;
 
@@ -152,7 +151,7 @@ public class ActiveEditorsOutlineService implements Disposable {
 
   private void notifyOutlineUpdated(String path) {
     for (Listener listener : Lists.newArrayList(listeners)) {
-      listener.onOutlineChanged(path, get(path));
+      listener.onOutlineChanged(path, getOutline(path));
     }
   }
 
@@ -170,7 +169,7 @@ public class ActiveEditorsOutlineService implements Disposable {
    * To get an outline that is guaranteed in-sync with the file it outlines, see {@link #getIfUpdated}.
    */
   @Nullable
-  public FlutterOutline get(String path) {
+  public FlutterOutline getOutline(String path) {
     return pathToOutline.get(path);
   }
 
@@ -182,13 +181,12 @@ public class ActiveEditorsOutlineService implements Disposable {
    */
   @Nullable
   public FlutterOutline getIfUpdated(@NotNull PsiFile file) {
-    final FlutterOutline outline = get(file.getVirtualFile().getCanonicalPath());
+    final FlutterOutline outline = getOutline(file.getVirtualFile().getCanonicalPath());
     if (isOutdated(outline, file)) {
       return null;
     }
     return outline;
   }
-
 
   /**
    * Checks that the {@param outline} matches the current version of {@param file}.
@@ -235,11 +233,10 @@ public class ActiveEditorsOutlineService implements Disposable {
    * Listener for changes to the active editors or open outlines.
    */
   public interface Listener {
-
     /**
-     * Called on a change in the {@link FlutterOutline} of file at {@param path}.
+     * Called on a change in the {@link FlutterOutline} of file at {@param filePath}.
      */
-    void onOutlineChanged(@NotNull String path, @Nullable FlutterOutline outline);
+    void onOutlineChanged(@NotNull String filePath, @Nullable FlutterOutline outline);
   }
 
   /**
@@ -248,13 +245,12 @@ public class ActiveEditorsOutlineService implements Disposable {
    * <p>
    * This class caches the updated outline inside {@link ActiveEditorsOutlineService#pathToOutline} for the file.
    */
-  private class OutlineListener/// You can pretty-print the json using the pretty_printer.dart script.
-    implements FlutterOutlineListener {
+  private class OutlineListener implements FlutterOutlineListener {
+    private final String path;
+
     OutlineListener(String path) {
       this.path = path;
     }
-
-    private final String path;
 
     @Override
     public void outlineUpdated(@NotNull String systemDependentPath,

--- a/src/io/flutter/editor/WidgetIndentsHighlightingPassFactory.java
+++ b/src/io/flutter/editor/WidgetIndentsHighlightingPassFactory.java
@@ -123,7 +123,7 @@ public class WidgetIndentsHighlightingPassFactory implements TextEditorHighlight
       }
       for (EditorEx editor : editorOutlineService.getActiveDartEditors()) {
         if (!editor.isDisposed()) {
-          runWidgetIndentsPass(editor, editorOutlineService.get(editor.getVirtualFile().getCanonicalPath()));
+          runWidgetIndentsPass(editor, editorOutlineService.getOutline(editor.getVirtualFile().getCanonicalPath()));
         }
       }
     });
@@ -166,7 +166,7 @@ public class WidgetIndentsHighlightingPassFactory implements TextEditorHighlight
     if (!FlutterUtils.couldContainWidgets(virtualFile)) {
       return filteredIndentsHighlightingPass;
     }
-    final FlutterOutline outline = editorOutlineService.get(virtualFile.getCanonicalPath());
+    final FlutterOutline outline = editorOutlineService.getOutline(virtualFile.getCanonicalPath());
 
     if (outline != null) {
       updateEditorSettings(editor);

--- a/src/io/flutter/inspections/FlutterDependencyInspection.java
+++ b/src/io/flutter/inspections/FlutterDependencyInspection.java
@@ -20,6 +20,7 @@ import io.flutter.FlutterBundle;
 import io.flutter.FlutterUtils;
 import io.flutter.dart.DartPlugin;
 import io.flutter.pub.PubRoot;
+import io.flutter.pub.PubRootCache;
 import io.flutter.sdk.FlutterSdk;
 import io.flutter.settings.FlutterSettings;
 import io.flutter.utils.FlutterModuleUtils;
@@ -50,7 +51,7 @@ public class FlutterDependencyInspection extends LocalInspectionTool {
     final Module module = ModuleUtilCore.findModuleForFile(file, project);
     if (!FlutterModuleUtils.isFlutterModule(module)) return null;
 
-    final PubRoot root = PubRoot.forPsiFile(psiFile);
+    final PubRoot root = PubRootCache.getInstance(project).getRoot(psiFile);
 
     if (root == null || myIgnoredPubspecPaths.contains(root.getPubspec().getPath())) return null;
 

--- a/src/io/flutter/project/FlutterIconProvider.java
+++ b/src/io/flutter/project/FlutterIconProvider.java
@@ -17,6 +17,7 @@ import com.jetbrains.lang.dart.psi.DartFile;
 import icons.FlutterIcons;
 import io.flutter.FlutterUtils;
 import io.flutter.pub.PubRoot;
+import io.flutter.pub.PubRootCache;
 import io.flutter.utils.FlutterModuleUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -40,13 +41,16 @@ public class FlutterIconProvider extends IconProvider {
       final VirtualFile file = ((PsiDirectory)element).getVirtualFile();
       if (!file.isInLocalFileSystem()) return null;
 
+      final PubRootCache pubRootCache = PubRootCache.getInstance(project);
+
       // Show an icon for flutter modules.
-      final PubRoot pubRoot = PubRoot.forDirectory(file);
+      // todo: this needs to be just when the dir == a flutter project
+      final PubRoot pubRoot = pubRootCache.getRoot(file);
       if (pubRoot != null && pubRoot.declaresFlutter()) {
         return FlutterIcons.Flutter;
       }
 
-      final PubRoot root = PubRoot.forDirectory(file.getParent());
+      final PubRoot root = pubRootCache.getRoot(file.getParent());
       if (root == null) return null;
 
       // TODO(devoncarew): should we just make the folder a source kind?

--- a/src/io/flutter/project/FlutterIconProvider.java
+++ b/src/io/flutter/project/FlutterIconProvider.java
@@ -38,28 +38,27 @@ public class FlutterIconProvider extends IconProvider {
 
     // Directories.
     if (element instanceof PsiDirectory) {
-      final VirtualFile file = ((PsiDirectory)element).getVirtualFile();
-      if (!file.isInLocalFileSystem()) return null;
+      final VirtualFile dir = ((PsiDirectory)element).getVirtualFile();
+      if (!dir.isInLocalFileSystem()) return null;
 
       final PubRootCache pubRootCache = PubRootCache.getInstance(project);
 
       // Show an icon for flutter modules.
-      // todo: this needs to be just when the dir == a flutter project
-      final PubRoot pubRoot = pubRootCache.getRoot(file);
-      if (pubRoot != null && pubRoot.declaresFlutter()) {
+      final PubRoot pubRoot = pubRootCache.getRoot(dir);
+      if (pubRoot != null && dir.equals(pubRoot.getRoot()) && pubRoot.declaresFlutter()) {
         return FlutterIcons.Flutter;
       }
 
-      final PubRoot root = pubRootCache.getRoot(file.getParent());
+      final PubRoot root = pubRootCache.getRoot(dir.getParent());
       if (root == null) return null;
 
       // TODO(devoncarew): should we just make the folder a source kind?
-      if (file.equals(root.getLib())) return AllIcons.Modules.SourceRoot;
+      if (dir.equals(root.getLib())) return AllIcons.Modules.SourceRoot;
 
-      if (Objects.equals(file, root.getAndroidDir())) return AllIcons.Nodes.KeymapTools;
-      if (Objects.equals(file, root.getiOsDir())) return AllIcons.Nodes.KeymapTools;
+      if (Objects.equals(dir, root.getAndroidDir())) return AllIcons.Nodes.KeymapTools;
+      if (Objects.equals(dir, root.getiOsDir())) return AllIcons.Nodes.KeymapTools;
 
-      if (file.isDirectory() && file.getName().equals(".idea")) return AllIcons.Modules.GeneratedFolder;
+      if (dir.isDirectory() && dir.getName().equals(".idea")) return AllIcons.Modules.GeneratedFolder;
     }
 
     // Files.

--- a/src/io/flutter/pub/PubRoot.java
+++ b/src/io/flutter/pub/PubRoot.java
@@ -56,7 +56,10 @@ public class PubRoot {
    */
   @Nullable
   public static PubRoot forFile(@Nullable VirtualFile file) {
-    if (file == null) return null;
+    if (file == null) {
+      return null;
+    }
+
     if (file.isDirectory()) {
       final PubRoot root = forDirectory(file.getParent());
       if (root != null) return root;
@@ -240,6 +243,8 @@ public class PubRoot {
    * Returns true if the pubspec declares a flutter dependency.
    */
   public boolean declaresFlutter() {
+    // todo: have an update cache method
+
     // Check if the cache needs to be updated.
     if (cachedPubspecInfo == null || cachedPubspecInfo.getModificationStamp() != pubspec.getModificationStamp()) {
       cachedPubspecInfo = FlutterUtils.getFlutterPubspecInfo(pubspec);

--- a/src/io/flutter/pub/PubRoot.java
+++ b/src/io/flutter/pub/PubRoot.java
@@ -243,14 +243,17 @@ public class PubRoot {
    * Returns true if the pubspec declares a flutter dependency.
    */
   public boolean declaresFlutter() {
-    // todo: have an update cache method
+    validateUpdateCachedPubspecInfo();
+    return cachedPubspecInfo.declaresFlutter();
+  }
 
-    // Check if the cache needs to be updated.
+  /**
+   * Check if the cache needs to be updated.
+   */
+  private void validateUpdateCachedPubspecInfo() {
     if (cachedPubspecInfo == null || cachedPubspecInfo.getModificationStamp() != pubspec.getModificationStamp()) {
       cachedPubspecInfo = FlutterUtils.getFlutterPubspecInfo(pubspec);
     }
-
-    return cachedPubspecInfo.declaresFlutter();
   }
 
   /**

--- a/src/io/flutter/pub/PubRootCache.java
+++ b/src/io/flutter/pub/PubRootCache.java
@@ -47,8 +47,6 @@ public class PubRootCache {
     return getRoot(file);
   }
 
-  // todo: fix the issue with all directories looking like flutter folders
-
   @Nullable
   public PubRoot getRoot(VirtualFile file) {
     file = findPubspecDir(file);
@@ -70,8 +68,6 @@ public class PubRootCache {
   public List<PubRoot> getRoots(Module module) {
     final List<PubRoot> result = new ArrayList<>();
 
-    // TODO: what if the content roots change?
-
     for (VirtualFile dir : ModuleRootManager.getInstance(module).getContentRoots()) {
       PubRoot root = cache.get(dir);
 
@@ -84,6 +80,7 @@ public class PubRootCache {
         result.add(root);
       }
     }
+
     return result;
   }
 

--- a/src/io/flutter/pub/PubRootCache.java
+++ b/src/io/flutter/pub/PubRootCache.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2019 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.pub;
+
+import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleManager;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.ModuleRootManager;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiFile;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Cache the information computed from pubspecs in the project.
+ */
+public class PubRootCache {
+  @NotNull
+  public static PubRootCache getInstance(@NotNull final Project project) {
+    return ServiceManager.getService(project, PubRootCache.class);
+  }
+
+  @NotNull final Project project;
+
+  private final Map<VirtualFile, PubRoot> cache = new HashMap<>();
+
+  private PubRootCache(@NotNull final Project project) {
+    this.project = project;
+  }
+
+  @Nullable
+  public PubRoot getRoot(@NotNull PsiFile psiFile) {
+    final VirtualFile file = psiFile.getVirtualFile();
+    if (file == null) {
+      return null;
+    }
+
+    return getRoot(file);
+  }
+
+  // todo: fix the issue with all directories looking like flutter folders
+
+  @Nullable
+  public PubRoot getRoot(VirtualFile file) {
+    file = findPubspecDir(file);
+    if (file == null) {
+      return null;
+    }
+
+    PubRoot root = cache.get(file);
+
+    if (root == null) {
+      cache.put(file, PubRoot.forDirectory(file));
+      root = cache.get(file);
+    }
+
+    return root;
+  }
+
+  @NotNull
+  public List<PubRoot> getRoots(Module module) {
+    final List<PubRoot> result = new ArrayList<>();
+
+    // TODO: what if the content roots change?
+
+    for (VirtualFile dir : ModuleRootManager.getInstance(module).getContentRoots()) {
+      PubRoot root = cache.get(dir);
+
+      if (root == null) {
+        cache.put(dir, PubRoot.forDirectory(dir));
+        root = cache.get(dir);
+      }
+
+      if (root != null) {
+        result.add(root);
+      }
+    }
+    return result;
+  }
+
+  @NotNull
+  public List<PubRoot> getRoots(@NotNull Project project) {
+    final List<PubRoot> result = new ArrayList<>();
+    for (Module module : ModuleManager.getInstance(project).getModules()) {
+      result.addAll(getRoots(module));
+    }
+    return result;
+  }
+
+  @Nullable
+  private VirtualFile findPubspecDir(VirtualFile file) {
+    if (file == null) {
+      return null;
+    }
+
+    if (file.isDirectory()) {
+      final VirtualFile pubspec = file.findChild("pubspec.yaml");
+      if (pubspec != null && pubspec.exists() && !pubspec.isDirectory()) {
+        return file;
+      }
+    }
+
+    return findPubspecDir(file.getParent());
+  }
+}

--- a/src/io/flutter/run/SdkFields.java
+++ b/src/io/flutter/run/SdkFields.java
@@ -17,6 +17,7 @@ import io.flutter.FlutterBundle;
 import io.flutter.FlutterUtils;
 import io.flutter.dart.DartPlugin;
 import io.flutter.pub.PubRoot;
+import io.flutter.pub.PubRootCache;
 import io.flutter.run.common.RunMode;
 import io.flutter.sdk.FlutterCommand;
 import io.flutter.sdk.FlutterSdk;
@@ -99,7 +100,7 @@ public class SdkFields {
     if (!main.canLaunch()) {
       throw new RuntimeConfigurationError(main.getError());
     }
-    if (PubRoot.forDirectory(main.get().getAppDir()) == null) {
+    if (PubRootCache.getInstance(project).getRoot(main.get().getAppDir()) == null) {
       throw new RuntimeConfigurationError("Entrypoint isn't within a Flutter pub root");
     }
   }

--- a/src/io/flutter/run/common/CommonTestConfigUtils.java
+++ b/src/io/flutter/run/common/CommonTestConfigUtils.java
@@ -11,6 +11,8 @@ import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.jetbrains.lang.dart.psi.DartCallExpression;
@@ -58,10 +60,15 @@ public abstract class CommonTestConfigUtils {
   public TestType asTestCall(@NotNull PsiElement element) {
     // Named tests.
     final TestType namedTestCall = findNamedTestCall(element);
-    if (namedTestCall != null) return namedTestCall;
+    if (namedTestCall != null) {
+      return namedTestCall;
+    }
 
     // Main.
-    if (isMainFunctionDeclarationWithTests(element)) return TestType.MAIN;
+    if (isMainFunctionDeclarationWithTests(element)) {
+      return TestType.MAIN;
+    }
+
     return null;
   }
 
@@ -71,20 +78,32 @@ public abstract class CommonTestConfigUtils {
   @NotNull
   protected Map<DartCallExpression, TestType> getTestsFromOutline(@NotNull PsiFile file) {
     final Project project = file.getProject();
-    final ActiveEditorsOutlineService service = getActiveEditorsOutlineService(project);
-    if (service == null) {
+    final ActiveEditorsOutlineService outlineService = getActiveEditorsOutlineService(project);
+    if (outlineService == null) {
       return new HashMap<>();
     }
-    final FlutterOutline outline = service.getIfUpdated(file);
+
+    final FlutterOutline outline = outlineService.getIfUpdated(file);
     // If the outline is outdated, then request a new pass to generate line markers.
     if (outline == null) {
-      service.addListener(forFile(file));
+      clearCachedInfo();
+      outlineService.addListener(forFile(file));
       return new HashMap<>();
     }
+
     // Visit the fields on the outline to get which calls are actual named tests.
-    final Map<DartCallExpression, TestType> callToTestType = new HashMap<>();
-    visit(outline, callToTestType, file);
-    return callToTestType;
+    if (cachedCallToTestType == null) {
+      cachedCallToTestType = new HashMap<>();
+      visit(outline, cachedCallToTestType, file);
+    }
+
+    return cachedCallToTestType;
+  }
+
+  Map<DartCallExpression, TestType> cachedCallToTestType;
+
+  private void clearCachedInfo() {
+    cachedCallToTestType = null;
   }
 
   @VisibleForTesting
@@ -188,7 +207,7 @@ public abstract class CommonTestConfigUtils {
    */
   private static final Map<String, LineMarkerUpdatingListener> listenerCache = new HashMap<>();
 
-  LineMarkerUpdatingListener forFile(@NotNull final PsiFile file) {
+  private LineMarkerUpdatingListener forFile(@NotNull final PsiFile file) {
     final String path = file.getVirtualFile().getCanonicalPath();
     final ActiveEditorsOutlineService service = getActiveEditorsOutlineService(file.getProject());
     if (!listenerCache.containsKey(path) && service != null) {
@@ -204,11 +223,9 @@ public abstract class CommonTestConfigUtils {
    * <p>
    * Used to ensure that we don't get stuck with out-of-date line markers.
    */
-  private static class LineMarkerUpdatingListener
-    implements ActiveEditorsOutlineService.Listener {
+  private class LineMarkerUpdatingListener implements ActiveEditorsOutlineService.Listener {
     @NotNull final Project project;
     @NotNull final ActiveEditorsOutlineService service;
-
 
     private LineMarkerUpdatingListener(@NotNull Project project, @NotNull ActiveEditorsOutlineService service) {
       this.project = project;
@@ -216,25 +233,25 @@ public abstract class CommonTestConfigUtils {
     }
 
     @Override
-    public void onOutlineChanged(@NotNull String path, @Nullable FlutterOutline outline) {
-      forceFileAnnotation();
+    public void onOutlineChanged(@NotNull String filePath, @Nullable FlutterOutline outline) {
+      CommonTestConfigUtils.this.clearCachedInfo();
+
+      forceFileAnnotation(LocalFileSystem.getInstance().findFileByPath(filePath));
       service.removeListener(this);
     }
 
     // TODO(djshuckerow): this can be merged with the Dart plugin's forceFileAnnotation:
     // https://github.com/JetBrains/intellij-plugins/blob/master/Dart/src/com/jetbrains/lang/dart/analyzer/DartServerData.java#L300
-    private void forceFileAnnotation() {
+    private void forceFileAnnotation(final VirtualFile file) {
       // It's ok to call DaemonCodeAnalyzer.restart() right in this thread, without invokeLater(),
       // but it will cache RemoteAnalysisServerImpl$ServerResponseReaderThread in FileStatusMap.threads and as a result,
       // DartAnalysisServerService.myProject will be leaked in tests
-      ApplicationManager.getApplication()
-        .invokeLater(
-          () -> {
-            DaemonCodeAnalyzer.getInstance(project).restart();
-          },
-          ModalityState.NON_MODAL,
-          project.getDisposed()
-        );
+
+      ApplicationManager.getApplication().invokeLater(
+        () -> DaemonCodeAnalyzer.getInstance(project).restart(),
+        ModalityState.NON_MODAL,
+        project.getDisposed()
+      );
     }
   }
 }

--- a/src/io/flutter/run/common/TestLineMarkerContributor.java
+++ b/src/io/flutter/run/common/TestLineMarkerContributor.java
@@ -55,7 +55,6 @@ public abstract class TestLineMarkerContributor extends RunLineMarkerContributor
 
   @NotNull
   private static Icon getTestStateIcon(@NotNull PsiElement element, @NotNull Icon defaultIcon) {
-
     // SMTTestProxy maps test run data to a URI derived from a location hint produced by `package:test`.
     // If we can find corresponding data, we can provide state-aware icons. If not, we default to
     // a standard Run state.

--- a/src/io/flutter/run/common/TestLineMarkerContributor.java
+++ b/src/io/flutter/run/common/TestLineMarkerContributor.java
@@ -20,6 +20,7 @@ import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiInvalidElementAccessException;
 import com.intellij.util.Function;
 import com.intellij.util.Time;
+import com.jetbrains.lang.dart.psi.DartCallExpression;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -43,12 +44,16 @@ public abstract class TestLineMarkerContributor extends RunLineMarkerContributor
   @Nullable
   @Override
   public Info getInfo(@NotNull PsiElement element) {
-    final TestType testCall = testConfigUtils.asTestCall(element);
-    if (testCall != null) {
-      final Icon icon = getTestStateIcon(element, testCall.getIcon());
-      final Function<PsiElement, String> tooltipProvider =
-        psiElement -> testCall.getTooltip(psiElement, testConfigUtils);
-      return new RunLineMarkerContributor.Info(icon, tooltipProvider, ExecutorAction.getActions());
+    // TODO(devoncarew): We should look for the leaf nodes here, and place the marker on that.
+    // https://github.com/flutter/flutter-intellij/issues/4036
+    if (element instanceof DartCallExpression) { // || element instanceof DartFunctionDeclarationWithBodyOrNative) {
+      final TestType testCall = testConfigUtils.asTestCall(element);
+      if (testCall != null) {
+        final Icon icon = getTestStateIcon(element, testCall.getIcon());
+        final Function<PsiElement, String> tooltipProvider =
+          psiElement -> testCall.getTooltip(psiElement, testConfigUtils);
+        return new RunLineMarkerContributor.Info(icon, tooltipProvider, ExecutorAction.getActions());
+      }
     }
     return null;
   }
@@ -81,8 +86,7 @@ public abstract class TestLineMarkerContributor extends RunLineMarkerContributor
 
       final TestStateStorage storage = TestStateStorage.getInstance(project);
       if (storage != null) {
-        final Map<String, TestStateStorage.Record> tests =
-          storage.getRecentTests(SCANNED_TEST_RESULT_LIMIT, getSinceDate());
+        final Map<String, TestStateStorage.Record> tests = storage.getRecentTests(SCANNED_TEST_RESULT_LIMIT, getSinceDate());
         if (tests != null) {
           // TODO(pq): investigate performance implications.
           for (Map.Entry<String, TestStateStorage.Record> entry : tests.entrySet()) {

--- a/src/io/flutter/run/test/FlutterTestConfigProducer.java
+++ b/src/io/flutter/run/test/FlutterTestConfigProducer.java
@@ -33,7 +33,7 @@ public class FlutterTestConfigProducer extends RunConfigurationProducer<TestConf
 
   private static boolean isFlutterContext(@NotNull ConfigurationContext context) {
     final PsiElement location = context.getPsiLocation();
-    return location != null && FlutterUtils.isInFlutterProject(location);
+    return location != null && FlutterUtils.isInFlutterProject(context.getProject(), location);
   }
 
   /**

--- a/src/io/flutter/run/test/FlutterTestLocationProvider.java
+++ b/src/io/flutter/run/test/FlutterTestLocationProvider.java
@@ -16,6 +16,7 @@ import org.jetbrains.annotations.Nullable;
 
 public class FlutterTestLocationProvider extends DartTestLocationProviderZ {
   public static final FlutterTestLocationProvider INSTANCE = new FlutterTestLocationProvider();
+
   private final TestConfigUtils testConfigUtils = TestConfigUtils.getInstance();
 
   @Nullable

--- a/src/io/flutter/run/test/TestConfigUtils.java
+++ b/src/io/flutter/run/test/TestConfigUtils.java
@@ -30,7 +30,8 @@ public class TestConfigUtils extends CommonTestConfigUtils {
   @Override
   public TestType asTestCall(@NotNull PsiElement element) {
     final DartFile file = FlutterUtils.getDartFile(element);
-    if (!FlutterUtils.isInTestDir(file) || !FlutterUtils.isInFlutterProject(element)) {
+
+    if (!FlutterUtils.isInTestDir(file)) {
       return null;
     }
 

--- a/src/io/flutter/util/DartTestLocationProviderZ.java
+++ b/src/io/flutter/util/DartTestLocationProviderZ.java
@@ -34,8 +34,8 @@ public class DartTestLocationProviderZ implements SMTestLocator, DumbAware {
   private static final List<Location> NONE = Collections.emptyList();
   private static final Gson GSON = new Gson();
 
-  public static final DartTestLocationProviderZ
-    INSTANCE = new DartTestLocationProviderZ();
+  public static final DartTestLocationProviderZ INSTANCE = new DartTestLocationProviderZ();
+
   public static final Type STRING_LIST_TYPE = new TypeToken<List<String>>() {
   }.getType();
 

--- a/testSrc/unit/io/flutter/testing/FakeActiveEditorsOutlineService.java
+++ b/testSrc/unit/io/flutter/testing/FakeActiveEditorsOutlineService.java
@@ -29,7 +29,7 @@ public class FakeActiveEditorsOutlineService extends ActiveEditorsOutlineService
   }
 
   public void loadOutline(@NotNull String flutterOutlinePath) {
-    String outlineContents = null;
+    String outlineContents;
     try {
       outlineContents = new String(Files.readAllBytes(Paths.get(flutterOutlinePath)));
     }
@@ -46,7 +46,7 @@ public class FakeActiveEditorsOutlineService extends ActiveEditorsOutlineService
 
   @Nullable
   @Override
-  public FlutterOutline get(String path) {
+  public FlutterOutline getOutline(String path) {
     return flutterOutline;
   }
 


### PR DESCRIPTION
- address some performance issues with displaying test markers
- fix https://github.com/flutter/flutter-intellij/issues/4012

The main portion of this PR is introducing a project service - `PubRootCache` - that caches the parsed pubspec info and `PubRoot`s. This information is requested frequently, especially when visiting the PSI AST of a Dart file, when looking for nodes that match `test` and `group`s in order to create in-line run line markers.