### PR TITLE
Log exception when jxbrowser license key file is missing

### DIFF
--- a/src/io/flutter/jxbrowser/JxBrowserManager.java
+++ b/src/io/flutter/jxbrowser/JxBrowserManager.java
@@ -133,11 +133,11 @@ public class JxBrowserManager {
     // Retrieve key
     try {
       final String key = JxBrowserUtils.getJxBrowserKey();
-      System.setProperty(JxBrowserUtils.PROPERTY_NAME, key);
+      System.setProperty(JxBrowserUtils.LICENSE_PROPERTY_NAME, key);
     }
     catch (FileNotFoundException e) {
       LOG.info(e.getMessage());
-      LOG.info(project.getName() + ": Unable to find JxBrowser licence key file");
+      LOG.info(project.getName() + ": Unable to find JxBrowser license key file");
       setStatusFailed("missingKey");
       return;
     }

--- a/src/io/flutter/jxbrowser/JxBrowserManager.java
+++ b/src/io/flutter/jxbrowser/JxBrowserManager.java
@@ -136,8 +136,7 @@ public class JxBrowserManager {
       System.setProperty(JxBrowserUtils.LICENSE_PROPERTY_NAME, key);
     }
     catch (FileNotFoundException e) {
-      LOG.info(e.getMessage());
-      LOG.info(project.getName() + ": Unable to find JxBrowser license key file");
+      LOG.info(project.getName() + ": Unable to find JxBrowser license key file", e);
       setStatusFailed("missingKey");
       return;
     }

--- a/src/io/flutter/utils/JxBrowserUtils.java
+++ b/src/io/flutter/utils/JxBrowserUtils.java
@@ -15,7 +15,7 @@ public class JxBrowserUtils {
   private static final String JXBROWSER_FILE_PREFIX = "jxbrowser";
   private static final String JXBROWSER_FILE_VERSION = "7.10";
   private static final String JXBROWSER_FILE_SUFFIX = "jar";
-  public static final String PROPERTY_NAME = "jxbrowser.license.key";
+  public static final String LICENSE_PROPERTY_NAME = "jxbrowser.license.key";
 
   public static String getPlatformFileName() throws FileNotFoundException {
     String name = "";
@@ -51,6 +51,10 @@ public class JxBrowserUtils {
   }
 
   public static String getJxBrowserKey() throws FileNotFoundException {
+    if (JxBrowserUtils.class.getResource("/jxbrowser/jxbrowser.properties") == null) {
+      throw new FileNotFoundException("jxbrowser.properties file does not exist");
+    }
+
     final Properties properties = new Properties();
     try {
       properties.load(JxBrowserUtils.class.getResourceAsStream("/jxbrowser/jxbrowser.properties"));
@@ -59,7 +63,7 @@ public class JxBrowserUtils {
       throw new FileNotFoundException("Unable to load properties of JxBrowser key file");
     }
 
-    final String value = properties.getProperty(PROPERTY_NAME);
+    final String value = properties.getProperty(LICENSE_PROPERTY_NAME);
     if (value == null) {
       throw new FileNotFoundException("No value for JxBrowser key exists");
     }


### PR DESCRIPTION
When there isn't a jxbrowser.properties file, the logs should show something like:
```
2020-09-10 17:26:22,153 [   6543]   INFO - ter.jxbrowser.JxBrowserManager - jxbrowser.properties file does not exist 
2020-09-10 17:26:22,153 [   6543]   INFO - ter.jxbrowser.JxBrowserManager - flutter_error_studies: Unable to find JxBrowser license key file 
```
instead of an NPE.

Since this should mostly occur in development, should I use `System.out.println` here instead?

Fixes https://github.com/flutter/flutter-intellij/issues/4812