### PR TITLE
Polish property display.

### DIFF
--- a/src/io/flutter/editor/PropertyEditorPanel.java
+++ b/src/io/flutter/editor/PropertyEditorPanel.java
@@ -479,22 +479,12 @@ public class PropertyEditorPanel extends SimpleToolWindowPanel {
     int added = 0;
     for (FlutterWidgetProperty property : properties) {
       final String name = property.getName();
-      if (name.startsWith("on") || name.endsWith("Callback")) {
-        continue;
-      }
-      if (name.equals("key")) {
-        continue;
-      }
       if (name.equals("child") || name.equals("children")) {
         continue;
       }
       if (name.equals("Container")) {
         final List<FlutterWidgetProperty> containerProperties = property.getChildren();
         // TODO(jacobr): add support for container properties.
-        continue;
-      }
-      // Text widget properties to demote.
-      if (name.equals("strutStyle") || name.equals("locale") || name.equals("semanticsLabel")) {
         continue;
       }
       final String documentation = property.getDocumentation();
@@ -513,6 +503,10 @@ public class PropertyEditorPanel extends SimpleToolWindowPanel {
             expression = "";
           }
           final JBTextField textField = new JBTextField(expression);
+          // Make sure we show the text at the beginning of the text field.
+          // The default is to show the end if the content scrolls which looks
+          // bad in a property editor.
+          textField.setCaretPosition(0);
           addTextFieldListeners(name, textField);
           field = textField;
         }
@@ -547,6 +541,10 @@ public class PropertyEditorPanel extends SimpleToolWindowPanel {
             // TODO(jacobr): show as boolean.
           }
           final JBTextField textField = new JBTextField(property.getExpression());
+          // Make sure we show the text at the beginning of the text field.
+          // The default is to show the end if the content scrolls which looks
+          // bad in a property editor.
+          textField.setCaretPosition(0);
           field = textField;
           addTextFieldListeners(name, textField);
         }

--- a/src/io/flutter/preview/PreviewView.java
+++ b/src/io/flutter/preview/PreviewView.java
@@ -423,12 +423,7 @@ public class PreviewView implements PersistentStateComponent<PreviewViewState> {
     // TODO(jacobr): this is the wrong spot.
     if (propertyEditToolbarGroup != null) {
       TitleAction propertyTitleAction;
-      if (currentOutline != null && Objects.equals(currentOutline.getKind(), FlutterOutlineKind.NEW_INSTANCE)) {
-        propertyTitleAction = new TitleAction(currentOutline.getClassName() + " Properties");
-      }
-      else {
-        propertyTitleAction = new TitleAction("Widget Properties");
-      }
+      propertyTitleAction = new TitleAction("Properties");
       propertyEditToolbarGroup.removeAll();
       propertyEditToolbarGroup.add(propertyTitleAction);
     }


### PR DESCRIPTION
Fix bad default where text fields were auto scrolled to the end resulting in empty content for long properties.
Remove some over aggressive filtering out of properties back from when we were trying to render this as a popup instead of a sidebar window.

Change the text from Widget Properties to just Properties.

Before:
![image](https://user-images.githubusercontent.com/1226812/70254721-651a8400-173a-11ea-811f-f1616fd85090.png)

After:
![image](https://user-images.githubusercontent.com/1226812/70254665-4c11d300-173a-11ea-8adf-1e5247e2f01e.png)
