### PR TITLE
Start paused during run mode

### DIFF
--- a/src/io/flutter/sdk/FlutterSdk.java
+++ b/src/io/flutter/sdk/FlutterSdk.java
@@ -244,7 +244,7 @@ public class FlutterSdk {
       args.add("--device-id=" + device.deviceId());
     }
 
-    if (mode == RunMode.DEBUG) {
+    if (mode == RunMode.DEBUG || mode == RunMode.RUN) {
       args.add("--start-paused");
     }
 
@@ -320,6 +320,8 @@ public class FlutterSdk {
       if (!myVersion.flutterTestSupportsMachineMode()) {
         throw new IllegalStateException("Flutter SDK is too old to debug tests");
       }
+    }
+    if (mode == RunMode.DEBUG || mode == RunMode.RUN) {
       args.add("--start-paused");
     }
     if (FlutterSettings.getInstance().isVerboseLogging()) {


### PR DESCRIPTION
App should be paused on run mode as well as on debug mode so we won't miss any events from the beginning of an app's running.

Verified that a project can be run without hangs in run mode (no breakpoints), profile mode, and release mode.