### PR TITLE
Prevent drawing child lines through other chars (https://github.com/flutter/flutter-intellij/issues/4297)

### DIFF
--- a/src/io/flutter/editor/WidgetIndentsHighlightingPass.java
+++ b/src/io/flutter/editor/WidgetIndentsHighlightingPass.java
@@ -365,6 +365,10 @@ public class WidgetIndentsHighlightingPass {
               );
             }
             else {
+              // If there are other characters on the same line as the widget, avoid drawing a backwards line
+              if (widgetLineStartX != widgetPoint.x) {
+                return;
+              }
               // Edge case where we draw a backwards line to clarify
               // that the node is still a child even though the line is in
               // the wrong direction. This is mainly for debugging but could help

--- a/src/io/flutter/editor/WidgetIndentsHighlightingPass.java
+++ b/src/io/flutter/editor/WidgetIndentsHighlightingPass.java
@@ -334,22 +334,11 @@ public class WidgetIndentsHighlightingPass {
           if (childLine != null) {
             final int childIndent = childLine.getIndent();
             // Draw horizontal line to the child.
-            final VisualPosition widgetVisualPosition = editor.offsetToVisualPosition(childLine.getGuideOffset());
+            final GuidelineOffsetDetail guidelineOffsetDetail = getGuidelineOffsetDetail(childLine, editor, doc, chars);
+            final VisualPosition widgetVisualPosition = editor.offsetToVisualPosition(guidelineOffsetDetail.textStartOffset);
             final Point widgetPoint = editor.visualPositionToXY(widgetVisualPosition);
 
-            // This additional point is computed because sometimes there are other characters on a line before the widget, e.g. if a
-            // widget has been moved to a line with other code but the new outline has not been received yet (see issue #4297)
-            // We want to compute the earliest position to avoid drawing a line through any characters before the widget if they're present.
-            final int startIndex = doc.getLineStartOffset(childLine.getLine());
-            final int endIndex = doc.getLineEndOffset(childLine.getLine());
-            int firstCharPosition = 0;
-            while (startIndex + firstCharPosition < endIndex && Character.isWhitespace(chars.charAt(startIndex + firstCharPosition))) {
-              firstCharPosition += 1;
-            }
-            final Point firstCharPoint = editor.visualPositionToXY(new VisualPosition(childLine.getLine(), firstCharPosition));
-
-            final int widgetLineStartX = min(widgetPoint.x, firstCharPoint.x);
-            final int deltaX = widgetLineStartX - start.x;
+            final int deltaX = widgetPoint.x - start.x;
             // We add a larger amount of panding at the end of the line if the indent is larger up until a max of 6 pixels which is the max
             // amount that looks reasonable. We could remove this and always used a fixed padding.
             final int padding = max(min(abs(deltaX) / 3, 6), 2);
@@ -360,13 +349,13 @@ public class WidgetIndentsHighlightingPass {
                 start.x + 2,
                 newY + lineHeight * 0.5,
                 //start.x + charWidth  * childIndent - padding,
-                widgetLineStartX - padding,
+                widgetPoint.x - padding,
                 newY + lineHeight * 0.5
               );
             }
             else {
               // If there are other characters on the same line as the widget, avoid drawing a backwards line
-              if (widgetLineStartX != widgetPoint.x) {
+              if (guidelineOffsetDetail.textStartOffset != guidelineOffsetDetail.offset) {
                 return;
               }
               // Edge case where we draw a backwards line to clarify
@@ -442,6 +431,38 @@ public class WidgetIndentsHighlightingPass {
         }
       }
       g2d.dispose();
+    }
+
+    private static class GuidelineOffsetDetail {
+      // This is the offset of the widget.
+      final int offset;
+      // This is the offset of the start of text in the line of the widget (which may differ from offset).
+      final int textStartOffset;
+
+      GuidelineOffsetDetail(int offset, int textStartOffset) {
+        this.offset = offset;
+        this.textStartOffset = textStartOffset;
+      }
+    }
+
+    private GuidelineOffsetDetail getGuidelineOffsetDetail(OutlineLocation childLine,
+                                                           Editor editor,
+                                                           Document doc,
+                                                           CharSequence chars) {
+      // This additional point is computed because sometimes there are other characters on a line before the widget, e.g. if a
+      // widget has been moved to a line with other code but the new outline has not been received yet (see issue #4297)
+      // We want to compute the earliest position to avoid drawing a line through any characters before the widget if they're present.
+      final int startIndex = doc.getLineStartOffset(childLine.getLine());
+      final int endIndex = doc.getLineEndOffset(childLine.getLine());
+      int firstCharPosition = 0;
+      while (startIndex + firstCharPosition < endIndex && Character.isWhitespace(chars.charAt(startIndex + firstCharPosition))) {
+        firstCharPosition += 1;
+      }
+
+      return new GuidelineOffsetDetail(
+        childLine.getGuideOffset(),
+        editor.logicalPositionToOffset(new LogicalPosition(childLine.getLine(), firstCharPosition))
+      );
     }
   }
 

--- a/src/io/flutter/editor/WidgetIndentsHighlightingPass.java
+++ b/src/io/flutter/editor/WidgetIndentsHighlightingPass.java
@@ -336,7 +336,17 @@ public class WidgetIndentsHighlightingPass {
             // Draw horizontal line to the child.
             final VisualPosition widgetVisualPosition = editor.offsetToVisualPosition(childLine.getGuideOffset());
             final Point widgetPoint = editor.visualPositionToXY(widgetVisualPosition);
-            final int deltaX = widgetPoint.x - start.x;
+
+            final int startIdx = doc.getLineStartOffset(childLine.getLine());
+            final int endIdx = doc.getLineEndOffset(childLine.getLine());
+            int firstCharPosition = 0;
+            while (startIdx + firstCharPosition < endIdx && Character.isWhitespace(chars.charAt(startIdx + firstCharPosition))) {
+              firstCharPosition += 1;
+            }
+            final Point firstCharPoint = editor.visualPositionToXY(new VisualPosition(childLine.getLine(), firstCharPosition));
+
+            final int widgetLineStartX = min(widgetPoint.x, firstCharPoint.x);
+            final int deltaX = widgetLineStartX - start.x;
             // We add a larger amount of panding at the end of the line if the indent is larger up until a max of 6 pixels which is the max
             // amount that looks reasonable. We could remove this and always used a fixed padding.
             final int padding = max(min(abs(deltaX) / 3, 6), 2);
@@ -347,7 +357,7 @@ public class WidgetIndentsHighlightingPass {
                 start.x + 2,
                 newY + lineHeight * 0.5,
                 //start.x + charWidth  * childIndent - padding,
-                widgetPoint.x - padding,
+                widgetLineStartX - padding,
                 newY + lineHeight * 0.5
               );
             }

--- a/src/io/flutter/editor/WidgetIndentsHighlightingPass.java
+++ b/src/io/flutter/editor/WidgetIndentsHighlightingPass.java
@@ -337,10 +337,13 @@ public class WidgetIndentsHighlightingPass {
             final VisualPosition widgetVisualPosition = editor.offsetToVisualPosition(childLine.getGuideOffset());
             final Point widgetPoint = editor.visualPositionToXY(widgetVisualPosition);
 
-            final int startIdx = doc.getLineStartOffset(childLine.getLine());
-            final int endIdx = doc.getLineEndOffset(childLine.getLine());
+            // This additional point is computed because sometimes there are other characters on a line before the widget, e.g. if a
+            // widget has been moved to a line with other code but the new outline has not been received yet (see issue #4297)
+            // We want to compute the earliest position to avoid drawing a line through any characters before the widget if they're present.
+            final int startIndex = doc.getLineStartOffset(childLine.getLine());
+            final int endIndex = doc.getLineEndOffset(childLine.getLine());
             int firstCharPosition = 0;
-            while (startIdx + firstCharPosition < endIdx && Character.isWhitespace(chars.charAt(startIdx + firstCharPosition))) {
+            while (startIndex + firstCharPosition < endIndex && Character.isWhitespace(chars.charAt(startIndex + firstCharPosition))) {
               firstCharPosition += 1;
             }
             final Point firstCharPoint = editor.visualPositionToXY(new VisualPosition(childLine.getLine(), firstCharPosition));

--- a/src/io/flutter/editor/WidgetIndentsHighlightingPass.java
+++ b/src/io/flutter/editor/WidgetIndentsHighlightingPass.java
@@ -354,7 +354,8 @@ public class WidgetIndentsHighlightingPass {
               );
             }
             else {
-              // If there are other characters on the same line as the widget, avoid drawing a backwards line
+              // If there are other characters on the same line as the widget,
+              // avoid drawing a backwards line.
               if (guidelineOffsetDetail.textStartOffset != guidelineOffsetDetail.offset) {
                 return;
               }
@@ -449,9 +450,12 @@ public class WidgetIndentsHighlightingPass {
                                                            Editor editor,
                                                            Document doc,
                                                            CharSequence chars) {
-      // This additional point is computed because sometimes there are other characters on a line before the widget, e.g. if a
-      // widget has been moved to a line with other code but the new outline has not been received yet (see issue #4297)
-      // We want to compute the earliest position to avoid drawing a line through any characters before the widget if they're present.
+      // This additional point is computed because sometimes there are other
+      // characters on a line before the widget, e.g. if a widget has been moved
+      // to a line with other code but the new outline has not been received yet
+      // (see issue #4297). We want to compute the earliest position to avoid
+      // drawing a line through any characters before the widget if they're
+      // present.
       final int startIndex = doc.getLineStartOffset(childLine.getLine());
       final int endIndex = doc.getLineEndOffset(childLine.getLine());
       int firstCharPosition = 0;


### PR DESCRIPTION
Fixes #4297 

Before (note line through `child:` briefly appears):
![no-guidelines_](https://user-images.githubusercontent.com/6379305/80626670-a5d5ab00-8a03-11ea-8356-3bbbbbe41f35.gif)

After:
![guidelines](https://user-images.githubusercontent.com/6379305/80626696-aec67c80-8a03-11ea-9533-81cacacf69f3.gif)
