### PR TITLE
fix a null assertion in the inspector

### DIFF
--- a/src/io/flutter/inspector/DiagnosticsNode.java
+++ b/src/io/flutter/inspector/DiagnosticsNode.java
@@ -73,7 +73,7 @@ public class DiagnosticsNode {
   }
 
   public DiagnosticsNode(JsonObject json,
-                         CompletableFuture<InspectorService.ObjectGroup> inspectorService,
+                         @NotNull CompletableFuture<InspectorService.ObjectGroup> inspectorService,
                          FlutterApp app,
                          boolean isProperty,
                          DiagnosticsNode parent) {
@@ -496,9 +496,9 @@ public class DiagnosticsNode {
   }
 
   /**
-   * Service used to retrieve more detailed information about the value of
-   * the property and its children and properties.
+   * Service used to retrieve more detailed information about the value of the property and its children and properties.
    */
+  @NotNull
   private final CompletableFuture<InspectorService.ObjectGroup> inspectorService;
 
   /**
@@ -805,6 +805,7 @@ public class DiagnosticsNode {
     this.location = location;
   }
 
+  @NotNull
   public CompletableFuture<InspectorService.ObjectGroup> getInspectorService() {
     return inspectorService;
   }

--- a/src/io/flutter/inspector/InspectorService.java
+++ b/src/io/flutter/inspector/InspectorService.java
@@ -64,8 +64,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
 /**
- * Manages all communication between inspector code running on the DartVM and
- * inspector code running in the IDE.
+ * Manages all communication between inspector code running on the DartVM and inspector code running in the IDE.
  */
 public class InspectorService implements Disposable {
 


### PR DESCRIPTION
- fix a null assertion in the inspector
- fix https://github.com/flutter/flutter-intellij/issues/4936

This is being reported frequently to crash reporting; the code here hasn't changed, so perhaps we're seeing a timing difference in the vm service becoming available when starting an app.

The main issue here was that when we went to create an `InspectorService.ObjectGroup` in the FlutterConsoleLogManager class, the VM service connection wasn't always ready. We now delay construction until the ObjectGroup is first needed.