### PR TITLE
Force property labels to respect the column width in the widget property editor.

### DIFF
--- a/src/io/flutter/editor/PropertyEditorPanel.java
+++ b/src/io/flutter/editor/PropertyEditorPanel.java
@@ -562,11 +562,20 @@ public class PropertyEditorPanel extends SimpleToolWindowPanel {
         add(field, "span, growx");
       }
       else {
-        final JBLabel label = new JBLabel(property.getName());
-        add(label, "right");
+        final String propertyName = property.getName();
+        final JBLabel label = new JBLabel(propertyName);
+        // 120 is the max width of the column but that does not appear to be
+        // applied unless it is also set here.
+        add(label, "right, wmax 120px");
+        final ArrayList<String> tooltipBlocks = new ArrayList<>();
+        tooltipBlocks.add("<strong>" + propertyName + "</strong>");
+
         if (documentation != null) {
-          label.setToolTipText(documentation);
+          tooltipBlocks.add(documentation);
         }
+        // Use multiple line breaks so there is a clear separation between blocks.
+        label.setToolTipText(Joiner.on("\n\n").join(tooltipBlocks));
+
         add(field, "wrap, growx");
       }
       if (documentation != null) {


### PR DESCRIPTION
Add tooltips including the property name in bold.

Screenshot of the tweaked UI with ellipsis showing for property names that are too long.

 ![image](https://user-images.githubusercontent.com/1226812/70185610-fcca9480-169e-11ea-9a42-b1e5ee3ad07f.png)
