### PR TITLE
simplify the logic we use to prevent reload on save

### DIFF
--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.form
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.form
@@ -98,7 +98,7 @@
           </component>
         </children>
       </grid>
-      <grid id="919ec" layout-manager="GridLayoutManager" row-count="5" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="919ec" layout-manager="GridLayoutManager" row-count="4" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -108,7 +108,7 @@
         <children>
           <component id="356a" class="javax.swing.JCheckBox" binding="myOpenInspectorOnAppLaunchCheckBox">
             <constraints>
-              <grid row="3" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="2" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text resource-bundle="io/flutter/FlutterBundle" key="settings.open.inspector.on.launch"/>
@@ -125,25 +125,16 @@
           </component>
           <component id="6d6f0" class="javax.swing.JCheckBox" binding="myDisableTrackWidgetCreationCheckBox">
             <constraints>
-              <grid row="4" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="3" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text resource-bundle="io/flutter/FlutterBundle" key="settings.disable.tracking.widget.creation"/>
               <toolTipText value="Disabling this setting breaks advanced Flutter Inspector functionality and performance tools. Only disable if you are noticing unexpected behavior differences between apps run in debug and release build."/>
             </properties>
           </component>
-          <component id="ff6b2" class="javax.swing.JCheckBox" binding="myHotReloadIgnoreErrorCheckBox">
-            <constraints>
-              <grid row="1" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="2" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <text resource-bundle="io/flutter/FlutterBundle" key="settings.hot.reload.with.error"/>
-              <toolTipText value="Hot reload changes into running Flutter apps even if there are analysis errors"/>
-            </properties>
-          </component>
           <component id="b1533" class="javax.swing.JCheckBox" binding="myShowStructuredErrors">
             <constraints>
-              <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text value="Show structured errors for Flutter framework issues"/>

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.java
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.java
@@ -58,7 +58,6 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
   private JCheckBox myReportUsageInformationCheckBox;
   private LinkLabel myPrivacyPolicy;
   private JCheckBox myHotReloadOnSaveCheckBox;
-  private JCheckBox myHotReloadIgnoreErrorCheckBox;
   private JCheckBox myEnableVerboseLoggingCheckBox;
   private JCheckBox myOpenInspectorOnAppLaunchCheckBox;
   private JCheckBox myFormatCodeOnSaveCheckBox;
@@ -129,8 +128,6 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
       }
     }, null);
 
-    myHotReloadOnSaveCheckBox.addChangeListener(
-      (e) -> myHotReloadIgnoreErrorCheckBox.setEnabled(myHotReloadOnSaveCheckBox.isSelected()));
     myFormatCodeOnSaveCheckBox.addChangeListener(
       (e) -> myOrganizeImportsOnSaveCheckBox.setEnabled(myFormatCodeOnSaveCheckBox.isSelected()));
 
@@ -180,10 +177,6 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     }
 
     if (settings.isReloadOnSave() != myHotReloadOnSaveCheckBox.isSelected()) {
-      return true;
-    }
-
-    if (settings.allowReloadWithErrors() != myHotReloadIgnoreErrorCheckBox.isSelected()) {
       return true;
     }
 
@@ -254,7 +247,6 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
 
     final FlutterSettings settings = FlutterSettings.getInstance();
     settings.setReloadOnSave(myHotReloadOnSaveCheckBox.isSelected());
-    settings.setReloadWithError(myHotReloadIgnoreErrorCheckBox.isSelected());
     settings.setFormatCodeOnSave(myFormatCodeOnSaveCheckBox.isSelected());
     settings.setOrganizeImportsOnSave(myOrganizeImportsOnSaveCheckBox.isSelected());
 
@@ -293,7 +285,6 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
 
     final FlutterSettings settings = FlutterSettings.getInstance();
     myHotReloadOnSaveCheckBox.setSelected(settings.isReloadOnSave());
-    myHotReloadIgnoreErrorCheckBox.setSelected(settings.allowReloadWithErrors());
     myFormatCodeOnSaveCheckBox.setSelected(settings.isFormatCodeOnSave());
     myOrganizeImportsOnSaveCheckBox.setSelected(settings.isOrganizeImportsOnSave());
 
@@ -309,8 +300,6 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
 
     myEnableHotUiCheckBox.setSelected(settings.isEnableHotUi());
 
-    myHotReloadIgnoreErrorCheckBox.setEnabled(myHotReloadOnSaveCheckBox.isSelected());
-
     myOrganizeImportsOnSaveCheckBox.setEnabled(myFormatCodeOnSaveCheckBox.isSelected());
 
     myShowAllRunConfigurationsInContextCheckBox.setSelected(settings.showAllRunConfigurationsInContext());
@@ -319,9 +308,14 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
   private void onVersionChanged() {
     final Workspace workspace = workspaceCache.get();
     if (workspaceCache.isBazel()) {
-        mySdkCombo.setEnabled(false);
-        mySdkCombo.getComboBox().getEditor().setItem(workspace.getRoot().getPath() + '/' + workspace.getSdkHome() + " <set by bazel project>");
-    } else {
+      // The workspace is not null if workspaceCache.isBazel() is true.
+      assert (workspace != null);
+
+      mySdkCombo.setEnabled(false);
+      mySdkCombo.getComboBox().getEditor()
+        .setItem(workspace.getRoot().getPath() + '/' + workspace.getSdkHome() + " <set by bazel project>");
+    }
+    else {
       mySdkCombo.setEnabled(true);
     }
 

--- a/src/io/flutter/settings/FlutterSettings.java
+++ b/src/io/flutter/settings/FlutterSettings.java
@@ -18,7 +18,6 @@ import java.util.EventListener;
 
 public class FlutterSettings {
   private static final String reloadOnSaveKey = "io.flutter.reloadOnSave";
-  private static final String reloadWithErrorKey = "io.flutter.reloadWithError";
   private static final String openInspectorOnAppLaunchKey = "io.flutter.openInspectorOnAppLaunch";
   private static final String verboseLoggingKey = "io.flutter.verboseLogging";
   private static final String formatCodeOnSaveKey = "io.flutter.formatCodeOnSave";
@@ -64,9 +63,6 @@ public class FlutterSettings {
     if (isReloadOnSave()) {
       analytics.sendEvent("settings", afterLastPeriod(reloadOnSaveKey));
     }
-    if (allowReloadWithErrors()) {
-      analytics.sendEvent("settings", afterLastPeriod(reloadWithErrorKey));
-    }
     if (isOpenInspectorOnAppLaunch()) {
       analytics.sendEvent("settings", afterLastPeriod(openInspectorOnAppLaunchKey));
     }
@@ -109,10 +105,6 @@ public class FlutterSettings {
     return getPropertiesComponent().getBoolean(reloadOnSaveKey, true);
   }
 
-  public boolean allowReloadWithErrors() {
-    return getPropertiesComponent().getBoolean(reloadWithErrorKey, false);
-  }
-
   public boolean isTrackWidgetCreationEnabled(Project project) {
     final FlutterSdk flutterSdk = FlutterSdk.getFlutterSdk(project);
     if (flutterSdk != null && flutterSdk.getVersion().isTrackWidgetCreationRecommended()) {
@@ -135,12 +127,6 @@ public class FlutterSettings {
 
   public void setReloadOnSave(boolean value) {
     getPropertiesComponent().setValue(reloadOnSaveKey, value, true);
-
-    fireEvent();
-  }
-
-  public void setReloadWithError(boolean value) {
-    getPropertiesComponent().setValue(reloadWithErrorKey, value, false);
 
     fireEvent();
   }


### PR DESCRIPTION
simplify the logic we use to prevent reload on save:

- remove the logic that would block a reload on save if there are analysis errors in the project; this was overly conservative - errors in tests shouldn't block reload, as well as errors in code that's not part of the app's execution path
- revert back to some older logic which does block reload on save if there are analysis errors in the file currently being edited (and that file is a Dart file)

cc @InMatrix for fyi about the UX change (to remove blocking reload on save on analysis errors - which had been discussed - but to continue to block on a much stricter sub-set; analysis errors in the current file)
