### PR TITLE
fix an issue with discovering hyperlinks in test consoles

### DIFF
--- a/src/io/flutter/console/FlutterConsoleFilter.java
+++ b/src/io/flutter/console/FlutterConsoleFilter.java
@@ -26,10 +26,15 @@ import io.flutter.sdk.FlutterSdk;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+/**
+ * The FlutterConsoleFilter handles link detection in consoles for:
+ * <p>
+ * - linking an action to the term 'flutter doctor'
+ * - linking the text "Launching lib/main.dart" or "open ios/Runner.xcworkspace"
+ * - some embedded paths, like "MyApp.xzzzz (lib/main.dart:6)"
+ */
 public class FlutterConsoleFilter implements Filter {
-
   private static class OpenExternalFileHyperlink implements HyperlinkInfo {
-
     private final String myPath;
 
     OpenExternalFileHyperlink(VirtualFile file) {
@@ -176,6 +181,7 @@ public class FlutterConsoleFilter implements Filter {
     if (file == null) {
       file = fileAtPath(pathPart);
     }
+
     if (file != null) {
       // "open ios/Runner.xcworkspace"
       final boolean openAsExternalFile = FlutterUtils.isXcodeFileName(pathPart);

--- a/src/io/flutter/run/SdkRunConfig.java
+++ b/src/io/flutter/run/SdkRunConfig.java
@@ -218,7 +218,6 @@ public class SdkRunConfig extends LocatableConfigurationBase
     // Set up additional console filters.
     final TextConsoleBuilder builder = launcher.getConsoleBuilder();
     builder.addFilter(new DartConsoleFilter(env.getProject(), mainFile.getFile()));
-
     if (module != null) {
       builder.addFilter(new FlutterConsoleFilter(module));
     }

--- a/src/io/flutter/run/SdkRunConfig.java
+++ b/src/io/flutter/run/SdkRunConfig.java
@@ -54,7 +54,7 @@ import static java.nio.file.FileVisitResult.CONTINUE;
 /**
  * Run configuration used for launching a Flutter app using the Flutter SDK.
  */
-public class SdkRunConfig extends LocatableConfigurationBase
+public class SdkRunConfig extends LocatableConfigurationBase<LaunchState>
   implements LaunchState.RunConfig, RefactoringListenerProvider, RunConfigurationWithSuppressedDefaultRunAction {
 
   private static final Logger LOG = Logger.getInstance(SdkRunConfig.class);
@@ -85,9 +85,7 @@ public class SdkRunConfig extends LocatableConfigurationBase
     return new FlutterConfigurationEditorForm(getProject());
   }
 
-  public static class RecursiveDeleter
-    extends SimpleFileVisitor<Path> {
-
+  public static class RecursiveDeleter extends SimpleFileVisitor<Path> {
     private final PathMatcher matcher;
 
     RecursiveDeleter(String pattern) {
@@ -217,10 +215,15 @@ public class SdkRunConfig extends LocatableConfigurationBase
                                    @Nullable Module module) {
     // Set up additional console filters.
     final TextConsoleBuilder builder = launcher.getConsoleBuilder();
+    // file:, package:, and dart: references
     builder.addFilter(new DartConsoleFilter(env.getProject(), mainFile.getFile()));
+    //// links often found when running tests
+    //builder.addFilter(new DartRelativePathsConsoleFilter(env.getProject(), mainFile.getAppDir().getPath()));
     if (module != null) {
+      // various flutter run links
       builder.addFilter(new FlutterConsoleFilter(module));
     }
+    // general urls
     builder.addFilter(new UrlFilter());
   }
 

--- a/src/io/flutter/run/bazelTest/BazelTestLaunchState.java
+++ b/src/io/flutter/run/bazelTest/BazelTestLaunchState.java
@@ -17,7 +17,7 @@ import com.intellij.execution.testframework.ui.BaseTestsOutputConsoleView;
 import com.intellij.execution.ui.ConsoleView;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
-import com.jetbrains.lang.dart.ide.runner.DartRelativePathsConsoleFilter;
+import com.jetbrains.lang.dart.ide.runner.DartConsoleFilter;
 import com.jetbrains.lang.dart.util.DartUrlResolver;
 import io.flutter.bazel.Workspace;
 import io.flutter.bazel.WorkspaceCache;
@@ -47,8 +47,8 @@ public class BazelTestLaunchState extends CommandLineState {
     this.config = config;
     this.fields = config.getFields();
     if (testFile == null) {
-      Workspace workspace = WorkspaceCache.getInstance(env.getProject()).get();
-      assert(workspace != null);
+      final Workspace workspace = WorkspaceCache.getInstance(env.getProject()).get();
+      assert (workspace != null);
       testFile = workspace.getRoot();
     }
     this.testFile = testFile;
@@ -106,8 +106,8 @@ public class BazelTestLaunchState extends CommandLineState {
     final ConsoleProps props = ConsoleProps.forBazel(config, executor, resolver);
     final BaseTestsOutputConsoleView console = SMTestRunnerConnectionUtil.createConsole(ConsoleProps.bazelFrameworkName, props);
 
-    final String baseDir = workspace.getRoot().getPath();
-    console.addMessageFilter(new DartRelativePathsConsoleFilter(project, baseDir));
+    // TODO(devoncarew): Will DartConsoleFilter work well in a Bazel context?
+    console.addMessageFilter(new DartConsoleFilter(project, testFile));
     console.addMessageFilter(new UrlFilter());
     return console;
   }

--- a/src/io/flutter/run/bazelTest/BazelTestLaunchState.java
+++ b/src/io/flutter/run/bazelTest/BazelTestLaunchState.java
@@ -18,6 +18,7 @@ import com.intellij.execution.ui.ConsoleView;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.jetbrains.lang.dart.ide.runner.DartConsoleFilter;
+import com.jetbrains.lang.dart.ide.runner.DartRelativePathsConsoleFilter;
 import com.jetbrains.lang.dart.util.DartUrlResolver;
 import io.flutter.bazel.Workspace;
 import io.flutter.bazel.WorkspaceCache;
@@ -108,6 +109,8 @@ public class BazelTestLaunchState extends CommandLineState {
 
     // TODO(devoncarew): Will DartConsoleFilter work well in a Bazel context?
     console.addMessageFilter(new DartConsoleFilter(project, testFile));
+    final String baseDir = workspace.getRoot().getPath();
+    console.addMessageFilter(new DartRelativePathsConsoleFilter(project, baseDir));
     console.addMessageFilter(new UrlFilter());
     return console;
   }

--- a/src/io/flutter/run/daemon/DaemonConsoleView.java
+++ b/src/io/flutter/run/daemon/DaemonConsoleView.java
@@ -46,6 +46,7 @@ public class DaemonConsoleView extends ConsoleViewImpl {
     };
 
     // Set up basic console filters. (More may be added later.)
+    // TODO(devoncarew): Do we need this filter? What about DartConsoleFilter (for package: uris)?
     builder.addFilter(new DartRelativePathsConsoleFilter(env.getProject(), workDir.getPath()));
     launcher.setConsoleBuilder(builder);
   }

--- a/src/io/flutter/run/test/TestLaunchState.java
+++ b/src/io/flutter/run/test/TestLaunchState.java
@@ -19,10 +19,9 @@ import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleUtil;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
-import com.jetbrains.lang.dart.ide.runner.DartRelativePathsConsoleFilter;
+import com.jetbrains.lang.dart.ide.runner.DartConsoleFilter;
 import com.jetbrains.lang.dart.util.DartUrlResolver;
 import io.flutter.FlutterBundle;
-import io.flutter.console.FlutterConsoleFilter;
 import io.flutter.pub.PubRoot;
 import io.flutter.run.common.ConsoleProps;
 import io.flutter.run.common.RunMode;
@@ -113,15 +112,11 @@ class TestLaunchState extends CommandLineState {
     final DartUrlResolver resolver = DartUrlResolver.getInstance(project, testFileOrDir);
     final ConsoleProps props = ConsoleProps.forPub(config, executor, resolver);
     final BaseTestsOutputConsoleView console = SMTestRunnerConnectionUtil.createConsole(ConsoleProps.pubFrameworkName, props);
+
     final Module module = ModuleUtil.findModuleForFile(testFileOrDir, project);
-    if (module != null) {
-      console.addMessageFilter(new FlutterConsoleFilter(module));
-    }
-    final String baseDir = getBaseDir();
-    if (baseDir != null) {
-      console.addMessageFilter(new DartRelativePathsConsoleFilter(project, baseDir));
-    }
+    console.addMessageFilter(new DartConsoleFilter(project, getTestFileOrDir()));
     console.addMessageFilter(new UrlFilter());
+
     return console;
   }
 

--- a/src/io/flutter/run/test/TestLaunchState.java
+++ b/src/io/flutter/run/test/TestLaunchState.java
@@ -20,6 +20,7 @@ import com.intellij.openapi.module.ModuleUtil;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.jetbrains.lang.dart.ide.runner.DartConsoleFilter;
+import com.jetbrains.lang.dart.ide.runner.DartRelativePathsConsoleFilter;
 import com.jetbrains.lang.dart.util.DartUrlResolver;
 import io.flutter.FlutterBundle;
 import io.flutter.pub.PubRoot;
@@ -115,6 +116,10 @@ class TestLaunchState extends CommandLineState {
 
     final Module module = ModuleUtil.findModuleForFile(testFileOrDir, project);
     console.addMessageFilter(new DartConsoleFilter(project, getTestFileOrDir()));
+    final String baseDir = getBaseDir();
+    if (baseDir != null) {
+      console.addMessageFilter(new DartRelativePathsConsoleFilter(project, baseDir));
+    }
     console.addMessageFilter(new UrlFilter());
 
     return console;


### PR DESCRIPTION
Fix an issue with discovering hyperlinks in test consoles:

- add a `DartConsoleFilter` console filter to the test console
- some related cleanup and normalization to our filters for various consoles
- fix https://github.com/flutter/flutter-intellij/issues/4429
- fix https://github.com/flutter/flutter-intellij/issues/3851

We'd never contributed a `DartConsoleFilter` to the test consoles before (which we should have), and recent changes in the `FlutterConsoleFilter` had caused the test console hyperlink support to regress further.

@gspencergoog, this will likely address the issue you're seeing. We have a release scheduled for next Friday, so you'll see this change then. If you want to try out a version before that, we now have a beta channel that gets automatically pushed to every Sunday AM. I can send you docs on how to switch to the beta channel if you like.
