### PR TITLE
Add jxbrowser installation events

### DIFF
--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -442,6 +442,7 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
     catch (TimeoutException e) {
       // TODO(helin24): Are there better options for this case? e.g. stop installation and retry, link to open in browser?
       presentLabel(toolWindow, INSTALLATION_TIMED_OUT_LABEL);
+      FlutterInitializer.getAnalytics().sendEvent("jxbrowser", "timedOut");
     }
   }
 

--- a/testSrc/unit/io/flutter/jxbrowser/JxBrowserManagerTest.java
+++ b/testSrc/unit/io/flutter/jxbrowser/JxBrowserManagerTest.java
@@ -6,6 +6,8 @@
 package io.flutter.jxbrowser;
 
 import com.intellij.openapi.project.Project;
+import io.flutter.FlutterInitializer;
+import io.flutter.analytics.Analytics;
 import io.flutter.utils.FileUtils;
 import io.flutter.utils.JxBrowserUtils;
 import org.junit.Assert;
@@ -27,7 +29,7 @@ import static org.powermock.api.mockito.PowerMockito.verifyStatic;
 import static org.powermock.api.mockito.PowerMockito.when;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({FileUtils.class, JxBrowserUtils.class})
+@PrepareForTest({FileUtils.class, JxBrowserUtils.class, FlutterInitializer.class})
 public class JxBrowserManagerTest {
   @Mock Project mockProject;
   final String PLATFORM_FILE_NAME = "test/platform/file/name";
@@ -37,6 +39,10 @@ public class JxBrowserManagerTest {
   @Before
   public void setUp() {
     JxBrowserManager.resetForTest();
+
+    final Analytics mockAnalytics = mock(Analytics.class);
+    PowerMockito.mockStatic(FlutterInitializer.class);
+    when(FlutterInitializer.getAnalytics()).thenReturn(mockAnalytics);
   }
 
   @Test

--- a/testSrc/unit/io/flutter/view/FlutterViewTest.java
+++ b/testSrc/unit/io/flutter/view/FlutterViewTest.java
@@ -8,7 +8,9 @@ package io.flutter.view;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.ui.components.labels.LinkListener;
+import io.flutter.FlutterInitializer;
 import io.flutter.ObservatoryConnector;
+import io.flutter.analytics.Analytics;
 import io.flutter.devtools.DevToolsManager;
 import io.flutter.inspector.InspectorService;
 import io.flutter.jxbrowser.JxBrowserManager;
@@ -30,7 +32,7 @@ import static org.mockito.Mockito.*;
 import static org.powermock.api.mockito.PowerMockito.when;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({DevToolsManager.class, JxBrowserManager.class, ThreadUtil.class})
+@PrepareForTest({DevToolsManager.class, JxBrowserManager.class, ThreadUtil.class, FlutterInitializer.class})
 public class FlutterViewTest {
   @Mock Project mockProject;
   @Mock FlutterApp mockApp;
@@ -205,6 +207,10 @@ public class FlutterViewTest {
 
     setUpInstallationInProgress();
     when(mockJxBrowserManager.waitForInstallation(INSTALLATION_WAIT_LIMIT_SECONDS)).thenThrow(new TimeoutException());
+
+    final Analytics mockAnalytics = mock(Analytics.class);
+    PowerMockito.mockStatic(FlutterInitializer.class);
+    when(FlutterInitializer.getAnalytics()).thenReturn(mockAnalytics);
 
     partialMockFlutterView.waitForJxBrowserInstallation(mockApp, mockInspectorService, mockToolWindow);
     verify(partialMockFlutterView, times(1)).presentLabel(mockToolWindow, INSTALLATION_TIMED_OUT_LABEL);


### PR DESCRIPTION
The table that's accessible in BigQuery seems to be delayed, so I think I have to check back tomorrow to see if my testing recorded events. 

Update - I still don't see this in BigQuery, but I do see it in analytics:
![Screen Shot 2020-09-02 at 9 54 50 AM](https://user-images.githubusercontent.com/6379305/92013331-75c84c80-ed02-11ea-8511-2927c95eb938.png)