### PR TITLE
rename a flutter refactor action

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -1064,7 +1064,7 @@
     </group>
 
     <!-- refactoring menu -->
-    <action class="io.flutter.actions.ExtractWidgetAction" id="Flutter.ExtractWidget" text="Flutter Widget...">
+    <action class="io.flutter.actions.ExtractWidgetAction" id="Flutter.ExtractWidget" text="Extract Flutter Widget...">
       <add-to-group group-id="IntroduceActionsGroup" anchor="after" relative-to-action="ExtractMethod"/>
       <keyboard-shortcut keymap="$default" first-keystroke="ctrl alt W"/>
     </action>

--- a/resources/META-INF/plugin_template.xml
+++ b/resources/META-INF/plugin_template.xml
@@ -188,7 +188,7 @@
     </group>
 
     <!-- refactoring menu -->
-    <action class="io.flutter.actions.ExtractWidgetAction" id="Flutter.ExtractWidget" text="Flutter Widget...">
+    <action class="io.flutter.actions.ExtractWidgetAction" id="Flutter.ExtractWidget" text="Extract Flutter Widget...">
       <add-to-group group-id="IntroduceActionsGroup" anchor="after" relative-to-action="ExtractMethod"/>
       <keyboard-shortcut keymap="$default" first-keystroke="ctrl alt W"/>
     </action>


### PR DESCRIPTION
- rename an action; `Flutter Widget...` ==> `Extract Flutter Widget...` (it wasn't clear in context what the action would perform)

before the change:

<img width="295" alt="Screen Shot 2019-12-21 at 8 25 28 AM" src="https://user-images.githubusercontent.com/1269969/71310680-c8a7e100-23cb-11ea-9308-3545e83c9cf6.png">
