### PR TITLE
Tidy up old domain name links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ file.
 * Open flutter-intellij project in IntelliJ (select and open the directory of the flutter-intellij repository). Build it using `Build` | `Make Project`
 * Try running the plugin; there is an existing launch config for "Flutter IntelliJ".
 * If the Flutter Plugin doesn't load (Dart code or files are unknown) see above "One-time Dart plugin install"
-* Install Flutter SDK from [Flutter SDK download](https://flutter.io/docs/get-started/install) or [github](https://github.com/flutter/flutter) and set it up according to its instructions.
+* Install Flutter SDK from [Flutter SDK download](https://flutter.dev/docs/get-started/install) or [github](https://github.com/flutter/flutter) and set it up according to its instructions.
 * Verify installation from the command line:
   - Connect an android device with USB debugging.
   - `cd <flutter>/examples/hello_world`

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-# <img src="https://flutter.io/images/flutter-mark-square-100.png" alt="Flutter" width="26" height="26" /> Flutter Plugin for IntelliJ
+# <img src="https://flutter.dev/images/favicon.png" alt="Flutter" width="26" height="26" /> Flutter Plugin for IntelliJ
 
 [![Build Status](https://travis-ci.org/flutter/flutter-intellij.svg)](https://travis-ci.org/flutter/flutter-intellij)
 
-An IntelliJ plugin for [Flutter](https://flutter.io/) development. Flutter is a new mobile
-app SDK to help developers and designers build modern mobile apps for iOS and Android.
+An IntelliJ plugin for [Flutter](https://flutter.dev/) development. Flutter is a multi-platform
+app SDK to help developers and designers build modern apps for iOS, Android and the web.
 
 ## Documentation
 
-- [flutter.io](https://flutter.io)
-- [Installing Flutter](https://flutter.io/docs/get-started/install)
-- [Getting Started with IntelliJ](https://flutter.io/docs/development/tools/ide)
+- [flutter.dev](https://flutter.dev)
+- [Installing Flutter](https://flutter.dev/docs/get-started/install)
+- [Getting Started with IntelliJ](https://flutter.dev/docs/development/tools/ide)
 
 ## Fast development
 
@@ -21,13 +21,13 @@ simulators, and hardware for iOS and Android.
 
 ## Quick-start
 
-A brief summary of the [getting started guide](https://flutter.io/docs/development/tools/ide):
+A brief summary of the [getting started guide](https://flutter.dev/docs/development/tools/ide):
 
-- install the [Flutter SDK](https://flutter.io/docs/get-started/install)
+- install the [Flutter SDK](https://flutter.dev/docs/get-started/install)
 - run `flutter doctor` from the command line to verify your installation
 - ensure you have a supported [IntelliJ development environment](https://www.jetbrains.com/idea/download), either:
   - IntelliJ 2018.1 or more recent, Community or Ultimate Edition, or
-  - Android Studio 3.2 (note: Android Studio Canary versions are generally _not_ supported)
+  - Android Studio 3.2 or later (note: Android Studio Canary versions are generally _not_ supported)
 - open the plugin preferences
   - `Preferences > Plugins` on macOS, `File > Settings > Plugins` on Linux, select "Browse repositories…"
 - search for and install the 'Flutter' plugin
@@ -56,5 +56,5 @@ Please note the following known issues:
   restart the IDE.
 - If you require network access to go through proxy settings, you will need to set the 
   `https_proxy` variable in your environment as as described in the 
-  [pub docs](https://www.dartlang.org/tools/pub/troubleshoot#pub-get-fails-from-behind-a-corporate-firewall).
+  [pub docs](https://dart.dev/tools/pub/troubleshoot#pub-get-fails-from-behind-a-corporate-firewall).
   (See also: [#2914](https://github.com/flutter/flutter-intellij/issues/2914).)

--- a/docs/android.md
+++ b/docs/android.md
@@ -1,7 +1,7 @@
 # Editing Android Native Code
 
 This is a replacement for:
-https://flutter.io/using-ide/#edit-android-code
+https://flutter.dev/using-ide/#edit-android-code
 
 ***
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -4,8 +4,8 @@ Manual tests to execute before plugin releases.
 
 ## Setup
 
-Pre-reqs: Run through the [flutter setup](https://flutter.io/docs/get-started/install) and
-[flutter getting started](https://flutter.io/docs/development/tools/ide) guides.
+Pre-reqs: Run through the [flutter setup](https://flutter.dev/docs/get-started/install) and
+[flutter getting started](https://flutter.dev/docs/development/tools/ide) guides.
 
 * Run `flutter upgrade` in a terminal to get the latest version prior to starting testing.
 
@@ -176,7 +176,7 @@ Verify installation and configuration in a fresh IDEA installation.
 
 * Follow the instructions to
   [simulate a fresh installation](https://github.com/flutter/flutter-intellij/wiki/Development#simulating-a-fresh-install).
-* (If not running in a "runtime workbench", [install the plugins](https://flutter.io/docs/development/packages-and-plugins/using-packages).)
+* (If not running in a "runtime workbench", [install the plugins](https://flutter.dev/docs/development/packages-and-plugins/using-packages).)
 * Open "Languages & Frameworks>Flutter" in Preferences and verify that there is
   no Flutter SDK set.
 * Set the Flutter SDK path to a valid SDK location.

--- a/flutter-studio/src/io/flutter/project/FlutterProjectStep.java
+++ b/flutter-studio/src/io/flutter/project/FlutterProjectStep.java
@@ -208,7 +208,7 @@ public class FlutterProjectStep extends SkippableWizardStep<FlutterProjectModel>
   }
 
   /**
-   * @see <a href="www.dartlang.org/tools/pub/pubspec#name">https://www.dartlang.org/tools/pub/pubspec#name</a>
+   * @see <a href="dart.dev/tools/pub/pubspec#name">https://dart.dev/tools/pub/pubspec#name</a>
    */
   @NotNull
   private Validator.Result validateFlutterModuleName(@NotNull String moduleName) {

--- a/resources/inspectionDescriptions/FlutterDependency.html
+++ b/resources/inspectionDescriptions/FlutterDependency.html
@@ -8,7 +8,7 @@
 <body>
 Flutter package dependency check.
 <!-- tooltip end -->
-Checks whether a Flutter <code><a href="https://www.dartlang.org/tools/pub/pubspec.html">pubspec.yaml</a></code> has been edited
-since the last <a href="https://flutter.io/upgrading/">package update</a>.
+Checks whether a Flutter <code><a href="https://dart.dev/tools/pub/pubspec">pubspec.yaml</a></code> has been edited
+since the last <a href="https://flutter.dev/upgrading/">package update</a>.
 </body>
 </html>

--- a/src/io/flutter/FlutterBundle.properties
+++ b/src/io/flutter/FlutterBundle.properties
@@ -30,7 +30,7 @@ dart.plugin.update.action.label=Update Dart
 dart.sdk.is.not.configured=Dart SDK is not configured
 
 error.folder.specified.as.sdk.not.exists=The folder specified as the Flutter SDK home does not exist.
-error.flutter.sdk.without.dart.sdk=The Flutter SDK installation is incomplete; please see: https://flutter.io/docs/get-started/install.
+error.flutter.sdk.without.dart.sdk=The Flutter SDK installation is incomplete; please see: https://flutter.dev/get-started.
 error.sdk.not.found.in.specified.location=Flutter SDK is not found in the specified location.
 
 flutter.command.exception.message=Exception: {0}
@@ -77,10 +77,10 @@ flutter.run.bazel.noTargetSet=No Bazel target set
 flutter.run.bazel.startWithSlashSlash=Bazel targets should start with '//'
 flutter.run.bazel.newBazelTestRunnerUnavailable=The new Bazel test runner is not available. Only Bazel targets can be run with the old test runner
 
-flutter.perf.linter.statefulWidget.url=https://docs.flutter.io/flutter/widgets/StatefulWidget-class.html#performance-considerations
-flutter.perf.linter.listViewLoad.url=https://docs.flutter.io/flutter/widgets/ListView-class.html
-flutter.perf.linter.animatedBuilder.url=https://docs.flutter.io/flutter/widgets/AnimatedBuilder-class.html#performance-optimizations
-flutter.perf.linter.opacityAnimations.url=https://docs.flutter.io/flutter/widgets/Opacity-class.html#performance-considerations-for-opacity-animation
+flutter.perf.linter.statefulWidget.url=https://api.flutter.dev/flutter/widgets/StatefulWidget-class.html#performance-considerations
+flutter.perf.linter.listViewLoad.url=https://api.flutter.dev/flutter/widgets/ListView-class.html
+flutter.perf.linter.animatedBuilder.url=https://api.flutter.dev/flutter/widgets/AnimatedBuilder-class.html#performance-optimizations
+flutter.perf.linter.opacityAnimations.url=https://api.flutter.dev/flutter/widgets/Opacity-class.html#performance-considerations-for-opacity-animation
 
 flutter.analytics.notification.content=The Flutter plugin anonymously reports feature usage statistics and crash reports to Google \
   in order to help Google contribute improvements to Flutter over time. See Google's privacy policy: \
@@ -91,11 +91,11 @@ flutter.initializer.module.converted.title=Flutter module type updated
 
 flutter.reload.firstRun.title=Flutter supports hot reload!
 flutter.reload.firstRun.content=Apply changes to your app in place, instantly.
-flutter.reload.firstRun.url=https://flutter.io/docs/development/tools/hot-reload
+flutter.reload.firstRun.url=https://flutter.dev/docs/development/tools/hot-reload
 
-flutter.io.gettingStarted.url=https://flutter.io/docs/get-started/install
-flutter.io.gettingStarted.IDE.url=https://flutter.io/docs/development/tools/ide
-flutter.io.runAndDebug.url=https://flutter.io/docs/development/tools/ide/android-studio#running-and-debugging
+flutter.io.gettingStarted.url=https://flutter.dev/docs/get-started/install
+flutter.io.gettingStarted.IDE.url=https://flutter.dev/docs/development/tools/ide
+flutter.io.runAndDebug.url=https://flutter.dev/docs/development/tools/ide/android-studio#running-and-debugging
 
 # suppress inspection "TrailingSpacesInProperty"
 flutter.view.togglePlatform.output=Switched platform rendering to {0}.\n

--- a/src/io/flutter/FlutterUtils.java
+++ b/src/io/flutter/FlutterUtils.java
@@ -242,7 +242,7 @@ public class FlutterUtils {
   /**
    * Checks whether a given string is a valid Dart identifier.
    * <p>
-   * See: https://www.dartlang.org/guides/language/spec
+   * See: https://dart.dev/guides/language/spec
    *
    * @param id the string to check
    * @return true if a valid identifer, false otherwise.
@@ -257,7 +257,7 @@ public class FlutterUtils {
    *
    * @param name the string to check
    * @return true if a valid package name, false otherwise.
-   * @see <a href="www.dartlang.org/tools/pub/pubspec#name">https://www.dartlang.org/tools/pub/pubspec#name</a>
+   * @see <a href="dart.dev/tools/pub/pubspec#name">https://dart.dev/tools/pub/pubspec#name</a>
    */
   public static boolean isValidPackageName(@NotNull String name) {
     return VALID_PACKAGE.matcher(name).matches();

--- a/src/io/flutter/module/FlutterModuleBuilder.java
+++ b/src/io/flutter/module/FlutterModuleBuilder.java
@@ -219,7 +219,7 @@ public class FlutterModuleBuilder extends ModuleBuilder {
   }
 
   /**
-   * @see <a href="www.dartlang.org/tools/pub/pubspec#name">https://www.dartlang.org/tools/pub/pubspec#name</a>
+   * @see <a href="dart.dev/tools/pub/pubspec#name">https://dart.dev/tools/pub/pubspec#name</a>
    */
   @Override
   public boolean validateModuleName(@NotNull String moduleName) throws ConfigurationException {

--- a/src/io/flutter/run/LaunchState.java
+++ b/src/io/flutter/run/LaunchState.java
@@ -183,7 +183,7 @@ public class LaunchState extends CommandLineState {
   protected void showNoDeviceConnectedMessage(Project project) {
     Messages.showDialog(
       project,
-      "No connected devices found; please connect a device, or see flutter.io/setup for getting started instructions.",
+      "No connected devices found; please connect a device, or see flutter.dev/setup for getting started instructions.",
       "No Connected Devices Found",
       new String[]{Messages.OK_BUTTON}, 0, AllIcons.General.InformationDialog);
   }

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/VmService.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/VmService.java
@@ -35,7 +35,7 @@ import org.dartlang.vm.service.element.*;
  * </pre>
  * where <strong>some-port</strong> is a port number of your choice
  * which this client will use to communicate with the Dart VM.
- * See https://www.dartlang.org/tools/dart-vm/ for more details.
+ * See https://dart.dev/tools/dart-vm for more details.
  * Once the VM is running, instantiate a new {@link VmService}
  * to connect to that VM via {@link VmService#connect(String)}
  * or {@link VmService#localConnect(int)}.


### PR DESCRIPTION
Replace instances of:

- [flutter.io]() with [flutter.dev]()
- [www.dartlang.org]() with [dart.dev]()
- [docs.flutter.io]() with [api.flutter.dev]()

Also fix a broken image link and remove a reference to Flutter being a mobile-only SDK