### PR TITLE
improved aesthetics for the run console folding

### DIFF
--- a/src/io/flutter/console/FlutterConsoleFolding.java
+++ b/src/io/flutter/console/FlutterConsoleFolding.java
@@ -14,67 +14,27 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
-import java.util.regex.Pattern;
 
 /**
- * Fold lines like
- * '/Users/.../projects/flutter/flutter/bin/flutter --no-color packages get'.
+ * Fold lines like '/Users/.../projects/flutter/flutter/bin/flutter --no-color packages get'.
  */
 public class FlutterConsoleFolding extends ConsoleFolding {
   private static final String flutterMarker =
     FlutterConstants.INDEPENDENT_PATH_SEPARATOR + FlutterSdkUtil.flutterScriptName() + " --no-color ";
 
-  // CoreSimulatorBridge: Requesting launch of ... with options: {
-  private static final Pattern iosPattern = Pattern.compile("^\\w+: .* \\{$");
-
-  //     [x86_64] libnetcore-856.20.4
-  // 0   libsystem_network.dylib             0x0000000111918682 __nw_create_backtrace_string + 123
-  // 1   libnetwork.dylib                    0x0000000111ab2932 nw_socket_add_input_handler + 3100
-  private static final String iosCrashFormat1 = "\t        [";
-
-  // (
-  //    0   Foundation                          0x0000000102c3697d __destroyPortContext + 283
-  //    1   CoreFoundation                      0x0000000105002370 ____CFMachPortChecker_block_invoke + 160
-  //    11  libdyld.dylib                       0x00000001073ac68d start + 1
-  // )
-  private static final String iosCrashFormat2 = "\t(";
-
-  // CoreSimulatorBridge: Beginning launch sequence for bundle 'com.yourcompany.flutterGallery'
-  //         retryTimeout: 300.000000 (default write com.apple.CoreSimulatorBridge LaunchRetryTimeout <value>)
-  //         bootTimeout: 300.000000 (default write com.apple.CoreSimulatorBridge BootRetryTimeout <value>)
-  //         bootLeeway: 120.000000 (default write com.apple.CoreSimulatorBridge BootLeeway <value>)
-  //         Note: Use 'xcrun simctl spawn booted defaults write <domain> <key> <value>' to modify defaults in the booted Simulator device.
-  //     Simulator booted at: 2017-02-24 07:56:56 +0000
-  //     Current time: 2017-02-24 07:57:56 +0000
-  //     Within boot leeway: YES
-  private static final String launchSequencePrefix = "CoreSimulatorBridge: Beginning launch sequence for bundle";
-
-  private boolean isFolding = false;
-
   @Override
   public boolean shouldFoldLine(@NotNull Project project, @NotNull String line) {
     if (line.contains(flutterMarker)) {
-      isFolding = false;
-      return true;
+      return line.indexOf(' ') > line.indexOf(flutterMarker);
     }
 
-    if (iosPattern.matcher(line).matches() || line.startsWith(iosCrashFormat1) || line.startsWith(launchSequencePrefix)) {
-      isFolding = true;
-      return false;
-    }
+    return false;
+  }
 
-    if (line.equals(iosCrashFormat2)) {
-      isFolding = true;
-      return true;
-    }
-
-    if (isFolding && line.startsWith(("\t"))) {
-      return true;
-    }
-    else {
-      isFolding = false;
-      return false;
-    }
+  @Override
+  public boolean shouldBeAttachedToThePreviousLine() {
+    // This ensures that we don't get appended to the previous (likely unrelated) line.
+    return false;
   }
 
   @Nullable
@@ -82,21 +42,14 @@ public class FlutterConsoleFolding extends ConsoleFolding {
   public String getPlaceholderText(@NotNull Project project, @NotNull List<String> lines) {
     final String fullText = StringUtil.join(lines, "\n");
     final int index = fullText.indexOf(flutterMarker);
-    if (index == -1) {
-      final String trimmed = fullText.trim();
-
-      if (trimmed.startsWith("(") && trimmed.endsWith(")")) {
-        return " ( ... )";
-      }
-      else if (lines.stream().anyMatch((s) -> s.endsWith("}"))) {
-        return " ... }";
-      }
-      else {
-        return " ...";
-      }
+    if (index != -1) {
+      String results = "flutter " + fullText.substring(index + flutterMarker.length());
+      results = results.replace("--machine ", "");
+      results = results.replace("--start-paused ", "");
+      return results;
     }
     else {
-      return "flutter " + fullText.substring(index + flutterMarker.length());
+      return fullText.trim();
     }
   }
 }


### PR DESCRIPTION
- improve aesthetics for the run console folding
- remove older iOS Simulator (and likely seldom used) foldings

This changes our console folding to not combine the `flutter test xyz...` folding with the proceeding line of text (generally something like 'Testing started at 10:14 AM ...'). This would look odd, esp. for the console for running tests.

Before:

<img width="641" alt="Screen Shot 2020-10-18 at 9 19 35 PM" src="https://user-images.githubusercontent.com/1269969/96401393-03171180-1188-11eb-9402-31df705a24cd.png">

Note there's no space between the '...' and the 'flutter test...' text.

After:

<img width="343" alt="Screen Shot 2020-10-18 at 3 24 06 PM" src="https://user-images.githubusercontent.com/1269969/96401419-175b0e80-1188-11eb-8280-1a42e637857c.png">

This PR also removes some older older, iOS specific foldings. These were untested, and likely encountered pretty infrequently.
