### PR TITLE
remove a delay on hot reload

### DIFF
--- a/src/io/flutter/run/FlutterReloadManager.java
+++ b/src/io/flutter/run/FlutterReloadManager.java
@@ -158,11 +158,6 @@ public class FlutterReloadManager {
       return;
     }
 
-    // Add an arbitrary 125ms delay to allow analysis to catch up. This delay gives the analysis server a
-    // small pause to return error results in the (relatively infrequent) case where the user makes a bad
-    // edit and immediately hits save.
-    final int reloadDelayMs = 125;
-
     // Transition the app to an about-to-reload state.
     final FlutterApp.State previousAppState = app.transitionStartingHotReload();
 
@@ -203,7 +198,7 @@ public class FlutterReloadManager {
           }), delay, TimeUnit.MILLISECONDS);
         }
       });
-    }, reloadDelayMs, TimeUnit.MILLISECONDS);
+    }, 0, TimeUnit.MILLISECONDS);
   }
 
   private void reloadApp(@NotNull FlutterApp app, @NotNull String reason) {


### PR DESCRIPTION
- remove a delay on hot reload

This delay was an artifact from when we used the results of the analysis server to inform whether we should issue a hot reload on save or not. We no longer use the analysis server results - we always reload, unless there are structural issues with the file (that info comes from IntelliJ's PSI model, and we don't need a delay to get that info).

Related to https://github.com/flutter/flutter/pull/55376.

cc @DanTup @jonahwilliams 

@stevemessick and @helin24 for review.
