### PR TITLE
Force VFS refresh to prevent adding multiple include statements

### DIFF
--- a/src/io/flutter/utils/AndroidUtils.java
+++ b/src/io/flutter/utils/AndroidUtils.java
@@ -500,6 +500,7 @@ public class AndroidUtils {
         addIncludeStatement();
         if (errorDuringOperation.get()) return;
         addCoeditTransformedProject(project);
+        // We may have multiple Gradle sync listeners. Write the files to disk synchronously so we won't edit them twice.
         projectRoot.refresh(false, true);
         AppExecutorUtil.getAppExecutorService().execute(() -> scheduleGradleSyncAfterSyncFinishes(project));
       }

--- a/src/io/flutter/utils/AndroidUtils.java
+++ b/src/io/flutter/utils/AndroidUtils.java
@@ -500,7 +500,7 @@ public class AndroidUtils {
         addIncludeStatement();
         if (errorDuringOperation.get()) return;
         addCoeditTransformedProject(project);
-        projectRoot.refresh(true, true);
+        projectRoot.refresh(false, true);
         AppExecutorUtil.getAppExecutorService().execute(() -> scheduleGradleSyncAfterSyncFinishes(project));
       }
     }


### PR DESCRIPTION
Force synchronous VFS refresh to prevent adding multiple, redundant include statements to settings.gradle.