### PR TITLE
Open DevTools in standard browser if jxbrowser license is missing

### DIFF
--- a/src/io/flutter/utils/JxBrowserUtils.java
+++ b/src/io/flutter/utils/JxBrowserUtils.java
@@ -70,4 +70,8 @@ public class JxBrowserUtils {
 
     return value;
   }
+
+  public static boolean licenseIsSet() {
+    return System.getProperty(JxBrowserUtils.LICENSE_PROPERTY_NAME) != null;
+  }
 }

--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -48,6 +48,7 @@ import io.flutter.run.daemon.FlutterApp;
 import io.flutter.settings.FlutterSettings;
 import io.flutter.utils.AsyncUtils;
 import io.flutter.utils.EventStream;
+import io.flutter.utils.JxBrowserUtils;
 import io.flutter.utils.VmServiceListenerAdapter;
 import io.flutter.vmService.ServiceExtensions;
 import org.dartlang.vm.service.VmService;
@@ -191,7 +192,10 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
     return perAppViewState.computeIfAbsent(app, k -> new PerAppState());
   }
 
-  private void addBrowserInspectorViewContent(FlutterApp app, @Nullable InspectorService inspectorService, ToolWindow toolWindow) {
+  private void addBrowserInspectorViewContent(FlutterApp app,
+                                              @Nullable InspectorService inspectorService,
+                                              ToolWindow toolWindow,
+                                              boolean isEmbedded) {
     final ContentManager contentManager = toolWindow.getContentManager();
 
     final String tabName;
@@ -212,10 +216,14 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
       emptyContent = null;
     }
 
-    // TODO(helin24): Add a message to communicate that opening devtools is in progress.
-
     final String browserUrl = app.getConnector().getBrowserUrl();
-    DevToolsManager.getInstance(app.getProject()).openBrowserIntoPanel(browserUrl, contentManager, tabName, "inspector");
+
+    if (isEmbedded) {
+      DevToolsManager.getInstance(app.getProject()).openBrowserIntoPanel(browserUrl, contentManager, tabName, "inspector");
+    } else {
+      DevToolsManager.getInstance(app.getProject()).openBrowserAndConnect(browserUrl, "inspector");
+      presentLabel(toolWindow, "DevTools inspector has been opened in the browser.");
+    }
   }
 
   private void addInspectorViewContent(FlutterApp app, @Nullable InspectorService inspectorService, ToolWindow toolWindow) {
@@ -383,10 +391,14 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
   }
 
   protected void handleJxBrowserInstalled(FlutterApp app, InspectorService inspectorService, ToolWindow toolWindow) {
+    presentDevTools(app, inspectorService, toolWindow, true);
+  }
+
+  protected void presentDevTools(FlutterApp app, InspectorService inspectorService, ToolWindow toolWindow, boolean isEmbedded) {
     final DevToolsManager devToolsManager = DevToolsManager.getInstance(app.getProject());
 
     if (devToolsManager.hasInstalledDevTools()) {
-      addBrowserInspectorViewContent(app, inspectorService, toolWindow);
+      addBrowserInspectorViewContent(app, inspectorService, toolWindow, isEmbedded);
     }
     else {
       presentLabel(toolWindow, INSTALLING_DEVTOOLS_LABEL);
@@ -394,7 +406,7 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
       final CompletableFuture<Boolean> result = devToolsManager.installDevTools();
       result.thenAccept(succeeded -> {
         if (succeeded) {
-          addBrowserInspectorViewContent(app, inspectorService, toolWindow);
+          addBrowserInspectorViewContent(app, inspectorService, toolWindow, isEmbedded);
         } else {
           // TODO(helin24): Handle with alternative instructions if devtools fails.
           presentLabel(toolWindow, DEVTOOLS_FAILED_LABEL);
@@ -447,11 +459,18 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
   }
 
   protected void handleJxBrowserInstallationFailed(FlutterApp app, InspectorService inspectorService, ToolWindow toolWindow) {
-    // Allow user to manually restart.
-    presentClickableLabel(toolWindow, "JxBrowser installation failed. Click to retry.", (linkLabel, data) -> {
-      JxBrowserManager.getInstance().retryFromFailed(app.getProject());
-      handleJxBrowserInstallationInProgress(app, inspectorService, toolWindow);
-    });
+    if (System.getProperty(JxBrowserUtils.LICENSE_PROPERTY_NAME) == null) {
+      // If the license isn't available, allow the user to open the equivalent page in a non-embedded browser window.
+      presentClickableLabel(toolWindow, "The JxBrowser license could not be found. Click to open Devtools in the browser.", (linkLabel, data) -> {
+        presentDevTools(app, inspectorService, toolWindow, false);
+      });
+    } else {
+      // Allow the user to manually restart.
+      presentClickableLabel(toolWindow, "JxBrowser installation failed. Click to retry.", (linkLabel, data) -> {
+        JxBrowserManager.getInstance().retryFromFailed(app.getProject());
+        handleJxBrowserInstallationInProgress(app, inspectorService, toolWindow);
+      });
+    }
   }
 
   protected void presentLabel(ToolWindow toolWindow, String text) {

--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -394,7 +394,7 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
     presentDevTools(app, inspectorService, toolWindow, true);
   }
 
-  protected void presentDevTools(FlutterApp app, InspectorService inspectorService, ToolWindow toolWindow, boolean isEmbedded) {
+  private void presentDevTools(FlutterApp app, InspectorService inspectorService, ToolWindow toolWindow, boolean isEmbedded) {
     final DevToolsManager devToolsManager = DevToolsManager.getInstance(app.getProject());
 
     if (devToolsManager.hasInstalledDevTools()) {
@@ -459,7 +459,7 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
   }
 
   protected void handleJxBrowserInstallationFailed(FlutterApp app, InspectorService inspectorService, ToolWindow toolWindow) {
-    if (System.getProperty(JxBrowserUtils.LICENSE_PROPERTY_NAME) == null) {
+    if (!JxBrowserUtils.licenseIsSet()) {
       // If the license isn't available, allow the user to open the equivalent page in a non-embedded browser window.
       presentClickableLabel(toolWindow, "The JxBrowser license could not be found. Open Devtools in the browser?", (linkLabel, data) -> {
         presentDevTools(app, inspectorService, toolWindow, false);

--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -461,12 +461,12 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
   protected void handleJxBrowserInstallationFailed(FlutterApp app, InspectorService inspectorService, ToolWindow toolWindow) {
     if (System.getProperty(JxBrowserUtils.LICENSE_PROPERTY_NAME) == null) {
       // If the license isn't available, allow the user to open the equivalent page in a non-embedded browser window.
-      presentClickableLabel(toolWindow, "The JxBrowser license could not be found. Click to open Devtools in the browser.", (linkLabel, data) -> {
+      presentClickableLabel(toolWindow, "The JxBrowser license could not be found. Open Devtools in the browser?", (linkLabel, data) -> {
         presentDevTools(app, inspectorService, toolWindow, false);
       });
     } else {
       // Allow the user to manually restart.
-      presentClickableLabel(toolWindow, "JxBrowser installation failed. Click to retry.", (linkLabel, data) -> {
+      presentClickableLabel(toolWindow, "JxBrowser installation failed. Retry?", (linkLabel, data) -> {
         JxBrowserManager.getInstance().retryFromFailed(app.getProject());
         handleJxBrowserInstallationInProgress(app, inspectorService, toolWindow);
       });

--- a/testSrc/unit/io/flutter/view/FlutterViewTest.java
+++ b/testSrc/unit/io/flutter/view/FlutterViewTest.java
@@ -16,6 +16,7 @@ import io.flutter.inspector.InspectorService;
 import io.flutter.jxbrowser.JxBrowserManager;
 import io.flutter.jxbrowser.JxBrowserStatus;
 import io.flutter.run.daemon.FlutterApp;
+import io.flutter.utils.JxBrowserUtils;
 import io.flutter.utils.ThreadUtil;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -32,7 +33,7 @@ import static org.mockito.Mockito.*;
 import static org.powermock.api.mockito.PowerMockito.when;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({DevToolsManager.class, JxBrowserManager.class, ThreadUtil.class, FlutterInitializer.class})
+@PrepareForTest({DevToolsManager.class, JxBrowserManager.class, ThreadUtil.class, FlutterInitializer.class, JxBrowserUtils.class})
 public class FlutterViewTest {
   @Mock Project mockProject;
   @Mock FlutterApp mockApp;
@@ -122,13 +123,16 @@ public class FlutterViewTest {
 
   @Test
   public void testHandleJxBrowserInstallationFailed() {
+    PowerMockito.mockStatic(JxBrowserUtils.class);
+    when(JxBrowserUtils.licenseIsSet()).thenReturn(true);
+
     // If JxBrowser failed to install, we should show a failure message that allows the user to manually retry.
     final FlutterView partialMockFlutterView = mock(FlutterView.class);
     doCallRealMethod().when(partialMockFlutterView).handleJxBrowserInstallationFailed(mockApp, mockInspectorService, mockToolWindow);
     partialMockFlutterView.handleJxBrowserInstallationFailed(mockApp, mockInspectorService, mockToolWindow);
     verify(partialMockFlutterView, times(1)).presentClickableLabel(
       eq(mockToolWindow),
-      eq("JxBrowser installation failed. Click to retry."),
+      eq("JxBrowser installation failed. Retry?"),
       any(LinkListener.class)
     );
   }


### PR DESCRIPTION
With this change, running the development workbench without a jxbrowser license shows a message in the inspector panel: "The JxBrowser license could not be found. Click to open Devtools in the browser." that can be clicked to open the same DevTools URL in the normal browser.

When we're ready to remove the old inspector view, we can also use this path for users who elect not to use JxBrowser.