### PR TITLE
Log versions of most tools

### DIFF
--- a/tool/kokoro/setup.sh
+++ b/tool/kokoro/setup.sh
@@ -20,7 +20,6 @@ setup() {
   (cd ..; tar fx java.tar.gz)
   export JAVA_HOME=`pwd`/../jdk-11.0.2.jdk/Contents/Home
   export PATH=$PATH:$JAVA_HOME/bin
-  java -version
   echo "JAVA_HOME=$JAVA_HOME"
 
   echo "install ant"
@@ -35,4 +34,5 @@ setup() {
   export FLUTTER_KEYSTORE_JXBROWSER_KEY_NAME=flutter-intellij-plugin-jxbrowser-license-key
 
   (cd tool/plugin; echo "pub get `pwd`"; pub get --no-precompile)
+  ./gradlew --version
 }


### PR DESCRIPTION
Log version info similar to:
> ------------------------------------------------------------
> Gradle 5.6.1
> ------------------------------------------------------------
>
>Build time:   2019-08-28 02:49:34 UTC
>Revision:     b6bd8e7934ca41d9e52610058aa7cb834df81fc4
>
>Kotlin:       1.3.41
>Groovy:       2.5.4
>Ant:          Apache Ant(TM) version 1.9.14 compiled on March 12 2019
>JVM:          11.0.7 (JetBrains s.r.o 11.0.7+10-b765.53)
>OS:           Mac OS X 10.15.6 x86_64