### PR TITLE
Skip start-paused for web server in run mode

### DIFF
--- a/src/io/flutter/sdk/FlutterSdk.java
+++ b/src/io/flutter/sdk/FlutterSdk.java
@@ -245,7 +245,8 @@ public class FlutterSdk {
       args.add("--device-id=" + device.deviceId());
     }
 
-    if (mode == RunMode.DEBUG || mode == RunMode.RUN) {
+    // The web-server 'device' does not provide structured errors in run mode and we don't get a debug URI to connect to and resume.
+    if (mode == RunMode.DEBUG || (mode == RunMode.RUN && !device.deviceId().equals("web-server"))) {
       args.add("--start-paused");
     }
 

--- a/src/io/flutter/sdk/FlutterSdk.java
+++ b/src/io/flutter/sdk/FlutterSdk.java
@@ -245,7 +245,8 @@ public class FlutterSdk {
       args.add("--device-id=" + device.deviceId());
     }
 
-    // The web-server 'device' does not provide structured errors in run mode and we don't get a debug URI to connect to and resume.
+    // TODO (helin24): Remove special handling for web-server if we can fix https://github.com/flutter/flutter-intellij/issues/4767.
+    // Currently we can't connect to the VM service for the web-server 'device' to resume.
     if (mode == RunMode.DEBUG || (mode == RunMode.RUN && !device.deviceId().equals("web-server"))) {
       args.add("--start-paused");
     }


### PR DESCRIPTION
I was initially thinking that I could make a change to flutter_tools to enable resuming on Chrome for our web-server device mode, but since run mode for web server doesn't show structured errors anyway, it makes more sense to skip starting paused for this device.

Fixes https://github.com/flutter/flutter-intellij/issues/4751