### PR TITLE
Fix local build overwriting JxBrowser key

### DIFF
--- a/tool/plugin/lib/runner.dart
+++ b/tool/plugin/lib/runner.dart
@@ -57,10 +57,12 @@ compile
     final jxBrowserKey =
         readTokenFromKeystore('FLUTTER_KEYSTORE_JXBROWSER_KEY_NAME');
     final propertiesFile = File("$rootPath/resources/jxbrowser/jxbrowser.properties");
-    final contents = '''
+    if (jxBrowserKey.isNotEmpty) {
+      final contents = '''
 jxbrowser.license.key=${jxBrowserKey}
 ''';
-    propertiesFile.writeAsStringSync(contents);
+      propertiesFile.writeAsStringSync(contents);
+    }
   }
 
   Future<int> buildPlugin(BuildSpec spec, String version) async {

--- a/tool/plugin/lib/util.dart
+++ b/tool/plugin/lib/util.dart
@@ -150,16 +150,5 @@ String readTokenFromKeystore(String keyName) {
   var name = env[keyName];
 
   var file = File('$base/${id}_$name');
-  if (file.existsSync()) {
-    return file.readAsStringSync();
-  }
-
-  // If building locally, this key may be in resources.
-  var localFile = File('resources/jxbrowser/jxbrowser.properties');
-  if (!file.existsSync()) {
-    return '';
-  }
-  
-  var keyAndValue = localFile.readAsStringSync().split('=');
-  return keyAndValue.length == 2 ? keyAndValue[1] : '';
+  return file.existsSync() ? file.readAsStringSync() : '';
 }


### PR DESCRIPTION
For local builds, the JxBrowser key will not be returned from the keystore and instead should be manually pasted into the resources directory. We should only try to fetch the key from the keystore, but skip writing into the resources directory unless the key isn't empty.