### PR TITLE
revert some forward looking API changes

### DIFF
--- a/src/io/flutter/FlutterUtils.java
+++ b/src/io/flutter/FlutterUtils.java
@@ -50,7 +50,6 @@ import org.yaml.snakeyaml.resolver.Resolver;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.nio.file.Paths;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
@@ -383,7 +382,8 @@ public class FlutterUtils {
   @Nullable
   public static Project findProject(@NotNull String path) {
     for (Project project : ProjectManager.getInstance().getOpenProjects()) {
-      if (ProjectUtil.isSameProject(Paths.get(path), project)) {
+      // TODO: Don't switch to ProjectUtil.isSameProject(Paths.get(path), project) until 2020.2.
+      if (ProjectUtil.isSameProject(path, project)) {
         return project;
       }
     }

--- a/src/io/flutter/analytics/ToolWindowTracker.java
+++ b/src/io/flutter/analytics/ToolWindowTracker.java
@@ -7,7 +7,6 @@ package io.flutter.analytics;
 
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.text.StringUtil;
-import com.intellij.openapi.wm.ToolWindowManager;
 import com.intellij.openapi.wm.ex.ToolWindowManagerEx;
 import com.intellij.openapi.wm.ex.ToolWindowManagerListener;
 import org.jetbrains.annotations.NotNull;
@@ -38,7 +37,8 @@ public class ToolWindowTracker implements ToolWindowManagerListener {
   }
 
   @Override
-  public void stateChanged(@NotNull ToolWindowManager toolWindowManager) {
+  // TODO: Change to stateChanged(ToolWindowManager) once 2020.1 is our min. platform version.
+  public void stateChanged() {
     update();
   }
 

--- a/src/io/flutter/perf/EditorPerfDecorations.java
+++ b/src/io/flutter/perf/EditorPerfDecorations.java
@@ -292,7 +292,8 @@ class PerfGutterIconRenderer extends GutterIconRenderer {
     this.highlighter = highlighter;
     this.range = range;
     this.perfModelForFile = perfModelForFile;
-    final TextAttributes textAttributes = highlighter.getTextAttributes(null);
+    // TODO: Don't change to getTextAttributes(null) until our min. platform version is 2020.2.
+    final TextAttributes textAttributes = highlighter.getTextAttributes();
     assert textAttributes != null;
     textAttributes.setEffectType(EffectType.LINE_UNDERSCORE);
 
@@ -410,7 +411,8 @@ class PerfGutterIconRenderer extends GutterIconRenderer {
 
   public void updateUI(boolean repaint) {
     final int count = getDisplayValue();
-    final TextAttributes textAttributes = highlighter.getTextAttributes(null);
+    // TODO: Don't change to getTextAttributes(null) until our min. platform version is 2020.2.
+    final TextAttributes textAttributes = highlighter.getTextAttributes();
     assert textAttributes != null;
     boolean changed = false;
     if (count > 0) {

--- a/src/io/flutter/preview/PreviewView.java
+++ b/src/io/flutter/preview/PreviewView.java
@@ -220,7 +220,8 @@ public class PreviewView implements PersistentStateComponent<PreviewViewState> {
 
       final ShowOnlyWidgetsAction showOnlyWidgetsAction = new ShowOnlyWidgetsAction();
 
-      toolWindowEx.setTitleActions(Arrays.asList(expandAllAction, collapseAllAction, showOnlyWidgetsAction));
+      // TODO: Don't avoid the varargs call until our min. platform version is 2020.2.
+      toolWindowEx.setTitleActions(expandAllAction, collapseAllAction, showOnlyWidgetsAction);
     }
 
     new TreeSpeedSearch(tree) {

--- a/src/io/flutter/survey/FlutterSurveyNotifications.java
+++ b/src/io/flutter/survey/FlutterSurveyNotifications.java
@@ -83,7 +83,8 @@ public class FlutterSurveyNotifications {
     final PropertiesComponent properties = PropertiesComponent.getInstance();
 
     // Don't prompt more often than every 40 hours.
-    final long lastPromptedMillis = properties.getLong(FLUTTER_LAST_SURVEY_PROMPT_KEY, 0);
+    // TODO: Don't change to getLong() until our min. platform version is 2020.1.
+    final long lastPromptedMillis = properties.getOrInitLong(FLUTTER_LAST_SURVEY_PROMPT_KEY, 0);
     if (System.currentTimeMillis() - lastPromptedMillis < PROMPT_INTERVAL_IN_MS) return;
 
     properties.setValue(FLUTTER_LAST_SURVEY_PROMPT_KEY, String.valueOf(System.currentTimeMillis()));

--- a/src/io/flutter/survey/FlutterSurveyService.java
+++ b/src/io/flutter/survey/FlutterSurveyService.java
@@ -29,7 +29,8 @@ public class FlutterSurveyService {
   private static boolean timeToUpdateCachedContent() {
     // Don't check more often than daily.
     final long currentTimeMillis = System.currentTimeMillis();
-    final long lastCheckedMillis = properties.getLong(FLUTTER_LAST_SURVEY_CONTENT_CHECK_KEY, 0);
+    // TODO: Don't change to getLong() until our min. platform version is 2020.1.
+    final long lastCheckedMillis = properties.getOrInitLong(FLUTTER_LAST_SURVEY_CONTENT_CHECK_KEY, 0);
     final boolean timeToUpdateCache = currentTimeMillis - lastCheckedMillis >= CHECK_INTERVAL_IN_MS;
     if (timeToUpdateCache) {
       properties.setValue(FLUTTER_LAST_SURVEY_CONTENT_CHECK_KEY, String.valueOf(currentTimeMillis));

--- a/tool/plugin/lib/edit.dart
+++ b/tool/plugin/lib/edit.dart
@@ -41,7 +41,7 @@ List<EditCommand> editCommands = [
         'import com.android.tools.idea.gradle.structure.actions.AndroidShowStructureSettingsAction;',
     replacement:
         'import com.android.tools.idea.gradle.actions.AndroidShowStructureSettingsAction;',
-    versions: ['3.6', '4.0', '2020.2'],
+    versions: ['4.0', '2020.2'],
   ),
   MultiSubst(
     path: 'flutter-studio/src/io/flutter/actions/OpenAndroidModule.java',
@@ -53,13 +53,13 @@ List<EditCommand> editCommands = [
       'findImportTarget',
       'importProjectCore(projectFile)',
     ],
-    versions: ['3.6', '4.0', '2020.2'],
+    versions: ['4.0', '2020.2'],
   ),
   Subst(
     path: 'flutter-studio/src/io/flutter/utils/AddToAppUtils.java',
     initial: '.project.importing.GradleProjectImporter',
     replacement: '.project.importing.NewProjectSetup',
-    versions: ['3.6', '4.0', '2020.2'],
+    versions: ['4.0', '2020.2'],
   ),
   Subst(
     path: 'src/io/flutter/utils/AndroidUtils.java',
@@ -79,7 +79,7 @@ List<EditCommand> editCommands = [
     replacement: """
     IdeaPluginDescriptor descriptor = PluginManager.getPlugin(PluginId.getId("io.flutter"));
 """,
-    versions: ['3.6', '4.0'],
+    versions: ['4.0'],
   ),
   Subst(
     path: 'src/io/flutter/FlutterUtils.java',
@@ -96,7 +96,8 @@ List<EditCommand> editCommands = [
   Subst(
     path: 'src/io/flutter/survey/FlutterSurveyService.java',
     initial: 'properties.getLong(FLUTTER_LAST_SURVEY_CONTENT_CHECK_KEY, 0)',
-    replacement: 'properties.getOrInitLong(FLUTTER_LAST_SURVEY_CONTENT_CHECK_KEY, 0)',
+    replacement:
+        'properties.getOrInitLong(FLUTTER_LAST_SURVEY_CONTENT_CHECK_KEY, 0)',
     version: '4.0',
   ),
   Subst(
@@ -113,7 +114,8 @@ List<EditCommand> editCommands = [
   ),
   Subst(
     path: 'src/io/flutter/preview/PreviewView.java',
-    initial: 'Arrays.asList(expandAllAction, collapseAllAction, showOnlyWidgetsAction)',
+    initial:
+        'Arrays.asList(expandAllAction, collapseAllAction, showOnlyWidgetsAction)',
     replacement: 'expandAllAction, collapseAllAction, showOnlyWidgetsAction',
     versions: ['4.0', '4.1'],
   ),
@@ -143,31 +145,7 @@ class EditAndroidModuleLibraryManager extends EditCommand {
 
   @override
   String convert(BuildSpec spec) {
-    if (spec.version.startsWith('3.6')) {
-      var processedFile, source;
-      processedFile = File(
-          'flutter-studio/src/io/flutter/android/AndroidModuleLibraryManager.java');
-      source = processedFile.readAsStringSync();
-      var original = source;
-      source = source.replaceAll(
-        'super(filePath',
-        'super(filePath.toString()',
-      );
-      // Starting with 3.6 we need to call a simplified init().
-      // This is where the $PROJECT_FILE$ macro is defined, #registerComponents.
-      source = source.replaceAll(
-        'getStateStore().setPath(path',
-        'getStateStore().setPath(path.toString()',
-      );
-      source = source.replaceAll(
-          "androidProject.init41", "androidProject.initPre41");
-      source = source.replaceAll("ProjectExImpl", "ProjectImpl");
-      source = source.replaceAll(
-          "import com.intellij.openapi.project.impl.ProjectExImpl;", "");
-      processedFile.writeAsStringSync(source);
-      return original;
-    } else if (spec.version.startsWith("4.0") ||
-        spec.version.startsWith("4.1")) {
+    if (spec.version.startsWith("4.0") || spec.version.startsWith("4.1")) {
       var processedFile, source;
       processedFile = File(
           'flutter-studio/src/io/flutter/android/AndroidModuleLibraryManager.java');
@@ -214,12 +192,6 @@ class EditFlutterProjectSystem extends EditCommand {
         'gradleProjectSystem.getAndroidFacetsWithPackageName(project, packageName, scope)',
         'Collections.emptyList()',
       );
-      if (spec.version.startsWith('3.6')) {
-        source = source.replaceAll(
-          'gradleProjectSystem.getSubmodules()',
-          'new java.util.ArrayList()',
-        );
-      }
       processedFile.writeAsStringSync(source);
       return original;
     } else {

--- a/tool/plugin/lib/edit.dart
+++ b/tool/plugin/lib/edit.dart
@@ -82,47 +82,9 @@ List<EditCommand> editCommands = [
     versions: ['4.0'],
   ),
   Subst(
-    path: 'src/io/flutter/FlutterUtils.java',
-    initial: 'ProjectUtil.isSameProject(Paths.get(path), project)',
-    replacement: 'ProjectUtil.isSameProject(path, project)',
-    versions: ['4.0', '4.1'],
-  ),
-  Subst(
     path: 'src/io/flutter/FlutterBundle.java',
     initial: 'AbstractBundle',
     replacement: 'CommonBundle',
-    version: '4.0',
-  ),
-  Subst(
-    path: 'src/io/flutter/survey/FlutterSurveyService.java',
-    initial: 'properties.getLong(FLUTTER_LAST_SURVEY_CONTENT_CHECK_KEY, 0)',
-    replacement:
-        'properties.getOrInitLong(FLUTTER_LAST_SURVEY_CONTENT_CHECK_KEY, 0)',
-    version: '4.0',
-  ),
-  Subst(
-    path: 'src/io/flutter/survey/FlutterSurveyNotifications.java',
-    initial: 'properties.getLong(FLUTTER_LAST_SURVEY_PROMPT_KEY, 0)',
-    replacement: 'properties.getOrInitLong(FLUTTER_LAST_SURVEY_PROMPT_KEY, 0)',
-    version: '4.0',
-  ),
-  Subst(
-    path: 'src/io/flutter/perf/EditorPerfDecorations.java',
-    initial: 'highlighter.getTextAttributes(null)',
-    replacement: 'highlighter.getTextAttributes()',
-    versions: ['4.0', '4.1'],
-  ),
-  Subst(
-    path: 'src/io/flutter/preview/PreviewView.java',
-    initial:
-        'Arrays.asList(expandAllAction, collapseAllAction, showOnlyWidgetsAction)',
-    replacement: 'expandAllAction, collapseAllAction, showOnlyWidgetsAction',
-    versions: ['4.0', '4.1'],
-  ),
-  Subst(
-    path: 'src/io/flutter/analytics/ToolWindowTracker.java',
-    initial: '@Override',
-    replacement: '',
     version: '4.0',
   ),
 ];


### PR DESCRIPTION
- revert some forward looking API changes
- remove the associated source re-writing
- add todos in the affected places w/ the versions that the newer APIs require
- also, remove support for re-writing source to support Android Studio 3.6

@stevemessick 
