### PR TITLE
handle displaying previews of cupertino colors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .packages
 .pub/
 .vscode/
+.sandbox/
 artifacts/
 build/
 flutter-gui-tests/.gradle/

--- a/flutter-intellij.iml
+++ b/flutter-intellij.iml
@@ -17,8 +17,12 @@
       <sourceFolder url="file://$MODULE_DIR$/tool/icon_generator/lib" isTestSource="false" />
       <excludeFolder url="file://$MODULE_DIR$/.dart_tool" />
       <excludeFolder url="file://$MODULE_DIR$/.pub" />
+      <excludeFolder url="file://$MODULE_DIR$/.sandbox" />
       <excludeFolder url="file://$MODULE_DIR$/artifacts" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
+      <excludeFolder url="file://$MODULE_DIR$/flutter-idea/testData/sample_tests/.dart_tool" />
+      <excludeFolder url="file://$MODULE_DIR$/flutter-idea/testData/sample_tests/.pub" />
+      <excludeFolder url="file://$MODULE_DIR$/flutter-idea/testData/sample_tests/build" />
       <excludeFolder url="file://$MODULE_DIR$/material-design-icons" />
       <excludeFolder url="file://$MODULE_DIR$/releases" />
       <excludeFolder url="file://$MODULE_DIR$/src/main" />

--- a/src/io/flutter/editor/FlutterCompletionContributor.java
+++ b/src/io/flutter/editor/FlutterCompletionContributor.java
@@ -52,6 +52,12 @@ public class FlutterCompletionContributor extends DartCompletionExtension {
               return new ColorIcon(ICON_SIZE, color.getAWTColor());
             }
           }
+          else if (Objects.equals(declaringType, "CupertinoColors")) {
+            final FlutterColors.FlutterColor color = FlutterCupertinoColors.getColor(name);
+            if (color != null) {
+              return new ColorIcon(ICON_SIZE, color.getAWTColor());
+            }
+          }
           else if (Objects.equals(declaringType, "Icons")) {
             final Icon icon = FlutterMaterialIcons.getIconForName(name);
             // If we have no icon, show an empty node (which is preferable to the default "IconData" text).

--- a/src/io/flutter/editor/FlutterCupertinoColors.java
+++ b/src/io/flutter/editor/FlutterCupertinoColors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 The Chromium Authors. All rights reserved.
+ * Copyright 2020 The Chromium Authors. All rights reserved.
  * Use of this source code is governed by a BSD-style license that can be
  * found in the LICENSE file.
  */
@@ -16,40 +16,18 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
-public class FlutterColors {
-  private static final Logger LOG = Logger.getInstance(FlutterColors.class);
-
-  public static class FlutterColor {
-    @NotNull
-    private final Color color;
-    private final boolean isPrimary;
-
-    FlutterColor(@NotNull Color color, boolean isPrimary) {
-      this.color = color;
-      this.isPrimary = isPrimary;
-    }
-
-    @NotNull
-    public Color getAWTColor() {
-      return color;
-    }
-
-    public boolean isPrimary() {
-      return isPrimary;
-    }
-  }
-
-  static final String primarySuffix = ".primary";
-  static final String defaultShade = "[500]";
+public class FlutterCupertinoColors {
+  private static final Logger LOG = Logger.getInstance(FlutterCupertinoColors.class);
 
   private static final Properties colors;
+
   private static final Map<Color, String> colorToName;
 
   static {
     colors = new Properties();
 
     try {
-      colors.load(FlutterUtils.class.getResourceAsStream("/flutter/colors.properties"));
+      colors.load(FlutterUtils.class.getResourceAsStream("/flutter/cupertino_colors.properties"));
     }
     catch (IOException e) {
       FlutterUtils.warn(LOG, e);
@@ -70,7 +48,7 @@ public class FlutterColors {
    * @return the AWT color corresponding to the given Flutter color key.
    */
   @Nullable
-  public static FlutterColor getColor(@NotNull String key) {
+  public static FlutterColors.FlutterColor getColor(@NotNull String key) {
     // Handle things like Colors.blue.shade200; convert the text to blue[200].
     if (key.contains(".shade")) {
       key = key.replace(".shade", "[") + "]";
@@ -79,13 +57,13 @@ public class FlutterColors {
     if (colors.containsKey(key)) {
       final Color color = getColorValue(key);
       if (color != null) {
-        return new FlutterColor(color, false);
+        return new FlutterColors.FlutterColor(color, false);
       }
     }
-    else if (colors.containsKey(key + primarySuffix)) {
-      final Color color = getColorValue(key + primarySuffix);
+    else if (colors.containsKey(key + FlutterColors.primarySuffix)) {
+      final Color color = getColorValue(key + FlutterColors.primarySuffix);
       if (color != null) {
-        return new FlutterColor(color, true);
+        return new FlutterColors.FlutterColor(color, true);
       }
     }
 
@@ -100,8 +78,8 @@ public class FlutterColors {
     String name = colorToName.get(color);
     if (name == null) return null;
     // Normalize to avoid including suffixes that are not required.
-    name = maybeTrimSuffix(name, primarySuffix);
-    name = maybeTrimSuffix(name, defaultShade);
+    name = maybeTrimSuffix(name, FlutterColors.primarySuffix);
+    name = maybeTrimSuffix(name, FlutterColors.defaultShade);
     return name;
   }
 

--- a/src/io/flutter/editor/FlutterEditorAnnotator.java
+++ b/src/io/flutter/editor/FlutterEditorAnnotator.java
@@ -65,6 +65,26 @@ public class FlutterEditorAnnotator implements Annotator {
           attachIcon(element, holder, icon);
         }
       }
+      else if (text.startsWith("CupertinoColors.")) {
+        final String key = text.substring("CupertinoColors.".length());
+        final FlutterColor color = FlutterCupertinoColors.getColor(key);
+        if (color != null) {
+          if (!color.isPrimary()) {
+            attachColorIcon(element, holder, color.getAWTColor());
+          }
+          else {
+            // If we're a primary color access, and
+            // - we're not followed by an array access (really referencing a more specific color)
+            // - we're not followed by a shadeXXX access
+            final boolean inColorIndexExpression = element.getParent() instanceof DartArrayAccessExpression;
+            final boolean inShadeExpression =
+              (element.getParent() instanceof DartReferenceExpression && element.getParent().getText().startsWith(text + ".shade"));
+            if (!inShadeExpression && !inColorIndexExpression) {
+              attachColorIcon(element, holder, color.getAWTColor());
+            }
+          }
+        }
+      }
     }
     else if (element instanceof DartNewExpression) {
       // const IconData(0xe914)


### PR DESCRIPTION
- handle displaying previews of cupertino colors

https://github.com/flutter/flutter-intellij/pull/4628 added support for displaying previews of Cupertino icons; this PR updates the plugin to also display Cupertino color previews.

cc @stevemessick @helin24 