### PR TITLE
Hot UI implementation

### DIFF
--- a/flutter-studio/src/io/flutter/editor/AndroidStudioColorPickerProvider.java
+++ b/flutter-studio/src/io/flutter/editor/AndroidStudioColorPickerProvider.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2019 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.editor;
+
+import com.android.tools.idea.ui.resourcechooser.colorpicker2.ColorPickerBuilder;
+import com.intellij.openapi.ui.popup.Balloon;
+import com.intellij.openapi.ui.popup.BalloonBuilder;
+import com.intellij.openapi.ui.popup.JBPopupFactory;
+import com.intellij.ui.awt.RelativePoint;
+import kotlin.Unit;
+
+import java.awt.event.ActionEvent;
+import java.awt.event.KeyEvent;
+
+import java.awt.*;
+import javax.swing.*;
+
+public class AndroidStudioColorPickerProvider implements ColorPickerProvider {
+  private Balloon popup;
+
+  @Override
+  public void show(
+    Color initialColor,
+    JComponent component,
+    Point offset,
+    Balloon.Position position,
+    ColorPickerProvider.ColorListener colorListener,
+    Runnable onCancel,
+    Runnable onOk
+  ) {
+    if (popup != null) {
+      popup.dispose();
+    }
+    popup = null;
+
+    final JComponent colorPanel = new ColorPickerBuilder()
+      .setOriginalColor(initialColor != null ? initialColor : new Color(255, 255, 255))
+      .addSaturationBrightnessComponent()
+      .addColorAdjustPanel()
+      .addColorValuePanel().withFocus()
+      .addOperationPanel(
+        (okColor) -> {
+          onOk.run();
+          return Unit.INSTANCE;
+        },
+        (cancelColor) -> {
+          onCancel.run();
+          return Unit.INSTANCE;
+        }
+      ).withFocus()
+      .setFocusCycleRoot(true)
+      .focusWhenDisplay(true)
+      .addKeyAction(
+        KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0),
+        new AbstractAction() {
+          @Override
+          public void actionPerformed(ActionEvent e) {
+            onCancel.run();
+          }
+        })
+
+      .addKeyAction(
+        KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0),
+        new AbstractAction() {
+          @Override
+          public void actionPerformed(ActionEvent e) {
+            onOk.run();
+          }
+        }
+      )
+      .addColorPickerListener((c, o) -> colorListener.colorChanged(c, null))
+      .build();
+    final BalloonBuilder balloonBuilder = JBPopupFactory.getInstance().createBalloonBuilder(colorPanel);
+    balloonBuilder.setFadeoutTime(0);
+    balloonBuilder.setAnimationCycle(0);
+    balloonBuilder.setHideOnClickOutside(true);
+    balloonBuilder.setHideOnKeyOutside(false);
+    balloonBuilder.setHideOnAction(false);
+    balloonBuilder.setCloseButtonEnabled(false);
+    balloonBuilder.setBlockClicksThroughBalloon(true);
+    balloonBuilder.setRequestFocus(true);
+    balloonBuilder.setShadow(true);
+    balloonBuilder.setFillColor(colorPanel.getBackground());
+    popup = balloonBuilder.createBalloon();
+    popup.show(new RelativePoint(component, offset), position);
+  }
+
+  @Override
+  public void dispose() {
+    if (popup != null) {
+      popup.dispose();
+    }
+    popup = null;
+  }
+}

--- a/product-matrix.json
+++ b/product-matrix.json
@@ -9,7 +9,8 @@
       "ideaVersion": "191.5791312",
       "dartPluginVersion": "191.8423",
       "sinceBuild": "191.8026",
-      "untilBuild": "191.*"
+      "untilBuild": "191.*",
+      "filesToSkip": ["src/io/flutter/editor/IntellijColorPickerProvider.java"]
     },
     {
       "comments": "Android Studio 3.6 Beta 4",
@@ -19,7 +20,8 @@
       "ideaVersion": "192.5947919",
       "dartPluginVersion": "192.6603.23",
       "sinceBuild": "192.6262",
-      "untilBuild": "192.7141"
+      "untilBuild": "192.7141",
+      "filesToSkip": ["src/io/flutter/editor/IntellijColorPickerProvider.java"]
     },
     {
       "comments": "IntelliJ 2019.2.4",

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -1077,8 +1077,17 @@
     <extensionPoint name="gradleSyncProvider" interface="io.flutter.android.GradleSyncProvider"/>
   </extensionPoints>
 
+  <extensionPoints>
+    <extensionPoint name="colorPickerProvider" interface="io.flutter.editor.ColorPickerProvider"/>
+  </extensionPoints>
+
+
   <extensions defaultExtensionNs="io.flutter">
     <gradleSyncProvider implementation="io.flutter.android.IntellijGradleSyncProvider" order="last"/>
+  </extensions>
+
+  <extensions defaultExtensionNs="io.flutter">
+    <colorPickerProvider implementation="io.flutter.editor.IntellijColorPickerProvider" order="last"/>
   </extensions>
 
   <extensions defaultExtensionNs="com.intellij">

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -1075,18 +1075,12 @@
 
   <extensionPoints>
     <extensionPoint name="gradleSyncProvider" interface="io.flutter.android.GradleSyncProvider"/>
-  </extensionPoints>
-
-  <extensionPoints>
     <extensionPoint name="colorPickerProvider" interface="io.flutter.editor.ColorPickerProvider"/>
   </extensionPoints>
 
 
   <extensions defaultExtensionNs="io.flutter">
     <gradleSyncProvider implementation="io.flutter.android.IntellijGradleSyncProvider" order="last"/>
-  </extensions>
-
-  <extensions defaultExtensionNs="io.flutter">
     <colorPickerProvider implementation="io.flutter.editor.IntellijColorPickerProvider" order="last"/>
   </extensions>
 

--- a/resources/META-INF/plugin_template.xml
+++ b/resources/META-INF/plugin_template.xml
@@ -211,8 +211,17 @@
     <extensionPoint name="gradleSyncProvider" interface="io.flutter.android.GradleSyncProvider"/>
   </extensionPoints>
 
+  <extensionPoints>
+    <extensionPoint name="colorPickerProvider" interface="io.flutter.editor.ColorPickerProvider"/>
+  </extensionPoints>
+
+
   <extensions defaultExtensionNs="io.flutter">
     <gradleSyncProvider implementation="io.flutter.android.IntellijGradleSyncProvider" order="last"/>
+  </extensions>
+
+  <extensions defaultExtensionNs="io.flutter">
+    <colorPickerProvider implementation="io.flutter.editor.IntellijColorPickerProvider" order="last"/>
   </extensions>
 
   <extensions defaultExtensionNs="com.intellij">

--- a/resources/META-INF/plugin_template.xml
+++ b/resources/META-INF/plugin_template.xml
@@ -209,18 +209,12 @@
 
   <extensionPoints>
     <extensionPoint name="gradleSyncProvider" interface="io.flutter.android.GradleSyncProvider"/>
-  </extensionPoints>
-
-  <extensionPoints>
     <extensionPoint name="colorPickerProvider" interface="io.flutter.editor.ColorPickerProvider"/>
   </extensionPoints>
 
 
   <extensions defaultExtensionNs="io.flutter">
     <gradleSyncProvider implementation="io.flutter.android.IntellijGradleSyncProvider" order="last"/>
-  </extensions>
-
-  <extensions defaultExtensionNs="io.flutter">
     <colorPickerProvider implementation="io.flutter.editor.IntellijColorPickerProvider" order="last"/>
   </extensions>
 

--- a/resources/META-INF/studio-contribs.xml
+++ b/resources/META-INF/studio-contribs.xml
@@ -16,6 +16,10 @@
     <gradleSyncProvider implementation="io.flutter.android.AndroidStudioGradleSyncProvider" order="first"/>
   </extensions>
 
+  <extensions defaultExtensionNs="io.flutter">
+    <colorPickerProvider implementation="io.flutter.editor.AndroidStudioColorPickerProvider" order="first"/>
+  </extensions>
+
   <extensions defaultExtensionNs="com.intellij">
     <externalSystemTaskNotificationListener implementation="io.flutter.utils.FlutterExternalSystemTaskNotificationListener"/>
     <androidStudioInitializer implementation="io.flutter.FlutterStudioInitializer"/>

--- a/resources/META-INF/studio-contribs.xml
+++ b/resources/META-INF/studio-contribs.xml
@@ -14,9 +14,6 @@
 
   <extensions defaultExtensionNs="io.flutter">
     <gradleSyncProvider implementation="io.flutter.android.AndroidStudioGradleSyncProvider" order="first"/>
-  </extensions>
-
-  <extensions defaultExtensionNs="io.flutter">
     <colorPickerProvider implementation="io.flutter.editor.AndroidStudioColorPickerProvider" order="first"/>
   </extensions>
 

--- a/resources/META-INF/studio-contribs_template.xml
+++ b/resources/META-INF/studio-contribs_template.xml
@@ -12,9 +12,6 @@
 
   <extensions defaultExtensionNs="io.flutter">
     <gradleSyncProvider implementation="io.flutter.android.AndroidStudioGradleSyncProvider" order="first"/>
-  </extensions>
-
-  <extensions defaultExtensionNs="io.flutter">
     <colorPickerProvider implementation="io.flutter.editor.AndroidStudioColorPickerProvider" order="first"/>
   </extensions>
 

--- a/resources/META-INF/studio-contribs_template.xml
+++ b/resources/META-INF/studio-contribs_template.xml
@@ -14,6 +14,10 @@
     <gradleSyncProvider implementation="io.flutter.android.AndroidStudioGradleSyncProvider" order="first"/>
   </extensions>
 
+  <extensions defaultExtensionNs="io.flutter">
+    <colorPickerProvider implementation="io.flutter.editor.AndroidStudioColorPickerProvider" order="first"/>
+  </extensions>
+
   <extensions defaultExtensionNs="com.intellij">
     <externalSystemTaskNotificationListener implementation="io.flutter.utils.FlutterExternalSystemTaskNotificationListener"/>
     <androidStudioInitializer implementation="io.flutter.FlutterStudioInitializer"/>

--- a/src/io/flutter/FlutterBundle.properties
+++ b/src/io/flutter/FlutterBundle.properties
@@ -216,6 +216,7 @@ shout.level.title=Shout
 settings.try.out.features.still.under.development=Try out features still under development (a restart may be required)
 settings.experimental.flutter.logging.view=Replace the Run and Debug console output with a custom Flutter Logging view
 settings.enable.android.gradle.sync=Enable code completion, navigation, etc. for Java / Kotlin (requires restart to do Gradle build)
+settings.enable.hot.ui=Enable Hot UI -- early preview of property editing in the outline view
 settings.report.google.analytics=&Report usage information to Google Analytics
 settings.enable.verbose.logging=Enable &verbose logging
 settings.format.code.on.save=Format code on save

--- a/src/io/flutter/editor/ColorField.java
+++ b/src/io/flutter/editor/ColorField.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright 2019 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.editor;
+
+import com.intellij.icons.AllIcons;
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.CustomShortcutSet;
+import com.intellij.openapi.project.DumbAwareAction;
+import com.intellij.openapi.ui.popup.Balloon;
+import com.intellij.ui.components.JBTextField;
+import com.intellij.ui.components.fields.ExtendableTextField;
+import io.flutter.inspector.InspectorObjectGroupManager;
+import io.flutter.inspector.InspectorService;
+import io.flutter.utils.ColorIconMaker;
+import org.dartlang.analysis.server.protocol.FlutterOutline;
+import org.dartlang.analysis.server.protocol.FlutterWidgetProperty;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.FocusEvent;
+import java.awt.event.FocusListener;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Field that displays a color property including a clickable color icon that
+ * opens a color picker.
+ */
+class ColorField extends ExtendableTextField {
+  private final FlutterWidgetProperty property;
+  private final String originalExpression;
+  private final String name;
+  private final Color initialColor;
+  private final Extension setColorExtension;
+  private Color currentColor;
+  ColorPickerProvider colorPicker;
+  private PropertyEditorPanel panel;
+  private Color colorAtPopupLaunch;
+  private String expressionAtPopupLaunch;
+
+  public ColorField(PropertyEditorPanel panel, String name, FlutterWidgetProperty property, Disposable parentDisposable) {
+    super("", 1);
+    this.name = name;
+    this.property = property;
+
+    final String expression = property.getExpression();
+    if (expression != null) {
+      setText(expression);
+    }
+    this.originalExpression = expression;
+    initialColor = parseColorExpression(expression);
+    currentColor = initialColor;
+
+    final ColorIconMaker maker = new ColorIconMaker();
+
+    final KeyStroke keyStroke = KeyStroke.getKeyStroke(10, 64);
+    setColorExtension =
+      new Extension() {
+        @Override
+        public boolean isIconBeforeText() {
+          return true;
+        }
+
+        public Icon getIcon(boolean hovered) {
+          if (currentColor == null) {
+            return AllIcons.Actions.Colors;
+          }
+          return maker.getCustomIcon(currentColor);
+        }
+
+        public String getTooltip() {
+          return "Edit color";
+        }
+
+        public Runnable getActionOnClick() {
+          return () -> showColorFieldPopup();
+        }
+      };
+    (new DumbAwareAction() {
+      public void actionPerformed(@NotNull AnActionEvent e) {
+        showColorFieldPopup();
+      }
+    }).registerCustomShortcutSet(new CustomShortcutSet(keyStroke), this, parentDisposable);
+    addExtension(setColorExtension);
+    panel.addTextFieldListeners(name, this);
+    this.panel = panel;
+  }
+
+  private static Color parseColorExpression(String expression) {
+    if (expression == null) return null;
+
+    final String colorsPrefix = "Colors.";
+    if (expression.startsWith(colorsPrefix)) {
+      final FlutterColors.FlutterColor flutterColor = FlutterColors.getColor(expression.substring(colorsPrefix.length()));
+      if (flutterColor != null) {
+        return flutterColor.getAWTColor();
+      }
+    }
+    return ExpressionParsingUtils.parseColor(expression);
+  }
+
+  private static String buildColorExpression(Color color) {
+    final String flutterColorName = FlutterColors.getColorName(color);
+    if (flutterColorName != null) {
+      // TODO(jacobr): only apply this conversion if the material library is
+      // already imported in the library being edited.
+      // We also need to be able to handle cases where the material library
+      // is imported with a prefix.
+      return "Colors." + flutterColorName;
+    }
+    final int alpha = color.getAlpha();
+    final int red = color.getRed();
+    final int green = color.getGreen();
+    final int blue = color.getBlue();
+    return String.format("Color(0x%02x%02x%02x%02x)", alpha, red, green, blue);
+  }
+
+  public void addTextFieldListeners(String name, JBTextField field) {
+    final FlutterOutline matchingOutline = panel.getCurrentOutline();
+    field.addActionListener(e -> panel.setPropertyValue(name, field.getText()));
+    field.addFocusListener(new FocusListener() {
+      @Override
+      public void focusGained(FocusEvent e) {
+        // The popup is gone if we have received the focus again.
+        disposeColorPicker();
+      }
+
+      @Override
+      public void focusLost(FocusEvent e) {
+        if (panel.getCurrentOutline() != matchingOutline) {
+          // Don't do anything. The user has moved on to a different outline node.
+          return;
+        }
+        if (e.isTemporary()) {
+          return;
+        }
+
+        if (colorPicker != null) {
+          // We lost focus due to the popup being opened so there is no need to
+          // update the value now. The popup will update the value when it is
+          // closed.
+          return;
+        }
+        panel.setPropertyValue(name, field.getText());
+      }
+    });
+  }
+
+  void cancelPopup() {
+    currentColor = colorAtPopupLaunch;
+    setText(expressionAtPopupLaunch);
+    panel.setPropertyValue(name, originalExpression, true);
+    repaint();
+    colorPicker.dispose();
+    colorPicker = null;
+  }
+
+  void disposeColorPicker() {
+    if (colorPicker != null) {
+      colorPicker.dispose();
+      colorPicker = null;
+    }
+  }
+
+  void showColorFieldPopup() {
+    disposeColorPicker();
+    assert (colorPicker == null);
+    colorPicker = ColorPickerProvider.EP_NAME.getExtensionList().get(0);
+    ;
+    if (colorPicker != null) {
+      colorAtPopupLaunch = currentColor;
+      final Insets insets = this.getInsets();
+
+      final Point bottomColorIconOffset =
+        new Point(insets.left  + setColorExtension.getIconGap(),
+                  this.getHeight() / 2);
+      colorPicker.show(currentColor, this, bottomColorIconOffset, Balloon.Position.atLeft, this::colorListener, this::cancelPopup, this::applyColor);
+      expressionAtPopupLaunch = getText();
+    }
+  }
+
+  private void colorListener(Color color, Object o) {
+    if (colorPicker == null) {
+      // This can happen after a call to cancel.
+      return;
+    }
+    currentColor = color;
+    final InspectorObjectGroupManager groupManager = panel.getGroupManager();
+    final String colorExpression = buildColorExpression(color);
+
+    // TODO(jacobr): colorField may no longer be the right field in the UI.
+    setText(colorExpression);
+    repaint();
+
+    if (panel.getNode() != null && groupManager != null) {
+      // TODO(jacobr): rate limit setting the color property if there is a performance issue.
+      final InspectorService.ObjectGroup group = groupManager.getCurrent();
+      final CompletableFuture<Boolean> valueFuture = groupManager.getCurrent().setColorProperty(panel.getNode(), color);
+      group.safeWhenComplete(valueFuture, (success, error) -> {
+        if (success == null || error != null) {
+          return;
+        }
+        // TODO(jacobr):
+        // If setting the property immediately failed, we may have to set the property value fully to see a result.
+        // This code is risky because it could cause the outline to change and too many hot reloads cause flaky app behavior.
+              /*
+              if (!success && color.equals(picker.getColor())) {
+                setPropertyValue(colorPropertyName, colorExpression);
+              }*/
+      });
+    }
+  }
+
+  private void applyColor() {
+    disposeColorPicker();
+    final String colorExpression = buildColorExpression(currentColor);
+    setText(colorExpression);
+    panel.setPropertyValue(name, colorExpression);
+    repaint();
+  }
+}

--- a/src/io/flutter/editor/ColorField.java
+++ b/src/io/flutter/editor/ColorField.java
@@ -170,7 +170,6 @@ class ColorField extends ExtendableTextField {
     disposeColorPicker();
     assert (colorPicker == null);
     colorPicker = ColorPickerProvider.EP_NAME.getExtensionList().get(0);
-    ;
     if (colorPicker != null) {
       colorAtPopupLaunch = currentColor;
       final Insets insets = this.getInsets();

--- a/src/io/flutter/editor/ColorPickerProvider.java
+++ b/src/io/flutter/editor/ColorPickerProvider.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.editor;
+
+import com.intellij.openapi.extensions.ExtensionPointName;
+import com.intellij.openapi.ui.popup.Balloon;
+
+import javax.swing.*;
+import java.awt.*;
+
+public interface ColorPickerProvider {
+  ExtensionPointName<ColorPickerProvider> EP_NAME = ExtensionPointName.create("io.flutter.colorPickerProvider");
+
+  public interface ColorListener {
+    void colorChanged(Color var1, Object var2);
+  }
+
+  void show(Color initialColor, JComponent component, Point offset, Balloon.Position position, ColorListener colorListener, Runnable onCancel, Runnable onOk);
+
+  void dispose();
+}

--- a/src/io/flutter/editor/FlutterEditorColors.java
+++ b/src/io/flutter/editor/FlutterEditorColors.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.editor;
+
+import com.intellij.ui.Gray;
+import com.intellij.ui.JBColor;
+
+import java.awt.*;
+
+public class FlutterEditorColors {
+  // These colors are by design identical for the light and dark theme.
+  @SuppressWarnings("UseJBColor") public final static Color TOOLTIP_BACKGROUND_COLOR = new Color(60, 60, 60, 230);
+  @SuppressWarnings("UseJBColor") public final static Color HIGHLIGHTED_RENDER_OBJECT_FILL_COLOR = new Color( 128, 128, 255, 128);
+  @SuppressWarnings("UseJBColor") public final static Color HIGHLIGHTED_RENDER_OBJECT_BORDER_COLOR = new Color(64, 64, 128, 128);
+
+  public final static JBColor VERY_LIGHT_GRAY = new JBColor(Gray._224, Gray._80);
+  public final static JBColor SHADOW_GRAY = new JBColor(Gray._192, Gray._100);
+  public final static JBColor OUTLINE_LINE_COLOR = new JBColor(Gray._128, Gray._128);
+  public final static JBColor OUTLINE_LINE_COLOR_PAST_BLOCK = new JBColor(new Color(128, 128, 128, 65), new Color(128, 128, 128, 65));
+  public final static JBColor BUILD_METHOD_STRIPE_COLOR = new JBColor(new Color(0xc0d8f0), new Color(0x8d7043));
+}

--- a/src/io/flutter/editor/InlinePreviewViewController.java
+++ b/src/io/flutter/editor/InlinePreviewViewController.java
@@ -1,0 +1,403 @@
+/*
+ * Copyright 2019 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.editor;
+
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.editor.VisualPosition;
+import com.intellij.openapi.editor.ex.EditorEx;
+import com.intellij.openapi.editor.markup.CustomHighlighterRenderer;
+import com.intellij.openapi.editor.markup.RangeHighlighter;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.ui.JBColor;
+import io.flutter.inspector.DiagnosticsNode;
+import io.flutter.inspector.InspectorService;
+import io.flutter.inspector.Screenshot;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.geom.Rectangle2D;
+
+/**
+ * PreviewViewController that renders inline in a code editor.
+ */
+public class InlinePreviewViewController extends PreviewViewControllerBase implements CustomHighlighterRenderer {
+
+  protected float previewWidthScale = 0.7f;
+
+  public InlinePreviewViewController(InlineWidgetViewModelData data, boolean drawBackground, Disposable disposable) {
+    super(data, drawBackground, disposable);
+    data.context.editorPositionService.addListener(getEditor(), new EditorPositionService.Listener() {
+                                                     @Override
+                                                     public void updateVisibleArea(Rectangle newRectangle) {
+                                                       InlinePreviewViewController.this.updateVisibleArea(newRectangle);
+                                                     }
+
+                                                     @Override
+                                                     public void onVisibleChanged() {
+                                                       InlinePreviewViewController.this.onVisibleChanged();
+                                                     }
+                                                   },
+                                                   this);
+  }
+
+  InlineWidgetViewModelData getData() {
+    return (InlineWidgetViewModelData)data;
+  }
+
+  protected EditorEx getEditor() {
+    return getData().editor;
+  }
+
+  public Point offsetToPoint(int offset) {
+    return getEditor().visualPositionToXY(getEditor().offsetToVisualPosition(offset));
+  }
+
+  @Override
+  public void forceRender() {
+    if (!visible) return;
+
+    getEditor().getComponent().repaint();
+    // TODO(jacobr): consider forcing a repaint of just a fraction of the
+    // editor window instead.
+    // For example, if the marker corresponded to just the lines in the text
+    // editor that the preview is rendereded on, we could do the following:
+
+    // final TextRange marker = data.getMarker();
+    // if (marker == null) return;
+    //
+    // data.editor.repaint(marker.getStartOffset(), marker.getEndOffset());
+  }
+
+  InspectorService.Location getLocation() {
+    final WidgetIndentGuideDescriptor descriptor = getDescriptor();
+    if (descriptor == null || descriptor.widget == null) return null;
+
+    return InspectorService.Location.outlineToLocation(getEditor(), descriptor.outlineNode);
+  }
+
+  public WidgetIndentGuideDescriptor getDescriptor() {
+    return getData().descriptor;
+  }
+
+  @Override
+  public void computeScreenshotBounds() {
+    final Rectangle previousScreenshotBounds = screenshotBounds;
+    screenshotBounds = null;
+    maxHeight = Math.round(PREVIEW_MAX_HEIGHT * 0.16f);
+    final WidgetIndentGuideDescriptor descriptor = getDescriptor();
+
+    final int lineHeight = getEditor() != null ? getEditor().getLineHeight() : defaultLineHeight;
+    extraHeight = descriptor != null && screenshot != null ? lineHeight : 0;
+
+    final Rectangle visibleRect = this.visibleRect;
+    if (visibleRect == null) {
+      return;
+    }
+
+    if (descriptor == null) {
+      // Special case to float in the bottom right corner.
+      final Screenshot latestScreenshot = getScreenshotNow();
+      int previewWidth = Math.round(PREVIEW_MAX_WIDTH * previewWidthScale);
+      int previewHeight = Math.round((PREVIEW_MAX_HEIGHT * 0.16f) * previewWidthScale);
+      if (latestScreenshot != null) {
+        previewWidth = (int)(latestScreenshot.image.getWidth() / getDPI());
+        previewHeight = (int)(latestScreenshot.image.getHeight() / getDPI());
+      }
+      final int previewStartX = Math.max(0, visibleRect.x + visibleRect.width - previewWidth - PREVIEW_PADDING_X);
+      previewHeight = Math.min(previewHeight, visibleRect.height);
+
+      maxHeight = visibleRect.height;
+      final int previewStartY = Math.max(visibleRect.y, visibleRect.y + visibleRect.height - previewHeight);
+      screenshotBounds = new Rectangle(previewStartX, previewStartY, previewWidth, previewHeight);
+      return;
+    }
+
+    final TextRange marker = getData().getMarker();
+    if (marker == null) return;
+    final int startOffset = marker.getStartOffset();
+    final Document doc = getData().document;
+    final int textLength = doc.getTextLength();
+    if (startOffset >= textLength) return;
+
+    final int endOffset = Math.min(marker.getEndOffset(), textLength);
+
+    int off;
+    final int startLine = doc.getLineNumber(startOffset);
+
+    final int widgetOffset = getDescriptor().widget.getGuideOffset();
+    final int widgetLine = doc.getLineNumber(widgetOffset);
+    final int lineEndOffset = doc.getLineEndOffset(widgetLine);
+
+    // Request a thumbnail and render it in the space available.
+    VisualPosition visualPosition = getEditor().offsetToVisualPosition(lineEndOffset); // e
+    visualPosition = new VisualPosition(Math.max(visualPosition.line, 0), 81);
+    final Point start = getEditor().visualPositionToXY(visualPosition);
+    final Point endz = offsetToPoint(endOffset);
+    final int endY = endz.y;
+    final int visibleEndX = visibleRect.x + visibleRect.width;
+    final int width = Math.max(0, visibleEndX - 20 - start.x);
+    final int height = Math.max(0, endY - start.y);
+    int previewStartY = start.y;
+    int previewStartX = start.x;
+    final int visibleStart = visibleRect.y;
+    final int visibleEnd = (int)visibleRect.getMaxY();
+
+    // Add extra room for the descriptor.
+    final Screenshot latestScreenshot = getScreenshotNow();
+    int previewWidth = PREVIEW_MAX_WIDTH;
+    int previewHeight = PREVIEW_MAX_HEIGHT / 6;
+    if (latestScreenshot != null) {
+      previewWidth = (int)(latestScreenshot.image.getWidth() / getDPI());
+      previewHeight = (int)(latestScreenshot.image.getHeight() / getDPI());
+    }
+    previewStartX = Math.max(previewStartX, visibleEndX - previewWidth - PREVIEW_PADDING_X);
+    previewHeight += extraHeight;
+    previewHeight = Math.min(previewHeight, height);
+
+    maxHeight = endz.y - start.y;
+    if (popupActive()) {
+      // Keep the bounds sticky maintining the same lastScreenshotBoundsWindow.
+      screenshotBounds = new Rectangle(lastScreenshotBoundsWindow);
+      screenshotBounds.translate(visibleRect.x, visibleRect.y);
+    }
+    else {
+      boolean lockUpdate = false;
+      if (isVisiblityLocked()) {
+        // TODO(jacobr): also need to keep sticky if there is some minor scrolling
+        if (previousScreenshotBounds != null && visibleRect.contains(previousScreenshotBounds)) {
+          screenshotBounds = new Rectangle(previousScreenshotBounds);
+
+          // Fixup if the screenshot changed
+          if (previewWidth != screenshotBounds.width) {
+            screenshotBounds.x += screenshotBounds.width - previewWidth;
+            screenshotBounds.width = previewWidth;
+          }
+          screenshotBounds.height = previewHeight;
+
+          // TODO(jacobr): refactor this code so there is less duplication.
+          lastScreenshotBoundsWindow = new Rectangle(screenshotBounds);
+          lastScreenshotBoundsWindow.translate(-visibleRect.x, -visibleRect.y);
+          lockUpdate = true;
+        }
+      }
+
+      if (!lockUpdate) {
+        lastLockedRectangle = null;
+        if (start.y <= visibleEnd && endY >= visibleStart) {
+          if (visibleStart > previewStartY) {
+            previewStartY = Math.max(previewStartY, visibleStart);
+            previewStartY = Math.min(previewStartY, Math.min(endY - previewHeight, visibleEnd - previewHeight));
+          }
+          screenshotBounds = new Rectangle(previewStartX, previewStartY, previewWidth, previewHeight);
+          lastScreenshotBoundsWindow = new Rectangle(screenshotBounds);
+          lastScreenshotBoundsWindow.translate(-visibleRect.x, -visibleRect.y);
+        }
+      }
+    }
+
+    if (popupActive()) {
+      lastLockedRectangle = new Rectangle(visibleRect);
+    }
+  }
+
+  @Override
+  protected Dimension getPreviewSize() {
+    int previewWidth;
+    int previewHeight;
+    previewWidth = PREVIEW_MAX_WIDTH;
+    previewHeight = PREVIEW_MAX_HEIGHT;
+
+    if (getDescriptor() == null) {
+      previewWidth = Math.round(previewWidth * previewWidthScale);
+      previewHeight = Math.round(previewHeight * previewWidthScale);
+    }
+    return new Dimension(previewWidth, previewHeight);
+  }
+
+  private void updateVisibleArea(Rectangle newRectangle) {
+    visibleRect = newRectangle;
+    if (getDescriptor() == null || getData().getMarker() == null) {
+      if (!visible) {
+        visible = true;
+        onVisibleChanged();
+      }
+      return;
+    }
+    final TextRange marker = getData().getMarker();
+    if (marker == null) return;
+
+    final Point start = offsetToPoint(marker.getStartOffset());
+    final Point end = offsetToPoint(marker.getEndOffset());
+    final boolean nowVisible = newRectangle == null || newRectangle.y <= end.y && newRectangle.y + newRectangle.height >= start.y ||
+                               updateVisiblityLocked(newRectangle);
+    if (visible != nowVisible) {
+      visible = nowVisible;
+      onVisibleChanged();
+    }
+  }
+
+  @Override
+  public void dispose() {
+  }
+
+  @Override
+  protected Component getComponent() {
+    return getEditor().getComponent();
+  }
+
+  @Override
+  protected VirtualFile getVirtualFile() {
+    return getEditor().getVirtualFile();
+  }
+
+  @Override
+  protected Document getDocument() {
+    return getEditor().getDocument();
+  }
+
+  @Override
+  protected void showPopup(Point location, DiagnosticsNode node) {
+    location =
+      SwingUtilities.convertPoint(
+        getEditor().getContentComponent(),
+        location,
+        getEditor().getComponent()
+      );
+    popup = PropertyEditorPanel
+      .showPopup(data.context.inspectorGroupManagerService, getEditor(), node, node.getCreationLocation().getLocation(),
+                 data.context.flutterDartAnalysisService, location);
+  }
+
+  @Override
+  TextRange getActiveRange() {
+    return getData().getMarker();
+  }
+
+  @Override
+  void setCustomCursor(@Nullable Cursor cursor) {
+    if (getEditor() == null) {
+      // TODO(jacobr): customize the cursor when there is not an associated editor.
+      return;
+    }
+    getEditor().setCustomCursor(this, cursor);
+  }
+
+  // Determine zOrder of overlapping previews.
+  // Ideally we should work harder to prevent overlapping.
+  public int getPriority() {
+    int priority = 0;
+    if (popupActive()) {
+      priority += 20;
+    }
+    if (isVisiblityLocked()) {
+      priority += 10;
+    }
+
+    if (isSelected) {
+      priority += 5;
+    }
+
+    if (getDescriptor() != null) {
+      priority += 1;
+    }
+
+    if (screenshot == null && (elements == null || elements.isEmpty())) {
+      priority -= 5;
+      if (getDescriptor() != null) {
+        priority -= 100;
+      }
+    }
+    else {
+      if (hasCurrentHits() || _mouseInScreenshot) {
+        priority += 10;
+      }
+    }
+    if (_mouseInScreenshot) {
+      priority += 20;
+    }
+    return priority;
+  }
+
+  @Override
+  public void paint(@NotNull Editor editor, @NotNull RangeHighlighter highlighter, @NotNull Graphics g) {
+    if (editor != getEditor()) {
+      // Don't want to render on the wrong editor. This shouldn't happen.
+      return;
+    }
+    if (getEditor().isPurePaintingMode()) {
+      // Don't show previews in pure mode.
+      return;
+    }
+    if (!highlighter.isValid()) {
+      return;
+    }
+    if (getDescriptor() != null && !getDescriptor().widget.isValid()) {
+      return;
+    }
+    final int lineHeight = editor.getLineHeight();
+    paint(g, lineHeight);
+  }
+
+  public void paint(@NotNull Graphics g, int lineHeight) {
+    final Graphics2D g2d = (Graphics2D)g.create();
+
+    final Screenshot latestScreenshot = getScreenshotNow();
+    if (latestScreenshot != null) {
+      final int imageWidth = (int)(latestScreenshot.image.getWidth() * getDPI());
+      final int imageHeight = (int)(latestScreenshot.image.getHeight() * getDPI());
+      if (extraHeight > 0) {
+        if (drawBackground) {
+          g2d.setColor(JBColor.LIGHT_GRAY);
+          g2d.fillRect(screenshotBounds.x, screenshotBounds.y, Math.min(screenshotBounds.width, imageWidth),
+                       Math.min(screenshotBounds.height, extraHeight));
+        }
+        final WidgetIndentGuideDescriptor descriptor = getDescriptor();
+        if (descriptor != null) {
+          final int line = descriptor.widget.getLine() + 1;
+          final int column = descriptor.widget.getColumn() + 1;
+          final int numActive = elements != null ? elements.size() : 0;
+          String message = descriptor.outlineNode.getClassName() + " ";//+ " Widget ";
+          if (numActive == 0) {
+            message += "(inactive)";
+          }
+          else if (numActive > 1) {
+            message += "(" + (activeIndex + 1) + " of " + numActive + ")";
+          }
+          if (numActive > 0 && screenshot != null && screenshot.transformedRect != null) {
+            final Rectangle2D bounds = screenshot.transformedRect.getRectangle();
+            final long w = Math.round(bounds.getWidth());
+            final long h = Math.round(bounds.getHeight());
+            message += " " + w + "x" + h;
+          }
+
+          g2d.setColor(JBColor.BLACK);
+          drawMultilineString(g2d,
+                              message,
+                              screenshotBounds.x + 4,
+                              screenshotBounds.y + lineHeight - 6, lineHeight);
+        }
+      }
+    }
+    super.paint(g, lineHeight);
+  }
+
+  @Override
+  String getNoScreenshotMessage() {
+    final WidgetIndentGuideDescriptor descriptor = getDescriptor();
+    if (descriptor == null) {
+      return super.getNoScreenshotMessage();
+    }
+    final int line = descriptor.widget.getLine() + 1;
+    final int column = descriptor.widget.getColumn() + 1;
+    return descriptor.outlineNode.getClassName() + " Widget " + line + ":" + column + "\n" +
+           "not currently active";
+  }
+}

--- a/src/io/flutter/editor/InlineWidgetViewModelData.java
+++ b/src/io/flutter/editor/InlineWidgetViewModelData.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.editor;
+
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.editor.ex.EditorEx;
+import com.intellij.openapi.util.TextRange;
+import org.jetbrains.annotations.Nullable;
+
+import java.awt.*;
+
+public class InlineWidgetViewModelData extends WidgetViewModelData {
+  public final WidgetIndentGuideDescriptor descriptor;
+  public final Document document;
+  public final EditorEx editor;
+
+  public InlineWidgetViewModelData(
+    WidgetIndentGuideDescriptor descriptor,
+    EditorEx editor,
+    WidgetEditingContext context
+  ) {
+    super(context);
+    this.descriptor = descriptor;
+    this.document = editor.getDocument();
+    this.editor = editor;
+  }
+
+  public TextRange getMarker() {
+    if (descriptor != null) {
+      return descriptor.getMarker();
+    }
+    return null;
+  }
+}

--- a/src/io/flutter/editor/IntellijColorPickerProvider.java
+++ b/src/io/flutter/editor/IntellijColorPickerProvider.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2019 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.editor;
+
+import com.intellij.openapi.ui.popup.Balloon;
+import com.intellij.ui.colorpicker.ColorPickerBuilder;
+import com.intellij.ui.colorpicker.LightCalloutPopup;
+import com.intellij.ui.colorpicker.MaterialGraphicalColorPipetteProvider;
+import kotlin.Unit;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.KeyEvent;
+
+public class IntellijColorPickerProvider implements ColorPickerProvider {
+  private LightCalloutPopup popup;
+
+  @Override
+  public void show(Color initialColor, JComponent component, Point offset, Balloon.Position position, ColorListener colorListener, Runnable onCancel, Runnable onOk) {
+    if (popup != null) {
+      popup.close();
+    }
+    popup = new ColorPickerBuilder()
+      .setOriginalColor(initialColor)
+      // TODO(jacobr): we would like to add the saturation and brightness
+      // component but for some reason it throws exceptions even though there
+      // are examples of it being used identically without throwing exceptions
+      // elsewhere in the IntelliJ code base.
+      //.addSaturationBrightnessComponent()
+      .addColorAdjustPanel(new MaterialGraphicalColorPipetteProvider())
+      .addColorValuePanel().withFocus()
+      .addOperationPanel(
+        (okColor) -> {
+          onOk.run();
+          return Unit.INSTANCE;
+        },
+        (cancelColor) -> {
+          onCancel.run();
+          return Unit.INSTANCE;
+        }
+      ).withFocus()
+      .setFocusCycleRoot(true)
+      .focusWhenDisplay(true)
+      .addKeyAction(
+        KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0),
+        new AbstractAction() {
+          @Override
+          public void actionPerformed(ActionEvent e) {
+            onCancel.run();
+          }
+        }
+      )
+      .addKeyAction(
+        KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0),
+        new AbstractAction() {
+          @Override
+          public void actionPerformed(ActionEvent e) {
+            onOk.run();
+          }
+        }
+      )
+      .addColorListener(colorListener::colorChanged, true)
+      .build();
+    popup.show(component, offset, position);
+  }
+
+  @Override
+  public void dispose() {
+    if (popup != null) {
+      popup.close();
+    }
+    popup = null;
+  }
+}

--- a/src/io/flutter/editor/IntellijColorPickerProvider.java_stub
+++ b/src/io/flutter/editor/IntellijColorPickerProvider.java_stub
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.editor;
+
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.KeyEvent;
+
+import com.intellij.openapi.ui.popup.Balloon;
+
+// Stub implementation of IntellijColorPickerProvider so that we don't throw
+// exceptions when running on AndroidStudio. We cannot include the real
+// implementation of IntellijColorPickerProvider when building for
+// AndroidStudio as it will generate compile errors.
+// see product-matrix.json which specifies that IntellijColorPickerProvider
+// should be stubbed out under AndroidStudio.
+public class IntellijColorPickerProvider implements ColorPickerProvider {
+
+  @Override
+  public void show(Color initialColor, JComponent component, Point offset, Balloon.Position position, ColorListener colorListener, Runnable onCancel, Runnable onOk) {
+  }
+
+  @Override
+  public void dispose() {
+  }
+}

--- a/src/io/flutter/editor/OutlineLocation.java
+++ b/src/io/flutter/editor/OutlineLocation.java
@@ -12,22 +12,50 @@ import com.intellij.openapi.vfs.VirtualFile;
 import org.dartlang.analysis.server.protocol.FlutterOutline;
 import org.jetbrains.annotations.Nullable;
 
-/**
- * Class that tracks the location of a FlutterOutline node in a document.
- * <p>
- * Once the track method has been called, edits to the document are reflected
- * by by all locations returned by the outline location.
- */
-public class OutlineLocation implements Comparable<OutlineLocation> {
-  private final int line;
-  private final int column;
-  private final int indent;
-  private final int offset;
-  private final int endOffset;
-  @Nullable
+class TextRangeTracker {
+  private final TextRange rawRange;
   private RangeMarker marker;
-  @Nullable
-  private String nodeStartingWord;
+  private String endingWord;
+
+  TextRangeTracker(int offset, int endOffset) {
+    rawRange = new TextRange(offset, endOffset);
+  }
+
+  void track(Document document) {
+    if (marker != null) {
+      assert(document == marker.getDocument());
+      return;
+    }
+    // Create a range marker that goes from the start of the indent for the line
+    // to the column of the actual entity.
+    final int docLength = document.getTextLength();
+    final int startOffset = Math.min(rawRange.getStartOffset(), docLength);
+    final int endOffset = Math.min(rawRange.getEndOffset(), docLength);
+
+    endingWord = getCurrentWord(document, endOffset - 1);
+    marker = document.createRangeMarker(startOffset, endOffset);
+  }
+
+  @Nullable TextRange getRange() {
+    if (marker == null) {
+      return rawRange;
+    }
+    if (!marker.isValid()) {
+      return null;
+    }
+    return new TextRange(marker.getStartOffset(), marker.getEndOffset());
+  }
+
+  void dispose() {
+    if (marker != null) {
+      marker.dispose();;
+    }
+    marker = null;
+  }
+
+  public boolean isTracking() {
+    return marker != null && marker.isValid();
+  }
 
   /**
    * Get the next word in the document starting at offset.
@@ -38,8 +66,9 @@ public class OutlineLocation implements Comparable<OutlineLocation> {
    * where RangeMarkers go off the rails and return strange values after
    * running a code formatter or other tool that generates widespread edits.
    */
-  private static String getCurrentWord(Document document, int offset) {
+  public static String getCurrentWord(Document document, int offset) {
     final int documentLength = document.getTextLength();
+    offset = Math.max(0, offset);
     if (offset < 0 || offset >= documentLength) return "";
     final CharSequence chars = document.getCharsSequence();
     // Clamp the max current word length at 20 to avoid slow behavior if the
@@ -53,6 +82,47 @@ public class OutlineLocation implements Comparable<OutlineLocation> {
     if (offset == end) return "";
     return chars.subSequence(offset, end).toString();
   }
+
+  public boolean isConsistentEndingWord() {
+    if (marker == null) {
+      return true;
+    }
+    if (!marker.isValid()) {
+      return false;
+    }
+    return // Verify that the word starting at the end of the marker matches
+           // its expected value. This is sometimes not the case if the logic
+           // to update marker locations has hit a bad edge case as sometimes
+           // happens when there is a large document edit due to running a
+           // code formatter.
+           endingWord.equals(TextRangeTracker.getCurrentWord(marker.getDocument(), marker.getEndOffset() - 1));
+  }
+}
+
+/**
+ * Class that tracks the location of a FlutterOutline node in a document.
+ * <p>
+ * Once the track method has been called, edits to the document are reflected
+ * by by all locations returned by the outline location.
+ */
+public class OutlineLocation implements Comparable<OutlineLocation> {
+  private final int line;
+  private final int column;
+  private final int indent;
+  private final int offset;
+  /**
+   * Tracker for the range of lines indent guides for the outline should show.
+   */
+  private final TextRangeTracker guideTracker;
+
+  /**
+   * Tracker for the entire range of text describing this outline location.
+   */
+  private final TextRangeTracker fullTracker;
+
+  @Nullable
+  private String nodeStartingWord;
+  private Document document;
 
   public OutlineLocation(
     FlutterOutline node,
@@ -75,15 +145,21 @@ public class OutlineLocation implements Comparable<OutlineLocation> {
     assert (column >= indent);
     assert (line >= 0);
     this.indent = indent;
-    this.offset = pass.getConvertedOffset(node);
-    this.endOffset = pass.getConvertedOffset(node.getOffset() + node.getLength());
+    int nodeOffset = pass.getConvertedOffset(node);
+    int endOffset = pass.getConvertedOffset(node.getOffset() + node.getLength());
+    fullTracker = new TextRangeTracker(nodeOffset, endOffset);
+    final int delta = Math.max(column - indent, 0);
+    this.offset = Math.max(nodeOffset - delta, 0);
+    guideTracker = new TextRangeTracker(offset, nodeOffset + 1);
   }
 
   public void dispose() {
-    if (marker != null) {
-      marker.dispose();
+    if (guideTracker != null) {
+      guideTracker.dispose();
     }
-    marker = null;
+    if (fullTracker != null) {
+      fullTracker.dispose();;
+    }
   }
 
   /**
@@ -94,26 +170,12 @@ public class OutlineLocation implements Comparable<OutlineLocation> {
    * also be called to ensure the range marker is disposed.
    */
   public void track(Document document) {
-    if (marker != null) {
-      // TODO(jacobr): it does indicate a bit of a logic bug if we are calling this method twice.
-      assert (marker.getDocument() == document);
-      return;
-    }
+    this.document = document;
 
     assert (indent <= column);
 
-    final int delta = Math.max(column - indent, 0);
-    final int markerEnd = offset;
-
-    // Create a range marker that goes from the start of the indent for the line
-    // to the column of the actual entity.
-    final int docLength = document.getTextLength();
-    int startOffset = Math.max(markerEnd - delta, 0);
-    startOffset = Math.min(startOffset, docLength);
-    final int endOffset = Math.min(markerEnd + 1, docLength);
-
-    marker = document.createRangeMarker(startOffset, endOffset);
-    nodeStartingWord = getCurrentWord(document, markerEnd);
+    fullTracker.track(document);
+    guideTracker.track(document);
   }
 
   @Override
@@ -134,41 +196,36 @@ public class OutlineLocation implements Comparable<OutlineLocation> {
            column == other.column &&
            indent == other.indent &&
            offset == other.offset &&
-           getOffset() == other.getOffset();
+           getGuideOffset() == other.getGuideOffset();
   }
 
   /**
    * Offset in the document accurate even if the document has been edited.
    */
-  public int getOffset() {
-    return marker == null ? offset : marker.getStartOffset();
+  public int getGuideOffset() {
+    if (guideTracker.isTracking()) {
+      return guideTracker.getRange().getStartOffset();
+    }
+    return offset;
   }
 
   // Sometimes markers stop being valid in which case we need to stop
   // displaying the rendering until they are valid again.
   public boolean isValid() {
-    if (marker == null) return true;
+    if (!guideTracker.isTracking()) return true;
 
-    return marker.isValid() &&
-           nodeStartingWord != null &&
-           // Verify that the word starting at the end of the marker matches
-           // its expected value. This is sometimes not the case if the logic
-           // to update marker locations has hit a bad edge case as sometimes
-           // happens when there is a large document edit due to running a
-           // code formatter.
-           nodeStartingWord.equals(getCurrentWord(marker.getDocument(), marker.getEndOffset() - 1));
+    return guideTracker.isConsistentEndingWord();
   }
 
   /**
    * Line in the document this outline node is at.
    */
   public int getLine() {
-    return marker == null ? line : marker.getDocument().getLineNumber(marker.getStartOffset());
+    return guideTracker.isTracking() ? document.getLineNumber(guideTracker.getRange().getStartOffset()) : line;
   }
 
-  private int getColumnForOffset(int offset) {
-    assert (marker != null);
-    final Document document = marker.getDocument();
+  public int getColumnForOffset(int offset) {
+    assert (document != null);
     final int currentLine = document.getLineNumber(offset);
     return offset - document.getLineStartOffset(currentLine);
   }
@@ -181,7 +238,12 @@ public class OutlineLocation implements Comparable<OutlineLocation> {
    * The indent will be 2 while the column is 9.
    */
   public int getIndent() {
-    return marker == null ? indent : getColumnForOffset(marker.getStartOffset());
+    if (!guideTracker.isTracking()) {
+      return indent;
+    }
+    final TextRange range = guideTracker.getRange();
+    assert (range != null);
+    return getColumnForOffset(range.getStartOffset());
   }
 
   /**
@@ -190,11 +252,20 @@ public class OutlineLocation implements Comparable<OutlineLocation> {
    * This is the column offset of the start of the widget constructor call.
    */
   public int getColumn() {
-    return marker == null ? column : getColumnForOffset(Math.max(marker.getStartOffset(), marker.getEndOffset() - 1));
+    if (!guideTracker.isTracking()) {
+      return column;
+    }
+    final TextRange range = guideTracker.getRange();
+    assert (range != null);
+    return getColumnForOffset(Math.max(range.getStartOffset(), range.getEndOffset() - 1));
   }
 
-  public TextRange getTextRange() {
-    return marker == null ? new TextRange(offset, endOffset) : new TextRange(marker.getStartOffset(), marker.getEndOffset());
+  public TextRange getGuideTextRange() {
+    return guideTracker.getRange();
+  }
+
+  public TextRange getFullRange() {
+    return fullTracker.getRange();
   }
 
   @Override

--- a/src/io/flutter/editor/PreviewViewController.java
+++ b/src/io/flutter/editor/PreviewViewController.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2019 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.editor;
+
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.openapi.vfs.VirtualFile;
+import io.flutter.inspector.DiagnosticsNode;
+import io.flutter.inspector.InspectorService;
+import org.jetbrains.annotations.Nullable;
+
+import java.awt.*;
+
+public class PreviewViewController extends PreviewViewControllerBase {
+
+  Rectangle screenshotBoundsOverride;
+  final Component component;
+
+  public PreviewViewController(WidgetViewModelData data, boolean drawBackground, Component component, Disposable parentDisposable) {
+    super(data, drawBackground, parentDisposable);
+    visible = true;
+    this.component = component;
+  }
+
+  public void setScreenshotBounds(Rectangle bounds) {
+    final boolean sizeChanged = screenshotBounds != null && (screenshotBounds.width != bounds.width || screenshotBounds.height != bounds.height);
+    screenshotBoundsOverride = bounds;
+    screenshotBounds = bounds;
+    if (sizeChanged) {
+      // Get a new screenshot as the existing screenshot isn't the right resolution.
+      // TODO(jacobr): only bother if the resolution is sufficiently different.
+      fetchScreenshot(false);
+    }
+  }
+
+  @Override
+  protected Component getComponent() {
+    return component;
+  }
+
+  @Override
+  protected VirtualFile getVirtualFile() {
+    return null;
+  }
+
+  @Override
+  protected Document getDocument() {
+    return null;
+  }
+
+  @Override
+  protected void showPopup(Point location, DiagnosticsNode node) {
+    popup = PropertyEditorPanel
+      .showPopup(data.context.inspectorGroupManagerService, data.context.project, getComponent(), node, node.getCreationLocation().getLocation(), data.context.flutterDartAnalysisService, location);
+  }
+
+  @Override
+  TextRange getActiveRange() {
+    return null;
+  }
+
+  @Override
+  void setCustomCursor(@Nullable Cursor cursor) {
+    getComponent().setCursor(cursor);
+  }
+
+  @Override
+  public void computeScreenshotBounds() {
+    screenshotBounds = screenshotBoundsOverride;
+  }
+
+  @Override
+  protected Dimension getPreviewSize() {
+    return screenshotBoundsOverride.getSize();
+  }
+
+  @Override
+  public void forceRender() {
+    if (component != null) {
+      component.revalidate();
+      component.repaint();
+    }
+  }
+
+  @Override
+  InspectorService.Location getLocation() {
+    return null;
+  }
+}

--- a/src/io/flutter/editor/PreviewViewControllerBase.java
+++ b/src/io/flutter/editor/PreviewViewControllerBase.java
@@ -1,0 +1,680 @@
+/*
+ * Copyright 2019 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.editor;
+
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.editor.*;
+import com.intellij.openapi.ui.popup.Balloon;
+import com.intellij.openapi.util.Disposer;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.ui.JBColor;
+import com.intellij.util.ui.JBUI;
+import com.intellij.util.ui.UIUtil;
+import io.flutter.inspector.*;
+import io.flutter.utils.AsyncRateLimiter;
+import io.flutter.utils.math.Matrix4;
+import io.flutter.utils.math.Vector3;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.awt.*;
+import java.awt.event.MouseEvent;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Rectangle2D;
+import java.util.ArrayList;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+
+import static io.flutter.inspector.InspectorService.toSourceLocationUri;
+import static java.lang.Math.*;
+
+/**
+ * Controller that displays interactive screen mirrors for specific widget
+ * subtrees or the entire app.
+ * <p>
+ * This controller abstracts away from the rendering code enough that it can be
+ * used both when rendering previews directly in the code editor and as part of
+ * a regular a regular component.
+ */
+public abstract class PreviewViewControllerBase extends WidgetViewController {
+  // Disable popup support initially as it isn't needed given we are showing
+  // properties in the outline view.
+  public static final boolean ENABLE_POPUP_SUPPORT = false;
+  public static final int PREVIEW_PADDING_X = 20;
+  public static final double MOUSE_FRAMES_PER_SECOND = 10.0;
+  public static final double SCREENSHOT_FRAMES_PER_SECOND = 3.0;
+  public static final int PREVIEW_MAX_WIDTH = 280;
+  public static final int PREVIEW_MAX_HEIGHT = 520;
+  private static final Stroke SOLID_STROKE = new BasicStroke(1);
+  private static final Color SHADOW_COLOR = new JBColor(new Color(0, 0, 0, 64), new Color(0, 0, 0, 64));
+  protected static final int defaultLineHeight = 20;
+  protected final boolean drawBackground;
+  protected Balloon popup;
+  protected Point lastPoint;
+  protected AsyncRateLimiter mouseRateLimiter;
+  protected AsyncRateLimiter screenshotRateLimiter;
+  protected boolean controlDown;
+  protected ArrayList<DiagnosticsNode> currentHits;
+  protected InspectorObjectGroupManager hover;
+  protected InspectorService.ObjectGroup screenshotGroup;
+  protected boolean screenshotDirty = false;
+  protected int extraHeight = 0;
+  protected boolean screenshotLoading;
+  protected boolean popopOpenInProgress;
+  protected boolean altDown;
+  protected Screenshot screenshot;
+  protected ArrayList<DiagnosticsNode> boxes;
+  Rectangle relativeRect;
+  Rectangle lastLockedRectangle;
+  Rectangle screenshotBounds;
+  // Screenshot bounds in absolute window coordinates.
+  Rectangle lastScreenshotBoundsWindow;
+  int maxHeight;
+  boolean _mouseInScreenshot = false;
+
+  public PreviewViewControllerBase(WidgetViewModelData data, boolean drawBackground, Disposable parent) {
+    super(data, parent);
+    this.drawBackground = drawBackground;
+  }
+
+  @Override
+  public void dispose() {
+    if (popup != null) {
+      popup.dispose();
+      popup = null;
+    }
+    if (hover != null) {
+      hover.clear(false);
+      hover = null;
+    }
+    screenshot = null;
+    super.dispose();
+  }
+
+  AsyncRateLimiter getMouseRateLimiter() {
+    if (mouseRateLimiter != null) return mouseRateLimiter;
+    mouseRateLimiter = new AsyncRateLimiter(MOUSE_FRAMES_PER_SECOND, () -> {
+      return updateMouse(false);
+    }, this);
+    return mouseRateLimiter;
+  }
+
+  AsyncRateLimiter getScreenshotRateLimiter() {
+    if (screenshotRateLimiter != null) return screenshotRateLimiter;
+    screenshotRateLimiter = new AsyncRateLimiter(SCREENSHOT_FRAMES_PER_SECOND, () -> {
+      return updateScreenshot();
+    }, this);
+    return screenshotRateLimiter;
+  }
+
+  public InspectorObjectGroupManager getHovers() {
+    if (hover != null && hover.getInspectorService() == getInspectorService()) {
+      return hover;
+    }
+    if (getInspectorService() == null) return null;
+    hover = new InspectorObjectGroupManager(getInspectorService(), "hover");
+    return hover;
+  }
+
+  public @Nullable
+  InspectorService.ObjectGroup getScreenshotGroup() {
+    if (screenshotGroup != null && screenshotGroup.getInspectorService() == getInspectorService()) {
+      return screenshotGroup;
+    }
+    if (getInspectorService() == null) return null;
+    screenshotGroup = getInspectorService().createObjectGroup("screenshot");
+    return screenshotGroup;
+  }
+
+  protected double getDPI() {
+    return JBUI.pixScale(getComponent());
+  }
+
+  protected abstract Component getComponent();
+
+  protected int toPixels(int value) {
+    return (int)(value * getDPI());
+  }
+
+  Rectangle getScreenshotBoundsTight() {
+    // TODO(jacobr): cache this.
+    if (screenshotBounds == null || extraHeight == 0) return screenshotBounds;
+    Rectangle bounds = new Rectangle(screenshotBounds);
+    bounds.height -= extraHeight;
+    bounds.y += extraHeight;
+    return bounds;
+  }
+
+  @Override
+  public void onSelectionChanged(DiagnosticsNode selection) {
+    super.onSelectionChanged(selection);
+    if (!visible) {
+      return;
+    }
+
+    if (getLocation() != null) {
+      // The screenshot is dirty because the selection could influence which
+      // of the widgets matching the location should be displayed.
+      screenshotDirty = true;
+    }
+    // Fetching a screenshot is somewhat slow so we schedule getting just the
+    // bounding boxes before the screenshot arives to show likely correct
+    // bounding boxes sooner.
+    getGroups().cancelNext();
+    InspectorService.ObjectGroup nextGroup = getGroups().getNext();
+    final CompletableFuture<ArrayList<DiagnosticsNode>> selectionResults = nextGroup.getBoundingBoxes(getSelectedElement(), selection);
+
+    nextGroup.safeWhenComplete(selectionResults, (boxes, error) -> {
+      if (nextGroup.isDisposed()) return;
+      if (error != null || boxes == null) {
+        return;
+      }
+      // To be paranoid, avoid the inspector going out of scope.
+      if (getGroups() == null) return;
+      getGroups().promoteNext();
+      this.boxes = boxes;
+      forceRender();
+    });
+
+    // Showing just the selected elements is dangerous as they may be out of
+    // sync with the current screenshot if it has changed. To be safe, schedule
+    // a screenshot with the updated UI.
+    getScreenshotRateLimiter().scheduleRequest();
+  }
+
+  public CompletableFuture<?> updateMouse(boolean navigateTo) {
+    final InspectorObjectGroupManager hoverGroups = getHovers();
+    if (hoverGroups == null || ((popupActive() || popopOpenInProgress) && !navigateTo)) {
+      return CompletableFuture.completedFuture(null);
+    }
+    final Screenshot latestScreenshot = getScreenshotNow();
+    if (screenshotBounds == null ||
+        latestScreenshot == null ||
+        lastPoint == null ||
+        !getScreenshotBoundsTight().contains(lastPoint) ||
+        getSelectedElement() == null) {
+      return CompletableFuture.completedFuture(null);
+    }
+    hoverGroups.cancelNext();
+    final InspectorService.ObjectGroup nextGroup = hoverGroups.getNext();
+    final Matrix4 matrix = buildTransformToScreenshot(latestScreenshot);
+    matrix.invert();
+    final Vector3 point = matrix.perspectiveTransform(new Vector3(lastPoint.getX(), lastPoint.getY(), 0));
+    final String file;
+    final int startLine, endLine;
+    if (controlDown || getVirtualFile() == null) {
+      file = null;
+    }
+    else {
+      file = toSourceLocationUri(getVirtualFile().getPath());
+    }
+
+    final TextRange activeRange = getActiveRange();
+    if (controlDown || activeRange == null || getDocument() == null) {
+      startLine = -1;
+      endLine = -1;
+    }
+    else {
+      startLine = getDocument().getLineNumber(activeRange.getStartOffset());
+      endLine = getDocument().getLineNumber(activeRange.getEndOffset());
+    }
+
+    final CompletableFuture<ArrayList<DiagnosticsNode>> hitResults =
+      nextGroup.hitTest(getSelectedElement(), point.getX(), point.getY(), file, startLine, endLine);
+    nextGroup.safeWhenComplete(hitResults, (hits, error) -> {
+
+      if (nextGroup.isDisposed()) return;
+      if (error != null || hits == null) {
+        return;
+      }
+      currentHits = hits;
+      hoverGroups.promoteNext();
+      // TODO(jacobr): consider removing the navigateTo option?
+      if (navigateTo && popopOpenInProgress) {
+        final DiagnosticsNode node = hits.size() > 0 ? hits.get(0) : null;
+        if (node == null) return;
+        final TransformedRect transform = node.getTransformToRoot();
+        if (transform != null) {
+          double x, y;
+          final Matrix4 transformMatrix = buildTransformToScreenshot(latestScreenshot);
+          transformMatrix.multiply(transform.getTransform());
+          final Rectangle2D rect = transform.getRectangle();
+          final Vector3 transformed = transformMatrix.perspectiveTransform(new Vector3(new double[]{rect.getCenterX(), rect.getMinY(), 0}));
+          final Point pendingPopupOpenLocation = new Point((int)Math.round(transformed.getX()), (int)Math.round(transformed.getY() + 1));
+          showPopup(pendingPopupOpenLocation, node);
+        }
+        popopOpenInProgress = false;
+      }
+      if (navigateTo && hits.size() > 0) {
+        getGroups().getCurrent().setSelection(hits.get(0).getValueRef(), false, false);
+      }
+      forceRender();
+    });
+    return hitResults;
+  }
+
+  protected abstract VirtualFile getVirtualFile();
+
+  abstract protected Document getDocument();
+
+  protected abstract void showPopup(Point location, DiagnosticsNode node);
+
+  abstract @Nullable TextRange getActiveRange();
+
+  void setMouseInScreenshot(boolean v) {
+    if (_mouseInScreenshot == v) return;
+    _mouseInScreenshot = v;
+    forceRender();
+  }
+
+  public void updateMouseCursor() {
+    if (screenshotBounds == null) {
+      setMouseInScreenshot(false);
+      return;
+    }
+    if (lastPoint != null && screenshotBounds.contains(lastPoint)) {
+      // TODO(jacobr): consider CROSSHAIR_CURSOR instead which gives more of
+      //  a pixel selection feel.
+      setCustomCursor(Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR));
+      setMouseInScreenshot(true);
+      if (!getScreenshotBoundsTight().contains(lastPoint)) {
+        cancelHovers();
+      }
+    }
+    else {
+      setCustomCursor(null);
+      _mouseOutOfScreenshot();
+    }
+  }
+
+  abstract void setCustomCursor(@Nullable Cursor cursor);
+
+  void registerLastEvent(MouseEvent event) {
+    lastPoint = event.getPoint();
+    controlDown = event.isControlDown();
+    altDown = event.isAltDown();
+    updateMouseCursor();
+  }
+
+  public void onMouseMoved(MouseEvent event) {
+    assert (!event.isConsumed());
+    registerLastEvent(event);
+    if (_mouseInScreenshot) {
+      event.consume();
+      if (getScreenshotBoundsTight().contains(lastPoint) && !popupActive()) {
+        getMouseRateLimiter().scheduleRequest();
+      }
+    }
+  }
+
+  boolean popupActive() {
+    return popup != null && !popup.isDisposed() || popopOpenInProgress;
+  }
+
+  protected void _hidePopup() {
+    if (popup != null && !popup.isDisposed()) {
+      popup.dispose();
+      popup = null;
+    }
+  }
+
+  public void onMousePressed(MouseEvent event) {
+    registerLastEvent(event);
+    final Point point = event.getPoint();
+    if (screenshotBounds != null && screenshotBounds.contains(point)) {
+      event.consume();
+      if (isPopupTrigger(event)) {
+        _hidePopup();
+        popopOpenInProgress = true;
+        updateMouse(true);
+      }
+    }
+  }
+
+  private boolean isPopupTrigger(MouseEvent event) {
+    return ENABLE_POPUP_SUPPORT && event.isPopupTrigger();
+  }
+
+  @Override
+  public void onMouseReleased(MouseEvent event) {
+    registerLastEvent(event);
+
+    if (screenshotBounds == null) return;
+    final Point point = event.getPoint();
+    if (screenshotBounds.contains(point)) {
+      Rectangle tightBounds = getScreenshotBoundsTight();
+      event.consume();
+      if (tightBounds.contains(point)) {
+        if (isPopupTrigger(event)) {
+          _hidePopup();
+          popopOpenInProgress = true;
+        }
+        updateMouse(true);
+      }
+      else {
+        // Title hit.
+        _hidePopup();
+        if (elements != null) {
+          if (elements.size() > 1) {
+            int newIndex = this.activeIndex + 1;
+            if (newIndex >= elements.size()) {
+              newIndex = 1; // Wrap around hack case because the first index is out of order.
+            }
+            // TODO(jacobr): we could update activeIndex now instead of waitng for the UI to update.
+            getGroups().getCurrent().setSelection(elements.get(newIndex).getValueRef(), false, true);
+          }
+          else if (elements.size() == 1) {
+            // Select current.
+            getGroups().getCurrent().setSelection(elements.get(0).getValueRef(), false, true);
+          }
+        }
+      }
+    }
+  }
+
+  public void onMouseExited(MouseEvent event) {
+    lastPoint = null;
+    controlDown = false;
+    altDown = false;
+    setMouseInScreenshot(false);
+    updateMouseCursor();
+  }
+
+  public void onFlutterFrame() {
+    fetchScreenshot(false);
+  }
+
+  public void _mouseOutOfScreenshot() {
+    setMouseInScreenshot(false);
+    lastPoint = null;
+    cancelHovers();
+  }
+
+  public void cancelHovers() {
+    hover = getHovers();
+    if (hover != null) {
+      hover.cancelNext();
+      controlDown = false;
+      altDown = false;
+    }
+    if (currentHits != null) {
+      currentHits = null;
+      forceRender();
+    }
+  }
+
+  public void onMouseEntered(MouseEvent event) {
+    onMouseMoved(event);
+  }
+
+  void clearState() {
+    screenshotDirty = true;
+    currentHits = new ArrayList<>();
+    if (hover != null) {
+      hover.clear(true);
+    }
+    screenshot = null;
+  }
+
+  @Override
+  public void onInspectorAvailabilityChanged() {
+    clearState();
+  }
+
+  public void onVisibleChanged() {
+    if (!visible) {
+      _hidePopup();
+    }
+    if (visible) {
+      computeScreenshotBounds();
+      if (getInspectorService() != null) {
+        if (screenshot == null || screenshotDirty) {
+          fetchScreenshot(false);
+        }
+      }
+    }
+  }
+
+  abstract public void computeScreenshotBounds();
+
+  @Override
+  public boolean updateVisiblityLocked(Rectangle newRectangle) {
+    if (popupActive()) {
+      lastLockedRectangle = new Rectangle(newRectangle);
+      return true;
+    }
+    if (lastLockedRectangle != null && visible) {
+      if (newRectangle.intersects(lastLockedRectangle)) {
+        return true;
+      }
+      // Stop locking.
+      lastLockedRectangle = null;
+    }
+    return false;
+  }
+
+  // When visibility is locked, we should try to keep the preview in view even
+  // if the user navigates around the code editor.
+  public boolean isVisiblityLocked() {
+    if (popupActive()) {
+      return true;
+    }
+    if (lastLockedRectangle != null && visible && visibleRect != null) {
+      return visibleRect.intersects(lastLockedRectangle);
+    }
+    return false;
+  }
+
+  public Screenshot getScreenshotNow() {
+    return screenshot;
+  }
+
+  /**
+   * Builds a transform that maps global window coordinates to coordinates
+   * within the screenshot.
+   */
+  protected Matrix4 buildTransformToScreenshot(Screenshot latestScreenshot) {
+    final Matrix4 matrix = Matrix4.identity();
+    matrix.translate(screenshotBounds.x, screenshotBounds.y + extraHeight, 0);
+    final Rectangle2D imageRect = latestScreenshot.transformedRect.getRectangle();
+    final double centerX = imageRect.getCenterX();
+    final double centerY = imageRect.getCenterY();
+    matrix.translate(-centerX, -centerY, 0);
+    matrix.scale(1 / getDPI(), 1 / getDPI(), 1 / getDPI());
+    matrix.translate(centerX * getDPI(), centerY * getDPI(), 0);
+    matrix.multiply(latestScreenshot.transformedRect.getTransform());
+    return matrix;
+  }
+
+  protected ArrayList<DiagnosticsNode> getNodesToHighlight() {
+    return currentHits != null && currentHits.size() > 0 ? currentHits : boxes;
+  }
+
+  protected void clearScreenshot() {
+    if (getScreenshotNow() != null) {
+      screenshot = null;
+      computeScreenshotBounds();
+      forceRender();
+    }
+  }
+
+  @Override
+  public void setElements(ArrayList<DiagnosticsNode> elements) {
+    super.setElements(elements);
+    currentHits = null;
+    boxes = null;
+  }
+
+  boolean hasCurrentHits() {
+    return currentHits != null && !currentHits.isEmpty();
+  }
+
+  public void onMaybeFetchScreenshot() {
+    if (screenshot == null || screenshotDirty) {
+      fetchScreenshot(false);
+    }
+  }
+
+  void fetchScreenshot(boolean mightBeIncompatible) {
+    if (mightBeIncompatible) {
+      screenshotLoading = true;
+    }
+    screenshotDirty = true;
+    if (!visible) return;
+
+    getScreenshotRateLimiter().scheduleRequest();
+  }
+
+  protected CompletableFuture<InspectorService.InteractiveScreenshot> updateScreenshot() {
+    final InspectorService.ObjectGroup group = getScreenshotGroup();
+    if (group == null) {
+      return CompletableFuture.completedFuture(null);
+    }
+
+    Dimension previewSize = getPreviewSize();
+    final long startTime = System.currentTimeMillis();
+    // 0.7 is a tweak to ensure we do not try to download enormous screenshots.
+    CompletableFuture<InspectorService.InteractiveScreenshot> screenshotFuture =
+      group.getScreenshotAtLocation(getLocation(), 10, toPixels(previewSize.width), toPixels(previewSize.height), getDPI() * 0.7);
+    group.safeWhenComplete(
+      screenshotFuture,
+      (pair, e2) -> {
+        if (e2 != null || group.isDisposed() || getInspectorService() == null) return;
+        if (pair == null) {
+          setElements(null);
+          screenshot = null;
+          boxes = null;
+        }
+        else {
+          setElements(pair.elements);
+          screenshot = pair.screenshot;
+          boxes = pair.boxes;
+        }
+        screenshotDirty = false;
+        screenshotLoading = false;
+        // This calculation might be out of date due to the new screenshot.
+        computeScreenshotBounds();
+        forceRender();
+      }
+    );
+    return screenshotFuture;
+  }
+
+  protected abstract Dimension getPreviewSize();
+
+  public void paint(@NotNull Graphics g, int lineHeight) {
+    final Graphics2D g2d = (Graphics2D)g.create();
+    // Required to render colors with an alpha channel. Rendering with an
+    // alpha chanel makes it easier to keep relationships between shadows
+    // and lines looking consistent when the background color changes such
+    // as in the case of selection or a different highlighter turning the
+    // background yellow.
+    g2d.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, 1));
+    final Rectangle clip = g2d.getClipBounds();
+    computeScreenshotBounds();
+    if (screenshotBounds == null || !clip.intersects(screenshotBounds)) {
+      return;
+    }
+
+    final Screenshot latestScreenshot = getScreenshotNow();
+    final int imageWidth = screenshotBounds.width;
+    final int imageHeight = screenshotBounds.height;
+
+    if (drawBackground) {
+      // TODO(jacobr): draw a shadow around the outline in a more principled way.
+      final int SHADOW_HEIGHT = 5;
+      for (int h = 1; h < SHADOW_HEIGHT; h++) {
+        g2d.setColor(new Color(43, 43, 43, 100 - h * 20));
+        g2d.fillRect(screenshotBounds.x - h + 1, screenshotBounds.y + min(screenshotBounds.height, imageHeight) + h,
+                     min(screenshotBounds.width, imageWidth) + h - 1,
+                     1);
+        g2d.fillRect(screenshotBounds.x - h + 1,
+                     screenshotBounds.y - h,
+                     min(screenshotBounds.width, imageWidth) + h - 1,
+                     1);
+        g2d.fillRect(screenshotBounds.x - h, screenshotBounds.y - h, 1, imageHeight + 2 * h);
+      }
+    }
+    g2d.clip(screenshotBounds);
+
+    final Font font = UIUtil.getFont(UIUtil.FontSize.MINI, UIUtil.getTreeFont());
+    g2d.setFont(font);
+    g2d.setColor(isSelected ? JBColor.GRAY : JBColor.LIGHT_GRAY);
+
+    if (latestScreenshot != null) {
+      g2d.clip(getScreenshotBoundsTight());
+
+      g2d.drawImage(latestScreenshot.image,
+                    new AffineTransform(1 / getDPI(), 0f, 0f, 1 / getDPI(), screenshotBounds.x, screenshotBounds.y + extraHeight), null);
+
+      final java.util.List<DiagnosticsNode> nodesToHighlight = getNodesToHighlight();
+      // Sometimes it is fine to display even if we are loading.
+      // TODO(jacobr): be smarter and track if the highlights are associated with a different screenshot.
+      if (nodesToHighlight != null && nodesToHighlight.size() > 0) { //&& !screenshotLoading) {
+        boolean first = true;
+        for (DiagnosticsNode box : nodesToHighlight) {
+          final TransformedRect transform = box.getTransformToRoot();
+          if (transform != null) {
+            double x, y;
+            final Matrix4 matrix = buildTransformToScreenshot(latestScreenshot);
+            matrix.multiply(transform.getTransform());
+            final Rectangle2D rect = transform.getRectangle();
+
+            final Vector3[] points = new Vector3[]{
+              matrix.perspectiveTransform(new Vector3(new double[]{rect.getMinX(), rect.getMinY(), 0})),
+              matrix.perspectiveTransform(new Vector3(new double[]{rect.getMaxX(), rect.getMinY(), 0})),
+              matrix.perspectiveTransform(new Vector3(new double[]{rect.getMaxX(), rect.getMaxY(), 0})),
+              matrix.perspectiveTransform(new Vector3(new double[]{rect.getMinX(), rect.getMaxY(), 0}))
+            };
+
+            // The widget's bounding box may be rotated or otherwise
+            // transformed so we can't simply draw a rectangle.
+            final Polygon polygon = new Polygon();
+            for (Vector3 point : points) {
+              polygon.addPoint((int)Math.round(point.getX()), (int)Math.round(point.getY()));
+            }
+
+            if (first && elements.size() > 0 && !Objects.equals(box.getValueRef(), elements.get(0).getValueRef())) {
+              g2d.setColor(FlutterEditorColors.HIGHLIGHTED_RENDER_OBJECT_BORDER_COLOR);
+              g2d.fillPolygon(polygon);
+            }
+            g2d.setStroke(SOLID_STROKE);
+            g2d.setColor(FlutterEditorColors.HIGHLIGHTED_RENDER_OBJECT_BORDER_COLOR);
+            g2d.drawPolygon(polygon);
+          }
+          first = false;
+        }
+      }
+    }
+    else {
+      if (drawBackground) {
+        g2d.setColor(isSelected ? JBColor.GRAY : JBColor.LIGHT_GRAY);
+        g2d.fillRect(screenshotBounds.x, screenshotBounds.y, screenshotBounds.width, screenshotBounds.height);
+        g2d.setColor(FlutterEditorColors.SHADOW_GRAY);
+      }
+      g2d.setColor(JBColor.BLACK);
+
+      drawMultilineString(g2d, getNoScreenshotMessage(), screenshotBounds.x + 4, screenshotBounds.y + +lineHeight - 4, lineHeight);
+    }
+    g2d.setClip(clip);
+
+    g2d.dispose();
+  }
+
+  String getNoScreenshotMessage() {
+    return getInspectorService() == null ? "Run the application to\nactivate device mirror." : "Loading...";
+  }
+
+  // TODO(jacobr): perhaps cache and optimize.
+  // This UI is sometimes rendered in the code editor where we can't simply use a JBLabel.
+  protected void drawMultilineString(Graphics g, String s, int x, int y, int lineHeight) {
+    for (String line : s.split("\n")) {
+      g.drawString(line, x, y);
+      y += lineHeight;
+    }
+  }
+}

--- a/src/io/flutter/editor/PreviewsForEditor.java
+++ b/src/io/flutter/editor/PreviewsForEditor.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2019 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.editor;
+
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.editor.ex.EditorEx;
+import com.intellij.openapi.editor.markup.CustomHighlighterRenderer;
+import com.intellij.openapi.editor.markup.RangeHighlighter;
+import com.intellij.openapi.util.Disposer;
+import org.jetbrains.annotations.NotNull;
+
+import java.awt.*;
+import java.awt.event.MouseEvent;
+import java.util.ArrayList;
+import java.util.Comparator;
+
+/**
+ * Class that manages rendering screenshots of all build methods in a file
+ * directly in the text editor.
+ */
+public class PreviewsForEditor implements CustomHighlighterRenderer {
+  static final boolean showOverallPreview = false;
+  private final EditorEx editor;
+  private final Disposable parentDisposable;
+  private final WidgetEditingContext data;
+  private final InlinePreviewViewController overallPreview;
+  private ArrayList<InlinePreviewViewController> previews;
+
+  public PreviewsForEditor(WidgetEditingContext data,
+                           EditorMouseEventService editorEventService,
+                           EditorEx editor,
+                           Disposable parentDisposable) {
+    this.data = data;
+    this.editor = editor;
+    this.parentDisposable = parentDisposable;
+    previews = new ArrayList<>();
+    if (showOverallPreview) {
+      overallPreview = new InlinePreviewViewController(
+        new InlineWidgetViewModelData(null, editor, data),
+        true,
+        parentDisposable
+      );
+    }
+    else {
+      overallPreview = null;
+    }
+    editorEventService.addListener(
+      editor,
+      new EditorMouseEventService.Listener() {
+
+        @Override
+        public void onMouseMoved(MouseEvent event) {
+          for (PreviewViewControllerBase preview : getAllPreviews(false)) {
+            if (event.isConsumed()) {
+              preview.onMouseExited(event);
+            }
+            else {
+              preview.onMouseMoved(event);
+            }
+          }
+        }
+
+        @Override
+        public void onMousePressed(MouseEvent event) {
+          for (PreviewViewControllerBase preview : getAllPreviews(false)) {
+            preview.onMousePressed(event);
+            if (event.isConsumed()) break;
+          }
+        }
+
+        @Override
+        public void onMouseReleased(MouseEvent event) {
+          for (PreviewViewControllerBase preview : getAllPreviews(false)) {
+            preview.onMouseReleased(event);
+            if (event.isConsumed()) break;
+          }
+        }
+
+        @Override
+        public void onMouseEntered(MouseEvent event) {
+          for (PreviewViewControllerBase preview : getAllPreviews(false)) {
+            if (event.isConsumed()) {
+              preview.onMouseExited(event);
+            }
+            else {
+              preview.onMouseEntered(event);
+            }
+          }
+        }
+
+        @Override
+        public void onMouseExited(MouseEvent event) {
+          for (PreviewViewControllerBase preview : getAllPreviews(false)) {
+            preview.onMouseExited(event);
+          }
+        }
+      },
+      parentDisposable
+    );
+  }
+
+  public void outlinesChanged(Iterable<WidgetIndentGuideDescriptor> newDescriptors) {
+    final ArrayList<InlinePreviewViewController> newPreviews = new ArrayList<>();
+
+    int i = 0;
+    // TODO(jacobr): be smarter about reusing.
+    for (WidgetIndentGuideDescriptor descriptor : newDescriptors) {
+      if (descriptor.parent == null) {
+        if (i >= previews.size() || !descriptor.equals(previews.get(i).getDescriptor())) {
+          newPreviews.add(new InlinePreviewViewController(new InlineWidgetViewModelData(descriptor, editor, data), true, parentDisposable));
+        }
+        else {
+          newPreviews.add(previews.get(i));
+          i++;
+        }
+      }
+    }
+    while (i < previews.size()) {
+      Disposer.dispose(previews.get(i));
+      i++;
+    }
+    previews = newPreviews;
+  }
+
+  protected Iterable<InlinePreviewViewController> getAllPreviews(boolean paintOrder) {
+    final ArrayList<InlinePreviewViewController> all = new ArrayList<>();
+    if (overallPreview != null) {
+      all.add(overallPreview);
+    }
+    all.addAll(previews);
+    if (paintOrder) {
+      all.sort(Comparator.comparingInt(InlinePreviewViewController::getPriority));
+    }
+    else {
+      all.sort((a, b) -> Integer.compare(b.getPriority(), a.getPriority()));
+    }
+    return all;
+  }
+
+  @Override
+  public void paint(@NotNull Editor editor, @NotNull RangeHighlighter highlighter, @NotNull Graphics graphics) {
+    for (InlinePreviewViewController preview : getAllPreviews(true)) {
+      if (preview.visible) {
+        preview.paint(editor, highlighter, graphics);
+      }
+    }
+  }
+}

--- a/src/io/flutter/editor/PropertyEditorPanel.java
+++ b/src/io/flutter/editor/PropertyEditorPanel.java
@@ -509,9 +509,6 @@ public class PropertyEditorPanel extends SimpleToolWindowPanel {
         }
         else {
           String expression = property.getExpression();
-          /*if (expression == null || expression.isEmpty()) {
-            continue;
-          }*/
           if (expression == null) {
             expression = "";
           }

--- a/src/io/flutter/editor/PropertyEditorPanel.java
+++ b/src/io/flutter/editor/PropertyEditorPanel.java
@@ -1,0 +1,840 @@
+/*
+ * Copyright 2019 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.editor;
+
+import com.google.common.base.Joiner;
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.actionSystem.ActionToolbar;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.editor.ex.EditorEx;
+import com.intellij.openapi.fileEditor.FileDocumentManager;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.ComboBox;
+import com.intellij.openapi.ui.SimpleToolWindowPanel;
+import com.intellij.openapi.ui.popup.Balloon;
+import com.intellij.openapi.ui.popup.BalloonBuilder;
+import com.intellij.openapi.ui.popup.JBPopupFactory;
+import com.intellij.openapi.util.Disposer;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.ui.JBColor;
+import com.intellij.ui.awt.RelativePoint;
+import com.intellij.ui.components.JBLabel;
+import com.intellij.ui.components.JBTextField;
+import com.intellij.util.ui.PositionTracker;
+import com.jetbrains.lang.dart.assists.AssistUtils;
+import com.jetbrains.lang.dart.assists.DartSourceEditException;
+import io.flutter.FlutterMessages;
+import io.flutter.dart.FlutterDartAnalysisServer;
+import io.flutter.hotui.StableWidgetTracker;
+import io.flutter.inspector.DiagnosticsNode;
+import io.flutter.inspector.InspectorGroupManagerService;
+import io.flutter.inspector.InspectorObjectGroupManager;
+import io.flutter.inspector.InspectorService;
+import io.flutter.preview.OutlineOffsetConverter;
+import io.flutter.preview.WidgetEditToolbar;
+import io.flutter.run.FlutterReloadManager;
+import io.flutter.run.daemon.FlutterApp;
+import io.flutter.utils.AsyncRateLimiter;
+import io.flutter.utils.AsyncUtils;
+import io.flutter.utils.EventStream;
+import net.miginfocom.swing.MigLayout;
+import org.dartlang.analysis.server.protocol.*;
+import org.jetbrains.annotations.NonNls;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.FocusEvent;
+import java.awt.event.FocusListener;
+import java.awt.event.ItemEvent;
+import java.util.List;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+
+class EnumValueWrapper {
+  final FlutterWidgetPropertyValueEnumItem item;
+  final String expression;
+
+  public EnumValueWrapper(FlutterWidgetPropertyValueEnumItem item) {
+    this.item = item;
+    this.expression = item.getName();
+    assert (this.expression != null);
+  }
+
+  public EnumValueWrapper(String expression) {
+    this.expression = expression;
+    item = null;
+  }
+
+  @Override
+  public String toString() {
+    if (expression != null) {
+      return expression;
+    }
+    return item != null ? item.getName() : "[null]";
+  }
+}
+
+class PropertyEnumComboBoxModel extends AbstractListModel<EnumValueWrapper>
+  implements ComboBoxModel<EnumValueWrapper> {
+  private final List<EnumValueWrapper> myList;
+  private EnumValueWrapper mySelected;
+  private String expression;
+
+  public PropertyEnumComboBoxModel(FlutterWidgetProperty property) {
+    final FlutterWidgetPropertyEditor editor = property.getEditor();
+    assert (editor != null);
+    myList = new ArrayList<>();
+    for (FlutterWidgetPropertyValueEnumItem item : editor.getEnumItems()) {
+      myList.add(new EnumValueWrapper(item));
+    }
+    String expression = property.getExpression();
+    if (expression == null) {
+      mySelected = null;
+      expression = "";
+      return;
+    }
+    if (property.getValue() != null) {
+      FlutterWidgetPropertyValue value = property.getValue();
+      FlutterWidgetPropertyValueEnumItem enumValue = value.getEnumValue();
+      if (enumValue != null) {
+        for (EnumValueWrapper e : myList) {
+          if (e != null && e.item != null && Objects.equals(e.item.getName(), enumValue.getName())) {
+            mySelected = e;
+          }
+        }
+      }
+    }
+    else {
+      final EnumValueWrapper newItem = new EnumValueWrapper(expression);
+      myList.add(newItem);
+      mySelected = newItem;
+    }
+    final String kind = editor.getKind();
+  }
+
+  @Override
+  public int getSize() {
+    return myList.size();
+  }
+
+  @Override
+  public EnumValueWrapper getElementAt(int index) {
+    return myList.get(index);
+  }
+
+  @Override
+  public EnumValueWrapper getSelectedItem() {
+    return mySelected;
+  }
+
+  @Override
+  public void setSelectedItem(Object item) {
+    if (item instanceof String) {
+      String expression = (String)item;
+      for (EnumValueWrapper e : myList) {
+        if (Objects.equals(e.expression, expression)) {
+          mySelected = e;
+          return;
+        }
+      }
+      EnumValueWrapper wrapper = new EnumValueWrapper(expression);
+      myList.add(wrapper);
+      this.fireIntervalAdded(this, myList.size() - 1, myList.size());
+      setSelectedItem(wrapper);
+      return;
+    }
+    setSelectedItem((EnumValueWrapper)item);
+  }
+
+  public void setSelectedItem(EnumValueWrapper item) {
+    mySelected = item;
+    fireContentsChanged(this, 0, getSize());
+  }
+}
+
+/**
+ * Panel that supports editing properties of a specified widget.
+ * <p>
+ * The property panel will update
+ */
+public class PropertyEditorPanel extends SimpleToolWindowPanel {
+  protected final AsyncRateLimiter retryLookupPropertiesRateLimiter;
+  /**
+   * Whether the property panel is being rendered in a fixed width context such
+   * as inside a baloon popup window or is within a resizeable window.
+   */
+  private final boolean fixedWidth;
+  private final InspectorGroupManagerService.Client inspectorStateServiceClient;
+  private final FlutterDartAnalysisServer flutterDartAnalysisService;
+  private final Project project;
+  private final boolean showWidgetEditToolbar;
+  private final Map<String, JComponent> fields = new HashMap<>();
+  private final Map<String, FlutterWidgetProperty> propertyMap = new HashMap<>();
+  private final Map<String, String> currentExpressionMap = new HashMap<>();
+  private final ArrayList<FlutterWidgetProperty> properties = new ArrayList<>();
+  private final Disposable parentDisposable;
+  // TODO(jacobr): figure out why this is needed.
+  int numFailures;
+  String previouslyFocusedProperty = null;
+  private DiagnosticsNode node;
+  /**
+   * Outline node
+   */
+  private FlutterOutline outline;
+
+  private EventStream<VirtualFile> activeFile;
+
+  /**
+   * Whether the property panel has already triggered a pending hot reload.
+   */
+  private boolean pendingHotReload;
+
+  /**
+   * Whether the property panel needs another hot reload to occur after the
+   * current pending hot reload is complete.
+   */
+  private boolean needHotReload;
+  private CompletableFuture<List<FlutterWidgetProperty>> propertyFuture;
+
+  public PropertyEditorPanel(
+    @Nullable InspectorGroupManagerService inspectorGroupManagerService,
+    Project project,
+    FlutterDartAnalysisServer flutterDartAnalysisService,
+    boolean showWidgetEditToolbar,
+    boolean fixedWidth,
+    Disposable parentDisposable
+  ) {
+    super(true, true);
+    setFocusable(true);
+    this.fixedWidth = fixedWidth;
+    this.parentDisposable = parentDisposable;
+
+    inspectorStateServiceClient = new InspectorGroupManagerService.Client(parentDisposable) {
+      @Override
+      public void onInspectorAvailabilityChanged() {
+        // The app has terminated or restarted. No way we are still waiting
+        // for a pending hot reload.
+        pendingHotReload = false;
+      }
+
+      @Override
+      public void notifyAppReloaded() {
+        pendingHotReload = false;
+      }
+
+      @Override
+      public void notifyAppRestarted() {
+        pendingHotReload = false;
+      }
+    };
+
+    retryLookupPropertiesRateLimiter = new AsyncRateLimiter(10, () -> {
+      // TODO(jacobr): is this still needed now that we have dealt with timeout
+      // issues by making the analysis server api async?
+      maybeLoadProperties();
+      return CompletableFuture.completedFuture(null);
+    }, parentDisposable);
+
+    inspectorGroupManagerService.addListener(inspectorStateServiceClient, parentDisposable);
+    this.project = project;
+    this.flutterDartAnalysisService = flutterDartAnalysisService;
+    this.showWidgetEditToolbar = showWidgetEditToolbar;
+  }
+
+  /**
+   * Display a popup containing the property editing panel for the specified widget.
+   */
+  public static Balloon showPopup(
+    InspectorGroupManagerService inspectorGroupManagerService,
+    EditorEx editor,
+    DiagnosticsNode node,
+    @NotNull InspectorService.Location location,
+    FlutterDartAnalysisServer service,
+    Point point
+  ) {
+    final Balloon balloon = showPopupHelper(inspectorGroupManagerService, editor.getProject(), node, location, service);
+    if (point != null) {
+      balloon.show(new PropertyBalloonPositionTrackerScreenshot(editor, point), Balloon.Position.below);
+    }
+    else {
+      final int offset = location.getOffset();
+      final TextRange textRange = new TextRange(offset, offset + 1);
+      balloon.show(new PropertyBalloonPositionTracker(editor, textRange), Balloon.Position.below);
+    }
+    return balloon;
+  }
+
+  public static Balloon showPopup(
+    InspectorGroupManagerService inspectorGroupManagerService,
+    Project project,
+    Component component,
+    @Nullable DiagnosticsNode node,
+    @NonNls InspectorService.Location location,
+    FlutterDartAnalysisServer service,
+    Point point
+  ) {
+    final Balloon balloon = showPopupHelper(inspectorGroupManagerService, project, node, location, service);
+    balloon.show(new RelativePoint(component, point), Balloon.Position.above);
+    return balloon;
+  }
+
+  public static Balloon showPopupHelper(
+    InspectorGroupManagerService inspectorService,
+    Project project,
+    @Nullable DiagnosticsNode node,
+    @NotNull InspectorService.Location location,
+    FlutterDartAnalysisServer service
+  ) {
+    final Color GRAPHITE_COLOR = new JBColor(new Color(236, 236, 236, 215), new Color(60, 63, 65, 215));
+
+    final Disposable panelDisposable = Disposer.newDisposable();
+    final PropertyEditorPanel panel =
+      new PropertyEditorPanel(inspectorService, project, service, true, true, panelDisposable);
+
+    final StableWidgetTracker tracker = new StableWidgetTracker(location, service, project, panelDisposable);
+
+    final EventStream<VirtualFile> activeFile = new EventStream<>(location.getFile());
+    panel.initalize(node, tracker.getCurrentOutlines(), activeFile);
+
+    panel.setBackground(GRAPHITE_COLOR);
+    panel.setOpaque(false);
+    final BalloonBuilder balloonBuilder = JBPopupFactory.getInstance().createBalloonBuilder(panel);
+    balloonBuilder.setFadeoutTime(0);
+    balloonBuilder.setFillColor(GRAPHITE_COLOR);
+    balloonBuilder.setAnimationCycle(0);
+    balloonBuilder.setHideOnClickOutside(true);
+    balloonBuilder.setHideOnKeyOutside(false);
+    balloonBuilder.setHideOnAction(false);
+    balloonBuilder.setCloseButtonEnabled(false);
+    balloonBuilder.setBlockClicksThroughBalloon(true);
+    balloonBuilder.setRequestFocus(true);
+    balloonBuilder.setShadow(true);
+    final Balloon balloon = balloonBuilder.createBalloon();
+    Disposer.register(balloon, panelDisposable);
+
+    return balloon;
+  }
+
+  InspectorObjectGroupManager getGroupManager() {
+    return inspectorStateServiceClient.getGroupManager();
+  }
+
+  int getOffset() {
+    if (outline == null) return -1;
+    final VirtualFile file = activeFile.getValue();
+
+    assert (activeFile.getValue() != null);
+    final OutlineOffsetConverter converter = new OutlineOffsetConverter(project, activeFile.getValue());
+    return converter.getConvertedOutlineOffset(outline);
+  }
+
+  InspectorService.Location getInspectorLocation() {
+    final VirtualFile file = activeFile.getValue();
+    if (file == null || outline == null) {
+      return null;
+    }
+
+    final Document document = FileDocumentManager.getInstance().getDocument(file);
+    return InspectorService.Location.outlineToLocation(project, activeFile.getValue(), outline, document);
+  }
+
+  void updateWidgetDescription() {
+    final VirtualFile file = activeFile.getValue();
+    final int offset = getOffset();
+
+    if (file == null ||
+        offset < 0 ||
+        outline == null ||
+        outline.getClassName() == null ||
+        (!FlutterOutlineKind.NEW_INSTANCE.equals(outline.getKind()))) {
+      if (!properties.isEmpty()) {
+        properties.clear();
+        rebuildUi();
+      }
+      return;
+    }
+
+    final CompletableFuture<List<FlutterWidgetProperty>> future =
+      flutterDartAnalysisService.getWidgetDescription(file, offset);
+    propertyFuture = future;
+
+    if (propertyFuture == null) return;
+
+    AsyncUtils.whenCompleteUiThread(propertyFuture, (updatedProperties, throwable) -> {
+      if (propertyFuture != future || updatedProperties == null || throwable != null) {
+        // This response is obsolete as there was a newer request.
+        return;
+      }
+      if (offset != getOffset() || !file.equals(activeFile.getValue())) {
+        return;
+      }
+      properties.clear();
+      properties.addAll(updatedProperties);
+      propertyMap.clear();
+      currentExpressionMap.clear();
+      for (FlutterWidgetProperty property : updatedProperties) {
+        final String name = property.getName();
+        propertyMap.put(name, property);
+        currentExpressionMap.put(name, property.getExpression());
+      }
+
+      if (propertyMap.isEmpty()) {
+        // TODO(jacobr): is this still needed now that we have dealt with timeout
+        // issues by making the analysis server api async?
+        numFailures++;
+        if (numFailures < 3) {
+          retryLookupPropertiesRateLimiter.scheduleRequest();
+        }
+        return;
+      }
+      numFailures = 0;
+      rebuildUi();
+    });
+  }
+
+  public void outlinesChanged(List<FlutterOutline> outlines) {
+    final FlutterOutline nextOutline = outlines.isEmpty() ? null : outlines.get(0);
+    if (nextOutline == outline) return;
+    this.outline = nextOutline;
+    maybeLoadProperties();
+    lookupMatchingElements();
+  }
+
+  public void lookupMatchingElements() {
+    final InspectorObjectGroupManager groupManager = getGroupManager();
+    if (groupManager == null || outline == null) return;
+    groupManager.cancelNext();
+    node = null;
+    final InspectorService.ObjectGroup group = groupManager.getNext();
+    final InspectorService.Location location = getInspectorLocation();
+    group.safeWhenComplete(group.getElementsAtLocation(location, 10), (elements, error) -> {
+      if (elements == null || error != null) {
+        return;
+      }
+      node = elements.isEmpty() ? null : elements.get(0);
+      groupManager.promoteNext();
+    });
+  }
+
+  public DiagnosticsNode getNode() {
+    return node;
+  }
+
+  void maybeLoadProperties() {
+    updateWidgetDescription();
+  }
+
+  public void initalize(
+    DiagnosticsNode node,
+    EventStream<List<FlutterOutline>> currentOutlines,
+    EventStream<VirtualFile> activeFile
+  ) {
+    this.node = node;
+    this.activeFile = activeFile;
+    currentOutlines.listen(this::outlinesChanged, true);
+    if (showWidgetEditToolbar) {
+      final WidgetEditToolbar widgetEditToolbar =
+        new WidgetEditToolbar(true, currentOutlines, activeFile, project, flutterDartAnalysisService);
+      final ActionToolbar toolbar = widgetEditToolbar.getToolbar();
+      toolbar.setShowSeparatorTitles(true);
+      setToolbar(toolbar.getComponent());
+    }
+
+    rebuildUi();
+  }
+
+  protected void rebuildUi() {
+    // TODO(jacobr): be lazier about only rebuilding what changed.
+    final Component focusOwner = KeyboardFocusManager.getCurrentKeyboardFocusManager().getFocusOwner();
+    if (focusOwner != null) {
+      if (isAncestorOf(focusOwner)) {
+        for (Map.Entry<String, JComponent> entry : fields.entrySet()) {
+          if (entry.getValue().isAncestorOf(focusOwner) || entry.getValue() == focusOwner) {
+            previouslyFocusedProperty = entry.getKey();
+            break;
+          }
+        }
+      }
+      else {
+        previouslyFocusedProperty = null;
+      }
+    }
+    removeAll();
+    // Layout Constraints
+    // Column constraints
+    final MigLayout manager = new MigLayout(
+      "insets 3", // Layout Constraints
+      fixedWidth ? "[::120]5[:20:400]" : "[::120]5[grow]", // Column constraints
+      "[23]4[23]"
+    );
+    setLayout(manager);
+    int added = 0;
+    for (FlutterWidgetProperty property : properties) {
+      final String name = property.getName();
+      if (name.startsWith("on") || name.endsWith("Callback")) {
+        continue;
+      }
+      if (name.equals("key")) {
+        continue;
+      }
+      if (name.equals("child") || name.equals("children")) {
+        continue;
+      }
+      if (name.equals("Container")) {
+        final List<FlutterWidgetProperty> containerProperties = property.getChildren();
+        // TODO(jacobr): add support for container properties.
+        continue;
+      }
+      // Text widget properties to demote.
+      if (name.equals("strutStyle") || name.equals("locale") || name.equals("semanticsLabel")) {
+        continue;
+      }
+      final String documentation = property.getDocumentation();
+      JComponent field = null;
+
+      if (property.getEditor() == null) {
+        // TODO(jacobr): detect color properties more robustly.
+        final boolean colorProperty = name.equals("color");
+        final String colorPropertyName = name;
+        if (colorProperty) {
+          field = buildColorProperty(name, property);
+        }
+        else {
+          String expression = property.getExpression();
+          /*if (expression == null || expression.isEmpty()) {
+            continue;
+          }*/
+          if (expression == null) {
+            expression = "";
+          }
+          final JBTextField textField = new JBTextField(expression);
+          addTextFieldListeners(name, textField);
+          field = textField;
+        }
+      }
+      else {
+        final FlutterWidgetPropertyEditor editor = property.getEditor();
+        if (editor.getEnumItems() != null) {
+          final ComboBox<EnumValueWrapper> comboBox = new ComboBox<>();
+          comboBox.setEditable(true);
+          comboBox.setModel(new PropertyEnumComboBoxModel(property));
+
+          // TODO(jacobr): need a bit more padding around comboBox to make it match the JBTextField.
+          field = comboBox;
+          comboBox.addItemListener(e -> {
+            if (e.getStateChange() == ItemEvent.SELECTED) {
+              final EnumValueWrapper wrapper = (EnumValueWrapper)e.getItem();
+              if (wrapper.item != null) {
+                setParsedPropertyValue(name, new FlutterWidgetPropertyValue(null, null, null, null, wrapper.item, null), false);
+              }
+              else {
+                setPropertyValue(name, wrapper.expression);
+              }
+            }
+          });
+        }
+        else {
+          // TODO(jacobr): use IntegerField and friends when appropriate.
+          // TODO(jacobr): we should probably use if (property.isSafeToUpdate())
+          // but that currently it seems to have a bunch of false positives.
+          final String kind = property.getEditor().getKind();
+          if (Objects.equals(kind, FlutterWidgetPropertyEditorKind.BOOL)) {
+            // TODO(jacobr): show as boolean.
+          }
+          final JBTextField textField = new JBTextField(property.getExpression());
+          field = textField;
+          addTextFieldListeners(name, textField);
+        }
+      }
+
+      if (name.equals("data")) {
+        if (documentation != null) {
+          field.setToolTipText(documentation);
+        }
+        else {
+          field.setToolTipText("data");
+        }
+        add(field, "span, growx");
+      }
+      else {
+        final JBLabel label = new JBLabel(property.getName());
+        add(label, "right");
+        if (documentation != null) {
+          label.setToolTipText(documentation);
+        }
+        add(field, "wrap, growx");
+      }
+      if (documentation != null) {
+        field.setToolTipText(documentation);
+      }
+      // Hack: set the preferred width of the ui elements to a small value
+      // so it doesn't cause the overall layout to be wider than it should
+      // be.
+      if (!fixedWidth) {
+        setPreferredFieldSize(field);
+      }
+
+      fields.put(name, field);
+      added++;
+    }
+    if (previouslyFocusedProperty != null && fields.containsKey(previouslyFocusedProperty)) {
+      fields.get(previouslyFocusedProperty).requestFocus();
+    }
+
+    if (added == 0) {
+      add(new JBLabel("No editable properties"));
+    }
+    // TODO(jacobr): why is this needed?
+    revalidate();
+    repaint();
+  }
+
+  private JTextField buildColorProperty(String name, FlutterWidgetProperty property) {
+    return new ColorField(this, name, property, parentDisposable);
+  }
+
+  public void addTextFieldListeners(String name, JBTextField field) {
+    final FlutterOutline matchingOutline = outline;
+    field.addActionListener(e -> setPropertyValue(name, field.getText()));
+    field.addFocusListener(new FocusListener() {
+      @Override
+      public void focusGained(FocusEvent e) {
+      }
+
+      @Override
+      public void focusLost(FocusEvent e) {
+        if (outline != matchingOutline) {
+          // Don't do anything. The user has moved on to a different outline node.
+          return;
+        }
+        setPropertyValue(name, field.getText());
+      }
+    });
+  }
+
+  private void setPreferredFieldSize(JComponent field) {
+    field.setPreferredSize(new Dimension(20, (int)field.getPreferredSize().getHeight()));
+  }
+
+  public String getDescription() {
+    final List<String> parts = new ArrayList<>();
+    if (outline != null && outline.getClassName() != null) {
+      parts.add(outline.getClassName());
+    }
+    parts.add("Properties");
+    return Joiner.on(" ").join(parts);
+  }
+
+  void setPropertyValue(String propertyName, String expression) {
+    setPropertyValue(propertyName, expression, false);
+  }
+
+  void setPropertyValue(String propertyName, String expression, boolean force) {
+    setParsedPropertyValue(propertyName, new FlutterWidgetPropertyValue(null, null, null, null, null, expression), force);
+  }
+
+  private void setParsedPropertyValue(String propertyName, FlutterWidgetPropertyValue value, boolean force) {
+    final boolean updated = setParsedPropertyValueHelper(propertyName, value);
+    if (!updated && force) {
+      hotReload();
+    }
+  }
+
+
+  private boolean setParsedPropertyValueHelper(String propertyName, FlutterWidgetPropertyValue value) {
+    // TODO(jacobr): also do simple tracking of how the previous expression maps to the current expression to avoid spurious edits.
+
+    // Treat an empty expression and empty value objects as omitted values
+    // indicating the property should be removed.
+    final FlutterWidgetPropertyValue emptyValue = new FlutterWidgetPropertyValue(null, null, null, null, null, null);
+
+    final FlutterWidgetProperty property = propertyMap.get(propertyName);
+    if (property == null) {
+      // UI is in the process of updating. Skip this action.
+      return false;
+    }
+
+    if (property.getExpression() != null && property.getExpression().equals(value.getExpression())) {
+      return false;
+    }
+
+    if (value != null && Objects.equals(value.getExpression(), "") || emptyValue.equals(value)) {
+      // Normalize empty expressions to simplify calling this api.
+      value = null;
+    }
+
+    final String lastExpression = currentExpressionMap.get(propertyName);
+    if (lastExpression != null && value != null && lastExpression.equals(value.getExpression())) {
+      return false;
+    }
+    currentExpressionMap.put(propertyName, value != null ? value.getExpression() : null);
+
+    final FlutterWidgetPropertyEditor editor = property.getEditor();
+    if (editor != null && value != null && value.getExpression() != null) {
+      final String expression = value.getExpression();
+      // Normalize expressions as primitive values.
+      final String kind = editor.getKind();
+      switch (kind) {
+        case FlutterWidgetPropertyEditorKind.BOOL: {
+          if (expression.equals("true")) {
+            value = new FlutterWidgetPropertyValue(true, null, null, null, null, null);
+          }
+          else if (expression.equals("false")) {
+            value = new FlutterWidgetPropertyValue(false, null, null, null, null, null);
+          }
+        }
+        break;
+        case FlutterWidgetPropertyEditorKind.STRING: {
+          // TODO(jacobr): there might be non-string literal cases that match this patterned.
+          if (expression.length() >= 2 && (
+            (expression.startsWith("'") && expression.endsWith("'")) ||
+            (expression.startsWith("\"") && expression.endsWith("\"")))) {
+            value = new FlutterWidgetPropertyValue(null, null, null, expression.substring(1, expression.length() - 1), null, null);
+          }
+        }
+        break;
+        case FlutterWidgetPropertyEditorKind.DOUBLE: {
+          try {
+            double doubleValue = Double.parseDouble(expression);
+            if (((double)((int)doubleValue)) == doubleValue) {
+              // Express doubles that can be expressed as ints as ints.
+              value = new FlutterWidgetPropertyValue(null, null, (int)doubleValue, null, null, null);
+            }
+            else {
+              value = new FlutterWidgetPropertyValue(null, doubleValue, null, null, null, null);
+            }
+          }
+          catch (NumberFormatException e) {
+            // Don't convert value.
+          }
+        }
+        break;
+        case FlutterWidgetPropertyEditorKind.INT: {
+          try {
+            int intValue = Integer.parseInt(expression);
+            value = new FlutterWidgetPropertyValue(null, null, intValue, null, null, null);
+          }
+          catch (NumberFormatException e) {
+            // Don't convert value.
+          }
+        }
+        break;
+      }
+    }
+    if (Objects.equals(property.getValue(), value)) {
+      // Short circuit as nothing changed.
+      return false;
+    }
+
+
+    final SourceChange change;
+    try {
+      change = flutterDartAnalysisService.setWidgetPropertyValue(property.getId(), value);
+    }
+    catch (Exception e) {
+      if (value != null && value.getExpression() != null) {
+        FlutterMessages.showInfo("Invalid property value", value.getExpression());
+      }
+      else {
+        FlutterMessages.showError("Unable to set propery value", e.getMessage());
+      }
+      return false;
+    }
+
+    if (change != null && change.getEdits() != null && !change.getEdits().isEmpty()) {
+      // TODO(jacobr): does running a write action make sense here? We are
+      // already on the UI thread.
+      ApplicationManager.getApplication().runWriteAction(() -> {
+        try {
+          AssistUtils.applySourceChange(project, change, false);
+          hotReload();
+        }
+        catch (DartSourceEditException exception) {
+          FlutterMessages.showInfo("Failed to apply code change", exception.getMessage());
+        }
+      });
+      return true;
+    }
+    return false;
+  }
+
+  private void hotReload() {
+    // TODO(jacobr): handle multiple simultaneously running Flutter applications.
+    final FlutterApp app = inspectorStateServiceClient.getApp();
+    if (app != null) {
+      final ArrayList<FlutterApp> apps = new ArrayList<>();
+      apps.add(app);
+      if (pendingHotReload) {
+        // It is important we don't try to trigger multiple hot reloads
+        // as that will result in annoying user visible error messages.
+        needHotReload = true;
+      }
+      else {
+        pendingHotReload = true;
+        needHotReload = false;
+        FlutterReloadManager.getInstance(project).saveAllAndReloadAll(apps, "Property Editor");
+      }
+    }
+  }
+
+  public FlutterOutline getCurrentOutline() {
+    return outline;
+  }
+}
+
+class PropertyBalloonPositionTracker extends PositionTracker<Balloon> {
+  private final Editor myEditor;
+  private final TextRange myRange;
+
+  PropertyBalloonPositionTracker(Editor editor, TextRange range) {
+    super(editor.getContentComponent());
+    myEditor = editor;
+    myRange = range;
+  }
+
+  static boolean insideVisibleArea(Editor e, TextRange r) {
+    final int textLength = e.getDocument().getTextLength();
+    if (r.getStartOffset() > textLength) return false;
+    if (r.getEndOffset() > textLength) return false;
+    final Rectangle visibleArea = e.getScrollingModel().getVisibleArea();
+    final Point point = e.logicalPositionToXY(e.offsetToLogicalPosition(r.getStartOffset()));
+
+    return visibleArea.contains(point);
+  }
+
+  @Override
+  public RelativePoint recalculateLocation(final Balloon balloon) {
+    final int startOffset = myRange.getStartOffset();
+    final int endOffset = myRange.getEndOffset();
+    final Point startPoint = myEditor.visualPositionToXY(myEditor.offsetToVisualPosition(startOffset));
+    final Point endPoint = myEditor.visualPositionToXY(myEditor.offsetToVisualPosition(endOffset));
+    final Point point = new Point((startPoint.x + endPoint.x) / 2, startPoint.y + myEditor.getLineHeight());
+
+    return new RelativePoint(myEditor.getContentComponent(), point);
+  }
+}
+
+class PropertyBalloonPositionTrackerScreenshot extends PositionTracker<Balloon> {
+  private final Editor myEditor;
+  private final Point point;
+
+  PropertyBalloonPositionTrackerScreenshot(Editor editor, Point point) {
+    super(editor.getComponent());
+    myEditor = editor;
+    this.point = point;
+  }
+
+  @Override
+  public RelativePoint recalculateLocation(final Balloon balloon) {
+    return new RelativePoint(myEditor.getComponent(), point);
+  }
+}
+

--- a/src/io/flutter/editor/WidgetEditingContext.java
+++ b/src/io/flutter/editor/WidgetEditingContext.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.editor;
+
+import com.intellij.openapi.project.Project;
+import io.flutter.dart.FlutterDartAnalysisServer;
+import io.flutter.inspector.InspectorGroupManagerService;
+
+/**
+ * Context with references to data useful for widget editing code.
+ */
+public class WidgetEditingContext {
+  public final Project project;
+  public final FlutterDartAnalysisServer flutterDartAnalysisService;
+  public final InspectorGroupManagerService inspectorGroupManagerService;
+  public final EditorPositionService editorPositionService;
+
+  public WidgetEditingContext(
+    Project project,
+    FlutterDartAnalysisServer flutterDartAnalysisService,
+    InspectorGroupManagerService inspectorGroupManagerService,
+    EditorPositionService editorPositionService
+  ) {
+    this.project = project;
+    this.flutterDartAnalysisService = flutterDartAnalysisService;
+    this.inspectorGroupManagerService = inspectorGroupManagerService;
+    this.editorPositionService = editorPositionService;
+  }
+}

--- a/src/io/flutter/editor/WidgetIndentGuideDescriptor.java
+++ b/src/io/flutter/editor/WidgetIndentGuideDescriptor.java
@@ -44,7 +44,7 @@ public class WidgetIndentGuideDescriptor {
     public int getEndOffset() {
       if (marker == null) {
         final Location location = attribute.getValueLocation();
-        final int startOffset = attribute.getValueLocation().getOffset();
+        final int startOffset = location.getOffset();
         final int endOffset = startOffset + location.getLength();
         return endOffset;
       }
@@ -62,7 +62,7 @@ public class WidgetIndentGuideDescriptor {
       // to the column of the actual entity.
       final int docLength = document.getTextLength();
       final Location location = attribute.getValueLocation();
-      final int startOffset = Math.min(attribute.getValueLocation().getOffset(), docLength);
+      final int startOffset = Math.min(location.getOffset(), docLength);
       final int endOffset = Math.min(startOffset + location.getLength(), docLength);
 
       marker = document.createRangeMarker(startOffset, endOffset);

--- a/src/io/flutter/editor/WidgetIndentGuideDescriptor.java
+++ b/src/io/flutter/editor/WidgetIndentGuideDescriptor.java
@@ -6,6 +6,11 @@
 package io.flutter.editor;
 
 import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.editor.RangeMarker;
+import com.intellij.openapi.util.TextRange;
+import org.dartlang.analysis.server.protocol.FlutterOutline;
+import org.dartlang.analysis.server.protocol.FlutterOutlineAttribute;
+import org.dartlang.analysis.server.protocol.Location;
 
 import java.util.ArrayList;
 
@@ -22,6 +27,54 @@ import java.util.ArrayList;
  * edited as there will be a slight delay before new analysis data is available.
  */
 public class WidgetIndentGuideDescriptor {
+  public static class WidgetPropertyDescriptor {
+    private RangeMarker marker;
+    private final FlutterOutlineAttribute attribute;
+
+    WidgetPropertyDescriptor(FlutterOutlineAttribute attribute) {
+      this.attribute = attribute;
+    }
+
+    public String getName() { return attribute.getName();}
+
+    public FlutterOutlineAttribute getAttribute() {
+      return attribute;
+    }
+
+    public int getEndOffset() {
+      if (marker == null) {
+        final Location location = attribute.getValueLocation();
+        final int startOffset = attribute.getValueLocation().getOffset();
+        final int endOffset = startOffset + location.getLength();
+        return endOffset;
+      }
+      return marker.getEndOffset();
+    }
+
+    public void track(Document document) {
+      if (marker != null) {
+        // TODO(jacobr): it does indicate a bit of a logic bug if we are calling this method twice.
+        assert (marker.getDocument() == document);
+        return;
+      }
+
+      // Create a range marker that goes from the start of the indent for the line
+      // to the column of the actual entity.
+      final int docLength = document.getTextLength();
+      final Location location = attribute.getValueLocation();
+      final int startOffset = Math.min(attribute.getValueLocation().getOffset(), docLength);
+      final int endOffset = Math.min(startOffset + location.getLength(), docLength);
+
+      marker = document.createRangeMarker(startOffset, endOffset);
+    }
+
+    public void dispose() {
+      if (marker != null) {
+        marker.dispose();
+      }
+    }
+  }
+
   public final WidgetIndentGuideDescriptor parent;
   public final ArrayList<OutlineLocation> childLines;
   public final OutlineLocation widget;
@@ -29,18 +82,24 @@ public class WidgetIndentGuideDescriptor {
   public final int startLine;
   public final int endLine;
 
-  public WidgetIndentGuideDescriptor(WidgetIndentGuideDescriptor parent,
-                                     int indentLevel,
-                                     int startLine,
-                                     int endLine,
-                                     ArrayList<OutlineLocation> childLines,
-                                     OutlineLocation widget) {
+  public final FlutterOutline outlineNode;
+
+  public WidgetIndentGuideDescriptor(
+    WidgetIndentGuideDescriptor parent,
+    int indentLevel,
+    int startLine,
+    int endLine,
+    ArrayList<OutlineLocation> childLines,
+    OutlineLocation widget,
+    FlutterOutline outlineNode
+  ) {
     this.parent = parent;
     this.childLines = childLines;
     this.widget = widget;
     this.indentLevel = indentLevel;
     this.startLine = startLine;
     this.endLine = endLine;
+    this.outlineNode =  outlineNode;
   }
 
   void dispose() {
@@ -51,6 +110,7 @@ public class WidgetIndentGuideDescriptor {
     for (OutlineLocation childLine : childLines) {
       childLine.dispose();
     }
+
     childLines.clear();
   }
 
@@ -62,7 +122,11 @@ public class WidgetIndentGuideDescriptor {
    * to stop listening for changes to the document once the descriptor is
    * obsolete.
    */
+  boolean tracked = false;
   public void trackLocations(Document document) {
+
+    if (tracked) return;
+    tracked = true;
     if (widget != null) {
       widget.track(document);
     }
@@ -70,6 +134,10 @@ public class WidgetIndentGuideDescriptor {
     for (OutlineLocation childLine : childLines) {
       childLine.track(document);
     }
+  }
+
+  public TextRange getMarker() {
+    return widget.getFullRange();
   }
 
   @Override
@@ -108,7 +176,7 @@ public class WidgetIndentGuideDescriptor {
     }
 
     for (int i = 0; i < childLines.size(); ++i) {
-      if (childLines.get(i).equals(that.childLines.get(i))) {
+      if (!childLines.get(i).equals(that.childLines.get(i))) {
         return false;
       }
     }

--- a/src/io/flutter/editor/WidgetIndentsHighlightingPass.java
+++ b/src/io/flutter/editor/WidgetIndentsHighlightingPass.java
@@ -6,11 +6,13 @@
 
 package io.flutter.editor;
 
+import com.intellij.openapi.Disposable;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.*;
 import com.intellij.openapi.editor.colors.EditorColors;
 import com.intellij.openapi.editor.colors.EditorColorsScheme;
 import com.intellij.openapi.editor.ex.EditorEx;
+import com.intellij.openapi.editor.impl.EditorImpl;
 import com.intellij.openapi.editor.markup.*;
 import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.project.Project;
@@ -18,12 +20,18 @@ import com.intellij.openapi.util.Key;
 import com.intellij.openapi.util.Segment;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiDocumentManager;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
 import com.intellij.ui.Gray;
 import com.intellij.ui.JBColor;
 import com.intellij.ui.paint.LinePainter2D;
 import com.intellij.util.DocumentUtil;
 import com.intellij.util.text.CharArrayUtil;
 import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService;
+import com.jetbrains.lang.dart.psi.DartCallExpression;
+import io.flutter.dart.FlutterDartAnalysisServer;
+import io.flutter.inspector.InspectorGroupManagerService;
 import io.flutter.settings.FlutterSettings;
 import org.dartlang.analysis.server.protocol.FlutterOutline;
 import org.jetbrains.annotations.NotNull;
@@ -77,7 +85,7 @@ import static java.lang.Math.*;
 // in font rendering would make that tricky.
 
 /**
- * A WidgetIndentsHighlightingPass drawsg UI as Code Guides for a code editor using a
+ * A WidgetIndentsHighlightingPass draws UI as Code Guides for a code editor using a
  * FlutterOutline.
  * <p>
  * This class is similar to a TextEditorHighlightingPass but doesn't actually
@@ -245,7 +253,7 @@ public class WidgetIndentsHighlightingPass {
 
       int endLine = doc.getLineNumber(endOffset);
       if (childLines != null && childLines.size() > 0) {
-        final VisualPosition endPositionLastChild = editor.offsetToVisualPosition(childLines.get(childLines.size() - 1).getOffset());
+        final VisualPosition endPositionLastChild = editor.offsetToVisualPosition(childLines.get(childLines.size() - 1).getGuideOffset());
         if (endPositionLastChild.line == endPosition.line) {
           // The last child is on the same line as the end of the block.
           // This happens if code wasn't formatted with flutter style, for example:
@@ -326,7 +334,7 @@ public class WidgetIndentsHighlightingPass {
           if (childLine != null) {
             final int childIndent = childLine.getIndent();
             // Draw horizontal line to the child.
-            final VisualPosition widgetVisualPosition = editor.offsetToVisualPosition(childLine.getOffset());
+            final VisualPosition widgetVisualPosition = editor.offsetToVisualPosition(childLine.getGuideOffset());
             final Point widgetPoint = editor.visualPositionToXY(widgetVisualPosition);
             final int deltaX = widgetPoint.x - start.x;
             // We add a larger amount of panding at the end of the line if the indent is larger up until a max of 6 pixels which is the max
@@ -425,13 +433,30 @@ public class WidgetIndentsHighlightingPass {
   private final Project myProject;
   private final VirtualFile myFile;
   private final boolean convertOffsets;
+  private final PsiFile psiFile;
+  private final EditorMouseEventService editorEventService;
+  private final WidgetEditingContext context;
 
-  WidgetIndentsHighlightingPass(@NotNull Project project, @NotNull EditorEx editor, boolean convertOffsets) {
+  WidgetIndentsHighlightingPass(
+    @NotNull Project project,
+    @NotNull EditorEx editor,
+    boolean convertOffsets,
+    FlutterDartAnalysisServer flutterDartAnalysisService,
+    InspectorGroupManagerService inspectorGroupManagerService,
+    EditorMouseEventService editorEventService,
+    EditorPositionService editorPositionService
+  ) {
     this.myDocument = editor.getDocument();
     this.myEditor = editor;
     this.myProject = project;
     this.myFile = editor.getVirtualFile();
     this.convertOffsets = convertOffsets;
+    this.editorEventService = editorEventService;
+    context = new WidgetEditingContext(
+      project, flutterDartAnalysisService, inspectorGroupManagerService, editorPositionService);
+    psiFile = PsiDocumentManager.getInstance(myProject).getPsiFile(myDocument);
+    final WidgetIndentsPassData data = getIndentsPassData();
+    setIndentsPassData(editor, data);
   }
 
   private static void drawVerticalLineHelper(
@@ -491,6 +516,7 @@ public class WidgetIndentsHighlightingPass {
   }
 
   private static WidgetIndentsPassData getIndentsPassData(Editor editor) {
+    if (editor == null) return null;
     return editor.getUserData(INDENTS_PASS_DATA_KEY);
   }
 
@@ -515,8 +541,24 @@ public class WidgetIndentsHighlightingPass {
     setIndentsPassData(editor, null);
   }
 
-  public static void run(@NotNull Project project, @NotNull EditorEx editor, @NotNull FlutterOutline outline, boolean convertOffsets) {
-    final WidgetIndentsHighlightingPass widgetIndentsHighlightingPass = new WidgetIndentsHighlightingPass(project, editor, convertOffsets);
+  public static void run(@NotNull Project project,
+                         @NotNull EditorEx editor,
+                         @NotNull FlutterOutline outline,
+                         FlutterDartAnalysisServer flutterDartAnalysisService,
+                         InspectorGroupManagerService inspectorGroupManagerService,
+                         EditorMouseEventService editorEventService,
+                         EditorPositionService editorPositionService,
+                         boolean convertOffsets
+  ) {
+    final WidgetIndentsHighlightingPass widgetIndentsHighlightingPass = new WidgetIndentsHighlightingPass(
+      project,
+      editor,
+      convertOffsets,
+      flutterDartAnalysisService,
+      inspectorGroupManagerService,
+      editorEventService,
+      editorPositionService
+    );
     widgetIndentsHighlightingPass.setOutline(outline);
   }
 
@@ -548,6 +590,7 @@ public class WidgetIndentsHighlightingPass {
     doCollectInformationUpdateOutline(data);
     doApplyIndentInformationToEditor(data);
     setIndentsPassData(data);
+    updatePreviewHighlighter(myEditor.getMarkupModel(), data);
   }
 
   private void updateHitTester(WidgetIndentHitTester hitTester, WidgetIndentsPassData data) {
@@ -583,13 +626,17 @@ public class WidgetIndentsHighlightingPass {
         ProgressManager.checkCanceled();
         final TextRange range;
         if (descriptor.widget != null) {
-          range = descriptor.widget.getTextRange();
+          range = descriptor.widget.getFullRange();
         }
         else {
           final int endOffset =
             descriptor.endLine < myDocument.getLineCount() ? myDocument.getLineStartOffset(descriptor.endLine) : myDocument.getTextLength();
           range = new TextRange(myDocument.getLineStartOffset(descriptor.startLine), endOffset);
         }
+        // TODO(jacobr): calling trackLocations multiple times is harmless
+        // but we should still audit where we are calling it so that we
+        // only call it once on each descriptor for typical use cases.
+        descriptor.trackLocations(myDocument);
         ranges.add(new TextRangeDescriptorPair(range, descriptor));
       }
       ranges.sort((a, b) -> Segment.BY_START_OFFSET_THEN_END_OFFSET.compare(a.range, b.range));
@@ -625,7 +672,7 @@ public class WidgetIndentsHighlightingPass {
 
         final int cmp = compare(entry, highlighter);
         if (cmp < 0) {
-          newHighlighters.add(createHighlighter(mm, entry));
+          newHighlighters.add(createHighlighter(mm, entry, data));
           curRange++;
         }
         else if (cmp > 0) {
@@ -646,11 +693,12 @@ public class WidgetIndentsHighlightingPass {
       }
     }
 
+
     final int startRangeIndex = curRange;
     assert myDocument != null;
     DocumentUtil.executeInBulk(myDocument, ranges.size() > 10000, () -> {
       for (int i = startRangeIndex; i < ranges.size(); i++) {
-        newHighlighters.add(createHighlighter(mm, ranges.get(i)));
+        newHighlighters.add(createHighlighter(mm, ranges.get(i), data));
       }
     });
 
@@ -702,6 +750,17 @@ public class WidgetIndentsHighlightingPass {
     return new OutlineLocation(node, line, column, indent, myFile, this);
   }
 
+  DartCallExpression getCallExpression(PsiElement element) {
+    if (element == null) {
+      return null;
+    }
+    if (element instanceof DartCallExpression) {
+      return (DartCallExpression)element;
+    }
+
+    return getCallExpression(element.getParent());
+  }
+
   private void buildWidgetDescriptors(
     final List<WidgetIndentGuideDescriptor> widgetDescriptors,
     FlutterOutline outlineNode,
@@ -710,17 +769,17 @@ public class WidgetIndentsHighlightingPass {
     if (outlineNode == null) return;
 
     final String kind = outlineNode.getKind();
-    final boolean widgetConstructor = "NEW_INSTANCE".equals(kind);
+    final boolean widgetConstructor = "NEW_INSTANCE".equals(kind) || (parent != null && ("VARIABLE".equals(kind)));
 
     final List<FlutterOutline> children = outlineNode.getChildren();
     if (children == null || children.isEmpty()) return;
 
     if (widgetConstructor) {
       final OutlineLocation location = computeLocation(outlineNode);
-
       int minChildIndent = Integer.MAX_VALUE;
       final ArrayList<OutlineLocation> childrenLocations = new ArrayList<>();
       int endLine = location.getLine();
+
       for (FlutterOutline child : children) {
         final OutlineLocation childLocation = computeLocation(child);
         if (childLocation.getLine() <= location.getLine()) {
@@ -735,6 +794,12 @@ public class WidgetIndentsHighlightingPass {
         endLine = max(endLine, childLocation.getLine());
         childrenLocations.add(childLocation);
       }
+      final Set<Integer> childrenOffsets = new HashSet<Integer>();
+      for (OutlineLocation childLocation : childrenLocations) {
+        childrenOffsets.add(childLocation.getGuideOffset());
+      }
+
+      final PsiElement element = psiFile.findElementAt(location.getGuideOffset());
       if (!childrenLocations.isEmpty()) {
         // The indent is only used for sorting and disambiguating descriptors
         // as at render time we will pick the real indent for the outline based
@@ -746,7 +811,8 @@ public class WidgetIndentsHighlightingPass {
           location.getLine(),
           endLine + 1,
           childrenLocations,
-          location
+          location,
+          outlineNode
         );
         if (!descriptor.childLines.isEmpty()) {
           widgetDescriptors.add(descriptor);
@@ -760,7 +826,7 @@ public class WidgetIndentsHighlightingPass {
   }
 
   @NotNull
-  private RangeHighlighter createHighlighter(MarkupModel mm, TextRangeDescriptorPair entry) {
+  private RangeHighlighter createHighlighter(MarkupModel mm, TextRangeDescriptorPair entry, WidgetIndentsPassData data) {
     final TextRange range = entry.range;
     final FlutterSettings settings = FlutterSettings.getInstance();
     if (range.getEndOffset() >= myDocument.getTextLength() && DEBUG_WIDGET_INDENTS) {
@@ -776,42 +842,33 @@ public class WidgetIndentsHighlightingPass {
     highlighter.setCustomRenderer(new WidgetCustomHighlighterRenderer(entry.descriptor, myDocument));
     return highlighter;
   }
-}
 
-/**
- * Data describing widget indents for an editor that is persisted across
- * multiple runs of the WidgetIndentsHighlightingPass.
- */
-class WidgetIndentsPassData {
-  /**
-   * Descriptors describing the data model to render the widget indents.
-   * <p>
-   * This data is computed from the FlutterOutline and contains additional
-   * information to manage how the locations need to be updated to reflect
-   * edits to the documents.
-   */
-  List<WidgetIndentGuideDescriptor> myDescriptors = Collections.emptyList();
+  private void updatePreviewHighlighter(MarkupModel mm, WidgetIndentsPassData data) {
+    final FlutterSettings settings = FlutterSettings.getInstance();
+    if (!settings.isEnableHotUiInCodeEditor()) return;
 
-  /**
-   * Descriptors combined with their current locations in the possibly modified document.
-   */
-  List<TextRangeDescriptorPair> myRangesWidgets = Collections.emptyList();
+    if (data.previewsForEditor == null && myEditor instanceof EditorImpl) {
+      // TODO(jacobr): is there a way to get access to a disposable that will
+      // trigger when the editor disposes than casting to EditorImpl?
 
-  /**
-   * Highlighters that perform the actual rendering of the widget indent
-   * guides.
-   */
-  List<RangeHighlighter> highlighters;
+      final Disposable parentDisposable = ((EditorImpl)myEditor).getDisposable();
 
-  /**
-   * Source of truth for whether other UI overlaps with the widget indents.
-   */
-  WidgetIndentHitTester hitTester;
-
-  /**
-   * Outline the widget indents are based on.
-   */
-  FlutterOutline outline;
+      final TextRange range = new TextRange(0, Integer.MAX_VALUE);
+      final RangeHighlighter highlighter =
+        mm.addRangeHighlighter(
+          0,
+          myDocument.getTextLength(),
+          HighlighterLayer.FIRST,
+          null,
+          HighlighterTargetArea.LINES_IN_RANGE
+        );
+      data.previewsForEditor = new PreviewsForEditor(context, editorEventService, myEditor, parentDisposable);
+      highlighter.setCustomRenderer(data.previewsForEditor);
+    }
+    if (data.previewsForEditor != null) {
+      data.previewsForEditor.outlinesChanged(data.myDescriptors);
+    }
+  }
 }
 
 class TextRangeDescriptorPair {

--- a/src/io/flutter/editor/WidgetIndentsPassData.java
+++ b/src/io/flutter/editor/WidgetIndentsPassData.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.editor;
+
+import com.intellij.openapi.editor.markup.RangeHighlighter;
+import io.flutter.inspector.DiagnosticsNode;
+import io.flutter.inspector.InspectorService;
+import org.dartlang.analysis.server.protocol.FlutterOutline;
+
+import java.awt.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Data describing widget indents for an editor that is persisted across
+ * multiple runs of the WidgetIndentsHighlightingPass.
+ */
+public class WidgetIndentsPassData {
+  public PreviewsForEditor previewsForEditor;
+  /**
+   * Descriptors describing the data model to render the widget indents.
+   * <p>
+   * This data is computed from the FlutterOutline and contains additional
+   * information to manage how the locations need to be updated to reflect
+   * edits to the documents.
+   */
+  java.util.List<WidgetIndentGuideDescriptor> myDescriptors = Collections.emptyList();
+
+  /**
+   * Descriptors combined with their current locations in the possibly modified document.
+   */
+  java.util.List<TextRangeDescriptorPair> myRangesWidgets = Collections.emptyList();
+
+  /**
+   * Highlighters that perform the actual rendering of the widget indent
+   * guides.
+   */
+  List<RangeHighlighter> highlighters;
+
+  /**
+   * Source of truth for whether other UI overlaps with the widget indents.
+   */
+  WidgetIndentHitTester hitTester;
+
+  /**
+   * Outline the widget indents are based on.
+   */
+  FlutterOutline outline;
+}

--- a/src/io/flutter/editor/WidgetViewController.java
+++ b/src/io/flutter/editor/WidgetViewController.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2019 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.editor;
+
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.util.Disposer;
+import io.flutter.inspector.DiagnosticsNode;
+import io.flutter.inspector.InspectorObjectGroupManager;
+import io.flutter.inspector.InspectorService;
+import io.flutter.inspector.InspectorGroupManagerService;
+import io.flutter.run.daemon.FlutterApp;
+
+import java.awt.*;
+import java.util.ArrayList;
+import java.util.Objects;
+
+/**
+ * Base class for a controller managing UI describing a widget.
+ *
+ * See PreviewViewController which extends this class to render previews of
+ * widgets. This class is also intented to be extended to support rendering
+ * visualizations of widget properties inline in a text editor.
+ */
+public abstract class WidgetViewController implements EditorMouseEventService.Listener, Disposable {
+  protected boolean isSelected = false;
+  protected final WidgetViewModelData data;
+
+  protected boolean visible = false;
+
+  Rectangle visibleRect;
+  DiagnosticsNode inspectorSelection;
+
+  final InspectorGroupManagerService.Client groupClient;
+
+  protected abstract void onFlutterFrame();
+
+  public InspectorObjectGroupManager getGroupManagner() {
+    return groupClient.getGroupManager();
+  }
+  public FlutterApp getApp() {
+    return groupClient.getApp();
+  }
+
+  InspectorObjectGroupManager getGroups() {
+    return groupClient.getGroupManager();
+  }
+
+  public ArrayList<DiagnosticsNode> elements;
+  public int activeIndex = 0;
+
+  WidgetViewController(WidgetViewModelData data, Disposable parent) {
+    this.data = data;
+    Disposer.register(parent, this);
+    groupClient = new InspectorGroupManagerService.Client(this) {
+      @Override
+      public void onInspectorAvailabilityChanged() {
+        WidgetViewController.this.onInspectorAvailabilityChanged();
+      }
+
+      @Override
+      public void requestRepaint(boolean force) {
+        onFlutterFrame();
+      }
+
+      @Override
+      public void onFlutterFrame() {
+        WidgetViewController.this.onFlutterFrame();
+      }
+
+      public void onSelectionChanged(DiagnosticsNode selection) {
+        WidgetViewController.this.onSelectionChanged(selection);
+      }
+    };
+    data.context.inspectorGroupManagerService.addListener(groupClient, parent);
+  }
+
+  /**
+   * Subclasses can override this method to be notified when whether the widget is visible in IntelliJ.
+   *
+   * This is whether the UI for this component is visible not whether the widget is visible on the device.
+   */
+  public void onVisibleChanged() {
+  }
+
+  public boolean updateVisiblityLocked(Rectangle newRectangle) { return false; }
+
+  public void onInspectorAvailabilityChanged() {
+    setElements(null);
+    inspectorSelection = null;
+    onVisibleChanged();
+    forceRender();
+  }
+
+  public abstract void forceRender();
+
+  public InspectorService getInspectorService() {
+    return groupClient.getInspectorService();
+  }
+
+  @Override
+  public void dispose() {
+  }
+
+  public void onSelectionChanged(DiagnosticsNode selection) {
+
+    final InspectorObjectGroupManager manager = getGroups();
+    if (manager != null ){
+      manager.cancelNext();;
+    }
+  }
+
+  abstract InspectorService.Location getLocation();
+
+  public boolean isElementsEmpty() {
+    return elements == null || elements.isEmpty();
+  }
+
+  public void setElements(ArrayList<DiagnosticsNode> elements) {
+    this.elements = elements;
+  }
+
+  public void onActiveElementsChanged() {
+    if (isElementsEmpty()) return;
+    final InspectorObjectGroupManager manager = getGroups();
+    if (manager == null) return;
+
+    if (isSelected) {
+      manager.getCurrent().setSelection(
+        getSelectedElement().getValueRef(),
+        false,
+        true
+      );
+    }
+  }
+
+  public DiagnosticsNode getSelectedElement() {
+    if (isElementsEmpty()) return null;
+    return elements.get(0);
+  }
+}

--- a/src/io/flutter/editor/WidgetViewModelData.java
+++ b/src/io/flutter/editor/WidgetViewModelData.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2019 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.editor;
+
+import com.intellij.openapi.editor.markup.RangeHighlighter;
+import com.intellij.openapi.util.TextRange;
+import org.jetbrains.annotations.Nullable;
+
+public class WidgetViewModelData {
+  public final WidgetEditingContext context;
+
+  public WidgetViewModelData(
+    WidgetEditingContext context
+  ) {
+    this.context = context;
+  }
+}

--- a/src/io/flutter/hotui/StableWidgetTracker.java
+++ b/src/io/flutter/hotui/StableWidgetTracker.java
@@ -108,8 +108,9 @@ public class StableWidgetTracker implements Disposable {
     }
     path.add(outline);
     if (converter.getConvertedOutlineOffset(outline) <= offset && offset <= converter.getConvertedOutlineEnd(outline)) {
-      if (outline.getChildren() != null) {
-        for (FlutterOutline child : outline.getChildren()) {
+      final List<FlutterOutline> children = outline.getChildren();
+      if (children != null) {
+        for (FlutterOutline child : children) {
           final boolean foundChild = findOutlineAtOffset(child, offset, path);
           if (foundChild) {
             return true;

--- a/src/io/flutter/hotui/StableWidgetTracker.java
+++ b/src/io/flutter/hotui/StableWidgetTracker.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2019 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.hotui;
+
+import com.google.common.collect.ImmutableList;
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Disposer;
+import com.intellij.openapi.util.io.FileUtil;
+import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService;
+import io.flutter.dart.FlutterDartAnalysisServer;
+import io.flutter.dart.FlutterOutlineListener;
+import io.flutter.inspector.InspectorService;
+import io.flutter.preview.OutlineOffsetConverter;
+import io.flutter.utils.EventStream;
+import org.dartlang.analysis.server.protocol.FlutterOutline;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Class that uses the FlutterOutline to maintain the source location for a
+ * Widget even when code edits that would otherwise confuse location tracking
+ * occur.
+ */
+public class StableWidgetTracker implements Disposable {
+  private final String currentFilePath;
+  private final InspectorService.Location initialLocation;
+  private final FlutterDartAnalysisServer flutterAnalysisServer;
+  private final DartAnalysisServerService analysisServerService;
+
+  private final OutlineOffsetConverter converter;
+  // Path to the current outline
+  private ArrayList<FlutterOutline> lastPath;
+
+  FlutterOutline root;
+
+  private final FlutterOutlineListener outlineListener = new FlutterOutlineListener() {
+    @Override
+    public void outlineUpdated(@NotNull String filePath, @NotNull FlutterOutline outline, @Nullable String instrumentedCode) {
+      if (Objects.equals(currentFilePath, filePath)) {
+        ApplicationManager.getApplication().invokeLater(() -> outlineChanged(outline));
+      }
+    }
+  };
+
+  private void outlineChanged(FlutterOutline outline) {
+    this.root = outline;
+    FlutterOutline match;
+    if (lastPath == null) {
+      // First outline.
+      lastPath = new ArrayList<>();
+      findOutlineAtOffset(root, initialLocation.getOffset(), lastPath);
+    }
+    else {
+      lastPath = findSimilarPath(root, lastPath);
+    }
+    currentOutlines.setValue(lastPath.isEmpty() ? ImmutableList.of() : ImmutableList.of(lastPath.get(lastPath.size() - 1)));
+  }
+
+  private static int findChildIndex(FlutterOutline node, FlutterOutline child) {
+    final List<FlutterOutline> children = node.getChildren();
+    for (int i = 0; i < children.size(); i++) {
+      if (children.get(i) == child) return i;
+    }
+    return -1;
+  }
+
+  private ArrayList<FlutterOutline> findSimilarPath(FlutterOutline root, ArrayList<FlutterOutline> lastPath) {
+    final ArrayList<FlutterOutline> path = new ArrayList<>();
+    FlutterOutline node = root;
+    path.add(node);
+    int i = 1;
+    while (i < lastPath.size() && node != null && !node.getChildren().isEmpty()) {
+      FlutterOutline oldChild = lastPath.get(i);
+      final int expectedIndex = findChildIndex(lastPath.get(i - 1), oldChild);
+      assert (expectedIndex != -1);
+      final List<FlutterOutline> children = node.getChildren();
+      final int index = Math.min(Math.max(0, expectedIndex), children.size());
+      node = children.get(index);
+      if (!Objects.equals(node.getClassName(), oldChild.getClassName()) && node.getChildren().size() == 1) {
+        final FlutterOutline child = node.getChildren().get(0);
+        if (Objects.equals(child.getClassName(), oldChild.getClassName())) {
+          // We have detected that the previous widget was wrapped by a new widget.
+          // Add the wrapping widget to the path and otherwise proceed normally.
+          path.add(node);
+          node = child;
+        }
+      }
+      // TODO(jacobr): consider doing some additional validation that the children have the same class names, etc.
+      // We could use that to be reslient to small changes such as adding a new parent widget, etc.
+      path.add(node);
+      i++;
+    }
+    return path;
+  }
+
+  private boolean findOutlineAtOffset(FlutterOutline outline, int offset, ArrayList<FlutterOutline> path) {
+    if (outline == null) {
+      return false;
+    }
+    path.add(outline);
+    if (converter.getConvertedOutlineOffset(outline) <= offset && offset <= converter.getConvertedOutlineEnd(outline)) {
+      if (outline.getChildren() != null) {
+        for (FlutterOutline child : outline.getChildren()) {
+          final boolean foundChild = findOutlineAtOffset(child, offset, path);
+          if (foundChild) {
+            return true;
+          }
+        }
+      }
+      return true;
+    }
+    path.remove(path.size() - 1);
+    return false;
+  }
+
+  private final EventStream<List<FlutterOutline>> currentOutlines;
+
+  public EventStream<List<FlutterOutline>> getCurrentOutlines() {
+    return currentOutlines;
+  }
+
+  public StableWidgetTracker(
+    InspectorService.Location initialLocation,
+    FlutterDartAnalysisServer flutterAnalysisServer,
+    Project project,
+    Disposable parentDisposable
+  ) {
+    Disposer.register(parentDisposable, this);
+    converter = new OutlineOffsetConverter(project, initialLocation.getFile());
+    currentOutlines = new EventStream<>(ImmutableList.of());
+    this.flutterAnalysisServer = flutterAnalysisServer;
+    this.initialLocation = initialLocation;
+    analysisServerService = DartAnalysisServerService.getInstance(project);
+    currentFilePath = FileUtil.toSystemDependentName(initialLocation.getFile().getPath());
+    flutterAnalysisServer.addOutlineListener(currentFilePath, outlineListener);
+  }
+
+  @Override
+  public void dispose() {
+    flutterAnalysisServer.removeOutlineListener(currentFilePath, outlineListener);
+  }
+
+  public boolean isValid() {
+    return !getCurrentOutlines().getValue().isEmpty();
+  }
+
+  public int getOffset() {
+    final List<FlutterOutline> outlines = getCurrentOutlines().getValue();
+    if (outlines.isEmpty()) return 0;
+    final FlutterOutline outline = outlines.get(0);
+    return converter.getConvertedOutlineOffset(outline);
+  }
+}

--- a/src/io/flutter/inspector/DiagnosticsNode.java
+++ b/src/io/flutter/inspector/DiagnosticsNode.java
@@ -886,7 +886,7 @@ public class DiagnosticsNode {
       if (service == null) {
         return;
       }
-      service.setSelection(ref, uiAlreadyUpdated);
+      service.setSelection(ref, uiAlreadyUpdated, false);
     });
   }
 }

--- a/src/io/flutter/inspector/InspectorService.java
+++ b/src/io/flutter/inspector/InspectorService.java
@@ -341,10 +341,10 @@ public class InspectorService implements Disposable {
     return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
   }
 
-  private void notifySelectionChanged() {
+  private void notifySelectionChanged(boolean uiAlreadyUpdated, boolean textEditorUpdated) {
     ApplicationManager.getApplication().invokeLater(() -> {
       for (InspectorServiceClient client : clients) {
-        client.onInspectorSelectionChanged(false, false);
+        client.onInspectorSelectionChanged(uiAlreadyUpdated, textEditorUpdated);
       }
     });
   }
@@ -366,9 +366,9 @@ public class InspectorService implements Disposable {
 
           // We create a dummy object group as this particular operation
           // doesn't actually require an object group.
-          createObjectGroup("dummy").setSelection(event.getInspectee(), true);
+          createObjectGroup("dummy").setSelection(event.getInspectee(), true, true);
           // Update the UI in IntelliJ.
-          notifySelectionChanged();
+          notifySelectionChanged(false, false);
         }
         break;
       }
@@ -1339,7 +1339,7 @@ public class InspectorService implements Disposable {
       });
     }
 
-    public void setSelection(InspectorInstanceRef selection, boolean uiAlreadyUpdated) {
+    public void setSelection(InspectorInstanceRef selection, boolean uiAlreadyUpdated, boolean textEditorUpdated) {
       if (disposed) {
         return;
       }
@@ -1347,42 +1347,62 @@ public class InspectorService implements Disposable {
         return;
       }
       if (useServiceExtensionApi()) {
-        handleSetSelectionDaemon(invokeVmServiceExtension("setSelectionById", selection), uiAlreadyUpdated);
+        handleSetSelectionDaemon(invokeVmServiceExtension("setSelectionById", selection), uiAlreadyUpdated, textEditorUpdated);
       }
       else {
-        handleSetSelectionVmService(invokeEval("setSelectionById", selection), uiAlreadyUpdated);
+        handleSetSelectionVmService(invokeEval("setSelectionById", selection), uiAlreadyUpdated, textEditorUpdated);
       }
+    }
+
+    public void setSelection(Location location, boolean uiAlreadyUpdated, boolean textEditorUpdated) {
+      if (disposed) {
+        return;
+      }
+      if (location == null) {
+        return;
+      }
+      if (useServiceExtensionApi()) {
+        JsonObject params = new JsonObject();
+        addLocationToParams(location, params);
+        handleSetSelectionDaemon(invokeVmServiceExtension("setSelectionByLocation", params), uiAlreadyUpdated, textEditorUpdated);
+      }
+      // skip if the vm service is expected to be used directly.
     }
 
     /**
      * Helper when we need to set selection given an VM Service InstanceRef
      * instead of an InspectorInstanceRef.
      */
-    public void setSelection(InstanceRef selection, boolean uiAlreadyUpdated) {
+    public void setSelection(InstanceRef selection, boolean uiAlreadyUpdated, boolean textEditorUpdated) {
       // There is no excuse for calling setSelection using a disposed ObjectGroup.
       assert (!disposed);
       // This call requires the VM Service protocol as an VM Service InstanceRef is specified.
-      handleSetSelectionVmService(invokeServiceMethodOnRefEval("setSelection", selection), uiAlreadyUpdated);
+      handleSetSelectionVmService(invokeServiceMethodOnRefEval("setSelection", selection), uiAlreadyUpdated, textEditorUpdated);
     }
 
-    private void handleSetSelectionVmService(CompletableFuture<InstanceRef> setSelectionResult, boolean uiAlreadyUpdated) {
+    private void handleSetSelectionVmService(CompletableFuture<InstanceRef> setSelectionResult,
+                                             boolean uiAlreadyUpdated,
+                                             boolean textEditorUpdated) {
       // TODO(jacobr): we need to cancel if another inspect request comes in while we are trying this one.
       skipIfDisposed(() -> setSelectionResult.thenAcceptAsync((InstanceRef instanceRef) -> skipIfDisposed(() -> {
-        handleSetSelectionHelper("true".equals(instanceRef.getValueAsString()), uiAlreadyUpdated);
+        handleSetSelectionHelper("true".equals(instanceRef.getValueAsString()), uiAlreadyUpdated, textEditorUpdated);
       })));
     }
 
-    private void handleSetSelectionHelper(boolean selectionChanged, boolean uiAlreadyUpdated) {
-      if (selectionChanged && !uiAlreadyUpdated) {
-        notifySelectionChanged();
+    private void handleSetSelectionHelper(boolean selectionChanged, boolean uiAlreadyUpdated, boolean textEditorUpdated) {
+      if (selectionChanged) {
+        notifySelectionChanged(uiAlreadyUpdated, textEditorUpdated);
       }
     }
 
-    private void handleSetSelectionDaemon(CompletableFuture<JsonElement> setSelectionResult, boolean uiAlreadyUpdated) {
+    private void handleSetSelectionDaemon(CompletableFuture<JsonElement> setSelectionResult,
+                                          boolean uiAlreadyUpdated,
+                                          boolean textEditorUpdated) {
       skipIfDisposed(() ->
                        // TODO(jacobr): we need to cancel if another inspect request comes in while we are trying this one.
                        setSelectionResult.thenAcceptAsync(
-                         (JsonElement json) -> skipIfDisposed(() -> handleSetSelectionHelper(json.getAsBoolean(), uiAlreadyUpdated)))
+                         (JsonElement json) -> skipIfDisposed(
+                           () -> handleSetSelectionHelper(json.getAsBoolean(), uiAlreadyUpdated, textEditorUpdated)))
       );
     }
 

--- a/src/io/flutter/preview/OutlineOffsetConverter.java
+++ b/src/io/flutter/preview/OutlineOffsetConverter.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.preview;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService;
+import org.dartlang.analysis.server.protocol.FlutterOutline;
+
+public class OutlineOffsetConverter {
+  private final VirtualFile currentFile;
+  private final Project project;
+  public OutlineOffsetConverter(Project project, VirtualFile currentFile) {
+    this.project = project;
+    this.currentFile = currentFile;
+  }
+
+  public int getConvertedFileOffset(int offset) {
+    return DartAnalysisServerService.getInstance(project).getConvertedOffset(currentFile, offset);
+  }
+
+  public int getConvertedOutlineOffset(FlutterOutline outline) {
+    final int offset = outline.getOffset();
+    return getConvertedFileOffset(offset);
+  }
+
+  public int getConvertedOutlineEnd(FlutterOutline outline) {
+    final int end = outline.getOffset() + outline.getLength();
+    return getConvertedFileOffset(end);
+  }
+
+  // TODO(jacobr): move this method to a different class or rename this class.
+  public FlutterOutline findOutlineAtOffset(FlutterOutline outline, int offset) {
+    if (outline == null) {
+      return null;
+    }
+    if (getConvertedOutlineOffset(outline) <= offset && offset <= getConvertedOutlineEnd(outline)) {
+      if (outline.getChildren() != null) {
+        for (FlutterOutline child : outline.getChildren()) {
+          final FlutterOutline foundChild = findOutlineAtOffset(child, offset);
+          if (foundChild != null) {
+            return foundChild;
+          }
+        }
+      }
+      return outline;
+    }
+    return null;
+  }
+}

--- a/src/io/flutter/preview/PreviewArea.java
+++ b/src/io/flutter/preview/PreviewArea.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2019 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.preview;
+
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.actionSystem.*;
+import com.intellij.openapi.actionSystem.ex.CustomComponentAction;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.SimpleToolWindowPanel;
+import com.intellij.ui.components.JBLabel;
+import com.intellij.util.ui.JBUI;
+import com.intellij.util.ui.UIUtil;
+import io.flutter.dart.FlutterDartAnalysisServer;
+import io.flutter.editor.*;
+import io.flutter.inspector.InspectorService;
+import io.flutter.inspector.InspectorGroupManagerService;
+import org.dartlang.analysis.server.protocol.FlutterOutline;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.ComponentAdapter;
+import java.awt.event.ComponentEvent;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Class that manages displaying the DeviceMirror.
+ */
+public class PreviewArea {
+  public static int BORDER_WIDTH = 0;
+
+  private final DefaultActionGroup toolbarGroup = new DefaultActionGroup();
+  private final ActionToolbar windowToolbar;
+
+  private final SimpleToolWindowPanel window;
+
+  private final JLayeredPane layeredPanel = new JLayeredPane();
+  private final JPanel deviceMirrorPanel;
+
+  private final PreviewViewController preview;
+  private final WidgetEditingContext context;
+  private final Set<FlutterOutline> outlinesWithWidgets;
+
+  private final InspectorGroupManagerService.Client inspectorClient;
+
+  public PreviewArea(Project project, Set<FlutterOutline> outlinesWithWidgets, Disposable parent) {
+    this.outlinesWithWidgets = outlinesWithWidgets;
+
+    context = new WidgetEditingContext(
+      project,
+      FlutterDartAnalysisServer.getInstance(project),
+      InspectorGroupManagerService.getInstance(project),
+      EditorPositionService.getInstance(project)
+    );
+
+    inspectorClient = new InspectorGroupManagerService.Client(parent);
+    context.inspectorGroupManagerService.addListener(inspectorClient, parent);
+    preview = new PreviewViewController(new WidgetViewModelData(context), false, layeredPanel, parent);
+
+    deviceMirrorPanel = new PreviewViewModelPanel(preview);
+
+    windowToolbar = ActionManager.getInstance().createActionToolbar("PreviewArea", toolbarGroup, true);
+    toolbarGroup.add(new TitleAction("Device Mirror"));
+
+    window = new SimpleToolWindowPanel(true, true);
+    window.setToolbar(windowToolbar.getComponent());
+
+    deviceMirrorPanel.setLayout(new BorderLayout());
+
+    // TODO(jacobr): reafactor to remove the layeredPanel as we aren't getting any benefit from it.
+    window.setContent(layeredPanel);
+    layeredPanel.add(deviceMirrorPanel, Integer.valueOf(0));
+
+    // Layers should cover the whole root panel.
+    layeredPanel.addComponentListener(new ComponentAdapter() {
+      @Override
+      public void componentResized(ComponentEvent e) {
+        final Dimension renderSize = getRenderSize();
+        preview.setScreenshotBounds(new Rectangle(0, 0, renderSize.width, renderSize.height));
+      }
+    });
+  }
+
+  /**
+   * Return the Swing component of the area.
+   */
+  public JComponent getComponent() {
+    return window;
+  }
+
+  public void select(@NotNull List<FlutterOutline> outlines, Editor editor) {
+    if (editor.isDisposed()) return;
+
+    final InspectorService.ObjectGroup group = getObjectGroup();
+    if (group != null && outlines.size() > 0) {
+      FlutterOutline outline = findWidgetToHighlight(outlines.get(0));
+      if (outline == null) return;
+      final InspectorService.Location location = InspectorService.Location.outlineToLocation(editor, outline);
+      if (location == null) return;
+      group.setSelection(location, false, true);
+    }
+  }
+
+  /**
+   * Find the first descendant of the outline that is a widget as long as there
+   * is only one path down the tree that leeds to a widget.
+   */
+  private FlutterOutline findWidgetToHighlight(FlutterOutline outline) {
+    if (outline == null || outline.getClassName() != null) return outline;
+    if (!outlinesWithWidgets.contains(outline)) return null;
+    FlutterOutline candidate = null;
+    for (FlutterOutline child : outline.getChildren()) {
+      if (outlinesWithWidgets.contains(child)) {
+        if (candidate != null) {
+          // It is ambiguous which candidate to show so don't show anything.
+          // TODO(jacobr): consider showing multiple locations instead if the
+          // inspector on device protocol is enhanced to support that.
+          return null;
+        }
+        candidate = findWidgetToHighlight(child);
+      }
+    }
+    return candidate;
+  }
+
+  public Dimension getRenderSize() {
+    final int width = layeredPanel.getWidth();
+    final int height = layeredPanel.getHeight();
+    for (Component child : layeredPanel.getComponents()) {
+      child.setBounds(0, 0, width, height);
+    }
+
+    final int renderWidth = width - 2 * BORDER_WIDTH;
+    final int renderHeight = height - 2 * BORDER_WIDTH;
+    return new Dimension(renderWidth, renderHeight);
+  }
+
+  InspectorService.ObjectGroup getObjectGroup() {
+    return inspectorClient.getCurrentObjectGroup();
+  }
+}
+
+class TitleAction extends AnAction implements CustomComponentAction {
+  TitleAction(String text) {
+    super(text);
+  }
+
+  @Override
+  public void actionPerformed(@NotNull AnActionEvent event) {
+  }
+
+  @Override
+  public JComponent createCustomComponent(Presentation presentation) {
+    final JPanel panel = new JPanel(new BorderLayout());
+
+    // Add left border to make the title look similar to the tool window title.
+    panel.setBorder(BorderFactory.createEmptyBorder(0, JBUI.scale(3), 0, 0));
+
+    final String text = getTemplatePresentation().getText();
+    panel.add(new JBLabel(text != null ? text : "", UIUtil.ComponentStyle.SMALL));
+
+    return panel;
+  }
+}

--- a/src/io/flutter/preview/PreviewView.java
+++ b/src/io/flutter/preview/PreviewView.java
@@ -5,18 +5,16 @@
  */
 package io.flutter.preview;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import com.google.common.util.concurrent.Uninterruptibles;
 import com.intellij.icons.AllIcons;
 import com.intellij.ide.CommonActionsManager;
-import com.intellij.ide.DataManager;
 import com.intellij.ide.DefaultTreeExpander;
 import com.intellij.ide.TreeExpander;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.actionSystem.*;
 import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.application.TransactionGuard;
 import com.intellij.openapi.components.PersistentStateComponent;
 import com.intellij.openapi.components.Storage;
 import com.intellij.openapi.editor.Caret;
@@ -26,6 +24,8 @@ import com.intellij.openapi.editor.event.CaretListener;
 import com.intellij.openapi.fileEditor.*;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.SimpleToolWindowPanel;
+import com.intellij.openapi.ui.Splitter;
+import com.intellij.openapi.ui.popup.Balloon;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -38,18 +38,15 @@ import com.intellij.ui.content.ContentManager;
 import com.intellij.ui.speedSearch.SpeedSearchUtil;
 import com.intellij.ui.treeStructure.Tree;
 import com.intellij.util.messages.MessageBusConnection;
-import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService;
-import com.jetbrains.lang.dart.assists.AssistUtils;
-import com.jetbrains.lang.dart.assists.DartSourceEditException;
-import icons.FlutterIcons;
 import io.flutter.FlutterInitializer;
-import io.flutter.FlutterMessages;
 import io.flutter.FlutterUtils;
 import io.flutter.dart.FlutterDartAnalysisServer;
 import io.flutter.dart.FlutterOutlineListener;
-import io.flutter.inspector.FlutterWidget;
+import io.flutter.editor.PropertyEditorPanel;
+import io.flutter.inspector.*;
 import io.flutter.settings.FlutterSettings;
 import io.flutter.utils.CustomIconMaker;
+import io.flutter.utils.EventStream;
 import org.dartlang.analysis.server.protocol.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -57,22 +54,22 @@ import org.jetbrains.annotations.Nullable;
 import javax.swing.*;
 import javax.swing.event.TreeSelectionEvent;
 import javax.swing.event.TreeSelectionListener;
-import javax.swing.tree.DefaultMutableTreeNode;
-import javax.swing.tree.DefaultTreeModel;
-import javax.swing.tree.TreeNode;
-import javax.swing.tree.TreePath;
+import javax.swing.tree.*;
 import java.awt.*;
+import java.awt.event.KeyEvent;
+import java.awt.event.KeyListener;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
 import java.util.List;
 import java.util.*;
-import java.util.concurrent.TimeUnit;
 
 @com.intellij.openapi.components.State(
   name = "FlutterPreviewView",
   storages = {@Storage("$WORKSPACE_FILE$")}
 )
-public class PreviewView implements PersistentStateComponent<PreviewViewState>, Disposable {
+public class PreviewView implements PersistentStateComponent<PreviewViewState> {
   public static final String TOOL_WINDOW_ID = "Flutter Outline";
 
   @NotNull
@@ -84,35 +81,30 @@ public class PreviewView implements PersistentStateComponent<PreviewViewState>, 
   @NotNull
   private final FlutterDartAnalysisServer flutterAnalysisServer;
 
-  final QuickAssistAction actionCenter;
-  final QuickAssistAction actionPadding;
-  final QuickAssistAction actionColumn;
-  final QuickAssistAction actionRow;
-  final QuickAssistAction actionContainer;
-  final QuickAssistAction actionMoveUp;
-  final QuickAssistAction actionMoveDown;
-  final QuickAssistAction actionRemove;
-  final ExtractMethodAction actionExtractMethod;
-  final ExtractWidgetAction actionExtractWidget;
+  private final InspectorGroupManagerService inspectorGroupManagerService;
+  private final InspectorGroupManagerService.Client inspectorStateServiceClient;
 
   private SimpleToolWindowPanel windowPanel;
-  private ActionToolbar windowToolbar;
 
-  private final Map<String, AnAction> messageToActionMap = new HashMap<>();
-  private final Map<AnAction, SourceChange> actionToChangeMap = new HashMap<>();
-
+  private boolean isSettingSplitterProportion = false;
+  private Splitter splitter;
+  private Splitter propertyEditSplitter;
   private JScrollPane scrollPane;
+  private JScrollPane propertyScrollPane;
   private OutlineTree tree;
+  private PreviewArea previewArea;
 
   private final Set<FlutterOutline> outlinesWithWidgets = Sets.newHashSet();
   private final Map<FlutterOutline, DefaultMutableTreeNode> outlineToNodeMap = Maps.newHashMap();
 
-  private VirtualFile currentFile;
+  private final EventStream<VirtualFile> currentFile;
   private String currentFilePath;
   FileEditor currentFileEditor;
   private Editor currentEditor;
   private FlutterOutline currentOutline;
+  private final EventStream<List<FlutterOutline>> activeOutlines;
 
+  private final WidgetEditToolbar widgetEditToolbar;
   private final FlutterOutlineListener outlineListener = new FlutterOutlineListener() {
     @Override
     public void outlineUpdated(@NotNull String filePath, @NotNull FlutterOutline outline, @Nullable String instrumentedCode) {
@@ -141,11 +133,24 @@ public class PreviewView implements PersistentStateComponent<PreviewViewState>, 
   };
 
   private final TreeSelectionListener treeSelectionListener = this::handleTreeSelectionEvent;
+  private PropertyEditorPanel propertyEditPanel;
+  private DefaultActionGroup propertyEditToolbarGroup;
+
+  private void minimizePreviewArea() {
+    // TODO(devoncarew): We should size the preview area to a fixed, smaller size (based on the largest
+    //                   non-preview sized content).
+    setSplitterProportion(0.85f);
+  }
 
   public PreviewView(@NotNull Project project) {
     this.project = project;
-
+    currentFile = new EventStream<>();
+    activeOutlines = new EventStream<>(ImmutableList.of());
     flutterAnalysisServer = FlutterDartAnalysisServer.getInstance(project);
+
+    inspectorGroupManagerService = InspectorGroupManagerService.getInstance(project);
+    inspectorStateServiceClient = new InspectorGroupManagerService.Client(project);
+    inspectorGroupManagerService.addListener(inspectorStateServiceClient, project);
 
     // Show preview for the file selected when the view is being opened.
     final VirtualFile[] selectedFiles = FileEditorManager.getInstance(project).getSelectedFiles();
@@ -168,20 +173,13 @@ public class PreviewView implements PersistentStateComponent<PreviewViewState>, 
       }
     });
 
-    actionCenter = new QuickAssistAction("dart.assist.flutter.wrap.center", FlutterIcons.Center, "Wrap with Center");
-    actionPadding = new QuickAssistAction("dart.assist.flutter.wrap.padding", FlutterIcons.Padding, "Wrap with Padding");
-    actionColumn = new QuickAssistAction("dart.assist.flutter.wrap.column", FlutterIcons.Column, "Wrap with Column");
-    actionRow = new QuickAssistAction("dart.assist.flutter.wrap.row", FlutterIcons.Row, "Wrap with Row");
-    actionContainer = new QuickAssistAction("dart.assist.flutter.wrap.container", FlutterIcons.Container, "Wrap with Container");
-    actionMoveUp = new QuickAssistAction("dart.assist.flutter.move.up", FlutterIcons.Up, "Move widget up");
-    actionMoveDown = new QuickAssistAction("dart.assist.flutter.move.down", FlutterIcons.Down, "Move widget down");
-    actionRemove = new QuickAssistAction("dart.assist.flutter.removeWidget", FlutterIcons.RemoveWidget, "Remove this widget");
-    actionExtractMethod = new ExtractMethodAction();
-    actionExtractWidget = new ExtractWidgetAction();
-  }
-
-  @Override
-  public void dispose() {
+    widgetEditToolbar = new WidgetEditToolbar(
+      FlutterSettings.getInstance().isEnableHotUi(),
+      activeOutlines,
+      currentFile,
+      project,
+      flutterAnalysisServer
+    );
   }
 
   @NotNull
@@ -199,28 +197,13 @@ public class PreviewView implements PersistentStateComponent<PreviewViewState>, 
     final ContentFactory contentFactory = ContentFactory.SERVICE.getInstance();
     final ContentManager contentManager = toolWindow.getContentManager();
 
-    final DefaultActionGroup toolbarGroup = new DefaultActionGroup();
-    toolbarGroup.add(actionCenter);
-    toolbarGroup.add(actionPadding);
-    toolbarGroup.add(actionColumn);
-    toolbarGroup.add(actionRow);
-    toolbarGroup.add(actionContainer);
-    toolbarGroup.addSeparator();
-    toolbarGroup.add(actionExtractMethod);
-    toolbarGroup.addSeparator();
-    toolbarGroup.add(actionMoveUp);
-    toolbarGroup.add(actionMoveDown);
-    toolbarGroup.addSeparator();
-    toolbarGroup.add(actionRemove);
-
     final Content content = contentFactory.createContent(null, null, false);
     content.setCloseable(false);
 
     windowPanel = new OutlineComponent(this);
     content.setComponent(windowPanel);
 
-    windowToolbar = ActionManager.getInstance().createActionToolbar("PreviewViewToolbar", toolbarGroup, true);
-    windowPanel.setToolbar(windowToolbar.getComponent());
+    windowPanel.setToolbar(widgetEditToolbar.getToolbar().getComponent());
 
     final DefaultMutableTreeNode rootNode = new DefaultMutableTreeNode();
 
@@ -276,11 +259,43 @@ public class PreviewView implements PersistentStateComponent<PreviewViewState>, 
     tree.addTreeSelectionListener(treeSelectionListener);
 
     scrollPane = ScrollPaneFactory.createScrollPane(tree);
-    windowPanel.setContent(scrollPane);
     content.setPreferredFocusableComponent(tree);
 
     contentManager.addContent(content);
     contentManager.setSelectedContent(content);
+
+    previewArea = new PreviewArea(project, outlinesWithWidgets, project);
+
+    splitter = new Splitter(true);
+    setSplitterProportion(getState().getSplitterProportion());
+    getState().addListener(e -> {
+      final float newProportion = getState().getSplitterProportion();
+      if (splitter.getProportion() != newProportion) {
+        setSplitterProportion(newProportion);
+      }
+    });
+    //noinspection Convert2Lambda
+    splitter.addPropertyChangeListener("proportion", new PropertyChangeListener() {
+      @Override
+      public void propertyChange(PropertyChangeEvent evt) {
+        if (!isSettingSplitterProportion) {
+          getState().setSplitterProportion(splitter.getProportion());
+        }
+      }
+    });
+    scrollPane.setMinimumSize(new Dimension(1, 1));
+    splitter.setFirstComponent(scrollPane);
+    windowPanel.setContent(splitter);
+  }
+
+  private InspectorService.ObjectGroup objectGroup;
+
+  InspectorService.ObjectGroup getObjectGroup() {
+    final InspectorObjectGroupManager groupManager = inspectorStateServiceClient.getGroupManager();
+    if (groupManager == null) {
+      return null;
+    }
+    return groupManager.getCurrent();
   }
 
   private void initTreePopup() {
@@ -297,68 +312,13 @@ public class PreviewView implements PersistentStateComponent<PreviewViewState>, 
           }
         }
 
-        // The corresponding tree item has just been selected.
-        // Wait short time for receiving assists from the server.
-        for (int i = 0; i < 20 && actionToChangeMap.isEmpty(); i++) {
-          Uninterruptibles.sleepUninterruptibly(5, TimeUnit.MILLISECONDS);
-        }
-
-        final DefaultActionGroup group = new DefaultActionGroup();
-        boolean hasAction = false;
-        if (actionCenter.isEnabled()) {
-          hasAction = true;
-          group.add(new TextOnlyActionWrapper(actionCenter));
-        }
-        if (actionPadding.isEnabled()) {
-          hasAction = true;
-          group.add(new TextOnlyActionWrapper(actionPadding));
-        }
-        if (actionColumn.isEnabled()) {
-          hasAction = true;
-          group.add(new TextOnlyActionWrapper(actionColumn));
-        }
-        if (actionRow.isEnabled()) {
-          hasAction = true;
-          group.add(new TextOnlyActionWrapper(actionRow));
-        }
-        if (actionContainer.isEnabled()) {
-          hasAction = true;
-          group.add(new TextOnlyActionWrapper(actionContainer));
-        }
-        group.addSeparator();
-        if (actionExtractMethod.isEnabled()) {
-          hasAction = true;
-          group.add(new TextOnlyActionWrapper(actionExtractMethod));
-        }
-        if (actionExtractWidget.isEnabled()) {
-          hasAction = true;
-          group.add(new TextOnlyActionWrapper(actionExtractWidget));
-        }
-        group.addSeparator();
-        if (actionMoveUp.isEnabled()) {
-          hasAction = true;
-          group.add(new TextOnlyActionWrapper(actionMoveUp));
-        }
-        if (actionMoveDown.isEnabled()) {
-          hasAction = true;
-          group.add(new TextOnlyActionWrapper(actionMoveDown));
-        }
-        group.addSeparator();
-        if (actionRemove.isEnabled()) {
-          hasAction = true;
-          group.add(new TextOnlyActionWrapper(actionRemove));
-        }
-
-        // Don't show the empty popup.
-        if (!hasAction) {
-          return;
-        }
-
-        final ActionManager actionManager = ActionManager.getInstance();
-        final ActionPopupMenu popupMenu = actionManager.createActionPopupMenu(ActionPlaces.UNKNOWN, group);
-        popupMenu.getComponent().show(comp, x, y);
+        widgetEditToolbar.createPopupMenu(comp, x, y);
       }
     });
+  }
+
+  private OutlineOffsetConverter getOutlineOffsetConverter() {
+    return new OutlineOffsetConverter(project, currentFile.getValue());
   }
 
   private void handleTreeSelectionEvent(TreeSelectionEvent e) {
@@ -367,8 +327,7 @@ public class PreviewView implements PersistentStateComponent<PreviewViewState>, 
       ApplicationManager.getApplication().invokeLater(() -> selectPath(selectionPath, false));
     }
 
-    final List<FlutterOutline> selectedOutlines = getOutlinesSelectedInTree();
-    updateActionsForOutlines(selectedOutlines);
+    activeOutlines.setValue(getOutlinesSelectedInTree());
   }
 
   private void selectPath(TreePath selectionPath, boolean focusEditor) {
@@ -381,57 +340,22 @@ public class PreviewView implements PersistentStateComponent<PreviewViewState>, 
       return;
     }
     final int offset = outline.getDartElement() != null ? outline.getDartElement().getLocation().getOffset() : outline.getOffset();
-    final int editorOffset = getConvertedFileOffset(offset);
+    final int editorOffset = getOutlineOffsetConverter().getConvertedFileOffset(offset);
 
     sendAnalyticEvent("jumpToSource");
 
     if (currentFile != null) {
       currentEditor.getCaretModel().removeCaretListener(caretListener);
       try {
-        new OpenFileDescriptor(project, currentFile, editorOffset).navigate(focusEditor);
+        new OpenFileDescriptor(project, currentFile.getValue(), editorOffset).navigate(focusEditor);
       }
       finally {
         currentEditor.getCaretModel().addCaretListener(caretListener);
       }
     }
-  }
 
-  private void updateActionsForOutlines(List<FlutterOutline> outlines) {
-    synchronized (actionToChangeMap) {
-      actionToChangeMap.clear();
-    }
-
-    final VirtualFile selectionFile = this.currentFile;
-    if (selectionFile != null && !outlines.isEmpty()) {
-      ApplicationManager.getApplication().executeOnPooledThread(() -> {
-        final FlutterOutline firstOutline = outlines.get(0);
-        final FlutterOutline lastOutline = outlines.get(outlines.size() - 1);
-        final int offset = getConvertedOutlineOffset(firstOutline);
-        final int length = getConvertedOutlineEnd(lastOutline) - offset;
-        final List<SourceChange> changes = flutterAnalysisServer.edit_getAssists(selectionFile, offset, length);
-
-        // If the current file or outline are different, ignore the changes.
-        // We will eventually get new changes.
-        final List<FlutterOutline> newOutlines = getOutlinesSelectedInTree();
-        if (!Objects.equals(this.currentFile, selectionFile) || !outlines.equals(newOutlines)) {
-          return;
-        }
-
-        // Associate changes with actions.
-        // Actions will be enabled / disabled in background.
-        for (SourceChange change : changes) {
-          final AnAction action = messageToActionMap.get(change.getMessage());
-          if (action != null) {
-            actionToChangeMap.put(action, change);
-          }
-        }
-
-        // Update actions immediately.
-        if (windowToolbar != null) {
-          ApplicationManager.getApplication().invokeLater(() -> windowToolbar.updateActionsImmediately());
-        }
-      });
-    }
+    // TODO(jacobr): refactor the previewArea to listen on the stream of selected outlines instead.
+    previewArea.select(ImmutableList.of(outline), currentEditor);
   }
 
   // TODO: Add parent relationship info to FlutterOutline instead of this O(n^2) traversal.
@@ -481,6 +405,36 @@ public class PreviewView implements PersistentStateComponent<PreviewViewState>, 
     if (currentEditor != null) {
       final Caret caret = currentEditor.getCaretModel().getPrimaryCaret();
       applyEditorSelectionToTree(caret);
+    }
+
+    if (FlutterSettings.getInstance().isEnableHotUi() && propertyEditPanel == null) {
+      propertyEditSplitter  = new Splitter(false, 0.75f);
+      propertyEditPanel = new PropertyEditorPanel(inspectorGroupManagerService, project, flutterAnalysisServer, false, false, project);
+      propertyEditPanel.initalize(null, activeOutlines, currentFile);
+      propertyEditToolbarGroup = new DefaultActionGroup();
+      final ActionToolbar windowToolbar = ActionManager.getInstance().createActionToolbar("PropertyArea", propertyEditToolbarGroup, true);
+
+
+      final SimpleToolWindowPanel window = new SimpleToolWindowPanel(true, true);
+      window.setToolbar(windowToolbar.getComponent());
+      propertyScrollPane = ScrollPaneFactory.createScrollPane(propertyEditPanel);
+      window.setContent(propertyScrollPane);
+      propertyEditSplitter.setFirstComponent(window.getComponent());
+      propertyEditSplitter.setSecondComponent(previewArea.getComponent());
+      splitter.setSecondComponent(propertyEditSplitter);
+    }
+
+    // TODO(jacobr): this is the wrong spot.
+    if (propertyEditToolbarGroup != null) {
+      TitleAction propertyTitleAction;
+      if (currentOutline != null && Objects.equals(currentOutline.getKind(), FlutterOutlineKind.NEW_INSTANCE)) {
+        propertyTitleAction = new TitleAction(currentOutline.getClassName() + " Properties");
+      }
+      else {
+        propertyTitleAction = new TitleAction("Widget Properties");
+      }
+      propertyEditToolbarGroup.removeAll();
+      propertyEditToolbarGroup.add(propertyTitleAction);
     }
   }
 
@@ -548,45 +502,13 @@ public class PreviewView implements PersistentStateComponent<PreviewViewState>, 
     return getOutlineOfNode(node);
   }
 
-  private int getConvertedFileOffset(int offset) {
-    return DartAnalysisServerService.getInstance(project).getConvertedOffset(currentFile, offset);
-  }
-
-  private int getConvertedOutlineOffset(FlutterOutline outline) {
-    final int offset = outline.getOffset();
-    return getConvertedFileOffset(offset);
-  }
-
-  private int getConvertedOutlineEnd(FlutterOutline outline) {
-    final int end = outline.getOffset() + outline.getLength();
-    return getConvertedFileOffset(end);
-  }
-
-  private FlutterOutline findOutlineAtOffset(FlutterOutline outline, int offset) {
-    if (outline == null) {
-      return null;
-    }
-    if (getConvertedOutlineOffset(outline) <= offset && offset <= getConvertedOutlineEnd(outline)) {
-      if (outline.getChildren() != null) {
-        for (FlutterOutline child : outline.getChildren()) {
-          final FlutterOutline foundChild = findOutlineAtOffset(child, offset);
-          if (foundChild != null) {
-            return foundChild;
-          }
-        }
-      }
-      return outline;
-    }
-    return null;
-  }
-
   private void addOutlinesCoveredByRange(List<FlutterOutline> covered, int start, int end, @Nullable FlutterOutline outline) {
     if (outline == null) {
       return;
     }
-
-    final int outlineStart = getConvertedOutlineOffset(outline);
-    final int outlineEnd = getConvertedOutlineEnd(outline);
+    final OutlineOffsetConverter converter = getOutlineOffsetConverter();
+    final int outlineStart = converter.getConvertedOutlineOffset(outline);
+    final int outlineEnd = converter.getConvertedOutlineEnd(outline);
     // The outline ends before, or starts after the selection.
     if (outlineEnd < start || outlineStart > end) {
       return;
@@ -607,9 +529,9 @@ public class PreviewView implements PersistentStateComponent<PreviewViewState>, 
   }
 
   private void setSelectedFile(VirtualFile newFile) {
-    if (currentFile != null) {
+    if (currentFile.getValue() != null) {
       flutterAnalysisServer.removeOutlineListener(currentFilePath, outlineListener);
-      currentFile = null;
+      currentFile.setValue(null);
       currentFilePath = null;
     }
 
@@ -621,7 +543,7 @@ public class PreviewView implements PersistentStateComponent<PreviewViewState>, 
     // Show the toolbar if the new file is a Dart file, or hide otherwise.
     if (windowPanel != null) {
       if (newFile != null) {
-        windowPanel.setToolbar(windowToolbar.getComponent());
+        windowPanel.setToolbar(widgetEditToolbar.getToolbar().getComponent());
       }
       else if (windowPanel.isToolbarVisible()) {
         windowPanel.setToolbar(null);
@@ -637,8 +559,8 @@ public class PreviewView implements PersistentStateComponent<PreviewViewState>, 
 
     // Subscribe for the outline for the new file.
     if (newFile != null) {
-      currentFile = newFile;
-      currentFilePath = FileUtil.toSystemDependentName(currentFile.getPath());
+      currentFile.setValue(newFile);
+      currentFilePath = FileUtil.toSystemDependentName(newFile.getPath());
       flutterAnalysisServer.addOutlineListener(currentFilePath, outlineListener);
     }
   }
@@ -662,14 +584,17 @@ public class PreviewView implements PersistentStateComponent<PreviewViewState>, 
 
     // If no covered outlines, try to find the outline under the caret.
     if (selectedOutlines.isEmpty()) {
-      final FlutterOutline outline = findOutlineAtOffset(currentOutline, caret.getOffset());
+      final FlutterOutline outline = getOutlineOffsetConverter().findOutlineAtOffset(currentOutline, caret.getOffset());
       if (outline != null) {
         selectedOutlines.add(outline);
       }
     }
 
-    updateActionsForOutlines(selectedOutlines);
+    activeOutlines.setValue(selectedOutlines);
+
     applyOutlinesSelectionToTree(selectedOutlines);
+
+    previewArea.select(selectedOutlines, currentEditor);
   }
 
   private void applyOutlinesSelectionToTree(List<FlutterOutline> outlines) {
@@ -720,148 +645,33 @@ public class PreviewView implements PersistentStateComponent<PreviewViewState>, 
     }
   }
 
-  private void applyChangeAndShowException(SourceChange change) {
-    ApplicationManager.getApplication().runWriteAction(() -> {
-      try {
-        AssistUtils.applySourceChange(project, change, false);
+  private void setSplitterProportion(float value) {
+    isSettingSplitterProportion = true;
+    try {
+      splitter.setProportion(value);
+    }
+    finally {
+      isSettingSplitterProportion = false;
+    }
+    doLayoutRecursively(splitter);
+  }
+
+  // TODO(jacobr): is this method really useful? This is from re-applying the
+  // PreviewArea but it doesn't really seem that useful.
+  private static void doLayoutRecursively(Component component) {
+    if (component != null) {
+      component.doLayout();
+      if (component instanceof Container) {
+        final Container container = (Container)component;
+        for (Component child : container.getComponents()) {
+          doLayoutRecursively(child);
+        }
       }
-      catch (DartSourceEditException exception) {
-        FlutterMessages.showError("Error applying change", exception.getMessage());
-      }
-    });
+    }
   }
 
   private void sendAnalyticEvent(@NotNull String name) {
     FlutterInitializer.getAnalytics().sendEvent("preview", name);
-  }
-
-  private class QuickAssistAction extends AnAction {
-    private final String id;
-
-    QuickAssistAction(@NotNull String id, Icon icon, String assistMessage) {
-      super(assistMessage, null, icon);
-      this.id = id;
-      messageToActionMap.put(assistMessage, this);
-    }
-
-    @Override
-    public void actionPerformed(@NotNull AnActionEvent e) {
-      sendAnalyticEvent(id);
-      final SourceChange change;
-      synchronized (actionToChangeMap) {
-        change = actionToChangeMap.get(this);
-        actionToChangeMap.clear();
-      }
-      if (change != null) {
-        applyChangeAndShowException(change);
-      }
-    }
-
-    @Override
-    public void update(AnActionEvent e) {
-      final boolean hasChange = actionToChangeMap.containsKey(this);
-      e.getPresentation().setEnabled(hasChange);
-    }
-
-    boolean isEnabled() {
-      return actionToChangeMap.containsKey(this);
-    }
-  }
-
-  private class ExtractMethodAction extends AnAction {
-    private final String id = "dart.assist.flutter.extractMethod";
-
-    ExtractMethodAction() {
-      super("Extract Method...", null, FlutterIcons.ExtractMethod);
-    }
-
-    @Override
-    public void actionPerformed(@NotNull AnActionEvent e) {
-      final AnAction action = ActionManager.getInstance().getAction("ExtractMethod");
-      if (action != null) {
-        final FlutterOutline outline = getWidgetOutline();
-        if (outline != null) {
-          TransactionGuard.submitTransaction(project, () -> {
-            // Ideally we don't need this - just caret at the beginning should be enough.
-            // Unfortunately this was implemented only recently.
-            // So, we have to select the widget range.
-            final int offset = getConvertedOutlineOffset(outline);
-            final int end = getConvertedOutlineEnd(outline);
-            currentEditor.getSelectionModel().setSelection(offset, end);
-
-            final JComponent editorComponent = currentEditor.getComponent();
-            final DataContext editorContext = DataManager.getInstance().getDataContext(editorComponent);
-            final AnActionEvent editorEvent = AnActionEvent.createFromDataContext(ActionPlaces.UNKNOWN, null, editorContext);
-
-            action.actionPerformed(editorEvent);
-          });
-        }
-      }
-    }
-
-    @Override
-    public void update(AnActionEvent e) {
-      final boolean isEnabled = isEnabled();
-      e.getPresentation().setEnabled(isEnabled);
-    }
-
-    boolean isEnabled() {
-      return getWidgetOutline() != null;
-    }
-
-    private FlutterOutline getWidgetOutline() {
-      final List<FlutterOutline> outlines = getOutlinesSelectedInTree();
-      if (outlines.size() == 1) {
-        final FlutterOutline outline = outlines.get(0);
-        if (outline.getDartElement() == null) {
-          return outline;
-        }
-      }
-      return null;
-    }
-  }
-
-  private class ExtractWidgetAction extends AnAction {
-    private final String id = "dart.assist.flutter.extractwidget";
-
-    ExtractWidgetAction() {
-      super("Extract Widget...");
-    }
-
-    @Override
-    public void actionPerformed(@NotNull AnActionEvent e) {
-      final AnAction action = ActionManager.getInstance().getAction("Flutter.ExtractWidget");
-      if (action != null) {
-        TransactionGuard.submitTransaction(project, () -> {
-          final JComponent editorComponent = currentEditor.getComponent();
-          final DataContext editorContext = DataManager.getInstance().getDataContext(editorComponent);
-          final AnActionEvent editorEvent = AnActionEvent.createFromDataContext(ActionPlaces.UNKNOWN, null, editorContext);
-
-          action.actionPerformed(editorEvent);
-        });
-      }
-    }
-
-    @Override
-    public void update(AnActionEvent e) {
-      final boolean isEnabled = isEnabled();
-      e.getPresentation().setEnabled(isEnabled);
-    }
-
-    boolean isEnabled() {
-      return getWidgetOutline() != null;
-    }
-
-    private FlutterOutline getWidgetOutline() {
-      final List<FlutterOutline> outlines = getOutlinesSelectedInTree();
-      if (outlines.size() == 1) {
-        final FlutterOutline outline = outlines.get(0);
-        if (outline.getDartElement() == null) {
-          return outline;
-        }
-      }
-      return null;
-    }
   }
 
   private class ShowOnlyWidgetsAction extends AnAction implements Toggleable, RightAlignedToolbarAction {
@@ -952,25 +762,7 @@ class OutlineObject {
 
     return icon;
   }
-
-  Icon getFlutterDecoratedIcon() {
-    final Icon icon = getIcon();
-    if (icon == null) return null;
-
-    LayeredIcon decorated = flutterDecoratedIcons.get(icon);
-    if (decorated == null) {
-      final Icon badgeIcon = FlutterIcons.Flutter_badge;
-
-      decorated = new LayeredIcon(2);
-      decorated.setIcon(badgeIcon, 0, 0, 1 + (icon.getIconHeight() - badgeIcon.getIconHeight()) / 2);
-      decorated.setIcon(icon, 1, badgeIcon.getIconWidth(), 0);
-
-      flutterDecoratedIcons.put(icon, decorated);
-    }
-
-    return decorated;
-  }
-
+  
   /**
    * Return the string that is suitable for speed search. It has every name part separated so that we search only inside individual name
    * parts, but not in their accidential concatenation.
@@ -1037,8 +829,7 @@ class OutlineTreeCellRenderer extends ColoredTreeCellRenderer {
       return;
     }
 
-    // Render the widget icon.
-    final Icon icon = node.getFlutterDecoratedIcon();
+    final Icon icon = node.getIcon();
     if (icon != null) {
       setIcon(icon);
     }

--- a/src/io/flutter/preview/PreviewViewModelPanel.java
+++ b/src/io/flutter/preview/PreviewViewModelPanel.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.preview;
+
+import com.intellij.openapi.ui.popup.Balloon;
+import io.flutter.editor.PreviewViewController;
+import io.flutter.editor.PreviewViewControllerBase;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
+import java.awt.event.MouseMotionListener;
+
+/**
+ * Class that provides the glue to render the preview view in a regular JPanel.
+ */
+public class PreviewViewModelPanel extends JPanel {
+  final PreviewViewControllerBase preview;
+
+  @Override
+  public void paint(Graphics g) {
+    super.paint(g);
+    preview.paint(g, 16);
+  }
+
+  public PreviewViewModelPanel(PreviewViewController preview) {
+    this.preview = preview;
+
+    addMouseMotionListener(new MouseMotionListener() {
+
+      @Override
+      public void mouseDragged(MouseEvent e) {
+        // The PreviewViewController does not care about drag events.
+        // If it ever does, this code will need to be updated.
+      }
+
+      @Override
+      public void mouseMoved(MouseEvent e) {
+        preview.onMouseMoved(e);
+      }
+    });
+    addMouseListener(new MouseListener() {
+      @Override
+      public void mouseClicked(MouseEvent e) {
+        // The PreviewViewController does not care about click events instead
+        // relying on mouseReleased events.
+        // If it ever does, this code will need to be updated.
+      }
+
+      @Override
+      public void mousePressed(MouseEvent e) {
+        preview.onMousePressed(e);
+      }
+
+      @Override
+      public void mouseReleased(MouseEvent e) {
+        preview.onMouseReleased(e);
+      }
+
+      @Override
+      public void mouseEntered(MouseEvent e) {
+        preview.onMouseEntered(e);
+      }
+
+      @Override
+      public void mouseExited(MouseEvent e) {
+        preview.onMouseExited(e);
+      }
+    });
+  }
+}

--- a/src/io/flutter/preview/PreviewViewState.java
+++ b/src/io/flutter/preview/PreviewViewState.java
@@ -8,6 +8,7 @@ package io.flutter.preview;
 import com.intellij.util.EventDispatcher;
 import com.intellij.util.xmlb.annotations.Attribute;
 
+import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 
 /**
@@ -16,7 +17,19 @@ import javax.swing.event.ChangeListener;
 public class PreviewViewState {
   private final EventDispatcher<ChangeListener> dispatcher = EventDispatcher.create(ChangeListener.class);
 
+  @Attribute(value = "splitter-proportion")
+  public float splitterProportion;
+
   public PreviewViewState() {
+  }
+
+  public float getSplitterProportion() {
+    return splitterProportion <= 0.0f ? 0.7f : splitterProportion;
+  }
+
+  public void setSplitterProportion(float value) {
+    splitterProportion = value;
+    dispatcher.getMulticaster().stateChanged(new ChangeEvent(this));
   }
 
   public void addListener(ChangeListener listener) {
@@ -33,5 +46,6 @@ public class PreviewViewState {
 
   void copyFrom(PreviewViewState other) {
     this.placeholder = other.placeholder;
+    splitterProportion = other.splitterProportion;
   }
 }

--- a/src/io/flutter/preview/WidgetEditToolbar.java
+++ b/src/io/flutter/preview/WidgetEditToolbar.java
@@ -1,0 +1,389 @@
+/*
+ * Copyright 2019 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.preview;
+
+import com.google.common.util.concurrent.Uninterruptibles;
+import com.intellij.ide.DataManager;
+import com.intellij.openapi.actionSystem.*;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.TransactionGuard;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.fileEditor.FileEditor;
+import com.intellij.openapi.fileEditor.FileEditorManager;
+import com.intellij.openapi.fileEditor.TextEditor;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.jetbrains.lang.dart.assists.AssistUtils;
+import com.jetbrains.lang.dart.assists.DartSourceEditException;
+import icons.FlutterIcons;
+import io.flutter.FlutterInitializer;
+import io.flutter.FlutterMessages;
+import io.flutter.dart.FlutterDartAnalysisServer;
+import io.flutter.inspector.InspectorService;
+import io.flutter.inspector.InspectorGroupManagerService;
+import io.flutter.run.FlutterReloadManager;
+import io.flutter.run.daemon.FlutterApp;
+import io.flutter.utils.EventStream;
+import org.dartlang.analysis.server.protocol.FlutterOutline;
+import org.dartlang.analysis.server.protocol.SourceChange;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+import java.awt.*;
+import java.util.*;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Toolbar containing all the widget refactor actions.
+ *
+ * This toolbar is extracted out from the OutlineView so that it can be reused
+ * anywhere we want to expose Flutter widget refactors. For example, as a
+ * toolbar of a property editing popop exposed directly in a code editor.
+ */
+public class WidgetEditToolbar {
+  private class QuickAssistAction extends AnAction {
+    private final String id;
+
+    QuickAssistAction(@NotNull String id, Icon icon, String assistMessage) {
+      super(assistMessage, null, icon);
+      this.id = id;
+      messageToActionMap.put(assistMessage, this);
+    }
+
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent e) {
+      sendAnalyticEvent(id);
+      final SourceChange change;
+      synchronized (actionToChangeMap) {
+        change = actionToChangeMap.get(this);
+        actionToChangeMap.clear();
+      }
+      if (change != null) {
+        applyChangeAndShowException(change);
+      }
+    }
+
+    @Override
+    public void update(AnActionEvent e) {
+      final boolean hasChange = actionToChangeMap.containsKey(this);
+      e.getPresentation().setEnabled(hasChange);
+    }
+
+    boolean isEnabled() {
+      return actionToChangeMap.containsKey(this);
+    }
+  }
+
+  private class ExtractMethodAction extends AnAction {
+    private final String id = "dart.assist.flutter.extractMethod";
+
+    ExtractMethodAction() {
+      super("Extract Method...", null, FlutterIcons.ExtractMethod);
+    }
+
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent e) {
+      final AnAction action = ActionManager.getInstance().getAction("ExtractMethod");
+      if (action != null) {
+        final FlutterOutline outline = getWidgetOutline();
+        if (outline != null) {
+          TransactionGuard.submitTransaction(project, () -> {
+            final Editor editor = getCurrentEditor();
+            if (editor == null) {
+              // It is a race condition if we hit this. Gracefully assume
+              // the action has just been canceled.
+              return;
+            }
+            final OutlineOffsetConverter converter = new OutlineOffsetConverter(project, activeFile.getValue());
+            final int offset = converter.getConvertedOutlineOffset(outline);
+            editor.getCaretModel().moveToOffset(offset);
+
+            final JComponent editorComponent = editor.getComponent();
+            final DataContext editorContext = DataManager.getInstance().getDataContext(editorComponent);
+            final AnActionEvent editorEvent = AnActionEvent.createFromDataContext(ActionPlaces.UNKNOWN, null, editorContext);
+
+            action.actionPerformed(editorEvent);
+          });
+        }
+      }
+    }
+
+    @Override
+    public void update(AnActionEvent e) {
+      final boolean isEnabled = isEnabled();
+      e.getPresentation().setEnabled(isEnabled);
+    }
+
+    boolean isEnabled() {
+      return getWidgetOutline() != null && getCurrentEditor() != null;
+    }
+  }
+
+  private class ExtractWidgetAction extends AnAction {
+    private final String id = "dart.assist.flutter.extractwidget";
+
+    ExtractWidgetAction() {
+      super("Extract Widget...");
+    }
+
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent e) {
+      final AnAction action = ActionManager.getInstance().getAction("Flutter.ExtractWidget");
+      if (action != null) {
+        TransactionGuard.submitTransaction(project, () -> {
+          final Editor editor = getCurrentEditor();
+          if (editor == null) {
+            // It is a race condition if we hit this. Gracefully assume
+            // the action has just been canceled.
+            return;
+          }
+          final JComponent editorComponent = editor.getComponent();
+          final DataContext editorContext = DataManager.getInstance().getDataContext(editorComponent);
+          final AnActionEvent editorEvent = AnActionEvent.createFromDataContext(ActionPlaces.UNKNOWN, null, editorContext);
+
+          action.actionPerformed(editorEvent);
+        });
+      }
+    }
+
+    @Override
+    public void update(AnActionEvent e) {
+      final boolean isEnabled = isEnabled();
+      e.getPresentation().setEnabled(isEnabled);
+    }
+
+    boolean isEnabled() {
+      return getWidgetOutline() != null && getCurrentEditor() != null;
+    }
+  }
+
+  final QuickAssistAction actionCenter;
+  final QuickAssistAction actionPadding;
+  final QuickAssistAction actionColumn;
+  final QuickAssistAction actionRow;
+  final QuickAssistAction actionContainer;
+  final QuickAssistAction actionMoveUp;
+  final QuickAssistAction actionMoveDown;
+  final QuickAssistAction actionRemove;
+  final ExtractMethodAction actionExtractMethod;
+  final ExtractWidgetAction actionExtractWidget;
+  private final FlutterDartAnalysisServer flutterAnalysisServer;
+  private final EventStream<VirtualFile> activeFile;
+  private final Map<String, AnAction> messageToActionMap = new HashMap<>();
+  private final Map<AnAction, SourceChange> actionToChangeMap = new HashMap<>();
+  private final Project project;
+  /**
+   * Wheter to trigger a hot reload after the widget refactor is executed.
+   */
+  private final boolean hotReloadOnAction;
+  /**
+   * EventStream providing the outline(s) that are currently considered active.
+   */
+  EventStream<List<FlutterOutline>> activeOutlines;
+  private ActionToolbar toolbar;
+
+  public WidgetEditToolbar(
+    boolean hotReloadOnAction,
+    EventStream<List<FlutterOutline>> activeOutlines,
+    EventStream<VirtualFile> activeFile,
+    Project project,
+    FlutterDartAnalysisServer flutterAnalysisServer
+  ) {
+    this.hotReloadOnAction = hotReloadOnAction;
+    this.project = project;
+    this.flutterAnalysisServer = flutterAnalysisServer;
+    this.activeFile = activeFile;
+    actionCenter = new QuickAssistAction("dart.assist.flutter.wrap.center", FlutterIcons.Center, "Wrap with Center");
+    actionPadding = new QuickAssistAction("dart.assist.flutter.wrap.padding", FlutterIcons.Padding, "Wrap with Padding");
+    actionColumn = new QuickAssistAction("dart.assist.flutter.wrap.column", FlutterIcons.Column, "Wrap with Column");
+    actionRow = new QuickAssistAction("dart.assist.flutter.wrap.row", FlutterIcons.Row, "Wrap with Row");
+    actionContainer = new QuickAssistAction("dart.assist.flutter.wrap.container", FlutterIcons.Container, "Wrap with Container");
+    actionMoveUp = new QuickAssistAction("dart.assist.flutter.move.up", FlutterIcons.Up, "Move widget up");
+    actionMoveDown = new QuickAssistAction("dart.assist.flutter.move.down", FlutterIcons.Down, "Move widget down");
+    actionRemove = new QuickAssistAction("dart.assist.flutter.removeWidget", FlutterIcons.RemoveWidget, "Remove this widget");
+    actionExtractMethod = new ExtractMethodAction();
+    actionExtractWidget = new ExtractWidgetAction();
+
+    this.activeOutlines = activeOutlines;
+    activeOutlines.listen(this::activeOutlineChanged);
+  }
+
+  Editor getCurrentEditor() {
+    final VirtualFile file = activeFile.getValue();
+    if (file == null) return null;
+
+    final FileEditor fileEditor = FileEditorManager.getInstance(project).getSelectedEditor(file);
+    if (fileEditor instanceof TextEditor) {
+      final TextEditor textEditor = (TextEditor)fileEditor;
+      final Editor editor = textEditor.getEditor();
+      if (!editor.isDisposed()) {
+        return editor;
+      }
+    }
+    return null;
+  }
+
+  public ActionToolbar getToolbar() {
+    if (toolbar == null) {
+      DefaultActionGroup toolbarGroup = new DefaultActionGroup();
+      toolbarGroup.add(actionCenter);
+      toolbarGroup.add(actionPadding);
+      toolbarGroup.add(actionColumn);
+      toolbarGroup.add(actionRow);
+      toolbarGroup.add(actionContainer);
+      toolbarGroup.addSeparator();
+      toolbarGroup.add(actionExtractMethod);
+      toolbarGroup.addSeparator();
+      toolbarGroup.add(actionMoveUp);
+      toolbarGroup.add(actionMoveDown);
+      toolbarGroup.addSeparator();
+      toolbarGroup.add(actionRemove);
+
+      toolbar = ActionManager.getInstance().createActionToolbar("PreviewViewToolbar", toolbarGroup, true);
+    }
+    return toolbar;
+  }
+
+  private void activeOutlineChanged(List<FlutterOutline> outlines) {
+    synchronized (actionToChangeMap) {
+      actionToChangeMap.clear();
+    }
+
+    final VirtualFile selectionFile = activeFile.getValue();
+    if (selectionFile != null && !outlines.isEmpty()) {
+      ApplicationManager.getApplication().executeOnPooledThread(() -> {
+        final OutlineOffsetConverter converter = new OutlineOffsetConverter(project, activeFile.getValue());
+        final FlutterOutline firstOutline = outlines.get(0);
+        final FlutterOutline lastOutline = outlines.get(outlines.size() - 1);
+        final int offset = converter.getConvertedOutlineOffset(firstOutline);
+        final int length = converter.getConvertedOutlineEnd(lastOutline) - offset;
+        final List<SourceChange> changes = flutterAnalysisServer.edit_getAssists(selectionFile, offset, length);
+
+        // If the current file or outline are different, ignore the changes.
+        // We will eventually get new changes.
+        final List<FlutterOutline> newOutlines = activeOutlines.getValue();
+        if (!Objects.equals(activeFile.getValue(), selectionFile) || !outlines.equals(newOutlines)) {
+          return;
+        }
+
+        // Associate changes with actions.
+        // Actions will be enabled / disabled in background.
+        for (SourceChange change : changes) {
+          final AnAction action = messageToActionMap.get(change.getMessage());
+          if (action != null) {
+            actionToChangeMap.put(action, change);
+          }
+        }
+
+        // Update actions immediately.
+        if (getToolbar() != null) {
+          ApplicationManager.getApplication().invokeLater(() -> getToolbar().updateActionsImmediately());
+        }
+      });
+    }
+  }
+
+  FlutterOutline getWidgetOutline() {
+    final List<FlutterOutline> outlines = activeOutlines.getValue();
+    if (outlines.size() == 1) {
+      final FlutterOutline outline = outlines.get(0);
+      if (outline.getDartElement() == null) {
+        return outline;
+      }
+    }
+    return null;
+  }
+
+  private void sendAnalyticEvent(@NotNull String name) {
+    FlutterInitializer.getAnalytics().sendEvent("preview", name);
+  }
+
+  private void applyChangeAndShowException(SourceChange change) {
+    ApplicationManager.getApplication().runWriteAction(() -> {
+      try {
+        AssistUtils.applySourceChange(project, change, false);
+        if (hotReloadOnAction) {
+          final InspectorService inspectorService = InspectorGroupManagerService.getInstance(project).getInspectorService();
+
+          if (inspectorService != null) {
+            ArrayList<FlutterApp> apps = new ArrayList<>();
+            apps.add(inspectorService.getApp());
+            FlutterReloadManager.getInstance(project).saveAllAndReloadAll(apps, "Refactor widget");
+          }
+        }
+      }
+      catch (DartSourceEditException exception) {
+        FlutterMessages.showError("Error applying change", exception.getMessage());
+      }
+    });
+  }
+
+  public void createPopupMenu(Component comp, int x, int y) {
+    // The corresponding tree item may have just been selected.
+    // Wait short time for receiving assists from the server.
+    // TODO(jacobr): this hard coded sleep seems like a hack. Figure out a
+    // more robust way to wait for all assists to be received.
+    for (int i = 0; i < 20 && actionToChangeMap.isEmpty(); i++) {
+      Uninterruptibles.sleepUninterruptibly(5, TimeUnit.MILLISECONDS);
+    }
+
+    final DefaultActionGroup group = new DefaultActionGroup();
+    boolean hasAction = false;
+    if (actionCenter.isEnabled()) {
+      hasAction = true;
+      group.add(new TextOnlyActionWrapper(actionCenter));
+    }
+    if (actionPadding.isEnabled()) {
+      hasAction = true;
+      group.add(new TextOnlyActionWrapper(actionPadding));
+    }
+    if (actionColumn.isEnabled()) {
+      hasAction = true;
+      group.add(new TextOnlyActionWrapper(actionColumn));
+    }
+    if (actionRow.isEnabled()) {
+      hasAction = true;
+      group.add(new TextOnlyActionWrapper(actionRow));
+    }
+    if (actionContainer.isEnabled()) {
+      hasAction = true;
+      group.add(new TextOnlyActionWrapper(actionContainer));
+    }
+    group.addSeparator();
+    if (actionExtractMethod.isEnabled()) {
+      hasAction = true;
+      group.add(new TextOnlyActionWrapper(actionExtractMethod));
+    }
+    if (actionExtractWidget.isEnabled()) {
+      hasAction = true;
+      group.add(new TextOnlyActionWrapper(actionExtractWidget));
+    }
+    group.addSeparator();
+    if (actionMoveUp.isEnabled()) {
+      hasAction = true;
+      group.add(new TextOnlyActionWrapper(actionMoveUp));
+    }
+    if (actionMoveDown.isEnabled()) {
+      hasAction = true;
+      group.add(new TextOnlyActionWrapper(actionMoveDown));
+    }
+    group.addSeparator();
+    if (actionRemove.isEnabled()) {
+      hasAction = true;
+      group.add(new TextOnlyActionWrapper(actionRemove));
+    }
+
+    // Don't show the empty popup.
+    if (!hasAction) {
+      return;
+    }
+
+    final ActionManager actionManager = ActionManager.getInstance();
+    final ActionPopupMenu popupMenu = actionManager.createActionPopupMenu(ActionPlaces.UNKNOWN, group);
+    popupMenu.getComponent().show(comp, x, y);
+  }
+}

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.form
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.form
@@ -224,7 +224,7 @@
           </component>
         </children>
       </grid>
-      <grid id="23e52" binding="experimentsPanel" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="23e52" binding="experimentsPanel" layout-manager="GridLayoutManager" row-count="3" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -247,6 +247,15 @@
             <properties>
               <text resource-bundle="io/flutter/FlutterBundle" key="settings.enable.android.gradle.sync"/>
               <toolTipText value="Provides advanced editing capabilities for Java and Kotlin code. Uses Gradle to find Android libraries then links them into the Flutter project."/>
+            </properties>
+          </component>
+          <component id="33088" class="javax.swing.JCheckBox" binding="myEnableHotUiCheckBox">
+            <constraints>
+              <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text resource-bundle="io/flutter/FlutterBundle" key="settings.enable.hot.ui"/>
+              <toolTipText value="Experimental features to graphically edit Flutter build methods."/>
             </properties>
           </component>
         </children>

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.java
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.java
@@ -64,6 +64,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
   private JCheckBox myDisableTrackWidgetCreationCheckBox;
   private JCheckBox myShowStructuredErrors;
   private JCheckBox mySyncAndroidLibrariesCheckBox;
+  private JCheckBox myEnableHotUiCheckBox;
 
   // Settings for Bazel users.
   private JPanel myBazelOptionsSection;
@@ -129,21 +130,17 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     myFormatCodeOnSaveCheckBox.addChangeListener(
       (e) -> myOrganizeImportsOnSaveCheckBox.setEnabled(myFormatCodeOnSaveCheckBox.isSelected()));
 
-    // Only show the experiments panel if there are visible items in it.
-    if (FlutterUtils.isAndroidStudio()) {
-      mySyncAndroidLibrariesCheckBox.setVisible(true);
-      experimentsPanel.setVisible(true);
-    }
-    else {
-      mySyncAndroidLibrariesCheckBox.setVisible(false);
-      experimentsPanel.setVisible(false);
-    }
+    // There are other experiments so it is alright to show the experiments
+    // panel even if the syncAndroidLibraries experiment is hidden.
+    // If there are only experiments available on Android studio then add back
+    // the following statement:
+    // experimentsPanel.setVisible(FlutterUtils.isAndroidStudio());
+    mySyncAndroidLibrariesCheckBox.setVisible(FlutterUtils.isAndroidStudio());
   }
 
   private void createUIComponents() {
     mySdkCombo = new ComboboxWithBrowseButton(new ComboBox<>());
   }
-
   @Override
   @NotNull
   public String getId() {
@@ -222,6 +219,10 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
       return true;
     }
 
+    if (settings.isEnableHotUi() != myEnableHotUiCheckBox.isSelected()) {
+      return true;
+    }
+
     if (settings.shouldUseBazel() != myUseBazelByDefaultCheckBox.isSelected()) {
       return true;
     }
@@ -264,6 +265,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     settings.setDisableTrackWidgetCreation(myDisableTrackWidgetCreationCheckBox.isSelected());
     settings.setVerboseLogging(myEnableVerboseLoggingCheckBox.isSelected());
     settings.setSyncingAndroidLibraries(mySyncAndroidLibrariesCheckBox.isSelected());
+    settings.setEnableHotUi(myEnableHotUiCheckBox.isSelected());
     settings.setShouldUseBazel(myUseBazelByDefaultCheckBox.isSelected());
     settings.setShowAllRunConfigurationsInContext(myShowAllRunConfigurationsInContextCheckBox.isSelected());
 
@@ -305,6 +307,8 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     myDisableTrackWidgetCreationCheckBox.setSelected(settings.isDisableTrackWidgetCreation());
     myEnableVerboseLoggingCheckBox.setSelected(settings.isVerboseLogging());
     mySyncAndroidLibrariesCheckBox.setSelected(settings.isSyncingAndroidLibraries());
+
+    myEnableHotUiCheckBox.setSelected(settings.isEnableHotUi());
 
     myHotReloadIgnoreErrorCheckBox.setEnabled(myHotReloadOnSaveCheckBox.isSelected());
 

--- a/src/io/flutter/settings/FlutterSettings.java
+++ b/src/io/flutter/settings/FlutterSettings.java
@@ -28,6 +28,7 @@ public class FlutterSettings {
   private static final String disableTrackWidgetCreationKey = "io.flutter.disableTrackWidgetCreation";
   private static final String showStructuredErrors = "io.flutter.showStructuredErrors";
   private static final String showBuildMethodGuidesKey = "io.flutter.editor.showBuildMethodGuides";
+  private static final String enableHotUiKey = "io.flutter.editor.enableHotUi";
 
   /**
    * The Dart plugin uses this registry key to avoid bazel users getting their settings overridden on projects that include a
@@ -279,5 +280,21 @@ public class FlutterSettings {
   private static String afterLastPeriod(String str) {
     final int index = str.lastIndexOf('.');
     return index == -1 ? str : str.substring(index + 1);
+  }
+
+  public boolean isEnableHotUi() {
+    return getPropertiesComponent().getBoolean(enableHotUiKey, false);
+  }
+
+  public void setEnableHotUi(boolean value) {
+    getPropertiesComponent().setValue(enableHotUiKey, value, false);
+
+    fireEvent();
+  }
+
+  public boolean isEnableHotUiInCodeEditor() {
+    // We leave this setting off for now to avoid possible performance and
+    // usability issues rendering previews directly in the code editor.
+    return false;
   }
 }

--- a/tool/plugin/lib/plugin.dart
+++ b/tool/plugin/lib/plugin.dart
@@ -578,6 +578,12 @@ class BuildCommand extends ProductCommand {
             FileSystemEntity.isFileSync(file) ? File(file) : Directory(file);
         if (entity.existsSync()) {
           await entity.rename('$file~');
+          if (entity is File) {
+            var stubFile = File('${file}_stub');
+            if (stubFile.existsSync()) {
+              await stubFile.copy('$file');
+            }
+          }
         }
       }
 


### PR DESCRIPTION
If I had more time I would have written less code.
I've commented on files that are not-enabled in the checked in code and files that are simple refactors of existing code to improve reuse.
High level: support in the outline view is exposed by this CL. Support directly in the code editor is protected by a flag in FlutterSettings that is hard coded to false to reduce the risk of a memory leak or performance regression.

Screenshots:
Setting to enable Hot Ui. Happy to hear suggestions for a better name for this setting. We could also call it Hot UI.
<img width="994" alt="Screen Shot 2019-12-02 at 6 32 14 PM" src="https://user-images.githubusercontent.com/1226812/70018810-228b5880-153c-11ea-88d5-dd49ec7beadf.png">

<img width="1234" alt="Screen Shot 2019-12-02 at 6 33 33 PM" src="https://user-images.githubusercontent.com/1226812/70018858-451d7180-153c-11ea-9606-dface9e9fb2d.png">

Screenshot showing what it looks like before the app is run.
A reasonable easy UI tweak would be to hide the screen mirror completely when the app is not running.
<img width="1234" alt="Screen Shot 2019-12-02 at 6 33 33 PM" src="https://user-images.githubusercontent.com/1226812/70018989-b0674380-153c-11ea-8802-81a91afa8569.png">

Screenshot showing when the app is running
<img width="1230" alt="Screen Shot 2019-12-02 at 6 56 11 PM" src="https://user-images.githubusercontent.com/1226812/70019011-c70d9a80-153c-11ea-9201-7a2cbcc87248.png">

Screenshot showing what happens when an outline node that isn't a simple NEW_INSTANCE outline node is selected.
<img width="524" alt="Screen Shot 2019-12-02 at 7 09 51 PM" src="https://user-images.githubusercontent.com/1226812/70019075-fe7c4700-153c-11ea-8fcf-758455da8f10.png">

Proof that Hot UI is disabled by default with no changes to the outline view or code editor.
<img width="1221" alt="Screen Shot 2019-12-02 at 6 27 54 PM" src="https://user-images.githubusercontent.com/1226812/70018744-f2dc5080-153b-11ea-8d87-5e28e4c60f10.png">
