### PR TITLE
Add "plugin make" that uses Gradle instead of Ant

### DIFF
--- a/tool/plugin/lib/plugin.dart
+++ b/tool/plugin/lib/plugin.dart
@@ -323,19 +323,25 @@ class AntBuildCommand extends BuildCommand {
     // create the jars
     createDir('build/flutter-intellij/lib');
     result = await jar(
-        'build/classes', 'build/flutter-intellij/lib/flutter-intellij.jar');
+      'build/classes',
+      'build/flutter-intellij/lib/flutter-intellij.jar',
+    );
     if (result != 0) {
       log('jar failed: ${result.toString()}');
       return result;
     }
     if (spec.isTestTarget && !isReleaseMode && !isDevChannel) {
-      _copyFile(File('build/flutter-intellij/lib/flutter-intellij.jar'),
-          Directory(testTargetPath(spec)),
-          filename: 'io.flutter.jar');
+      _copyFile(
+        File('build/flutter-intellij/lib/flutter-intellij.jar'),
+        Directory(testTargetPath(spec)),
+        filename: 'io.flutter.jar',
+      );
     }
     if (spec.isAndroidStudio) {
       result = await jar(
-          'build/studio', 'build/flutter-intellij/lib/flutter-studio.jar');
+        'build/studio',
+        'build/flutter-intellij/lib/flutter-studio.jar',
+      );
       if (result != 0) {
         log('jar failed: ${result.toString()}');
         return result;
@@ -349,8 +355,11 @@ class AntBuildCommand extends BuildCommand {
       return result;
     }
     if (spec.copyIjVersion && !isReleaseMode && !isDevChannel) {
-      _copyFile(File(releasesFilePath(spec)), Directory(ijVersionPath(spec)),
-          filename: 'flutter-intellij.zip');
+      _copyFile(
+        File(releasesFilePath(spec)),
+        Directory(ijVersionPath(spec)),
+        filename: 'flutter-intellij.zip',
+      );
     }
     return result;
   }
@@ -364,10 +373,12 @@ class GradleBuildCommand extends BuildCommand {
   }
 
   Future<int> savePluginArtifact(BuildSpec spec, String version) async {
-    var file = File(releasesFilePath(spec));
+    final file = File(releasesFilePath(spec));
     _copyFile(
-        File('build/distributions/flutter-intellij-$version.zip'), file.parent,
-        filename: p.basename(file.path));
+      File('build/distributions/flutter-intellij-$version.zip'),
+      file.parent,
+      filename: p.basename(file.path),
+    );
     return 0;
   }
 
@@ -463,8 +474,8 @@ abstract class BuildCommand extends ProductCommand {
 
       log('spec.version: ${spec.version}');
 
-      var compileFn = () async {
-        var r = await externalBuildCommand(spec);
+      final compileFn = () async {
+        final r = await externalBuildCommand(spec);
         if (r == 0) {
           // copy resources
           copyResources(from: 'src', to: 'build/classes');

--- a/tool/plugin/lib/plugin.dart
+++ b/tool/plugin/lib/plugin.dart
@@ -21,7 +21,8 @@ Future<int> main(List<String> args) async {
   var runner = new BuildCommandRunner();
 
   runner.addCommand(new LintCommand(runner));
-  runner.addCommand(new BuildCommand(runner));
+  runner.addCommand(new AntBuildCommand(runner));
+  runner.addCommand(new GradleBuildCommand(runner));
   runner.addCommand(new TestCommand(runner));
   runner.addCommand(new DeployCommand(runner));
   runner.addCommand(new GenerateCommand(runner));
@@ -309,13 +310,87 @@ void _copyResources(Directory from, Directory to) {
   }
 }
 
+class AntBuildCommand extends BuildCommand {
+  AntBuildCommand(BuildCommandRunner runner) : super(runner, 'build');
+
+  Future<int> externalBuildCommand(BuildSpec spec) async {
+    return runner.javac2(spec);
+  }
+
+  Future<int> savePluginArtifact(BuildSpec spec, String version) async {
+    int result;
+
+    // create the jars
+    createDir('build/flutter-intellij/lib');
+    result = await jar(
+        'build/classes', 'build/flutter-intellij/lib/flutter-intellij.jar');
+    if (result != 0) {
+      log('jar failed: ${result.toString()}');
+      return result;
+    }
+    if (spec.isTestTarget && !isReleaseMode && !isDevChannel) {
+      _copyFile(File('build/flutter-intellij/lib/flutter-intellij.jar'),
+          Directory(testTargetPath(spec)),
+          filename: 'io.flutter.jar');
+    }
+    if (spec.isAndroidStudio) {
+      result = await jar(
+          'build/studio', 'build/flutter-intellij/lib/flutter-studio.jar');
+      if (result != 0) {
+        log('jar failed: ${result.toString()}');
+        return result;
+      }
+    }
+
+    // zip it up
+    result = await zip('build/flutter-intellij', releasesFilePath(spec));
+    if (result != 0) {
+      log('zip failed: ${result.toString()}');
+      return result;
+    }
+    if (spec.copyIjVersion && !isReleaseMode && !isDevChannel) {
+      _copyFile(File(releasesFilePath(spec)), Directory(ijVersionPath(spec)),
+          filename: 'flutter-intellij.zip');
+    }
+    return result;
+  }
+}
+
+class GradleBuildCommand extends BuildCommand {
+  GradleBuildCommand(BuildCommandRunner runner) : super(runner, 'make');
+
+  Future<int> externalBuildCommand(BuildSpec spec) async {
+    return runner.buildPlugin(spec, pluginVersion);
+  }
+
+  Future<int> savePluginArtifact(BuildSpec spec, String version) async {
+    var file = File(releasesFilePath(spec));
+    _copyFile(
+        File('build/distributions/flutter-intellij-$version.zip'), file.parent,
+        filename: p.basename(file.path));
+    return 0;
+  }
+
+  Future<int> doit() async {
+    try {
+      return await super.doit();
+    } finally {
+      if (Platform.isWindows) {
+        return await exec('.\\gradlew.bat', ['--stop']);
+      } else {
+        return await exec('./gradlew', ['--stop']);
+      }
+    }
+  }
+}
+
 /// Build deployable plugin files. If the --release argument is given
 /// then perform additional checks to verify that the release environment
 /// is in good order.
-class BuildCommand extends ProductCommand {
+abstract class BuildCommand extends ProductCommand {
   final BuildCommandRunner runner;
 
-  BuildCommand(this.runner) : super('build') {
+  BuildCommand(this.runner, String commandName) : super(commandName) {
     argParser.addOption('only-version',
         abbr: 'o',
         help: 'Only build the specified IntelliJ version; useful for sharding '
@@ -330,6 +405,12 @@ class BuildCommand extends ProductCommand {
 
   String get description => 'Build a deployable version of the Flutter plugin, '
       'compiled against the specified artifacts.';
+
+  Future<int> externalBuildCommand(BuildSpec spec);
+
+  Future<int> savePluginArtifact(BuildSpec spec, String version);
+
+  String get pluginVersion => release ?? 'DEV';
 
   Future<int> doit() async {
     if (isReleaseMode) {
@@ -383,7 +464,7 @@ class BuildCommand extends ProductCommand {
       log('spec.version: ${spec.version}');
 
       var compileFn = () async {
-        var r = await runner.javac2(spec);
+        var r = await externalBuildCommand(spec);
         if (r == 0) {
           // copy resources
           copyResources(from: 'src', to: 'build/classes');
@@ -395,42 +476,13 @@ class BuildCommand extends ProductCommand {
       };
 
       result = await applyEdits(spec, compileFn);
-
       if (result != 0) {
         return result;
       }
 
-      // create the jars
-      createDir('build/flutter-intellij/lib');
-      result = await jar(
-          'build/classes', 'build/flutter-intellij/lib/flutter-intellij.jar');
+      result = await savePluginArtifact(spec, pluginVersion);
       if (result != 0) {
-        log('jar failed: ${result.toString()}');
         return result;
-      }
-      if (spec.isTestTarget && !isReleaseMode && !isDevChannel) {
-        _copyFile(File('build/flutter-intellij/lib/flutter-intellij.jar'),
-            Directory(testTargetPath(spec)),
-            filename: 'io.flutter.jar');
-      }
-      if (spec.isAndroidStudio) {
-        result = await jar(
-            'build/studio', 'build/flutter-intellij/lib/flutter-studio.jar');
-        if (result != 0) {
-          log('jar failed: ${result.toString()}');
-          return result;
-        }
-      }
-
-      // zip it up
-      result = await zip('build/flutter-intellij', releasesFilePath(spec));
-      if (result != 0) {
-        log('zip failed: ${result.toString()}');
-        return result;
-      }
-      if (spec.copyIjVersion && !isReleaseMode && !isDevChannel) {
-        _copyFile(File(releasesFilePath(spec)), Directory(ijVersionPath(spec)),
-            filename: 'flutter-intellij.zip');
       }
 
       separator('Built artifact');

--- a/tool/plugin/lib/runner.dart
+++ b/tool/plugin/lib/runner.dart
@@ -56,15 +56,15 @@ compile
   }
 
   Future<int> buildPlugin(BuildSpec spec, String version) async {
-    var contents = '''
+    final contents = '''
 org.gradle.parallel=true
 org.gradle.jvmargs=-Xms128m -Xmx1024m -XX:+CMSClassUnloadingEnabled
 dartVersion=${spec.dartPluginVersion}
 flutterPluginVersion=$version
 ide=${spec.ideaProduct}
 ''';
-    var propertiesFile = File("$rootPath/gradle.properties");
-    var source = propertiesFile.readAsStringSync();
+    final propertiesFile = File("$rootPath/gradle.properties");
+    final source = propertiesFile.readAsStringSync();
     propertiesFile.writeAsStringSync(contents);
     // Using the Gradle daemon causes a strange problem.
     // --daemon => Invalid byte 1 of 1-byte UTF-8 sequence, which is nonsense.

--- a/tool/plugin/lib/runner.dart
+++ b/tool/plugin/lib/runner.dart
@@ -28,7 +28,7 @@ class BuildCommandRunner extends CommandRunner {
     );
   }
 
-  // Use this to compile plugin sources to get forms processed.
+  // Use this to compile plugin sources using ant to get forms processed.
   Future<int> javac2(BuildSpec spec) async {
     var args = '''
 -f tool/plugin/compile.xml
@@ -52,6 +52,31 @@ compile
       } else {
         throw x;
       }
+    }
+  }
+
+  Future<int> buildPlugin(BuildSpec spec, String version) async {
+    var contents = '''
+org.gradle.parallel=true
+org.gradle.jvmargs=-Xms128m -Xmx1024m -XX:+CMSClassUnloadingEnabled
+dartVersion=${spec.dartPluginVersion}
+flutterPluginVersion=$version
+ide=${spec.ideaProduct}
+''';
+    var propertiesFile = File("$rootPath/gradle.properties");
+    var source = propertiesFile.readAsStringSync();
+    propertiesFile.writeAsStringSync(contents);
+    // Using the Gradle daemon causes a strange problem.
+    // --daemon => Invalid byte 1 of 1-byte UTF-8 sequence, which is nonsense.
+    // During instrumentation of FlutterProjectStep.form, which is a UTF-8 file.
+    try {
+      if (Platform.isWindows) {
+        return await exec('.\\gradlew.bat', ['buildPlugin']);
+      } else {
+        return await exec('./gradlew', ['buildPlugin']);
+      }
+    } finally {
+      propertiesFile.writeAsStringSync(source);
     }
   }
 }

--- a/tool/plugin/test/plugin_test.dart
+++ b/tool/plugin/test/plugin_test.dart
@@ -12,7 +12,11 @@ import 'package:test/test.dart';
 void main() {
   group("create", () {
     test('build', () {
-      expect(new BuildCommand(new BuildCommandRunner()).name, "build");
+      expect(new AntBuildCommand(new BuildCommandRunner()).name, "build");
+    });
+
+    test('make', () {
+      expect(new GradleBuildCommand(new BuildCommandRunner()).name, "make");
     });
 
     test('test', () {
@@ -238,14 +242,23 @@ void main() {
 BuildCommandRunner makeTestRunner() {
   var runner = new BuildCommandRunner();
   runner.addCommand(new TestBuildCommand(runner));
+  runner.addCommand(new TestMakeCommand(runner));
   runner.addCommand(new TestTestCommand(runner));
   runner.addCommand(new TestDeployCommand(runner));
   runner.addCommand(new TestGenCommand(runner));
   return runner;
 }
 
-class TestBuildCommand extends BuildCommand {
+class TestBuildCommand extends AntBuildCommand {
   TestBuildCommand(runner) : super(runner);
+
+  bool get isTesting => true;
+
+  Future<int> doit() async => new Future(() => 0);
+}
+
+class TestMakeCommand extends GradleBuildCommand {
+  TestMakeCommand(runner) : super(runner);
 
   bool get isTesting => true;
 

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -65,6 +65,6 @@ elif [ "$UNIT_TEST_BOT" = true ] ; then
 else
 
   # Run the build.
-  ./bin/plugin build --only-version=$IDEA_VERSION
+  ./bin/plugin make --only-version=$IDEA_VERSION
 
 fi


### PR DESCRIPTION
There's more refactoring here since Gradle builds the plugin and we don't need to copy files or zip them up.

See the comment in runner.dart for yet another strange error that took some digging to find a work around.

This changes travis to use the Gradle builder. We'll see how well that works...