### PR TITLE
Remove extra page param when launching DevTools

### DIFF
--- a/src/io/flutter/devtools/DevToolsManager.java
+++ b/src/io/flutter/devtools/DevToolsManager.java
@@ -389,14 +389,14 @@ class DevToolsInstance {
 
   public void openBrowserAndConnect(String serviceProtocolUri, String page) {
     BrowserLauncher.getInstance().browse(
-      DevToolsUtils.generateDevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false, null),
+      DevToolsUtils.generateDevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false),
       null
     );
   }
 
   public void openPanel(String serviceProtocolUri, ContentManager contentManager, String tabName, String pageName) {
     final String color = ColorUtil.toHex(UIUtil.getEditorPaneBackground());
-    final String url = DevToolsUtils.generateDevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, null, true, pageName, color);
+    final String url = DevToolsUtils.generateDevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, pageName, true, color);
 
     ApplicationManager.getApplication().invokeLater(() -> {
       new EmbeddedBrowser().openPanel(contentManager, tabName, url);

--- a/src/io/flutter/devtools/DevToolsUtils.java
+++ b/src/io/flutter/devtools/DevToolsUtils.java
@@ -18,10 +18,9 @@ public class DevToolsUtils {
     int devtoolsPort,
     String serviceProtocolUri,
     String page,
-    boolean embed,
-    String pageName
+    boolean embed
   ) {
-    return generateDevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, embed, pageName, null);
+    return generateDevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, embed, null);
   }
 
   public static String generateDevToolsUrl(
@@ -30,18 +29,16 @@ public class DevToolsUtils {
     String serviceProtocolUri,
     String page,
     boolean embed,
-    String pageName,
     String colorHexCode
   ) {
     final List<String> params = new ArrayList<>();
 
     params.add("ide=" + FlutterSdkUtil.getFlutterHostEnvValue());
+    if (page != null) {
+      params.add("page=" + page);
+    }
     if (colorHexCode != null) {
       params.add("backgroundColor=" + colorHexCode);
-    }
-
-    if (pageName != null) {
-      params.add("page=" + pageName);
     }
     if (embed) {
       params.add("embed=true");
@@ -50,8 +47,7 @@ public class DevToolsUtils {
     if (serviceProtocolUri != null) {
       try {
         final String urlParam = URLEncoder.encode(serviceProtocolUri, "UTF-8");
-        final String pageParam = page == null ? "" : ("#" + page);
-        params.add("uri=" + urlParam + pageParam);
+        params.add("uri=" + urlParam);
       }
       catch (UnsupportedEncodingException ignored) {
       }

--- a/testSrc/unit/io/flutter/devtools/DevToolsUtilsTest.java
+++ b/testSrc/unit/io/flutter/devtools/DevToolsUtilsTest.java
@@ -30,18 +30,18 @@ public class DevToolsUtilsTest {
     PowerMockito.when(FlutterSdkUtil.getFlutterHostEnvValue()).thenReturn("IntelliJ-IDEA");
 
     assertEquals(
-      "http://127.0.0.1:9100/?ide=IntelliJ-IDEA&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F#timeline",
+      "http://127.0.0.1:9100/?ide=IntelliJ-IDEA&page=timeline&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F",
       generateDevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false, null)
     );
 
     assertEquals(
-      "http://127.0.0.1:9100/?ide=IntelliJ-IDEA&embed=true&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F#timeline",
+      "http://127.0.0.1:9100/?ide=IntelliJ-IDEA&page=timeline&embed=true&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F",
       generateDevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, true, null)
     );
 
     assertEquals(
-      "http://127.0.0.1:9100/?ide=IntelliJ-IDEA&page=timeline&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F#timeline",
-      generateDevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false, pageName)
+      "http://127.0.0.1:9100/?ide=IntelliJ-IDEA&page=timeline&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F",
+      generateDevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false)
     );
 
     assertEquals(
@@ -53,17 +53,17 @@ public class DevToolsUtilsTest {
 
     assertEquals(
       generateDevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false, null),
-      "http://127.0.0.1:9100/?ide=Android-Studio&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F#timeline"
+      "http://127.0.0.1:9100/?ide=Android-Studio&page=timeline&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F"
     );
 
     assertEquals(
-      generateDevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false, null, "3c3f41"),
-      "http://127.0.0.1:9100/?ide=Android-Studio&backgroundColor=3c3f41&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F#timeline"
+      generateDevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false, "3c3f41"),
+      "http://127.0.0.1:9100/?ide=Android-Studio&page=timeline&backgroundColor=3c3f41&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F"
     );
 
     assertEquals(
-      generateDevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false, null, "ffffff"),
-      "http://127.0.0.1:9100/?ide=Android-Studio&backgroundColor=ffffff&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F#timeline"
+      generateDevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false, "ffffff"),
+      "http://127.0.0.1:9100/?ide=Android-Studio&page=timeline&backgroundColor=ffffff&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F"
     );
   }
 }


### PR DESCRIPTION
There are currently two page params used while creating a DevTools URL, and the one in the form `#timeline` doesn't seem to do anything. I wanted to remove this since it's clearer and it will make adding a "simulated" embedded browser page (for developers without a JxBrowser license) a little easier.

I checked that opening DevTools from the run console and from the performance tab hasn't changed.