### PR TITLE
[WIP] Generate dev channel change log

### DIFF
--- a/product-matrix.json
+++ b/product-matrix.json
@@ -1,6 +1,7 @@
 {
   "list": [
     {
+      "channel": "stable",
       "comments": "IntelliJ 2019.1.3, Android Studio 3.5",
       "name": "IntelliJ 2019.1.3",
       "version": "3.5",
@@ -13,6 +14,7 @@
       "filesToSkip": ["src/io/flutter/editor/IntellijColorPickerProvider.java"]
     },
     {
+      "channel": "stable",
       "comments": "Android Studio 3.6 Beta 4",
       "name": "Android Studio 3.6",
       "version": "3.6",
@@ -24,6 +26,7 @@
       "filesToSkip": ["src/io/flutter/editor/IntellijColorPickerProvider.java"]
     },
     {
+      "channel": "stable",
       "comments": "IntelliJ 2019.2.4",
       "name": "IntelliJ 2019.2.4",
       "version": "2019.2.4",
@@ -34,6 +37,7 @@
       "untilBuild": "192.*"
     },
     {
+      "channel": "stable",
       "comments": "IntelliJ 2019.3",
       "name": "IntelliJ 2019.3",
       "version": "2019.3",
@@ -43,6 +47,18 @@
       "dartPluginVersion": "193.5432",
       "sinceBuild": "193.3519.25",
       "untilBuild": "193.*"
+    },
+    {
+      "channel": "dev",
+      "comments": "Android Studio 4.0 Canary 4",
+      "name": "Android Studio 4.0",
+      "version": "4.0",
+      "ideaProduct": "android-studio",
+      "ideaVersion": "192.5947919",
+      "dartPluginVersion": "192.6603.23",
+      "sinceBuild": "192.6262",
+      "untilBuild": "192.7141",
+      "filesToSkip": ["src/io/flutter/editor/IntellijColorPickerProvider.java"]
     }
   ]
 }


### PR DESCRIPTION
The `print` on line 1188 produces:
```
## Changes since release_42
- if track widget creation is not enabled, pass in --no-track-widget-creation (#4196)
- Surface reload exceptions (#4198)
- provide more stack trace details for inspector timeouts (#4193)
- Update change log for M42.1 (#4192)
```

This is not ready for review because `buildSpecs` is empty at line 560.