### PR TITLE
Show run console and skip breakpoints during test run

### DIFF
--- a/src/io/flutter/run/test/FlutterTestRunner.java
+++ b/src/io/flutter/run/test/FlutterTestRunner.java
@@ -14,10 +14,13 @@ import com.intellij.execution.executors.DefaultDebugExecutor;
 import com.intellij.execution.process.*;
 import com.intellij.execution.runners.ExecutionEnvironment;
 import com.intellij.execution.runners.GenericProgramRunner;
+import com.intellij.execution.runners.RunContentBuilder;
 import com.intellij.execution.ui.RunContentDescriptor;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.util.Key;
 import com.intellij.openapi.wm.ToolWindowId;
+import com.intellij.util.TimeoutUtil;
 import com.intellij.xdebugger.XDebugProcess;
 import com.intellij.xdebugger.XDebugProcessStarter;
 import com.intellij.xdebugger.XDebugSession;
@@ -30,8 +33,14 @@ import io.flutter.run.common.CommonTestConfigUtils;
 import io.flutter.sdk.FlutterSdk;
 import io.flutter.settings.FlutterSettings;
 import io.flutter.utils.StdoutJsonParser;
+import org.dartlang.vm.service.VmService;
+import org.dartlang.vm.service.consumer.SuccessConsumer;
+import org.dartlang.vm.service.consumer.VMConsumer;
+import org.dartlang.vm.service.element.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.io.IOException;
 
 /**
  * Runs a Flutter test configuration in the debugger.
@@ -62,8 +71,63 @@ public class FlutterTestRunner extends GenericProgramRunner {
   @Override
   protected RunContentDescriptor doExecute(@NotNull RunProfileState state, @NotNull ExecutionEnvironment env)
     throws ExecutionException {
-    return runInDebugger((TestLaunchState)state, env);
+    if (env.getExecutor().getId().equals(ToolWindowId.RUN)) {
+      return run((TestLaunchState)state, env);
+    } else {
+      return runInDebugger((TestLaunchState)state, env);
+    }
   }
+
+  protected RunContentDescriptor run(@NotNull TestLaunchState launcher, @NotNull ExecutionEnvironment env)
+    throws ExecutionException {
+    final ExecutionResult executionResult = launcher.execute(env.getExecutor(), this);
+    final ObservatoryConnector connector = new Connector(executionResult.getProcessHandler());
+
+    ApplicationManager.getApplication().executeOnPooledThread(() -> {
+      // Poll, waiting for "flutter run" to give us a websocket.
+      // This is adapted from DartVmServiceDebugProcess::scheduleConnect
+      String url = connector.getWebSocketUrl();
+
+      while (url == null) {
+        TimeoutUtil.sleep(100);
+        url = connector.getWebSocketUrl();
+      }
+
+      final VmService vmService;
+      try {
+        vmService = VmService.connect(url);
+        vmService.getVM(new VMConsumer() {
+          @Override
+          public void received(VM response) {
+            final ElementList<IsolateRef> isolates = response.getIsolates();
+
+            for (IsolateRef isolateRef : isolates) {
+              vmService.resume(isolateRef.getId(), new SuccessConsumer() {
+                @Override
+                public void received(Success response) {}
+
+                @Override
+                public void onError(RPCError error) {
+                  LOG.error(error);
+                }
+              });
+            }
+          }
+
+          @Override
+          public void onError(RPCError error) {
+            LOG.error(error);
+          }
+        });
+      }
+      catch (IOException | RuntimeException e) {
+        LOG.error("Failed to connect to the VM observatory service at: " + url + "\n"
+                  + e.toString());
+      }
+    });
+
+  return new RunContentBuilder(executionResult, env).showRunContent(env.getContentToReuse());
+}
 
   protected RunContentDescriptor runInDebugger(@NotNull TestLaunchState launcher, @NotNull ExecutionEnvironment env)
     throws ExecutionException {

--- a/src/io/flutter/run/test/FlutterTestRunner.java
+++ b/src/io/flutter/run/test/FlutterTestRunner.java
@@ -93,9 +93,9 @@ public class FlutterTestRunner extends GenericProgramRunner {
         url = connector.getWebSocketUrl();
       }
 
-      final VmService vmService;
       try {
-        vmService = VmService.connect(url);
+        // We want to resume any isolates paused at start.
+        final VmService vmService = VmService.connect(url);
         vmService.getVM(new VMConsumer() {
           @Override
           public void received(VM response) {

--- a/src/io/flutter/run/test/FlutterTestRunner.java
+++ b/src/io/flutter/run/test/FlutterTestRunner.java
@@ -89,9 +89,12 @@ public class FlutterTestRunner extends GenericProgramRunner {
       String url = connector.getWebSocketUrl();
 
       while (url == null) {
+        if (launcher.isTerminated()) return;
         TimeoutUtil.sleep(100);
         url = connector.getWebSocketUrl();
       }
+
+      if (launcher.isTerminated()) return;
 
       try {
         // We want to resume any isolates paused at start.

--- a/src/io/flutter/run/test/FlutterTestRunner.java
+++ b/src/io/flutter/run/test/FlutterTestRunner.java
@@ -85,7 +85,7 @@ public class FlutterTestRunner extends GenericProgramRunner {
 
     ApplicationManager.getApplication().executeOnPooledThread(() -> {
       // Poll, waiting for "flutter run" to give us a websocket.
-      // This is adapted from DartVmServiceDebugProcess::scheduleConnect
+      // This is adapted from DartVmServiceDebugProcess::scheduleConnect.
       String url = connector.getWebSocketUrl();
 
       while (url == null) {

--- a/src/io/flutter/run/test/TestLaunchState.java
+++ b/src/io/flutter/run/test/TestLaunchState.java
@@ -51,6 +51,8 @@ class TestLaunchState extends CommandLineState {
 
   private final boolean testConsoleEnabled;
 
+  private ProcessHandler processHandler;
+
   private TestLaunchState(@NotNull ExecutionEnvironment env, @NotNull TestConfig config, @NotNull VirtualFile testFileOrDir,
                           @NotNull PubRoot pubRoot, boolean testConsoleEnabled) {
     super(env);
@@ -94,6 +96,7 @@ class TestLaunchState extends CommandLineState {
     switch (result.status) {
       case OK:
         assert result.processHandler != null;
+        processHandler = result.processHandler;
         return result.processHandler;
       case EXCEPTION:
         assert result.exception != null;
@@ -145,5 +148,9 @@ class TestLaunchState extends CommandLineState {
   @NotNull
   PubRoot getPubRoot() {
     return pubRoot;
+  }
+
+  public boolean isTerminated() {
+    return processHandler != null && processHandler.isProcessTerminated();
   }
 }


### PR DESCRIPTION
I had previously changed test runs to start paused and to use the FlutterTestRunner instead of the default runner so that we could resume once the IDE was listening for vm service messages. However, the FlutterTestRunner was set up for debugging and this caused test runs to show the debugging console and recognize breakpoints. This change skips the debugging setup for run mode tests.

![Screen Shot 2020-08-07 at 9 49 20 AM](https://user-images.githubusercontent.com/6379305/89669190-db582300-d893-11ea-8316-c0990f9b2075.png)

To check that process termination works correctly (so we don't keep waiting for the observatory URI if the user has stopped the test run), I ran with a debugging statement in the waiting loop and verified that the execution gives up if the run is stopped before the tests run:
```
      while (url == null) {
        if (launcher.isTerminated()) return;
        System.out.println("Waiting");
        TimeoutUtil.sleep(1000);
        url = connector.getWebSocketUrl();
      }
```