### PR TITLE
Fix Android Studio canary build

### DIFF
--- a/flutter-studio/src/io/flutter/module/FlutterDescriptionProvider.java
+++ b/flutter-studio/src/io/flutter/module/FlutterDescriptionProvider.java
@@ -83,7 +83,7 @@ public class FlutterDescriptionProvider implements ModuleDescriptionProvider {
     // Using an optional value because the model cannot be created until after the gallery entry is initialized.
     private OptionalValueProperty<FlutterProjectModel> mySharedModel;
 
-    private FlutterGalleryEntry(@NotNull OptionalValueProperty<FlutterProjectModel> sharedModel) {
+    protected FlutterGalleryEntry(@NotNull OptionalValueProperty<FlutterProjectModel> sharedModel) {
       mySharedModel = sharedModel;
     }
 

--- a/flutter-studio/src/io/flutter/project/FlutterProjectStep.java
+++ b/flutter-studio/src/io/flutter/project/FlutterProjectStep.java
@@ -5,6 +5,9 @@
  */
 package io.flutter.project;
 
+import static javax.swing.ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER;
+import static javax.swing.ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED;
+
 import com.android.tools.adtui.util.FormScalingUtil;
 import com.android.tools.adtui.validation.Validator;
 import com.android.tools.adtui.validation.ValidatorPanel;
@@ -19,7 +22,7 @@ import com.android.tools.idea.observable.ui.SelectedItemProperty;
 import com.android.tools.idea.observable.ui.SelectedProperty;
 import com.android.tools.idea.observable.ui.TextProperty;
 import com.android.tools.idea.ui.validation.validators.PathValidator;
-import com.android.tools.idea.ui.wizard.StudioWizardStepPanel;
+import com.android.tools.idea.ui.wizard.deprecated.StudioWizardStepPanel;
 import com.android.tools.idea.ui.wizard.WizardUtils;
 import com.android.tools.idea.wizard.model.ModelWizard;
 import com.android.tools.idea.wizard.model.ModelWizardStep;
@@ -57,6 +60,7 @@ import java.awt.event.MouseEvent;
 import java.io.File;
 import java.util.Collection;
 import java.util.List;
+import javax.swing.BorderFactory;
 import javax.swing.DefaultComboBoxModel;
 import javax.swing.Icon;
 import javax.swing.JComboBox;
@@ -105,7 +109,7 @@ public class FlutterProjectStep extends SkippableWizardStep<FlutterProjectModel>
     myProjectType = new OptionalValueProperty<>(type);
     myValidatorPanel = new ValidatorPanel(this, myPanel);
     myInstallSdkAction = new InstallSdkAction(this);
-    myRootPanel = StudioWizardStepPanel.wrappedWithVScroll(myValidatorPanel);
+    myRootPanel = wrappedWithVScroll(myValidatorPanel);
     FormScalingUtil.scaleComponentTree(this.getClass(), myRootPanel);
   }
 
@@ -451,4 +455,15 @@ public class FlutterProjectStep extends SkippableWizardStep<FlutterProjectModel>
     comboBox.setSelectedItem(currentItem); // to set focus on current item in combo popup
     comboBox.getEditor().setItem(currentItem); // to set current item in combo itself
   }
+  /**
+   * When creating a StudioWizardStepPanel which may be so tall as to require vertical scrolling,
+   * using this helper method to automatically wrap it with an appropriate JScrollPane.
+   */
+  @NotNull
+  public static JBScrollPane wrappedWithVScroll(@NotNull JPanel innerPanel) {
+    JBScrollPane sp = new JBScrollPane(new StudioWizardStepPanel(innerPanel), VERTICAL_SCROLLBAR_AS_NEEDED, HORIZONTAL_SCROLLBAR_NEVER);
+    sp.setBorder(BorderFactory.createEmptyBorder());
+    return sp;
+  }
+
 }

--- a/flutter-studio/src/io/flutter/project/FlutterSettingsStep.java
+++ b/flutter-studio/src/io/flutter/project/FlutterSettingsStep.java
@@ -5,6 +5,8 @@
  */
 package io.flutter.project;
 
+import static io.flutter.project.FlutterProjectStep.wrappedWithVScroll;
+
 import com.android.tools.adtui.util.FormScalingUtil;
 import com.android.tools.adtui.validation.ValidatorPanel;
 import com.android.tools.idea.observable.BindingsManager;
@@ -15,7 +17,6 @@ import com.android.tools.idea.observable.core.ObservableBool;
 import com.android.tools.idea.observable.expressions.Expression;
 import com.android.tools.idea.observable.ui.SelectedProperty;
 import com.android.tools.idea.observable.ui.TextProperty;
-import com.android.tools.idea.ui.wizard.StudioWizardStepPanel;
 import com.android.tools.idea.wizard.model.ModelWizard;
 import com.android.tools.idea.wizard.model.ModelWizardStep;
 import com.intellij.openapi.project.Project;
@@ -66,7 +67,7 @@ public class FlutterSettingsStep extends ModelWizardStep<FlutterProjectModel> {
   public FlutterSettingsStep(FlutterProjectModel model, String title, Icon icon) {
     super(model, title, icon);
     myValidatorPanel = new ValidatorPanel(this, myRootPanel);
-    myRoot = StudioWizardStepPanel.wrappedWithVScroll(myRootPanel);
+    myRoot = wrappedWithVScroll(myRootPanel);
     FormScalingUtil.scaleComponentTree(this.getClass(), myRoot);
   }
 

--- a/flutter-studio/testSrc/com/android/tools/idea/tests/gui/framework/fixture/MacMenuFixture.java
+++ b/flutter-studio/testSrc/com/android/tools/idea/tests/gui/framework/fixture/MacMenuFixture.java
@@ -25,6 +25,7 @@ import org.fest.swing.timing.Wait;
 import org.jetbrains.annotations.NotNull;
 
 // Use the MenuItemFixture from fest to control Mac menus.
+// This is currently unused. If menus work properly now this class should be deleted.
 public class MacMenuFixture extends MenuFixture {
 
   @NotNull private final Robot myRobot;
@@ -41,7 +42,6 @@ public class MacMenuFixture extends MenuFixture {
    *
    * @param path the series of menu names, e.g. {@link invokeActionByMenuPath("Build", "Make Project ")}
    */
-  @Override
   void invokeMenuPath(@NotNull String... path) {
     JMenuItem menuItem = findActionMenuItem(path);
     assertWithMessage("Menu path \"" + Joiner.on(" -> ").join(path) + "\" is not enabled").that(menuItem.isEnabled()).isTrue();


### PR DESCRIPTION
You can mostly ignore `IdeaFrameFixture.java `. See its class comment for instructions to produce a new version of it.

The new method in `FlutterProjectStep` was copied from an old version of `StudioWizardStepPanel`, which has been deleted in Android Studio. I'm in the process of re-implementing these classes; this is part of the new project wizard.

Once this is merged the next dev channel build will work for canary again.

Tested by building a new plugin, installing it into canary 7, then creating a Flutter app.
