### PR TITLE
Only show the Flutter device selector in projects that have a Flutter module

### DIFF
--- a/src/io/flutter/actions/DeviceSelectorAction.java
+++ b/src/io/flutter/actions/DeviceSelectorAction.java
@@ -5,7 +5,12 @@
  */
 package io.flutter.actions;
 
-import com.intellij.openapi.actionSystem.*;
+import com.intellij.openapi.actionSystem.ActionPlaces;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.DefaultActionGroup;
+import com.intellij.openapi.actionSystem.Presentation;
+import com.intellij.openapi.actionSystem.Separator;
 import com.intellij.openapi.actionSystem.ex.ComboBoxAction;
 import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.Project;
@@ -18,11 +23,15 @@ import io.flutter.FlutterUtils;
 import io.flutter.run.FlutterDevice;
 import io.flutter.run.daemon.DeviceService;
 import io.flutter.sdk.AndroidEmulatorManager;
+import io.flutter.utils.FlutterModuleUtils;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import javax.swing.JComponent;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
-import javax.swing.*;
-import java.util.*;
 
 public class DeviceSelectorAction extends ComboBoxAction implements DumbAware {
   private final List<AnAction> actions = new ArrayList<>();
@@ -81,7 +90,7 @@ public class DeviceSelectorAction extends ComboBoxAction implements DumbAware {
     });
   }
 
-  private void updateVisibility(final Project project, final Presentation presentation) {
+  private static void updateVisibility(final Project project, final Presentation presentation) {
     final boolean visible = isSelectorVisible(project);
     presentation.setVisible(visible);
 
@@ -95,8 +104,10 @@ public class DeviceSelectorAction extends ComboBoxAction implements DumbAware {
     }
   }
 
-  private boolean isSelectorVisible(@Nullable Project project) {
-    return project != null && DeviceService.getInstance(project).getStatus() != DeviceService.State.INACTIVE;
+  private static boolean isSelectorVisible(@Nullable Project project) {
+    return project != null &&
+           DeviceService.getInstance(project).getStatus() != DeviceService.State.INACTIVE &&
+           FlutterModuleUtils.hasFlutterModule(project);
   }
 
   private void updateActions(@NotNull Project project, Presentation presentation) {


### PR DESCRIPTION
For example, Android apps (without add-to-app) or Java projects do not need the device selector.