### PR TITLE
make the settings page more compact

### DIFF
--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.form
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="io.flutter.sdk.FlutterSettingsConfigurable">
-  <grid id="27dc6" binding="mainPanel" layout-manager="GridLayoutManager" row-count="8" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="mainPanel" layout-manager="GridLayoutManager" row-count="7" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="972" height="825"/>
@@ -187,29 +187,10 @@
           </component>
         </children>
       </grid>
-      <grid id="a6e3b" binding="myBazelOptionsSection" layout-manager="GridLayoutManager" row-count="1" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="23e52" binding="experimentsPanel" layout-manager="GridLayoutManager" row-count="5" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties/>
-        <border type="etched" title="Bazel"/>
-        <children>
-          <component id="e902c" class="javax.swing.JCheckBox" binding="myShowAllRunConfigurationsInContextCheckBox">
-            <constraints>
-              <grid row="0" column="0" row-span="1" col-span="3" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <text value="Always suggest multiple run configurations for test code"/>
-              <toolTipText value="If there is a defined run configuration to watch a specific test and one to just run it, show both."/>
-            </properties>
-          </component>
-        </children>
-      </grid>
-      <grid id="23e52" binding="experimentsPanel" layout-manager="GridLayoutManager" row-count="4" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
-        <margin top="0" left="0" bottom="0" right="0"/>
-        <constraints>
-          <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="etched" title="Experiments"/>
@@ -242,10 +223,19 @@
           </component>
           <component id="2032d" class="javax.swing.JCheckBox" binding="myEnableEmbeddedBrowsersCheckBox">
             <constraints>
-              <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text value="Enable embedded DevTools inspector"/>
+            </properties>
+          </component>
+          <component id="e902c" class="javax.swing.JCheckBox" binding="myShowAllRunConfigurationsInContextCheckBox">
+            <constraints>
+              <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Show all possible run configurations for apps or tests, even if a created configuration already exists"/>
+              <toolTipText value="If there is a defined run configuration to watch a specific test and one to just run it, show both."/>
             </properties>
           </component>
         </children>
@@ -253,7 +243,7 @@
       <grid id="3bf2f" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="7" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="7" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.java
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.java
@@ -56,7 +56,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
   private ComboboxWithBrowseButton mySdkCombo;
   private JBLabel myVersionLabel;
   private JCheckBox myReportUsageInformationCheckBox;
-  private LinkLabel myPrivacyPolicy;
+  private LinkLabel<?> myPrivacyPolicy;
   private JCheckBox myHotReloadOnSaveCheckBox;
   private JCheckBox myEnableVerboseLoggingCheckBox;
   private JCheckBox myOpenInspectorOnAppLaunchCheckBox;
@@ -68,8 +68,6 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
   private JCheckBox myEnableHotUiCheckBox;
   private JCheckBox myEnableEmbeddedBrowsersCheckBox;
 
-  // Settings for Bazel users.
-  private JPanel myBazelOptionsSection;
   private JCheckBox myShowAllRunConfigurationsInContextCheckBox;
 
   // Settings for UI as Code experiments:
@@ -120,7 +118,6 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
                                        FileChooserDescriptorFactory.createSingleFolderDescriptor(),
                                        TextComponentAccessor.STRING_COMBOBOX_WHOLE_TEXT);
 
-    //noinspection unchecked
     myPrivacyPolicy.setListener((linkLabel, data) -> {
       try {
         BrowserLauncher.getInstance().browse(new URI(FlutterBundle.message("flutter.analytics.privacyUrl")));

--- a/src/io/flutter/settings/FlutterSettings.java
+++ b/src/io/flutter/settings/FlutterSettings.java
@@ -95,6 +95,10 @@ public class FlutterSettings {
     if (isShowStructuredErrors()) {
       analytics.sendEvent("settings", afterLastPeriod(showStructuredErrors));
     }
+
+    if (showAllRunConfigurationsInContext()) {
+      analytics.sendEvent("settings", "showAllRunConfigurations");
+    }
   }
 
   public void addListener(Listener listener) {
@@ -196,7 +200,7 @@ public class FlutterSettings {
   }
 
   /**
-   * Tells IntelliJ to show all run configurations possible when the user clicks on the left-hand green arror to run a test.
+   * Tells IntelliJ to show all run configurations possible when the user clicks on the left-hand green arrow to run a test.
    * <p>
    * Useful for {@link io.flutter.run.bazelTest.FlutterBazelTestConfigurationType} to show both watch and regular configurations
    * in the left-hand gutter.


### PR DESCRIPTION
- move the `Always suggest multiple run configurations for test code` settings from the bazel area to the experiments area
- rename it to `Show all possible run configurations for apps or tests, even if a created configuration already exists`
- delete the `Bazel` settings area

I considered moving the setting into the `General` section, but I don't think we want to recommend this as a normal / higher volume user setting.
