### PR TITLE
Delay flutter daemon start until indexing finished

### DIFF
--- a/src/io/flutter/run/daemon/DeviceService.java
+++ b/src/io/flutter/run/daemon/DeviceService.java
@@ -12,6 +12,7 @@ import com.intellij.execution.ExecutionException;
 import com.intellij.openapi.application.ApplicationInfo;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.project.DumbService;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ex.ProjectRootManagerEx;
 import com.intellij.openapi.util.Disposer;
@@ -225,6 +226,8 @@ public class DeviceService {
     emulatorManager.refresh();
 
     try {
+      // Wait for indexing to finish before starting daemon process
+      DumbService.getInstance(project).waitForSmartMode();
       return nextCommand.start(request::isCancelled, this::refreshDeviceSelection, this::daemonStopped);
     }
     catch (ExecutionException executionException) {

--- a/src/io/flutter/run/daemon/DeviceService.java
+++ b/src/io/flutter/run/daemon/DeviceService.java
@@ -226,7 +226,9 @@ public class DeviceService {
     emulatorManager.refresh();
 
     try {
-      // Wait for indexing to finish before starting daemon process
+      // Wait for indexing to finish before starting daemon process.
+      // There seem to be initialization processes in some situations (new project and on IDE startup) that cause `flutter daemon` command
+      // to fail if it's called too early.
       DumbService.getInstance(project).waitForSmartMode();
       return nextCommand.start(request::isCancelled, this::refreshDeviceSelection, this::daemonStopped);
     }


### PR DESCRIPTION
Verify that opening workbench, opening project(s), quitting, then re-opening workbench consistently results in re-opened projects having device options.
Fixes https://github.com/flutter/flutter-intellij/issues/3892