### PR TITLE
Don't use deprecated API. Hide 'Allow parallel run' checkbox.

### DIFF
--- a/src/io/flutter/FlutterUtils.java
+++ b/src/io/flutter/FlutterUtils.java
@@ -114,10 +114,6 @@ public class FlutterUtils {
     return StringUtil.equals(PlatformUtils.getPlatformPrefix(), "AndroidStudio");
   }
 
-  public static boolean is2018_3_or_higher() {
-    return getBaselineVersion() >= 183;
-  }
-
   /**
    * Write a warning message to the IntelliJ log.
    * <p>

--- a/src/io/flutter/run/FlutterRunConfigurationType.java
+++ b/src/io/flutter/run/FlutterRunConfigurationType.java
@@ -8,6 +8,7 @@ package io.flutter.run;
 import com.intellij.execution.configurations.ConfigurationFactory;
 import com.intellij.execution.configurations.ConfigurationTypeBase;
 import com.intellij.execution.configurations.RunConfiguration;
+import com.intellij.execution.configurations.RunConfigurationSingletonPolicy;
 import com.intellij.openapi.extensions.Extensions;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.search.FileTypeIndex;
@@ -36,7 +37,6 @@ public class FlutterRunConfigurationType extends ConfigurationTypeBase {
     return FileTypeIndex.containsFileOfType(DartFileType.INSTANCE, GlobalSearchScope.projectScope(project)) &&
            FlutterModuleUtils.hasFlutterModule(project);
   }
-
 
   public Factory getFactory() {
     return factory;
@@ -67,6 +67,12 @@ public class FlutterRunConfigurationType extends ConfigurationTypeBase {
     @Override
     public boolean isApplicable(@NotNull Project project) {
       return FlutterRunConfigurationType.doShowFlutterRunConfigurationForProject(project);
+    }
+
+    @NotNull
+    @Override
+    public RunConfigurationSingletonPolicy getSingletonPolicy() {
+      return RunConfigurationSingletonPolicy.MULTIPLE_INSTANCE_ONLY;
     }
   }
 }

--- a/src/io/flutter/run/FlutterRunner.java
+++ b/src/io/flutter/run/FlutterRunner.java
@@ -5,12 +5,6 @@
  */
 package io.flutter.run;
 
-import com.intellij.execution.ExecutionException;
-import com.intellij.execution.RunnerAndConfigurationSettings;
-import com.intellij.execution.configurations.RunProfileState;
-import com.intellij.execution.runners.ExecutionEnvironment;
-import com.intellij.execution.ui.RunContentDescriptor;
-import io.flutter.FlutterUtils;
 import io.flutter.sdk.FlutterSdk;
 import org.jetbrains.annotations.NotNull;
 
@@ -26,20 +20,6 @@ public class FlutterRunner extends LaunchState.Runner<SdkRunConfig> {
   @Override
   public String getRunnerId() {
     return "FlutterRunner";
-  }
-
-  @SuppressWarnings("Duplicates")
-  @Override
-  protected RunContentDescriptor doExecute(@NotNull RunProfileState state, @NotNull ExecutionEnvironment env) throws ExecutionException {
-    if (FlutterUtils.is2018_3_or_higher()) {
-      // Force "allow running in parallel" (see: #2875).
-      // TODO(pq): when 2018.3 is our lower bound, migrate to using `RunConfigurationSingletonPolicy` (see: #2897).
-      final RunnerAndConfigurationSettings settings = env.getRunnerAndConfigurationSettings();
-      if (settings != null) {
-        settings.setSingleton(false);
-      }
-    }
-    return super.doExecute(state, env);
   }
 
   @Override

--- a/src/io/flutter/run/bazel/BazelRunner.java
+++ b/src/io/flutter/run/bazel/BazelRunner.java
@@ -5,12 +5,6 @@
  */
 package io.flutter.run.bazel;
 
-import com.intellij.execution.ExecutionException;
-import com.intellij.execution.RunnerAndConfigurationSettings;
-import com.intellij.execution.configurations.RunProfileState;
-import com.intellij.execution.runners.ExecutionEnvironment;
-import com.intellij.execution.ui.RunContentDescriptor;
-import io.flutter.FlutterUtils;
 import io.flutter.run.LaunchState;
 import org.jetbrains.annotations.NotNull;
 
@@ -24,19 +18,5 @@ public class BazelRunner extends LaunchState.Runner<BazelRunConfig> {
   @Override
   public String getRunnerId() {
     return "FlutterBazelRunner";
-  }
-
-  @SuppressWarnings("Duplicates")
-  @Override
-  protected RunContentDescriptor doExecute(@NotNull RunProfileState state, @NotNull ExecutionEnvironment env) throws ExecutionException {
-    if (FlutterUtils.is2018_3_or_higher()) {
-      // Force "allow running in parallel" (see: #2875).
-      // TODO(pq): when 2018.3 is our lower bound, migrate to using `RunConfigurationSingletonPolicy` (see: #2897).
-      final RunnerAndConfigurationSettings settings = env.getRunnerAndConfigurationSettings();
-      if (settings != null) {
-        settings.setSingleton(false);
-      }
-    }
-    return super.doExecute(state, env);
   }
 }

--- a/src/io/flutter/run/bazel/FlutterBazelRunConfigurationType.java
+++ b/src/io/flutter/run/bazel/FlutterBazelRunConfigurationType.java
@@ -10,6 +10,7 @@ import com.intellij.execution.ExecutionBundle;
 import com.intellij.execution.configurations.ConfigurationFactory;
 import com.intellij.execution.configurations.ConfigurationTypeBase;
 import com.intellij.execution.configurations.RunConfiguration;
+import com.intellij.execution.configurations.RunConfigurationSingletonPolicy;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.search.FileTypeIndex;
 import com.intellij.psi.search.GlobalSearchScope;
@@ -86,6 +87,12 @@ public class FlutterBazelRunConfigurationType extends ConfigurationTypeBase {
     @NotNull
     public String getId() {
       return FlutterBundle.message("runner.flutter.bazel.configuration.name");
+    }
+
+    @NotNull
+    @Override
+    public RunConfigurationSingletonPolicy getSingletonPolicy() {
+      return RunConfigurationSingletonPolicy.MULTIPLE_INSTANCE_ONLY;
     }
   }
 }


### PR DESCRIPTION
The effect is as if 'Allow parallel run' check box is always checked (but it doesn't appear in UI at all).