### PR TITLE
Avoid start-paused for directory scope tests

### DIFF
--- a/src/io/flutter/run/test/TestFields.java
+++ b/src/io/flutter/run/test/TestFields.java
@@ -236,7 +236,7 @@ public class TestFields {
       throw new ExecutionException("Test file isn't within a Flutter pub root");
     }
 
-    return sdk.flutterTest(root, fileOrDir, testName, mode).startProcess(project);
+    return sdk.flutterTest(root, fileOrDir, testName, mode, getScope()).startProcess(project);
   }
 
   private void checkSdk(@NotNull Project project) throws RuntimeConfigurationError {

--- a/src/io/flutter/sdk/FlutterSdk.java
+++ b/src/io/flutter/sdk/FlutterSdk.java
@@ -29,6 +29,7 @@ import io.flutter.pub.PubRoot;
 import io.flutter.run.FlutterDevice;
 import io.flutter.run.FlutterLaunchMode;
 import io.flutter.run.common.RunMode;
+import io.flutter.run.test.TestFields;
 import io.flutter.settings.FlutterSettings;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -309,7 +310,7 @@ public class FlutterSdk {
   }
 
   public FlutterCommand flutterTest(@NotNull PubRoot root, @NotNull VirtualFile fileOrDir, @Nullable String testNameSubstring,
-                                    @NotNull RunMode mode) {
+                                    @NotNull RunMode mode, TestFields.Scope scope) {
 
     final List<String> args = new ArrayList<>();
     if (myVersion.flutterTestSupportsMachineMode()) {
@@ -321,7 +322,7 @@ public class FlutterSdk {
         throw new IllegalStateException("Flutter SDK is too old to debug tests");
       }
     }
-    if (mode == RunMode.DEBUG || mode == RunMode.RUN) {
+    if (mode == RunMode.DEBUG || (mode == RunMode.RUN && !scope.equals(TestFields.Scope.DIRECTORY))) {
       args.add("--start-paused");
     }
     if (FlutterSettings.getInstance().isVerboseLogging()) {

--- a/src/io/flutter/sdk/FlutterSdk.java
+++ b/src/io/flutter/sdk/FlutterSdk.java
@@ -322,6 +322,8 @@ public class FlutterSdk {
         throw new IllegalStateException("Flutter SDK is too old to debug tests");
       }
     }
+    // Starting the app paused so the IDE can catch early errors is ideal. However, we don't have a way to resume for multiple test files
+    // yet, so we want to exclude directory scope tests from starting paused. See https://github.com/flutter/flutter-intellij/issues/4737.
     if (mode == RunMode.DEBUG || (mode == RunMode.RUN && !scope.equals(TestFields.Scope.DIRECTORY))) {
       args.add("--start-paused");
     }


### PR DESCRIPTION
This fixes https://github.com/flutter/flutter-intellij/issues/4737 temporarily.

We previously tried starting all tests with `--start-paused` for structured errors, but this causes directory scope tests to hang because we need to connect to multiple observatory URIs sequentially to run each contained test (and this isn't implemented yet).