### PR TITLE
add support for 'flutter pub outdated'

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -1008,12 +1008,12 @@
               text="Flutter Doctor"
               description="Run 'flutter doctor'"/>
       <separator/>
-      <action id="flutter.packages.get" class="io.flutter.actions.FlutterPackagesGetAction"
-              text="Flutter Packages Get"
-              description="Run 'flutter packages get'"/>
-      <action id="flutter.packages.upgrade" class="io.flutter.actions.FlutterPackagesUpgradeAction"
-              text="Flutter Packages Upgrade"
-              description="Run 'flutter packages upgrade'"/>
+      <action id="flutter.pub.get" class="io.flutter.actions.FlutterPackagesGetAction"
+              text="Flutter Pub Get"
+              description="Run 'flutter pub get'"/>
+      <action id="flutter.pub.upgrade" class="io.flutter.actions.FlutterPackagesUpgradeAction"
+              text="Flutter Pub Upgrade"
+              description="Run 'flutter pub upgrade'"/>
       <separator/>
       <action id="flutter.clean" class="io.flutter.actions.FlutterCleanAction"
               text="Flutter Clean"
@@ -1043,8 +1043,8 @@
       <separator/>
       <group text="Flutter" description="Flutter Tools" icon="FlutterIcons.Flutter" popup="true">
         <separator/>
-        <reference ref="flutter.packages.get"/>
-        <reference ref="flutter.packages.upgrade"/>
+        <reference ref="flutter.pub.get"/>
+        <reference ref="flutter.pub.upgrade"/>
         <separator/>
         <reference ref="flutter.androidstudio.open"/>
         <reference ref="flutter.xcode.open"/>

--- a/resources/META-INF/plugin_template.xml
+++ b/resources/META-INF/plugin_template.xml
@@ -70,12 +70,12 @@
               text="Flutter Doctor"
               description="Run 'flutter doctor'"/>
       <separator/>
-      <action id="flutter.packages.get" class="io.flutter.actions.FlutterPackagesGetAction"
-              text="Flutter Packages Get"
-              description="Run 'flutter packages get'"/>
-      <action id="flutter.packages.upgrade" class="io.flutter.actions.FlutterPackagesUpgradeAction"
-              text="Flutter Packages Upgrade"
-              description="Run 'flutter packages upgrade'"/>
+      <action id="flutter.pub.get" class="io.flutter.actions.FlutterPackagesGetAction"
+              text="Flutter Pub Get"
+              description="Run 'flutter pub get'"/>
+      <action id="flutter.pub.upgrade" class="io.flutter.actions.FlutterPackagesUpgradeAction"
+              text="Flutter Pub Upgrade"
+              description="Run 'flutter pub upgrade'"/>
       <separator/>
       <action id="flutter.clean" class="io.flutter.actions.FlutterCleanAction"
               text="Flutter Clean"
@@ -105,8 +105,8 @@
       <separator/>
       <group text="Flutter" description="Flutter Tools" icon="FlutterIcons.Flutter" popup="true">
         <separator/>
-        <reference ref="flutter.packages.get"/>
-        <reference ref="flutter.packages.upgrade"/>
+        <reference ref="flutter.pub.get"/>
+        <reference ref="flutter.pub.upgrade"/>
         <separator/>
         <reference ref="flutter.androidstudio.open"/>
         <reference ref="flutter.xcode.open"/>

--- a/src/io/flutter/FlutterBundle.properties
+++ b/src/io/flutter/FlutterBundle.properties
@@ -50,7 +50,7 @@ open.observatory.action.text=Open Observatory
 open.observatory.action.description=Open Observatory: a Profiler for Dart apps
 
 outdated.dependencies.inspection.name=Outdated package dependencies
-packages.get.never.done='Packages get' has not been run
+pub.get.not.run='Pub get' has not been run
 pubspec.edited=Pubspec has been edited
 get.dependencies=Get dependencies
 upgrade.dependencies=Upgrade dependencies

--- a/src/io/flutter/ProjectOpenActivity.java
+++ b/src/io/flutter/ProjectOpenActivity.java
@@ -81,15 +81,15 @@ public class ProjectOpenActivity implements StartupActivity, DumbAware {
     @NotNull private final PubRoot myRoot;
 
     public PackagesOutOfDateNotification(@NotNull Project project, @NotNull PubRoot root) {
-      super("Flutter Packages", FlutterIcons.Flutter, "Flutter packages get.",
+      super("Flutter Packages", FlutterIcons.Flutter, "Flutter pub get.",
             null, "The pubspec.yaml file has been modified since " +
-                  "the last time 'flutter packages get' was run.",
+                  "the last time 'flutter pub get' was run.",
             NotificationType.INFORMATION, null);
 
       myProject = project;
       myRoot = root;
 
-      addAction(new AnAction("Run 'flutter packages get'") {
+      addAction(new AnAction("Run 'flutter pub get'") {
         @Override
         public void actionPerformed(@NotNull AnActionEvent event) {
           expire();
@@ -100,8 +100,8 @@ public class ProjectOpenActivity implements StartupActivity, DumbAware {
             return;
           }
 
-          if (sdk.startPackagesGet(root, project) == null) {
-            Messages.showErrorDialog("Unable to run 'flutter packages get'", "Error");
+          if (sdk.startPubGet(root, project) == null) {
+            Messages.showErrorDialog("Unable to run 'flutter pub get'", "Error");
           }
         }
       });

--- a/src/io/flutter/actions/FlutterPackagesGetAction.java
+++ b/src/io/flutter/actions/FlutterPackagesGetAction.java
@@ -14,14 +14,13 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class FlutterPackagesGetAction extends FlutterSdkAction {
-
   @Override
   public void startCommand(@NotNull Project project, @NotNull FlutterSdk sdk, @Nullable PubRoot root, @NotNull DataContext context) {
     if (root == null) {
       FlutterMessages.showError("Cannot Find Pub Root",
-                                "Flutter packages get can only be run within a directory with a pubspec.yaml file");
+                                "Flutter pub get can only be run within a directory with a pubspec.yaml file");
       return;
     }
-    sdk.startPackagesGet(root, project);
+    sdk.startPubGet(root, project);
   }
 }

--- a/src/io/flutter/actions/FlutterPackagesUpgradeAction.java
+++ b/src/io/flutter/actions/FlutterPackagesUpgradeAction.java
@@ -15,14 +15,13 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class FlutterPackagesUpgradeAction extends FlutterSdkAction {
-
   @Override
   public void startCommand(@NotNull Project project, @NotNull FlutterSdk sdk, @Nullable PubRoot root, @NotNull DataContext context) {
     if (root == null) {
       FlutterMessages.showError("Cannot Find Pub Root",
-                                "Flutter packages upgrade can only be run within a directory with a pubspec.yaml file");
+                                "Flutter pub upgrade can only be run within a directory with a pubspec.yaml file");
       return;
     }
-    sdk.startPackagesUpgrade(root, project);
+    sdk.startPubUpgrade(root, project);
   }
 }

--- a/src/io/flutter/editor/FlutterPubspecNotificationProvider.java
+++ b/src/io/flutter/editor/FlutterPubspecNotificationProvider.java
@@ -82,24 +82,28 @@ public class FlutterPubspecNotificationProvider extends EditorNotifications.Prov
       icon(FlutterIcons.Flutter);
       text("Flutter commands");
 
-      // "flutter.packages.get"
-      HyperlinkLabel label = createActionLabel("Packages get", () -> runPackagesGet(false));
+      // "flutter.pub.get"
+      HyperlinkLabel label = createActionLabel("Pub get", () -> runPubGet(false));
       label.setToolTipText("Install referenced packages");
 
-      // "flutter.packages.upgrade"
-      label = createActionLabel("Packages upgrade", () -> runPackagesGet(true));
+      // "flutter.pub.upgrade"
+      label = createActionLabel("Pub upgrade", () -> runPubGet(true));
       label.setToolTipText("Upgrade referenced packages to the latest versions");
 
-      myLinksPanel.add(new JSeparator(SwingConstants.VERTICAL));
-      label = createActionLabel("Flutter upgrade", "flutter.upgrade");
-      label.setToolTipText("Upgrade the Flutter framework to the latest version");
+      // If the SDK is the right version, add a 'flutter pub outdated' command.
+      final FlutterSdk sdk = FlutterSdk.getFlutterSdk(project);
+      if (sdk != null && sdk.getVersion().isPubOutdatedSupported()) {
+        // "flutter.pub.outdated"
+        label = createActionLabel("Pub outdated", this::runPubOutdated);
+        label.setToolTipText("Analyze packages to determine which ones can be upgraded");
+      }
 
       myLinksPanel.add(new JSeparator(SwingConstants.VERTICAL));
       label = createActionLabel("Flutter doctor", "flutter.doctor");
       label.setToolTipText("Validate installed tools and their versions");
     }
 
-    private void runPackagesGet(boolean upgrade) {
+    private void runPubGet(boolean upgrade) {
       final FlutterSdk sdk = FlutterSdk.getFlutterSdk(project);
       if (sdk == null) {
         return;
@@ -108,11 +112,23 @@ public class FlutterPubspecNotificationProvider extends EditorNotifications.Prov
       final PubRoot root = PubRoot.forDirectory(myFile.getParent());
       if (root != null) {
         if (!upgrade) {
-          sdk.startPackagesGet(root, project);
+          sdk.startPubGet(root, project);
         }
         else {
-          sdk.startPackagesUpgrade(root, project);
+          sdk.startPubUpgrade(root, project);
         }
+      }
+    }
+
+    private void runPubOutdated() {
+      final FlutterSdk sdk = FlutterSdk.getFlutterSdk(project);
+      if (sdk == null) {
+        return;
+      }
+
+      final PubRoot root = PubRoot.forDirectory(myFile.getParent());
+      if (root != null) {
+        sdk.startPubOutdated(root, project);
       }
     }
   }

--- a/src/io/flutter/inspections/FlutterDependencyInspection.java
+++ b/src/io/flutter/inspections/FlutterDependencyInspection.java
@@ -61,7 +61,7 @@ public class FlutterDependencyInspection extends LocalInspectionTool {
     // TODO(pq): consider validating package name here (`get` will fail if it's invalid).
 
     if (root.getPackagesFile() == null) {
-      return createProblemDescriptors(manager, psiFile, root, FlutterBundle.message("packages.get.never.done"));
+      return createProblemDescriptors(manager, psiFile, root, FlutterBundle.message("pub.get.not.run"));
     }
 
     if (!root.hasUpToDatePackages()) {
@@ -77,8 +77,8 @@ public class FlutterDependencyInspection extends LocalInspectionTool {
                                                        @NotNull final PubRoot root,
                                                        @NotNull final String errorMessage) {
     final LocalQuickFix[] fixes = new LocalQuickFix[]{
-      new PackageUpdateFix(FlutterBundle.message("get.dependencies"), FlutterSdk::startPackagesGet),
-      new PackageUpdateFix(FlutterBundle.message("upgrade.dependencies"), FlutterSdk::startPackagesUpgrade),
+      new PackageUpdateFix(FlutterBundle.message("get.dependencies"), FlutterSdk::startPubGet),
+      new PackageUpdateFix(FlutterBundle.message("upgrade.dependencies"), FlutterSdk::startPubUpgrade),
       new IgnoreWarningFix(myIgnoredPubspecPaths, root.getPubspec().getPath())};
 
     return new ProblemDescriptor[]{

--- a/src/io/flutter/preview/PreviewView.java
+++ b/src/io/flutter/preview/PreviewView.java
@@ -41,7 +41,6 @@ import io.flutter.FlutterUtils;
 import io.flutter.dart.FlutterDartAnalysisServer;
 import io.flutter.dart.FlutterOutlineListener;
 import io.flutter.editor.PropertyEditorPanel;
-import io.flutter.inspector.FlutterWidget;
 import io.flutter.inspector.InspectorGroupManagerService;
 import io.flutter.settings.FlutterSettings;
 import io.flutter.utils.CustomIconMaker;
@@ -428,8 +427,7 @@ public class PreviewView implements PersistentStateComponent<PreviewViewState> {
 
     // TODO(jacobr): this is the wrong spot.
     if (propertyEditToolbarGroup != null) {
-      TitleAction propertyTitleAction;
-      propertyTitleAction = new TitleAction("Properties");
+      final TitleAction propertyTitleAction = new TitleAction("Properties");
       propertyEditToolbarGroup.removeAll();
       propertyEditToolbarGroup.add(propertyTitleAction);
     }
@@ -752,10 +750,6 @@ class OutlineObject {
 
     if (icon == null) {
       final String className = outline.getClassName();
-      final FlutterWidget widget = FlutterWidget.getCatalog().getWidget(className);
-      if (widget != null) {
-        icon = widget.getIcon();
-      }
       if (icon == null) {
         icon = iconMaker.fromWidgetName(className);
       }
@@ -874,8 +868,6 @@ class OutlineTreeCellRenderer extends ColoredTreeCellRenderer {
           }
 
           appendSearch(attribute.getLabel(), SimpleTextAttributes.GRAYED_ATTRIBUTES);
-
-          // TODO(scheglov): custom display for units, colors, iterables, and icons?
         }
       }
     }
@@ -895,12 +887,12 @@ class OutlineTreeCellRenderer extends ColoredTreeCellRenderer {
     return false;
   }
 
-  private static boolean isAttributeElidable(String name) {
-    return StringUtil.equals("text", name) || StringUtil.equals("icon", name);
-  }
-
   void appendSearch(@NotNull String text, @NotNull SimpleTextAttributes attributes) {
     SpeedSearchUtil.appendFragmentsForSpeedSearch(tree, text, attributes, selected, this);
+  }
+
+  private static boolean isAttributeElidable(String name) {
+    return StringUtil.equals("text", name) || StringUtil.equals("icon", name);
   }
 }
 

--- a/src/io/flutter/sdk/FlutterCommand.java
+++ b/src/io/flutter/sdk/FlutterCommand.java
@@ -35,7 +35,7 @@ public class FlutterCommand {
   private static final Logger LOG = Logger.getInstance(FlutterCommand.class);
 
   private static final Set<Type> pubRelatedCommands = new HashSet<>(
-    Arrays.asList(Type.PACKAGES_GET, Type.PACKAGES_UPGRADE, Type.UPGRADE));
+    Arrays.asList(Type.PUB_GET, Type.PUB_UPGRADE, Type.PUB_OUTDATED, Type.UPGRADE));
 
   @NotNull
   protected final FlutterSdk sdk;
@@ -275,8 +275,9 @@ public class FlutterCommand {
     CREATE("Flutter create", "create"),
     DOCTOR("Flutter doctor", "doctor", "--verbose"),
     MAKE_HOST_APP_EDITABLE("Flutter make-host-app-editable", "make-host-app-editable"),
-    PACKAGES_GET("Flutter packages get", "packages", "get"),
-    PACKAGES_UPGRADE("Flutter packages upgrade", "packages", "upgrade"),
+    PUB_GET("Flutter pub get", "pub", "get"),
+    PUB_UPGRADE("Flutter pub upgrade", "pub", "upgrade"),
+    PUB_OUTDATED("Flutter pub outdated", "pub", "outdated"),
     PUB("Flutter pub", "pub"),
     RUN("Flutter run", "run"),
     UPGRADE("Flutter upgrade", "upgrade"),

--- a/src/io/flutter/sdk/FlutterSdk.java
+++ b/src/io/flutter/sdk/FlutterSdk.java
@@ -189,11 +189,15 @@ public class FlutterSdk {
   }
 
   public FlutterCommand flutterPackagesGet(@NotNull PubRoot root) {
-    return new FlutterCommand(this, root.getRoot(), FlutterCommand.Type.PACKAGES_GET);
+    return new FlutterCommand(this, root.getRoot(), FlutterCommand.Type.PUB_GET);
   }
 
   public FlutterCommand flutterPackagesUpgrade(@NotNull PubRoot root) {
-    return new FlutterCommand(this, root.getRoot(), FlutterCommand.Type.PACKAGES_UPGRADE);
+    return new FlutterCommand(this, root.getRoot(), FlutterCommand.Type.PUB_UPGRADE);
+  }
+
+  public FlutterCommand flutterPackagesOutdated(@NotNull PubRoot root) {
+    return new FlutterCommand(this, root.getRoot(), FlutterCommand.Type.PUB_OUTDATED);
   }
 
   public FlutterCommand flutterPub(@Nullable PubRoot root, String... args) {
@@ -389,13 +393,13 @@ public class FlutterSdk {
   }
 
   /**
-   * Starts running 'flutter packages get' on the given pub root provided it's in one of this project's modules.
+   * Starts running 'flutter pub get' on the given pub root provided it's in one of this project's modules.
    * <p>
    * Shows output in the console associated with the given module.
    * <p>
    * Returns the process if successfully started.
    */
-  public Process startPackagesGet(@NotNull PubRoot root, @NotNull Project project) {
+  public Process startPubGet(@NotNull PubRoot root, @NotNull Project project) {
     final Module module = root.getModule(project);
     if (module == null) return null;
     // Ensure pubspec is saved.
@@ -405,18 +409,33 @@ public class FlutterSdk {
   }
 
   /**
-   * Starts running 'flutter packages upgrade' on the given pub root.
+   * Starts running 'flutter pub upgrade' on the given pub root.
    * <p>
    * Shows output in the console associated with the given module.
    * <p>
    * Returns the process if successfully started.
    */
-  public Process startPackagesUpgrade(@NotNull PubRoot root, @NotNull Project project) {
+  public Process startPubUpgrade(@NotNull PubRoot root, @NotNull Project project) {
     final Module module = root.getModule(project);
     if (module == null) return null;
     // Ensure pubspec is saved.
     FileDocumentManager.getInstance().saveAllDocuments();
     return flutterPackagesUpgrade(root).startInModuleConsole(module, root::refresh, null);
+  }
+
+  /**
+   * Starts running 'flutter pub outdated' on the given pub root.
+   * <p>
+   * Shows output in the console associated with the given module.
+   * <p>
+   * Returns the process if successfully started.
+   */
+  public Process startPubOutdated(@NotNull PubRoot root, @NotNull Project project) {
+    final Module module = root.getModule(project);
+    if (module == null) return null;
+    // Ensure pubspec is saved.
+    FileDocumentManager.getInstance().saveAllDocuments();
+    return flutterPackagesOutdated(root).startInModuleConsole(module, root::refresh, null);
   }
 
   @NotNull

--- a/src/io/flutter/sdk/FlutterSdkVersion.java
+++ b/src/io/flutter/sdk/FlutterSdkVersion.java
@@ -34,6 +34,11 @@ public class FlutterSdkVersion {
    */
   private static final FlutterSdkVersion MIN_ANDROIDX_SDK = new FlutterSdkVersion("1.7.8");
 
+  /**
+   * The version of the stable channel that suppoorts --androidx in the create command.
+   */
+  private static final FlutterSdkVersion MIN_PUB_OUTDATED_SDK = new FlutterSdkVersion("1.16.4");
+
   @Nullable
   private final Version version;
 
@@ -105,6 +110,11 @@ public class FlutterSdkVersion {
 
   public boolean flutterTestSupportsFiltering() {
     return isMinRecommendedSupported();
+  }
+
+  public boolean isPubOutdatedSupported() {
+    //noinspection ConstantConditions
+    return version != null && version.compareTo(MIN_PUB_OUTDATED_SDK.version) >= 0;
   }
 
   @Override


### PR DESCRIPTION
- add support for 'flutter pub outdated' (expose it in the pubspec file's header action bar); this is contingent on having a recent enough Flutter SDK
- remove `flutter upgrade` from the pubspec file's header action bar
- rename user facing references to `flutter packages` to `flutter pub`
- fix https://github.com/flutter/flutter-intellij/issues/4439
- fix https://github.com/flutter/flutter-intellij/issues/4440

<img width="474" alt="Screen Shot 2020-03-27 at 4 19 04 PM" src="https://user-images.githubusercontent.com/1269969/77826594-98a86200-70cd-11ea-8ff7-b5e701535fb6.png">

<img width="624" alt="Screen Shot 2020-03-27 at 4 19 14 PM" src="https://user-images.githubusercontent.com/1269969/77826604-a8c04180-70cd-11ea-89ac-4e4216f3499e.png">
