### PR TITLE
FlutterDependencyInspection shouldn't work in a non-Flutter project

### DIFF
--- a/src/io/flutter/inspections/FlutterDependencyInspection.java
+++ b/src/io/flutter/inspections/FlutterDependencyInspection.java
@@ -50,13 +50,14 @@ public class FlutterDependencyInspection extends LocalInspectionTool {
 
     if (!ProjectRootManager.getInstance(project).getFileIndex().isInContent(file)) return null;
 
-    final FlutterSdk sdk = FlutterSdk.getFlutterSdk(project);
     final Module module = ModuleUtilCore.findModuleForFile(file, project);
     if (!FlutterModuleUtils.isFlutterModule(module)) return null;
 
     final PubRoot root = PubRootCache.getInstance(project).getRoot(psiFile);
 
     if (root == null || myIgnoredPubspecPaths.contains(root.getPubspec().getPath())) return null;
+
+    if (!root.declaresFlutter()) return null;
 
     // TODO(pq): consider validating package name here (`get` will fail if it's invalid).
 


### PR DESCRIPTION
Dart SDK from `flutter/bin/cache/dart-sdk` may be used for pure Dart projects, without any Flutter-related code. Flutter-specific inspection shouldn't work in this case.

Once the Flutter plugin update with this fix is published, I'll enable 'Outdated Dependencies' inspection from the Dart plugin for such cases. I don't want to enable it right now to avoid having 2 similar warnings from 2 inspections at the same time.