### PR TITLE
Add null check to device refresh

### DIFF
--- a/src/io/flutter/actions/DeviceSelectorRefresherAction.java
+++ b/src/io/flutter/actions/DeviceSelectorRefresherAction.java
@@ -28,6 +28,8 @@ public class DeviceSelectorRefresherAction extends AnAction {
 
   @Override
   public void update(@NotNull AnActionEvent e) {
-    e.getPresentation().setVisible(FlutterModuleUtils.hasInternalDartSdkPath(e.getProject()));
+    if (e.getProject() != null) {
+      e.getPresentation().setVisible(FlutterModuleUtils.hasInternalDartSdkPath(e.getProject()));
+    }
   }
 }


### PR DESCRIPTION
Need to check for null project. I should have caught this in the code review.