### PR TITLE
[ISSUE-3347]

### DIFF
--- a/src/io/flutter/editor/ExpressionParsingUtils.java
+++ b/src/io/flutter/editor/ExpressionParsingUtils.java
@@ -40,4 +40,58 @@ public class ExpressionParsingUtils {
     //noinspection UseJBColor
     return new Color((int)(value >> 16) & 0xFF, (int)(value >> 8) & 0xFF, (int)value & 0xFF, (int)(value >> 24) & 0xFF);
   }
+
+  public static Color parseColorComponents(String callText, String prefix, boolean isARGB) {
+    if (callText.startsWith(prefix) && callText.endsWith(")")) {
+      final String colorString = callText.substring(prefix.length(), callText.length() - 1).trim();
+      final String[] maybeNumbers = colorString.split(",");
+      if (maybeNumbers.length < 4) {
+        return null;
+      }
+      return isARGB ? parseARGBColorComponents(maybeNumbers) : parseRGBOColorComponents(maybeNumbers);
+    }
+    return null;
+  }
+
+  private static Color parseARGBColorComponents(String[] maybeNumbers) {
+    if (maybeNumbers.length < 4) {
+      return null;
+    }
+    final int[] argb = new int[4];
+    for (int i = 0; i < 4; ++i) {
+      try {
+        argb[i] = Integer.parseUnsignedInt(maybeNumbers[i].trim());
+      }
+      catch (NumberFormatException ignored) {
+        return null;
+      }
+    }
+    //noinspection UseJBColor
+    return new Color(argb[1], argb[2], argb[3], argb[0]);
+  }
+
+  private static Color parseRGBOColorComponents(String[] maybeNumbers) {
+    final float[] rgbo = new float[4];
+    for (int i = 0; i < 4; ++i) {
+      try {
+        if (i == 3) {
+          rgbo[i] = Float.parseFloat(maybeNumbers[i].trim());
+          if (rgbo[3] < 0.0f || rgbo[3] > 1.0f) {
+            return null;
+          }
+        }
+        else {
+          rgbo[i] = (float)Integer.parseUnsignedInt(maybeNumbers[i].trim()) / 255;
+          if (rgbo[i] < 0.0f || rgbo[i] > 1.0f) {
+            return null;
+          }
+        }
+      }
+      catch (NumberFormatException ignored) {
+        return null;
+      }
+    }
+    //noinspection UseJBColor
+    return new Color(rgbo[0], rgbo[1], rgbo[2], rgbo[3]);
+  }
 }

--- a/src/io/flutter/editor/ExpressionParsingUtils.java
+++ b/src/io/flutter/editor/ExpressionParsingUtils.java
@@ -59,8 +59,14 @@ public class ExpressionParsingUtils {
     }
     final int[] argb = new int[4];
     for (int i = 0; i < 4; ++i) {
+      final String maybeNumber = maybeNumbers[i].trim();
       try {
-        argb[i] = Integer.parseUnsignedInt(maybeNumbers[i].trim());
+        if (maybeNumber.startsWith("0x")) {
+          argb[i] = Integer.parseUnsignedInt(maybeNumber.substring(2), 16);
+        }
+        else {
+          argb[i] = Integer.parseUnsignedInt(maybeNumber);
+        }
       }
       catch (NumberFormatException ignored) {
         return null;
@@ -73,15 +79,21 @@ public class ExpressionParsingUtils {
   private static Color parseRGBOColorComponents(String[] maybeNumbers) {
     final float[] rgbo = new float[4];
     for (int i = 0; i < 4; ++i) {
+      final String maybeNumber = maybeNumbers[i].trim();
       try {
         if (i == 3) {
-          rgbo[i] = Float.parseFloat(maybeNumbers[i].trim());
+          rgbo[i] = Float.parseFloat(maybeNumber);
           if (rgbo[3] < 0.0f || rgbo[3] > 1.0f) {
             return null;
           }
         }
         else {
-          rgbo[i] = (float)Integer.parseUnsignedInt(maybeNumbers[i].trim()) / 255;
+          if (maybeNumber.startsWith("0x")) {
+            rgbo[i] = (float)Integer.parseUnsignedInt(maybeNumber.substring(2), 16) / 255;
+          }
+          else {
+            rgbo[i] = (float)Integer.parseUnsignedInt(maybeNumber) / 255;
+          }
           if (rgbo[i] < 0.0f || rgbo[i] > 1.0f) {
             return null;
           }

--- a/src/io/flutter/editor/FlutterEditorAnnotator.java
+++ b/src/io/flutter/editor/FlutterEditorAnnotator.java
@@ -91,7 +91,9 @@ public class FlutterEditorAnnotator implements Annotator {
       final String text = element.getText();
 
       final String constIconDataText = "const IconData(";
-      final String constColorText = "const Color(";
+      final String constColorConstrutorText = "const Color(";
+      final String constColorFromARGB = "const Color.fromARGB(";
+      final String constColorFromRGBO = "const Color.fromRGBO(";
 
       if (text.startsWith(constIconDataText)) {
         final Integer val = ExpressionParsingUtils.parseNumberFromCallParam(text, constIconDataText);
@@ -110,13 +112,26 @@ public class FlutterEditorAnnotator implements Annotator {
           }
         }
       }
-      else if (text.startsWith(constColorText)) {
-        final Color color = ExpressionParsingUtils.parseColor(text, constColorText);
+      else if (text.startsWith(constColorConstrutorText)) {
+        final Color color = ExpressionParsingUtils.parseColor(text, constColorConstrutorText);
+        if (color != null) {
+          attachColorIcon(element, holder, color);
+        }
+      }
+      else if (text.startsWith(constColorFromARGB)) {
+        final Color color = ExpressionParsingUtils.parseColorComponents(text, constColorFromARGB, true);
+        if (color != null) {
+          attachColorIcon(element, holder, color);
+        }
+      }
+      else if (text.startsWith(constColorFromRGBO)) {
+        final Color color = ExpressionParsingUtils.parseColorComponents(text, constColorFromRGBO, false);
         if (color != null) {
           attachColorIcon(element, holder, color);
         }
       }
     }
+
     else if (element instanceof DartCallExpression) {
       // Look for call expressions that are really new (constructor) expressions; The IntelliJ parser can't
       // distinguish between call expressions, and call expressions that are really constructor calls.
@@ -125,7 +140,9 @@ public class FlutterEditorAnnotator implements Annotator {
       final String text = element.getText();
 
       final String iconDataText = "IconData(";
-      final String colorText = "Color(";
+      final String colorConstructorText = "Color(";
+      final String colorFromARGB = "Color.fromARGB(";
+      final String colorFromRGBO = "Color.fromRGBO(";
 
       if (text.startsWith(iconDataText)) {
         final Integer val = ExpressionParsingUtils.parseNumberFromCallParam(text, iconDataText);
@@ -144,8 +161,20 @@ public class FlutterEditorAnnotator implements Annotator {
           }
         }
       }
-      else if (text.startsWith(colorText)) {
-        final Color color = ExpressionParsingUtils.parseColor(text, colorText);
+      else if (text.startsWith(colorConstructorText)) {
+        final Color color = ExpressionParsingUtils.parseColor(text, colorConstructorText);
+        if (color != null) {
+          attachColorIcon(element, holder, color);
+        }
+      }
+      else if (text.startsWith(colorFromARGB)) {
+        final Color color = ExpressionParsingUtils.parseColorComponents(text, colorFromARGB, true);
+        if (color != null) {
+          attachColorIcon(element, holder, color);
+        }
+      }
+      else if (text.startsWith(colorFromRGBO)) {
+        final Color color = ExpressionParsingUtils.parseColorComponents(text, colorFromRGBO, false);
         if (color != null) {
           attachColorIcon(element, holder, color);
         }

--- a/testSrc/unit/io/flutter/editor/FlutterEditorAnnotatorTest.java
+++ b/testSrc/unit/io/flutter/editor/FlutterEditorAnnotatorTest.java
@@ -195,7 +195,7 @@ public class FlutterEditorAnnotatorTest extends AbstractDartElementTest {
   @Test
   public void locatesConstARGBColor() throws Exception {
     run(() -> {
-      final PsiElement testIdentifier = setUpDartElement("main() { const Colors.fromARGB(255, 255, 0,0); }", "Colors", LeafPsiElement.class);
+      final PsiElement testIdentifier = setUpDartElement("main() { const Colors.fromARGB(255, 255, 0,0); }", "main", LeafPsiElement.class);
       final DartNewExpression element = DartSyntax.findEnclosingNewExpression(testIdentifier);
       assert element != null;
 
@@ -216,7 +216,7 @@ public class FlutterEditorAnnotatorTest extends AbstractDartElementTest {
   @Test
   public void locatesARGBColor() throws Exception {
     run(() -> {
-      final PsiElement testIdentifier = setUpDartElement("main() { Colors.fromARGB(255, 255, 0,0); }", "Colors", LeafPsiElement.class);
+      final PsiElement testIdentifier = setUpDartElement("main() { Colors.fromARGB(255, 255, 0,0); }", "main", LeafPsiElement.class);
       final DartNewExpression element = DartSyntax.findEnclosingNewExpression(testIdentifier);
       assert element != null;
 
@@ -237,7 +237,7 @@ public class FlutterEditorAnnotatorTest extends AbstractDartElementTest {
   @Test
   public void locatesConstRGBOColor() throws Exception {
     run(() -> {
-      final PsiElement testIdentifier = setUpDartElement("main() { const Colors.fromRGBO(255,0,0,1.0); }", "Colors", LeafPsiElement.class);
+      final PsiElement testIdentifier = setUpDartElement("main() { const Colors.fromRGBO(255,0,0,1.0); }", "main", LeafPsiElement.class);
       final DartNewExpression element = DartSyntax.findEnclosingNewExpression(testIdentifier);
       assert element != null;
 
@@ -258,7 +258,7 @@ public class FlutterEditorAnnotatorTest extends AbstractDartElementTest {
   @Test
   public void locatesRGBOColor() throws Exception {
     run(() -> {
-      final PsiElement testIdentifier = setUpDartElement("main() { Colors.fromRGBO(255, 255, 0, 1.0); }", "Colors", LeafPsiElement.class);
+      final PsiElement testIdentifier = setUpDartElement("main() { Colors.fromRGBO(255, 255, 0, 1.0); }", "main", LeafPsiElement.class);
       final DartNewExpression element = DartSyntax.findEnclosingNewExpression(testIdentifier);
       assert element != null;
 

--- a/testSrc/unit/io/flutter/editor/FlutterEditorAnnotatorTest.java
+++ b/testSrc/unit/io/flutter/editor/FlutterEditorAnnotatorTest.java
@@ -195,7 +195,7 @@ public class FlutterEditorAnnotatorTest extends AbstractDartElementTest {
   @Test
   public void locatesConstARGBColor() throws Exception {
     run(() -> {
-      final PsiElement testIdentifier = setUpDartElement("main() { const Colors.fromARGB(255, 255, 0,0); }", "Colors.fromARGB", LeafPsiElement.class);
+      final PsiElement testIdentifier = setUpDartElement("main() { const Colors.fromARGB(255, 255, 0,0); }", "Colors", LeafPsiElement.class);
       final DartNewExpression element = DartSyntax.findEnclosingNewExpression(testIdentifier);
       assert element != null;
 
@@ -216,7 +216,7 @@ public class FlutterEditorAnnotatorTest extends AbstractDartElementTest {
   @Test
   public void locatesARGBColor() throws Exception {
     run(() -> {
-      final PsiElement testIdentifier = setUpDartElement("main() { Colors.fromARGB(255, 255, 0,0); }", "Colors.fromARGB", LeafPsiElement.class);
+      final PsiElement testIdentifier = setUpDartElement("main() { Colors.fromARGB(255, 255, 0,0); }", "Colors", LeafPsiElement.class);
       final DartNewExpression element = DartSyntax.findEnclosingNewExpression(testIdentifier);
       assert element != null;
 
@@ -237,7 +237,7 @@ public class FlutterEditorAnnotatorTest extends AbstractDartElementTest {
   @Test
   public void locatesConstRGBOColor() throws Exception {
     run(() -> {
-      final PsiElement testIdentifier = setUpDartElement("main() { const Colors.fromRGBO(255,0,0,1.0); }", "Colors.fromRGBO", LeafPsiElement.class);
+      final PsiElement testIdentifier = setUpDartElement("main() { const Colors.fromRGBO(255,0,0,1.0); }", "Colors", LeafPsiElement.class);
       final DartNewExpression element = DartSyntax.findEnclosingNewExpression(testIdentifier);
       assert element != null;
 
@@ -258,7 +258,7 @@ public class FlutterEditorAnnotatorTest extends AbstractDartElementTest {
   @Test
   public void locatesRGBOColor() throws Exception {
     run(() -> {
-      final PsiElement testIdentifier = setUpDartElement("main() { Colors.fromRGBO(255, 255, 0, 1.0); }", "Colors.fromRGBO", LeafPsiElement.class);
+      final PsiElement testIdentifier = setUpDartElement("main() { Colors.fromRGBO(255, 255, 0, 1.0); }", "Colors", LeafPsiElement.class);
       final DartNewExpression element = DartSyntax.findEnclosingNewExpression(testIdentifier);
       assert element != null;
 

--- a/testSrc/unit/io/flutter/editor/FlutterEditorAnnotatorTest.java
+++ b/testSrc/unit/io/flutter/editor/FlutterEditorAnnotatorTest.java
@@ -256,7 +256,7 @@ public class FlutterEditorAnnotatorTest extends AbstractDartElementTest {
   }
 
   @Test
-  public void locatesRBOColor() throws Exception {
+  public void locatesRGBOColor() throws Exception {
     run(() -> {
       final PsiElement testIdentifier = setUpDartElement("main() { Colors.fromRGBO(255, 255, 0, 1.0); }", "Colors.fromRGBO", LeafPsiElement.class);
       final DartNewExpression element = DartSyntax.findEnclosingNewExpression(testIdentifier);

--- a/testSrc/unit/io/flutter/editor/FlutterEditorAnnotatorTest.java
+++ b/testSrc/unit/io/flutter/editor/FlutterEditorAnnotatorTest.java
@@ -191,4 +191,88 @@ public class FlutterEditorAnnotatorTest extends AbstractDartElementTest {
       assertEquals(HighlightSeverity.INFORMATION, annotation.getSeverity());
     });
   }
+
+  @Test
+  public void locatesConstARGBColor() throws Exception {
+    run(() -> {
+      final PsiElement testIdentifier = setUpDartElement("main() { const Colors.fromARGB(255, 255, 0,0); }", "Colors.fromARGB", LeafPsiElement.class);
+      final DartNewExpression element = DartSyntax.findEnclosingNewExpression(testIdentifier);
+      assert element != null;
+
+      final FlutterEditorAnnotator annotator = new FlutterEditorAnnotator();
+      final AnnotationSession annotationSession = new AnnotationSession(testIdentifier.getContainingFile());
+      final AnnotationHolderImpl annotationHolder = new AnnotationHolderImpl(annotationSession);
+
+      annotator.annotate(element, annotationHolder);
+
+      assertTrue(annotationHolder.hasAnnotations());
+      assertEquals(1, annotationHolder.size());
+
+      final Annotation annotation = annotationHolder.get(0);
+      assertEquals(HighlightSeverity.INFORMATION, annotation.getSeverity());
+    });
+  }
+
+  @Test
+  public void locatesARGBColor() throws Exception {
+    run(() -> {
+      final PsiElement testIdentifier = setUpDartElement("main() { Colors.fromARGB(255, 255, 0,0); }", "Colors.fromARGB", LeafPsiElement.class);
+      final DartNewExpression element = DartSyntax.findEnclosingNewExpression(testIdentifier);
+      assert element != null;
+
+      final FlutterEditorAnnotator annotator = new FlutterEditorAnnotator();
+      final AnnotationSession annotationSession = new AnnotationSession(testIdentifier.getContainingFile());
+      final AnnotationHolderImpl annotationHolder = new AnnotationHolderImpl(annotationSession);
+
+      annotator.annotate(element, annotationHolder);
+
+      assertTrue(annotationHolder.hasAnnotations());
+      assertEquals(1, annotationHolder.size());
+
+      final Annotation annotation = annotationHolder.get(0);
+      assertEquals(HighlightSeverity.INFORMATION, annotation.getSeverity());
+    });
+  }
+
+  @Test
+  public void locatesConstRGBOColor() throws Exception {
+    run(() -> {
+      final PsiElement testIdentifier = setUpDartElement("main() { const Colors.fromRGBO(255,0,0,1.0); }", "Colors.fromRGBO", LeafPsiElement.class);
+      final DartNewExpression element = DartSyntax.findEnclosingNewExpression(testIdentifier);
+      assert element != null;
+
+      final FlutterEditorAnnotator annotator = new FlutterEditorAnnotator();
+      final AnnotationSession annotationSession = new AnnotationSession(testIdentifier.getContainingFile());
+      final AnnotationHolderImpl annotationHolder = new AnnotationHolderImpl(annotationSession);
+
+      annotator.annotate(element, annotationHolder);
+
+      assertTrue(annotationHolder.hasAnnotations());
+      assertEquals(1, annotationHolder.size());
+
+      final Annotation annotation = annotationHolder.get(0);
+      assertEquals(HighlightSeverity.INFORMATION, annotation.getSeverity());
+    });
+  }
+
+  @Test
+  public void locatesRBOColor() throws Exception {
+    run(() -> {
+      final PsiElement testIdentifier = setUpDartElement("main() { Colors.fromRGBO(255, 255, 0, 1.0); }", "Colors.fromRGBO", LeafPsiElement.class);
+      final DartNewExpression element = DartSyntax.findEnclosingNewExpression(testIdentifier);
+      assert element != null;
+
+      final FlutterEditorAnnotator annotator = new FlutterEditorAnnotator();
+      final AnnotationSession annotationSession = new AnnotationSession(testIdentifier.getContainingFile());
+      final AnnotationHolderImpl annotationHolder = new AnnotationHolderImpl(annotationSession);
+
+      annotator.annotate(element, annotationHolder);
+
+      assertTrue(annotationHolder.hasAnnotations());
+      assertEquals(1, annotationHolder.size());
+
+      final Annotation annotation = annotationHolder.get(0);
+      assertEquals(HighlightSeverity.INFORMATION, annotation.getSeverity());
+    });
+  }
 }

--- a/testSrc/unit/io/flutter/editor/FlutterEditorAnnotatorTest.java
+++ b/testSrc/unit/io/flutter/editor/FlutterEditorAnnotatorTest.java
@@ -195,7 +195,7 @@ public class FlutterEditorAnnotatorTest extends AbstractDartElementTest {
   @Test
   public void locatesConstARGBColor() throws Exception {
     run(() -> {
-      final PsiElement testIdentifier = setUpDartElement("main() { const Colors.fromARGB(255, 255, 0,0); }", "main", LeafPsiElement.class);
+      final PsiElement testIdentifier = setUpDartElement("main() { const Color.fromARGB(255, 255, 0, 0); }", "Color", LeafPsiElement.class);
       final DartNewExpression element = DartSyntax.findEnclosingNewExpression(testIdentifier);
       assert element != null;
 
@@ -216,8 +216,8 @@ public class FlutterEditorAnnotatorTest extends AbstractDartElementTest {
   @Test
   public void locatesARGBColor() throws Exception {
     run(() -> {
-      final PsiElement testIdentifier = setUpDartElement("main() { Colors.fromARGB(255, 255, 0,0); }", "main", LeafPsiElement.class);
-      final DartNewExpression element = DartSyntax.findEnclosingNewExpression(testIdentifier);
+      final PsiElement testIdentifier = setUpDartElement("main() { Color.fromARGB(255, 255, 0, 0); }", "Color", LeafPsiElement.class);
+      final DartCallExpression element = DartSyntax.findEnclosingFunctionCall(testIdentifier, "Color.fromARGB");
       assert element != null;
 
       final FlutterEditorAnnotator annotator = new FlutterEditorAnnotator();
@@ -237,7 +237,7 @@ public class FlutterEditorAnnotatorTest extends AbstractDartElementTest {
   @Test
   public void locatesConstRGBOColor() throws Exception {
     run(() -> {
-      final PsiElement testIdentifier = setUpDartElement("main() { const Colors.fromRGBO(255,0,0,1.0); }", "main", LeafPsiElement.class);
+      final PsiElement testIdentifier = setUpDartElement("main() { const Color.fromRGBO(255, 0, 0, 1.0); }", "Color", LeafPsiElement.class);
       final DartNewExpression element = DartSyntax.findEnclosingNewExpression(testIdentifier);
       assert element != null;
 
@@ -258,8 +258,8 @@ public class FlutterEditorAnnotatorTest extends AbstractDartElementTest {
   @Test
   public void locatesRGBOColor() throws Exception {
     run(() -> {
-      final PsiElement testIdentifier = setUpDartElement("main() { Colors.fromRGBO(255, 255, 0, 1.0); }", "main", LeafPsiElement.class);
-      final DartNewExpression element = DartSyntax.findEnclosingNewExpression(testIdentifier);
+      final PsiElement testIdentifier = setUpDartElement("main() { Color.fromRGBO(255, 255, 0, 1.0); }", "Color", LeafPsiElement.class);
+      final DartCallExpression element = DartSyntax.findEnclosingFunctionCall(testIdentifier, "Color.fromRGBO");
       assert element != null;
 
       final FlutterEditorAnnotator annotator = new FlutterEditorAnnotator();


### PR DESCRIPTION
##  Goal
The goal of this pull request is to resolve the issue displaying color icons in IntelliJ Idea and Android studio for `Colors.fromARGB` and `Colors.fromRGBO` functions.

## Changes
Added annotation support for `const Color.fromARGB`, `Color.fromARGB`, `const Color.fromRGBO`, `Color.fromRBGO`
Added helper functions to `ExpressionParsingUtils.java` to parse color components and create corresponding Color
Added unit tests

## Fixes
https://github.com/flutter/flutter-intellij/issues/3347