### PR TITLE
[WIP] Add JxBrowser dependencies

### DIFF
--- a/flutter-idea/build.gradle
+++ b/flutter-idea/build.gradle
@@ -33,6 +33,8 @@ intellij {
 dependencies {
   testCompile "org.powermock:powermock-api-mockito2:2.0.0"
   testCompile "org.powermock:powermock-module-junit4:2.0.0"
+  compileOnly fileTree(dir: "$project.rootDir/lib/jxbrowser",
+                       includes: ["*.jar"])
 }
 
 /* Need to swizzle source and resource paths to match standard or buildPlugin does nothing. */

--- a/flutter-intellij-community.iml
+++ b/flutter-intellij-community.iml
@@ -92,5 +92,32 @@
     <orderEntry type="library" name="com.android.tools.analytics-library:protos" level="project" />
     <orderEntry type="module" module-name="intellij.android.gradle.dsl" />
     <orderEntry type="module" module-name="intellij.android.projectSystem" />
+    <orderEntry type="module-library">
+      <library>
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/lib/jxbrowser/jxbrowser-7.8.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library">
+      <library>
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/lib/jxbrowser/jxbrowser-swing-7.8.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library">
+      <library>
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/lib/jxbrowser/jxbrowser-mac-7.8.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
   </component>
 </module>

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -1075,6 +1075,9 @@
       <action id="flutter.submitFeedback" class="io.flutter.actions.FlutterSubmitFeedback"
               text="Submit Feedback..."
               description="Provide feedback for the Flutter plugin"/>
+      <action id="flutter.testJxBrowser" class="io.flutter.actions.TestJxBrowserAction"
+              text="Test JxBrowser"
+              description="Open the sample JxBrowser pane"/>
     </group>
 
     <!-- project explorer actions -->

--- a/resources/META-INF/plugin_template.xml
+++ b/resources/META-INF/plugin_template.xml
@@ -101,6 +101,9 @@
       <action id="flutter.submitFeedback" class="io.flutter.actions.FlutterSubmitFeedback"
               text="Submit Feedback..."
               description="Provide feedback for the Flutter plugin"/>
+      <action id="flutter.testJxBrowser" class="io.flutter.actions.TestJxBrowserAction"
+              text="Test JxBrowser"
+              description="Open the sample JxBrowser pane"/>
     </group>
 
     <!-- project explorer actions -->

--- a/src/io/flutter/actions/TestJxBrowserAction.java
+++ b/src/io/flutter/actions/TestJxBrowserAction.java
@@ -1,0 +1,57 @@
+package io.flutter.actions;
+
+import static com.teamdev.jxbrowser.engine.RenderingMode.HARDWARE_ACCELERATED;
+
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.teamdev.jxbrowser.browser.Browser;
+import com.teamdev.jxbrowser.engine.Engine;
+import com.teamdev.jxbrowser.engine.EngineOptions;
+import com.teamdev.jxbrowser.view.swing.BrowserView;
+import java.awt.BorderLayout;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import javax.swing.JFrame;
+import javax.swing.JTextField;
+import javax.swing.SwingUtilities;
+import javax.swing.WindowConstants;
+import org.jetbrains.annotations.NotNull;
+
+public class TestJxBrowserAction extends AnAction {
+  @Override
+  public void actionPerformed(@NotNull AnActionEvent event) {
+    System.setProperty("jxbrowser.license.key", "6P830J66YAO1XQRI1FNEXP8ZTHUOQTY2YUJRCN9RTARQ58QFAP63GRRH20B3P5PB7PC8");
+
+    // Creating and running Chromium engine
+    EngineOptions options =
+      EngineOptions.newBuilder(HARDWARE_ACCELERATED).build();
+    Engine engine = Engine.newInstance(options);
+    Browser browser = engine.newBrowser();
+
+    SwingUtilities.invokeLater(() -> {
+      // Creating Swing component for rendering web content
+      // loaded in the given Browser instance.
+      BrowserView view = BrowserView.newInstance(browser);
+
+      // Creating and displaying Swing app frame.
+      JFrame frame = new JFrame("Hello World");
+      // Close Engine and onClose app window
+      frame.addWindowListener(new WindowAdapter() {
+        @Override
+        public void windowClosing(WindowEvent e) {
+          engine.close();
+        }
+      });
+      frame.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
+      JTextField addressBar = new JTextField("https://www.google.com");
+      addressBar.addActionListener(e ->
+                                     browser.navigation().loadUrl(addressBar.getText()));
+      frame.add(addressBar, BorderLayout.NORTH);
+      frame.add(view, BorderLayout.CENTER);
+      frame.setSize(800, 500);
+      frame.setLocationRelativeTo(null);
+      frame.setVisible(true);
+    });
+
+  }
+}

--- a/tool/plugin/compile.xml
+++ b/tool/plugin/compile.xml
@@ -60,6 +60,9 @@ Include -D arguments to define these properties: idea.product, idea.version.
       <fileset dir="${basedir}/artifacts/Dart/lib">
         <include name="*.jar"/>
       </fileset>
+      <fileset dir="${basedir}/lib/jxbrowser">
+        <include name="*.jar"/>
+      </fileset>
     </path>
 
     <path id="junit.jars">


### PR DESCRIPTION
This adds the dependencies for using JxBrowser, but only for Mac. Linux and Windows need to have additional libraries defined in the *.iml files. The changes need to be made to both *.iml files, but I only did one.

I don't plan to commit this PR. It's just to get @helin24 going. The required binaries are not part of this PR.

Also, the build script still needs to be updated to pull in the jar files when the plugin is built for distribution. I'll do that later.

@jacob314 @devoncarew 