### PR TITLE
Fix version headings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-#48.0
+# 48.0
 - Show notification for when devtools build is slow (#4728)
 - Use the new, generated metadata from flutter/tools_metadata (#4724)
 - Remove the framework metadata generation code from this repo (#4721)
@@ -17,7 +17,7 @@
 - Split icon generation into two scripts + use single set of downloaded files (#4671)
 - Update build script (#4674)
 
-#47.1
+# 47.1
 - Revert "Start paused during run mode (#4622)" (#4673)
 - Add target to registerComponents() (#4672)
 

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -29,7 +29,8 @@
 
   <change-notes>
     <![CDATA[
-#48.0<ul>
+<h1>48.0</h1>
+<ul>
   <li>Show notification for when devtools build is slow (#4728)</li>
   <li>Use the new, generated metadata from flutter/tools_metadata (#4724)</li>
   <li>Remove the framework metadata generation code from this repo (#4721)</li>
@@ -47,7 +48,9 @@
   <li>Simplify regex and sort colors (#4687)</li>
   <li>Split icon generation into two scripts + use single set of downloaded files (#4671)</li>
   <li>Update build script (#4674)</li>
-</ul>#47.1<ul>
+</ul>
+<h1>47.1</h1>
+<ul>
   <li>Revert "Start paused during run mode (#4622)" (#4673)</li>
   <li>Add target to registerComponents() (#4672)</li>
 </ul>


### PR DESCRIPTION
I just noticed that the last two versions weren't bold on the IntelliJ plugin web site, assuming this was not intentional.