### PR TITLE
Remove hard coded refresh rate for fps calculation.

### DIFF
--- a/src/io/flutter/vmService/FlutterFramesMonitor.java
+++ b/src/io/flutter/vmService/FlutterFramesMonitor.java
@@ -122,7 +122,8 @@ public class FlutterFramesMonitor {
       return 0.0;
     }
 
-    return frameCount * 60.0 / costCount;
+    final double targetDisplayRefreshRate = vmServiceManager.getCurrentDisplayRefreshRateRaw();
+    return frameCount * targetDisplayRefreshRate / costCount;
   }
 
   public void addListener(Listener listener) {


### PR DESCRIPTION
We were hard coding 60.0. Now we pull the actual refresh rate from the VM and use it in our frame calculation. Verified that we correctly show 90.0 FPS for a pixel 4.

Before:
<img width="443" alt="Screen Shot 2020-01-16 at 9 38 35 AM" src="https://user-images.githubusercontent.com/43759233/72548652-fbff5380-3843-11ea-8847-84510eadbbcd.png">

After:
<img width="438" alt="Screen Shot 2020-01-16 at 9 33 14 AM" src="https://user-images.githubusercontent.com/43759233/72548546-c22e4d00-3843-11ea-9dfc-e6dd458a5437.png">

Fixes https://github.com/flutter/flutter-intellij/issues/4205