### PR TITLE
Launch flutter attach when the Android app starts

### DIFF
--- a/flutter-studio/flutter-studio.iml
+++ b/flutter-studio/flutter-studio.iml
@@ -49,5 +49,6 @@
     <orderEntry type="library" name="com.android.tools:repository" level="project" />
     <orderEntry type="library" name="studio-analytics-proto" level="project" />
     <orderEntry type="module" module-name="intellij.groovy.psi" />
+    <orderEntry type="module" module-name="intellij.java.debugger.impl" />
   </component>
 </module>

--- a/flutter-studio/src/io/flutter/FlutterStudioStartupActivity.java
+++ b/flutter-studio/src/io/flutter/FlutterStudioStartupActivity.java
@@ -38,6 +38,7 @@ import io.flutter.run.FlutterReloadManager;
 import io.flutter.run.SdkRunConfig;
 import io.flutter.sdk.FlutterSdk;
 import io.flutter.settings.FlutterSettings;
+import io.flutter.utils.AddToAppUtils;
 import io.flutter.utils.AndroidUtils;
 import io.flutter.utils.FlutterModuleUtils;
 import java.lang.reflect.Field;
@@ -52,32 +53,8 @@ public class FlutterStudioStartupActivity implements StartupActivity {
 
   @Override
   public void runActivity(@NotNull Project project) {
-    MessageBusConnection connection = project.getMessageBus().connect(project);
-    // GRADLE_SYNC_TOPIC is not public in Android Studio 3.5. It is in 3.6. It isn't defined in 3.4.
-    //noinspection unchecked
-    Topic<GradleSyncListener> topic = getStaticFieldValue(GradleSyncState.class, Topic.class, "GRADLE_SYNC_TOPIC");
-    assert topic != null;
-    connection.subscribe(topic, makeSyncListener(project));
-
-    if (!FlutterModuleUtils.hasFlutterModule(project)) {
-      connection.subscribe(ProjectTopics.MODULES, new ModuleListener() {
-        @Override
-        public void moduleAdded(@NotNull Project proj, @NotNull Module mod) {
-          if (AndroidUtils.FLUTTER_MODULE_NAME.equals(mod.getName())) {
-            //connection.disconnect(); TODO(messick) Test this deletion!
-            AppExecutorUtil.getAppExecutorService().execute(() -> {
-              AndroidUtils.enableCoeditIfAddToAppDetected(project);
-            });
-          }
-        }
-      });
+    if (!AddToAppUtils.initializeAndDetectFlutter(project)) {
       return;
-    }
-    else {
-      if (ANDROID_PROJECT_TYPE.equals(ProjectTypeService.getProjectType(project))) {
-        // This is an add-to-app project.
-        connection.subscribe(DebuggerManagerListener.TOPIC, makeAddToAppAttachListener(project));
-      }
     }
 
     // Unset this flag for all projects, mainly to ease the upgrade from 3.0.1 to 3.1.
@@ -89,105 +66,5 @@ public class FlutterStudioStartupActivity implements StartupActivity {
       // TODO(messick): Remove the flag once this sync mechanism is stable.
       AndroidModuleLibraryManager.startWatching(project);
     }
-  }
-
-  // Derived from the method in ReflectionUtil, with the addition of setAccessible().
-  public static <T> T getStaticFieldValue(@NotNull Class objectClass,
-                                          @Nullable("null means any type") Class<T> fieldType,
-                                          @NotNull @NonNls String fieldName) {
-    try {
-      final Field field = findAssignableField(objectClass, fieldType, fieldName);
-      if (!Modifier.isStatic(field.getModifiers())) {
-        throw new IllegalArgumentException("Field " + objectClass + "." + fieldName + " is not static");
-      }
-      field.setAccessible(true);
-      //noinspection unchecked
-      return (T)field.get(null);
-    }
-    catch (NoSuchFieldException | IllegalAccessException e) {
-      return null;
-    }
-  }
-
-  @NotNull
-  private static GradleSyncListener makeSyncListener(@NotNull Project project) {
-    return new GradleSyncListener() {
-      @Override
-      public void syncSucceeded(@NotNull Project project) {
-        AndroidUtils.checkDartSupport(project);
-      }
-
-      @Override
-      public void syncFailed(@NotNull Project project, @NotNull String errorMessage) {
-        AndroidUtils.checkDartSupport(project);
-      }
-
-      @Override
-      public void syncSkipped(@NotNull Project project) {
-        AndroidUtils.checkDartSupport(project);
-      }
-
-      @Override
-      public void sourceGenerationFinished(@NotNull Project project) {
-      }
-    };
-  }
-
-  @NotNull
-  private static DebuggerManagerListener makeAddToAppAttachListener(@NotNull Project project) {
-
-    return new DebuggerManagerListener() {
-
-      DebugProcessListener dpl = new DebugProcessListener() {
-        @Override
-        public void processDetached(@NotNull DebugProcess process, boolean closedByUser) {
-          ThreeState state = project.getUserData(ATTACH_IS_ACTIVE);
-          if (state != null) {
-            project.putUserData(ATTACH_IS_ACTIVE, null);
-          }
-        }
-
-        @Override
-        public void processAttached(@NotNull DebugProcess process) {
-          if (project.getUserData(ATTACH_IS_ACTIVE) != null) {
-            return;
-          }
-          // Launch flutter attach if a run config can be found.
-          if (findRunConfig(project) == null) {
-            // Either there is no Flutter run config or there are more than one.
-            if (RunManagerEx.getInstanceEx(project).getSelectedConfiguration() instanceof SdkRunConfig) {
-              // The selected run config at this point is not Flutter, so we can't start the process automatically.
-              return;
-            }
-          }
-          FlutterSdk sdk = FlutterSdk.getFlutterSdk(project);
-          if (sdk == null) {
-            return;
-          }
-          // If needed, DataContext could be saved by FlutterReloadManager.beforeActionPerformed() in project user data.
-          DataContext context = DataContext.EMPTY_CONTEXT;
-          List<Module> modules = FlutterModuleUtils.findModulesWithFlutterContents(project);
-          assert modules.size() == 1; // TODO(messick) Need to change this if multiple :flutter sub-projects supported.
-          PubRoot pubRoot = PubRoot.forDirectory(Objects.requireNonNull(modules.get(0).getModuleFile()).getParent());
-          Application app = ApplicationManager.getApplication();
-          project.putUserData(ATTACH_IS_ACTIVE, ThreeState.fromBoolean(true));
-          // Note: Using block comments to preserve formatting.
-          app.invokeLater( /* After the Android launch completes, */
-            () -> app.executeOnPooledThread( /* but not on the EDT, */
-              () -> app.runReadAction( /* with read access, */
-                () -> new AttachDebuggerAction().startCommand(project, sdk, pubRoot, context)))); /* attach. */
-        }
-      };
-
-      @Override
-      public void sessionCreated(DebuggerSession session) {
-        session.getProcess().addDebugProcessListener(dpl);
-      }
-
-      @Override
-      public void sessionRemoved(DebuggerSession session) {
-        session.getProcess().removeDebugProcessListener(dpl);
-      }
-    };
   }
 }

--- a/flutter-studio/src/io/flutter/FlutterStudioStartupActivity.java
+++ b/flutter-studio/src/io/flutter/FlutterStudioStartupActivity.java
@@ -5,28 +5,45 @@
  */
 package io.flutter;
 
+import static com.android.tools.idea.gradle.project.importing.NewProjectSetup.ANDROID_PROJECT_TYPE;
 import static com.intellij.util.ReflectionUtil.findAssignableField;
+import static io.flutter.actions.AttachDebuggerAction.ATTACH_IS_ACTIVE;
+import static io.flutter.actions.AttachDebuggerAction.findRunConfig;
 
 import com.android.tools.idea.gradle.project.sync.GradleSyncListener;
 import com.android.tools.idea.gradle.project.sync.GradleSyncState;
 import com.intellij.ProjectTopics;
-import com.intellij.openapi.actionSystem.ActionManager;
-import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.debugger.engine.DebugProcess;
+import com.intellij.debugger.engine.DebugProcessListener;
+import com.intellij.debugger.impl.DebuggerManagerListener;
+import com.intellij.debugger.impl.DebuggerSession;
+import com.intellij.execution.RunManagerEx;
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.application.Application;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.ModuleListener;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectTypeService;
 import com.intellij.openapi.startup.StartupActivity;
+import com.intellij.util.ThreeState;
 import com.intellij.util.concurrency.AppExecutorUtil;
 import com.intellij.util.messages.MessageBusConnection;
 import com.intellij.util.messages.Topic;
-import io.flutter.actions.OpenAndroidModule;
+import io.flutter.actions.AttachDebuggerAction;
 import io.flutter.android.AndroidModuleLibraryManager;
 import io.flutter.project.FlutterProjectCreator;
+import io.flutter.pub.PubRoot;
+import io.flutter.run.FlutterReloadManager;
+import io.flutter.run.SdkRunConfig;
+import io.flutter.sdk.FlutterSdk;
 import io.flutter.settings.FlutterSettings;
 import io.flutter.utils.AndroidUtils;
 import io.flutter.utils.FlutterModuleUtils;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.util.List;
+import java.util.Objects;
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -37,17 +54,17 @@ public class FlutterStudioStartupActivity implements StartupActivity {
   public void runActivity(@NotNull Project project) {
     MessageBusConnection connection = project.getMessageBus().connect(project);
     // GRADLE_SYNC_TOPIC is not public in Android Studio 3.5. It is in 3.6. It isn't defined in 3.4.
-    Topic topic = getStaticFieldValue(GradleSyncState.class, Topic.class, "GRADLE_SYNC_TOPIC");
-    assert topic != null;
     //noinspection unchecked
-    connection.subscribe((Topic<GradleSyncListener>)topic, makeSyncListener(project));
+    Topic<GradleSyncListener> topic = getStaticFieldValue(GradleSyncState.class, Topic.class, "GRADLE_SYNC_TOPIC");
+    assert topic != null;
+    connection.subscribe(topic, makeSyncListener(project));
 
     if (!FlutterModuleUtils.hasFlutterModule(project)) {
       connection.subscribe(ProjectTopics.MODULES, new ModuleListener() {
         @Override
         public void moduleAdded(@NotNull Project proj, @NotNull Module mod) {
           if (AndroidUtils.FLUTTER_MODULE_NAME.equals(mod.getName())) {
-            connection.disconnect();
+            //connection.disconnect(); TODO(messick) Test this deletion!
             AppExecutorUtil.getAppExecutorService().execute(() -> {
               AndroidUtils.enableCoeditIfAddToAppDetected(project);
             });
@@ -55,6 +72,12 @@ public class FlutterStudioStartupActivity implements StartupActivity {
         }
       });
       return;
+    }
+    else {
+      if (ANDROID_PROJECT_TYPE.equals(ProjectTypeService.getProjectType(project))) {
+        // This is an add-to-app project.
+        connection.subscribe(DebuggerManagerListener.TOPIC, makeAddToAppAttachListener(project));
+      }
     }
 
     // Unset this flag for all projects, mainly to ease the upgrade from 3.0.1 to 3.1.
@@ -106,6 +129,64 @@ public class FlutterStudioStartupActivity implements StartupActivity {
 
       @Override
       public void sourceGenerationFinished(@NotNull Project project) {
+      }
+    };
+  }
+
+  @NotNull
+  private static DebuggerManagerListener makeAddToAppAttachListener(@NotNull Project project) {
+
+    return new DebuggerManagerListener() {
+
+      DebugProcessListener dpl = new DebugProcessListener() {
+        @Override
+        public void processDetached(@NotNull DebugProcess process, boolean closedByUser) {
+          ThreeState state = project.getUserData(ATTACH_IS_ACTIVE);
+          if (state != null) {
+            project.putUserData(ATTACH_IS_ACTIVE, null);
+          }
+        }
+
+        @Override
+        public void processAttached(@NotNull DebugProcess process) {
+          if (project.getUserData(ATTACH_IS_ACTIVE) != null) {
+            return;
+          }
+          // Launch flutter attach if a run config can be found.
+          if (findRunConfig(project) == null) {
+            // Either there is no Flutter run config or there are more than one.
+            if (RunManagerEx.getInstanceEx(project).getSelectedConfiguration() instanceof SdkRunConfig) {
+              // The selected run config at this point is not Flutter, so we can't start the process automatically.
+              return;
+            }
+          }
+          FlutterSdk sdk = FlutterSdk.getFlutterSdk(project);
+          if (sdk == null) {
+            return;
+          }
+          // If needed, DataContext could be saved by FlutterReloadManager.beforeActionPerformed() in project user data.
+          DataContext context = DataContext.EMPTY_CONTEXT;
+          List<Module> modules = FlutterModuleUtils.findModulesWithFlutterContents(project);
+          assert modules.size() == 1; // TODO(messick) Need to change this if multiple :flutter sub-projects supported.
+          PubRoot pubRoot = PubRoot.forDirectory(Objects.requireNonNull(modules.get(0).getModuleFile()).getParent());
+          Application app = ApplicationManager.getApplication();
+          project.putUserData(ATTACH_IS_ACTIVE, ThreeState.fromBoolean(true));
+          // Note: Using block comments to preserve formatting.
+          app.invokeLater( /* After the Android launch completes, */
+            () -> app.executeOnPooledThread( /* but not on the EDT, */
+              () -> app.runReadAction( /* with read access, */
+                () -> new AttachDebuggerAction().startCommand(project, sdk, pubRoot, context)))); /* attach. */
+        }
+      };
+
+      @Override
+      public void sessionCreated(DebuggerSession session) {
+        session.getProcess().addDebugProcessListener(dpl);
+      }
+
+      @Override
+      public void sessionRemoved(DebuggerSession session) {
+        session.getProcess().removeDebugProcessListener(dpl);
       }
     };
   }

--- a/flutter-studio/src/io/flutter/FlutterStudioStartupActivity.java
+++ b/flutter-studio/src/io/flutter/FlutterStudioStartupActivity.java
@@ -5,49 +5,13 @@
  */
 package io.flutter;
 
-import static com.android.tools.idea.gradle.project.importing.NewProjectSetup.ANDROID_PROJECT_TYPE;
-import static com.intellij.util.ReflectionUtil.findAssignableField;
-import static io.flutter.actions.AttachDebuggerAction.ATTACH_IS_ACTIVE;
-import static io.flutter.actions.AttachDebuggerAction.findRunConfig;
-
-import com.android.tools.idea.gradle.project.sync.GradleSyncListener;
-import com.android.tools.idea.gradle.project.sync.GradleSyncState;
-import com.intellij.ProjectTopics;
-import com.intellij.debugger.engine.DebugProcess;
-import com.intellij.debugger.engine.DebugProcessListener;
-import com.intellij.debugger.impl.DebuggerManagerListener;
-import com.intellij.debugger.impl.DebuggerSession;
-import com.intellij.execution.RunManagerEx;
-import com.intellij.openapi.actionSystem.DataContext;
-import com.intellij.openapi.application.Application;
-import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.module.Module;
-import com.intellij.openapi.project.ModuleListener;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.project.ProjectTypeService;
 import com.intellij.openapi.startup.StartupActivity;
-import com.intellij.util.ThreeState;
-import com.intellij.util.concurrency.AppExecutorUtil;
-import com.intellij.util.messages.MessageBusConnection;
-import com.intellij.util.messages.Topic;
-import io.flutter.actions.AttachDebuggerAction;
 import io.flutter.android.AndroidModuleLibraryManager;
 import io.flutter.project.FlutterProjectCreator;
-import io.flutter.pub.PubRoot;
-import io.flutter.run.FlutterReloadManager;
-import io.flutter.run.SdkRunConfig;
-import io.flutter.sdk.FlutterSdk;
 import io.flutter.settings.FlutterSettings;
 import io.flutter.utils.AddToAppUtils;
-import io.flutter.utils.AndroidUtils;
-import io.flutter.utils.FlutterModuleUtils;
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
-import java.util.List;
-import java.util.Objects;
-import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 public class FlutterStudioStartupActivity implements StartupActivity {
 

--- a/flutter-studio/src/io/flutter/utils/AddToAppUtils.java
+++ b/flutter-studio/src/io/flutter/utils/AddToAppUtils.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2019 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.utils;
+
+import static com.android.tools.idea.gradle.project.importing.NewProjectSetup.ANDROID_PROJECT_TYPE;
+import static com.intellij.util.ReflectionUtil.findAssignableField;
+import static io.flutter.actions.AttachDebuggerAction.ATTACH_IS_ACTIVE;
+import static io.flutter.actions.AttachDebuggerAction.findRunConfig;
+
+import com.android.tools.idea.gradle.project.sync.GradleSyncListener;
+import com.android.tools.idea.gradle.project.sync.GradleSyncState;
+import com.intellij.ProjectTopics;
+import com.intellij.debugger.engine.DebugProcess;
+import com.intellij.debugger.engine.DebugProcessListener;
+import com.intellij.debugger.impl.DebuggerManagerListener;
+import com.intellij.debugger.impl.DebuggerSession;
+import com.intellij.execution.RunManagerEx;
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.application.Application;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.project.ModuleListener;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectTypeService;
+import com.intellij.util.ThreeState;
+import com.intellij.util.concurrency.AppExecutorUtil;
+import com.intellij.util.messages.MessageBusConnection;
+import com.intellij.util.messages.Topic;
+import io.flutter.actions.AttachDebuggerAction;
+import io.flutter.pub.PubRoot;
+import io.flutter.run.SdkRunConfig;
+import io.flutter.sdk.FlutterSdk;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.List;
+import java.util.Objects;
+import org.jetbrains.annotations.NonNls;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class AddToAppUtils {
+
+  private AddToAppUtils() {
+  }
+
+  public static boolean initializeAndDetectFlutter(@NotNull Project project) {
+    MessageBusConnection connection = project.getMessageBus().connect(project);
+    // GRADLE_SYNC_TOPIC is not public in Android Studio 3.5. It is in 3.6. It isn't defined in 3.4.
+    //noinspection unchecked
+    Topic<GradleSyncListener> topic = getStaticFieldValue(GradleSyncState.class, Topic.class, "GRADLE_SYNC_TOPIC");
+    assert topic != null;
+    connection.subscribe(topic, makeSyncListener(project));
+
+    if (!FlutterModuleUtils.hasFlutterModule(project)) {
+      connection.subscribe(ProjectTopics.MODULES, new ModuleListener() {
+        @Override
+        public void moduleAdded(@NotNull Project proj, @NotNull Module mod) {
+          if (AndroidUtils.FLUTTER_MODULE_NAME.equals(mod.getName())) {
+            //connection.disconnect(); TODO(messick) Test this deletion!
+            AppExecutorUtil.getAppExecutorService().execute(() -> {
+              AndroidUtils.enableCoeditIfAddToAppDetected(project);
+            });
+          }
+        }
+      });
+      return false;
+    }
+    else {
+      if (ANDROID_PROJECT_TYPE.equals(ProjectTypeService.getProjectType(project))) {
+        // This is an add-to-app project.
+        connection.subscribe(DebuggerManagerListener.TOPIC, makeAddToAppAttachListener(project));
+      }
+    }
+    return true;
+  }
+
+  // Derived from the method in ReflectionUtil, with the addition of setAccessible().
+  public static <T> T getStaticFieldValue(@NotNull Class objectClass,
+                                          @Nullable("null means any type") Class<T> fieldType,
+                                          @NotNull @NonNls String fieldName) {
+    try {
+      final Field field = findAssignableField(objectClass, fieldType, fieldName);
+      if (!Modifier.isStatic(field.getModifiers())) {
+        throw new IllegalArgumentException("Field " + objectClass + "." + fieldName + " is not static");
+      }
+      field.setAccessible(true);
+      //noinspection unchecked
+      return (T)field.get(null);
+    }
+    catch (NoSuchFieldException | IllegalAccessException e) {
+      return null;
+    }
+  }
+
+  @NotNull
+  private static GradleSyncListener makeSyncListener(@NotNull Project project) {
+    return new GradleSyncListener() {
+      @Override
+      public void syncSucceeded(@NotNull Project project) {
+        AndroidUtils.checkDartSupport(project);
+      }
+
+      @Override
+      public void syncFailed(@NotNull Project project, @NotNull String errorMessage) {
+        AndroidUtils.checkDartSupport(project);
+      }
+
+      @Override
+      public void syncSkipped(@NotNull Project project) {
+        AndroidUtils.checkDartSupport(project);
+      }
+
+      @Override
+      public void sourceGenerationFinished(@NotNull Project project) {
+      }
+    };
+  }
+
+  @NotNull
+  private static DebuggerManagerListener makeAddToAppAttachListener(@NotNull Project project) {
+
+    return new DebuggerManagerListener() {
+
+      DebugProcessListener dpl = new DebugProcessListener() {
+        @Override
+        public void processDetached(@NotNull DebugProcess process, boolean closedByUser) {
+          ThreeState state = project.getUserData(ATTACH_IS_ACTIVE);
+          if (state != null) {
+            project.putUserData(ATTACH_IS_ACTIVE, null);
+          }
+        }
+
+        @Override
+        public void processAttached(@NotNull DebugProcess process) {
+          if (project.getUserData(ATTACH_IS_ACTIVE) != null) {
+            return;
+          }
+          // Launch flutter attach if a run config can be found.
+          if (findRunConfig(project) == null) {
+            // Either there is no Flutter run config or there are more than one.
+            if (RunManagerEx.getInstanceEx(project).getSelectedConfiguration() instanceof SdkRunConfig) {
+              // The selected run config at this point is not Flutter, so we can't start the process automatically.
+              return;
+            }
+          }
+          FlutterSdk sdk = FlutterSdk.getFlutterSdk(project);
+          if (sdk == null) {
+            return;
+          }
+          // If needed, DataContext could be saved by FlutterReloadManager.beforeActionPerformed() in project user data.
+          DataContext context = DataContext.EMPTY_CONTEXT;
+          List<Module> modules = FlutterModuleUtils.findModulesWithFlutterContents(project);
+          assert modules.size() == 1; // TODO(messick) Need to change this if multiple :flutter sub-projects supported.
+          PubRoot pubRoot = PubRoot.forDirectory(Objects.requireNonNull(modules.get(0).getModuleFile()).getParent());
+          Application app = ApplicationManager.getApplication();
+          project.putUserData(ATTACH_IS_ACTIVE, ThreeState.fromBoolean(true));
+          // Note: Using block comments to preserve formatting.
+          app.invokeLater( /* After the Android launch completes, */
+            () -> app.executeOnPooledThread( /* but not on the EDT, */
+              () -> app.runReadAction( /* with read access, */
+                () -> new AttachDebuggerAction().startCommand(project, sdk, pubRoot, context)))); /* attach. */
+        }
+      };
+
+      @Override
+      public void sessionCreated(DebuggerSession session) {
+        session.getProcess().addDebugProcessListener(dpl);
+      }
+
+      @Override
+      public void sessionRemoved(DebuggerSession session) {
+        session.getProcess().removeDebugProcessListener(dpl);
+      }
+    };
+  }
+}

--- a/src/io/flutter/actions/AttachDebuggerAction.java
+++ b/src/io/flutter/actions/AttachDebuggerAction.java
@@ -6,11 +6,14 @@
 package io.flutter.actions;
 
 import com.google.common.base.Joiner;
+import com.intellij.execution.ExecutionListener;
+import com.intellij.execution.ExecutionManager;
 import com.intellij.execution.Executor;
 import com.intellij.execution.ProgramRunnerUtil;
 import com.intellij.execution.RunManagerEx;
 import com.intellij.execution.RunnerAndConfigurationSettings;
 import com.intellij.execution.configurations.RunConfiguration;
+import com.intellij.execution.process.ProcessHandler;
 import com.intellij.execution.runners.ExecutionEnvironment;
 import com.intellij.execution.runners.ExecutionEnvironmentBuilder;
 import com.intellij.openapi.actionSystem.AnActionEvent;
@@ -20,7 +23,10 @@ import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.DialogWrapper;
 import com.intellij.openapi.ui.Messages;
+import com.intellij.openapi.util.Key;
 import com.intellij.openapi.wm.ToolWindowId;
+import com.intellij.util.ThreeState;
+import com.intellij.util.messages.MessageBusConnection;
 import io.flutter.FlutterConstants;
 import io.flutter.FlutterInitializer;
 import io.flutter.pub.PubRoot;
@@ -32,6 +38,7 @@ import io.flutter.sdk.FlutterSdk;
 import io.flutter.sdk.FlutterSdkUtil;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Consumer;
 import javax.swing.JComponent;
 import javax.swing.JPanel;
 import javax.swing.JTextPane;
@@ -39,6 +46,15 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class AttachDebuggerAction extends FlutterSdkAction {
+
+  // Is 'flutter attach' running for a project?
+  // The three states are true, false, and non-existent (null).
+  //   true = run automatically via the debug listener in FlutterStudioStartupActivity
+  //   false = run from button press here
+  //   null = no attach process is running
+  // The button is still required because there may be multiple Flutter run configs.
+  public static final Key<ThreeState> ATTACH_IS_ACTIVE = new Key<>("attach-is-active");
+
   @Override
   public void startCommand(@NotNull Project project, @NotNull FlutterSdk sdk, @Nullable PubRoot root, @NotNull DataContext context) {
     // NOTE: When making changes here, consider making similar changes to RunFlutterAction.
@@ -91,6 +107,10 @@ public class AttachDebuggerAction extends FlutterSdkAction {
     ExecutionEnvironment env = builder.activeTarget().dataContext(context).build();
     FlutterLaunchMode.addToEnvironment(env, FlutterLaunchMode.DEBUG);
 
+    if (project.getUserData(ATTACH_IS_ACTIVE) == null) {
+      project.putUserData(ATTACH_IS_ACTIVE, ThreeState.fromBoolean(false));
+      onAttachTermination(project, (p) -> p.putUserData(ATTACH_IS_ACTIVE, null));
+    }
     ProgramRunnerUtil.executeConfiguration(env, false, true);
   }
 
@@ -121,12 +141,15 @@ public class AttachDebuggerAction extends FlutterSdkAction {
     else {
       enabled = true;
     }
+    if (enabled && (project.getUserData(ATTACH_IS_ACTIVE) != null)) {
+      enabled = false;
+    }
     e.getPresentation().setVisible(true);
     e.getPresentation().setEnabled(enabled);
   }
 
   @Nullable
-  private static RunConfiguration findRunConfig(Project project) {
+  public static RunConfiguration findRunConfig(Project project) {
     // Look for a Flutter run config. If exactly one is found then return it otherwise return null.
     RunManagerEx mgr = RunManagerEx.getInstanceEx(project);
     List<RunConfiguration> configs = mgr.getAllConfigurationsList();
@@ -139,6 +162,33 @@ public class AttachDebuggerAction extends FlutterSdkAction {
       }
     }
     return count == 1 ? sdkConfig : null;
+  }
+
+  private static void onAttachTermination(@NotNull Project project, @NotNull Consumer<Project> runner) {
+    MessageBusConnection connection = project.getMessageBus().connect();
+
+    // Need an ExecutionListener to clean up project-scoped state when the Stop button is clicked.
+    connection.subscribe(ExecutionManager.EXECUTION_TOPIC, new ExecutionListener() {
+      Object handler;
+
+      @Override
+      public void processStarted(@NotNull String executorId, @NotNull ExecutionEnvironment env, @NotNull ProcessHandler handler) {
+        if (env.getRunProfile() instanceof SdkAttachConfig) {
+          this.handler = handler;
+        }
+      }
+
+      @Override
+      public void processTerminated(@NotNull String executorId,
+                                    @NotNull ExecutionEnvironment env,
+                                    @NotNull ProcessHandler handler,
+                                    int exitCode) {
+        if (this.handler == handler) {
+          runner.accept(project);
+          connection.disconnect();
+        }
+      }
+    });
   }
 
   private static void showSelectConfigDialog() {

--- a/tool/plugin/lib/plugin.dart
+++ b/tool/plugin/lib/plugin.dart
@@ -607,7 +607,7 @@ class BuildCommand extends ProductCommand {
         processedFile.writeAsStringSync(source);
 
         processedFile = File(
-            'flutter-studio/src/io/flutter/FlutterStudioStartupActivity.java');
+            'flutter-studio/src/io/flutter/utils/AddToAppUtils.java');
         source = processedFile.readAsStringSync();
         files[processedFile] = source;
         source = source.replaceAll(

--- a/tool/plugin/lib/plugin.dart
+++ b/tool/plugin/lib/plugin.dart
@@ -268,7 +268,7 @@ final Ansi ansi = new Ansi(true);
 
 void separator(String name) {
   log('');
-  log('${ansi.yellow}${ansi.bold}$name${ansi.none}', indent: false);
+  log('${ansi.red}${ansi.bold}$name${ansi.none}', indent: false);
 }
 
 String substituteTemplateVariables(String line, BuildSpec spec) {
@@ -591,49 +591,9 @@ class BuildCommand extends ProductCommand {
       var files = <File, String>{};
       var processedFile, source;
 
-      // TODO: Remove this when we no longer support 191.x
+      // TODO: Remove this when we no longer support AS 3.5
 
-      // This is for versions prior to AS 3.5
-      if (spec.version.startsWith('2019.1')) {
-        processedFile = File(
-            'flutter-studio/src/io/flutter/FlutterStudioStartupActivity.java');
-        source = processedFile.readAsStringSync();
-        files[processedFile] = source;
-        source = source.replaceAll(
-            'Topic topic = GradleSyncState.GRADLE_SYNC_TOPIC;', '');
-        source = source.replaceAll(
-            'connection.subscribe((Topic<GradleSyncListener>)topic, makeSyncListener(project));',
-            '');
-        processedFile.writeAsStringSync(source);
-      }
-
-      if (!spec.version.startsWith('3.5') &&
-          !spec.version.startsWith('3.6') &&
-          !spec.version.startsWith('2019.2') &&
-          !(spec.version == '2019.1.2')) {
-        processedFile = File(
-            'flutter-studio/src/io/flutter/project/FlutterProjectModel.java');
-        source = processedFile.readAsStringSync();
-        files[processedFile] = source;
-        source = source.replaceAll('addListener(()', 'addListener(sender');
-        processedFile.writeAsStringSync(source);
-
-        processedFile = File(
-            'flutter-studio/src/io/flutter/project/FlutterSettingsStep.java');
-        source = processedFile.readAsStringSync();
-        files[processedFile] = source;
-        source = source.replaceAll('listen', 'receive');
-        processedFile.writeAsStringSync(source);
-
-        processedFile = File('resources/META-INF/studio-contribs_template.xml');
-        source = processedFile.readAsStringSync();
-        files[processedFile] = source;
-        source = source.replaceAll(
-            'JavaNewProjectOrModuleGroup', 'NewProjectOrModuleGroup');
-        processedFile.writeAsStringSync(source);
-      }
-
-      if (spec.version.startsWith('2019.1') || spec.version.startsWith('3.5')) {
+      if (spec.version.startsWith('3.5')) {
         processedFile = File(
             'flutter-studio/src/io/flutter/android/AndroidModuleLibraryManager.java');
         source = processedFile.readAsStringSync();
@@ -644,6 +604,15 @@ class BuildCommand extends ProductCommand {
         var end = source.indexOf(last);
         // Change the initializer to use null, equivalent to original code.
         source = '${source.substring(0, end + last.length)}null;\n}}';
+        processedFile.writeAsStringSync(source);
+
+        processedFile = File(
+            'flutter-studio/src/io/flutter/FlutterStudioStartupActivity.java');
+        source = processedFile.readAsStringSync();
+        files[processedFile] = source;
+        source = source.replaceAll(
+            'connection.subscribe(DebuggerManagerListener.TOPIC, makeAddToAppAttachListener(project));',
+            '');
         processedFile.writeAsStringSync(source);
       }
 


### PR DESCRIPTION
When an Android project containing an add-to-app module is opened, add a listener that detects app launches. The listener then launches `fluter attach` for it. The Attach button on the toolbar will seldom need to be used; only when there are multiple Flutter run configs is it needed. In conjunction, change the Attach button to be disabled when the attach process is running, and re-enable it when the process terminates.

@xster I'm not sure if this gets everything in the video you added to #4064, but I'll get you a new build to check out.
@devoncarew @DaveShuckerow for review.