### PR TITLE
Skip transparent background if hardware accelerated causes error

### DIFF
--- a/src/io/flutter/jxbrowser/EmbeddedBrowser.java
+++ b/src/io/flutter/jxbrowser/EmbeddedBrowser.java
@@ -21,14 +21,23 @@ import java.awt.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.teamdev.jxbrowser.engine.RenderingMode.HARDWARE_ACCELERATED;
-import static com.teamdev.jxbrowser.engine.RenderingMode.OFF_SCREEN;
 
 public class EmbeddedBrowser {
   public void openPanel(ContentManager contentManager, String tabName, String url) {
+    final EngineOptions options =
+      EngineOptions.newBuilder(HARDWARE_ACCELERATED).build();
+    final Engine engine = Engine.newInstance(options);
+    final Browser browser = engine.newBrowser();
+
+    try {
+      browser.settings().enableTransparentBackground();
+    } catch (UnsupportedRenderingModeException ex) {
+      // Skip using a transparent background if an exception is thrown.
+    }
+
     // Multiple LoadFinished events can occur, but we only need to add content the first time.
     final AtomicBoolean contentLoaded = new AtomicBoolean(false);
 
-    final Browser browser = createBrowser();
     browser.navigation().loadUrl(url);
     browser.navigation().on(LoadFinished.class, event -> {
       if (!contentLoaded.compareAndSet(false, true)) {
@@ -54,24 +63,5 @@ public class EmbeddedBrowser {
         contentManager.addContent(content);
       });
     });
-  }
-
-  private Browser createBrowser() {
-    EngineOptions options =
-      EngineOptions.newBuilder(HARDWARE_ACCELERATED).build();
-    Engine engine = Engine.newInstance(options);
-    Browser browser = engine.newBrowser();
-
-    try {
-      browser.settings().enableTransparentBackground();
-    } catch (UnsupportedRenderingModeException ex) {
-      options =
-        EngineOptions.newBuilder(OFF_SCREEN).build();
-      engine = Engine.newInstance(options);
-      browser = engine.newBrowser();
-      browser.settings().enableTransparentBackground();
-    }
-
-    return browser;
   }
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter-intellij/issues/4803

It seems that hardware accelerated mode can fail on Windows, but we aren't sure if this is due to a machine setting or a JxBrowser limitation. Adding this check so that we can try a backup mode.

~~Verified that this works, but it is comically zoomed in:
<img width="1044" alt="Annotation 2020-09-08 162604" src="https://user-images.githubusercontent.com/6379305/92537178-5e043300-f1f0-11ea-96a4-0d1d53090b34.png">~~

The `OFFSCREEN` mode works fine; in the previous screenshot my windows device had a strange zoom setting.
![Screenshot 2020-09-09 151929](https://user-images.githubusercontent.com/6379305/92660948-4ee4ba00-f2b0-11ea-95b1-84a706ae10e3.png)

The `HARDWARE_ACCELERATED` mode works too; in comments below the issue was also due to the local zoom setting.
![Screenshot 2020-09-09 154410](https://user-images.githubusercontent.com/6379305/92662459-b51f0c00-f2b3-11ea-841a-1b62e460d34a.png)
