### PR TITLE
remove the explicit disable track widget creation option

### DIFF
--- a/src/io/flutter/sdk/FlutterSdk.java
+++ b/src/io/flutter/sdk/FlutterSdk.java
@@ -39,10 +39,7 @@ import io.flutter.utils.JsonUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static java.util.Arrays.asList;
 
@@ -243,11 +240,11 @@ public class FlutterSdk {
     }
 
     if (flutterLaunchMode == FlutterLaunchMode.DEBUG) {
-      if (FlutterSettings.getInstance().isTrackWidgetCreationEnabled(project)) {
-        args.add("--track-widget-creation");
-      }
-      else {
-        args.add("--no-track-widget-creation");
+      if (getVersion().isTrackWidgetCreationRecommended()) {
+        // Ensure additionalArgs doesn't have any arg like 'track-widget-creation'.
+        if (Arrays.stream(additionalArgs).noneMatch(s -> s.contains("track-widget-creation"))) {
+          args.add("--track-widget-creation");
+        }
       }
     }
 

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.form
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.form
@@ -98,7 +98,7 @@
           </component>
         </children>
       </grid>
-      <grid id="919ec" layout-manager="GridLayoutManager" row-count="4" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="919ec" layout-manager="GridLayoutManager" row-count="3" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -121,15 +121,6 @@
             <properties>
               <text resource-bundle="io/flutter/FlutterBundle" key="settings.hot.reload.on.save"/>
               <toolTipText value="On a &quot;Save All&quot; action, hot reload changes into running Flutter apps."/>
-            </properties>
-          </component>
-          <component id="6d6f0" class="javax.swing.JCheckBox" binding="myDisableTrackWidgetCreationCheckBox">
-            <constraints>
-              <grid row="3" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <text resource-bundle="io/flutter/FlutterBundle" key="settings.disable.tracking.widget.creation"/>
-              <toolTipText value="Disabling this setting breaks advanced Flutter Inspector functionality and performance tools. Only disable if you are noticing unexpected behavior differences between apps run in debug and release build."/>
             </properties>
           </component>
           <component id="b1533" class="javax.swing.JCheckBox" binding="myShowStructuredErrors">

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.java
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.java
@@ -62,7 +62,6 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
   private JCheckBox myOpenInspectorOnAppLaunchCheckBox;
   private JCheckBox myFormatCodeOnSaveCheckBox;
   private JCheckBox myOrganizeImportsOnSaveCheckBox;
-  private JCheckBox myDisableTrackWidgetCreationCheckBox;
   private JCheckBox myShowStructuredErrors;
   private JCheckBox mySyncAndroidLibrariesCheckBox;
   private JCheckBox myEnableHotUiCheckBox;
@@ -207,10 +206,6 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
       return true;
     }
 
-    if (settings.isDisableTrackWidgetCreation() != myDisableTrackWidgetCreationCheckBox.isSelected()) {
-      return true;
-    }
-
     if (settings.isVerboseLogging() != myEnableVerboseLoggingCheckBox.isSelected()) {
       return true;
     }
@@ -265,7 +260,6 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     settings.setShowClosingLabels(myShowClosingLabels.isSelected());
     settings.setShowStructuredErrors(myShowStructuredErrors.isSelected());
     settings.setOpenInspectorOnAppLaunch(myOpenInspectorOnAppLaunchCheckBox.isSelected());
-    settings.setDisableTrackWidgetCreation(myDisableTrackWidgetCreationCheckBox.isSelected());
     settings.setVerboseLogging(myEnableVerboseLoggingCheckBox.isSelected());
     settings.setSyncingAndroidLibraries(mySyncAndroidLibrariesCheckBox.isSelected());
     settings.setEnableHotUi(myEnableHotUiCheckBox.isSelected());
@@ -306,7 +300,6 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
 
     myShowStructuredErrors.setSelected(settings.isShowStructuredErrors());
     myOpenInspectorOnAppLaunchCheckBox.setSelected(settings.isOpenInspectorOnAppLaunch());
-    myDisableTrackWidgetCreationCheckBox.setSelected(settings.isDisableTrackWidgetCreation());
     myEnableVerboseLoggingCheckBox.setSelected(settings.isVerboseLogging());
     mySyncAndroidLibrariesCheckBox.setSelected(settings.isSyncingAndroidLibraries());
 
@@ -344,9 +337,6 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     }
 
     final ModalityState modalityState = ModalityState.current();
-
-    final boolean trackWidgetCreationRecommended = sdk.getVersion().isTrackWidgetCreationRecommended();
-    myDisableTrackWidgetCreationCheckBox.setVisible(trackWidgetCreationRecommended);
 
     // TODO(devoncarew): Switch this to expecting json output.
     sdk.flutterVersion().start((ProcessOutput output) -> {

--- a/src/io/flutter/settings/FlutterSettings.java
+++ b/src/io/flutter/settings/FlutterSettings.java
@@ -9,13 +9,11 @@ import com.intellij.ide.plugins.IdeaPluginDescriptor;
 import com.intellij.ide.plugins.PluginManagerCore;
 import com.intellij.ide.util.PropertiesComponent;
 import com.intellij.openapi.components.ServiceManager;
-import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.registry.Registry;
 import com.intellij.util.EventDispatcher;
 import com.jetbrains.lang.dart.analyzer.DartClosingLabelManager;
 import io.flutter.FlutterUtils;
 import io.flutter.analytics.Analytics;
-import io.flutter.sdk.FlutterSdk;
 
 import java.util.EventListener;
 
@@ -27,7 +25,6 @@ public class FlutterSettings {
   private static final String organizeImportsOnSaveKey = "io.flutter.organizeImportsOnSave";
   private static final String showOnlyWidgetsKey = "io.flutter.showOnlyWidgets";
   private static final String syncAndroidLibrariesKey = "io.flutter.syncAndroidLibraries";
-  private static final String disableTrackWidgetCreationKey = "io.flutter.disableTrackWidgetCreation";
   private static final String showStructuredErrors = "io.flutter.showStructuredErrors";
   private static final String showBuildMethodGuidesKey = "io.flutter.editor.showBuildMethodGuides";
   private static final String enableHotUiKey = "io.flutter.editor.enableHotUi";
@@ -84,9 +81,6 @@ public class FlutterSettings {
     if (isSyncingAndroidLibraries()) {
       analytics.sendEvent("settings", afterLastPeriod(syncAndroidLibrariesKey));
     }
-    if (isDisableTrackWidgetCreation()) {
-      analytics.sendEvent("settings", afterLastPeriod(disableTrackWidgetCreationKey));
-    }
 
     if (isShowBuildMethodGuides()) {
       analytics.sendEvent("settings", afterLastPeriod(showBuildMethodGuidesKey));
@@ -107,26 +101,6 @@ public class FlutterSettings {
 
   public boolean isReloadOnSave() {
     return getPropertiesComponent().getBoolean(reloadOnSaveKey, true);
-  }
-
-  public boolean isTrackWidgetCreationEnabled(Project project) {
-    final FlutterSdk flutterSdk = FlutterSdk.getFlutterSdk(project);
-    if (flutterSdk != null && flutterSdk.getVersion().isTrackWidgetCreationRecommended()) {
-      return !getPropertiesComponent().getBoolean(disableTrackWidgetCreationKey, false);
-    }
-    else {
-      return false;
-    }
-  }
-
-  public boolean isDisableTrackWidgetCreation() {
-    return getPropertiesComponent().getBoolean(disableTrackWidgetCreationKey, false);
-  }
-
-  public void setDisableTrackWidgetCreation(boolean value) {
-    getPropertiesComponent().setValue(disableTrackWidgetCreationKey, value, false);
-
-    fireEvent();
   }
 
   public void setReloadOnSave(boolean value) {


### PR DESCRIPTION
- remove the explicit disable track widget creation option (users can still pass it in via run command line options)
- pass in `--track-widget-creation` if the flutter sdk supports the option
- don't pass it in if the user has an explicit value for track-widget-creation in the additional args
