### PR TITLE
Fix plugin build for use with 4.0 and 4.1

### DIFF
--- a/src/io/flutter/analytics/Analytics.java
+++ b/src/io/flutter/analytics/Analytics.java
@@ -189,9 +189,9 @@ public class Analytics {
             if (postData.length() != 0) {
               postData.append('&');
             }
-            postData.append(URLEncoder.encode(param.getKey(), StandardCharsets.UTF_8));
+            postData.append(URLEncoder.encode(param.getKey(), "UTF-8"));
             postData.append('=');
-            postData.append(URLEncoder.encode(param.getValue(), StandardCharsets.UTF_8));
+            postData.append(URLEncoder.encode(param.getValue(), "UTF-8"));
           }
           final byte[] postDataBytes = postData.toString().getBytes(StandardCharsets.UTF_8);
           final HttpURLConnection conn = (HttpURLConnection)new URL(url).openConnection();

--- a/src/io/flutter/dart/DartSyntax.java
+++ b/src/io/flutter/dart/DartSyntax.java
@@ -28,7 +28,7 @@ public class DartSyntax {
    */
   @Nullable
   public static DartCallExpression findEnclosingFunctionCall(@NotNull PsiElement elt, @NotNull String functionName) {
-    return findEnclosingFunctionCall(elt, functionName, new Equator<>() {
+    return findEnclosingFunctionCall(elt, functionName, new Equator<String, String>() {
       @Override
       boolean equate(@NotNull String first, @NotNull String second) {
         return Objects.equals(first, second);
@@ -43,7 +43,7 @@ public class DartSyntax {
    */
   @Nullable
   public static DartCallExpression findEnclosingFunctionCall(@NotNull PsiElement elt, @NotNull Pattern functionRegex) {
-    return findEnclosingFunctionCall(elt, functionRegex, new Equator<>() {
+    return findEnclosingFunctionCall(elt, functionRegex, new Equator<Pattern, String>() {
       @Override
       boolean equate(@NotNull Pattern first, @NotNull String second) {
         return first.matcher(second).matches();

--- a/src/io/flutter/devtools/DevToolsUtils.java
+++ b/src/io/flutter/devtools/DevToolsUtils.java
@@ -7,8 +7,8 @@ package io.flutter.devtools;
 
 import io.flutter.sdk.FlutterSdkUtil;
 
+import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -45,8 +45,12 @@ public class DevToolsUtils {
     }
 
     if (serviceProtocolUri != null) {
-      final String urlParam = URLEncoder.encode(serviceProtocolUri, StandardCharsets.UTF_8);
-      params.add("uri=" + urlParam);
+      try {
+        final String urlParam = URLEncoder.encode(serviceProtocolUri, "UTF-8");
+        params.add("uri=" + urlParam);
+      }
+      catch (UnsupportedEncodingException ignored) {
+      }
     }
     return "http://" + devtoolsHost + ":" + devtoolsPort + "/?" + String.join("&", params);
   }

--- a/src/io/flutter/run/SdkRunConfig.java
+++ b/src/io/flutter/run/SdkRunConfig.java
@@ -158,7 +158,7 @@ public class SdkRunConfig extends LocatableConfigurationBase<LaunchState>
       String existingJson = null;
       if (Files.exists(cachedParametersPath)) {
         try {
-          existingJson = Files.readString(cachedParametersPath);
+          existingJson = new String(Files.readAllBytes(cachedParametersPath), StandardCharsets.UTF_8);
         }
         catch (IOException e) {
           FlutterUtils.warn(LOG, "Unable to get existing json from " + cachedParametersPath);

--- a/src/io/flutter/run/test/DartTestLocationProviderZ.java
+++ b/src/io/flutter/run/test/DartTestLocationProviderZ.java
@@ -117,7 +117,7 @@ public class DartTestLocationProviderZ implements SMTestLocator, DumbAware {
     final List<Location> locations = new ArrayList<>();
 
     if (psiFile instanceof DartFile && !nodes.isEmpty()) {
-      final PsiElementProcessor<PsiElement> collector = new PsiElementProcessor<>() {
+      final PsiElementProcessor<PsiElement> collector = new PsiElementProcessor<PsiElement>() {
         @Override
         public boolean execute(@NotNull final PsiElement element) {
           if (element instanceof DartCallExpression) {

--- a/src/io/flutter/sdk/FlutterPluginLibraryType.java
+++ b/src/io/flutter/sdk/FlutterPluginLibraryType.java
@@ -22,7 +22,7 @@ public class FlutterPluginLibraryType extends LibraryType<FlutterPluginLibraryPr
   public static final String FLUTTER_PLUGINS_LIBRARY_NAME = "Flutter Plugins";
 
   public static final PersistentLibraryKind<FlutterPluginLibraryProperties> LIBRARY_KIND =
-    new PersistentLibraryKind<>("FlutterPluginsLibraryType") {
+    new PersistentLibraryKind<FlutterPluginLibraryProperties>("FlutterPluginsLibraryType") {
       @Override
       @NotNull
       public FlutterPluginLibraryProperties createDefaultProperties() {


### PR DESCRIPTION
This reverts some Java 11 changes.

On a Mac, I can build the plugin one at a time.
```shell
export JAVA_HOME=/Applications/Android\ Studio\ 4.1\ Preview.app/Contents/jre/jdk/Contents/Home
export PATH=$JAVA_HOME/bin:$PATH
bin/plugin build -o4.1 -u
```
