### PR TITLE
Smooth out the rough spots in add-to-app support

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -184,7 +184,10 @@ Verify installation and configuration in a fresh IDEA installation.
 * Verify project creation, run/debug.
 
 ## Add-to-app module integration test
-Create and debug a Flutter module in an Android app.
+Create and debug a Flutter module in an Android app. Do this twice, once 
+using Java and again with Kotlin as the language choice for the Android app.
+The location of the Flutter module is important. Put it in the Android app
+directory once and put it outside the app another time.
 
 ###Create an Android app
 
@@ -219,6 +222,19 @@ Go to the editor for MainActivity.kt. Change the onCreate method:
             FlutterEngineCache.getInstance().put("1", engine)
             startActivity(FlutterActivity.withCachedEngine("1").build(this))
         }
+    }
+```
+If you opted to use Java, use this:
+```java
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_main);
+        FlutterEngine engine = new FlutterEngine(getApplicationContext());
+        engine.getDartExecutor().executeDartEntrypoint(DartExecutor.DartEntrypoint.createDefault());
+        findViewById(R.id.fab).setOnClickListener(view -> {
+            FlutterEngineCache.getInstance().put("1", engine);
+            startActivity(FlutterActivity.withCachedEngine("1").build(this));
+        });
     }
 ```
 You need to add some imports. Click on each red name then type

--- a/flutter-studio/src/io/flutter/FlutterStudioStartupActivity.java
+++ b/flutter-studio/src/io/flutter/FlutterStudioStartupActivity.java
@@ -43,7 +43,6 @@ public class FlutterStudioStartupActivity implements StartupActivity {
     connection.subscribe((Topic<GradleSyncListener>)topic, makeSyncListener(project));
 
     if (!FlutterModuleUtils.hasFlutterModule(project)) {
-      // TODO(messick): Remove this subscription after Android Q sources are published. Will be done by FlutterInitializer.
       connection.subscribe(ProjectTopics.MODULES, new ModuleListener() {
         @Override
         public void moduleAdded(@NotNull Project proj, @NotNull Module mod) {

--- a/flutter-studio/src/io/flutter/module/FlutterModuleModel.java
+++ b/flutter-studio/src/io/flutter/module/FlutterModuleModel.java
@@ -37,15 +37,6 @@ public class FlutterModuleModel extends FlutterProjectModel {
       // The FlutterProjectType.MODULE is used in two places. In FlutterProjectModel it is used to create a new top-level
       // Flutter project. Here, it is used to create an Android module for add-to-app. In both cases the Flutter tool creates
       // a new project. In this case, we go on to link that project into an Android project as a new module.
-      useAndroidX().set(true);
-      // The host project is an Android app. This module should be created in its root directory.
-      // Android Studio supports a colon-separated convention to specify sub-directories, which is not yet supported here.
-      Project hostProject = project().getValue();
-      String hostPath = hostProject.getBasePath();
-      if (hostPath == null) {
-        throw new InvalidDataException(); // Can't happen
-      }
-      projectLocation().set(hostPath);
       // Create the Flutter module as if it were a normal project that just happens to be located in an Android project directory.
       new FlutterProjectCreator(this).createModule();
       // Import the Flutter module into the Android project as if it had been created without any Android dependencies.

--- a/src/io/flutter/FlutterInitializer.java
+++ b/src/io/flutter/FlutterInitializer.java
@@ -64,22 +64,6 @@ public class FlutterInitializer implements StartupActivity {
 
   @Override
   public void runActivity(@NotNull Project project) {
-    // TODO(messick): Remove 'FlutterUtils.isAndroidStudio()' after Android Q sources are published.
-    if (FlutterUtils.isAndroidStudio() && !FlutterModuleUtils.hasFlutterModule(project)) {
-      final MessageBusConnection connection = project.getMessageBus().connect(project);
-      connection.subscribe(ProjectTopics.MODULES, new ModuleListener() {
-        @Override
-        public void moduleAdded(@NotNull Project proj, @NotNull Module mod) {
-          if (AndroidUtils.FLUTTER_MODULE_NAME.equals(mod.getName())) {
-            connection.disconnect();
-            AppExecutorUtil.getAppExecutorService().execute(() -> {
-              AndroidUtils.enableCoeditIfAddToAppDetected(project);
-            });
-          }
-        }
-      });
-    }
-
     // Convert all modules of deprecated type FlutterModuleType.
     if (FlutterModuleUtils.convertFromDeprecatedModuleType(project)) {
       // If any modules were converted over, create a notification

--- a/src/io/flutter/utils/AndroidUtils.java
+++ b/src/io/flutter/utils/AndroidUtils.java
@@ -467,6 +467,8 @@ public class AndroidUtils {
   }
 
   private static class CoEditHelper {
+    // TODO(messick) Rewrite this to use ProjectBuildModel. See FlutterModuleImporter for an example.
+
     @NotNull
     private final Project project;
     @NotNull
@@ -502,6 +504,9 @@ public class AndroidUtils {
         addCoeditTransformedProject(project);
         // We may have multiple Gradle sync listeners. Write the files to disk synchronously so we won't edit them twice.
         projectRoot.refresh(false, true);
+        if (!projectRoot.equals(flutterModuleDir.getParent())) {
+          flutterModuleDir.refresh(false, true);
+        }
         AppExecutorUtil.getAppExecutorService().execute(() -> scheduleGradleSyncAfterSyncFinishes(project));
       }
     }


### PR DESCRIPTION
Finish up some in-progress changes and clean up a few things for add-to-app:
- Add Java code to the testing instructions, and note that both Java and Kotlin need to be tested.
(The compileOptions section is added when using Kotlin but not Java.)
- Eliminate redundant Gradle sync listeners (cleans up duplicated lines in settings.gradle).
- Change the build.gradle editing to use the proper framework. Add compileOptions.
- Use the module location setting that was added to the UI in a previous PR.
- Set the project type to "io.flutter" when a project is created so it doesn't use the default.
- If there is only one Flutter run config, use it for attach whether it is selected or not.
- Remove TODOs that only apply to IJ support for add-to-app. That isn't happening.
