### PR TITLE
Separate build vs test scripts

### DIFF
--- a/kokoro/macos_external/kokoro_build.sh
+++ b/kokoro/macos_external/kokoro_build.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# This script should execute during the scheduled builds.
+date
+echo "Automatic build started"
+
 # Fail on any error.
 set -e
 

--- a/kokoro/macos_external/kokoro_test.sh
+++ b/kokoro/macos_external/kokoro_test.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# All runs triggered by the github webhook go through this script.
+# The job name ends in "presubmit" for newly created PRs and
+# it ends in "continuous" for merged commits.
+
 # Fail on any error.
 set -e
 
@@ -12,4 +16,8 @@ set -e
 # in the job configuration.
 cd ${KOKORO_ARTIFACTS_DIR}/github/flutter-intellij-kokoro
 
-./tool/kokoro/test.sh
+if [[ $KOKORO_JOB_NAME =~ .*presubmit ]]; then
+  ./tool/kokoro/test.sh
+else
+  ./tool/kokoro/build.sh
+fi

--- a/tool/kokoro/build.sh
+++ b/tool/kokoro/build.sh
@@ -6,4 +6,6 @@ setup
 echo "kokoro build start"
 ./bin/plugin build --channel=dev
 
+# TODO(messick) Save build artifacts.
+
 echo "kokoro build finished"

--- a/tool/kokoro/setup.sh
+++ b/tool/kokoro/setup.sh
@@ -24,7 +24,5 @@ setup() {
   (cd ..; tar fx ant.tar.gz)
   export PATH=$PATH:`pwd`/../apache-ant-1.10.7/bin
 
-  echo "pub get `pwd`"; pub get --no-precompile
-  (cd testData/sample_tests; echo "pub get `pwd`"; pub get --no-precompile)
   (cd tool/plugin; echo "pub get `pwd`"; pub get --no-precompile)
 }

--- a/tool/kokoro/test.sh
+++ b/tool/kokoro/test.sh
@@ -1,16 +1,10 @@
 #!/bin/bash
 
-
 source ./tool/kokoro/setup.sh
 setup
+(cd testData/sample_tests; echo "pub get `pwd`"; pub get --no-precompile)
 
 echo "kokoro test start"
 ./bin/plugin test
 
 echo "kokoro test finished"
-
-# TODO(messick): This is temporary, duplicating build.sh
-echo "kokoro build start"
-./bin/plugin build --channel=dev
-
-echo "kokoro build finished"


### PR DESCRIPTION
Distinguish build vs test runs by looking at the job name and do no more work than necessary in each.