### PR TITLE
Add more detail for JxBrowser failed downloads

### DIFF
--- a/src/io/flutter/jxbrowser/JxBrowserManager.java
+++ b/src/io/flutter/jxbrowser/JxBrowserManager.java
@@ -228,7 +228,7 @@ public class JxBrowserManager {
         }
         catch (IOException e) {
           LOG.info(project.getName() + ": JxBrowser file downloaded failed: " + currentFileName);
-          setStatusFailed("fileDownloadFailed-" + currentFileName);
+          setStatusFailed("fileDownloadFailed-" + currentFileName + ":" + e.getMessage());
         }
       }
     };

--- a/src/io/flutter/jxbrowser/JxBrowserManager.java
+++ b/src/io/flutter/jxbrowser/JxBrowserManager.java
@@ -110,7 +110,15 @@ public class JxBrowserManager {
   }
 
   private void setStatusFailed(String failureReason) {
-    FlutterInitializer.getAnalytics().sendEvent("jxbrowser", "installationFailed-" + failureReason);
+    setStatusFailed(failureReason, null);
+  }
+
+  private void setStatusFailed(String failureReason, Long time) {
+    if (time != null) {
+      FlutterInitializer.getAnalytics().sendEventMetric("jxbrowser", "installationFailed-" + failureReason, time.intValue());
+    } else {
+      FlutterInitializer.getAnalytics().sendEvent("jxbrowser", "installationFailed-" + failureReason);
+    }
     status.set(JxBrowserStatus.INSTALLATION_FAILED);
     installation.complete(JxBrowserStatus.INSTALLATION_FAILED);
   }
@@ -212,6 +220,7 @@ public class JxBrowserManager {
       @Override
       public void run(@NotNull ProgressIndicator indicator) {
         String currentFileName = null;
+        final long startTime = System.currentTimeMillis();
         try {
           for (int i = 0; i < fileDownloaders.size(); i++) {
             final FileDownloader downloader = fileDownloaders.get(i);
@@ -227,8 +236,9 @@ public class JxBrowserManager {
           loadClasses(fileNames);
         }
         catch (IOException e) {
+          final long elapsedTime = System.currentTimeMillis() - startTime;
           LOG.info(project.getName() + ": JxBrowser file downloaded failed: " + currentFileName);
-          setStatusFailed("fileDownloadFailed-" + currentFileName + ":" + e.getMessage());
+          setStatusFailed("fileDownloadFailed-" + currentFileName + ":" + e.getMessage(), elapsedTime);
         }
       }
     };


### PR DESCRIPTION
This adds the exception message and elapsed time to analytics if one of the file downloads fails.

I was hoping to check bytes downloaded, but I couldn't find a way to do that using this API. I tried just checking the size of `new File(DOWNLOAD_PATH + "/" + currentFileName)` but it seems the file doesn't appear unless it's completely downloaded. Any other ideas on this?