### PR TITLE
Enable embedded browser by default in dev

### DIFF
--- a/src/io/flutter/FlutterUtils.java
+++ b/src/io/flutter/FlutterUtils.java
@@ -11,6 +11,8 @@ import com.intellij.execution.configurations.GeneralCommandLine;
 import com.intellij.execution.util.ExecUtil;
 import com.intellij.ide.actions.ShowSettingsUtilImpl;
 import com.intellij.ide.impl.ProjectUtil;
+import com.intellij.ide.plugins.IdeaPluginDescriptor;
+import com.intellij.ide.plugins.PluginManagerCore;
 import com.intellij.ide.util.PropertiesComponent;
 import com.intellij.openapi.application.ApplicationInfo;
 import com.intellij.openapi.application.ApplicationManager;
@@ -38,12 +40,6 @@ import io.flutter.pub.PubRoot;
 import io.flutter.pub.PubRootCache;
 import io.flutter.utils.AndroidUtils;
 import io.flutter.utils.FlutterModuleUtils;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Properties;
-import java.util.regex.Pattern;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.SystemIndependent;
@@ -53,6 +49,13 @@ import org.yaml.snakeyaml.constructor.SafeConstructor;
 import org.yaml.snakeyaml.nodes.Tag;
 import org.yaml.snakeyaml.representer.Representer;
 import org.yaml.snakeyaml.resolver.Resolver;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.regex.Pattern;
 
 public class FlutterUtils {
   public static class FlutterPubspecInfo {
@@ -551,5 +554,11 @@ public class FlutterUtils {
       }
     }
     return null;
+  }
+
+  public static boolean isPluginVersionDev() {
+    final IdeaPluginDescriptor descriptor = PluginManagerCore.getPlugin(FlutterUtils.getPluginId());
+    assert descriptor != null;
+    return descriptor.getVersion().contains("dev");
   }
 }

--- a/src/io/flutter/settings/FlutterSettings.java
+++ b/src/io/flutter/settings/FlutterSettings.java
@@ -11,6 +11,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.registry.Registry;
 import com.intellij.util.EventDispatcher;
 import com.jetbrains.lang.dart.analyzer.DartClosingLabelManager;
+import io.flutter.FlutterUtils;
 import io.flutter.analytics.Analytics;
 import io.flutter.sdk.FlutterSdk;
 
@@ -262,11 +263,11 @@ public class FlutterSettings {
   }
 
   public boolean isEnableEmbeddedBrowsers() {
-    return getPropertiesComponent().getBoolean(enableEmbeddedBrowsersKey, false);
+    return getPropertiesComponent().getBoolean(enableEmbeddedBrowsersKey, FlutterUtils.isPluginVersionDev());
   }
 
   public void setEnableEmbeddedBrowsers(boolean value) {
-    getPropertiesComponent().setValue(enableEmbeddedBrowsersKey, value, false);
+    getPropertiesComponent().setValue(enableEmbeddedBrowsersKey, value, FlutterUtils.isPluginVersionDev());
 
     fireEvent();
   }


### PR DESCRIPTION
Users on the dev release of our plugin should automatically have the embedded browser setting enabled. I verified that this setting can also be turned off.