### PR TITLE
Add experimental setting for embedding devtools

### DIFF
--- a/src/io/flutter/ProjectOpenActivity.java
+++ b/src/io/flutter/ProjectOpenActivity.java
@@ -59,7 +59,7 @@ public class ProjectOpenActivity implements StartupActivity, DumbAware {
 
     // Set up JxBrowser listening and check if it's already enabled.
     JxBrowserManager.getInstance().listenForSettingChanges(project);
-    if (FlutterSettings.getInstance().isEnableEmbeddedInspector()) {
+    if (FlutterSettings.getInstance().isEnableEmbeddedBrowsers()) {
       JxBrowserManager.getInstance().setUp(project);
     }
 

--- a/src/io/flutter/ProjectOpenActivity.java
+++ b/src/io/flutter/ProjectOpenActivity.java
@@ -24,6 +24,7 @@ import io.flutter.jxbrowser.JxBrowserManager;
 import io.flutter.pub.PubRoot;
 import io.flutter.pub.PubRoots;
 import io.flutter.sdk.FlutterSdk;
+import io.flutter.settings.FlutterSettings;
 import io.flutter.utils.AndroidUtils;
 import io.flutter.utils.FlutterModuleUtils;
 import org.jetbrains.annotations.NotNull;
@@ -56,7 +57,9 @@ public class ProjectOpenActivity implements StartupActivity, DumbAware {
       return;
     }
 
-    if (JxBrowserManager.ENABLE_JX_BROWSER) {
+    // Set up JxBrowser listening and check if it's already enabled.
+    JxBrowserManager.getInstance().listenForSettingChanges(project);
+    if (FlutterSettings.getInstance().isEnableEmbeddedInspector()) {
       JxBrowserManager.getInstance().setUp(project);
     }
 

--- a/src/io/flutter/jxbrowser/JxBrowserManager.java
+++ b/src/io/flutter/jxbrowser/JxBrowserManager.java
@@ -19,7 +19,6 @@ import com.intellij.util.containers.ContainerUtil;
 import com.intellij.util.download.DownloadableFileDescription;
 import com.intellij.util.download.DownloadableFileService;
 import com.intellij.util.download.FileDownloader;
-import com.intellij.util.lang.UrlClassLoader;
 import io.flutter.settings.FlutterSettings;
 import io.flutter.utils.FileUtils;
 import io.flutter.utils.JxBrowserUtils;
@@ -101,7 +100,7 @@ public class JxBrowserManager {
       final FlutterSettings settings = FlutterSettings.getInstance();
 
       // Set up JxBrowser files if the embedded inspector option has been turned on and the files aren't already loaded.
-      if (settings.isEnableEmbeddedInspector() && getStatus().equals(JxBrowserStatus.NOT_INSTALLED)) {
+      if (settings.isEnableEmbeddedBrowsers() && getStatus().equals(JxBrowserStatus.NOT_INSTALLED)) {
         setUp(project);
       }
     }

--- a/src/io/flutter/jxbrowser/JxBrowserManager.java
+++ b/src/io/flutter/jxbrowser/JxBrowserManager.java
@@ -19,6 +19,8 @@ import com.intellij.util.containers.ContainerUtil;
 import com.intellij.util.download.DownloadableFileDescription;
 import com.intellij.util.download.DownloadableFileService;
 import com.intellij.util.download.FileDownloader;
+import com.intellij.util.lang.UrlClassLoader;
+import io.flutter.settings.FlutterSettings;
 import io.flutter.utils.FileUtils;
 import io.flutter.utils.JxBrowserUtils;
 import org.jetbrains.annotations.NotNull;
@@ -33,6 +35,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 // JxBrowser provides Chromium to display web pages within IntelliJ. This class manages downloading the required files and adding them to
@@ -43,10 +46,8 @@ public class JxBrowserManager {
   @VisibleForTesting
   protected static final String DOWNLOAD_PATH = PathManager.getPluginsPath() + File.separatorChar + "flutter-intellij" + File.separatorChar + "jxbrowser";
   private static final AtomicReference<JxBrowserStatus> status = new AtomicReference<>(JxBrowserStatus.NOT_INSTALLED);
+  private static final AtomicBoolean listeningForSetting = new AtomicBoolean(false);
   private static final Logger LOG = Logger.getInstance(JxBrowserManager.class);
-  // We will be gating JxBrowser features until all of the features are landed.
-  // To test JxBrowser, set this to true and also add license key to VM options (-Djxbrowser.license.key=<key>).
-  public static final boolean ENABLE_JX_BROWSER = false;
   private static CompletableFuture<JxBrowserStatus> installation = new CompletableFuture<>();
 
   private JxBrowserManager() {}
@@ -88,9 +89,36 @@ public class JxBrowserManager {
     setUp(project);
   }
 
+  private class SettingsListener implements FlutterSettings.Listener {
+    final Project project;
+
+    public SettingsListener(Project project) {
+      this.project = project;
+    }
+
+    @Override
+    public void settingsChanged() {
+      final FlutterSettings settings = FlutterSettings.getInstance();
+
+      // Set up JxBrowser files if the embedded inspector option has been turned on and the files aren't already loaded.
+      if (settings.isEnableEmbeddedInspector() && getStatus().equals(JxBrowserStatus.NOT_INSTALLED)) {
+        setUp(project);
+      }
+    }
+  }
+
   private void setStatusFailed() {
     status.set(JxBrowserStatus.INSTALLATION_FAILED);
     installation.complete(JxBrowserStatus.INSTALLATION_FAILED);
+  }
+
+  public void listenForSettingChanges(Project project) {
+    if (!listeningForSetting.compareAndSet(false, true)) {
+      // We can return early because another project already triggered the listener.
+      return;
+    }
+
+    FlutterSettings.getInstance().addListener(new SettingsListener(project));
   }
 
   public void setUp(Project project) {
@@ -103,7 +131,7 @@ public class JxBrowserManager {
 
     // Retrieve key
     try {
-      final String key = JxBrowserUtils.getJxBrowserKey(project);
+      final String key = JxBrowserUtils.getJxBrowserKey();
       System.setProperty(JxBrowserUtils.PROPERTY_NAME, key);
     }
     catch (FileNotFoundException e) {

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.form
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.form
@@ -206,7 +206,7 @@
           </component>
         </children>
       </grid>
-      <grid id="23e52" binding="experimentsPanel" layout-manager="GridLayoutManager" row-count="3" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="23e52" binding="experimentsPanel" layout-manager="GridLayoutManager" row-count="4" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -238,6 +238,14 @@
             <properties>
               <text resource-bundle="io/flutter/FlutterBundle" key="settings.enable.hot.ui"/>
               <toolTipText value="Experimental features to graphically edit Flutter build methods."/>
+            </properties>
+          </component>
+          <component id="2032d" class="javax.swing.JCheckBox" binding="myEnableEmbeddedInspectorCheckBox">
+            <constraints>
+              <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Enable embedded DevTools inspector"/>
             </properties>
           </component>
         </children>

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.form
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.form
@@ -240,7 +240,7 @@
               <toolTipText value="Experimental features to graphically edit Flutter build methods."/>
             </properties>
           </component>
-          <component id="2032d" class="javax.swing.JCheckBox" binding="myEnableEmbeddedInspectorCheckBox">
+          <component id="2032d" class="javax.swing.JCheckBox" binding="myEnableEmbeddedBrowsersCheckBox">
             <constraints>
               <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.java
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.java
@@ -66,6 +66,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
   private JCheckBox myShowStructuredErrors;
   private JCheckBox mySyncAndroidLibrariesCheckBox;
   private JCheckBox myEnableHotUiCheckBox;
+  private JCheckBox myEnableEmbeddedInspectorCheckBox;
 
   // Settings for Bazel users.
   private JPanel myBazelOptionsSection;
@@ -137,6 +138,8 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     // the following statement:
     // experimentsPanel.setVisible(FlutterUtils.isAndroidStudio());
     mySyncAndroidLibrariesCheckBox.setVisible(FlutterUtils.isAndroidStudio());
+
+    myEnableEmbeddedInspectorCheckBox.setVisible(true);
   }
 
   private void createUIComponents() {
@@ -220,6 +223,10 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
       return true;
     }
 
+    if (settings.isEnableEmbeddedInspector() != myEnableEmbeddedInspectorCheckBox.isSelected()) {
+      return true;
+    }
+
     //noinspection RedundantIfStatement
     if (settings.showAllRunConfigurationsInContext() != myShowAllRunConfigurationsInContextCheckBox.isSelected()) {
       return true;
@@ -262,6 +269,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     settings.setVerboseLogging(myEnableVerboseLoggingCheckBox.isSelected());
     settings.setSyncingAndroidLibraries(mySyncAndroidLibrariesCheckBox.isSelected());
     settings.setEnableHotUi(myEnableHotUiCheckBox.isSelected());
+    settings.setEnableEmbeddedInspector(myEnableEmbeddedInspectorCheckBox.isSelected());
     settings.setShowAllRunConfigurationsInContext(myShowAllRunConfigurationsInContextCheckBox.isSelected());
 
     reset(); // because we rely on remembering initial state
@@ -303,6 +311,8 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     mySyncAndroidLibrariesCheckBox.setSelected(settings.isSyncingAndroidLibraries());
 
     myEnableHotUiCheckBox.setSelected(settings.isEnableHotUi());
+
+    myEnableEmbeddedInspectorCheckBox.setSelected(settings.isEnableEmbeddedInspector());
 
     myOrganizeImportsOnSaveCheckBox.setEnabled(myFormatCodeOnSaveCheckBox.isSelected());
 

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.java
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.java
@@ -66,7 +66,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
   private JCheckBox myShowStructuredErrors;
   private JCheckBox mySyncAndroidLibrariesCheckBox;
   private JCheckBox myEnableHotUiCheckBox;
-  private JCheckBox myEnableEmbeddedInspectorCheckBox;
+  private JCheckBox myEnableEmbeddedBrowsersCheckBox;
 
   // Settings for Bazel users.
   private JPanel myBazelOptionsSection;
@@ -139,7 +139,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     // experimentsPanel.setVisible(FlutterUtils.isAndroidStudio());
     mySyncAndroidLibrariesCheckBox.setVisible(FlutterUtils.isAndroidStudio());
 
-    myEnableEmbeddedInspectorCheckBox.setVisible(true);
+    myEnableEmbeddedBrowsersCheckBox.setVisible(true);
   }
 
   private void createUIComponents() {
@@ -223,7 +223,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
       return true;
     }
 
-    if (settings.isEnableEmbeddedInspector() != myEnableEmbeddedInspectorCheckBox.isSelected()) {
+    if (settings.isEnableEmbeddedBrowsers() != myEnableEmbeddedBrowsersCheckBox.isSelected()) {
       return true;
     }
 
@@ -269,7 +269,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     settings.setVerboseLogging(myEnableVerboseLoggingCheckBox.isSelected());
     settings.setSyncingAndroidLibraries(mySyncAndroidLibrariesCheckBox.isSelected());
     settings.setEnableHotUi(myEnableHotUiCheckBox.isSelected());
-    settings.setEnableEmbeddedInspector(myEnableEmbeddedInspectorCheckBox.isSelected());
+    settings.setEnableEmbeddedBrowsers(myEnableEmbeddedBrowsersCheckBox.isSelected());
     settings.setShowAllRunConfigurationsInContext(myShowAllRunConfigurationsInContextCheckBox.isSelected());
 
     reset(); // because we rely on remembering initial state
@@ -312,7 +312,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
 
     myEnableHotUiCheckBox.setSelected(settings.isEnableHotUi());
 
-    myEnableEmbeddedInspectorCheckBox.setSelected(settings.isEnableEmbeddedInspector());
+    myEnableEmbeddedBrowsersCheckBox.setSelected(settings.isEnableEmbeddedBrowsers());
 
     myOrganizeImportsOnSaveCheckBox.setEnabled(myFormatCodeOnSaveCheckBox.isSelected());
 

--- a/src/io/flutter/settings/FlutterSettings.java
+++ b/src/io/flutter/settings/FlutterSettings.java
@@ -28,7 +28,7 @@ public class FlutterSettings {
   private static final String showStructuredErrors = "io.flutter.showStructuredErrors";
   private static final String showBuildMethodGuidesKey = "io.flutter.editor.showBuildMethodGuides";
   private static final String enableHotUiKey = "io.flutter.editor.enableHotUi";
-  private static final String enableEmbeddedInspectorKey = "io.flutter.editor.enableEmbeddedInspector";
+  private static final String enableEmbeddedBrowsersKey = "io.flutter.editor.enableEmbeddedBrowsers";
 
   /**
    * Registry key to suggest all run configurations instead of just one.
@@ -261,12 +261,12 @@ public class FlutterSettings {
     return false;
   }
 
-  public boolean isEnableEmbeddedInspector() {
-    return getPropertiesComponent().getBoolean(enableEmbeddedInspectorKey, false);
+  public boolean isEnableEmbeddedBrowsers() {
+    return getPropertiesComponent().getBoolean(enableEmbeddedBrowsersKey, false);
   }
 
-  public void setEnableEmbeddedInspector(boolean value) {
-    getPropertiesComponent().setValue(enableEmbeddedInspectorKey, value, false);
+  public void setEnableEmbeddedBrowsers(boolean value) {
+    getPropertiesComponent().setValue(enableEmbeddedBrowsersKey, value, false);
 
     fireEvent();
   }

--- a/src/io/flutter/settings/FlutterSettings.java
+++ b/src/io/flutter/settings/FlutterSettings.java
@@ -28,6 +28,7 @@ public class FlutterSettings {
   private static final String showStructuredErrors = "io.flutter.showStructuredErrors";
   private static final String showBuildMethodGuidesKey = "io.flutter.editor.showBuildMethodGuides";
   private static final String enableHotUiKey = "io.flutter.editor.enableHotUi";
+  private static final String enableEmbeddedInspectorKey = "io.flutter.editor.enableEmbeddedInspector";
 
   /**
    * Registry key to suggest all run configurations instead of just one.
@@ -258,5 +259,15 @@ public class FlutterSettings {
     // We leave this setting off for now to avoid possible performance and
     // usability issues rendering previews directly in the code editor.
     return false;
+  }
+
+  public boolean isEnableEmbeddedInspector() {
+    return getPropertiesComponent().getBoolean(enableEmbeddedInspectorKey, false);
+  }
+
+  public void setEnableEmbeddedInspector(boolean value) {
+    getPropertiesComponent().setValue(enableEmbeddedInspectorKey, value, false);
+
+    fireEvent();
   }
 }

--- a/src/io/flutter/utils/JxBrowserUtils.java
+++ b/src/io/flutter/utils/JxBrowserUtils.java
@@ -5,7 +5,6 @@
  */
 package io.flutter.utils;
 
-import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.SystemInfo;
 
 import java.io.FileNotFoundException;
@@ -51,7 +50,7 @@ public class JxBrowserUtils {
     return "https://storage.googleapis.com/flutter_infra/flutter/intellij/jxbrowser/" + fileName;
   }
 
-  public static String getJxBrowserKey(Project project) throws FileNotFoundException {
+  public static String getJxBrowserKey() throws FileNotFoundException {
     final Properties properties = new Properties();
     try {
       properties.load(JxBrowserUtils.class.getResourceAsStream("/jxbrowser/jxbrowser.properties"));

--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -506,7 +506,7 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
 
     toolWindow.setIcon(ExecutionUtil.getLiveIndicator(FlutterIcons.Flutter_13));
 
-    if (JxBrowserManager.ENABLE_JX_BROWSER) {
+    if (FlutterSettings.getInstance().isEnableEmbeddedInspector()) {
       JxBrowserStatus jxBrowserStatus = JxBrowserManager.getInstance().getStatus();
 
       if (jxBrowserStatus.equals(JxBrowserStatus.INSTALLED)) {

--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -506,7 +506,7 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
 
     toolWindow.setIcon(ExecutionUtil.getLiveIndicator(FlutterIcons.Flutter_13));
 
-    if (FlutterSettings.getInstance().isEnableEmbeddedInspector()) {
+    if (FlutterSettings.getInstance().isEnableEmbeddedBrowsers()) {
       JxBrowserStatus jxBrowserStatus = JxBrowserManager.getInstance().getStatus();
 
       if (jxBrowserStatus.equals(JxBrowserStatus.INSTALLED)) {

--- a/testSrc/unit/io/flutter/jxbrowser/JxBrowserManagerTest.java
+++ b/testSrc/unit/io/flutter/jxbrowser/JxBrowserManagerTest.java
@@ -45,7 +45,7 @@ public class JxBrowserManagerTest {
     final JxBrowserManager manager = JxBrowserManager.getInstance();
 
     PowerMockito.mockStatic(JxBrowserUtils.class);
-    when(JxBrowserUtils.getJxBrowserKey(any(Project.class))).thenThrow(new FileNotFoundException("Key not found"));
+    when(JxBrowserUtils.getJxBrowserKey()).thenThrow(new FileNotFoundException("Key not found"));
 
     manager.setUp(mockProject);
     Assert.assertEquals(JxBrowserStatus.INSTALLATION_FAILED, manager.getStatus());
@@ -57,7 +57,7 @@ public class JxBrowserManagerTest {
     final JxBrowserManager manager = JxBrowserManager.getInstance();
 
     PowerMockito.mockStatic(JxBrowserUtils.class);
-    when(JxBrowserUtils.getJxBrowserKey(any(Project.class))).thenReturn("KEY");
+    when(JxBrowserUtils.getJxBrowserKey()).thenReturn("KEY");
 
     PowerMockito.mockStatic(FileUtils.class);
     when(FileUtils.makeDirectory(DOWNLOAD_PATH)).thenReturn(false);
@@ -75,7 +75,7 @@ public class JxBrowserManagerTest {
     when(FileUtils.makeDirectory(DOWNLOAD_PATH)).thenReturn(true);
 
     PowerMockito.mockStatic(JxBrowserUtils.class);
-    when(JxBrowserUtils.getJxBrowserKey(any(Project.class))).thenReturn("KEY");
+    when(JxBrowserUtils.getJxBrowserKey()).thenReturn("KEY");
     when(JxBrowserUtils.getPlatformFileName()).thenThrow(new FileNotFoundException());
 
     manager.setUp(mockProject);
@@ -95,7 +95,7 @@ public class JxBrowserManagerTest {
     when(FileUtils.loadClass(any(ClassLoader.class), endsWith(SWING_FILE_NAME))).thenReturn(true);
 
     PowerMockito.mockStatic(JxBrowserUtils.class);
-    when(JxBrowserUtils.getJxBrowserKey(any(Project.class))).thenReturn("KEY");
+    when(JxBrowserUtils.getJxBrowserKey()).thenReturn("KEY");
     when(JxBrowserUtils.getPlatformFileName()).thenReturn(PLATFORM_FILE_NAME);
     when(JxBrowserUtils.getApiFileName()).thenReturn(API_FILE_NAME);
     when(JxBrowserUtils.getSwingFileName()).thenReturn(SWING_FILE_NAME);
@@ -119,7 +119,7 @@ public class JxBrowserManagerTest {
     when(FileUtils.deleteFile(anyString())).thenReturn(true);
 
     PowerMockito.mockStatic(JxBrowserUtils.class);
-    when(JxBrowserUtils.getJxBrowserKey(any(Project.class))).thenReturn("KEY");
+    when(JxBrowserUtils.getJxBrowserKey()).thenReturn("KEY");
     when(JxBrowserUtils.getPlatformFileName()).thenReturn(PLATFORM_FILE_NAME);
     when(JxBrowserUtils.getApiFileName()).thenReturn(API_FILE_NAME);
     when(JxBrowserUtils.getSwingFileName()).thenReturn(SWING_FILE_NAME);


### PR DESCRIPTION
This adds a setting under Flutter > Experiments that's off by default:
![Screen Shot 2020-08-26 at 7 34 47 PM](https://user-images.githubusercontent.com/6379305/91376995-45991f00-e7d3-11ea-86fc-adef15662d27.png)

If the setting is enabled, then the Inspector panel will display the embedded DevTools page. Newly enabling the setting will run the setup steps for JxBrowser if they have not already been run previously.

