### PR TITLE
Use daemon API to get devtools host and port for internal use

### DIFF
--- a/src/io/flutter/devtools/DevToolsManager.java
+++ b/src/io/flutter/devtools/DevToolsManager.java
@@ -264,7 +264,7 @@ public class DevToolsManager {
         final Optional<FlutterApp> first =
           FlutterApp.allFromProjectProcess(project).stream().filter((FlutterApp app) -> app.getProject() == project).findFirst();
 
-        if (first.isEmpty()) {
+        if (!first.isPresent()) {
           return;
         }
 

--- a/src/io/flutter/devtools/DevToolsManager.java
+++ b/src/io/flutter/devtools/DevToolsManager.java
@@ -274,8 +274,8 @@ public class DevToolsManager {
         FlutterApp app = first.get();
 
         app.serveDevTools().thenAccept((DaemonApi.DevToolsAddress address) -> {
-          if (!app.isConnected() || !project.isOpen()) {
-            // We can skip opening DevTools if the app has been disconnected or the project has been closed.
+          if (!project.isOpen()) {
+            // We should skip starting DevTools (and doing any UI work) if the project has been closed.
             return;
           }
           if (address == null) {

--- a/src/io/flutter/devtools/DevToolsManager.java
+++ b/src/io/flutter/devtools/DevToolsManager.java
@@ -260,6 +260,8 @@ public class DevToolsManager {
       devToolsInstance.openBrowserAndConnect(uri, screen);
     }
     else {
+      // For internal users, we can connect to the DevTools server started by flutter daemon. For external users, the flutter daemon has an
+      // older version of DevTools, so we launch the server using `pub global run` instead.
       if (isBazel(project)) {
         final Optional<FlutterApp> first =
           FlutterApp.allFromProjectProcess(project).stream().filter((FlutterApp app) -> app.getProject() == project).findFirst();

--- a/src/io/flutter/devtools/DevToolsManager.java
+++ b/src/io/flutter/devtools/DevToolsManager.java
@@ -9,8 +9,6 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.gson.JsonSyntaxException;
-import com.intellij.execution.ExecutionException;
-import com.intellij.execution.configurations.GeneralCommandLine;
 import com.intellij.execution.process.OSProcessHandler;
 import com.intellij.execution.process.ProcessAdapter;
 import com.intellij.execution.process.ProcessEvent;
@@ -27,11 +25,8 @@ import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.progress.Task;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Key;
-import com.intellij.openapi.util.io.FileUtil;
-import com.intellij.openapi.vfs.CharsetToolkit;
 import com.intellij.ui.content.ContentManager;
 import io.flutter.FlutterMessages;
-import io.flutter.FlutterUtils;
 import io.flutter.bazel.Workspace;
 import io.flutter.bazel.WorkspaceCache;
 import io.flutter.console.FlutterConsoles;
@@ -40,7 +35,6 @@ import io.flutter.run.daemon.FlutterApp;
 import io.flutter.sdk.FlutterCommand;
 import io.flutter.sdk.FlutterSdk;
 import io.flutter.utils.JsonUtils;
-import io.flutter.utils.MostlySilentOsProcessHandler;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -201,19 +195,13 @@ public class DevToolsManager {
       return null;
     }
 
-    final GeneralCommandLine commandLine = new GeneralCommandLine().withWorkDirectory(workspace.getRoot().getPath());
-    commandLine.setExePath(FileUtil.toSystemDependentName(workspace.getRoot().getPath() + "/" + workspace.getLaunchScript()));
-    commandLine.setCharset(CharsetToolkit.UTF8_CHARSET);
-    commandLine.addParameters(workspace.getDevtoolsScript(), "--", "--machine", "--port=0");
-    OSProcessHandler handler;
+    final FlutterApp flutterApp = FlutterApp.firstFromProjectProcess(project);
 
-    try {
-      handler = new MostlySilentOsProcessHandler(commandLine);
+    if (flutterApp == null) {
+      return null;
     }
-    catch (ExecutionException e) {
-      FlutterUtils.warn(LOG, e);
-      handler = null;
-    }
+    final OSProcessHandler handler = (OSProcessHandler)flutterApp.getProcessHandler();
+    flutterApp.serveDevTools();
 
     if (handler != null) {
       FlutterConsoles.displayProcessLater(handler, project, null, handler::startNotify);
@@ -310,6 +298,7 @@ class DevToolsInstance {
       @Override
       public void onTextAvailable(@NotNull ProcessEvent event, @NotNull Key outputType) {
         final String text = event.getText().trim();
+        System.out.println(text);
 
         if (text.startsWith("{") && text.endsWith("}")) {
           // {"event":"server.started","params":{"host":"127.0.0.1","port":9100}}

--- a/src/io/flutter/run/daemon/DaemonApi.java
+++ b/src/io/flutter/run/daemon/DaemonApi.java
@@ -80,6 +80,10 @@ public class DaemonApi {
     return send("app.stop", new AppStop(appId));
   }
 
+  CompletableFuture<List<String>> devToolsServe() {
+    return send("devtools.serve", new DevToolsServe());
+  }
+
   CompletableFuture<Boolean> detachApp(@NotNull String appId) {
     return send("app.detach", new AppDetach(appId));
   }
@@ -463,6 +467,33 @@ public class DaemonApi {
 
     @Override
     List<String> parseResult(JsonElement result) {
+      // {"platforms":["ios","android"]}
+
+      if (!(result instanceof JsonObject)) {
+        return Collections.emptyList();
+      }
+
+      final JsonElement obj = ((JsonObject)result).get("platforms");
+      if (!(obj instanceof JsonArray)) {
+        return Collections.emptyList();
+      }
+
+      final List<String> platforms = new ArrayList<>();
+
+      for (int i = 0; i < ((JsonArray)obj).size(); i++) {
+        final JsonElement element = ((JsonArray)obj).get(i);
+        platforms.add(element.getAsString());
+      }
+
+      return platforms;
+    }
+  }
+
+  private static class DevToolsServe extends Params<List<String>> {
+    @Override
+    List<String> parseResult(JsonElement result) {
+      // There should be no result here, just skip adding this class and send empty params?
+      System.out.println(result);
       // {"platforms":["ios","android"]}
 
       if (!(result instanceof JsonObject)) {

--- a/src/io/flutter/run/daemon/DaemonApi.java
+++ b/src/io/flutter/run/daemon/DaemonApi.java
@@ -13,7 +13,6 @@ import com.intellij.execution.process.ProcessHandler;
 import com.intellij.execution.process.ProcessOutputTypes;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.util.Key;
-import com.intellij.openapi.util.Pair;
 import io.flutter.FlutterUtils;
 import io.flutter.settings.FlutterSettings;
 import io.flutter.utils.StdoutJsonParser;
@@ -81,7 +80,7 @@ public class DaemonApi {
     return send("app.stop", new AppStop(appId));
   }
 
-  CompletableFuture<Pair<String, Integer>> devToolsServe() {
+  CompletableFuture<DevToolsAddress> devToolsServe() {
     return send("devtools.serve", new DevToolsServe());
   }
 
@@ -490,9 +489,20 @@ public class DaemonApi {
     }
   }
 
-  private static class DevToolsServe extends Params<Pair<String, Integer>> {
+  public static class DevToolsAddress {
+    public String host;
+    public int port;
+
+    public DevToolsAddress(String host, int port) {
+      this.host = host;
+      this.port = port;
+    }
+  }
+
+
+  private static class DevToolsServe extends Params<DevToolsAddress> {
     @Override
-    Pair<String, Integer> parseResult(JsonElement result) {
+    DevToolsAddress parseResult(JsonElement result) {
       if (!(result instanceof JsonObject)) {
         return null;
       }
@@ -503,7 +513,7 @@ public class DaemonApi {
         return null;
       }
 
-      return Pair.create(host, port);
+      return new DevToolsAddress(host, port);
     }
   }
 }

--- a/src/io/flutter/run/daemon/DaemonApi.java
+++ b/src/io/flutter/run/daemon/DaemonApi.java
@@ -493,10 +493,6 @@ public class DaemonApi {
   private static class DevToolsServe extends Params<Pair<String, Integer>> {
     @Override
     Pair<String, Integer> parseResult(JsonElement result) {
-      // There should be no result here, just skip adding this class and send empty params?
-      System.out.println(result);
-      // {"platforms":["ios","android"]}
-
       if (!(result instanceof JsonObject)) {
         return null;
       }

--- a/src/io/flutter/run/daemon/FlutterApp.java
+++ b/src/io/flutter/run/daemon/FlutterApp.java
@@ -24,7 +24,6 @@ import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Disposer;
 import com.intellij.openapi.util.Key;
-import com.intellij.openapi.util.Pair;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.util.EventDispatcher;
@@ -455,7 +454,7 @@ public class FlutterApp implements Disposable {
     return future;
   }
 
-  public CompletableFuture<Pair<String, Integer>> serveDevTools() {
+  public CompletableFuture<DaemonApi.DevToolsAddress> serveDevTools() {
     return myDaemonApi.devToolsServe();
   }
 

--- a/src/io/flutter/run/daemon/FlutterApp.java
+++ b/src/io/flutter/run/daemon/FlutterApp.java
@@ -454,6 +454,10 @@ public class FlutterApp implements Disposable {
     return future;
   }
 
+  public CompletableFuture<List<String>> serveDevTools() {
+    return myDaemonApi.devToolsServe();
+  }
+
   public CompletableFuture<String> togglePlatform() {
     if (myAppId == null) {
       FlutterUtils.warn(LOG, "cannot invoke togglePlatform on Flutter app because app id is not set");

--- a/src/io/flutter/run/daemon/FlutterApp.java
+++ b/src/io/flutter/run/daemon/FlutterApp.java
@@ -24,6 +24,7 @@ import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Disposer;
 import com.intellij.openapi.util.Key;
+import com.intellij.openapi.util.Pair;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.util.EventDispatcher;
@@ -454,7 +455,7 @@ public class FlutterApp implements Disposable {
     return future;
   }
 
-  public CompletableFuture<List<String>> serveDevTools() {
+  public CompletableFuture<Pair<String, Integer>> serveDevTools() {
     return myDaemonApi.devToolsServe();
   }
 


### PR DESCRIPTION
Instead of building and serving devtools independently, we want to make a request to flutter daemon to start serving devtools which should already be built.

This change requires https://github.com/flutter/flutter/pull/62702 to be merged internally.