### PR TITLE
Enable Gradle logging for dev channel

### DIFF
--- a/tool/plugin/lib/runner.dart
+++ b/tool/plugin/lib/runner.dart
@@ -68,7 +68,11 @@ jxbrowser.license.key=${jxBrowserKey}
 
   Future<int> buildPlugin(BuildSpec spec, String version) async {
     writeJxBrowserKeyToFile();
-    return await runGradleCommand(['buildPlugin'], spec, version, 'false');
+    if (spec.isDevChannel)
+      return await runGradleCommand(
+          ['-i', 'buildPlugin'], spec, version, 'false');
+    else
+      return await runGradleCommand(['buildPlugin'], spec, version, 'false');
   }
 
   Future<int> runGradleCommand(List<String> command, BuildSpec spec,


### PR DESCRIPTION
I don't know if this is a permanent change yet. I need it for debugging the Kokoro build.