### PR TITLE
Kokoro build configuration

### DIFF
--- a/kokoro/macos_external/continuous.cfg
+++ b/kokoro/macos_external/continuous.cfg
@@ -1,0 +1,6 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+
+# Location of the bash script. Should have value <github_scm.name>/<path_from_repository_root>.
+# github_scm.name is specified in the job configuration (next section).
+build_file: "flutter-intellij-kokoro/kokoro/macos_external/kokoro_build.sh"

--- a/kokoro/macos_external/continuous.cfg
+++ b/kokoro/macos_external/continuous.cfg
@@ -1,6 +1,2 @@
-# Format: //devtools/kokoro/config/proto/build.proto
-
-
-# Location of the bash script. Should have value <github_scm.name>/<path_from_repository_root>.
-# github_scm.name is specified in the job configuration (next section).
+# Location of the bash script.
 build_file: "flutter-intellij-kokoro/kokoro/macos_external/kokoro_build.sh"

--- a/kokoro/macos_external/kokoro_build.sh
+++ b/kokoro/macos_external/kokoro_build.sh
@@ -3,18 +3,13 @@
 # Fail on any error.
 set -e
 
-# Display commands being run.
-# WARNING: please only enable 'set -x' if necessary for debugging, and be very
-#  careful if you handle credentials (e.g. from Keystore) with 'set -x':
-#  statements like "export VAR=$(cat /tmp/keystore/credentials)" will result in
-#  the credentials being printed in build logs.
-#  Additionally, recursive invocation with credentials as command-line
-#  parameters, will print the full command, with credentials, in the build logs.
+# Display commands being run. Only do this while debugging and be careful
+# that no confidential information is displayed.
 # set -x
-
 
 # Code under repo is checked out to ${KOKORO_ARTIFACTS_DIR}/github.
 # The final directory name in this path is determined by the scm name specified
 # in the job configuration.
 cd ${KOKORO_ARTIFACTS_DIR}/github/flutter-intellij-kokoro
+
 ./tool/kokoro/build.sh

--- a/kokoro/macos_external/kokoro_build.sh
+++ b/kokoro/macos_external/kokoro_build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Fail on any error.
+set -e
+
+# Display commands being run.
+# WARNING: please only enable 'set -x' if necessary for debugging, and be very
+#  careful if you handle credentials (e.g. from Keystore) with 'set -x':
+#  statements like "export VAR=$(cat /tmp/keystore/credentials)" will result in
+#  the credentials being printed in build logs.
+#  Additionally, recursive invocation with credentials as command-line
+#  parameters, will print the full command, with credentials, in the build logs.
+# set -x
+
+
+# Code under repo is checked out to ${KOKORO_ARTIFACTS_DIR}/github.
+# The final directory name in this path is determined by the scm name specified
+# in the job configuration.
+cd ${KOKORO_ARTIFACTS_DIR}/github/flutter-intellij-kokoro
+./tool/kokoro/build.sh

--- a/kokoro/macos_external/presubmit.cfg
+++ b/kokoro/macos_external/presubmit.cfg
@@ -1,0 +1,6 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+
+# Location of the bash script. Should have value <github_scm.name>/<path_from_repository_root>.
+# github_scm.name is specified in the job configuration (next section).
+build_file: "flutter-intellij-kokoro/kokoro/macos_external/kokoro_build.sh"

--- a/kokoro/macos_external/presubmit.cfg
+++ b/kokoro/macos_external/presubmit.cfg
@@ -1,6 +1,2 @@
-# Format: //devtools/kokoro/config/proto/build.proto
-
-
-# Location of the bash script. Should have value <github_scm.name>/<path_from_repository_root>.
-# github_scm.name is specified in the job configuration (next section).
+# Location of the bash script.
 build_file: "flutter-intellij-kokoro/kokoro/macos_external/kokoro_build.sh"

--- a/tool/kokoro/build.sh
+++ b/tool/kokoro/build.sh
@@ -3,13 +3,8 @@
 # Fail on any error.
 set -e
 
-# Display commands being run.
-# WARNING: please only enable 'set -x' if necessary for debugging, and be very
-#  careful if you handle credentials (e.g. from Keystore) with 'set -x':
-#  statements like "export VAR=$(cat /tmp/keystore/credentials)" will result in
-#  the credentials being printed in build logs.
-#  Additionally, recursive invocation with credentials as command-line
-#  parameters, will print the full command, with credentials, in the build logs.
+# Display commands being run. Only do this while debugging and be careful
+# that no confidential information is displayed.
 # set -x
 
 if [ "$1" == "release" ]; then

--- a/tool/kokoro/build.sh
+++ b/tool/kokoro/build.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Fail on any error.
+set -e
+
+# Display commands being run.
+# WARNING: please only enable 'set -x' if necessary for debugging, and be very
+#  careful if you handle credentials (e.g. from Keystore) with 'set -x':
+#  statements like "export VAR=$(cat /tmp/keystore/credentials)" will result in
+#  the credentials being printed in build logs.
+#  Additionally, recursive invocation with credentials as command-line
+#  parameters, will print the full command, with credentials, in the build logs.
+# set -x
+
+if [ "$1" == "release" ]; then
+  # do release build
+  echo "release build"
+else
+  # do dev build
+  echo "dev build"
+fi
+echo "kokoro build finished"


### PR DESCRIPTION
First cut at defining build files for Kokoro. This version does nothing. It will be useful to verify the config is correct before digging into the actual build mechanics.

@athomas @devoncarew @keertip 