### PR TITLE
Use Gradle to compile for Kokoro

### DIFF
--- a/tool/kokoro/build.sh
+++ b/tool/kokoro/build.sh
@@ -4,6 +4,6 @@ source ./tool/kokoro/setup.sh
 setup
 
 echo "kokoro build start"
-./bin/plugin build --channel=dev
+./bin/plugin make --channel=dev
 
 echo "kokoro build finished"

--- a/tool/kokoro/deploy.sh
+++ b/tool/kokoro/deploy.sh
@@ -4,7 +4,7 @@ source ./tool/kokoro/setup.sh
 setup
 
 echo "kokoro build start"
-./bin/plugin build --channel=dev
+./bin/plugin make --channel=dev
 
 echo "kokoro build finished"
 


### PR DESCRIPTION
The Ant script has to manage the entire class path. Changing to Java 14 on Kokoro breaks it. This change switches to using Gradle instead. We won't know that it works until this is merged, but it should since the Gradle-driven tests do work.