### PR TITLE
Fix bug with missing inspector selection icon on Flutter builds without the "enableOnDeviceInspector" extension.

### DIFF
--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -158,17 +158,15 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
     final FlutterViewAction currentExtension[] = { null };
 
     app.getVMServiceManager().hasServiceExtension(ServiceExtensions.enableOnDeviceInspector.getExtension(), (hasExtension) -> {
-      if (hasExtension) {
-        if (toolWindow.isDisposed()) return;
+      if (toolWindow.isDisposed()) return;
 
-        FlutterViewAction nextExtension = hasExtension ? selectModeAction : legacySelectModeAction;
-        if (currentExtension[0] != nextExtension) {
-          if (currentExtension[0] != null) {
-            toolbarGroup.remove(currentExtension[0]);
-          }
-          toolbarGroup.add(nextExtension, Constraints.FIRST);
-          currentExtension[0] = nextExtension;
+      FlutterViewAction nextExtension = hasExtension ? selectModeAction : legacySelectModeAction;
+      if (currentExtension[0] != nextExtension) {
+        if (currentExtension[0] != null) {
+          toolbarGroup.remove(currentExtension[0]);
         }
+        toolbarGroup.add(nextExtension, Constraints.FIRST);
+        currentExtension[0] = nextExtension;
       }
     });
 


### PR DESCRIPTION
Remove the nonsense `if (hasExtension) call`.