### PR TITLE
Support for debugging add-to-app modules in Android Studio

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -182,3 +182,67 @@ Verify installation and configuration in a fresh IDEA installation.
 * Set the Flutter SDK path to a valid SDK location.
   * Verify that invalid locations are rejected (and cannot be applied).
 * Verify project creation, run/debug.
+
+## Add-to-app module integration test
+Create and debug a Flutter module in an Android app.
+
+###Create an Android app
+
+Start Android Studio and use the File > New > New Project menu to fire 
+up the new project wizard. Choose the template that includes a Basic
+Activity. One the next page, use Kotlin and minimum API level 16.
+Let the system stabilize (Gradle sync).
+
+Close the editor for content_main.xml. Switch the Project view to
+the Project Files mode. Collapse the Gradle window if it is open.
+
+###Create a Flutter module
+
+Use the File > New > New Module menu to start the new module wizard.
+Choose the Flutter Module template. Fill out the wizard pages and
+click Finish, then wait a bit. Android Studio needs to do two
+successive Gradle sync's. The first one generates an error message,
+which is corrected by the second one. Ignore the error. Let the
+system stabilize again.
+
+###Link the Flutter module to the Android app
+
+Go to the editor for MainActivity.kt. Change the onCreate method:
+```kotlin
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
+        setSupportActionBar(toolbar)
+        System.loadLibrary("flutter")
+        val engine = FlutterEngine(this.applicationContext)
+        FlutterMain.startInitialization(this.applicationContext)
+        FlutterMain.ensureInitializationComplete(this, null)
+        engine.dartExecutor.executeDartEntrypoint(DartExecutor.DartEntrypoint.createDefault())
+        fab.setOnClickListener { view ->
+            FlutterEngineCache.getInstance().put("1", engine)
+            startActivity(FlutterActivity.withCachedEngine("1").build(this))
+        }
+    }
+```
+You need to add some imports. Click on each red name then type
+`alt-return`. Accept the suggestion. "FlutterActivity" has two choices;
+use the one from io.flutter.embedGradle.
+
+Open an editor on the AndroidManifest.xml. Add this line to the
+<application> tag:
+```xml
+        <activity android:name="io.flutter.embedding.android.FlutterActivity" />
+```
+###Debug the app
+
+The run config should show the Flutter run config, which makes the Flutter Attach
+button active. Click the Flutter Attach button, or use the menu item Run > Flutter
+Attach. (Note: with the kotlin code above you need to start the attach process
+before starting the Android app.)
+
+Change the run config to "app" for the Android app. Click the Debug button.
+Wait for the app to launch.
+
+When the app is visible, click the mail icon at bottom right. The Flutter
+screen should become visible. At this point you can set breakpoints and
+do hot reload as for a stand-alone Flutter app.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -213,10 +213,7 @@ Go to the editor for MainActivity.kt. Change the onCreate method:
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
         setSupportActionBar(toolbar)
-        System.loadLibrary("flutter")
         val engine = FlutterEngine(this.applicationContext)
-        FlutterMain.startInitialization(this.applicationContext)
-        FlutterMain.ensureInitializationComplete(this, null)
         engine.dartExecutor.executeDartEntrypoint(DartExecutor.DartEntrypoint.createDefault())
         fab.setOnClickListener { view ->
             FlutterEngineCache.getInstance().put("1", engine)

--- a/flutter-studio/src/io/flutter/module/FlutterModuleModel.java
+++ b/flutter-studio/src/io/flutter/module/FlutterModuleModel.java
@@ -5,36 +5,19 @@
  */
 package io.flutter.module;
 
-import com.android.tools.idea.gradle.parser.BuildFileKey;
-import com.android.tools.idea.gradle.parser.Dependency;
-import com.android.tools.idea.gradle.parser.GradleBuildFile;
-import com.android.tools.idea.gradle.parser.GradleSettingsFile;
-import com.android.tools.idea.gradle.parser.Repository;
-import com.intellij.execution.process.OSProcessHandler;
-import com.intellij.execution.process.ProcessAdapter;
-import com.intellij.execution.process.ProcessEvent;
 import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.command.WriteCommandAction;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.InvalidDataException;
-import com.intellij.openapi.util.io.FileUtilRt;
 import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
-import io.flutter.FlutterUtils;
-import io.flutter.actions.FlutterBuildActionGroup;
 import io.flutter.project.FlutterProjectCreator;
 import io.flutter.project.FlutterProjectModel;
-import io.flutter.pub.PubRoot;
-import io.flutter.sdk.FlutterSdk;
 import io.flutter.utils.AndroidUtils;
 import java.io.File;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.charset.Charset;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.concurrent.atomic.AtomicReference;
+import java.nio.charset.StandardCharsets;
 import org.jetbrains.annotations.NotNull;
 
 public class FlutterModuleModel extends FlutterProjectModel {
@@ -105,25 +88,9 @@ public class FlutterModuleModel extends FlutterProjectModel {
       }
       addGradleToModule(flutterModuleDir);
 
-      // Build the AAR repository, needed by Gradle linkage.
-      PubRoot pubRoot = PubRoot.forDirectory(VfsUtil.findFileByIoFile(flutterProject, true));
-      FlutterSdk sdk = FlutterSdk.forPath(model.flutterSdk().get());
-      if (sdk == null) {
-        return; // The error would have been shown in super.handleFinished().
-      }
-      OSProcessHandler handler =
-        FlutterBuildActionGroup.build(hostProject, pubRoot, sdk, FlutterBuildActionGroup.BuildType.AAR, "Building AAR");
-      handler.addProcessListener(new ProcessAdapter() {
-        @Override
-        public void processTerminated(@NotNull ProcessEvent event) {
-
-          new ModuleCoEditHelper(hostProject, model.packageName().get(), flutterModuleDir).enable();
-
-          // Ensure Gradle sync runs to link in the new add-to-app module.
-          AndroidUtils.scheduleGradleSync(hostProject);
-          // TODO(messick) Generate run configs for release and debug. (If needed.)
-        }
-      });
+      // Ensure Gradle sync runs to link in the new add-to-app module.
+      AndroidUtils.scheduleGradleSync(hostProject);
+      // TODO(messick) Generate run configs for release and debug. (If needed.)
     }
 
     private static void addGradleToModule(VirtualFile moduleDir) {
@@ -137,83 +104,19 @@ public class FlutterModuleModel extends FlutterProjectModel {
           }
           if (settingsFile.exists()) {
             // The default module template does not have a settings.gradle file so this should not happen.
-            settingsWriter.append(new String(settingsFile.contentsToByteArray(false), Charset.defaultCharset()));
+            settingsWriter.append(new String(settingsFile.contentsToByteArray(false), StandardCharsets.UTF_8));
             settingsWriter.append(System.lineSeparator());
           }
           settingsWriter.append("// Generated file. Do not edit.");
           settingsWriter.append(System.lineSeparator());
           settingsWriter.append("include ':.android'");
           settingsWriter.append(System.lineSeparator());
-          settingsFile.setBinaryContent(settingsWriter.toString().getBytes(Charset.defaultCharset()));
+          settingsFile.setBinaryContent(settingsWriter.toString().getBytes(StandardCharsets.UTF_8));
         }
         catch (IOException e) {
           // Should not happen
         }
       });
-    }
-  }
-
-  // Edit settings.gradle according to add-to-app docs.
-  private static class ModuleCoEditHelper {
-    @NotNull
-    private final Project project;
-    @NotNull
-    private final String packageName;
-    @NotNull
-    private final String projectName;
-    @NotNull
-    private final String pathToModule;
-
-    private ModuleCoEditHelper(@NotNull Project project, @NotNull String packageName, @NotNull VirtualFile flutterModuleDir) {
-      this.project = project;
-      this.packageName = packageName;
-      this.projectName = flutterModuleDir.getName();
-      File flutterModuleRoot = new File(flutterModuleDir.getPath());
-      VirtualFile projectRoot = FlutterUtils.getProjectRoot(project);
-      this.pathToModule = Objects.requireNonNull(FileUtilRt.getRelativePath(new File(projectRoot.getPath(), "app"), flutterModuleRoot));
-    }
-
-    private void enable() {
-      GradleSettingsFile settingsFile = GradleSettingsFile.get(project);
-      if (settingsFile == null) {
-        return;
-      }
-      GradleBuildFile gradleBuildFile = settingsFile.getModuleBuildFile(":app");
-      if (gradleBuildFile == null) {
-        return;
-      }
-
-      AtomicReference<List<Repository>> repositories = new AtomicReference<>();
-      ApplicationManager.getApplication().runReadAction(() -> {
-        //noinspection unchecked
-        List<Repository> repBlock = (List<Repository>)gradleBuildFile.getValue(BuildFileKey.LIBRARY_REPOSITORY);
-        repositories.set(repBlock != null ? repBlock : new ArrayList<>());
-      });
-      repositories.get().add(new Repository(Repository.Type.URL, pathToModule.replace('\\', '/') + "/build/host/outputs/repo"));
-
-      AtomicReference<List<Dependency>> dependencies = new AtomicReference<>();
-      ApplicationManager.getApplication().runReadAction(() -> {
-        //noinspection unchecked
-        List<Dependency> depBlock = (List<Dependency>)gradleBuildFile.getValue(BuildFileKey.DEPENDENCIES);
-        dependencies.set(depBlock != null ? depBlock : new ArrayList<>());
-      });
-      Dependency.Scope scope = Dependency.Scope.getDefaultScope(project);
-      String fqn = packagePrefix(packageName) + "." + projectName;
-      dependencies.get().add(new Dependency(scope, Dependency.Type.EXTERNAL, fqn + ":flutter_release:1.0@aar"));
-
-      WriteCommandAction.writeCommandAction(project).run(() -> {
-        gradleBuildFile.removeValue(null, BuildFileKey.DEPENDENCIES);
-        gradleBuildFile.setValue(BuildFileKey.LIBRARY_REPOSITORY, repositories.get());
-        gradleBuildFile.setValue(BuildFileKey.DEPENDENCIES, dependencies.get());
-      });
-    }
-
-    private static String packagePrefix(@NotNull String packageName) {
-      int idx = packageName.lastIndexOf('.');
-      if (idx <= 0) {
-        return packageName;
-      }
-      return packageName.substring(0, idx);
     }
   }
 }

--- a/flutter-studio/src/io/flutter/module/ImportFlutterModuleStep.java
+++ b/flutter-studio/src/io/flutter/module/ImportFlutterModuleStep.java
@@ -82,6 +82,11 @@ public class ImportFlutterModuleStep extends SkippableWizardStep<FlutterProjectM
     return myValidatorPanel.hasErrors().not();
   }
 
+  @Override
+  protected void onEntering() {
+    getModel().projectType().setValue(FlutterProjectType.IMPORT);
+  }
+
   @NotNull
   private static Validator.Result validateFlutterModuleLocation(String path) {
     VirtualFile file = VfsUtil.findFileByIoFile(new File(path), true);

--- a/src/io/flutter/FlutterUtils.java
+++ b/src/io/flutter/FlutterUtils.java
@@ -176,7 +176,14 @@ public class FlutterUtils {
    * Test if the given element is contained in a module with a pub root that declares a flutter dependency.
    */
   public static boolean isInFlutterProject(@NotNull Project project, @NotNull PsiElement element) {
-    final PubRoot pubRoot = PubRootCache.getInstance(project).getRoot(element.getContainingFile());
+    PsiFile file = element.getContainingFile();
+    if (file == null) {
+      return false;
+    }
+    final PubRoot pubRoot = PubRootCache.getInstance(project).getRoot(file);
+    if (pubRoot == null) {
+      return false;
+    }
     return pubRoot.declaresFlutter();
   }
 
@@ -430,7 +437,10 @@ public class FlutterUtils {
     assert projectDir != null;
     VirtualFile androidDir = getFlutterManagedAndroidDir(projectDir);
     if (androidDir == null) {
-      return false;
+      androidDir = getAndroidProjectDir(projectDir);
+      if (androidDir == null) {
+        return false;
+      }
     }
     VirtualFile propFile = androidDir.findChild("gradle.properties");
     if (propFile == null) {
@@ -448,6 +458,10 @@ public class FlutterUtils {
       return Boolean.parseBoolean(value);
     }
     return false;
+  }
+
+  private static VirtualFile getAndroidProjectDir(VirtualFile dir) {
+    return (dir.findChild("app") == null) ? null : dir;
   }
 
   @Nullable

--- a/src/io/flutter/ProjectOpenActivity.java
+++ b/src/io/flutter/ProjectOpenActivity.java
@@ -65,7 +65,9 @@ public class ProjectOpenActivity implements StartupActivity, DumbAware {
       sdk.queryFlutterConfig("android-studio-dir", false);
     });
     if (FlutterUtils.isAndroidStudio() && !FLUTTER_PROJECT_TYPE.equals(ProjectTypeService.getProjectType(project))) {
-      ProjectTypeService.setProjectType(project, FLUTTER_PROJECT_TYPE);
+      if (!AndroidUtils.isAndroidProject(project)) {
+        ProjectTypeService.setProjectType(project, FLUTTER_PROJECT_TYPE);
+      }
     }
 
     // If this project is intended as a bazel project, don't run the pub alerts.

--- a/src/io/flutter/actions/FlutterBuildActionGroup.java
+++ b/src/io/flutter/actions/FlutterBuildActionGroup.java
@@ -27,7 +27,7 @@ import org.jetbrains.annotations.NotNull;
 
 public class FlutterBuildActionGroup extends DefaultActionGroup {
 
-  public static OSProcessHandler build(Project project, PubRoot pubRoot, FlutterSdk sdk, BuildType buildType, String desc) {
+  public static OSProcessHandler build(Project project, @NotNull PubRoot pubRoot, FlutterSdk sdk, BuildType buildType, String desc) {
     ProgressHelper progressHelper = new ProgressHelper(project);
     progressHelper.start(desc);
     OSProcessHandler processHandler = sdk.flutterBuild(pubRoot, buildType.type).startInConsole(project);


### PR DESCRIPTION
Address all P1 items in #4064.
cc: @xster 

## Create and debug a Flutter module in an Android app

### Create an Android app

Start Android Studio and use the File > New > New Project menu to fire 
up the new project wizard. Choose the template that includes a Basic
Activity. One the next page, use Kotlin and minimum API level 16.
Let the system stabilize (Gradle sync).

Close the editor for content_main.xml. Switch the Project view to
the Project Files mode. Collapse the Gradle window if it is open.

### Create a Flutter module

Use the File > New > New Module menu to start the new module wizard.
Choose the Flutter Module template. Fill out the wizard pages and
click Finish, then wait a bit. Android Studio needs to do two
successive Gradle sync's. The first one generates an error message,
which is corrected by the second one. Ignore the error. Let the
system stabilize again.

### Link the Flutter module to the Android app

Go to the editor for MainActivity.kt. Change the onCreate method:
```kotlin
    override fun onCreate(savedInstanceState: Bundle?) {
        super.onCreate(savedInstanceState)
        setContentView(R.layout.activity_main)
        setSupportActionBar(toolbar)
        val engine = FlutterEngine(this.applicationContext)
        engine.dartExecutor.executeDartEntrypoint(DartExecutor.DartEntrypoint.createDefault())
        fab.setOnClickListener { view ->
            FlutterEngineCache.getInstance().put("1", engine)
            startActivity(FlutterActivity.withCachedEngine("1").build(this))
        }
    }
```
You need to add some imports. Click on each red name then type
`alt-return`. Accept the suggestion. "FlutterActivity" has two choices;
use the one from io.flutter.embedGradle.

Open an editor on the AndroidManifest.xml. Add this line to the
<application> tag:
```xml
        <activity android:name="io.flutter.embedding.android.FlutterActivity" />
```
### Debug the app

The run config should show the Flutter run config, which makes the Flutter Attach
button active. Click the Flutter Attach button, or use the menu item Run > Flutter
Attach. (Note: with the kotlin code above you need to start the attach process
before starting the Android app.)

Change the run config to "app" for the Android app. Click the Debug button.
Wait for the app to launch.

When the app is visible, click the mail icon at bottom right. The Flutter
screen should become visible. At this point you can set breakpoints and
do hot reload as for a stand-alone Flutter app.
