### PR TITLE
Allow internal Dart SDK paths

### DIFF
--- a/src/io/flutter/sdk/FlutterSdk.java
+++ b/src/io/flutter/sdk/FlutterSdk.java
@@ -44,6 +44,8 @@ public class FlutterSdk {
   public static final String FLUTTER_SDK_GLOBAL_LIB_NAME = "Flutter SDK";
 
   public static final String DART_SDK_SUFFIX = "/bin/cache/dart-sdk";
+  public static final String LINUX_DART_SUFFIX = "/google-dartlang";
+  public static final String MAC_DART_SUFFIX = "/dart_lang/macos_sdk";
 
   private static final String DART_CORE_SUFFIX = DART_SDK_SUFFIX + "/lib/core";
 

--- a/src/io/flutter/utils/FlutterModuleUtils.java
+++ b/src/io/flutter/utils/FlutterModuleUtils.java
@@ -81,12 +81,16 @@ public class FlutterModuleUtils {
       //   [Dart support enabled && referenced Dart SDK is the one inside a Flutter SDK]
       final DartSdk dartSdk = DartPlugin.getDartSdk(module.getProject());
       final String dartSdkPath = dartSdk != null ? dartSdk.getHomePath() : null;
-      return dartSdkPath != null && dartSdkPath.endsWith(FlutterSdk.DART_SDK_SUFFIX) && DartPlugin.isDartSdkEnabled(module);
+      return validDartSdkPath(dartSdkPath) && DartPlugin.isDartSdkEnabled(module);
     }
     else {
       // If not IntelliJ, assume a small IDE (no multi-module project support).
       return declaresFlutter(module);
     }
+  }
+
+  private static boolean validDartSdkPath(String path) {
+    return path != null && (path.endsWith(FlutterSdk.DART_SDK_SUFFIX) || path.endsWith(FlutterSdk.LINUX_DART_SUFFIX) || path.endsWith(FlutterSdk.MAC_DART_SUFFIX));
   }
 
   public static boolean hasFlutterModule(@NotNull Project project) {

--- a/src/io/flutter/utils/FlutterModuleUtils.java
+++ b/src/io/flutter/utils/FlutterModuleUtils.java
@@ -90,7 +90,10 @@ public class FlutterModuleUtils {
   }
 
   private static boolean validDartSdkPath(String path) {
-    return path != null && (path.endsWith(FlutterSdk.DART_SDK_SUFFIX) || path.endsWith(FlutterSdk.LINUX_DART_SUFFIX) || path.endsWith(FlutterSdk.MAC_DART_SUFFIX));
+    return path != null &&
+           (path.endsWith(FlutterSdk.DART_SDK_SUFFIX) ||
+            path.endsWith(FlutterSdk.LINUX_DART_SUFFIX) ||
+            path.endsWith(FlutterSdk.MAC_DART_SUFFIX));
   }
 
   public static boolean hasFlutterModule(@NotNull Project project) {


### PR DESCRIPTION
Dart SDK path check was too stringent before, resulting in device selector not appearing for internal projects.

Before:
<img width="816" alt="Screen Shot 2020-05-13 at 4 22 49 PM" src="https://user-images.githubusercontent.com/6379305/81877809-f3413480-953a-11ea-9a5b-503b448d6e8f.png">


After (Mac):
<img width="817" alt="Screen Shot 2020-05-13 at 4 18 49 PM" src="https://user-images.githubusercontent.com/6379305/81877802-ec1a2680-953a-11ea-99d4-dc4865e36564.png">

After (Linux):
<img width="727" alt="Screen Shot 2020-05-13 at 5 05 52 PM" src="https://user-images.githubusercontent.com/6379305/81878158-10c2ce00-953c-11ea-8c17-8acd321f2a11.png">
