### PR TITLE
support pausing a running app

### DIFF
--- a/src/io/flutter/vmService/DartVmServiceDebugProcess.java
+++ b/src/io/flutter/vmService/DartVmServiceDebugProcess.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2020 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
 package io.flutter.vmService;
 
 import com.google.gson.JsonObject;
@@ -56,7 +61,7 @@ import java.util.List;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 
-public class DartVmServiceDebugProcess extends XDebugProcess {
+public abstract class DartVmServiceDebugProcess extends XDebugProcess {
   private static final Logger LOG = Logger.getInstance(DartVmServiceDebugProcess.class.getName());
 
   @NotNull private final ExecutionResult myExecutionResult;
@@ -93,6 +98,8 @@ public class DartVmServiceDebugProcess extends XDebugProcess {
       new DartVmServiceBreakpointHandler(this),
       new DartExceptionBreakpointHandler(this)
     };
+
+    session.setPauseActionSupported(true);
 
     session.addSessionListener(new XDebugSessionListener() {
       @Override


### PR DESCRIPTION
- support pausing a running app
- make the `DartVmServiceDebugProcess` class abstract as we don't instantiate it but instead have 3 concrete subclasses

<img width="106" alt="Screen Shot 2020-09-17 at 9 18 59 AM" src="https://user-images.githubusercontent.com/1269969/93498629-e22c7980-f8c6-11ea-8973-30b5665ec1e7.png">

W/ this change, the 'pause' button becomes enabled when the app is running (not paused).

cc @jwren, @alexander-doroshko  as we'll likely want a similar change in the Dart plugin