### PR TITLE
Split icon generation into two scripts + use single set of downloaded files

### DIFF
--- a/tool/colors/flutter/colors_cupertino.dart
+++ b/tool/colors/flutter/colors_cupertino.dart
@@ -1,14 +1,16 @@
+/// This file was downloaded by update_colors.dart.
+
 // Copyright 2014 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
 // @dart = 2.8
 
+import '../stubs.dart';
+
 // Examples can assume:
 // Widget child;
 // BuildContext context;
-
-import '../stubs.dart';
 
 /// A palette of [Color] constants that describe colors commonly used when
 /// matching the iOS platform aesthetics.

--- a/tool/colors/flutter/colors_cupertino.dart
+++ b/tool/colors/flutter/colors_cupertino.dart
@@ -79,8 +79,7 @@ class CupertinoColors {
   /// Not the same grey as disabled buttons etc.
   ///
   /// This is the disabled color in the iOS palette.
-  static const CupertinoDynamicColor inactiveGray =
-      CupertinoDynamicColor.withBrightness(
+  static const CupertinoDynamicColor inactiveGray = CupertinoDynamicColor.withBrightness(
     debugLabel: 'inactiveGray',
     color: Color(0xFF999999),
     darkColor: Color(0xFF757575),
@@ -101,8 +100,7 @@ class CupertinoColors {
   ///
   ///  * [UIColor.systemBlue](https://developer.apple.com/documentation/uikit/uicolor/3173141-systemblue),
   ///    the `UIKit` equivalent.
-  static const CupertinoDynamicColor systemBlue =
-      CupertinoDynamicColor.withBrightnessAndContrast(
+  static const CupertinoDynamicColor systemBlue = CupertinoDynamicColor.withBrightnessAndContrast(
     debugLabel: 'systemBlue',
     color: Color.fromARGB(255, 0, 122, 255),
     darkColor: Color.fromARGB(255, 10, 132, 255),
@@ -116,8 +114,7 @@ class CupertinoColors {
   ///
   ///  * [UIColor.systemGreen](https://developer.apple.com/documentation/uikit/uicolor/3173144-systemgreen),
   ///    the `UIKit` equivalent.
-  static const CupertinoDynamicColor systemGreen =
-      CupertinoDynamicColor.withBrightnessAndContrast(
+  static const CupertinoDynamicColor systemGreen = CupertinoDynamicColor.withBrightnessAndContrast(
     debugLabel: 'systemGreen',
     color: Color.fromARGB(255, 52, 199, 89),
     darkColor: Color.fromARGB(255, 48, 209, 88),
@@ -131,8 +128,7 @@ class CupertinoColors {
   ///
   ///  * [UIColor.systemIndigo](https://developer.apple.com/documentation/uikit/uicolor/3173146-systemindigo),
   ///    the `UIKit` equivalent.
-  static const CupertinoDynamicColor systemIndigo =
-      CupertinoDynamicColor.withBrightnessAndContrast(
+  static const CupertinoDynamicColor systemIndigo = CupertinoDynamicColor.withBrightnessAndContrast(
     debugLabel: 'systemIndigo',
     color: Color.fromARGB(255, 88, 86, 214),
     darkColor: Color.fromARGB(255, 94, 92, 230),
@@ -146,8 +142,7 @@ class CupertinoColors {
   ///
   ///  * [UIColor.systemOrange](https://developer.apple.com/documentation/uikit/uicolor/3173147-systemorange),
   ///    the `UIKit` equivalent.
-  static const CupertinoDynamicColor systemOrange =
-      CupertinoDynamicColor.withBrightnessAndContrast(
+  static const CupertinoDynamicColor systemOrange = CupertinoDynamicColor.withBrightnessAndContrast(
     debugLabel: 'systemOrange',
     color: Color.fromARGB(255, 255, 149, 0),
     darkColor: Color.fromARGB(255, 255, 159, 10),
@@ -161,8 +156,7 @@ class CupertinoColors {
   ///
   ///  * [UIColor.systemPink](https://developer.apple.com/documentation/uikit/uicolor/3173148-systempink),
   ///    the `UIKit` equivalent.
-  static const CupertinoDynamicColor systemPink =
-      CupertinoDynamicColor.withBrightnessAndContrast(
+  static const CupertinoDynamicColor systemPink = CupertinoDynamicColor.withBrightnessAndContrast(
     debugLabel: 'systemPink',
     color: Color.fromARGB(255, 255, 45, 85),
     darkColor: Color.fromARGB(255, 255, 55, 95),
@@ -176,8 +170,7 @@ class CupertinoColors {
   ///
   ///  * [UIColor.systemPurple](https://developer.apple.com/documentation/uikit/uicolor/3173149-systempurple),
   ///    the `UIKit` equivalent.
-  static const CupertinoDynamicColor systemPurple =
-      CupertinoDynamicColor.withBrightnessAndContrast(
+  static const CupertinoDynamicColor systemPurple = CupertinoDynamicColor.withBrightnessAndContrast(
     debugLabel: 'systemPurple',
     color: Color.fromARGB(255, 175, 82, 222),
     darkColor: Color.fromARGB(255, 191, 90, 242),
@@ -191,8 +184,7 @@ class CupertinoColors {
   ///
   ///  * [UIColor.systemRed](https://developer.apple.com/documentation/uikit/uicolor/3173150-systemred),
   ///    the `UIKit` equivalent.
-  static const CupertinoDynamicColor systemRed =
-      CupertinoDynamicColor.withBrightnessAndContrast(
+  static const CupertinoDynamicColor systemRed = CupertinoDynamicColor.withBrightnessAndContrast(
     debugLabel: 'systemRed',
     color: Color.fromARGB(255, 255, 59, 48),
     darkColor: Color.fromARGB(255, 255, 69, 58),
@@ -206,8 +198,7 @@ class CupertinoColors {
   ///
   ///  * [UIColor.systemTeal](https://developer.apple.com/documentation/uikit/uicolor/3173151-systemteal),
   ///    the `UIKit` equivalent.
-  static const CupertinoDynamicColor systemTeal =
-      CupertinoDynamicColor.withBrightnessAndContrast(
+  static const CupertinoDynamicColor systemTeal = CupertinoDynamicColor.withBrightnessAndContrast(
     debugLabel: 'systemTeal',
     color: Color.fromARGB(255, 90, 200, 250),
     darkColor: Color.fromARGB(255, 100, 210, 255),
@@ -221,8 +212,7 @@ class CupertinoColors {
   ///
   ///  * [UIColor.systemYellow](https://developer.apple.com/documentation/uikit/uicolor/3173152-systemyellow),
   ///    the `UIKit` equivalent.
-  static const CupertinoDynamicColor systemYellow =
-      CupertinoDynamicColor.withBrightnessAndContrast(
+  static const CupertinoDynamicColor systemYellow = CupertinoDynamicColor.withBrightnessAndContrast(
     debugLabel: 'systemYellow',
     color: Color.fromARGB(255, 255, 204, 0),
     darkColor: Color.fromARGB(255, 255, 214, 10),
@@ -236,8 +226,7 @@ class CupertinoColors {
   ///
   ///  * [UIColor.systemGray](https://developer.apple.com/documentation/uikit/uicolor/3173143-systemgray),
   ///    the `UIKit` equivalent.
-  static const CupertinoDynamicColor systemGrey =
-      CupertinoDynamicColor.withBrightnessAndContrast(
+  static const CupertinoDynamicColor systemGrey = CupertinoDynamicColor.withBrightnessAndContrast(
     debugLabel: 'systemGrey',
     color: Color.fromARGB(255, 142, 142, 147),
     darkColor: Color.fromARGB(255, 142, 142, 147),
@@ -251,8 +240,7 @@ class CupertinoColors {
   ///
   ///  * [UIColor.systemGray2](https://developer.apple.com/documentation/uikit/uicolor/3255071-systemgray2),
   ///    the `UIKit` equivalent.
-  static const CupertinoDynamicColor systemGrey2 =
-      CupertinoDynamicColor.withBrightnessAndContrast(
+  static const CupertinoDynamicColor systemGrey2 = CupertinoDynamicColor.withBrightnessAndContrast(
     debugLabel: 'systemGrey2',
     color: Color.fromARGB(255, 174, 174, 178),
     darkColor: Color.fromARGB(255, 99, 99, 102),
@@ -266,8 +254,7 @@ class CupertinoColors {
   ///
   ///  * [UIColor.systemGray3](https://developer.apple.com/documentation/uikit/uicolor/3255072-systemgray3),
   ///    the `UIKit` equivalent.
-  static const CupertinoDynamicColor systemGrey3 =
-      CupertinoDynamicColor.withBrightnessAndContrast(
+  static const CupertinoDynamicColor systemGrey3 = CupertinoDynamicColor.withBrightnessAndContrast(
     debugLabel: 'systemGrey3',
     color: Color.fromARGB(255, 199, 199, 204),
     darkColor: Color.fromARGB(255, 72, 72, 74),
@@ -281,8 +268,7 @@ class CupertinoColors {
   ///
   ///  * [UIColor.systemGray4](https://developer.apple.com/documentation/uikit/uicolor/3255073-systemgray4),
   ///    the `UIKit` equivalent.
-  static const CupertinoDynamicColor systemGrey4 =
-      CupertinoDynamicColor.withBrightnessAndContrast(
+  static const CupertinoDynamicColor systemGrey4 = CupertinoDynamicColor.withBrightnessAndContrast(
     debugLabel: 'systemGrey4',
     color: Color.fromARGB(255, 209, 209, 214),
     darkColor: Color.fromARGB(255, 58, 58, 60),
@@ -296,8 +282,7 @@ class CupertinoColors {
   ///
   ///  * [UIColor.systemGray5](https://developer.apple.com/documentation/uikit/uicolor/3255074-systemgray5),
   ///    the `UIKit` equivalent.
-  static const CupertinoDynamicColor systemGrey5 =
-      CupertinoDynamicColor.withBrightnessAndContrast(
+  static const CupertinoDynamicColor systemGrey5 = CupertinoDynamicColor.withBrightnessAndContrast(
     debugLabel: 'systemGrey5',
     color: Color.fromARGB(255, 229, 229, 234),
     darkColor: Color.fromARGB(255, 44, 44, 46),
@@ -311,8 +296,7 @@ class CupertinoColors {
   ///
   ///  * [UIColor.systemGray6](https://developer.apple.com/documentation/uikit/uicolor/3255075-systemgray6),
   ///    the `UIKit` equivalent.
-  static const CupertinoDynamicColor systemGrey6 =
-      CupertinoDynamicColor.withBrightnessAndContrast(
+  static const CupertinoDynamicColor systemGrey6 = CupertinoDynamicColor.withBrightnessAndContrast(
     debugLabel: 'systemGrey6',
     color: Color.fromARGB(255, 242, 242, 247),
     darkColor: Color.fromARGB(255, 28, 28, 30),
@@ -346,7 +330,7 @@ class CupertinoColors {
     darkElevatedColor: Color.fromARGB(153, 235, 235, 245),
     highContrastElevatedColor: Color.fromARGB(173, 60, 60, 67),
     darkHighContrastElevatedColor: Color.fromARGB(173, 235, 235, 245),
-  );
+);
 
   /// The color for text labels containing tertiary content, equivalent to
   /// [UIColor.tertiaryLabel](https://developer.apple.com/documentation/uikit/uicolor/3173153-tertiarylabel).
@@ -392,8 +376,7 @@ class CupertinoColors {
 
   /// An overlay fill color for medium-size shapes, equivalent to
   /// [UIColor.secondarySystemFill](https://developer.apple.com/documentation/uikit/uicolor/3255069-secondarysystemfill).
-  static const CupertinoDynamicColor secondarySystemFill =
-      CupertinoDynamicColor(
+  static const CupertinoDynamicColor secondarySystemFill = CupertinoDynamicColor(
     debugLabel: 'secondarySystemFill',
     color: Color.fromARGB(40, 120, 120, 128),
     darkColor: Color.fromARGB(81, 120, 120, 128),
@@ -421,8 +404,7 @@ class CupertinoColors {
 
   /// An overlay fill color for large areas containing complex content, equivalent
   /// to [UIColor.quaternarySystemFill](https://developer.apple.com/documentation/uikit/uicolor/3255068-quaternarysystemfill).
-  static const CupertinoDynamicColor quaternarySystemFill =
-      CupertinoDynamicColor(
+  static const CupertinoDynamicColor quaternarySystemFill = CupertinoDynamicColor(
     debugLabel: 'quaternarySystemFill',
     color: Color.fromARGB(20, 116, 116, 128),
     darkColor: Color.fromARGB(45, 118, 118, 128),
@@ -468,8 +450,7 @@ class CupertinoColors {
   /// [UIColor.secondarySystemBackground](https://developer.apple.com/documentation/uikit/uicolor/3173137-secondarysystembackground).
   ///
   /// Typically used for designs that have a white primary background in a light environment.
-  static const CupertinoDynamicColor secondarySystemBackground =
-      CupertinoDynamicColor(
+  static const CupertinoDynamicColor secondarySystemBackground = CupertinoDynamicColor(
     debugLabel: 'secondarySystemBackground',
     color: Color.fromARGB(255, 242, 242, 247),
     darkColor: Color.fromARGB(255, 28, 28, 30),
@@ -485,8 +466,7 @@ class CupertinoColors {
   /// to [UIColor.tertiarySystemBackground](https://developer.apple.com/documentation/uikit/uicolor/3173154-tertiarysystembackground).
   ///
   /// Typically used for designs that have a white primary background in a light environment.
-  static const CupertinoDynamicColor tertiarySystemBackground =
-      CupertinoDynamicColor(
+  static const CupertinoDynamicColor tertiarySystemBackground = CupertinoDynamicColor(
     debugLabel: 'tertiarySystemBackground',
     color: Color.fromARGB(255, 255, 255, 255),
     darkColor: Color.fromARGB(255, 44, 44, 46),
@@ -502,8 +482,7 @@ class CupertinoColors {
   /// [UIColor.systemGroupedBackground](https://developer.apple.com/documentation/uikit/uicolor/3173145-systemgroupedbackground).
   ///
   /// Typically used for grouped content, including table views and platter-based designs.
-  static const CupertinoDynamicColor systemGroupedBackground =
-      CupertinoDynamicColor(
+  static const CupertinoDynamicColor systemGroupedBackground = CupertinoDynamicColor(
     debugLabel: 'systemGroupedBackground',
     color: Color.fromARGB(255, 242, 242, 247),
     darkColor: Color.fromARGB(255, 0, 0, 0),
@@ -519,8 +498,7 @@ class CupertinoColors {
   /// equivalent to [UIColor.secondarySystemGroupedBackground](https://developer.apple.com/documentation/uikit/uicolor/3173138-secondarysystemgroupedbackground).
   ///
   /// Typically used for grouped content, including table views and platter-based designs.
-  static const CupertinoDynamicColor secondarySystemGroupedBackground =
-      CupertinoDynamicColor(
+  static const CupertinoDynamicColor secondarySystemGroupedBackground = CupertinoDynamicColor(
     debugLabel: 'secondarySystemGroupedBackground',
     color: Color.fromARGB(255, 255, 255, 255),
     darkColor: Color.fromARGB(255, 28, 28, 30),
@@ -536,8 +514,7 @@ class CupertinoColors {
   /// equivalent to [UIColor.tertiarySystemGroupedBackground](https://developer.apple.com/documentation/uikit/uicolor/3173155-tertiarysystemgroupedbackground).
   ///
   /// Typically used for grouped content, including table views and platter-based designs.
-  static const CupertinoDynamicColor tertiarySystemGroupedBackground =
-      CupertinoDynamicColor(
+  static const CupertinoDynamicColor tertiarySystemGroupedBackground = CupertinoDynamicColor(
     debugLabel: 'tertiarySystemGroupedBackground',
     color: Color.fromARGB(255, 242, 242, 247),
     darkColor: Color.fromARGB(255, 44, 44, 46),
@@ -711,18 +688,18 @@ class CupertinoDynamicColor extends Color with Diagnosticable {
     @required Color highContrastElevatedColor,
     @required Color darkHighContrastElevatedColor,
   }) : this._(
-          color,
-          color,
-          darkColor,
-          highContrastColor,
-          darkHighContrastColor,
-          elevatedColor,
-          darkElevatedColor,
-          highContrastElevatedColor,
-          darkHighContrastElevatedColor,
-          null,
-          debugLabel,
-        );
+         color,
+         color,
+         darkColor,
+         highContrastColor,
+         darkHighContrastColor,
+         elevatedColor,
+         darkElevatedColor,
+         highContrastElevatedColor,
+         darkHighContrastElevatedColor,
+         null,
+         debugLabel,
+       );
 
   /// Creates an adaptive [Color] that changes its effective color based on the
   /// given [BuildContext]'s brightness (from [MediaQueryData.platformBrightness]
@@ -737,16 +714,16 @@ class CupertinoDynamicColor extends Color with Diagnosticable {
     @required Color highContrastColor,
     @required Color darkHighContrastColor,
   }) : this(
-          debugLabel: debugLabel,
-          color: color,
-          darkColor: darkColor,
-          highContrastColor: highContrastColor,
-          darkHighContrastColor: darkHighContrastColor,
-          elevatedColor: color,
-          darkElevatedColor: darkColor,
-          highContrastElevatedColor: highContrastColor,
-          darkHighContrastElevatedColor: darkHighContrastColor,
-        );
+    debugLabel: debugLabel,
+    color: color,
+    darkColor: darkColor,
+    highContrastColor: highContrastColor,
+    darkHighContrastColor: darkHighContrastColor,
+    elevatedColor: color,
+    darkElevatedColor: darkColor,
+    highContrastElevatedColor: highContrastColor,
+    darkHighContrastElevatedColor: darkHighContrastColor,
+  );
 
   /// Creates an adaptive [Color] that changes its effective color based on the given
   /// [BuildContext]'s brightness (from [MediaQueryData.platformBrightness] or
@@ -758,16 +735,16 @@ class CupertinoDynamicColor extends Color with Diagnosticable {
     @required Color color,
     @required Color darkColor,
   }) : this(
-          debugLabel: debugLabel,
-          color: color,
-          darkColor: darkColor,
-          highContrastColor: color,
-          darkHighContrastColor: darkColor,
-          elevatedColor: color,
-          darkElevatedColor: darkColor,
-          highContrastElevatedColor: color,
-          darkHighContrastElevatedColor: darkColor,
-        );
+    debugLabel: debugLabel,
+    color: color,
+    darkColor: darkColor,
+    highContrastColor: color,
+    darkHighContrastColor: darkColor,
+    elevatedColor: color,
+    darkElevatedColor: darkColor,
+    highContrastElevatedColor: color,
+    darkHighContrastElevatedColor: darkColor,
+  );
 
   const CupertinoDynamicColor._(
     this._effectiveColor,
@@ -781,19 +758,19 @@ class CupertinoDynamicColor extends Color with Diagnosticable {
     this.darkHighContrastElevatedColor,
     this._debugResolveContext,
     this._debugLabel,
-  )   : assert(color != null),
-        assert(darkColor != null),
-        assert(highContrastColor != null),
-        assert(darkHighContrastColor != null),
-        assert(elevatedColor != null),
-        assert(darkElevatedColor != null),
-        assert(highContrastElevatedColor != null),
-        assert(darkHighContrastElevatedColor != null),
-        assert(_effectiveColor != null),
-        // The super constructor has to be called with a dummy value in order to mark
-        // this constructor const.
-        // The field `value` is overridden in the class implementation.
-        super(0);
+  ) : assert(color != null),
+      assert(darkColor != null),
+      assert(highContrastColor != null),
+      assert(darkHighContrastColor != null),
+      assert(elevatedColor != null),
+      assert(darkElevatedColor != null),
+      assert(highContrastElevatedColor != null),
+      assert(darkHighContrastElevatedColor != null),
+      assert(_effectiveColor != null),
+      // The super constructor has to be called with a dummy value in order to mark
+      // this constructor const.
+      // The field `value` is overridden in the class implementation.
+      super(0);
 
   /// The current effective color.
   ///
@@ -905,34 +882,34 @@ class CupertinoDynamicColor extends Color with Diagnosticable {
   /// value will be used ([Brightness.light] platform brightness, normal contrast,
   /// [CupertinoUserInterfaceLevelData.base] elevation level), unless [nullOk] is
   /// set to false, in which case an exception will be thrown.
-  static Color resolve(Color resolvable, BuildContext context,
-      {bool nullOk = true}) {
-    if (resolvable == null) return null;
+  static Color resolve(Color resolvable, BuildContext context, { bool nullOk = true }) {
+    if (resolvable == null)
+      return null;
     assert(context != null);
     return (resolvable is CupertinoDynamicColor)
-        ? resolvable.resolveFrom(context, nullOk: nullOk)
-        : resolvable;
+      ? resolvable.resolveFrom(context, nullOk: nullOk)
+      : resolvable;
   }
 
   bool get _isPlatformBrightnessDependent {
-    return color != darkColor ||
-        elevatedColor != darkElevatedColor ||
-        highContrastColor != darkHighContrastColor ||
-        highContrastElevatedColor != darkHighContrastElevatedColor;
+    return color != darkColor
+        || elevatedColor != darkElevatedColor
+        || highContrastColor != darkHighContrastColor
+        || highContrastElevatedColor != darkHighContrastElevatedColor;
   }
 
   bool get _isHighContrastDependent {
-    return color != highContrastColor ||
-        darkColor != darkHighContrastColor ||
-        elevatedColor != highContrastElevatedColor ||
-        darkElevatedColor != darkHighContrastElevatedColor;
+    return color != highContrastColor
+        || darkColor != darkHighContrastColor
+        || elevatedColor != highContrastElevatedColor
+        || darkElevatedColor != darkHighContrastElevatedColor;
   }
 
   bool get _isInterfaceElevationDependent {
-    return color != elevatedColor ||
-        darkColor != darkElevatedColor ||
-        highContrastColor != highContrastElevatedColor ||
-        darkHighContrastColor != darkHighContrastElevatedColor;
+    return color != elevatedColor
+        || darkColor != darkElevatedColor
+        || highContrastColor != highContrastElevatedColor
+        || darkHighContrastColor != darkHighContrastElevatedColor;
   }
 
   /// Resolves this [CupertinoDynamicColor] using the provided [BuildContext].
@@ -963,20 +940,18 @@ class CupertinoDynamicColor extends Color with Diagnosticable {
   /// brightness, normal contrast, [CupertinoUserInterfaceLevelData.base] elevation
   /// level), unless [nullOk] is set to false, in which case an exception will be
   /// thrown.
-  CupertinoDynamicColor resolveFrom(BuildContext context,
-      {bool nullOk = true}) {
+  CupertinoDynamicColor resolveFrom(BuildContext context, { bool nullOk = true }) {
     final Brightness brightness = _isPlatformBrightnessDependent
-        ? CupertinoTheme.brightnessOf(context, nullOk: nullOk) ??
-            Brightness.light
-        : Brightness.light;
+      ? CupertinoTheme.brightnessOf(context, nullOk: nullOk) ?? Brightness.light
+      : Brightness.light;
 
-    final bool isHighContrastEnabled = _isHighContrastDependent &&
-        (MediaQuery.of(context, nullOk: nullOk)?.highContrast ?? false);
+    final bool isHighContrastEnabled = _isHighContrastDependent
+      && (MediaQuery.of(context, nullOk: nullOk)?.highContrast ?? false);
+
 
     final CupertinoUserInterfaceLevelData level = _isInterfaceElevationDependent
-        ? CupertinoUserInterfaceLevel.of(context, nullOk: nullOk) ??
-            CupertinoUserInterfaceLevelData.base
-        : CupertinoUserInterfaceLevelData.base;
+      ? CupertinoUserInterfaceLevel.of(context, nullOk: nullOk) ?? CupertinoUserInterfaceLevelData.base
+      : CupertinoUserInterfaceLevelData.base;
 
     Color resolved;
     switch (brightness) {
@@ -986,22 +961,17 @@ class CupertinoDynamicColor extends Color with Diagnosticable {
             resolved = isHighContrastEnabled ? highContrastColor : color;
             break;
           case CupertinoUserInterfaceLevelData.elevated:
-            resolved = isHighContrastEnabled
-                ? highContrastElevatedColor
-                : elevatedColor;
+            resolved = isHighContrastEnabled ? highContrastElevatedColor : elevatedColor;
             break;
         }
         break;
       case Brightness.dark:
         switch (level) {
           case CupertinoUserInterfaceLevelData.base:
-            resolved =
-                isHighContrastEnabled ? darkHighContrastColor : darkColor;
+            resolved = isHighContrastEnabled ? darkHighContrastColor : darkColor;
             break;
           case CupertinoUserInterfaceLevelData.elevated:
-            resolved = isHighContrastEnabled
-                ? darkHighContrastElevatedColor
-                : darkElevatedColor;
+            resolved = isHighContrastEnabled ? darkHighContrastElevatedColor : darkElevatedColor;
             break;
         }
     }
@@ -1028,18 +998,20 @@ class CupertinoDynamicColor extends Color with Diagnosticable {
 
   @override
   bool operator ==(Object other) {
-    if (identical(this, other)) return true;
-    if (other.runtimeType != runtimeType) return false;
-    return other is CupertinoDynamicColor &&
-        other.value == value &&
-        other.color == color &&
-        other.darkColor == darkColor &&
-        other.highContrastColor == highContrastColor &&
-        other.darkHighContrastColor == darkHighContrastColor &&
-        other.elevatedColor == elevatedColor &&
-        other.darkElevatedColor == darkElevatedColor &&
-        other.highContrastElevatedColor == highContrastElevatedColor &&
-        other.darkHighContrastElevatedColor == darkHighContrastElevatedColor;
+    if (identical(this, other))
+      return true;
+    if (other.runtimeType != runtimeType)
+      return false;
+    return other is CupertinoDynamicColor
+        && other.value == value
+        && other.color == color
+        && other.darkColor == darkColor
+        && other.highContrastColor == highContrastColor
+        && other.darkHighContrastColor == darkHighContrastColor
+        && other.elevatedColor == elevatedColor
+        && other.darkElevatedColor == darkElevatedColor
+        && other.highContrastElevatedColor == highContrastElevatedColor
+        && other.darkHighContrastElevatedColor == darkHighContrastElevatedColor;
   }
 
   @override
@@ -1058,30 +1030,20 @@ class CupertinoDynamicColor extends Color with Diagnosticable {
   }
 
   @override
-  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
+  String toString({ DiagnosticLevel minLevel = DiagnosticLevel.info }) {
     String toString(String name, Color color) {
       final String marker = color == _effectiveColor ? '*' : '';
       return '$marker$name = $color$marker';
     }
 
-    final List<String> xs = <String>[
-      toString('color', color),
+    final List<String> xs = <String>[toString('color', color),
       if (_isPlatformBrightnessDependent) toString('darkColor', darkColor),
-      if (_isHighContrastDependent)
-        toString('highContrastColor', highContrastColor),
-      if (_isPlatformBrightnessDependent && _isHighContrastDependent)
-        toString('darkHighContrastColor', darkHighContrastColor),
-      if (_isInterfaceElevationDependent)
-        toString('elevatedColor', elevatedColor),
-      if (_isPlatformBrightnessDependent && _isInterfaceElevationDependent)
-        toString('darkElevatedColor', darkElevatedColor),
-      if (_isHighContrastDependent && _isInterfaceElevationDependent)
-        toString('highContrastElevatedColor', highContrastElevatedColor),
-      if (_isPlatformBrightnessDependent &&
-          _isHighContrastDependent &&
-          _isInterfaceElevationDependent)
-        toString(
-            'darkHighContrastElevatedColor', darkHighContrastElevatedColor),
+      if (_isHighContrastDependent) toString('highContrastColor', highContrastColor),
+      if (_isPlatformBrightnessDependent && _isHighContrastDependent) toString('darkHighContrastColor', darkHighContrastColor),
+      if (_isInterfaceElevationDependent) toString('elevatedColor', elevatedColor),
+      if (_isPlatformBrightnessDependent && _isInterfaceElevationDependent) toString('darkElevatedColor', darkElevatedColor),
+      if (_isHighContrastDependent && _isInterfaceElevationDependent) toString('highContrastElevatedColor', highContrastElevatedColor),
+      if (_isPlatformBrightnessDependent && _isHighContrastDependent && _isInterfaceElevationDependent) toString('darkHighContrastElevatedColor', darkHighContrastElevatedColor),
     ];
 
     return '${_debugLabel ?? objectRuntimeType(this, 'CupertinoDynamicColor')}(${xs.join(', ')}, resolved by: ${_debugResolveContext?.widget ?? "UNRESOLVED"})';
@@ -1096,29 +1058,20 @@ class CupertinoDynamicColor extends Color with Diagnosticable {
     if (_isPlatformBrightnessDependent)
       properties.add(createCupertinoColorProperty('darkColor', darkColor));
     if (_isHighContrastDependent)
-      properties.add(
-          createCupertinoColorProperty('highContrastColor', highContrastColor));
+      properties.add(createCupertinoColorProperty('highContrastColor', highContrastColor));
     if (_isPlatformBrightnessDependent && _isHighContrastDependent)
-      properties.add(createCupertinoColorProperty(
-          'darkHighContrastColor', darkHighContrastColor));
+      properties.add(createCupertinoColorProperty('darkHighContrastColor', darkHighContrastColor));
     if (_isInterfaceElevationDependent)
-      properties
-          .add(createCupertinoColorProperty('elevatedColor', elevatedColor));
+      properties.add(createCupertinoColorProperty('elevatedColor', elevatedColor));
     if (_isPlatformBrightnessDependent && _isInterfaceElevationDependent)
-      properties.add(
-          createCupertinoColorProperty('darkElevatedColor', darkElevatedColor));
+      properties.add(createCupertinoColorProperty('darkElevatedColor', darkElevatedColor));
     if (_isHighContrastDependent && _isInterfaceElevationDependent)
-      properties.add(createCupertinoColorProperty(
-          'highContrastElevatedColor', highContrastElevatedColor));
-    if (_isPlatformBrightnessDependent &&
-        _isHighContrastDependent &&
-        _isInterfaceElevationDependent)
-      properties.add(createCupertinoColorProperty(
-          'darkHighContrastElevatedColor', darkHighContrastElevatedColor));
+      properties.add(createCupertinoColorProperty('highContrastElevatedColor', highContrastElevatedColor));
+    if (_isPlatformBrightnessDependent && _isHighContrastDependent && _isInterfaceElevationDependent)
+      properties.add(createCupertinoColorProperty('darkHighContrastElevatedColor', darkHighContrastElevatedColor));
 
     if (_debugResolveContext != null)
-      properties.add(
-          DiagnosticsProperty<Element>('last resolved', _debugResolveContext));
+      properties.add(DiagnosticsProperty<Element>('last resolved', _debugResolveContext));
   }
 }
 
@@ -1128,10 +1081,10 @@ class CupertinoDynamicColor extends Color with Diagnosticable {
 DiagnosticsProperty<Color> createCupertinoColorProperty(
   String name,
   Color value, {
-  bool showName = true,
-  Object defaultValue = kNoDefaultValue,
-  DiagnosticsTreeStyle style = DiagnosticsTreeStyle.singleLine,
-  DiagnosticLevel level = DiagnosticLevel.info,
+    bool showName = true,
+    Object defaultValue = kNoDefaultValue,
+    DiagnosticsTreeStyle style = DiagnosticsTreeStyle.singleLine,
+    DiagnosticLevel level = DiagnosticLevel.info,
 }) {
   if (value is CupertinoDynamicColor) {
     return DiagnosticsProperty<CupertinoDynamicColor>(

--- a/tool/colors/flutter/colors_cupertino.dart
+++ b/tool/colors/flutter/colors_cupertino.dart
@@ -1,4 +1,4 @@
-/// This file was downloaded by update_colors.dart.
+// This file was downloaded by update_colors.dart.
 
 // Copyright 2014 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/tool/colors/flutter/colors_material.dart
+++ b/tool/colors/flutter/colors_material.dart
@@ -1,3 +1,5 @@
+/// This file was downloaded by update_colors.dart.
+
 // Copyright 2014 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/tool/colors/flutter/colors_material.dart
+++ b/tool/colors/flutter/colors_material.dart
@@ -24,8 +24,7 @@ class MaterialColor extends ColorSwatch<int> {
   /// values in the swatch, as would be passed to the [new Color] constructor
   /// for that same color, and as is exposed by [value]. (This is distinct from
   /// the specific index of the color in the swatch.)
-  const MaterialColor(int primary, Map<int, Color> swatch)
-      : super(primary, swatch);
+  const MaterialColor(int primary, Map<int, Color> swatch) : super(primary, swatch);
 
   /// The lightest shade.
   Color get shade50 => this[50];
@@ -73,8 +72,7 @@ class MaterialColor extends ColorSwatch<int> {
 class MaterialAccentColor extends ColorSwatch<int> {
   /// Creates a color swatch with a variety of shades appropriate for accent
   /// colors.
-  const MaterialAccentColor(int primary, Map<int, Color> swatch)
-      : super(primary, swatch);
+  const MaterialAccentColor(int primary, Map<int, Color> swatch) : super(primary, swatch);
 
   /// The lightest shade.
   Color get shade50 => this[50];
@@ -451,7 +449,7 @@ class Colors {
   static const MaterialColor red = MaterialColor(
     _redPrimaryValue,
     <int, Color>{
-      50: Color(0xFFFFEBEE),
+       50: Color(0xFFFFEBEE),
       100: Color(0xFFFFCDD2),
       200: Color(0xFFEF9A9A),
       300: Color(0xFFE57373),
@@ -533,7 +531,7 @@ class Colors {
   static const MaterialColor pink = MaterialColor(
     _pinkPrimaryValue,
     <int, Color>{
-      50: Color(0xFFFCE4EC),
+       50: Color(0xFFFCE4EC),
       100: Color(0xFFF8BBD0),
       200: Color(0xFFF48FB1),
       300: Color(0xFFF06292),
@@ -615,7 +613,7 @@ class Colors {
   static const MaterialColor purple = MaterialColor(
     _purplePrimaryValue,
     <int, Color>{
-      50: Color(0xFFF3E5F5),
+       50: Color(0xFFF3E5F5),
       100: Color(0xFFE1BEE7),
       200: Color(0xFFCE93D8),
       300: Color(0xFFBA68C8),
@@ -697,7 +695,7 @@ class Colors {
   static const MaterialColor deepPurple = MaterialColor(
     _deepPurplePrimaryValue,
     <int, Color>{
-      50: Color(0xFFEDE7F6),
+       50: Color(0xFFEDE7F6),
       100: Color(0xFFD1C4E9),
       200: Color(0xFFB39DDB),
       300: Color(0xFF9575CD),
@@ -779,7 +777,7 @@ class Colors {
   static const MaterialColor indigo = MaterialColor(
     _indigoPrimaryValue,
     <int, Color>{
-      50: Color(0xFFE8EAF6),
+       50: Color(0xFFE8EAF6),
       100: Color(0xFFC5CAE9),
       200: Color(0xFF9FA8DA),
       300: Color(0xFF7986CB),
@@ -863,7 +861,7 @@ class Colors {
   static const MaterialColor blue = MaterialColor(
     _bluePrimaryValue,
     <int, Color>{
-      50: Color(0xFFE3F2FD),
+       50: Color(0xFFE3F2FD),
       100: Color(0xFFBBDEFB),
       200: Color(0xFF90CAF9),
       300: Color(0xFF64B5F6),
@@ -945,7 +943,7 @@ class Colors {
   static const MaterialColor lightBlue = MaterialColor(
     _lightBluePrimaryValue,
     <int, Color>{
-      50: Color(0xFFE1F5FE),
+       50: Color(0xFFE1F5FE),
       100: Color(0xFFB3E5FC),
       200: Color(0xFF81D4FA),
       300: Color(0xFF4FC3F7),
@@ -1029,7 +1027,7 @@ class Colors {
   static const MaterialColor cyan = MaterialColor(
     _cyanPrimaryValue,
     <int, Color>{
-      50: Color(0xFFE0F7FA),
+       50: Color(0xFFE0F7FA),
       100: Color(0xFFB2EBF2),
       200: Color(0xFF80DEEA),
       300: Color(0xFF4DD0E1),
@@ -1111,7 +1109,7 @@ class Colors {
   static const MaterialColor teal = MaterialColor(
     _tealPrimaryValue,
     <int, Color>{
-      50: Color(0xFFE0F2F1),
+       50: Color(0xFFE0F2F1),
       100: Color(0xFFB2DFDB),
       200: Color(0xFF80CBC4),
       300: Color(0xFF4DB6AC),
@@ -1196,7 +1194,7 @@ class Colors {
   static const MaterialColor green = MaterialColor(
     _greenPrimaryValue,
     <int, Color>{
-      50: Color(0xFFE8F5E9),
+       50: Color(0xFFE8F5E9),
       100: Color(0xFFC8E6C9),
       200: Color(0xFFA5D6A7),
       300: Color(0xFF81C784),
@@ -1281,7 +1279,7 @@ class Colors {
   static const MaterialColor lightGreen = MaterialColor(
     _lightGreenPrimaryValue,
     <int, Color>{
-      50: Color(0xFFF1F8E9),
+       50: Color(0xFFF1F8E9),
       100: Color(0xFFDCEDC8),
       200: Color(0xFFC5E1A5),
       300: Color(0xFFAED581),
@@ -1363,7 +1361,7 @@ class Colors {
   static const MaterialColor lime = MaterialColor(
     _limePrimaryValue,
     <int, Color>{
-      50: Color(0xFFF9FBE7),
+       50: Color(0xFFF9FBE7),
       100: Color(0xFFF0F4C3),
       200: Color(0xFFE6EE9C),
       300: Color(0xFFDCE775),
@@ -1445,7 +1443,7 @@ class Colors {
   static const MaterialColor yellow = MaterialColor(
     _yellowPrimaryValue,
     <int, Color>{
-      50: Color(0xFFFFFDE7),
+       50: Color(0xFFFFFDE7),
       100: Color(0xFFFFF9C4),
       200: Color(0xFFFFF59D),
       300: Color(0xFFFFF176),
@@ -1527,7 +1525,7 @@ class Colors {
   static const MaterialColor amber = MaterialColor(
     _amberPrimaryValue,
     <int, Color>{
-      50: Color(0xFFFFF8E1),
+       50: Color(0xFFFFF8E1),
       100: Color(0xFFFFECB3),
       200: Color(0xFFFFE082),
       300: Color(0xFFFFD54F),
@@ -1611,7 +1609,7 @@ class Colors {
   static const MaterialColor orange = MaterialColor(
     _orangePrimaryValue,
     <int, Color>{
-      50: Color(0xFFFFF3E0),
+       50: Color(0xFFFFF3E0),
       100: Color(0xFFFFE0B2),
       200: Color(0xFFFFCC80),
       300: Color(0xFFFFB74D),
@@ -1695,7 +1693,7 @@ class Colors {
   static const MaterialColor deepOrange = MaterialColor(
     _deepOrangePrimaryValue,
     <int, Color>{
-      50: Color(0xFFFBE9E7),
+       50: Color(0xFFFBE9E7),
       100: Color(0xFFFFCCBC),
       200: Color(0xFFFFAB91),
       300: Color(0xFFFF8A65),
@@ -1775,7 +1773,7 @@ class Colors {
   static const MaterialColor brown = MaterialColor(
     _brownPrimaryValue,
     <int, Color>{
-      50: Color(0xFFEFEBE9),
+       50: Color(0xFFEFEBE9),
       100: Color(0xFFD7CCC8),
       200: Color(0xFFBCAAA4),
       300: Color(0xFFA1887F),
@@ -1824,12 +1822,11 @@ class Colors {
   static const MaterialColor grey = MaterialColor(
     _greyPrimaryValue,
     <int, Color>{
-      50: Color(0xFFFAFAFA),
+       50: Color(0xFFFAFAFA),
       100: Color(0xFFF5F5F5),
       200: Color(0xFFEEEEEE),
       300: Color(0xFFE0E0E0),
-      350: Color(
-          0xFFD6D6D6), // only for raised button while pressed in light theme
+      350: Color(0xFFD6D6D6), // only for raised button while pressed in light theme
       400: Color(0xFFBDBDBD),
       500: Color(_greyPrimaryValue),
       600: Color(0xFF757575),
@@ -1871,7 +1868,7 @@ class Colors {
   static const MaterialColor blueGrey = MaterialColor(
     _blueGreyPrimaryValue,
     <int, Color>{
-      50: Color(0xFFECEFF1),
+       50: Color(0xFFECEFF1),
       100: Color(0xFFCFD8DC),
       200: Color(0xFFB0BEC5),
       300: Color(0xFF90A4AE),

--- a/tool/colors/flutter/colors_material.dart
+++ b/tool/colors/flutter/colors_material.dart
@@ -1,4 +1,4 @@
-/// This file was downloaded by update_colors.dart.
+// This file was downloaded by update_colors.dart.
 
 // Copyright 2014 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be

--- a/tool/colors/generate_properties.dart
+++ b/tool/colors/generate_properties.dart
@@ -1,0 +1,87 @@
+// Copyright 2020 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:path/path.dart' as path;
+
+import 'flutter/colors_cupertino.dart';
+import 'flutter/colors_material.dart';
+import 'generated/colors_cupertino.dart' as cupertino;
+import 'generated/colors_material.dart' as material;
+import 'stubs.dart';
+
+void main(List<String> args) async {
+  // Verify that we're running from the project root.
+  if (path.basename(Directory.current.path) != 'flutter-intellij') {
+    print('Please run this script from the directory root.');
+    exit(1);
+  }
+
+  print('Generating property files:');
+  generatePropertiesFiles();
+}
+
+void generatePropertiesFiles() {
+  final output = 'resources/flutter/';
+  generateProperties(material.colors, '$output/colors.properties');
+  generateProperties(cupertino.colors, '$output/cupertino_colors.properties');
+}
+
+void generateProperties(Map<String, Color> colors, String filename) {
+  const validShades = [
+    50,
+    100,
+    200,
+    300,
+    350,
+    400,
+    500,
+    600,
+    700,
+    800,
+    850,
+    900
+  ];
+  StringBuffer buf = StringBuffer();
+  buf.writeln('# Generated file - do not edit.');
+  buf.writeln();
+  buf.writeln('# suppress inspection "UnusedProperty" for whole file');
+
+  for (String name in colors.keys) {
+    Color color = colors[name];
+    if (color is MaterialColor) {
+      buf.writeln('$name.primary=${color}');
+      for (var shade in validShades) {
+        if (color[shade] != null) {
+          buf.writeln('$name[$shade]=${color[shade]}');
+        }
+      }
+    } else if (color is MaterialAccentColor) {
+      buf.writeln('$name.primary=${color}');
+      for (var shade in validShades) {
+        if (color[shade] != null) {
+          buf.writeln('$name[$shade]=${color[shade]}');
+        }
+      }
+    } else if (color is CupertinoDynamicColor) {
+      buf.writeln('$name=${color.color}');
+      buf.writeln('$name.darkColor=${color.darkColor}');
+      buf.writeln('$name.darkElevatedColor=${color.darkElevatedColor}');
+      buf.writeln('$name.darkHighContrastColor=${color.darkHighContrastColor}');
+      buf.writeln(
+          '$name.darkHighContrastElevatedColor=${color.darkHighContrastElevatedColor}');
+      buf.writeln('$name.elevatedColor=${color.elevatedColor}');
+      buf.writeln('$name.highContrastColor=${color.highContrastColor}');
+      buf.writeln(
+          '$name.highContrastElevatedColor=${color.highContrastElevatedColor}');
+    } else {
+      buf.writeln('$name=$color');
+    }
+  }
+
+  new File(filename).writeAsStringSync(buf.toString());
+
+  print('wrote $filename');
+}

--- a/tool/colors/update_colors.dart
+++ b/tool/colors/update_colors.dart
@@ -28,6 +28,7 @@ void main(List<String> args) async {
 }
 
 Future<void> generateDartFiles() async {
+  // TODO: Use the files from the local flutter checkout instead of a download
   // download material/colors.dart and cupertino/colors.dart
   await Future.wait([
     downloadFile(materialColorsUrl, materialFile),
@@ -54,7 +55,7 @@ Future<void> downloadFile(String url, File file) async {
         data.join('').replaceFirst(imports, "import '../stubs.dart';\n\n");
 
     file.writeAsStringSync(
-      '/// This file was downloaded by update_colors.dart.\n\n'
+      '// This file was downloaded by update_colors.dart.\n\n'
       '$contents',
     );
   } finally {

--- a/tool/colors/update_colors.dart
+++ b/tool/colors/update_colors.dart
@@ -7,11 +7,14 @@ import 'dart:io';
 
 import 'package:path/path.dart' as path;
 
-import 'flutter/colors_cupertino.dart';
-import 'flutter/colors_material.dart';
-import 'generated/colors_cupertino.dart' as cupertino;
-import 'generated/colors_material.dart' as material;
-import 'stubs.dart';
+const flutterPackageSourceUrl =
+    'https://raw.githubusercontent.com/flutter/flutter/'
+    'master/packages/flutter/lib/src';
+const materialColorsUrl = '$flutterPackageSourceUrl/material/colors.dart';
+const cupertinoColorsUrl = '$flutterPackageSourceUrl/cupertino/colors.dart';
+final materialFile = File('tool/colors/flutter/colors_material.dart');
+final cupertinoFile = File('tool/colors/flutter/colors_cupertino.dart');
+final generatedFilesPath = 'tool/colors/generated';
 
 void main(List<String> args) async {
   // Verify that we're running from the project root.
@@ -20,62 +23,40 @@ void main(List<String> args) async {
     exit(1);
   }
 
-  // TODO(dantup): Split into two scripts instead of using a flag? It's to allow
-  // easier debugging of the second step.
-  if (args.contains('--generate-properties')) {
-    print('Generating property files:');
-    generatePropertiesFiles();
-
-    exit(0);
-  } else {
-    print('Generating dart files:');
-    await generateDartFiles();
-
-    // Re-run the script with `--generate-properties` so it can load the files
-    // we generated.
-    final results = Process.runSync(Platform.resolvedExecutable,
-        [Platform.script.toFilePath(), '--generate-propertes']);
-    stdout.write(results.stdout);
-    stderr.write(results.stderr);
-
-    exit(0);
-  }
+  print('Generating dart files:');
+  await generateDartFiles();
 }
 
-Future generateDartFiles() async {
-  // TODO: Use the files from the local flutter checkout instead of a download
-  // here.
-
+Future<void> generateDartFiles() async {
   // download material/colors.dart and cupertino/colors.dart
-  String materialData =
-      await downloadUrl('https://raw.githubusercontent.com/flutter/flutter/'
-          'master/packages/flutter/lib/src/material/colors.dart');
-  String cupertinoData =
-      await downloadUrl('https://raw.githubusercontent.com/flutter/flutter/'
-          'master/packages/flutter/lib/src/cupertino/colors.dart');
+  await Future.wait([
+    downloadFile(materialColorsUrl, materialFile),
+    downloadFile(cupertinoColorsUrl, cupertinoFile)
+  ]);
 
   // parse into metadata
-  List<String> materialColors = extractColorNames(materialData);
-  List<String> cupertinoColors = extractColorNames(cupertinoData);
+  List<String> materialColors = extractColorNames(materialFile);
+  List<String> cupertinoColors = extractColorNames(cupertinoFile);
 
   // generate .properties files
   generateDart(materialColors, 'colors_material.dart', 'Colors');
   generateDart(cupertinoColors, 'colors_cupertino.dart', 'CupertinoColors');
 }
 
-void generatePropertiesFiles() {
-  final output = 'resources/flutter/';
-  generateProperties(material.colors, '$output/colors.properties');
-  generateProperties(cupertino.colors, '$output/cupertino_colors.properties');
-}
-
-Future<String> downloadUrl(String url) async {
+Future<void> downloadFile(String url, File file) async {
+  RegExp imports = new RegExp(r'(?:^import.*;\n{1,})+', multiLine: true);
   HttpClient client = new HttpClient();
   try {
     HttpClientRequest request = await client.getUrl(Uri.parse(url));
     HttpClientResponse response = await request.close();
     List<String> data = await utf8.decoder.bind(response).toList();
-    return data.join('');
+    String contents =
+        data.join('').replaceFirst(imports, "import '../stubs.dart';\n\n");
+
+    file.writeAsStringSync(
+      '/// This file was downloaded by update_colors.dart.\n\n'
+      '$contents',
+    );
   } finally {
     client.close();
   }
@@ -94,7 +75,9 @@ final RegExp regexpColor2 = new RegExp(r'static const \w*Color (\S+) = \w+;');
 final RegExp regexpColor3 =
     new RegExp(r'static const \w*Color (\S+) = \w+.\w+\(');
 
-List<String> extractColorNames(String data) {
+List<String> extractColorNames(File file) {
+  String data = file.readAsStringSync();
+
   List<String> names = [
     ...regexpColor1.allMatches(data).map((Match match) => match.group(1)),
     ...regexpColor2.allMatches(data).map((Match match) => match.group(1)),
@@ -121,65 +104,8 @@ final Map<String, Color> colors = <String, Color>{''');
 
   buf.writeln('};');
 
-  File out = new File('tool/colors/generated/$filename');
+  File out = File('$generatedFilesPath/$filename');
   out.writeAsStringSync(buf.toString());
 
   print('wrote ${out.path}');
-}
-
-void generateProperties(Map<String, Color> colors, String filename) {
-  const validShades = [
-    50,
-    100,
-    200,
-    300,
-    350,
-    400,
-    500,
-    600,
-    700,
-    800,
-    850,
-    900
-  ];
-  StringBuffer buf = StringBuffer();
-  buf.writeln('# Generated file - do not edit.');
-  buf.writeln();
-  buf.writeln('# suppress inspection "UnusedProperty" for whole file');
-
-  for (String name in colors.keys) {
-    Color color = colors[name];
-    if (color is MaterialColor) {
-      buf.writeln('$name.primary=${color}');
-      for (var shade in validShades) {
-        if (color[shade] != null) {
-          buf.writeln('$name[$shade]=${color[shade]}');
-        }
-      }
-    } else if (color is MaterialAccentColor) {
-      buf.writeln('$name.primary=${color}');
-      for (var shade in validShades) {
-        if (color[shade] != null) {
-          buf.writeln('$name[$shade]=${color[shade]}');
-        }
-      }
-    } else if (color is CupertinoDynamicColor) {
-      buf.writeln('$name=${color.color}');
-      buf.writeln('$name.darkColor=${color.darkColor}');
-      buf.writeln('$name.darkElevatedColor=${color.darkElevatedColor}');
-      buf.writeln('$name.darkHighContrastColor=${color.darkHighContrastColor}');
-      buf.writeln(
-          '$name.darkHighContrastElevatedColor=${color.darkHighContrastElevatedColor}');
-      buf.writeln('$name.elevatedColor=${color.elevatedColor}');
-      buf.writeln('$name.highContrastColor=${color.highContrastColor}');
-      buf.writeln(
-          '$name.highContrastElevatedColor=${color.highContrastElevatedColor}');
-    } else {
-      buf.writeln('$name=$color');
-    }
-  }
-
-  new File(filename).writeAsStringSync(buf.toString());
-
-  print('wrote $filename');
 }

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:grinder/grinder.dart';
@@ -39,31 +38,8 @@ generate() => null;
 
 @Task('Generate Flutter color information')
 colors() async {
-  final String kUrl = 'https://raw.githubusercontent.com/flutter/flutter/'
-      'master/packages/flutter/lib/src/material/colors.dart';
-
-  // Get color file from flutter.
-  HttpClientRequest request = await new HttpClient().getUrl(Uri.parse(kUrl));
-  HttpClientResponse response = await request.close();
-  List<String> data = await utf8.decoder.bind(response).toList();
-
-  // Remove an import and define the Color class.
-  String str = data.join('');
-  str = str.replaceFirst(
-      "import 'dart:ui' show Color;", "import 'update_colors.dart';");
-  str = str.replaceFirst("import 'package:flutter/painting.dart';", '');
-  File file = new File('tool/colors/colors.dart');
-  file.writeAsStringSync(str);
-
-  // Run tool/color/update_colors.dart, pipe output to //resources/flutter/color.properties.
-  ProcessResult result = Process.runSync(
-      Platform.resolvedExecutable, ['tool/colors/update_colors.dart']);
-  if (result.exitCode != 0) {
-    fail('${result.stdout}\n${result.stderr}');
-  }
-  File outFile = new File('resources/flutter/colors.properties');
-  outFile.writeAsStringSync(result.stdout.toString());
-  log('wrote ${outFile.path}');
+  await Dart.runAsync('tool/colors/update_colors.dart');
+  await Dart.runAsync('tool/colors/generate_properties.dart');
 }
 
 @Task('Generate Flutter icon information')


### PR DESCRIPTION
This splits the `update_colors.dart` script into two scripts so it no longer calls itself (which simplifies debugging, and avoids getting into the situation where a broken generated file prevents running the script to regenerate it) and also consolidates the downloaded files so there's just one set.

Running `grind colors` works properly this time, and generates the same files that were in the repo - with the exception of the downloaded files being unformatted (I didn't commit the format changes because it would make this PR harder to review - I can add them once this is reviewed, or just send another PR with just the (un)formatting changes).

@devoncarew the rebase was messy, so I manually applied your changes to my existing change. If you think I've missed anything, let me know!