### PR TITLE
Return null workspace if missing flutter.json

### DIFF
--- a/src/io/flutter/bazel/Workspace.java
+++ b/src/io/flutter/bazel/Workspace.java
@@ -220,11 +220,11 @@ public class Workspace {
     final String readonlyPath = "../READONLY/" + root.getName();
     final VirtualFile readonlyRoot = root.findFileByRelativePath(readonlyPath);
     VirtualFile configFile = root.findFileByRelativePath(PLUGIN_CONFIG_PATH);
-    if (configFile == null && readonlyRoot == null) return null;
-
     if (configFile == null && readonlyRoot != null) {
       configFile = readonlyRoot.findFileByRelativePath(PLUGIN_CONFIG_PATH);
     }
+    if (configFile == null) return null;
+
     final PluginConfig config = configFile == null ? null : PluginConfig.load(configFile);
 
     final String daemonScript = config == null ? null : getScriptFromPath(root, readonlyPath, config.getDaemonScript());

--- a/src/io/flutter/bazel/Workspace.java
+++ b/src/io/flutter/bazel/Workspace.java
@@ -220,6 +220,8 @@ public class Workspace {
     final String readonlyPath = "../READONLY/" + root.getName();
     final VirtualFile readonlyRoot = root.findFileByRelativePath(readonlyPath);
     VirtualFile configFile = root.findFileByRelativePath(PLUGIN_CONFIG_PATH);
+    if (configFile == null && readonlyRoot == null) return null;
+
     if (configFile == null && readonlyRoot != null) {
       configFile = readonlyRoot.findFileByRelativePath(PLUGIN_CONFIG_PATH);
     }

--- a/testSrc/unit/io/flutter/bazel/WorkspaceTest.java
+++ b/testSrc/unit/io/flutter/bazel/WorkspaceTest.java
@@ -23,7 +23,7 @@ public class WorkspaceTest {
   public final TestDir tmp = new TestDir();
 
   @Test
-  public void canLoadWorkspaceWithoutConfigFile() throws Exception {
+  public void doesNotLoadWorkspaceWithoutConfigFile() throws Exception {
     final VirtualFile expectedRoot = tmp.ensureDir("abc");
     tmp.writeFile("abc/WORKSPACE", "");
 
@@ -33,9 +33,7 @@ public class WorkspaceTest {
 
     final Workspace w = Workspace.loadUncached(fixture.getProject());
 
-    assertNotNull("expected a workspace", w);
-    assertEquals(expectedRoot, w.getRoot());
-    assertFalse("config shouldn't be there", w.hasPluginConfig());
+    assertNull(w);
   }
 
   @Test


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter-intellij/issues/4825

To test:
- Typical flutter project like flutter gallery can be run 
- Flutter project included inside a directory with a bazel WORKSPACE file (but without flutter.json file) can be run as a flutter project - verify that in Flutter language settings, the flutter SDK is customizable and not set by bazel
- Flutter project that has a flutter.json file has SDK set by bazel

We discussed potentially simplifying the `Workspace` and `WorkspaceCache` setup process since it is confusing to follow; but for now this change should be sufficient.