### PR TITLE
in-line run config names to address runtime warnings

### DIFF
--- a/src/io/flutter/run/FlutterRunConfigurationType.java
+++ b/src/io/flutter/run/FlutterRunConfigurationType.java
@@ -17,15 +17,16 @@ import com.jetbrains.lang.dart.DartFileType;
 import icons.FlutterIcons;
 import io.flutter.FlutterBundle;
 import io.flutter.utils.FlutterModuleUtils;
+import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 
 public class FlutterRunConfigurationType extends ConfigurationTypeBase {
-
   private final Factory factory;
 
   public FlutterRunConfigurationType() {
     super("FlutterRunConfigurationType", FlutterBundle.message("runner.flutter.configuration.name"),
           FlutterBundle.message("runner.flutter.configuration.description"), FlutterIcons.Flutter);
+
     factory = new Factory(this);
     addFactory(factory);
   }
@@ -51,6 +52,13 @@ public class FlutterRunConfigurationType extends ConfigurationTypeBase {
       super(type);
     }
 
+    @NotNull
+    @Override
+    @NonNls
+    public String getId() {
+      return "Flutter";
+    }
+
     @Override
     @NotNull
     public RunConfiguration createTemplateConfiguration(@NotNull Project project) {
@@ -59,7 +67,7 @@ public class FlutterRunConfigurationType extends ConfigurationTypeBase {
 
     @Override
     @NotNull
-    public RunConfiguration createConfiguration(String name, RunConfiguration template) {
+    public RunConfiguration createConfiguration(String name, @NotNull RunConfiguration template) {
       // Override the default name which is always "Unnamed".
       return super.createConfiguration(template.getProject().getName(), template);
     }

--- a/src/io/flutter/run/bazel/BazelFields.java
+++ b/src/io/flutter/run/bazel/BazelFields.java
@@ -151,10 +151,10 @@ public class BazelFields {
     }
 
     final String launchScript = getLaunchScriptFromWorkspace(project);
-
     if (launchScript == null) {
       throw new RuntimeConfigurationError(FlutterBundle.message("flutter.run.bazel.noLaunchingScript"));
     }
+
     final VirtualFile scriptFile = LocalFileSystem.getInstance().findFileByPath(launchScript);
     if (scriptFile == null) {
       throw new RuntimeConfigurationError(
@@ -296,7 +296,6 @@ public class BazelFields {
 
     return commandLine;
   }
-
 
   public void writeTo(Element element) {
     ElementIO.addOption(element, "bazelTarget", bazelTarget);

--- a/src/io/flutter/run/bazelTest/BazelTestFields.java
+++ b/src/io/flutter/run/bazelTest/BazelTestFields.java
@@ -178,8 +178,7 @@ public class BazelTestFields {
    */
   @NotNull
   GeneralCommandLine getLaunchCommand(@NotNull final Project project,
-                                      @NotNull final RunMode mode)
-    throws ExecutionException {
+                                      @NotNull final RunMode mode) throws ExecutionException {
     try {
       checkRunnable(project);
     }

--- a/src/io/flutter/run/bazelTest/BazelTestLaunchState.java
+++ b/src/io/flutter/run/bazelTest/BazelTestLaunchState.java
@@ -45,8 +45,10 @@ public class BazelTestLaunchState extends CommandLineState {
 
   protected BazelTestLaunchState(ExecutionEnvironment env, @NotNull BazelTestConfig config, @Nullable VirtualFile testFile) {
     super(env);
+
     this.config = config;
     this.fields = config.getFields();
+
     if (testFile == null) {
       final Workspace workspace = WorkspaceCache.getInstance(env.getProject()).get();
       assert (workspace != null);

--- a/src/io/flutter/run/bazelTest/BazelTestRunner.java
+++ b/src/io/flutter/run/bazelTest/BazelTestRunner.java
@@ -241,7 +241,6 @@ public class BazelTestRunner extends GenericProgramRunner {
   }
 
   private static final class BazelPositionMapper extends FlutterPositionMapper {
-
     @NotNull final Connector connector;
 
     public BazelPositionMapper(@NotNull final Project project,
@@ -268,7 +267,7 @@ public class BazelTestRunner extends GenericProgramRunner {
       int workspaceEndOffset = filePath.lastIndexOf(workspaceDirName + "/");
       if (workspaceEndOffset != -1) {
         workspaceEndOffset += workspaceDirName.length();
-        results.add(workspaceDirName + "://" + filePath.substring(workspaceEndOffset, filePath.length()));
+        results.add(workspaceDirName + "://" + filePath.substring(workspaceEndOffset));
       }
       return results;
     }
@@ -286,7 +285,7 @@ public class BazelTestRunner extends GenericProgramRunner {
       // uri then return the super invocation of this method. This prevents the unknown URI type from being passed to the analysis server.
       if (StringUtils.isEmpty(workspaceDirName) || !uri.startsWith(workspaceDirName + ":/")) return super.findLocalFile(uri);
 
-      final String pathFromWorkspace = uri.substring(workspaceDirName.length() + 1, uri.length());
+      final String pathFromWorkspace = uri.substring(workspaceDirName.length() + 1);
 
       // For each root in each module, look for a bazel workspace path, if found attempt to compute the VirtualFile, return when found.
       return ApplicationManager.getApplication().runReadAction((Computable<VirtualFile>)() -> {

--- a/src/io/flutter/run/test/FlutterTestConfigType.java
+++ b/src/io/flutter/run/test/FlutterTestConfigType.java
@@ -12,6 +12,7 @@ import com.intellij.openapi.extensions.Extensions;
 import com.intellij.openapi.project.Project;
 import icons.FlutterIcons;
 import io.flutter.run.FlutterRunConfigurationType;
+import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -19,8 +20,8 @@ import org.jetbrains.annotations.NotNull;
  */
 public class FlutterTestConfigType extends ConfigurationTypeBase {
   protected FlutterTestConfigType() {
-    super("FlutterTestConfigType", "Flutter Test",
-          "description", FlutterIcons.Flutter_test);
+    super("FlutterTestConfigType", "Flutter Test", "description", FlutterIcons.Flutter_test);
+
     addFactory(new Factory(this));
   }
 
@@ -31,6 +32,13 @@ public class FlutterTestConfigType extends ConfigurationTypeBase {
   private static class Factory extends ConfigurationFactory {
     public Factory(FlutterTestConfigType type) {
       super(type);
+    }
+
+    @NotNull
+    @Override
+    @NonNls
+    public String getId() {
+      return "Flutter Test";
     }
 
     @NotNull


### PR DESCRIPTION
- in-line run config names to address runtime warnings

These warnings are new, and are likely a result of the work that JetBrains is doing to better support I18N of IntelliJ.

```
2020-04-10 15:55:36,818 [   7666]   WARN - util.DeprecatedMethodException - The default implementation of ConfigurationFactory.getId is deprecated, you need to override it in io.flutter.run.FlutterRunConfigurationType$Factory. The default implementation delegates to 'getName' which may be localized but return value of this method must not depend on current localization. 
com.intellij.util.DeprecatedMethodException: The default implementation of ConfigurationFactory.getId is deprecated, you need to override it in io.flutter.run.FlutterRunConfigurationType$Factory. The default implementation delegates to 'getName' which may be localized but return value of this method must not depend on current localization.
	at com.intellij.util.DeprecatedMethodException.reportDefaultImplementation(DeprecatedMethodException.java:28)
	at com.intellij.execution.configurations.ConfigurationFactory.getId(ConfigurationFactory.java:80)
	at com.intellij.execution.impl.RunManagerImpl.getFactory(RunManagerImpl.kt:977)
	at com.intellij.execution.impl.RunManagerImpl.getFactory(RunManagerImpl.kt:970)
	at com.intellij.execution.impl.RunnerAndConfigurationSettingsImpl.readExternal(RunnerAndConfigurationSettingsImpl.kt:209)
	at com.intellij.execution.impl.RunConfigurationSchemeManager.readData(RunConfigurationSchemeManager.kt:65)
	at com.intellij.execution.impl.RunConfigurationSchemeManager.createScheme(RunConfigurationSchemeManager.kt:48)
	at com.intellij.execution.impl.RunConfigurationSchemeManager.createScheme(RunConfigurationSchemeManager.kt:22)
	at com.intellij.configurationStore.LazySchemeProcessor.createScheme$default(scheme-impl.kt:65)
	at com.intellij.configurationStore.schemeManager.SchemeLoader.loadScheme(schemeLoader.kt:175)
	at com.intellij.configurationStore.schemeManager.SchemeManagerImpl$loadSchemes$isLoadOnlyFromProvider$2.invoke(SchemeManagerImpl.kt:194)
	at com.intellij.configurationStore.schemeManager.SchemeManagerImpl$loadSchemes$isLoadOnlyFromProvider$2.invoke(SchemeManagerImpl.kt:43)
	at com.intellij.configurationStore.SchemeManagerIprProvider.processChildren(SchemeManagerIprProvider.kt:48)
	at com.intellij.configurationStore.schemeManager.SchemeManagerImpl.loadSchemes(SchemeManagerImpl.kt:192)
	at com.intellij.configurationStore.schemeManager.SchemeManagerImpl.reload(SchemeManagerImpl.kt:253)
	at com.intellij.execution.impl.RunManagerImpl.loadState(RunManagerImpl.kt:748)
```
