### PR TITLE
make the flutter settings page slightly more compact

### DIFF
--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.form
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.form
@@ -59,7 +59,7 @@
           </component>
         </children>
       </grid>
-      <grid id="e885c" layout-manager="GridLayoutManager" row-count="4" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="e885c" layout-manager="GridLayoutManager" row-count="3" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -76,24 +76,24 @@
               <toolTipText value="Report anonymized usage information to Google Analytics."/>
             </properties>
           </component>
-          <component id="c59f0" class="com.intellij.ui.components.labels.LinkLabel" binding="myPrivacyPolicy">
-            <constraints>
-              <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="3" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <horizontalAlignment value="2"/>
-              <horizontalTextPosition value="2"/>
-              <text value="https://www.google.com/policies/privacy"/>
-              <toolTipText value="http://www.google.com/policies/privacy/"/>
-            </properties>
-          </component>
           <component id="be19f" class="javax.swing.JCheckBox" binding="myEnableVerboseLoggingCheckBox" default-binding="true">
             <constraints>
-              <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="1" column="0" row-span="1" col-span="3" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text resource-bundle="io/flutter/FlutterBundle" key="settings.enable.verbose.logging"/>
               <toolTipText value="Enables verbose logging (this can be useful for diagnostic purposes)."/>
+            </properties>
+          </component>
+          <component id="c59f0" class="com.intellij.ui.components.labels.LinkLabel" binding="myPrivacyPolicy">
+            <constraints>
+              <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <horizontalAlignment value="2"/>
+              <horizontalTextPosition value="2"/>
+              <text value="www.google.com/policies/privacy"/>
+              <toolTipText value="http://www.google.com/policies/privacy/"/>
             </properties>
           </component>
         </children>

--- a/src/io/flutter/settings/FlutterSettings.java
+++ b/src/io/flutter/settings/FlutterSettings.java
@@ -95,6 +95,10 @@ public class FlutterSettings {
     if (isShowStructuredErrors()) {
       analytics.sendEvent("settings", afterLastPeriod(showStructuredErrors));
     }
+
+    if (isEnableEmbeddedBrowsers()) {
+      analytics.sendEvent("settings", afterLastPeriod(enableEmbeddedBrowsersKey));
+    }
   }
 
   public void addListener(Listener listener) {


### PR DESCRIPTION
- make the flutter settings page slightly more compact
- record analytics for the JxBrowser setting

<img width="1109" alt="Screen Shot 2020-09-28 at 5 27 25 PM" src="https://user-images.githubusercontent.com/1269969/94499100-a6d85780-01b0-11eb-9865-a6d81dce91f1.png">
