### PR TITLE
Check for BUILD file for bazel projects only

### DIFF
--- a/src/io/flutter/run/MainFile.java
+++ b/src/io/flutter/run/MainFile.java
@@ -20,6 +20,7 @@ import com.jetbrains.lang.dart.psi.DartFile;
 import com.jetbrains.lang.dart.psi.DartImportStatement;
 import com.jetbrains.lang.dart.util.DartResolveUtil;
 import io.flutter.FlutterBundle;
+import io.flutter.bazel.WorkspaceCache;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -120,14 +121,17 @@ public class MainFile {
   @Nullable
   private static VirtualFile findAppDir(@Nullable VirtualFile file, @NotNull Project project) {
     for (VirtualFile candidate = file; inProject(candidate, project); candidate = candidate.getParent()) {
-      if (isAppDir(candidate)) return candidate;
+      if (isAppDir(candidate, project)) return candidate;
     }
     return null;
   }
 
-  private static boolean isAppDir(@NotNull VirtualFile dir) {
+  private static boolean isAppDir(@NotNull VirtualFile dir, @NotNull Project project) {
     return dir.isDirectory() && (
-      dir.findChild("pubspec.yaml") != null || dir.findChild(".packages") != null);
+      dir.findChild("pubspec.yaml") != null ||
+      (WorkspaceCache.getInstance(project).isBazel() && dir.findChild("BUILD") != null) ||
+      dir.findChild(".packages") != null
+    );
   }
 
   private static boolean inProject(@Nullable VirtualFile file, @NotNull Project project) {

--- a/src/io/flutter/run/MainFile.java
+++ b/src/io/flutter/run/MainFile.java
@@ -122,19 +122,19 @@ public class MainFile {
   @Nullable
   private static VirtualFile findAppDir(@Nullable VirtualFile file, @NotNull Project project) {
     if (WorkspaceCache.getInstance(project).isBazel()) {
-      Workspace workspace = WorkspaceCache.getInstance(project).get();
-      if (workspace != null) {
-        return workspace.getRoot();
-      }
+      final Workspace workspace = WorkspaceCache.getInstance(project).get();
+      assert(workspace != null);
+      return workspace.getRoot();
     }
 
     for (VirtualFile candidate = file; inProject(candidate, project); candidate = candidate.getParent()) {
-      if (isAppDir(candidate)) return candidate;
+      if (isAppDir(candidate, project)) return candidate;
     }
     return null;
   }
 
-  private static boolean isAppDir(@NotNull VirtualFile dir) {
+  private static boolean isAppDir(@NotNull VirtualFile dir, @NotNull Project project) {
+    assert(!WorkspaceCache.getInstance(project).isBazel());
     return dir.isDirectory() && (
       dir.findChild("pubspec.yaml") != null ||
       dir.findChild(".packages") != null

--- a/src/io/flutter/run/MainFile.java
+++ b/src/io/flutter/run/MainFile.java
@@ -20,6 +20,7 @@ import com.jetbrains.lang.dart.psi.DartFile;
 import com.jetbrains.lang.dart.psi.DartImportStatement;
 import com.jetbrains.lang.dart.util.DartResolveUtil;
 import io.flutter.FlutterBundle;
+import io.flutter.bazel.Workspace;
 import io.flutter.bazel.WorkspaceCache;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -120,16 +121,22 @@ public class MainFile {
 
   @Nullable
   private static VirtualFile findAppDir(@Nullable VirtualFile file, @NotNull Project project) {
+    if (WorkspaceCache.getInstance(project).isBazel()) {
+      Workspace workspace = WorkspaceCache.getInstance(project).get();
+      if (workspace != null) {
+        return workspace.getRoot();
+      }
+    }
+
     for (VirtualFile candidate = file; inProject(candidate, project); candidate = candidate.getParent()) {
-      if (isAppDir(candidate, project)) return candidate;
+      if (isAppDir(candidate)) return candidate;
     }
     return null;
   }
 
-  private static boolean isAppDir(@NotNull VirtualFile dir, @NotNull Project project) {
+  private static boolean isAppDir(@NotNull VirtualFile dir) {
     return dir.isDirectory() && (
       dir.findChild("pubspec.yaml") != null ||
-      (WorkspaceCache.getInstance(project).isBazel() && dir.findChild("BUILD") != null) ||
       dir.findChild(".packages") != null
     );
   }


### PR DESCRIPTION
We removed a check for BUILD to fix https://github.com/flutter/flutter-intellij/issues/4692 but this caused problems for internal projects.