### PR TITLE
Re-enable attach button for add-to-app projects

### DIFF
--- a/src/io/flutter/actions/AttachDebuggerAction.java
+++ b/src/io/flutter/actions/AttachDebuggerAction.java
@@ -104,7 +104,7 @@ public class AttachDebuggerAction extends FlutterSdkAction {
       return;
     }
     boolean enabled;
-    RunnerAndConfigurationSettings settings = RunFlutterAction.getRunConfigSettings(e);
+    RunnerAndConfigurationSettings settings = RunManagerEx.getInstanceEx(project).getSelectedConfiguration();
     if (settings == null) {
       enabled = false;
     }
@@ -112,6 +112,7 @@ public class AttachDebuggerAction extends FlutterSdkAction {
       RunConfiguration configuration = settings.getConfiguration();
       enabled = configuration instanceof SdkRunConfig;
     }
+    e.getPresentation().setVisible(true);
     e.getPresentation().setEnabled(enabled);
   }
 


### PR DESCRIPTION
IntelliJ seems to have tightened the expectations on UI performance, and we may be lagging.

The event used here changes status from running to canceled by the time the code at line 107 executes. Once canceled, we can't get the project anymore.

Also, Android apps (without Flutter) won't display the attach button. After a module is added the button needs to be made visible again (without restarting the IDE).