### PR TITLE
Change the plugin tool to properly build the dev channel

### DIFF
--- a/tool/kokoro/setup.sh
+++ b/tool/kokoro/setup.sh
@@ -24,5 +24,8 @@ setup() {
   (cd ..; tar fx ant.tar.gz)
   export PATH=$PATH:`pwd`/../apache-ant-1.10.7/bin
 
+  export FLUTTER_KEYSTORE_ID=74840
+  export FLUTTER_KEYSTORE_NAME=flutter-intellij-kokoro
+
   (cd tool/plugin; echo "pub get `pwd`"; pub get --no-precompile)
 }

--- a/tool/plugin/lib/plugin.dart
+++ b/tool/plugin/lib/plugin.dart
@@ -982,16 +982,7 @@ class DeployCommand extends ProductCommand {
       return 1;
     }
 
-    var token;
-    if (isTesting) {
-      stdout.writeln('Please enter the permanent token '
-          'for the JetBrains Marketplace');
-      stdout.write('Token: ');
-      token = stdin.readLineSync();
-    } else {
-      token = readTokenFile();
-    }
-
+    var token = readTokenFile();
     var value = 0;
     var originalDir = Directory.current;
     for (var spec in specs) {
@@ -999,15 +990,19 @@ class DeployCommand extends ProductCommand {
       var filePath = releasesFilePath(spec);
       log("uploading $filePath");
       var file = File(filePath);
-      Directory.current = file.parent;
+      changeDirectory(file.parent);
       var pluginNumber = plugins[spec.pluginId];
       value = await upload(p.basename(file.path), pluginNumber, token, spec.channel);
       if (value != 0) {
         return value;
       }
     }
-    Directory.current = originalDir;
+    changeDirectory(originalDir);
     return value;
+  }
+
+  void changeDirectory(Directory dir) {
+    Directory.current = dir.path;
   }
 
   String readTokenFile() {

--- a/tool/plugin/lib/plugin.dart
+++ b/tool/plugin/lib/plugin.dart
@@ -228,7 +228,7 @@ Future<bool> performReleaseChecks(ProductCommand cmd) async {
       return true;
     }
     if (cmd.isDevChannel) {
-      log('release node is incompatible with the dev channel');
+      log('release mode is incompatible with the dev channel');
       return false;
     }
     if (!cmd.isReleaseValid) {
@@ -351,8 +351,6 @@ Future<int> zip(String directory, String outFile) async {
 String _nextRelease() {
   var num = RegExp(r'release_(\d+)').matchAsPrefix(lastReleaseName).group(1);
   var val = int.parse(num) + 1;
-  // If we have 10 point releases then we will have a problem here.
-  // We currently have no way to determine what the last point release was.
   return '$val.0';
 }
 
@@ -963,7 +961,7 @@ class BuildSpec {
   }
 
   void buildForDev() {
-    // Build everything. For stable channel we do not build specs on the dev channel.
+    // Build everything. For release builds we do not build specs on the dev channel.
     channel = 'dev';
   }
 

--- a/tool/plugin/lib/plugin.dart
+++ b/tool/plugin/lib/plugin.dart
@@ -1269,6 +1269,7 @@ class TestCommand extends ProductCommand {
 }
 
 Future<String> makeDevLog(BuildSpec spec) async {
+  if (lastReleaseName.isEmpty) return ''; // The shallow on travis causes problems.
   _checkGitDir();
   var gitDir = await GitDir.fromExisting(rootPath);
   var since = lastReleaseName;

--- a/tool/plugin/lib/plugin.dart
+++ b/tool/plugin/lib/plugin.dart
@@ -349,8 +349,8 @@ Future<int> zip(String directory, String outFile) async {
 }
 
 String _nextRelease() {
-  var num = RegExp(r'release_(\d+)').matchAsPrefix(lastReleaseName).group(1);
-  var val = int.parse(num) + 1;
+  var current = RegExp(r'release_(\d+)').matchAsPrefix(lastReleaseName).group(1);
+  var val = int.parse(current) + 1;
   return '$val.0';
 }
 

--- a/tool/plugin/lib/plugin.dart
+++ b/tool/plugin/lib/plugin.dart
@@ -1306,9 +1306,17 @@ Future<String> lastRelease() async {
   // TODO(messick): Add git magic to ensure the latest release branch exists locally.
   // For more context, see comments on this method in the PR:
   // https://github.com/flutter/flutter-intellij/pull/4213
-  var processResult = await gitDir.runCommand(['branch', '--list', 'release*']);
+  var processResult = await gitDir.runCommand(['branch', '--list', 'release_*']);
   String out = processResult.stdout;
-  return out.trim().split('\n').last.trim();
+  var release = out.trim().split('\n').last.trim();
+  release = ''; // DEBUG delete
+  if (!release.isEmpty) return release;
+  processResult = await gitDir.runCommand(['branch', '--list', '-a', '*release_*']);
+  out = processResult.stdout;
+  var remote = out.trim().split('\n').last.trim(); // "remotes/origin/release_43"
+  release = remote.substring(remote.lastIndexOf('/') + 1);
+  await gitDir.runCommand(['branch', '--track', release, remote]);
+  return release;
 }
 
 void _checkGitDir() async {

--- a/tool/plugin/lib/plugin.dart
+++ b/tool/plugin/lib/plugin.dart
@@ -1269,7 +1269,7 @@ class TestCommand extends ProductCommand {
 }
 
 Future<String> makeDevLog(BuildSpec spec) async {
-  if (lastReleaseName.isEmpty) return ''; // The shallow on travis causes problems.
+  if (lastReleaseName == null) return ''; // The shallow on travis causes problems.
   _checkGitDir();
   var gitDir = await GitDir.fromExisting(rootPath);
   var since = lastReleaseName;

--- a/tool/plugin/lib/plugin.dart
+++ b/tool/plugin/lib/plugin.dart
@@ -1306,9 +1306,6 @@ Future<DateTime> dateOfLastRelease() async {
 Future<String> lastRelease() async {
   _checkGitDir();
   var gitDir = await GitDir.fromExisting(rootPath);
-  // TODO(messick): Add git magic to ensure the latest release branch exists locally.
-  // For more context, see comments on this method in the PR:
-  // https://github.com/flutter/flutter-intellij/pull/4213
   var processResult = await gitDir.runCommand(['branch', '--list', 'release_*']);
   String out = processResult.stdout;
   var release = out.trim().split('\n').last.trim();

--- a/tool/plugin/lib/plugin.dart
+++ b/tool/plugin/lib/plugin.dart
@@ -1192,8 +1192,10 @@ abstract class ProductCommand extends Command {
     if (rel != null) {
       rootPath = p.normalize(p.join(rootPath, rel));
     }
-    lastReleaseName = await lastRelease();
-    lastReleaseDate = await dateOfLastRelease();
+    if (isDevChannel) {
+      lastReleaseName = await lastRelease();
+      lastReleaseDate = await dateOfLastRelease();
+    }
   }
 
   Future<int> _initSpecs() async {
@@ -1309,11 +1311,9 @@ Future<String> lastRelease() async {
   var processResult = await gitDir.runCommand(['branch', '--list', 'release_*']);
   String out = processResult.stdout;
   var release = out.trim().split('\n').last.trim();
-  release = ''; // DEBUG delete
   if (!release.isEmpty) return release;
   processResult = await gitDir.runCommand(['branch', '--list', '-a', '*release_*']);
   out = processResult.stdout;
-  print(out);
   var remote = out.trim().split('\n').last.trim(); // "remotes/origin/release_43"
   print(remote);
   release = remote.substring(remote.lastIndexOf('/') + 1);

--- a/tool/plugin/lib/plugin.dart
+++ b/tool/plugin/lib/plugin.dart
@@ -1313,7 +1313,9 @@ Future<String> lastRelease() async {
   if (!release.isEmpty) return release;
   processResult = await gitDir.runCommand(['branch', '--list', '-a', '*release_*']);
   out = processResult.stdout;
+  print(out);
   var remote = out.trim().split('\n').last.trim(); // "remotes/origin/release_43"
+  print(remote);
   release = remote.substring(remote.lastIndexOf('/') + 1);
   await gitDir.runCommand(['branch', '--track', release, remote]);
   return release;

--- a/tool/plugin/test/plugin_test.dart
+++ b/tool/plugin/test/plugin_test.dart
@@ -119,6 +119,7 @@ void main() {
 
   group('deploy', () {
     test('clean', () async {
+      var dir = Directory.current;
       var runner = makeTestRunner();
       await runner.run([
         "-r=19",
@@ -127,8 +128,7 @@ void main() {
         "--no-as",
         "--no-ij"
       ]).whenComplete(() {
-        var dir = (runner.commands['deploy'] as DeployCommand).tempDir;
-        expect(new Directory(dir).existsSync(), false);
+        expect(Directory.current.path, equals(dir.path));
       });
     });
 
@@ -147,15 +147,8 @@ void main() {
       await runner.run(["--release=19", "-d../..", "deploy"]).whenComplete(() {
         cmd = (runner.commands['deploy'] as TestDeployCommand);
       });
-      expect(
-          cmd.paths.map((p) => p.substring(p.indexOf('releases'))),
-          orderedEquals([
-            'releases/release_19/3.5/flutter-intellij.zip',
-            'releases/release_19/3.6/flutter-intellij.zip',
-            'releases/release_19/2019.3/flutter-intellij.zip',
-            'releases/release_19/4.0/flutter-intellij.zip',
-            'releases/release_19/2020.1/flutter-intellij.zip',
-          ]));
+      var specs = cmd.specs.where((s) => !s.isDevChannel).toList();
+      expect(cmd.paths.length, specs.length);
     });
   });
 
@@ -268,7 +261,14 @@ class TestDeployCommand extends DeployCommand {
 
   bool get isTesting => true;
 
-  Future<int> upload(String filePath, String pluginNumber) {
+  String readTokenFile() {
+    return "token";
+  }
+
+  void changeDirectory(Directory dir) {}
+
+  Future<int> upload(String filePath, String pluginNumber, String token,
+      String channel) {
     paths.add(filePath);
     plugins.add(pluginNumber);
     return new Future(() => 0);


### PR DESCRIPTION
The initial dev channel support only built the specs that identified as dev channel specs. This makes a number of changes in how things are built:

- A dev channel build produces all versions
- A master branch build produces all versions, plus the version for integration tests
- A release build produces only the versions intended to be published (no change)

The dev channel version is now derived from the previous release and the number of weeks since its branch was committed. This is how it looks in the plugin management page:

<img width="219" alt="Screen Shot 2020-02-05 at 10 46 46 AM" src="https://user-images.githubusercontent.com/8518285/73883262-7a825c00-4818-11ea-8293-2248f3b73b4d.png">

(There may be unresolved issues with point releases. I couldn't test that.)

I did a little refactoring, too. Initialization of globals was really confusing, and now that it has to be done async it needed to be cleaned up.

@devoncarew 