### PR TITLE
Show error dialog when creating a project with canary builds

### DIFF
--- a/flutter-studio/src/io/flutter/actions/FlutterNewProjectAction.java
+++ b/flutter-studio/src/io/flutter/actions/FlutterNewProjectAction.java
@@ -5,7 +5,6 @@
  */
 package io.flutter.actions;
 
-
 import com.android.tools.idea.ui.wizard.StudioWizardDialogBuilder;
 import com.android.tools.idea.wizard.model.ModelWizard;
 import com.android.tools.idea.wizard.model.ModelWizardDialog;
@@ -14,7 +13,6 @@ import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.DumbAware;
-import com.intellij.openapi.ui.DialogBuilder;
 import com.intellij.openapi.ui.Messages;
 import com.intellij.openapi.wm.impl.welcomeScreen.NewWelcomeScreen;
 import com.intellij.ui.LayeredIcon;
@@ -61,7 +59,8 @@ public class FlutterNewProjectAction extends AnAction implements DumbAware {
       catch (NoSuchElementException ex) {
         // This happens if no Flutter SDK is installed and the user cancels the FlutterProjectStep.
       }
-    } catch (NoSuchMethodError x) {
+    }
+    catch (NoSuchMethodError x) {
       Messages.showMessageDialog("Android Studio canary is not supported", "Unsupported IDE", Messages.getErrorIcon());
     }
   }

--- a/flutter-studio/src/io/flutter/actions/FlutterNewProjectAction.java
+++ b/flutter-studio/src/io/flutter/actions/FlutterNewProjectAction.java
@@ -14,6 +14,8 @@ import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.DumbAware;
+import com.intellij.openapi.ui.DialogBuilder;
+import com.intellij.openapi.ui.Messages;
 import com.intellij.openapi.wm.impl.welcomeScreen.NewWelcomeScreen;
 import com.intellij.ui.LayeredIcon;
 import com.intellij.ui.OffsetIcon;
@@ -47,16 +49,20 @@ public class FlutterNewProjectAction extends AnAction implements DumbAware {
   @Override
   public void actionPerformed(AnActionEvent e) {
     FlutterProjectModel model = new FlutterProjectModel(FlutterProjectType.APP);
-    ModelWizard wizard = new ModelWizard.Builder()
-      .addStep(new ChoseProjectTypeStep(model))
-      .build();
-    StudioWizardDialogBuilder builder = new StudioWizardDialogBuilder(wizard, "Create New Flutter Project");
-    ModelWizardDialog dialog = builder.build();
     try {
-      dialog.show();
-    }
-    catch (NoSuchElementException ex) {
-      // This happens if no Flutter SDK is installed and the user cancels the FlutterProjectStep.
+      ModelWizard wizard = new ModelWizard.Builder()
+        .addStep(new ChoseProjectTypeStep(model))
+        .build();
+      StudioWizardDialogBuilder builder = new StudioWizardDialogBuilder(wizard, "Create New Flutter Project");
+      ModelWizardDialog dialog = builder.build();
+      try {
+        dialog.show();
+      }
+      catch (NoSuchElementException ex) {
+        // This happens if no Flutter SDK is installed and the user cancels the FlutterProjectStep.
+      }
+    } catch (NoSuchMethodError x) {
+      Messages.showMessageDialog("Android Studio canary is not supported", "Unsupported IDE", Messages.getErrorIcon());
     }
   }
 


### PR DESCRIPTION
We can't currently restrict installation of the beta plugin into Android Studio canary. When trying to create a project you get an error. This adds a catch-block for that error which pops up a message, rather than just reporting a random error.

<img width="664" alt="Screen Shot 2019-11-25 at 11 53 09 AM" src="https://user-images.githubusercontent.com/8518285/69573550-2f77dd00-0f7b-11ea-9181-c807b137e83d.png">

Hopefully, this will reduce the number of issues like #4136