### PR TITLE
Use Build Variants view to control Flutter build mode

### DIFF
--- a/flutter-studio/src/io/flutter/android/AndroidBuildVariantDetector.java
+++ b/flutter-studio/src/io/flutter/android/AndroidBuildVariantDetector.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.android;
+
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleManager;
+import com.intellij.openapi.project.Project;
+import org.jetbrains.android.facet.AndroidFacet;
+
+public class AndroidBuildVariantDetector implements BuildVariantDetector {
+
+  @Override
+  public String selectedBuildVariant(Project project) {
+    Module flutterModule = ModuleManager.getInstance(project).findModuleByName("flutter");
+    if (flutterModule == null) {
+      return null;
+    }
+    AndroidFacet facet = AndroidFacet.getInstance(flutterModule);
+    if (facet == null) {
+      return null;
+    }
+    String variant = facet.getProperties().SELECTED_BUILD_VARIANT;
+    if (variant == null || variant.isEmpty()) {
+      return null;
+    }
+    return variant;
+  }
+}

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -1027,10 +1027,12 @@
 
   <extensionPoints>
     <extensionPoint name="gradleSyncProvider" interface="io.flutter.android.GradleSyncProvider"/>
+    <extensionPoint name="buildVariantDetector" interface="io.flutter.android.BuildVariantDetector"/>
   </extensionPoints>
 
   <extensions defaultExtensionNs="io.flutter">
     <gradleSyncProvider implementation="io.flutter.android.IntellijGradleSyncProvider" order="last"/>
+    <buildVariantDetector implementation="io.flutter.android.IntellijBuildVariantDetector" order="last"/>
   </extensions>
 
   <extensions defaultExtensionNs="com.intellij">

--- a/resources/META-INF/plugin_template.xml
+++ b/resources/META-INF/plugin_template.xml
@@ -209,10 +209,12 @@
 
   <extensionPoints>
     <extensionPoint name="gradleSyncProvider" interface="io.flutter.android.GradleSyncProvider"/>
+    <extensionPoint name="buildVariantDetector" interface="io.flutter.android.BuildVariantDetector"/>
   </extensionPoints>
 
   <extensions defaultExtensionNs="io.flutter">
     <gradleSyncProvider implementation="io.flutter.android.IntellijGradleSyncProvider" order="last"/>
+    <buildVariantDetector implementation="io.flutter.android.IntellijBuildVariantDetector" order="last"/>
   </extensions>
 
   <extensions defaultExtensionNs="com.intellij">

--- a/resources/META-INF/studio-contribs.xml
+++ b/resources/META-INF/studio-contribs.xml
@@ -14,6 +14,7 @@
 
   <extensions defaultExtensionNs="io.flutter">
     <gradleSyncProvider implementation="io.flutter.android.AndroidStudioGradleSyncProvider" order="first"/>
+    <buildVariantDetector implementation="io.flutter.android.AndroidBuildVariantDetector" order="first"/>
   </extensions>
 
   <extensions defaultExtensionNs="com.intellij">

--- a/resources/META-INF/studio-contribs_template.xml
+++ b/resources/META-INF/studio-contribs_template.xml
@@ -12,6 +12,7 @@
 
   <extensions defaultExtensionNs="io.flutter">
     <gradleSyncProvider implementation="io.flutter.android.AndroidStudioGradleSyncProvider" order="first"/>
+    <buildVariantDetector implementation="io.flutter.android.AndroidBuildVariantDetector" order="first"/>
   </extensions>
 
   <extensions defaultExtensionNs="com.intellij">

--- a/src/io/flutter/actions/FlutterBuildActionGroup.java
+++ b/src/io/flutter/actions/FlutterBuildActionGroup.java
@@ -27,10 +27,10 @@ import org.jetbrains.annotations.NotNull;
 
 public class FlutterBuildActionGroup extends DefaultActionGroup {
 
-  public static OSProcessHandler build(Project project, @NotNull PubRoot pubRoot, FlutterSdk sdk, BuildType buildType, String desc) {
+  public static OSProcessHandler build(@NotNull Project project, @NotNull PubRoot pubRoot, FlutterSdk sdk, BuildType buildType, String desc) {
     ProgressHelper progressHelper = new ProgressHelper(project);
     progressHelper.start(desc);
-    OSProcessHandler processHandler = sdk.flutterBuild(pubRoot, buildType.type).startInConsole(project);
+    OSProcessHandler processHandler = sdk.flutterBuild(project, pubRoot, buildType.type).startInConsole(project);
     if (processHandler == null) {
       progressHelper.done();
     }

--- a/src/io/flutter/actions/OpenInXcodeAction.java
+++ b/src/io/flutter/actions/OpenInXcodeAction.java
@@ -74,7 +74,7 @@ public class OpenInXcodeAction extends AnAction {
 
       // TODO(pq): consider a popup explaining why we're doing a build.
       // Note: we build only for the simulator to bypass device provisioning issues.
-      final OSProcessHandler processHandler = sdk.flutterBuild(pubRoot, "ios", "--simulator").startInConsole(project);
+      final OSProcessHandler processHandler = sdk.flutterBuild(project, pubRoot, "ios", "--simulator").startInConsole(project);
       if (processHandler == null) {
         progressHelper.done();
         FlutterMessages.showError("Error Opening Xcode", "unable to run `flutter build`");

--- a/src/io/flutter/android/BuildVariantDetector.java
+++ b/src/io/flutter/android/BuildVariantDetector.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2019 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.android;
+
+import com.intellij.openapi.extensions.ExtensionPointName;
+import com.intellij.openapi.project.Project;
+
+/// Extension point to determine the selected build variant for the :flutter module of a <code>project</code>.
+public interface BuildVariantDetector {
+  ExtensionPointName<BuildVariantDetector> EP_NAME = ExtensionPointName.create("io.flutter.buildVariantDetector");
+
+  String selectedBuildVariant(Project project);
+}

--- a/src/io/flutter/android/IntellijBuildVariantDetector.java
+++ b/src/io/flutter/android/IntellijBuildVariantDetector.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2019 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.android;
+
+import com.intellij.openapi.project.Project;
+
+public class IntellijBuildVariantDetector implements BuildVariantDetector {
+
+  @Override
+  public String selectedBuildVariant(Project project) {
+    return null;
+  }
+}


### PR DESCRIPTION
After creating an add-to-app module in an Android app, use Android Studio's Build Variants tool window to set the build variant for the "flutter" module. That value (debug/profile/release) will be passed as the corresponding parameter to the build command when a build is initiated from the menu, Build > Flutter > Build {AAR,APK,App Bundle,iOS}.

The add-to-app (Flutter) module must be selected to see the Build > Flutter  menu.

@devoncarew @xster @matthew-carroll for comments on using the tool window this way.

<img width="388" alt="Screen Shot 2019-11-22 at 2 13 09 PM" src="https://user-images.githubusercontent.com/8518285/69464112-4f689000-0d32-11ea-822d-747c51a2b197.png">
