### PR TITLE
Use --package-name in flutter create

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,8 @@ out/
 packages
 pubspec.lock
 releases/
+.idea/encodings.xml
+.idea/gradle.xml
+.idea/jarRepositories.xml
+.idea/kotlinc.xml
+.idea/modules/

--- a/flutter-studio/src/io/flutter/project/FlutterProjectCreator.java
+++ b/flutter-studio/src/io/flutter/project/FlutterProjectCreator.java
@@ -238,6 +238,7 @@ public class FlutterProjectCreator {
       .setType(myModel.projectType().getValue())
       .setAndroidX(myModel.isGeneratingAndroidX())
       .setOrg(myModel.packageName().get().isEmpty() ? null : reversedOrgFromPackage(myModel.packageName().get()))
+      .setProject(myModel.packageName().get().isEmpty() ? null : projectFromPackage(myModel.packageName().get()))
       .setKotlin(isNotModule() && myModel.useKotlin().get() ? true : null)
       .setSwift(isNotModule() && myModel.useSwift().get() ? true : null)
       .setOffline(myModel.isOfflineSelected().get())
@@ -282,12 +283,28 @@ public class FlutterProjectCreator {
     return true;
   }
 
-  private static String reversedOrgFromPackage(@NotNull String packageName) {
+  @Nullable
+  public static String reversedOrgFromPackage(@NotNull String packageName) {
+    if (packageName.isEmpty()) {
+      return null;
+    }
     int idx = packageName.lastIndexOf('.');
     if (idx <= 0) {
       return packageName;
     }
     return packageName.substring(0, idx);
+  }
+
+  @Nullable
+  private static String projectFromPackage(@NotNull String packageName) {
+    if (packageName.isEmpty()) {
+      return null;
+    }
+    int idx = packageName.lastIndexOf('.');
+    if (idx <= 0) {
+      return null;
+    }
+    return packageName.substring(idx + 1);
   }
 
   public static class MyConversionListener implements ConversionListener {
@@ -300,17 +317,17 @@ public class FlutterProjectCreator {
     }
 
     @Override
-    public void successfullyConverted(File backupDir) {
+    public void successfullyConverted(@NotNull File backupDir) {
       myConverted = true;
     }
 
     @Override
-    public void error(String message) {
+    public void error(@NotNull String message) {
     }
 
     //@Override
     @SuppressWarnings("override")
-    public void cannotWriteToFiles(List<? extends File> readonlyFiles) {
+    public void cannotWriteToFiles(@NotNull List<? extends File> readonlyFiles) {
     }
 
     public boolean isConversionNeeded() {

--- a/flutter-studio/src/io/flutter/project/FlutterProjectStep.java
+++ b/flutter-studio/src/io/flutter/project/FlutterProjectStep.java
@@ -117,7 +117,8 @@ public class FlutterProjectStep extends SkippableWizardStep<FlutterProjectModel>
     myProjectLocation.getChildComponent().setText(initialLocation);
     TextProperty locationText = new TextProperty(myProjectLocation.getChildComponent());
     myBindings.bind(model.projectLocation(), locationText);
-    myBindings.bindTwoWay(new TextProperty(myProjectName), model.projectName());
+    myProjectName.setText(model.projectName().get());
+    myBindings.bind(getModel().projectName(), new TextProperty(myProjectName));
 
     myBindings.bind(model.description(), new TextProperty(myDescription));
 

--- a/flutter-studio/src/io/flutter/project/FlutterSettingsStep.form
+++ b/flutter-studio/src/io/flutter/project/FlutterSettingsStep.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="io.flutter.project.FlutterSettingsStep">
-  <grid id="27dc6" binding="myRootPanel" layout-manager="GridLayoutManager" row-count="16" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="myRootPanel" layout-manager="GridLayoutManager" row-count="13" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="500" height="452"/>
@@ -8,24 +8,14 @@
     <properties/>
     <border type="none"/>
     <children>
-      <component id="29b06" class="com.intellij.ui.components.JBLabel">
-        <constraints>
-          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties>
-          <font style="1"/>
-          <labelFor value="6c9b3"/>
-          <text value="Company domain"/>
-        </properties>
-      </component>
       <vspacer id="85806">
         <constraints>
-          <grid row="15" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="12" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
       <component id="3d5fb" class="javax.swing.JLabel" binding="myLanguageLabel">
         <constraints>
-          <grid row="12" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="9" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <font style="1"/>
@@ -35,44 +25,31 @@
       </component>
       <component id="ab6e5" class="com.intellij.ui.components.JBLabel">
         <constraints>
-          <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <font style="1"/>
           <text value="Package name"/>
         </properties>
       </component>
-      <component id="6c9b3" class="javax.swing.JTextField" binding="myCompanyDomain">
+      <component id="4d99a" class="javax.swing.JTextField" binding="myPackageName">
         <constraints>
-          <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+          <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false">
             <preferred-size width="150" height="-1"/>
           </grid>
         </constraints>
         <properties/>
       </component>
-      <component id="ad519" class="com.android.tools.adtui.LabelWithEditButton" binding="myPackageName">
-        <constraints>
-          <grid row="7" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties/>
-      </component>
-      <vspacer id="58cc2">
+      <vspacer id="e58d7">
         <constraints>
           <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
             <preferred-size width="-1" height="16"/>
           </grid>
         </constraints>
       </vspacer>
-      <vspacer id="e58d7">
-        <constraints>
-          <grid row="8" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
-            <preferred-size width="-1" height="16"/>
-          </grid>
-        </constraints>
-      </vspacer>
       <component id="533e3" class="javax.swing.JCheckBox" binding="myKotlinCheckBox">
         <constraints>
-          <grid row="13" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="10" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Kotlin"/>
@@ -81,7 +58,7 @@
       </component>
       <component id="15a79" class="javax.swing.JCheckBox" binding="mySwiftCheckBox">
         <constraints>
-          <grid row="14" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="11" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Swift"/>
@@ -114,7 +91,7 @@
       </component>
       <component id="5bff0" class="com.intellij.ui.components.JBLabel" binding="myAndroidXLabel">
         <constraints>
-          <grid row="9" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <font style="1"/>
@@ -123,7 +100,7 @@
       </component>
       <component id="f10cb" class="javax.swing.JCheckBox" binding="myUseAndroidxCheckBox">
         <constraints>
-          <grid row="10" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="7" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Use androidx.* artifacts"/>
@@ -131,7 +108,7 @@
       </component>
       <vspacer id="5a8f6">
         <constraints>
-          <grid row="11" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
+          <grid row="8" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
             <preferred-size width="-1" height="16"/>
           </grid>
         </constraints>

--- a/src/io/flutter/sdk/AbstractLibraryManager.java
+++ b/src/io/flutter/sdk/AbstractLibraryManager.java
@@ -5,6 +5,7 @@
  */
 package io.flutter.sdk;
 
+import com.intellij.openapi.application.AppUIExecutor;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.WriteAction;
 import com.intellij.openapi.module.Module;
@@ -95,7 +96,7 @@ public abstract class AbstractLibraryManager<K extends LibraryProperties> {
         model.addRoot(url, OrderRootType.CLASSES);
       }
 
-      model.commit();
+      AppUIExecutor.onUiThread().inSmartMode(project).execute(() -> model.commit());
     });
 
     updateModuleLibraryDependencies(library);

--- a/src/io/flutter/sdk/FlutterCreateAdditionalSettings.java
+++ b/src/io/flutter/sdk/FlutterCreateAdditionalSettings.java
@@ -22,6 +22,8 @@ public class FlutterCreateAdditionalSettings {
   @Nullable
   private String org;
   @Nullable
+  private String project;
+  @Nullable
   private Boolean swift;
   @Nullable
   private Boolean kotlin;
@@ -39,6 +41,7 @@ public class FlutterCreateAdditionalSettings {
                                           @Nullable FlutterProjectType type,
                                           @Nullable String description,
                                           @Nullable String org,
+                                          @Nullable String project,
                                           @Nullable Boolean swift,
                                           @Nullable Boolean kotlin,
                                           @Nullable Boolean offlineMode,
@@ -47,6 +50,7 @@ public class FlutterCreateAdditionalSettings {
     this.type = type;
     this.description = description;
     this.org = org;
+    this.project = project;
     this.swift = swift;
     this.kotlin = kotlin;
     this.offlineMode = offlineMode;
@@ -62,8 +66,17 @@ public class FlutterCreateAdditionalSettings {
     return org;
   }
 
+  @Nullable
+  public String getProject() {
+    return project;
+  }
+
   public void setOrg(@Nullable String value) {
     org = value;
+  }
+
+  public void setProject(@Nullable String value) {
+    project = value;
   }
 
   public void setSwift(boolean value) {
@@ -98,6 +111,11 @@ public class FlutterCreateAdditionalSettings {
     if (!StringUtil.isEmptyOrSpaces(org)) {
       args.add("--org");
       args.add(org);
+    }
+
+    if (!StringUtil.isEmptyOrSpaces(project)) {
+      args.add("--project-name");
+      args.add(project);
     }
 
     if (swift == null || Boolean.FALSE.equals(swift)) {
@@ -152,6 +170,8 @@ public class FlutterCreateAdditionalSettings {
     @Nullable
     private String org;
     @Nullable
+    private String project;
+    @Nullable
     private Boolean swift;
     @Nullable
     private Boolean kotlin;
@@ -182,6 +202,11 @@ public class FlutterCreateAdditionalSettings {
       return this;
     }
 
+    public Builder setProject(@Nullable String project) {
+      this.project = project;
+      return this;
+    }
+
     public Builder setSwift(@Nullable Boolean swift) {
       this.swift = swift;
       return this;
@@ -203,7 +228,7 @@ public class FlutterCreateAdditionalSettings {
     }
 
     public FlutterCreateAdditionalSettings build() {
-      return new FlutterCreateAdditionalSettings(includeDriverTest, type, description, org, swift, kotlin, offlineMode, isAndroidX);
+      return new FlutterCreateAdditionalSettings(includeDriverTest, type, description, org, project, swift, kotlin, offlineMode, isAndroidX);
     }
   }
 }


### PR DESCRIPTION
This makes a few changes to the new project wizard.
- Use the --package-name option to pass the package name to `flutter create`
- Simplify the layout of the settings page, making it more compatible with Android Studio
  - Remove company domain
  - Make the package name a text field instead of a label that converts to a text field when edited
- Add some annotations

It also disallows committing project roots while the indexer is running.

Fixes #4352 

<img width="883" alt="Screen Shot 2020-02-20 at 1 41 02 PM" src="https://user-images.githubusercontent.com/8518285/74981235-bb689c00-53e6-11ea-860f-5ddbae318858.png">