### PR TITLE
Save files before launching debug tests

### DIFF
--- a/src/io/flutter/run/bazelTest/BazelTestLaunchState.java
+++ b/src/io/flutter/run/bazelTest/BazelTestLaunchState.java
@@ -15,6 +15,7 @@ import com.intellij.execution.runners.ExecutionEnvironment;
 import com.intellij.execution.testframework.sm.SMTestRunnerConnectionUtil;
 import com.intellij.execution.testframework.ui.BaseTestsOutputConsoleView;
 import com.intellij.execution.ui.ConsoleView;
+import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.jetbrains.lang.dart.ide.runner.DartConsoleFilter;
@@ -77,6 +78,7 @@ public class BazelTestLaunchState extends CommandLineState {
     catch (RuntimeConfigurationError e) {
       throw new ExecutionException(e);
     }
+    FileDocumentManager.getInstance().saveAllDocuments();
 
     final VirtualFile virtualFile = fields.getFile();
 

--- a/src/io/flutter/run/test/TestLaunchState.java
+++ b/src/io/flutter/run/test/TestLaunchState.java
@@ -15,6 +15,7 @@ import com.intellij.execution.runners.ExecutionEnvironment;
 import com.intellij.execution.testframework.sm.SMTestRunnerConnectionUtil;
 import com.intellij.execution.testframework.ui.BaseTestsOutputConsoleView;
 import com.intellij.execution.ui.ConsoleView;
+import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleUtil;
 import com.intellij.openapi.project.Project;
@@ -68,6 +69,7 @@ class TestLaunchState extends CommandLineState {
     catch (RuntimeConfigurationError e) {
       throw new ExecutionException(e);
     }
+    FileDocumentManager.getInstance().saveAllDocuments();
 
     final VirtualFile fileOrDir = fields.getFileOrDir();
     assert (fileOrDir != null);


### PR DESCRIPTION
Save all editors before launching test runner. This seems like something the IntelliJ framework should do, but it isn't happening when launched in debug mode.

Fixes #4548 