### PR TITLE
Load correct file path for JxBrowser files

### DIFF
--- a/src/io/flutter/jxbrowser/JxBrowserManager.java
+++ b/src/io/flutter/jxbrowser/JxBrowserManager.java
@@ -210,7 +210,7 @@ public class JxBrowserManager {
     ProgressManager.getInstance().runProcessWithProgressAsynchronously(task, processIndicator);
   }
 
-  protected void loadClasses(String[] fileNames) {
+  private void loadClasses(String[] fileNames) {
     for (String fileName : fileNames) {
       final boolean success = FileUtils.loadClass(this.getClass().getClassLoader(), getFilePath(fileName));
       if (success) {

--- a/src/io/flutter/jxbrowser/JxBrowserManager.java
+++ b/src/io/flutter/jxbrowser/JxBrowserManager.java
@@ -158,7 +158,7 @@ public class JxBrowserManager {
     // Delete any already existing files.
     // TODO(helin24): Handle if files cannot be deleted.
     for (String fileName : fileNames) {
-      String filePath = getFilePath(fileName);
+      final String filePath = getFilePath(fileName);
       if (!FileUtils.deleteFile(filePath)) {
         LOG.info(project.getName() + ": Existing file could not be deleted - " + filePath);
       }

--- a/src/io/flutter/jxbrowser/JxBrowserManager.java
+++ b/src/io/flutter/jxbrowser/JxBrowserManager.java
@@ -19,7 +19,6 @@ import com.intellij.util.containers.ContainerUtil;
 import com.intellij.util.download.DownloadableFileDescription;
 import com.intellij.util.download.DownloadableFileService;
 import com.intellij.util.download.FileDownloader;
-import com.intellij.util.lang.UrlClassLoader;
 import io.flutter.utils.FileUtils;
 import io.flutter.utils.JxBrowserUtils;
 import org.jetbrains.annotations.NotNull;
@@ -27,8 +26,6 @@ import org.jetbrains.annotations.NotNull;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -161,8 +158,9 @@ public class JxBrowserManager {
     // Delete any already existing files.
     // TODO(helin24): Handle if files cannot be deleted.
     for (String fileName : fileNames) {
-      if (!FileUtils.deleteFile(fileName)) {
-        LOG.info(project.getName() + ": Existing file could not be deleted - " + fileName);
+      String filePath = getFilePath(fileName);
+      if (!FileUtils.deleteFile(filePath)) {
+        LOG.info(project.getName() + ": Existing file could not be deleted - " + filePath);
       }
     }
 
@@ -213,21 +211,21 @@ public class JxBrowserManager {
   }
 
   protected void loadClasses(String[] fileNames) {
-    final UrlClassLoader classLoader = (UrlClassLoader) this.getClass().getClassLoader();
-    try {
-      for (String fileName : fileNames) {
-        final File file = new File(fileName);
-        final URL url = file.toURI().toURL();
-        classLoader.addURL(url);
-        LOG.info("Loaded JxBrowser file successfully: " + url.toString());
+    for (String fileName : fileNames) {
+      final boolean success = FileUtils.loadClass(this.getClass().getClassLoader(), getFilePath(fileName));
+      if (success) {
+        LOG.info("Loaded JxBrowser file successfully: " + fileName);
+      } else {
+        LOG.info("Failed to load JxBrowser file: " + fileName);
+        setStatusFailed();
+        return;
       }
+    }
+    status.set(JxBrowserStatus.INSTALLED);
+    installation.complete(JxBrowserStatus.INSTALLED);
+  }
 
-      status.set(JxBrowserStatus.INSTALLED);
-      installation.complete(JxBrowserStatus.INSTALLED);
-    }
-    catch (MalformedURLException e) {
-      LOG.info("Failed to load JxBrowser files");
-      setStatusFailed();
-    }
+  private String getFilePath(String fileName) {
+    return DOWNLOAD_PATH + File.separatorChar + fileName;
   }
 }

--- a/testSrc/unit/io/flutter/jxbrowser/JxBrowserManagerTest.java
+++ b/testSrc/unit/io/flutter/jxbrowser/JxBrowserManagerTest.java
@@ -85,15 +85,14 @@ public class JxBrowserManagerTest {
   @Test
   public void testSetUpIfAllFilesExist() throws FileNotFoundException {
     // If all of the files are already downloaded, we should load the existing files.
-    final JxBrowserManager partialMockManager = mock(JxBrowserManager.class);
-    doCallRealMethod().when(partialMockManager).setUp(mockProject);
+    final JxBrowserManager manager = JxBrowserManager.getInstance();
 
     PowerMockito.mockStatic(FileUtils.class);
     when(FileUtils.makeDirectory(DOWNLOAD_PATH)).thenReturn(true);
     when(FileUtils.fileExists(anyString())).thenReturn(true);
-    when(FileUtils.loadClass(any(ClassLoader.class), eq(PLATFORM_FILE_NAME))).thenReturn(true);
-    when(FileUtils.loadClass(any(ClassLoader.class), eq(API_FILE_NAME))).thenReturn(true);
-    when(FileUtils.loadClass(any(ClassLoader.class), eq(SWING_FILE_NAME))).thenReturn(true);
+    when(FileUtils.loadClass(any(ClassLoader.class), endsWith(PLATFORM_FILE_NAME))).thenReturn(true);
+    when(FileUtils.loadClass(any(ClassLoader.class), endsWith(API_FILE_NAME))).thenReturn(true);
+    when(FileUtils.loadClass(any(ClassLoader.class), endsWith(SWING_FILE_NAME))).thenReturn(true);
 
     PowerMockito.mockStatic(JxBrowserUtils.class);
     when(JxBrowserUtils.getJxBrowserKey(any(Project.class))).thenReturn("KEY");
@@ -101,9 +100,9 @@ public class JxBrowserManagerTest {
     when(JxBrowserUtils.getApiFileName()).thenReturn(API_FILE_NAME);
     when(JxBrowserUtils.getSwingFileName()).thenReturn(SWING_FILE_NAME);
 
-    partialMockManager.setUp(mockProject);
+    manager.setUp(mockProject);
     final String[] expectedFileNames = {PLATFORM_FILE_NAME, API_FILE_NAME, SWING_FILE_NAME};
-    verify(partialMockManager, times(1)).loadClasses(expectedFileNames);
+    Assert.assertEquals(JxBrowserStatus.INSTALLED, manager.getStatus());
   }
 
   @Test

--- a/testSrc/unit/io/flutter/jxbrowser/JxBrowserManagerTest.java
+++ b/testSrc/unit/io/flutter/jxbrowser/JxBrowserManagerTest.java
@@ -17,6 +17,7 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import java.io.File;
 import java.io.FileNotFoundException;
 
 import static io.flutter.jxbrowser.JxBrowserManager.DOWNLOAD_PATH;
@@ -127,11 +128,11 @@ public class JxBrowserManagerTest {
     partialMockManager.setUp(mockProject);
 
     verifyStatic(FileUtils.class);
-    FileUtils.deleteFile(PLATFORM_FILE_NAME);
+    FileUtils.deleteFile(DOWNLOAD_PATH + File.separatorChar + PLATFORM_FILE_NAME);
     verifyStatic(FileUtils.class);
-    FileUtils.deleteFile(API_FILE_NAME);
+    FileUtils.deleteFile(DOWNLOAD_PATH + File.separatorChar + API_FILE_NAME);
     verifyStatic(FileUtils.class);
-    FileUtils.deleteFile(SWING_FILE_NAME);
+    FileUtils.deleteFile(DOWNLOAD_PATH + File.separatorChar + SWING_FILE_NAME);
 
     final String[] expectedFileNames = {PLATFORM_FILE_NAME, API_FILE_NAME, SWING_FILE_NAME};
     verify(partialMockManager, times(1)).downloadJxBrowser(mockProject, expectedFileNames);


### PR DESCRIPTION
While refactoring the `JxBrowserManager` file (https://github.com/flutter/flutter-intellij/pull/4714), I left out the download path while loading files.

This can be tested by running `bin/plugin build` with JxBrowser enabled and the key included, then installing and running the plugin .jar file.