### PR TITLE
Fix dev channel build

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,6 +10,7 @@
 name = "flutter-intellij"
 org.gradle.parallel=true
 org.gradle.jvmargs=-Xms128m -Xmx1024m -XX:+CMSClassUnloadingEnabled
+javaVersion = JavaVersion.VERSION_11
 dartVersion=202.6397.47
 flutterPluginVersion=49
 ide=android-studio

--- a/tool/kokoro/build.sh
+++ b/tool/kokoro/build.sh
@@ -4,6 +4,17 @@ source ./tool/kokoro/setup.sh
 setup
 
 echo "kokoro build start"
-./bin/plugin make --channel=dev
+
+./bin/plugin make --channel=dev -o4.0 -u
+./bin/plugin make --channel=dev -o4.1 -u
+
+curl https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_osx-x64_bin.tar.gz > ../java.tar.gz
+(cd ..; tar fx java.tar.gz)
+export JAVA_HOME=`pwd`/../jdk-11.0.2.jdk/Contents/Home
+export PATH=$PATH:$JAVA_HOME/bin
+echo "JAVA_HOME=$JAVA_HOME"
+
+./bin/plugin make --channel=dev -o4.2 -u
+./bin/plugin make --channel=dev -o2020.3 -u
 
 echo "kokoro build finished"

--- a/tool/kokoro/build.sh
+++ b/tool/kokoro/build.sh
@@ -5,8 +5,8 @@ setup
 
 echo "kokoro build start"
 
-./bin/plugin make --channel=dev -o4.0 -u
-./bin/plugin make --channel=dev -o4.1 -u
+./bin/plugin make --channel=dev -o4.0 -u -m1
+./bin/plugin make --channel=dev -o4.1 -u -m2
 
 curl https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_osx-x64_bin.tar.gz > ../java.tar.gz
 (cd ..; tar fx java.tar.gz)
@@ -14,7 +14,7 @@ export JAVA_HOME=`pwd`/../jdk-11.0.2.jdk/Contents/Home
 export PATH=$PATH:$JAVA_HOME/bin
 echo "JAVA_HOME=$JAVA_HOME"
 
-./bin/plugin make --channel=dev -o4.2 -u
-./bin/plugin make --channel=dev -o2020.3 -u
+./bin/plugin make --channel=dev -o4.2 -u -m3
+./bin/plugin make --channel=dev -o2020.3 -u -m4
 
 echo "kokoro build finished"

--- a/tool/kokoro/deploy.sh
+++ b/tool/kokoro/deploy.sh
@@ -4,7 +4,18 @@ source ./tool/kokoro/setup.sh
 setup
 
 echo "kokoro build start"
-./bin/plugin make --channel=dev
+
+./bin/plugin make --channel=dev -o4.0 -u -m1
+./bin/plugin make --channel=dev -o4.1 -u -m2
+
+curl https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_osx-x64_bin.tar.gz > ../java.tar.gz
+(cd ..; tar fx java.tar.gz)
+export JAVA_HOME=`pwd`/../jdk-11.0.2.jdk/Contents/Home
+export PATH=$PATH:$JAVA_HOME/bin
+echo "JAVA_HOME=$JAVA_HOME"
+
+./bin/plugin make --channel=dev -o4.2 -u -m3
+./bin/plugin make --channel=dev -o2020.3 -u -m4
 
 echo "kokoro build finished"
 

--- a/tool/kokoro/setup.sh
+++ b/tool/kokoro/setup.sh
@@ -16,10 +16,7 @@ setup() {
   flutter doctor
   export FLUTTER_SDK=`pwd`/../flutter
 
-  curl https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_osx-x64_bin.tar.gz > ../java.tar.gz
-  (cd ..; tar fx java.tar.gz)
-  export JAVA_HOME=`pwd`/../jdk-11.0.2.jdk/Contents/Home
-  export PATH=$PATH:$JAVA_HOME/bin
+  java -version
   echo "JAVA_HOME=$JAVA_HOME"
 
   export FLUTTER_KEYSTORE_ID=74840

--- a/tool/kokoro/test.sh
+++ b/tool/kokoro/test.sh
@@ -2,6 +2,13 @@
 
 source ./tool/kokoro/setup.sh
 setup
+
+curl https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_osx-x64_bin.tar.gz > ../java.tar.gz
+(cd ..; tar fx java.tar.gz)
+export JAVA_HOME=`pwd`/../jdk-11.0.2.jdk/Contents/Home
+export PATH=$PATH:$JAVA_HOME/bin
+echo "JAVA_HOME=$JAVA_HOME"
+
 (cd testData/sample_tests; echo "pub get `pwd`"; pub get --no-precompile)
 
 echo "kokoro test start"

--- a/tool/plugin/lib/runner.dart
+++ b/tool/plugin/lib/runner.dart
@@ -89,7 +89,6 @@ flutterPluginVersion=${version}
 ide=${spec.ideaProduct}
 testing=$testing
 ''';
-    print(contents);
     final propertiesFile = File("$rootPath/gradle.properties");
     final source = propertiesFile.readAsStringSync();
     propertiesFile.writeAsStringSync(contents);

--- a/tool/plugin/lib/runner.dart
+++ b/tool/plugin/lib/runner.dart
@@ -68,10 +68,7 @@ jxbrowser.license.key=${jxBrowserKey}
 
   Future<int> buildPlugin(BuildSpec spec, String version) async {
     writeJxBrowserKeyToFile();
-    if (spec.isDevChannel)
-      return await runGradleCommand(['buildPlugin'], spec, version, 'false');
-    else
-      return await runGradleCommand(['buildPlugin'], spec, version, 'false');
+    return await runGradleCommand(['buildPlugin'], spec, version, 'false');
   }
 
   Future<int> runGradleCommand(List<String> command, BuildSpec spec,

--- a/tool/plugin/lib/runner.dart
+++ b/tool/plugin/lib/runner.dart
@@ -69,23 +69,27 @@ jxbrowser.license.key=${jxBrowserKey}
   Future<int> buildPlugin(BuildSpec spec, String version) async {
     writeJxBrowserKeyToFile();
     if (spec.isDevChannel)
-      return await runGradleCommand(
-          ['buildPlugin'], spec, version, 'false');
+      return await runGradleCommand(['buildPlugin'], spec, version, 'false');
     else
       return await runGradleCommand(['buildPlugin'], spec, version, 'false');
   }
 
   Future<int> runGradleCommand(List<String> command, BuildSpec spec,
       String version, String testing) async {
+    var javaVersion = ['4.0', '4.1'].contains(spec.version)
+        ? 'JavaVersion.VERSION_8'
+        : 'JavaVersion.VERSION_11';
     final contents = '''
 name = "flutter-intellij"
 org.gradle.parallel=true
 org.gradle.jvmargs=-Xms128m -Xmx1024m -XX:+CMSClassUnloadingEnabled
+javaVersion = $javaVersion
 dartVersion=${spec.dartPluginVersion}
-flutterPluginVersion=${version}.${pluginCount.toString()}
+flutterPluginVersion=${version}
 ide=${spec.ideaProduct}
 testing=$testing
 ''';
+    print(contents);
     final propertiesFile = File("$rootPath/gradle.properties");
     final source = propertiesFile.readAsStringSync();
     propertiesFile.writeAsStringSync(contents);

--- a/tool/plugin/lib/util.dart
+++ b/tool/plugin/lib/util.dart
@@ -152,3 +152,33 @@ String readTokenFromKeystore(String keyName) {
   var file = File('$base/${id}_$name');
   return file.existsSync() ? file.readAsStringSync() : '';
 }
+
+
+int get devBuildNumber {
+  // The dev channel is automatically refreshed weekly, so the build number
+  // is just the number of weeks since the last stable release.
+  var today = DateTime.now();
+  var daysSinceRelease = today.difference(lastReleaseDate).inDays;
+  var weekNumber = daysSinceRelease ~/ 7 + 1;
+  return weekNumber;
+}
+
+String buildVersionNumber(BuildSpec spec) {
+  var releaseNo = spec.isDevChannel ? _nextRelease() : spec.release;
+  if (releaseNo == null) {
+    releaseNo = 'SNAPSHOT';
+  } else {
+    releaseNo = '$releaseNo.${pluginCount}';
+    if (spec.isDevChannel) {
+      releaseNo += '-dev.$devBuildNumber';
+    }
+  }
+  return releaseNo;
+}
+
+String _nextRelease() {
+  var current =
+  RegExp(r'release_(\d+)').matchAsPrefix(lastReleaseName).group(1);
+  var val = int.parse(current) + 1;
+  return '$val.0';
+}


### PR DESCRIPTION
Specifying Java target compatibility apparently doesn't work they way I expect it to. Class files built by Java 11 that specify Java 8 compatibility still have class file version 55 so the plugin can't be used in Android Studio 4.0 and 4.1. That might be a bug in the IntelliJ plugin for Gradle.

There are a number of changes here:
- Add Java version to Gradle script, set it in the plugin tool based on build version
- Unroll the build loop to do a single build at a time, manually incrementing the minor version number
- Change the Java version halfway through
- Refactor two utility functions (devBuildNumber(), _nextRelease()) into util.dart
- Move build version constructor from a switch branch to buildVersionNumber() in util.dart
- Use buildVersionNumber() everywhere that needs to use that value
- Move ++pluginCount into the main loop
