### PR TITLE
remove the two secondary UI guides settings

### DIFF
--- a/src/io/flutter/editor/WidgetIndentsHighlightingPassFactory.java
+++ b/src/io/flutter/editor/WidgetIndentsHighlightingPassFactory.java
@@ -48,9 +48,7 @@ public class WidgetIndentsHighlightingPassFactory implements TextEditorHighlight
   private final Listener settingsListener;
   private final ActiveEditorsOutlineService.Listener outlineListener;
 
-  // Current configuration settings used to display Widget Indent Guides cached
-  // from the FlutterSettings class.
-  private boolean isShowMultipleChildrenGuides;
+  // Current configuration settings used to display Widget Indent Guides cached from the FlutterSettings class.
   private boolean isShowBuildMethodGuides;
 
   public WidgetIndentsHighlightingPassFactory(@NotNull Project project) {
@@ -92,7 +90,6 @@ public class WidgetIndentsHighlightingPassFactory implements TextEditorHighlight
       isShowBuildMethodGuides = settings.isShowBuildMethodGuides();
       updateAllEditors();
     }
-    isShowMultipleChildrenGuides = settings.isShowMultipleChildrenGuides() && isShowBuildMethodGuides;
   }
 
   /**
@@ -205,7 +202,7 @@ public class WidgetIndentsHighlightingPassFactory implements TextEditorHighlight
     if (documentLength != outlineLength &&
         documentLength != DartAnalysisServerService.getInstance(project).getConvertedOffset(file, outlineLength)) {
       // Outline is out of date. That is ok. Ignore it for now.
-      // An up to date outline will probably arive shortly. Showing an
+      // An up to date outline will probably arrive shortly. Showing an
       // outline from data inconsistent with the current
       // content will show annoying flicker. It is better to
       // instead
@@ -232,8 +229,7 @@ public class WidgetIndentsHighlightingPassFactory implements TextEditorHighlight
       }
       final FlutterSettings settings = FlutterSettings.getInstance();
       // Skip if none of the settings that impact Widget Idents were changed.
-      if (isShowBuildMethodGuides == settings.isShowBuildMethodGuides() &&
-          isShowMultipleChildrenGuides == settings.isShowMultipleChildrenGuides()) {
+      if (isShowBuildMethodGuides == settings.isShowBuildMethodGuides()) {
         // Change doesn't matter for us.
         return;
       }

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.form
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.form
@@ -151,7 +151,7 @@
           </component>
         </children>
       </grid>
-      <grid id="32490" layout-manager="GridLayoutManager" row-count="6" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="32490" layout-manager="GridLayoutManager" row-count="4" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -168,27 +168,9 @@
               <toolTipText value="Visualize the widget tree structure from the outline view directly in build methods."/>
             </properties>
           </component>
-          <component id="70776" class="javax.swing.JCheckBox" binding="myShowMultipleChildrenGuides">
-            <constraints>
-              <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="2" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <text value="Emphasize widgets with multiple children"/>
-              <toolTipText value="Make lines indicating the relationship between a widget and its multiple children more visible."/>
-            </properties>
-          </component>
-          <component id="23423483" class="javax.swing.JCheckBox" binding="myShowBuildMethodsOnScrollbar">
-            <constraints>
-              <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="2" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <text value="Show where build methods are on the scrollbar"/>
-              <toolTipText value="When this option is checked lines are drawn on the scrollbar indicating where build methods are."/>
-            </properties>
-          </component>
           <component id="a0dd8" class="javax.swing.JCheckBox" binding="myFormatCodeOnSaveCheckBox" default-binding="true">
             <constraints>
-              <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text resource-bundle="io/flutter/FlutterBundle" key="settings.format.code.on.save"/>
@@ -197,7 +179,7 @@
           </component>
           <component id="8bd46" class="javax.swing.JCheckBox" binding="myOrganizeImportsOnSaveCheckBox" default-binding="true">
             <constraints>
-              <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="2" use-parent-layout="false"/>
+              <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="2" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text resource-bundle="io/flutter/FlutterBundle" key="settings.organize.imports.on.save"/>
@@ -206,7 +188,7 @@
           </component>
           <component id="92f7c" class="javax.swing.JCheckBox" binding="myShowClosingLabels" default-binding="true">
             <constraints>
-              <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text value="Show closing labels in Dart source code"/>

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.java
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.java
@@ -72,8 +72,6 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
 
   // Settings for UI as Code experiments:
   private JCheckBox myShowBuildMethodGuides;
-  private JCheckBox myShowMultipleChildrenGuides;
-  private JCheckBox myShowBuildMethodsOnScrollbar;
   private JCheckBox myShowClosingLabels;
   private FixedSizeButton myCopyButton;
   private JPanel experimentsPanel;
@@ -130,13 +128,6 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
       (e) -> myHotReloadIgnoreErrorCheckBox.setEnabled(myHotReloadOnSaveCheckBox.isSelected()));
     myFormatCodeOnSaveCheckBox.addChangeListener(
       (e) -> myOrganizeImportsOnSaveCheckBox.setEnabled(myFormatCodeOnSaveCheckBox.isSelected()));
-
-    // These options are only enabled if build method guides are enabled as the
-    // same class handles all these cases.
-    myShowBuildMethodGuides.addChangeListener((e) -> {
-      myShowMultipleChildrenGuides.setEnabled(myShowBuildMethodGuides.isSelected());
-      myShowBuildMethodsOnScrollbar.setEnabled(myShowBuildMethodGuides.isSelected());
-    });
 
     // Only show the experiments panel if there are visible items in it.
     if (FlutterUtils.isAndroidStudio()) {
@@ -206,12 +197,6 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     if (settings.isShowBuildMethodGuides() != myShowBuildMethodGuides.isSelected()) {
       return true;
     }
-    if (settings.isShowMultipleChildrenGuides() != myShowMultipleChildrenGuides.isSelected()) {
-      return true;
-    }
-    if (settings.isShowBuildMethodsOnScrollbar() != myShowBuildMethodsOnScrollbar.isSelected()) {
-      return true;
-    }
 
     if (settings.isShowClosingLabels() != myShowClosingLabels.isSelected()) {
       return true;
@@ -273,8 +258,6 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     settings.setOrganizeImportsOnSave(myOrganizeImportsOnSaveCheckBox.isSelected());
 
     settings.setShowBuildMethodGuides(myShowBuildMethodGuides.isSelected());
-    settings.setShowMultipleChildrenGuides(myShowMultipleChildrenGuides.isSelected());
-    settings.setShowBuildMethodsOnScrollbar(myShowBuildMethodsOnScrollbar.isSelected());
     settings.setShowClosingLabels(myShowClosingLabels.isSelected());
     settings.setShowStructuredErrors(myShowStructuredErrors.isSelected());
     settings.setOpenInspectorOnAppLaunch(myOpenInspectorOnAppLaunchCheckBox.isSelected());
@@ -314,8 +297,6 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     myOrganizeImportsOnSaveCheckBox.setSelected(settings.isOrganizeImportsOnSave());
 
     myShowBuildMethodGuides.setSelected(settings.isShowBuildMethodGuides());
-    myShowMultipleChildrenGuides.setSelected(settings.isShowMultipleChildrenGuides());
-    myShowBuildMethodsOnScrollbar.setSelected(settings.isShowBuildMethodsOnScrollbar());
 
     myShowClosingLabels.setSelected(settings.isShowClosingLabels());
 
@@ -328,11 +309,6 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     myHotReloadIgnoreErrorCheckBox.setEnabled(myHotReloadOnSaveCheckBox.isSelected());
 
     myOrganizeImportsOnSaveCheckBox.setEnabled(myFormatCodeOnSaveCheckBox.isSelected());
-
-    // These options are only enabled if build method guides are enabled as the
-    // same class handles all these cases.
-    myShowMultipleChildrenGuides.setEnabled(myShowBuildMethodGuides.isSelected());
-    myShowBuildMethodsOnScrollbar.setEnabled(myShowBuildMethodGuides.isSelected());
 
     myUseBazelByDefaultCheckBox.setSelected(settings.shouldUseBazel());
     myShowAllRunConfigurationsInContextCheckBox.setSelected(settings.showAllRunConfigurationsInContext());

--- a/src/io/flutter/settings/FlutterSettings.java
+++ b/src/io/flutter/settings/FlutterSettings.java
@@ -27,6 +27,7 @@ public class FlutterSettings {
   private static final String syncAndroidLibrariesKey = "io.flutter.syncAndroidLibraries";
   private static final String disableTrackWidgetCreationKey = "io.flutter.disableTrackWidgetCreation";
   private static final String showStructuredErrors = "io.flutter.showStructuredErrors";
+  private static final String showBuildMethodGuidesKey = "io.flutter.editor.showBuildMethodGuides";
 
   /**
    * The Dart plugin uses this registry key to avoid bazel users getting their settings overridden on projects that include a
@@ -43,11 +44,6 @@ public class FlutterSettings {
    * in the left-hand gutter.
    */
   private static final String suggestAllRunConfigurationsFromContextKey = "suggest.all.run.configurations.from.context";
-
-  // Settings for UI as Code experiments.
-  private static final String showBuildMethodGuidesKey = "io.flutter.editor.showBuildMethodGuides";
-  private static final String showMultipleChildrenGuidesKey = "io.flutter.editor.showMultipleChildrenGuides";
-  private static final String showBuildMethodsOnScrollbarKey = "io.flutter.editor.showBuildMethodsOnScrollbarKey";
 
   public static FlutterSettings getInstance() {
     return ServiceManager.getService(FlutterSettings.class);
@@ -101,12 +97,6 @@ public class FlutterSettings {
 
     if (isShowBuildMethodGuides()) {
       analytics.sendEvent("settings", afterLastPeriod(showBuildMethodGuidesKey));
-    }
-    if (isShowMultipleChildrenGuides()) {
-      analytics.sendEvent("settings", afterLastPeriod(showMultipleChildrenGuidesKey));
-    }
-    if (isShowBuildMethodsOnScrollbar()) {
-      analytics.sendEvent("settings", afterLastPeriod(showBuildMethodsOnScrollbarKey));
     }
 
     if (isShowStructuredErrors()) {
@@ -274,32 +264,12 @@ public class FlutterSettings {
     fireEvent();
   }
 
-  public boolean isShowBuildMethodsOnScrollbar() {
-    return getPropertiesComponent().getBoolean(showBuildMethodsOnScrollbarKey, false);
-  }
-
-  public void setShowBuildMethodsOnScrollbar(boolean value) {
-    getPropertiesComponent().setValue(showBuildMethodsOnScrollbarKey, value, false);
-
-    fireEvent();
-  }
-
   public boolean isShowClosingLabels() {
     return DartClosingLabelManager.getInstance().getShowClosingLabels();
   }
 
   public void setShowClosingLabels(boolean value) {
     DartClosingLabelManager.getInstance().setShowClosingLabels(value);
-  }
-
-  public boolean isShowMultipleChildrenGuides() {
-    return getPropertiesComponent().getBoolean(showMultipleChildrenGuidesKey, false);
-  }
-
-  public void setShowMultipleChildrenGuides(boolean value) {
-    getPropertiesComponent().setValue(showMultipleChildrenGuidesKey, value, false);
-
-    fireEvent();
   }
 
   protected void fireEvent() {


### PR DESCRIPTION
- remove the two secondary UI guides settings
- closes https://github.com/flutter/flutter-intellij/issues/4001

@jacob314 @InMatrix 

The new settings page UI:

<img width="416" alt="Screen Shot 2019-11-18 at 2 08 52 PM" src="https://user-images.githubusercontent.com/1269969/69098952-7f502480-0a0e-11ea-9786-a08db0ee0d1d.png">
