### PR TITLE
Use 0.4.18 IntelliJ plugin for Gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,12 +17,11 @@ buildscript {
       url 'https://jetbrains.bintray.com/intellij-third-party-dependencies'
     }
   }
-  dependencies {
-    classpath "org.jetbrains.intellij.plugins:gradle-intellij-plugin:0.5.0-SNAPSHOT"
-  }
 }
 
-apply plugin: 'org.jetbrains.intellij'
+plugins {
+  id "org.jetbrains.intellij" version "0.4.18"
+}
 
 repositories {
   mavenLocal()

--- a/flutter-studio/build.gradle
+++ b/flutter-studio/build.gradle
@@ -31,12 +31,14 @@ java {
 
 intellij {
   // This adds nullability assertions, but also compiles forms.
-  instrumentCode = true
+  if (testing == false) {
+    instrumentCode = true
+  }
   updateSinceUntilBuild = false
   downloadSources false
   localPath "${project.rootDir.absolutePath}/artifacts/$ide"
   plugins "java", "Dart:$dartVersion", "properties", "junit",
-          "gradle", "android", "Groovy", "smali", "IntelliLang", "org.jetbrains.android"
+          "gradle", "android", "Groovy", "smali", "IntelliLang", "android"//"org.jetbrains.android"
   sourceCompatibility = JavaVersion.VERSION_11
   targetCompatibility = JavaVersion.VERSION_11
 }


### PR DESCRIPTION
Also, stop compiling forms when running tests, since it intermittently fails with AS 4.1. And the Android plugin no longer gets loaded by its id, so use its name.