### PR TITLE
make the device param into various run methods not null

### DIFF
--- a/src/io/flutter/run/LaunchState.java
+++ b/src/io/flutter/run/LaunchState.java
@@ -273,7 +273,7 @@ public class LaunchState extends CommandLineState {
     LaunchState getState(@NotNull Executor executor, @NotNull ExecutionEnvironment environment) throws ExecutionException;
 
     @NotNull
-    GeneralCommandLine getCommand(ExecutionEnvironment environment, FlutterDevice device) throws ExecutionException;
+    GeneralCommandLine getCommand(ExecutionEnvironment environment, @NotNull FlutterDevice device) throws ExecutionException;
   }
 
   /**

--- a/src/io/flutter/run/SdkAttachConfig.java
+++ b/src/io/flutter/run/SdkAttachConfig.java
@@ -104,7 +104,7 @@ public class SdkAttachConfig extends SdkRunConfig {
 
   @NotNull
   @Override
-  public GeneralCommandLine getCommand(@NotNull ExecutionEnvironment env, FlutterDevice device) throws ExecutionException {
+  public GeneralCommandLine getCommand(@NotNull ExecutionEnvironment env, @NotNull FlutterDevice device) throws ExecutionException {
     return getFields().createFlutterSdkAttachCommand(env.getProject(), FlutterLaunchMode.fromEnv(env), device);
   }
 

--- a/src/io/flutter/run/SdkFields.java
+++ b/src/io/flutter/run/SdkFields.java
@@ -111,7 +111,7 @@ public class SdkFields {
   public GeneralCommandLine createFlutterSdkRunCommand(@NotNull Project project,
                                                        @NotNull RunMode runMode,
                                                        @NotNull FlutterLaunchMode flutterLaunchMode,
-                                                       @Nullable FlutterDevice device
+                                                       @NotNull FlutterDevice device
   ) throws ExecutionException {
     final MainFile main = MainFile.verify(filePath, project).get();
 

--- a/src/io/flutter/run/SdkRunConfig.java
+++ b/src/io/flutter/run/SdkRunConfig.java
@@ -229,7 +229,7 @@ public class SdkRunConfig extends LocatableConfigurationBase<LaunchState>
 
   @NotNull
   @Override
-  public GeneralCommandLine getCommand(@NotNull ExecutionEnvironment env, @Nullable FlutterDevice device) throws ExecutionException {
+  public GeneralCommandLine getCommand(@NotNull ExecutionEnvironment env, @NotNull FlutterDevice device) throws ExecutionException {
     final SdkFields launchFields = fields.copy();
     final Project project = env.getProject();
     final RunMode mode = RunMode.fromEnv(env);

--- a/src/io/flutter/run/bazel/BazelRunConfig.java
+++ b/src/io/flutter/run/bazel/BazelRunConfig.java
@@ -85,7 +85,7 @@ public class BazelRunConfig extends RunConfigurationBase<LaunchState>
 
   @NotNull
   @Override
-  public GeneralCommandLine getCommand(ExecutionEnvironment env, FlutterDevice device) throws ExecutionException {
+  public GeneralCommandLine getCommand(ExecutionEnvironment env, @NotNull FlutterDevice device) throws ExecutionException {
     final BazelFields launchFields = fields.copy();
     final RunMode mode = RunMode.fromEnv(env);
     return launchFields.getLaunchCommand(env.getProject(), device, mode);

--- a/src/io/flutter/run/daemon/FlutterApp.java
+++ b/src/io/flutter/run/daemon/FlutterApp.java
@@ -634,14 +634,14 @@ public class FlutterApp implements Disposable {
            !debugProcess.getSession().isStopped();
   }
 
-  @Nullable
+  @NotNull
   public FlutterDevice device() {
     return myDevice;
   }
 
   @Nullable
   public String deviceId() {
-    return myDevice != null ? myDevice.deviceId() : null;
+    return myDevice.deviceId();
   }
 
   public void setFlutterDebugProcess(FlutterDebugProcess flutterDebugProcess) {

--- a/src/io/flutter/sdk/FlutterSdk.java
+++ b/src/io/flutter/sdk/FlutterSdk.java
@@ -231,7 +231,7 @@ public class FlutterSdk {
 
   public FlutterCommand flutterRun(@NotNull PubRoot root,
                                    @NotNull VirtualFile main,
-                                   @Nullable FlutterDevice device,
+                                   @NotNull FlutterDevice device,
                                    @NotNull RunMode mode,
                                    @NotNull FlutterLaunchMode flutterLaunchMode,
                                    @NotNull Project project,
@@ -251,9 +251,7 @@ public class FlutterSdk {
       }
     }
 
-    if (device != null) {
-      args.add("--device-id=" + device.deviceId());
-    }
+    args.add("--device-id=" + device.deviceId());
 
     // TODO (helin24): Remove special handling for web-server if we can fix https://github.com/flutter/flutter-intellij/issues/4767.
     // Currently we can't connect to the VM service for the web-server 'device' to resume.


### PR DESCRIPTION
- make the `device` param into various run methods not null

Found while working on some changes to `FlutterSdk. flutterRun()`.
