### PR TITLE
Display structured errors immediately

### DIFF
--- a/src/io/flutter/run/SdkFields.java
+++ b/src/io/flutter/run/SdkFields.java
@@ -130,7 +130,7 @@ public class SdkFields {
     if (buildFlavor != null) {
       args = ArrayUtil.append(args, "--flavor=" + buildFlavor);
     }
-    if (FlutterSettings.getInstance().isShowStructuredErrors()) {
+    if (FlutterSettings.getInstance().isShowStructuredErrors() && flutterSdk.getVersion().isDartDefineSupported()) {
       args = ArrayUtil.append(args, "--dart-define=flutter.inspector.structuredErrors=true");
     }
     command = flutterSdk.flutterRun(root, main.getFile(), device, runMode, flutterLaunchMode, project, args);

--- a/src/io/flutter/run/SdkFields.java
+++ b/src/io/flutter/run/SdkFields.java
@@ -20,6 +20,7 @@ import io.flutter.pub.PubRootCache;
 import io.flutter.run.common.RunMode;
 import io.flutter.sdk.FlutterCommand;
 import io.flutter.sdk.FlutterSdk;
+import io.flutter.settings.FlutterSettings;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -128,6 +129,9 @@ public class SdkFields {
     String[] args = additionalArgs == null ? new String[]{ } : additionalArgs.split(" ");
     if (buildFlavor != null) {
       args = ArrayUtil.append(args, "--flavor=" + buildFlavor);
+    }
+    if (FlutterSettings.getInstance().isShowStructuredErrors()) {
+      args = ArrayUtil.append(args, "--dart-define=flutter.inspector.structuredErrors=true");
     }
     command = flutterSdk.flutterRun(root, main.getFile(), device, runMode, flutterLaunchMode, project, args);
     return command.createGeneralCommandLine(project);

--- a/src/io/flutter/sdk/FlutterSdkVersion.java
+++ b/src/io/flutter/sdk/FlutterSdkVersion.java
@@ -30,14 +30,19 @@ public class FlutterSdkVersion {
   private static final FlutterSdkVersion MIN_SAFE_TRACK_WIDGET_CREATION_SDK = new FlutterSdkVersion("0.10.2");
 
   /**
-   * The version of the stable channel that suppoorts --androidx in the create command.
+   * The version of the stable channel that supports --androidx in the create command.
    */
   private static final FlutterSdkVersion MIN_ANDROIDX_SDK = new FlutterSdkVersion("1.7.8");
 
   /**
-   * The version of the stable channel that suppoorts --androidx in the create command.
+   * The version of the stable channel that supports --androidx in the create command.
    */
   private static final FlutterSdkVersion MIN_PUB_OUTDATED_SDK = new FlutterSdkVersion("1.16.4");
+
+  /**
+   * The version that supports --dart-define in the run command.
+   */
+  private static final FlutterSdkVersion MIN_DART_DEFINE_SDK = new FlutterSdkVersion("1.12.0");
 
   @Nullable
   private final Version version;
@@ -102,6 +107,10 @@ public class FlutterSdkVersion {
   public boolean isAndroidxSupported() {
     //noinspection ConstantConditions
     return version != null && version.compareTo(MIN_ANDROIDX_SDK.version) >= 0;
+  }
+
+  public boolean isDartDefineSupported() {
+    return version != null && version.compareTo(MIN_DART_DEFINE_SDK.version) >= 0;
   }
 
   public boolean flutterTestSupportsMachineMode() {


### PR DESCRIPTION
https://github.com/flutter/flutter/pull/58118 added a flag to set structured errors on startup. This change sets the flag for the run command without requiring changes to an individual project's config.

Running with an early error should cause:
```
Launching lib/main.dart on iPhone SE (2nd generation) in debug mode...
Running pod install...                                              1.7s
Running Xcode build...
Xcode build done.                                           33.6s
Waiting for iPhone SE (2nd generation) to report its views...
Debug service listening on ws://127.0.0.1:50854/5Ztl1ytHvmY=/ws
Syncing files to device iPhone SE (2nd generation)...

════════ Exception caught by widgets library ═══════════════════════════════════════════════════════
The following FormatException was thrown building GalleryApp(dirty):
FormatException

The relevant error-causing widget was: 
  GalleryApp file:///Users/helinx/Documents/gallery/lib/main.dart:22:16
When the exception was thrown, this was the stack: 
#0      GalleryApp.build (package:gallery/main.dart:37:5)
#1      StatelessElement.build (package:flutter/src/widgets/framework.dart:4585:28)
#2      ComponentElement.performRebuild (package:flutter/src/widgets/framework.dart:4511:15)
#3      Element.rebuild (package:flutter/src/widgets/framework.dart:4227:5)
#4      BuildOwner.buildScope (package:flutter/src/widgets/framework.dart:2632:33)
...
════════════════════════════════════════════════════════════════════════════════════════════════════
```