### PR TITLE
Send IntelliJ component background color to devtools

### DIFF
--- a/src/io/flutter/devtools/DevToolsManager.java
+++ b/src/io/flutter/devtools/DevToolsManager.java
@@ -30,8 +30,8 @@ import com.intellij.openapi.util.Key;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.vfs.CharsetToolkit;
 import com.intellij.ui.ColorUtil;
-import com.intellij.ui.content.Content;
 import com.intellij.ui.content.ContentManager;
+import com.intellij.util.ui.UIUtil;
 import io.flutter.FlutterMessages;
 import io.flutter.FlutterUtils;
 import io.flutter.bazel.Workspace;
@@ -48,7 +48,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.awt.*;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
@@ -397,11 +396,7 @@ class DevToolsInstance {
   }
 
   public void openPanel(String serviceProtocolUri, ContentManager contentManager, String tabName, String pageName) {
-    String color = null;
-    if (contentManager.getContents().length > 0) {
-      final Container container = Objects.requireNonNull(contentManager.getContent(0)).getComponent().getParent();
-      color = ColorUtil.toHex(new Color(container.getBackground().getRGB()));
-    }
+    final String color = ColorUtil.toHex(new Color(UIUtil.getEditorPaneBackground().getRGB()));
     final String url = DevToolsUtils.generateDevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, null, true, pageName, color);
 
     ApplicationManager.getApplication().invokeLater(() -> {

--- a/src/io/flutter/devtools/DevToolsManager.java
+++ b/src/io/flutter/devtools/DevToolsManager.java
@@ -47,7 +47,6 @@ import io.flutter.utils.MostlySilentOsProcessHandler;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.awt.*;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
@@ -396,7 +395,7 @@ class DevToolsInstance {
   }
 
   public void openPanel(String serviceProtocolUri, ContentManager contentManager, String tabName, String pageName) {
-    final String color = ColorUtil.toHex(new Color(UIUtil.getEditorPaneBackground().getRGB()));
+    final String color = ColorUtil.toHex(UIUtil.getEditorPaneBackground());
     final String url = DevToolsUtils.generateDevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, null, true, pageName, color);
 
     ApplicationManager.getApplication().invokeLater(() -> {

--- a/src/io/flutter/devtools/DevToolsManager.java
+++ b/src/io/flutter/devtools/DevToolsManager.java
@@ -29,6 +29,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Key;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.vfs.CharsetToolkit;
+import com.intellij.ui.ColorUtil;
 import com.intellij.ui.content.ContentManager;
 import io.flutter.FlutterMessages;
 import io.flutter.FlutterUtils;
@@ -45,6 +46,9 @@ import io.flutter.utils.MostlySilentOsProcessHandler;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import javax.swing.JComponent;
+import java.awt.Color;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
@@ -393,7 +397,12 @@ class DevToolsInstance {
   }
 
   public void openPanel(String serviceProtocolUri, ContentManager contentManager, String tabName, String pageName) {
-    String url = DevToolsUtils.generateDevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, null, true, pageName);
+    String color = null;
+    if (contentManager.getContents().length > 0) {
+      final JComponent component = Objects.requireNonNull(contentManager.getContent(0)).getComponent();
+      color = ColorUtil.toHex(new Color(component.getBackground().getRGB()));
+    }
+    final String url = DevToolsUtils.generateDevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, null, true, pageName, color);
 
     ApplicationManager.getApplication().invokeLater(() -> {
       new EmbeddedBrowser().openPanel(contentManager, tabName, url);

--- a/src/io/flutter/devtools/DevToolsManager.java
+++ b/src/io/flutter/devtools/DevToolsManager.java
@@ -30,6 +30,7 @@ import com.intellij.openapi.util.Key;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.vfs.CharsetToolkit;
 import com.intellij.ui.ColorUtil;
+import com.intellij.ui.content.Content;
 import com.intellij.ui.content.ContentManager;
 import io.flutter.FlutterMessages;
 import io.flutter.FlutterUtils;
@@ -46,8 +47,7 @@ import io.flutter.utils.MostlySilentOsProcessHandler;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import javax.swing.JComponent;
-import java.awt.Color;
+import java.awt.*;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -399,8 +399,8 @@ class DevToolsInstance {
   public void openPanel(String serviceProtocolUri, ContentManager contentManager, String tabName, String pageName) {
     String color = null;
     if (contentManager.getContents().length > 0) {
-      final JComponent component = Objects.requireNonNull(contentManager.getContent(0)).getComponent();
-      color = ColorUtil.toHex(new Color(component.getBackground().getRGB()));
+      final Container container = Objects.requireNonNull(contentManager.getContent(0)).getComponent().getParent();
+      color = ColorUtil.toHex(new Color(container.getBackground().getRGB()));
     }
     final String url = DevToolsUtils.generateDevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, null, true, pageName, color);
 

--- a/src/io/flutter/devtools/DevToolsUtils.java
+++ b/src/io/flutter/devtools/DevToolsUtils.java
@@ -21,9 +21,24 @@ public class DevToolsUtils {
     boolean embed,
     String pageName
   ) {
+    return generateDevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, embed, pageName, null);
+  }
+
+  public static String generateDevToolsUrl(
+    String devtoolsHost,
+    int devtoolsPort,
+    String serviceProtocolUri,
+    String page,
+    boolean embed,
+    String pageName,
+    String colorHexCode
+  ) {
     final List<String> params = new ArrayList<>();
 
     params.add("ide=" + FlutterSdkUtil.getFlutterHostEnvValue());
+    if (colorHexCode != null) {
+      params.add("backgroundColor=" + colorHexCode);
+    }
 
     if (pageName != null) {
       params.add("page=" + pageName);

--- a/testSrc/unit/io/flutter/devtools/DevToolsUtilsTest.java
+++ b/testSrc/unit/io/flutter/devtools/DevToolsUtilsTest.java
@@ -60,5 +60,10 @@ public class DevToolsUtilsTest {
       generateDevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false, null, "3c3f41"),
       "http://127.0.0.1:9100/?ide=Android-Studio&backgroundColor=3c3f41&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F#timeline"
     );
+
+    assertEquals(
+      generateDevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false, null, "ffffff"),
+      "http://127.0.0.1:9100/?ide=Android-Studio&backgroundColor=ffffff&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F#timeline"
+    );
   }
 }

--- a/testSrc/unit/io/flutter/devtools/DevToolsUtilsTest.java
+++ b/testSrc/unit/io/flutter/devtools/DevToolsUtilsTest.java
@@ -55,5 +55,10 @@ public class DevToolsUtilsTest {
       generateDevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false, null),
       "http://127.0.0.1:9100/?ide=Android-Studio&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F#timeline"
     );
+
+    assertEquals(
+      generateDevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false, null, "3c3f41"),
+      "http://127.0.0.1:9100/?ide=Android-Studio&backgroundColor=3c3f41&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F#timeline"
+    );
   }
 }


### PR DESCRIPTION
Found that the class `UIUtil` has static methods to get default colors that I'm assuming come from the theme. 

Light:
![Screen Shot 2020-09-01 at 8 37 41 AM](https://user-images.githubusercontent.com/6379305/91874353-f9b10480-ec2e-11ea-8882-ea0a5a5a0dab.png)

Dark:
![Screen Shot 2020-09-01 at 8 36 30 AM](https://user-images.githubusercontent.com/6379305/91874356-fcabf500-ec2e-11ea-9029-0e2f0a735b02.png)
