### PR TITLE
Start paused for run mode and use FlutterTestRunner for run tests

### DIFF
--- a/src/io/flutter/run/test/FlutterTestRunner.java
+++ b/src/io/flutter/run/test/FlutterTestRunner.java
@@ -17,6 +17,7 @@ import com.intellij.execution.runners.GenericProgramRunner;
 import com.intellij.execution.ui.RunContentDescriptor;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.util.Key;
+import com.intellij.openapi.wm.ToolWindowId;
 import com.intellij.xdebugger.XDebugProcess;
 import com.intellij.xdebugger.XDebugProcessStarter;
 import com.intellij.xdebugger.XDebugSession;
@@ -44,7 +45,7 @@ public class FlutterTestRunner extends GenericProgramRunner {
 
   @Override
   public boolean canRun(@NotNull String executorId, @NotNull RunProfile profile) {
-    if (!DefaultDebugExecutor.EXECUTOR_ID.equals(executorId) || !(profile instanceof TestConfig)) {
+    if (!(DefaultDebugExecutor.EXECUTOR_ID.equals(executorId) || ToolWindowId.RUN.equals(executorId)) || !(profile instanceof TestConfig)) {
       return false;
     }
 

--- a/src/io/flutter/sdk/FlutterSdk.java
+++ b/src/io/flutter/sdk/FlutterSdk.java
@@ -244,7 +244,7 @@ public class FlutterSdk {
       args.add("--device-id=" + device.deviceId());
     }
 
-    if (mode == RunMode.DEBUG) {
+    if (mode == RunMode.DEBUG || mode == RunMode.RUN) {
       args.add("--start-paused");
     }
 
@@ -320,6 +320,8 @@ public class FlutterSdk {
       if (!myVersion.flutterTestSupportsMachineMode()) {
         throw new IllegalStateException("Flutter SDK is too old to debug tests");
       }
+    }
+    if (mode == RunMode.DEBUG || mode == RunMode.RUN) {
       args.add("--start-paused");
     }
     if (FlutterSettings.getInstance().isVerboseLogging()) {


### PR DESCRIPTION
We reverted a change (https://github.com/flutter/flutter-intellij/pull/4673) that was similar to this one because it was breaking tests.

However, we still want to start with the app paused to catch early errors since we're now expecting structured errors from flutter_tools. If we do not start paused, there's a chance that the app will start running before flutter_tools has started listening for errors and we will miss early ones.

While looking into why run mode during tests doesn't resume app execution, I found that running tests (NOT in debug mode) uses the runner `DefaultRunProgramRunner` from the IntelliJ platform - it seems like we should be using a flutter-specific test runner for run and debug modes? But I'm not sure whether there's a reason we have been using the default runner.

I tested this change by running the gallery app and running the sample tests of the gallery app.