### PR TITLE
redirect json parsing calls to JsonUtils

### DIFF
--- a/src/io/flutter/dart/FlutterDartAnalysisServer.java
+++ b/src/io/flutter/dart/FlutterDartAnalysisServer.java
@@ -10,7 +10,10 @@ import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.google.dart.server.AnalysisServerListenerAdapter;
 import com.google.dart.server.ResponseListener;
-import com.google.gson.*;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.ServiceManager;
@@ -20,6 +23,7 @@ import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.util.Consumer;
 import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService;
+import io.flutter.utils.JsonUtils;
 import org.dartlang.analysis.server.protocol.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -190,7 +194,7 @@ public class FlutterDartAnalysisServer implements Disposable {
       // Short circuit just in case we have been disposed in the time it took
       // for us to get around to listening for the response.
       if (isDisposed) return;
-      processResponse(new JsonParser().parse(jsonString).getAsJsonObject());
+      processResponse(JsonUtils.parseString(jsonString).getAsJsonObject());
     });
   }
 

--- a/src/io/flutter/devtools/DevToolsManager.java
+++ b/src/io/flutter/devtools/DevToolsManager.java
@@ -7,7 +7,6 @@ package io.flutter.devtools;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
 import com.google.gson.JsonSyntaxException;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configurations.GeneralCommandLine;
@@ -225,6 +224,7 @@ public class DevToolsManager {
 
     return handler;
   }
+
   private boolean isBazel(Project project) {
     return WorkspaceCache.getInstance(project).isBazel();
   }
@@ -283,12 +283,14 @@ public class DevToolsManager {
           if (address == null) {
             @Nullable final OSProcessHandler handler = getProcessHandlerForBazel();
             startDevToolsServerAndConnect(handler, uri, screen);
-          } else {
+          }
+          else {
             devToolsInstance = new DevToolsInstance(address.host, address.port);
             devToolsInstance.openBrowserAndConnect(uri, screen);
           }
         });
-      } else {
+      }
+      else {
         @Nullable final OSProcessHandler handler = getProcessHandlerForPub();
         startDevToolsServerAndConnect(handler, uri, screen);
       }
@@ -348,8 +350,7 @@ class DevToolsInstance {
           // {"event":"server.started","params":{"host":"127.0.0.1","port":9100}}
 
           try {
-            final JsonParser jsonParser = new JsonParser();
-            final JsonElement element = jsonParser.parse(text);
+            final JsonElement element = JsonUtils.parseString(text);
 
             // params.port
             final JsonObject obj = element.getAsJsonObject();

--- a/src/io/flutter/inspector/FlutterWidget.java
+++ b/src/io/flutter/inspector/FlutterWidget.java
@@ -10,7 +10,6 @@ import com.google.common.io.ByteStreams;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
 import com.intellij.openapi.diagnostic.Logger;
 import icons.FlutterIcons;
 import io.flutter.FlutterUtils;
@@ -163,8 +162,7 @@ public class FlutterWidget {
         final URL resource = getClass().getResource("widgets.json");
         final byte[] contentBytes = ByteStreams.toByteArray((InputStream)resource.getContent());
         final String content = new String(contentBytes, Charsets.UTF_8);
-        final JsonParser parser = new JsonParser();
-        json = parser.parse(content);
+        json = JsonUtils.parseString(content);
         if (!(json instanceof JsonArray)) throw new IllegalStateException("Unexpected Json format: expected array");
         ((JsonArray)json).forEach(element -> {
           if (!(element instanceof JsonObject)) throw new IllegalStateException("Unexpected Json format: expected object");

--- a/src/io/flutter/inspector/InspectorService.java
+++ b/src/io/flutter/inspector/InspectorService.java
@@ -6,7 +6,10 @@
 package io.flutter.inspector;
 
 import com.google.common.base.Joiner;
-import com.google.gson.*;
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.editor.Document;
@@ -34,6 +37,7 @@ import io.flutter.bazel.WorkspaceCache;
 import io.flutter.pub.PubRoot;
 import io.flutter.run.FlutterDebugProcess;
 import io.flutter.run.daemon.FlutterApp;
+import io.flutter.utils.JsonUtils;
 import io.flutter.utils.StreamSubscription;
 import io.flutter.utils.VmServiceListenerAdapter;
 import io.flutter.vmService.ServiceExtensions;
@@ -1068,7 +1072,7 @@ public class InspectorService implements Disposable {
     CompletableFuture<JsonElement> instanceRefToJson(InstanceRef instanceRef) {
       if (instanceRef.getValueAsString() != null && !instanceRef.getValueAsStringIsTruncated()) {
         // In some situations, the string may already be fully populated.
-        final JsonElement json = new JsonParser().parse(instanceRef.getValueAsString());
+        final JsonElement json = JsonUtils.parseString(instanceRef.getValueAsString());
         return CompletableFuture.completedFuture(json);
       }
       else {
@@ -1076,7 +1080,7 @@ public class InspectorService implements Disposable {
         return nullIfDisposed(() -> getInspectorLibrary().getInstance(instanceRef, this).thenApplyAsync((Instance instance) -> {
           return nullValueIfDisposed(() -> {
             final String json = instance.getValueAsString();
-            return new JsonParser().parse(json);
+            return JsonUtils.parseString(json);
           });
         }));
       }

--- a/src/io/flutter/logging/FlutterConsoleLogManager.java
+++ b/src/io/flutter/logging/FlutterConsoleLogManager.java
@@ -7,7 +7,10 @@
 package io.flutter.logging;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.gson.*;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSyntaxException;
 import com.intellij.execution.ui.ConsoleView;
 import com.intellij.execution.ui.ConsoleViewContentType;
 import com.intellij.ide.util.PropertiesComponent;
@@ -25,6 +28,7 @@ import io.flutter.inspector.DiagnosticsTreeStyle;
 import io.flutter.inspector.InspectorService;
 import io.flutter.run.daemon.FlutterApp;
 import io.flutter.settings.FlutterSettings;
+import io.flutter.utils.JsonUtils;
 import io.flutter.vmService.VmServiceConsumers;
 import org.dartlang.vm.service.VmService;
 import org.dartlang.vm.service.consumer.GetObjectConsumer;
@@ -381,7 +385,7 @@ public class FlutterConsoleLogManager {
         // Handle json in the error payload.
         boolean isJson = false;
         try {
-          final JsonElement json = new JsonParser().parse(string);
+          final JsonElement json = JsonUtils.parseString(string);
           isJson = true;
 
           string = new GsonBuilder().setPrettyPrinting().create().toJson(json);

--- a/src/io/flutter/logging/tree/DataPanel.java
+++ b/src/io/flutter/logging/tree/DataPanel.java
@@ -8,7 +8,6 @@ package io.flutter.logging.tree;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
-import com.google.gson.JsonParser;
 import com.intellij.execution.filters.Filter;
 import com.intellij.execution.filters.HyperlinkInfo;
 import com.intellij.openapi.project.Project;
@@ -267,7 +266,7 @@ public class DataPanel extends JPanel {
   }
 
   private boolean updateJsonTextData(String data) {
-    @SuppressWarnings("ConstantConditions") final JsonElement jsonElement = new JsonParser().parse((String)data);
+    @SuppressWarnings("ConstantConditions") final JsonElement jsonElement = JsonUtils.parseString((String)data);
     final String text = gsonHelper.toJson(jsonElement);
     if (text.isEmpty()) {
       return false;

--- a/src/io/flutter/run/bazelTest/BazelTestRunner.java
+++ b/src/io/flutter/run/bazelTest/BazelTestRunner.java
@@ -5,7 +5,10 @@
  */
 package io.flutter.run.bazelTest;
 
-import com.google.gson.*;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSyntaxException;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.ExecutionResult;
 import com.intellij.execution.configurations.RunProfile;
@@ -38,6 +41,7 @@ import io.flutter.run.FlutterPositionMapper;
 import io.flutter.run.common.CommonTestConfigUtils;
 import io.flutter.run.test.FlutterTestRunner;
 import io.flutter.settings.FlutterSettings;
+import io.flutter.utils.JsonUtils;
 import io.flutter.utils.StdoutJsonParser;
 import org.apache.commons.lang.StringUtils;
 import org.jetbrains.annotations.NotNull;
@@ -189,8 +193,7 @@ public class BazelTestRunner extends GenericProgramRunner {
     private void dispatchJson(String json) {
       final JsonObject obj;
       try {
-        final JsonParser jp = new JsonParser();
-        final JsonElement elem = jp.parse(json);
+        final JsonElement elem = JsonUtils.parseString(json);
         obj = elem.getAsJsonObject();
       }
       catch (JsonSyntaxException e) {

--- a/src/io/flutter/run/daemon/DaemonApi.java
+++ b/src/io/flutter/run/daemon/DaemonApi.java
@@ -15,6 +15,7 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.util.Key;
 import io.flutter.FlutterUtils;
 import io.flutter.settings.FlutterSettings;
+import io.flutter.utils.JsonUtils;
 import io.flutter.utils.StdoutJsonParser;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -253,8 +254,7 @@ public class DaemonApi {
     final JsonObject obj;
 
     try {
-      final JsonParser jsonParser = new JsonParser();
-      final JsonElement element = jsonParser.parse(message);
+      final JsonElement element = JsonUtils.parseString(message);
       obj = element.getAsJsonObject();
     }
     catch (JsonSyntaxException e) {

--- a/src/io/flutter/run/test/FlutterTestRunner.java
+++ b/src/io/flutter/run/test/FlutterTestRunner.java
@@ -5,7 +5,10 @@
  */
 package io.flutter.run.test;
 
-import com.google.gson.*;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSyntaxException;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.ExecutionResult;
 import com.intellij.execution.configurations.RunProfile;
@@ -32,6 +35,7 @@ import io.flutter.run.FlutterPositionMapper;
 import io.flutter.run.common.CommonTestConfigUtils;
 import io.flutter.sdk.FlutterSdk;
 import io.flutter.settings.FlutterSettings;
+import io.flutter.utils.JsonUtils;
 import io.flutter.utils.StdoutJsonParser;
 import io.flutter.vmService.VmServiceConsumers;
 import org.dartlang.vm.service.VmService;
@@ -231,8 +235,7 @@ public class FlutterTestRunner extends GenericProgramRunner {
     private void dispatchJson(String json) {
       final JsonObject obj;
       try {
-        final JsonParser jp = new JsonParser();
-        final JsonElement elem = jp.parse(json);
+        final JsonElement elem = JsonUtils.parseString(json);
         obj = elem.getAsJsonObject();
       }
       catch (JsonSyntaxException e) {

--- a/src/io/flutter/sdk/FlutterSdk.java
+++ b/src/io/flutter/sdk/FlutterSdk.java
@@ -5,7 +5,10 @@
  */
 package io.flutter.sdk;
 
-import com.google.gson.*;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSyntaxException;
 import com.intellij.execution.process.*;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
@@ -32,6 +35,7 @@ import io.flutter.run.FlutterLaunchMode;
 import io.flutter.run.common.RunMode;
 import io.flutter.run.test.TestFields;
 import io.flutter.settings.FlutterSettings;
+import io.flutter.utils.JsonUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -532,8 +536,7 @@ public class FlutterSdk {
       final Integer code = process.getExitCode();
       if (code != null && code == 0) {
         try {
-          final JsonParser jp = new JsonParser();
-          final JsonElement elem = jp.parse(stdout.toString());
+          final JsonElement elem = JsonUtils.parseString(stdout.toString());
           if (elem.isJsonNull()) {
             FlutterUtils.warn(LOG, "Invalid Json from flutter config");
             return null;

--- a/src/io/flutter/survey/FlutterSurveyService.java
+++ b/src/io/flutter/survey/FlutterSurveyService.java
@@ -6,12 +6,12 @@
 package io.flutter.survey;
 
 import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
 import com.google.gson.JsonSyntaxException;
 import com.intellij.ide.util.PropertiesComponent;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.util.io.HttpRequests;
+import io.flutter.utils.JsonUtils;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
@@ -54,7 +54,7 @@ public class FlutterSurveyService {
   private static FlutterSurvey fetchSurveyContent() {
     try {
       final String contents = HttpRequests.request(CONTENT_URL).readString();
-      final JsonObject json = new JsonParser().parse(contents).getAsJsonObject();
+      final JsonObject json = JsonUtils.parseString(contents).getAsJsonObject();
       return FlutterSurvey.fromJson(json);
     }
     catch (IOException | JsonSyntaxException e) {

--- a/src/io/flutter/test/DartTestEventsConverterZ.java
+++ b/src/io/flutter/test/DartTestEventsConverterZ.java
@@ -12,6 +12,7 @@ import com.intellij.util.PathUtil;
 import com.jetbrains.lang.dart.ide.runner.util.DartTestLocationProvider;
 import com.jetbrains.lang.dart.util.DartUrlResolver;
 import gnu.trove.TIntLongHashMap;
+import io.flutter.utils.JsonUtils;
 import jetbrains.buildServer.messages.serviceMessages.ServiceMessageVisitor;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -119,10 +120,9 @@ public class DartTestEventsConverterZ extends OutputToGeneralTestEventsConverter
 
   @SuppressWarnings("SimplifiableIfStatement")
   private boolean processEventText(final String text) throws JsonSyntaxException, ParseException {
-    JsonParser jp = new JsonParser();
     JsonElement elem;
     try {
-      elem = jp.parse(text);
+      elem = JsonUtils.parseString(text);
     }
     catch (JsonSyntaxException ex) {
       if (text.contains("\"json\" is not an allowed value for option \"reporter\"")) {

--- a/src/io/flutter/utils/JsonUtils.java
+++ b/src/io/flutter/utils/JsonUtils.java
@@ -5,14 +5,12 @@
  */
 package io.flutter.utils;
 
-import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonNull;
-import com.google.gson.JsonObject;
+import com.google.gson.*;
 import org.apache.commons.lang.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.io.Reader;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -53,5 +51,19 @@ public class JsonUtils {
 
   public static boolean hasJsonData(@Nullable String data) {
     return StringUtils.isNotEmpty(data) && !Objects.equals(data, "null");
+  }
+
+  /**
+   * Parses the specified JSON string into a JsonElement.
+   */
+  public static JsonElement parseString(String json) throws JsonSyntaxException {
+    return new JsonParser().parse(json);
+  }
+
+  /**
+   * Parses the specified JSON string into a JsonElement.
+   */
+  public static JsonElement parseReader(Reader reader) throws JsonIOException, JsonSyntaxException {
+    return new JsonParser().parse(reader);
   }
 }

--- a/testSrc/unit/io/flutter/logging/FlutterConsoleLogManagerTest.java
+++ b/testSrc/unit/io/flutter/logging/FlutterConsoleLogManagerTest.java
@@ -5,7 +5,6 @@
  */
 package io.flutter.logging;
 
-import com.google.gson.JsonParser;
 import com.intellij.execution.filters.Filter;
 import com.intellij.execution.filters.HyperlinkInfo;
 import com.intellij.execution.process.ProcessHandler;
@@ -14,6 +13,7 @@ import com.intellij.execution.ui.ConsoleViewContentType;
 import com.intellij.openapi.actionSystem.AnAction;
 import io.flutter.run.FlutterDebugProcess;
 import io.flutter.run.daemon.FlutterApp;
+import io.flutter.utils.JsonUtils;
 import io.flutter.vmService.VMServiceManager;
 import org.dartlang.vm.service.VmService;
 import org.dartlang.vm.service.element.Event;
@@ -32,7 +32,7 @@ public class FlutterConsoleLogManagerTest {
   public void testBasicLogging() {
     final ConsoleViewMock console = new ConsoleViewMock();
     final FlutterConsoleLogManager logManager = new FlutterConsoleLogManager(console, createFlutterApp());
-    final Event event = new Event(new JsonParser().parse(
+    final Event event = new Event(JsonUtils.parseReader(
       new InputStreamReader(FlutterConsoleLogManagerTest.class.getResourceAsStream("console_log_1.json"))).getAsJsonObject());
 
     logManager.processLoggingEvent(event);
@@ -44,7 +44,7 @@ public class FlutterConsoleLogManagerTest {
   public void testNoLoggerName() {
     final ConsoleViewMock console = new ConsoleViewMock();
     final FlutterConsoleLogManager logManager = new FlutterConsoleLogManager(console, createFlutterApp());
-    final Event event = new Event(new JsonParser().parse(
+    final Event event = new Event(JsonUtils.parseReader(
       new InputStreamReader(FlutterConsoleLogManagerTest.class.getResourceAsStream("console_log_2.json"))).getAsJsonObject());
 
     logManager.processLoggingEvent(event);
@@ -56,7 +56,7 @@ public class FlutterConsoleLogManagerTest {
   public void testWithError() {
     final ConsoleViewMock console = new ConsoleViewMock();
     final FlutterConsoleLogManager logManager = new FlutterConsoleLogManager(console, createFlutterApp());
-    final Event event = new Event(new JsonParser().parse(
+    final Event event = new Event(JsonUtils.parseReader(
       new InputStreamReader(FlutterConsoleLogManagerTest.class.getResourceAsStream("console_log_3.json"))).getAsJsonObject());
 
     logManager.processLoggingEvent(event);
@@ -68,7 +68,7 @@ public class FlutterConsoleLogManagerTest {
   public void testWithStacktrace() {
     final ConsoleViewMock console = new ConsoleViewMock();
     final FlutterConsoleLogManager logManager = new FlutterConsoleLogManager(console, createFlutterApp());
-    final Event event = new Event(new JsonParser().parse(
+    final Event event = new Event(JsonUtils.parseReader(
       new InputStreamReader(FlutterConsoleLogManagerTest.class.getResourceAsStream("console_log_4.json"))).getAsJsonObject());
 
     logManager.processLoggingEvent(event);

--- a/testSrc/unit/io/flutter/perf/FlutterWidgetPerfTest.java
+++ b/testSrc/unit/io/flutter/perf/FlutterWidgetPerfTest.java
@@ -7,7 +7,6 @@ package io.flutter.perf;
 
 import com.google.common.collect.Lists;
 import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
 import com.intellij.codeHighlighting.BackgroundEditorHighlighter;
 import com.intellij.mock.MockVirtualFileSystem;
 import com.intellij.openapi.editor.Editor;
@@ -21,6 +20,7 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.pom.Navigatable;
 import io.flutter.inspector.DiagnosticsNode;
 import io.flutter.run.daemon.FlutterApp;
+import io.flutter.utils.JsonUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Ignore;
@@ -74,8 +74,7 @@ class MockWidgetPerfProvider implements WidgetPerfProvider {
   }
 
   public void simulateWidgetPerfEvent(PerfReportKind kind, String json) {
-    final JsonParser parser = new JsonParser();
-    widgetPerfListener.onWidgetPerfEvent(kind, (JsonObject)parser.parse(json));
+    widgetPerfListener.onWidgetPerfEvent(kind, (JsonObject)JsonUtils.parseString(json));
   }
 
   public void repaint(When when) {

--- a/testSrc/unit/io/flutter/run/daemon/DaemonApiTest.java
+++ b/testSrc/unit/io/flutter/run/daemon/DaemonApiTest.java
@@ -7,7 +7,7 @@ package io.flutter.run.daemon;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
+import io.flutter.utils.JsonUtils;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -88,7 +88,7 @@ public class DaemonApiTest {
     checkLog("{\"method\":\"device.enable\",\"id\":0}");
     assertFalse(result.isDone());
 
-    api.dispatch(new JsonParser().parse("{id: \"0\"}").getAsJsonObject(), null);
+    api.dispatch(JsonUtils.parseString("{id: \"0\"}").getAsJsonObject(), null);
     assertTrue(result.isDone());
     assertNull(result.get());
   }
@@ -119,7 +119,7 @@ public class DaemonApiTest {
   }
 
   private void replyWithResult(Future result, String resultJson) {
-    api.dispatch(new JsonParser().parse("{id: \"0\", result: " + resultJson + "}").getAsJsonObject(), null);
+    api.dispatch(JsonUtils.parseString("{id: \"0\", result: " + resultJson + "}").getAsJsonObject(), null);
     assertTrue(result.isDone());
   }
 

--- a/testSrc/unit/io/flutter/testing/FakeActiveEditorsOutlineService.java
+++ b/testSrc/unit/io/flutter/testing/FakeActiveEditorsOutlineService.java
@@ -5,9 +5,9 @@
  */
 package io.flutter.testing;
 
-import com.google.gson.JsonParser;
 import com.intellij.openapi.project.Project;
 import io.flutter.editor.ActiveEditorsOutlineService;
+import io.flutter.utils.JsonUtils;
 import org.dartlang.analysis.server.protocol.FlutterOutline;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -42,7 +42,7 @@ public class FakeActiveEditorsOutlineService extends ActiveEditorsOutlineService
     }
     FlutterOutline flutterOutline = null;
     if (outlineContents != null) {
-      flutterOutline = FlutterOutline.fromJson(new JsonParser().parse(outlineContents).getAsJsonObject());
+      flutterOutline = FlutterOutline.fromJson(JsonUtils.parseString(outlineContents).getAsJsonObject());
     }
     pathToFlutterOutline.put(filePath, flutterOutline);
 


### PR DESCRIPTION
- introduce a wrapper around some deprecated json parsing APIs (`JsonUtils.parseString` and `JsonUtils.parseReader`)
- redirect the existing json parsing calls to JsonUtils

This reduces the number of warnings we see when building the plugin.
