### PR TITLE
remove a log error about no isolates

### DIFF
--- a/src/io/flutter/vmService/VmServiceWrapper.java
+++ b/src/io/flutter/vmService/VmServiceWrapper.java
@@ -113,10 +113,6 @@ public class VmServiceWrapper implements Disposable {
             getVm(new VmServiceConsumers.VmConsumerWrapper() {
               @Override
               public void received(final VM vm) {
-                if (vm.getIsolates().isEmpty()) {
-                  Logging.getLogger().logError("No isolates found after VM start: " + vm.getIsolates().size());
-                }
-
                 for (final IsolateRef isolateRef : vm.getIsolates()) {
                   getIsolate(isolateRef.getId(), new VmServiceConsumers.GetIsolateConsumerWrapper() {
                     @Override


### PR DESCRIPTION
- remove a log error about no isolates at initial app connection

I believe that DDS can change the timing of when isolates are reported to exist; @bkonyi to confirm.

cc @bkonyi, @jwren 