### PR TITLE
Prevent repeat downloads of JxBrowser files

### DIFF
--- a/src/io/flutter/jxbrowser/JxBrowserManager.java
+++ b/src/io/flutter/jxbrowser/JxBrowserManager.java
@@ -173,7 +173,7 @@ public class JxBrowserManager {
     final String[] fileNames = {platformFileName, JxBrowserUtils.getApiFileName(), JxBrowserUtils.getSwingFileName()};
     boolean allDownloaded = true;
     for (String fileName : fileNames) {
-      if (!FileUtils.getInstance().fileExists(fileName)) {
+      if (!FileUtils.getInstance().fileExists(getFilePath(fileName))) {
         allDownloaded = false;
         break;
       }


### PR DESCRIPTION
I was confused about why analytics showed multiple "installed" events per client, and it turns out I wasn't checking the full file path when deciding whether or not to download the JxBrowser files again! (So files were getting downloaded on every restart)