### PR TITLE
Add device selector refresh button for internal projects

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -1012,8 +1012,8 @@
               description="Flutter Device Selection"
               icon="FlutterIcons.Phone"/>
       <action id="Flutter.DeviceSelectorRefresher" class="io.flutter.actions.DeviceSelectorRefresherAction"
-              text="Refresh Flutter Device Selection"
-              description="Refresh Flutter Device Selection" />
+              text="Refresh Device List"
+              description="Refresh device list" />
       <separator/>
       <add-to-group anchor="before" group-id="RunContextGroup" relative-to-action="RunConfiguration"/>
       <add-to-group anchor="before" group-id="ToolbarRunGroup" relative-to-action="RunConfiguration"/>

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -1011,6 +1011,9 @@
       <action id="Flutter.DeviceSelector" class="io.flutter.actions.DeviceSelectorAction"
               description="Flutter Device Selection"
               icon="FlutterIcons.Phone"/>
+      <action id="Flutter.DeviceSelectorRefresher" class="io.flutter.actions.DeviceSelectorRefresherAction"
+              text="Refresh Flutter Device Selection"
+              description="Refresh Flutter Device Selection" />
       <separator/>
       <add-to-group anchor="before" group-id="RunContextGroup" relative-to-action="RunConfiguration"/>
       <add-to-group anchor="before" group-id="ToolbarRunGroup" relative-to-action="RunConfiguration"/>

--- a/resources/META-INF/plugin_template.xml
+++ b/resources/META-INF/plugin_template.xml
@@ -51,6 +51,9 @@
       <action id="Flutter.DeviceSelector" class="io.flutter.actions.DeviceSelectorAction"
               description="Flutter Device Selection"
               icon="FlutterIcons.Phone"/>
+      <action id="Flutter.DeviceSelectorRefresher" class="io.flutter.actions.DeviceSelectorRefresherAction"
+              text="Refresh Flutter Device Selection"
+              description="Refresh Flutter Device Selection" />
       <separator/>
       <add-to-group anchor="before" group-id="RunContextGroup" relative-to-action="RunConfiguration"/>
       <add-to-group anchor="before" group-id="ToolbarRunGroup" relative-to-action="RunConfiguration"/>

--- a/resources/META-INF/plugin_template.xml
+++ b/resources/META-INF/plugin_template.xml
@@ -52,8 +52,8 @@
               description="Flutter Device Selection"
               icon="FlutterIcons.Phone"/>
       <action id="Flutter.DeviceSelectorRefresher" class="io.flutter.actions.DeviceSelectorRefresherAction"
-              text="Refresh Flutter Device Selection"
-              description="Refresh Flutter Device Selection" />
+              text="Refresh Device List"
+              description="Refresh device list" />
       <separator/>
       <add-to-group anchor="before" group-id="RunContextGroup" relative-to-action="RunConfiguration"/>
       <add-to-group anchor="before" group-id="ToolbarRunGroup" relative-to-action="RunConfiguration"/>

--- a/src/io/flutter/actions/DeviceSelectorRefresherAction.java
+++ b/src/io/flutter/actions/DeviceSelectorRefresherAction.java
@@ -28,6 +28,6 @@ public class DeviceSelectorRefresherAction extends AnAction {
 
   @Override
   public void update(@NotNull AnActionEvent e) {
-    e.getPresentation().setVisible(FlutterModuleUtils.isFlutterBazelProject(e.getProject()));
+    e.getPresentation().setVisible(FlutterModuleUtils.hasInternalDartSdkPath(e.getProject()));
   }
 }

--- a/src/io/flutter/actions/DeviceSelectorRefresherAction.java
+++ b/src/io/flutter/actions/DeviceSelectorRefresherAction.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.actions;
+
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.project.Project;
+import io.flutter.editor.FlutterMaterialIcons;
+import io.flutter.run.daemon.DeviceService;
+import io.flutter.utils.FlutterModuleUtils;
+import org.jetbrains.annotations.NotNull;
+
+public class DeviceSelectorRefresherAction extends AnAction {
+  public DeviceSelectorRefresherAction() {
+    super(FlutterMaterialIcons.getIconForName("refresh"));
+  }
+
+  @Override
+  public void actionPerformed(@NotNull AnActionEvent e) {
+    final Project project = e.getProject();
+    if (project != null) {
+      DeviceService.getInstance(project).restart();
+    }
+  }
+
+  @Override
+  public void update(@NotNull AnActionEvent e) {
+    e.getPresentation().setVisible(FlutterModuleUtils.isFlutterBazelProject(e.getProject()));
+  }
+}

--- a/src/io/flutter/utils/FlutterModuleUtils.java
+++ b/src/io/flutter/utils/FlutterModuleUtils.java
@@ -96,6 +96,12 @@ public class FlutterModuleUtils {
             path.endsWith(FlutterSdk.MAC_DART_SUFFIX));
   }
 
+  public static boolean hasInternalDartSdkPath(Project project) {
+    DartSdk dartSdk = DartPlugin.getDartSdk(project);
+    final String dartSdkPath = dartSdk != null ? dartSdk.getHomePath() : null;
+    return dartSdkPath.endsWith(FlutterSdk.LINUX_DART_SUFFIX) || dartSdkPath.endsWith(FlutterSdk.MAC_DART_SUFFIX);
+  }
+
   public static boolean hasFlutterModule(@NotNull Project project) {
     if (project.isDisposed()) return false;
 


### PR DESCRIPTION
External project:
<img width="538" alt="Screen Shot 2020-05-14 at 2 28 27 PM" src="https://user-images.githubusercontent.com/6379305/82084276-e4c05d80-969f-11ea-8955-7954324f35e8.png">

Internal project with gcert/prodaccess active:
<img width="563" alt="Screen Shot 2020-05-14 at 4 26 30 PM" src="https://user-images.githubusercontent.com/6379305/82084301-f144b600-969f-11ea-82de-605a6d0450f7.png">

Internal project that lost and regained prodaccess can refresh/retrieve devices menu (really slow on chrometop, sorry):
![May-15-2020 11-50-10](https://user-images.githubusercontent.com/6379305/82085786-5e594b00-96a2-11ea-83aa-a68f651dad74.gif)

Eventually recovers device menu:
<img width="730" alt="Screen Shot 2020-05-15 at 11 54 25 AM" src="https://user-images.githubusercontent.com/6379305/82086101-d9226600-96a2-11ea-9953-73c3c00cc705.png">

