### PR TITLE
Fix white screen during embedded browser load

### DIFF
--- a/src/io/flutter/jxbrowser/EmbeddedBrowser.java
+++ b/src/io/flutter/jxbrowser/EmbeddedBrowser.java
@@ -24,6 +24,7 @@ public class EmbeddedBrowser {
       EngineOptions.newBuilder(HARDWARE_ACCELERATED).build();
     Engine engine = Engine.newInstance(options);
     Browser browser = engine.newBrowser();
+    browser.settings().enableTransparentBackground();
 
     if (contentManager.isDisposed()) {
       return;

--- a/src/io/flutter/jxbrowser/EmbeddedBrowser.java
+++ b/src/io/flutter/jxbrowser/EmbeddedBrowser.java
@@ -11,6 +11,7 @@ import com.intellij.ui.content.ContentManager;
 import com.teamdev.jxbrowser.browser.Browser;
 import com.teamdev.jxbrowser.engine.Engine;
 import com.teamdev.jxbrowser.engine.EngineOptions;
+import com.teamdev.jxbrowser.time.Timestamp;
 import com.teamdev.jxbrowser.view.swing.BrowserView;
 import icons.FlutterIcons;
 
@@ -37,12 +38,13 @@ public class EmbeddedBrowser {
     BrowserView view = BrowserView.newInstance(browser);
     view.setPreferredSize(new Dimension(contentManager.getComponent().getWidth(), contentManager.getComponent().getHeight()));
 
+    // Wait for browser to load devtools before component is shown.
+    browser.navigation().loadUrlAndWait(url, Timestamp.fromSeconds(30));
+
     content.setComponent(view);
     content.putUserData(ToolWindow.SHOW_CONTENT_ICON, Boolean.TRUE);
     // TODO(helin24): Use differentiated icons for each tab and copy from devtools toolbar.
     content.setIcon(FlutterIcons.Phone);
     contentManager.addContent(content);
-
-    browser.navigation().loadUrl(url);
   }
 }


### PR DESCRIPTION
The transparent background setting shows a grey screen briefly instead of a white background, and waiting to create the `BrowserView` allows us to skip a white background that is probably from the initial browser page being about:blank.

Before:
![Aug-27-2020 16-34-44](https://user-images.githubusercontent.com/6379305/91505068-8ea8ac00-e883-11ea-8042-f5fd0c106116.gif)

After:
![Aug-27-2020 16-32-30](https://user-images.githubusercontent.com/6379305/91505076-936d6000-e883-11ea-98a1-f4c9183b11a6.gif)
