### PR TITLE
Use PluginManager method for Android Studio and move function

### DIFF
--- a/src/io/flutter/FlutterUtils.java
+++ b/src/io/flutter/FlutterUtils.java
@@ -12,7 +12,7 @@ import com.intellij.execution.util.ExecUtil;
 import com.intellij.ide.actions.ShowSettingsUtilImpl;
 import com.intellij.ide.impl.ProjectUtil;
 import com.intellij.ide.plugins.IdeaPluginDescriptor;
-import com.intellij.ide.plugins.PluginManagerCore;
+import com.intellij.ide.plugins.PluginManager;
 import com.intellij.ide.util.PropertiesComponent;
 import com.intellij.openapi.application.ApplicationInfo;
 import com.intellij.openapi.application.ApplicationManager;
@@ -556,9 +556,4 @@ public class FlutterUtils {
     return null;
   }
 
-  public static boolean isPluginVersionDev() {
-    final IdeaPluginDescriptor descriptor = PluginManagerCore.getPlugin(FlutterUtils.getPluginId());
-    assert descriptor != null;
-    return descriptor.getVersion().contains("dev");
-  }
 }

--- a/src/io/flutter/settings/FlutterSettings.java
+++ b/src/io/flutter/settings/FlutterSettings.java
@@ -5,6 +5,8 @@
  */
 package io.flutter.settings;
 
+import com.intellij.ide.plugins.IdeaPluginDescriptor;
+import com.intellij.ide.plugins.PluginManager;
 import com.intellij.ide.util.PropertiesComponent;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.project.Project;
@@ -263,12 +265,18 @@ public class FlutterSettings {
   }
 
   public boolean isEnableEmbeddedBrowsers() {
-    return getPropertiesComponent().getBoolean(enableEmbeddedBrowsersKey, FlutterUtils.isPluginVersionDev());
+    return getPropertiesComponent().getBoolean(enableEmbeddedBrowsersKey, isPluginVersionDev());
   }
 
   public void setEnableEmbeddedBrowsers(boolean value) {
-    getPropertiesComponent().setValue(enableEmbeddedBrowsersKey, value, FlutterUtils.isPluginVersionDev());
+    getPropertiesComponent().setValue(enableEmbeddedBrowsersKey, value, isPluginVersionDev());
 
     fireEvent();
+  }
+
+  private static boolean isPluginVersionDev() {
+    final IdeaPluginDescriptor descriptor = PluginManager.getPlugin(FlutterUtils.getPluginId());
+    assert descriptor != null;
+    return descriptor.getVersion().contains("dev") || descriptor.getVersion().contains("SNAPSHOT");
   }
 }


### PR DESCRIPTION
`PluginManagerCore` seems to be incompatible with Android Studio, so I changed back to using `PluginManager` though the function there is deprecated.

Also moving `isPluginVersionDev` out of utils since we want to limit divergence of release vs. dev/local behavior and keep it only within settings.