### PR TITLE
Simplify flutter-intellij project setup for new contributors

### DIFF
--- a/.idea/libraries/com_google_protobuf_protobuf_java_3_5_1.xml
+++ b/.idea/libraries/com_google_protobuf_protobuf_java_3_5_1.xml
@@ -1,0 +1,10 @@
+<component name="libraryTable">
+  <library name="com.google.protobuf:protobuf-java:3.5.1" type="repository">
+    <properties maven-id="com.google.protobuf:protobuf-java:3.5.1" />
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/google/protobuf/protobuf-java/3.5.1/protobuf-java-3.5.1.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/org_powermock_powermock_api_mockito2_2_0_2.xml
+++ b/.idea/libraries/org_powermock_powermock_api_mockito2_2_0_2.xml
@@ -1,0 +1,18 @@
+<component name="libraryTable">
+  <library name="org.powermock:powermock-api-mockito2:2.0.2" type="repository">
+    <properties maven-id="org.powermock:powermock-api-mockito2:2.0.2" />
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/powermock/powermock-api-mockito2/2.0.2/powermock-api-mockito2-2.0.2.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/org/powermock/powermock-api-support/2.0.2/powermock-api-support-2.0.2.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/org/powermock/powermock-reflect/2.0.2/powermock-reflect-2.0.2.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/net/bytebuddy/byte-buddy/1.9.3/byte-buddy-1.9.3.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/net/bytebuddy/byte-buddy-agent/1.9.3/byte-buddy-agent-1.9.3.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/org/powermock/powermock-core/2.0.2/powermock-core-2.0.2.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/org/javassist/javassist/3.24.0-GA/javassist-3.24.0-GA.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/org/mockito/mockito-core/2.23.0/mockito-core-2.23.0.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/org/objenesis/objenesis/2.6/objenesis-2.6.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/libraries/org_powermock_powermock_module_junit4_2_0_2.xml
+++ b/.idea/libraries/org_powermock_powermock_module_junit4_2_0_2.xml
@@ -1,0 +1,19 @@
+<component name="libraryTable">
+  <library name="org.powermock:powermock-module-junit4:2.0.2" type="repository">
+    <properties maven-id="org.powermock:powermock-module-junit4:2.0.2" />
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/powermock/powermock-module-junit4/2.0.2/powermock-module-junit4-2.0.2.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/org/powermock/powermock-module-junit4-common/2.0.2/powermock-module-junit4-common-2.0.2.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/org/powermock/powermock-reflect/2.0.2/powermock-reflect-2.0.2.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/org/objenesis/objenesis/3.0.1/objenesis-3.0.1.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/net/bytebuddy/byte-buddy/1.9.3/byte-buddy-1.9.3.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/net/bytebuddy/byte-buddy-agent/1.9.3/byte-buddy-agent-1.9.3.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/org/powermock/powermock-core/2.0.2/powermock-core-2.0.2.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/org/javassist/javassist/3.24.0-GA/javassist-3.24.0-GA.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/junit/junit/4.12/junit-4.12.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,12 +22,6 @@ file.
   - extend it with additional plugin libraries (only until Android Q is released)
     - plugins/android/lib/android.jar
     - plugins/gradle/lib/gradle-common.jar
-* In the Project Structure dialog (`File | Project Structure`), select "Libraries" 
-  - click the "+" sign at the top "From maven..." to add libraries for PowerMock. Do this twice, for:
-    - powermock-module-junit4
-    - powermock-api-mockito2
-    - com.google.protobuf:protobuf-java:3.5.1
-  - Use the 2.0.0 version, or whatever is current in `flutter-intellij.iml`
 * One-time Dart plugin install - first-time a new IDE is installed and run you will need to install the Dart plugin.  `Configure | Plugins` and install the Dart plugin, then restart the IDE
 * Open flutter-intellij project in IntelliJ (select and open the directory of the flutter-intellij repository). Build it using `Build` | `Make Project`
 * Try running the plugin; there is an existing launch config for "Flutter IntelliJ".


### PR DESCRIPTION
Keep info about maven libs under git: libs will get auto-downloaded for new contributors as soon as they open the project.

To reviewers: please check `com_google_protobuf_protobuf_java_3_5_1.xml`, `org_powermock_powermock_api_mockito2_2_0_2.xml`, and `org_powermock_powermock_module_junit4_2_0_2.xml` files in your local project setup. I guess they are 100% equivalent to the ones from this PR - this means that this PR is safe to accept. Otherwise, we should first understand why these files are different on your end.