### PR TITLE
adjust the layout for the jsbrowser error feedback ui

### DIFF
--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -200,12 +200,18 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
                                               boolean isEmbedded) {
     final ContentManager contentManager = toolWindow.getContentManager();
 
+    final String tabName;
     final FlutterDevice device = app.device();
-    final List<FlutterDevice> existingDevices = new ArrayList<>();
-    for (FlutterApp otherApp : perAppViewState.keySet()) {
-      existingDevices.add(otherApp.device());
+    if (device == null) {
+      tabName = app.getProject().getName();
     }
-    final String tabName = device.getUniqueName(existingDevices);
+    else {
+      final List<FlutterDevice> existingDevices = new ArrayList<>();
+      for (FlutterApp otherApp : perAppViewState.keySet()) {
+        existingDevices.add(otherApp.device());
+      }
+      tabName = device.getUniqueName(existingDevices);
+    }
 
     if (emptyContent != null) {
       contentManager.removeContent(emptyContent, true);
@@ -231,12 +237,18 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
     runnerTabs.setSelectionChangeHandler(this::onTabSelectionChange);
     final JPanel tabContainer = new JPanel(new BorderLayout());
 
+    final String tabName;
     final FlutterDevice device = app.device();
-    final List<FlutterDevice> existingDevices = new ArrayList<>();
-    for (FlutterApp otherApp : perAppViewState.keySet()) {
-      existingDevices.add(otherApp.device());
+    if (device == null) {
+      tabName = app.getProject().getName();
     }
-    final String tabName = device.getUniqueName(existingDevices);
+    else {
+      final List<FlutterDevice> existingDevices = new ArrayList<>();
+      for (FlutterApp otherApp : perAppViewState.keySet()) {
+        existingDevices.add(otherApp.device());
+      }
+      tabName = device.getUniqueName(existingDevices);
+    }
 
     final Content content = contentManager.getFactory().createContent(null, tabName, false);
     tabContainer.add(runnerTabs.getComponent(), BorderLayout.CENTER);
@@ -768,7 +780,9 @@ class ToggleSelectWidgetMode extends FlutterViewToggleableAction {
       // If toggling inspect mode on, bring the app's device to the foreground.
       if (isSelected()) {
         final FlutterDevice device = app.device();
-        device.bringToFront();
+        if (device != null) {
+          device.bringToFront();
+        }
       }
     }
   }
@@ -794,7 +808,9 @@ class ToggleOnDeviceWidgetInspector extends FlutterViewToggleableAction {
       // If toggling inspect mode on, bring the app's device to the foreground.
       if (isSelected()) {
         final FlutterDevice device = app.device();
-        device.bringToFront();
+        if (device != null) {
+          device.bringToFront();
+        }
       }
     }
   }

--- a/testSrc/unit/io/flutter/view/FlutterViewTest.java
+++ b/testSrc/unit/io/flutter/view/FlutterViewTest.java
@@ -15,6 +15,7 @@ import io.flutter.devtools.DevToolsManager;
 import io.flutter.inspector.InspectorService;
 import io.flutter.jxbrowser.JxBrowserManager;
 import io.flutter.jxbrowser.JxBrowserStatus;
+import io.flutter.run.FlutterDevice;
 import io.flutter.run.daemon.FlutterApp;
 import io.flutter.utils.JxBrowserUtils;
 import io.flutter.utils.ThreadUtil;
@@ -25,6 +26,7 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeoutException;
 
@@ -37,6 +39,7 @@ import static org.powermock.api.mockito.PowerMockito.when;
 public class FlutterViewTest {
   @Mock Project mockProject;
   @Mock FlutterApp mockApp;
+  @Mock FlutterDevice mockDevice;
   @Mock InspectorService mockInspectorService;
   @Mock ToolWindow mockToolWindow;
   @Mock DevToolsManager mockDevToolsManager;
@@ -56,12 +59,14 @@ public class FlutterViewTest {
     when(mockApp.getConnector()).thenReturn(mockObservatoryConnector);
     when(mockObservatoryConnector.getBrowserUrl()).thenReturn(testUrl);
     when(mockToolWindow.getContentManager()).thenReturn(null);
-    when(mockApp.device()).thenReturn(null);
+    when(mockApp.device()).thenReturn(mockDevice);
+    when(mockDevice.getUniqueName(Collections.emptyList())).thenReturn("mock device");
     when(mockApp.getProject()).thenReturn(mockProject);
     when(mockProject.getName()).thenReturn(projectName);
 
     flutterView.handleJxBrowserInstalled(mockApp, mockInspectorService, mockToolWindow);
-    verify(mockDevToolsManager, times(1)).openBrowserIntoPanel(testUrl, null, projectName, "inspector");
+    verify(mockDevToolsManager, times(1)).
+      openBrowserIntoPanel(testUrl, null, "mock device", "inspector");
   }
 
   @Test
@@ -84,7 +89,8 @@ public class FlutterViewTest {
     when(mockApp.getConnector()).thenReturn(mockObservatoryConnector);
     when(mockObservatoryConnector.getBrowserUrl()).thenReturn(testUrl);
     when(mockToolWindow.getContentManager()).thenReturn(null);
-    when(mockApp.device()).thenReturn(null);
+    when(mockApp.device()).thenReturn(mockDevice);
+    when(mockDevice.getUniqueName(Collections.emptyList())).thenReturn("mock device");
     when(mockApp.getProject()).thenReturn(mockProject);
     when(mockProject.getName()).thenReturn(projectName);
 
@@ -112,7 +118,8 @@ public class FlutterViewTest {
     when(mockApp.getConnector()).thenReturn(mockObservatoryConnector);
     when(mockObservatoryConnector.getBrowserUrl()).thenReturn(testUrl);
     when(mockToolWindow.getContentManager()).thenReturn(null);
-    when(mockApp.device()).thenReturn(null);
+    when(mockApp.device()).thenReturn(mockDevice);
+    when(mockDevice.getUniqueName(Collections.emptyList())).thenReturn("mock device");
     when(mockApp.getProject()).thenReturn(mockProject);
     when(mockProject.getName()).thenReturn(projectName);
 

--- a/testSrc/unit/io/flutter/view/FlutterViewTest.java
+++ b/testSrc/unit/io/flutter/view/FlutterViewTest.java
@@ -15,7 +15,6 @@ import io.flutter.devtools.DevToolsManager;
 import io.flutter.inspector.InspectorService;
 import io.flutter.jxbrowser.JxBrowserManager;
 import io.flutter.jxbrowser.JxBrowserStatus;
-import io.flutter.run.FlutterDevice;
 import io.flutter.run.daemon.FlutterApp;
 import io.flutter.utils.JxBrowserUtils;
 import io.flutter.utils.ThreadUtil;
@@ -26,7 +25,6 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeoutException;
 
@@ -39,7 +37,6 @@ import static org.powermock.api.mockito.PowerMockito.when;
 public class FlutterViewTest {
   @Mock Project mockProject;
   @Mock FlutterApp mockApp;
-  @Mock FlutterDevice mockDevice;
   @Mock InspectorService mockInspectorService;
   @Mock ToolWindow mockToolWindow;
   @Mock DevToolsManager mockDevToolsManager;
@@ -59,14 +56,12 @@ public class FlutterViewTest {
     when(mockApp.getConnector()).thenReturn(mockObservatoryConnector);
     when(mockObservatoryConnector.getBrowserUrl()).thenReturn(testUrl);
     when(mockToolWindow.getContentManager()).thenReturn(null);
-    when(mockApp.device()).thenReturn(mockDevice);
-    when(mockDevice.getUniqueName(Collections.emptyList())).thenReturn("mock device");
+    when(mockApp.device()).thenReturn(null);
     when(mockApp.getProject()).thenReturn(mockProject);
     when(mockProject.getName()).thenReturn(projectName);
 
     flutterView.handleJxBrowserInstalled(mockApp, mockInspectorService, mockToolWindow);
-    verify(mockDevToolsManager, times(1)).
-      openBrowserIntoPanel(testUrl, null, "mock device", "inspector");
+    verify(mockDevToolsManager, times(1)).openBrowserIntoPanel(testUrl, null, projectName, "inspector");
   }
 
   @Test
@@ -89,8 +84,7 @@ public class FlutterViewTest {
     when(mockApp.getConnector()).thenReturn(mockObservatoryConnector);
     when(mockObservatoryConnector.getBrowserUrl()).thenReturn(testUrl);
     when(mockToolWindow.getContentManager()).thenReturn(null);
-    when(mockApp.device()).thenReturn(mockDevice);
-    when(mockDevice.getUniqueName(Collections.emptyList())).thenReturn("mock device");
+    when(mockApp.device()).thenReturn(null);
     when(mockApp.getProject()).thenReturn(mockProject);
     when(mockProject.getName()).thenReturn(projectName);
 
@@ -118,8 +112,7 @@ public class FlutterViewTest {
     when(mockApp.getConnector()).thenReturn(mockObservatoryConnector);
     when(mockObservatoryConnector.getBrowserUrl()).thenReturn(testUrl);
     when(mockToolWindow.getContentManager()).thenReturn(null);
-    when(mockApp.device()).thenReturn(mockDevice);
-    when(mockDevice.getUniqueName(Collections.emptyList())).thenReturn("mock device");
+    when(mockApp.device()).thenReturn(null);
     when(mockApp.getProject()).thenReturn(mockProject);
     when(mockProject.getName()).thenReturn(projectName);
 

--- a/testSrc/unit/io/flutter/view/FlutterViewTest.java
+++ b/testSrc/unit/io/flutter/view/FlutterViewTest.java
@@ -132,7 +132,7 @@ public class FlutterViewTest {
     partialMockFlutterView.handleJxBrowserInstallationFailed(mockApp, mockInspectorService, mockToolWindow);
     verify(partialMockFlutterView, times(1)).presentClickableLabel(
       eq(mockToolWindow),
-      eq("JxBrowser installation failed"),
+      eq("JxBrowser installation failed."),
       eq("Retry?"),
       any(LinkListener.class)
     );

--- a/testSrc/unit/io/flutter/view/FlutterViewTest.java
+++ b/testSrc/unit/io/flutter/view/FlutterViewTest.java
@@ -132,7 +132,8 @@ public class FlutterViewTest {
     partialMockFlutterView.handleJxBrowserInstallationFailed(mockApp, mockInspectorService, mockToolWindow);
     verify(partialMockFlutterView, times(1)).presentClickableLabel(
       eq(mockToolWindow),
-      eq("JxBrowser installation failed. Retry?"),
+      eq("JxBrowser installation failed"),
+      eq("Retry?"),
       any(LinkListener.class)
     );
   }


### PR DESCRIPTION
- adjust the layout for the jsbrowser error feedback ui
- remove one or two null checks that are now no longer needed (since we've propagated our nullability annotations a bit further through the project)

This breaks the error feedback UI from a single long line into two shorter ones; this is to make it work better in (generally fairly narrow) tool windows.

<img width="340" alt="Screen Shot 2020-10-04 at 3 55 08 PM" src="https://user-images.githubusercontent.com/1269969/95041267-1061d580-068b-11eb-87fd-9fe4b87026a2.png">
