### PR TITLE
update the product matrix for 2019.3 stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,6 @@ env:
   - DART_BOT=true
   - CHECK_BOT=true
   - UNIT_TEST_BOT=true
-  - IDEA_VERSION=2019.1.2
   - IDEA_VERSION=3.5
   - IDEA_VERSION=3.6
   - IDEA_VERSION=2019.2.4

--- a/product-matrix.json
+++ b/product-matrix.json
@@ -1,17 +1,6 @@
 {
   "list": [
     {
-      "comments": "IntelliJ 2019.1.2",
-      "name": "IntelliJ 2019.1.2",
-      "version": "2019.1.2",
-      "ijVersion": "2019.1.2",
-      "ideaProduct": "android-studio",
-      "ideaVersion": "191.5585527",
-      "dartPluginVersion": "191.7221",
-      "sinceBuild": "191.6707",
-      "untilBuild": "191.7478"
-    },
-    {
       "comments": "IntelliJ 2019.1.3, Android Studio 3.5",
       "name": "IntelliJ 2019.1.3",
       "version": "3.5",
@@ -43,13 +32,13 @@
       "untilBuild": "192.*"
     },
     {
-      "comments": "IntelliJ 2019.3 EAP",
+      "comments": "IntelliJ 2019.3",
       "name": "IntelliJ 2019.3",
       "version": "2019.3",
       "isTestTarget": "true",
       "ideaProduct": "ideaIC",
-      "ideaVersion": "193.3519.25",
-      "dartPluginVersion": "193.4778.7",
+      "ideaVersion": "2019.3",
+      "dartPluginVersion": "193.5432",
       "sinceBuild": "193.3519.25",
       "untilBuild": "193.*"
     }

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -13,7 +13,7 @@
 
   <category>Custom Languages</category>
   <version>SNAPSHOT</version>
-  <idea-version since-build="191.6707" until-build="193.*"/>
+  <idea-version since-build="191.8026" until-build="193.*"/>
 
   <depends>Dart</depends>
 

--- a/tool/plugin/test/plugin_test.dart
+++ b/tool/plugin/test/plugin_test.dart
@@ -37,7 +37,6 @@ void main() {
             orderedEquals([
               'android-studio',
               'android-studio',
-              'android-studio',
               'ideaIC',
               'ideaIC',
             ]));
@@ -54,7 +53,6 @@ void main() {
             orderedEquals([
               'android-studio',
               'android-studio',
-              'android-studio',
               'ideaIC',
               'ideaIC',
             ]));
@@ -69,7 +67,6 @@ void main() {
         expect(
             specs.map((spec) => spec.ideaProduct).toList(),
             orderedEquals([
-              'android-studio',
               'android-studio',
               'android-studio',
               'ideaIC',
@@ -150,7 +147,6 @@ void main() {
       expect(
           cmd.paths.map((p) => p.substring(p.indexOf('releases'))),
           orderedEquals([
-            'releases/release_19/2019.1.2/flutter-intellij.zip',
             'releases/release_19/3.5/flutter-intellij.zip',
             'releases/release_19/3.6/flutter-intellij.zip',
             'releases/release_19/2019.2.4/flutter-intellij.zip',


### PR DESCRIPTION
- update the product matrix for 2019.3 stable
- remove support for `2019.1` (but keep the 2019.1 based Android Studio 3.5 build)

@stevemessick 
