### PR TITLE
Defend against invalid refresh rates for flutter desktop devices.

### DIFF
--- a/src/io/flutter/NotificationManager.java
+++ b/src/io/flutter/NotificationManager.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter;
+
+import javax.annotation.Nullable;
+import java.util.HashSet;
+import java.util.Set;
+
+// TODO(kenz): it would be nice to consolidate all notifications to use a single manager. Perhaps we should
+// make `FlutterMessages` a private class in this file. Optionally, we could also move this functionality
+// into `FlutterMessages`.
+public class NotificationManager {
+  private static final Set<String> shownNotifications = new HashSet<>();
+
+  public static void showError(String title, String message, @Nullable String id, @Nullable Boolean showOnce) {
+    if (shouldNotify(id, showOnce)) {
+      shownNotifications.add(id);
+      FlutterMessages.showError(title, message);
+    }
+  }
+
+  public static void showWarning(String title, String message, @Nullable String id, @Nullable Boolean showOnce) {
+    if (shouldNotify(id, showOnce)) {
+      shownNotifications.add(id);
+      FlutterMessages.showWarning(title, message);
+    }
+  }
+
+  public static void showInfo(String title, String message, @Nullable String id, @Nullable Boolean showOnce) {
+    if (shouldNotify(id, showOnce)) {
+      shownNotifications.add(id);
+      FlutterMessages.showInfo(title, message);
+    }
+  }
+
+  private static boolean shouldNotify(@Nullable String id, @Nullable Boolean showOnce) {
+    // This notification has already been shown and it can only be shown once.
+    return id == null || !shownNotifications.contains(id) || showOnce == null || !showOnce;
+  }
+
+  public static void reset() {
+    shownNotifications.clear();
+  }
+}

--- a/src/io/flutter/NotificationManager.java
+++ b/src/io/flutter/NotificationManager.java
@@ -5,9 +5,9 @@
  */
 package io.flutter;
 
-import javax.annotation.Nullable;
 import java.util.HashSet;
 import java.util.Set;
+import org.jetbrains.annotations.Nullable;
 
 // TODO(kenz): it would be nice to consolidate all notifications to use a single manager. Perhaps we should
 // make `FlutterMessages` a private class in this file. Optionally, we could also move this functionality

--- a/src/io/flutter/performance/PerfFPSPanel.java
+++ b/src/io/flutter/performance/PerfFPSPanel.java
@@ -11,7 +11,6 @@ import com.intellij.ui.components.JBLabel;
 import com.intellij.ui.components.JBPanel;
 import com.intellij.util.ui.JBUI;
 import com.intellij.util.ui.UIUtil;
-import io.flutter.inspector.FrameRenderingDisplay;
 import io.flutter.run.daemon.FlutterApp;
 import io.flutter.vmService.FlutterFramesMonitor;
 import org.jetbrains.annotations.NotNull;

--- a/src/io/flutter/run/daemon/FlutterApp.java
+++ b/src/io/flutter/run/daemon/FlutterApp.java
@@ -44,6 +44,7 @@ import io.flutter.utils.MostlySilentOsProcessHandler;
 import io.flutter.utils.ProgressHelper;
 import io.flutter.utils.StreamSubscription;
 import io.flutter.utils.VmServiceListenerAdapter;
+import io.flutter.vmService.DisplayRefreshRateManager;
 import io.flutter.vmService.ServiceExtensions;
 import io.flutter.vmService.VMServiceManager;
 import org.dartlang.vm.service.VmService;
@@ -686,6 +687,11 @@ public class FlutterApp implements Disposable {
   @Nullable
   public VMServiceManager getVMServiceManager() {
     return myVMServiceManager;
+  }
+
+  @Nullable
+  public DisplayRefreshRateManager getDisplayRefreshRateManager() {
+    return myVMServiceManager != null ? myVMServiceManager.displayRefreshRateManager : null;
   }
 
   @NotNull

--- a/src/io/flutter/vmService/DisplayRefreshRateManager.java
+++ b/src/io/flutter/vmService/DisplayRefreshRateManager.java
@@ -137,7 +137,7 @@ public class DisplayRefreshRateManager {
   }
 
   private boolean invalidFps(double fps) {
-    // Use an epsilon to avoid issues with double comparison.
-    return fps > -1.0 && fps < 1.0;
+    // 24 FPS is the lowest frame rate that can be considered "smooth".
+    return fps < 24.0;
   }
 }

--- a/src/io/flutter/vmService/DisplayRefreshRateManager.java
+++ b/src/io/flutter/vmService/DisplayRefreshRateManager.java
@@ -118,7 +118,7 @@ public class DisplayRefreshRateManager {
           else {
             final double fps = object.get(fpsField).getAsDouble();
             // Defend against invalid refresh rate for Flutter Desktop devices (0.0).
-            if (fps == 0.0) {
+            if (invalidFps(fps)) {
               NotificationManager.showWarning(
                 "Flutter device frame rate invalid",
                 "Device returned a target frame rate of " + fps + " FPS." + " Using 60 FPS instead.",
@@ -134,5 +134,10 @@ public class DisplayRefreshRateManager {
       }
     );
     return ret;
+  }
+
+  private boolean invalidFps(double fps) {
+    // Use an epsilon to avoid issues with double comparison.
+    return fps > -1.0 && fps < 1.0;
   }
 }

--- a/src/io/flutter/vmService/DisplayRefreshRateManager.java
+++ b/src/io/flutter/vmService/DisplayRefreshRateManager.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2020 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.vmService;
+
+import com.google.gson.JsonObject;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.diagnostic.Logger;
+import io.flutter.NotificationManager;
+import io.flutter.utils.EventStream;
+import io.flutter.utils.StreamSubscription;
+import org.dartlang.vm.service.VmService;
+import org.dartlang.vm.service.consumer.ServiceExtensionConsumer;
+import org.dartlang.vm.service.element.RPCError;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+
+public class DisplayRefreshRateManager {
+  private static final Logger LOG = Logger.getInstance(DisplayRefreshRateManager.class);
+  private static final String INVALID_DISPLAY_REFRESH_RATE = "INVALID_DISPLAY_REFRESH_RATE";
+
+  public static final double defaultRefreshRate = 60.0;
+
+  private final VMServiceManager vmServiceManager;
+  private final VmService vmService;
+  private final EventStream<Double> displayRefreshRateStream;
+
+  DisplayRefreshRateManager(VMServiceManager vmServiceManager, VmService vmService) {
+    this.vmServiceManager = vmServiceManager;
+    this.vmService = vmService;
+    displayRefreshRateStream = new EventStream<>();
+  }
+
+  public void queryRefreshRate() {
+    // This needs to happen on the UI thread.
+    //noinspection CodeBlock2Expr
+    ApplicationManager.getApplication().invokeLater(() -> {
+      getDisplayRefreshRate().thenAcceptAsync(displayRefreshRateStream::setValue);
+    });
+  }
+
+  public int getTargetMicrosPerFrame() {
+    Double fps = getCurrentDisplayRefreshRateRaw();
+    if (fps == null) {
+      fps = defaultRefreshRate;
+    }
+    return (int)Math.round((Math.floor(1000000.0f / fps)));
+  }
+
+  /**
+   * Returns a StreamSubscription providing the queried display refresh rate.
+   * <p>
+   * The current value of the subscription can be null occasionally during initial application startup and for a brief time when doing a
+   * hot restart.
+   */
+  public StreamSubscription<Double> getCurrentDisplayRefreshRate(Consumer<Double> onValue, boolean onUIThread) {
+    return displayRefreshRateStream.listen(onValue, onUIThread);
+  }
+
+  /**
+   * Return the current display refresh rate, if any.
+   * <p>
+   * Note that this may not be immediately populated at app startup for Flutter apps. In that case, this will return
+   * the default value (defaultRefreshRate). Clients that wish to be notified when the refresh rate is discovered
+   * should prefer the StreamSubscription variant of this method (getCurrentDisplayRefreshRate()).
+   */
+  public Double getCurrentDisplayRefreshRateRaw() {
+    synchronized (displayRefreshRateStream) {
+      Double fps = displayRefreshRateStream.getValue();
+      if (fps == null) {
+        fps = defaultRefreshRate;
+      }
+      return fps;
+    }
+  }
+
+  private CompletableFuture<Double> getDisplayRefreshRate() {
+    final double unknownRefreshRate = 0.0;
+
+    final String flutterViewId = vmServiceManager.getFlutterViewId().exceptionally(exception -> {
+      // We often see "java.lang.RuntimeException: Method not found" from here; perhaps a race condition?
+      LOG.warn(exception.getMessage());
+      return null;
+    }).join();
+
+    if (flutterViewId == null) {
+      // Fail gracefully by returning the default.
+      return CompletableFuture.completedFuture(defaultRefreshRate);
+    }
+
+    return invokeGetDisplayRefreshRate(flutterViewId);
+  }
+
+  private CompletableFuture<Double> invokeGetDisplayRefreshRate(String flutterViewId) {
+    final CompletableFuture<Double> ret = new CompletableFuture<>();
+
+    final JsonObject params = new JsonObject();
+    params.addProperty("viewId", flutterViewId);
+
+    vmService.callServiceExtension(
+      vmServiceManager.getCurrentFlutterIsolateRaw().getId(), ServiceExtensions.displayRefreshRate, params,
+      new ServiceExtensionConsumer() {
+        @Override
+        public void onError(RPCError error) {
+          ret.completeExceptionally(new RuntimeException(error.getMessage()));
+        }
+
+        @Override
+        public void received(JsonObject object) {
+          final String fpsField = "fps";
+
+          if (object == null || !object.has(fpsField)) {
+            ret.complete(null);
+          }
+          else {
+            final double fps = object.get(fpsField).getAsDouble();
+            // Defend against invalid refresh rate for Flutter Desktop devices (0.0).
+            if (fps == 0.0) {
+              NotificationManager.showWarning(
+                "Flutter device frame rate invalid",
+                "Device returned a target frame rate of " + fps + " FPS." + " Using 60 FPS instead.",
+                INVALID_DISPLAY_REFRESH_RATE,
+                true
+              );
+              ret.complete(defaultRefreshRate);
+            } else {
+              ret.complete(fps);
+            }
+          }
+        }
+      }
+    );
+    return ret;
+  }
+}

--- a/src/io/flutter/vmService/VMServiceManager.java
+++ b/src/io/flutter/vmService/VMServiceManager.java
@@ -14,6 +14,7 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.util.Disposer;
 import com.intellij.openapi.util.text.StringUtil;
 import gnu.trove.THashMap;
+import io.flutter.FlutterMessages;
 import io.flutter.inspector.EvalOnDartLibrary;
 import io.flutter.run.daemon.FlutterApp;
 import io.flutter.utils.EventStream;
@@ -630,7 +631,16 @@ public class VMServiceManager implements FlutterApp.FlutterAppListener, Disposab
             ret.complete(null);
           }
           else {
-            ret.complete(object.get(fpsField).getAsDouble());
+            final double fps = object.get(fpsField).getAsDouble();
+            // Defend against invalid refresh rate for Flutter Desktop devices (0.0).
+            if (fps == 0.0) {
+              FlutterMessages.showWarning("Flutter device frame rate invalid",
+                                       "Device returned a target frame rate of " + fps + " FPS." + " Using 60 FPS instead."
+                                       );
+              ret.complete(defaultRefreshRate);
+            } else {
+              ret.complete(fps);
+            }
           }
         }
       }

--- a/src/io/flutter/vmService/VMServiceManager.java
+++ b/src/io/flutter/vmService/VMServiceManager.java
@@ -9,12 +9,10 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.intellij.openapi.Disposable;
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.util.Disposer;
 import com.intellij.openapi.util.text.StringUtil;
 import gnu.trove.THashMap;
-import io.flutter.FlutterMessages;
 import io.flutter.inspector.EvalOnDartLibrary;
 import io.flutter.run.daemon.FlutterApp;
 import io.flutter.utils.EventStream;
@@ -37,8 +35,6 @@ import java.util.function.Consumer;
 import static io.flutter.vmService.ServiceExtensions.enableOnDeviceInspector;
 
 public class VMServiceManager implements FlutterApp.FlutterAppListener, Disposable {
-  public final double defaultRefreshRate = 60.0;
-
   private static final Logger LOG = Logger.getInstance(VMServiceManager.class);
 
   @NotNull private final FlutterApp app;
@@ -54,8 +50,6 @@ public class VMServiceManager implements FlutterApp.FlutterAppListener, Disposab
 
   private final EventStream<IsolateRef> flutterIsolateRefStream;
 
-  private final EventStream<Double> displayRefreshRateStream;
-
   private volatile boolean firstFrameEventReceived = false;
   private final VmService vmService;
 
@@ -67,6 +61,8 @@ public class VMServiceManager implements FlutterApp.FlutterAppListener, Disposab
 
   private final Set<String> registeredServices = new HashSet<>();
 
+  @NotNull public final DisplayRefreshRateManager displayRefreshRateManager;
+
   public VMServiceManager(@NotNull FlutterApp app, @NotNull VmService vmService) {
     this.app = app;
     this.vmService = vmService;
@@ -75,9 +71,9 @@ public class VMServiceManager implements FlutterApp.FlutterAppListener, Disposab
     assert (app.getFlutterDebugProcess() != null);
 
     this.heapMonitor = new HeapMonitor(app.getFlutterDebugProcess().getVmServiceWrapper());
-    this.flutterFramesMonitor = new FlutterFramesMonitor(this, vmService);
+    this.displayRefreshRateManager = new DisplayRefreshRateManager(this, vmService);
+    this.flutterFramesMonitor = new FlutterFramesMonitor(displayRefreshRateManager, vmService);
     flutterIsolateRefStream = new EventStream<>();
-    displayRefreshRateStream = new EventStream<>();
 
     // The VM Service depends on events from the Extension event stream to determine when Flutter.Frame
     // events are fired. Without the call to listen, events from the stream will not be sent.
@@ -358,11 +354,7 @@ public class VMServiceManager implements FlutterApp.FlutterAppListener, Disposab
       pendingServiceExtensions.clear();
 
       // Query for display refresh rate and add the value to the stream.
-      // This needs to happen on the UI thread.
-      //noinspection CodeBlock2Expr
-      ApplicationManager.getApplication().invokeLater(() -> {
-        getDisplayRefreshRate().thenAcceptAsync(displayRefreshRateStream::setValue);
-      });
+      displayRefreshRateManager.queryRefreshRate();
     }
   }
 
@@ -557,98 +549,7 @@ public class VMServiceManager implements FlutterApp.FlutterAppListener, Disposab
     }
   }
 
-  public int getTargetMicrosPerFrame() {
-    Double fps = getCurrentDisplayRefreshRateRaw();
-    if (fps == null) {
-      fps = defaultRefreshRate;
-    }
-    return (int)Math.round((Math.floor(1000000.0f / fps)));
-  }
-
-  /**
-   * Returns a StreamSubscription providing the queried display refresh rate.
-   * <p>
-   * The current value of the subscription can be null occasionally during initial application startup and for a brief time when doing a
-   * hot restart.
-   */
-  public StreamSubscription<Double> getCurrentDisplayRefreshRate(Consumer<Double> onValue, boolean onUIThread) {
-    return displayRefreshRateStream.listen(onValue, onUIThread);
-  }
-
-  /**
-   * Return the current display refresh rate, if any.
-   * <p>
-   * Note that this may not be immediately populated at app startup for Flutter apps. In that case, this will return
-   * the default value (defaultRefreshRate). Clients that wish to be notified when the refresh rate is discovered
-   * should prefer the StreamSubscription variant of this method (getCurrentDisplayRefreshRate()).
-   */
-  public Double getCurrentDisplayRefreshRateRaw() {
-    synchronized (displayRefreshRateStream) {
-      Double fps = displayRefreshRateStream.getValue();
-      if (fps == null) {
-        fps = defaultRefreshRate;
-      }
-      return fps;
-    }
-  }
-
-  public CompletableFuture<Double> getDisplayRefreshRate() {
-    final double unknownRefreshRate = 0.0;
-
-    final String flutterViewId = getFlutterViewId().exceptionally(exception -> {
-      // We often see "java.lang.RuntimeException: Method not found" from here; perhaps a race condition?
-      LOG.warn(exception.getMessage());
-      return null;
-    }).join();
-
-    if (flutterViewId == null) {
-      // Fail gracefully by returning the default.
-      return CompletableFuture.completedFuture(defaultRefreshRate);
-    }
-
-    return invokeGetDisplayRefreshRate(flutterViewId);
-  }
-
-  private CompletableFuture<Double> invokeGetDisplayRefreshRate(String flutterViewId) {
-    final CompletableFuture<Double> ret = new CompletableFuture<>();
-
-    final JsonObject params = new JsonObject();
-    params.addProperty("viewId", flutterViewId);
-
-    vmService.callServiceExtension(
-      getCurrentFlutterIsolateRaw().getId(), ServiceExtensions.displayRefreshRate, params,
-      new ServiceExtensionConsumer() {
-        @Override
-        public void onError(RPCError error) {
-          ret.completeExceptionally(new RuntimeException(error.getMessage()));
-        }
-
-        @Override
-        public void received(JsonObject object) {
-          final String fpsField = "fps";
-
-          if (object == null || !object.has(fpsField)) {
-            ret.complete(null);
-          }
-          else {
-            final double fps = object.get(fpsField).getAsDouble();
-            // Defend against invalid refresh rate for Flutter Desktop devices (0.0).
-            if (fps == 0.0) {
-              FlutterMessages.showWarning("Flutter device frame rate invalid",
-                                       "Device returned a target frame rate of " + fps + " FPS." + " Using 60 FPS instead."
-                                       );
-              ret.complete(defaultRefreshRate);
-            } else {
-              ret.complete(fps);
-            }
-          }
-        }
-      }
-    );
-    return ret;
-  }
-
-  private CompletableFuture<String> getFlutterViewId() {
+  public CompletableFuture<String> getFlutterViewId() {
     return getFlutterViewsList().exceptionally(exception -> {
       throw new RuntimeException(exception.getMessage());
     }).thenApplyAsync((JsonElement element) -> {


### PR DESCRIPTION
This warns the user when an invalid refresh rate was received and uses the default (60 FPS) instead.

![Screen Shot 2020-01-17 at 9 40 46 AM](https://user-images.githubusercontent.com/43759233/72634653-d5a6ea00-390f-11ea-8c13-63a56017a002.png)
