### PR TITLE
refactor the reload on save implementation

### DIFF
--- a/src/io/flutter/run/LaunchState.java
+++ b/src/io/flutter/run/LaunchState.java
@@ -39,9 +39,7 @@ import com.intellij.xdebugger.XDebuggerManager;
 import com.jetbrains.lang.dart.ide.runner.DartExecutionHelper;
 import com.jetbrains.lang.dart.util.DartUrlResolver;
 import io.flutter.FlutterConstants;
-import io.flutter.FlutterInitializer;
 import io.flutter.FlutterUtils;
-import io.flutter.actions.RestartFlutterApp;
 import io.flutter.dart.DartPlugin;
 import io.flutter.logging.FlutterLog;
 import io.flutter.logging.FlutterLogView;
@@ -398,9 +396,8 @@ public class LaunchState extends CommandLineState {
               final FlutterLaunchMode launchMode = FlutterLaunchMode.fromEnv(env);
               if (launchMode.supportsReload() && app.isStarted()) {
                 // Map a re-run action to a flutter hot restart.
-                FileDocumentManager.getInstance().saveAllDocuments();
-                FlutterInitializer.sendAnalyticsAction(RestartFlutterApp.class.getSimpleName());
-                app.performRestartApp(FlutterConstants.RELOAD_REASON_SAVE);
+                final FlutterReloadManager reloadManager = FlutterReloadManager.getInstance(env.getProject());
+                reloadManager.saveAllAndRestart(app, FlutterConstants.RELOAD_REASON_MANUAL);
               }
             }
 

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.java
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.java
@@ -141,6 +141,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
   private void createUIComponents() {
     mySdkCombo = new ComboboxWithBrowseButton(new ComboBox<>());
   }
+
   @Override
   @NotNull
   public String getId() {
@@ -178,10 +179,9 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
       return true;
     }
 
-    if (settings.isReloadWithError() != myHotReloadIgnoreErrorCheckBox.isSelected()) {
+    if (settings.allowReloadWithErrors() != myHotReloadIgnoreErrorCheckBox.isSelected()) {
       return true;
     }
-
 
     if (settings.isFormatCodeOnSave() != myFormatCodeOnSaveCheckBox.isSelected()) {
       return true;
@@ -294,7 +294,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
 
     final FlutterSettings settings = FlutterSettings.getInstance();
     myHotReloadOnSaveCheckBox.setSelected(settings.isReloadOnSave());
-    myHotReloadIgnoreErrorCheckBox.setSelected(settings.isReloadWithError());
+    myHotReloadIgnoreErrorCheckBox.setSelected(settings.allowReloadWithErrors());
     myFormatCodeOnSaveCheckBox.setSelected(settings.isFormatCodeOnSave());
     myOrganizeImportsOnSaveCheckBox.setSelected(settings.isOrganizeImportsOnSave());
 

--- a/src/io/flutter/settings/FlutterSettings.java
+++ b/src/io/flutter/settings/FlutterSettings.java
@@ -72,7 +72,7 @@ public class FlutterSettings {
     if (isReloadOnSave()) {
       analytics.sendEvent("settings", afterLastPeriod(reloadOnSaveKey));
     }
-    if (isReloadWithError()) {
+    if (allowReloadWithErrors()) {
       analytics.sendEvent("settings", afterLastPeriod(reloadWithErrorKey));
     }
     if (isOpenInspectorOnAppLaunch()) {
@@ -120,7 +120,7 @@ public class FlutterSettings {
     return getPropertiesComponent().getBoolean(reloadOnSaveKey, true);
   }
 
-  public boolean isReloadWithError() {
+  public boolean allowReloadWithErrors() {
     return getPropertiesComponent().getBoolean(reloadWithErrorKey, false);
   }
 


### PR DESCRIPTION
refactor the reload on save implementation:

- stop using an app global `handlingSave` flag (if this ever gets out of sync, reload on save will stop working until IntelliJ is restarted)
- switch to using the FlutterApp state to indicate that a reload is - or will soon be - in progress
- rename a preference method reload to reload on save for clarity
- some cleanup around the UI of reload on save for consistency w/ the different ways it can be invoked
- fix https://github.com/flutter/flutter-intellij/issues/3235
