### PR TITLE
remove use of deprecated APIs

### DIFF
--- a/src/io/flutter/FlutterErrorReportSubmitter.java
+++ b/src/io/flutter/FlutterErrorReportSubmitter.java
@@ -50,15 +50,14 @@ public class FlutterErrorReportSubmitter extends ErrorReportSubmitter {
     return "Create Flutter Bug Report";
   }
 
-  @SuppressWarnings("deprecation")
   @Override
-  public void submitAsync(@NotNull IdeaLoggingEvent[] events,
-                          @Nullable String additionalInfo,
-                          @NotNull Component parentComponent,
-                          @NotNull Consumer<SubmittedReportInfo> consumer) {
+  public boolean submit(@NotNull IdeaLoggingEvent[] events,
+                        @Nullable String additionalInfo,
+                        @NotNull Component parentComponent,
+                        @NotNull Consumer<SubmittedReportInfo> consumer) {
     if (events.length == 0) {
       fail(consumer);
-      return;
+      return false;
     }
 
     String stackTrace = null;
@@ -98,7 +97,7 @@ public class FlutterErrorReportSubmitter extends ErrorReportSubmitter {
     final Project project = PROJECT.getData(dataContext);
     if (project == null) {
       fail(consumer);
-      return;
+      return false;
     }
 
     final StringBuilder builder = new StringBuilder();
@@ -191,7 +190,7 @@ public class FlutterErrorReportSubmitter extends ErrorReportSubmitter {
 
     if (file == null) {
       fail(consumer);
-      return;
+      return false;
     }
 
     // Open the file.
@@ -201,13 +200,8 @@ public class FlutterErrorReportSubmitter extends ErrorReportSubmitter {
       null,
       "",
       SubmittedReportInfo.SubmissionStatus.NEW_ISSUE));
-  }
 
-  @SuppressWarnings("deprecation")
-  @Override
-  public SubmittedReportInfo submit(IdeaLoggingEvent[] events, Component parentComponent) {
-    // obsolete API
-    return new SubmittedReportInfo(null, "0", SubmittedReportInfo.SubmissionStatus.FAILED);
+    return true;
   }
 
   private static String getFlutterVersion(final FlutterSdk sdk) {

--- a/src/io/flutter/editor/FlutterCompletionContributor.java
+++ b/src/io/flutter/editor/FlutterCompletionContributor.java
@@ -9,7 +9,6 @@ import com.intellij.codeInsight.lookup.LookupElementBuilder;
 import com.intellij.openapi.project.Project;
 import com.intellij.util.ui.ColorIcon;
 import com.intellij.util.ui.EmptyIcon;
-import com.intellij.util.ui.JBUI;
 import com.jetbrains.lang.dart.ide.completion.DartCompletionExtension;
 import com.jetbrains.lang.dart.ide.completion.DartServerCompletionContributor;
 import org.apache.commons.lang.StringUtils;
@@ -23,7 +22,7 @@ import java.util.Objects;
 
 public class FlutterCompletionContributor extends DartCompletionExtension {
   private static final int ICON_SIZE = 16;
-  private static final Icon EMPTY_ICON = JBUI.scale(EmptyIcon.create(ICON_SIZE));
+  private static final Icon EMPTY_ICON = EmptyIcon.create(ICON_SIZE);
 
   @Override
   @Nullable
@@ -50,7 +49,7 @@ public class FlutterCompletionContributor extends DartCompletionExtension {
           if (Objects.equals(declaringType, "Colors")) {
             final FlutterColors.FlutterColor color = FlutterColors.getColor(name);
             if (color != null) {
-              return JBUI.scale(new ColorIcon(ICON_SIZE, color.getAWTColor()));
+              return new ColorIcon(ICON_SIZE, color.getAWTColor());
             }
           }
           else if (Objects.equals(declaringType, "Icons")) {


### PR DESCRIPTION
- move away from use of deprecated APIs (planned for removal in IntelliJ 2020.3)

```
JBUI.scale() (2) (scheduled for removal in a future release)
- Deprecated method JBUI.scale() is invoked in FlutterCompletionContributor.findIcon(). This method will be removed in a future release
- Deprecated method JBUI.scale() is invoked in FlutterCompletionContributor.<clinit>(). This method will be removed in a future release

ErrorReportSubmitter.submit() (1) (scheduled for removal in 2020.3)
- Deprecated method ErrorReportSubmitter.submit() is overridden in class FlutterErrorReportSubmitter. This method will be removed in 2020.3

ErrorReportSubmitter.submitAsync() (1) (scheduled for removal in 2020.3)
- Deprecated method ErrorReportSubmitter.submitAsync() is overridden in class FlutterErrorReportSubmitter. This method will be removed in 2020.3
```
