### PR TITLE
resume isolates at test start

### DIFF
--- a/src/io/flutter/run/test/FlutterTestRunner.java
+++ b/src/io/flutter/run/test/FlutterTestRunner.java
@@ -37,13 +37,12 @@ import io.flutter.sdk.FlutterSdk;
 import io.flutter.settings.FlutterSettings;
 import io.flutter.utils.JsonUtils;
 import io.flutter.utils.StdoutJsonParser;
+import io.flutter.utils.VmServiceListenerAdapter;
 import io.flutter.vmService.VmServiceConsumers;
+import io.flutter.vmService.VmServiceConsumers.EmptyResumeConsumer;
 import org.dartlang.vm.service.VmService;
 import org.dartlang.vm.service.consumer.VMConsumer;
-import org.dartlang.vm.service.element.ElementList;
-import org.dartlang.vm.service.element.IsolateRef;
-import org.dartlang.vm.service.element.RPCError;
-import org.dartlang.vm.service.element.VM;
+import org.dartlang.vm.service.element.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -97,44 +96,93 @@ public class FlutterTestRunner extends GenericProgramRunner {
       String url = connector.getWebSocketUrl();
 
       while (url == null) {
-        if (launcher.isTerminated()) return;
+        if (launcher.isTerminated()) {
+          return;
+        }
+
         TimeoutUtil.sleep(100);
+
         url = connector.getWebSocketUrl();
       }
 
-      if (launcher.isTerminated()) return;
+      if (launcher.isTerminated()) {
+        return;
+      }
+
+      final VmService vmService;
 
       try {
-        // We want to resume any isolates paused at start.
-        final VmService vmService = VmService.connect(url);
-        vmService.getVM(new VMConsumer() {
-          @Override
-          public void received(VM response) {
-            final ElementList<IsolateRef> isolates = response.getIsolates();
-
-            for (IsolateRef isolateRef : isolates) {
-              vmService.resume(isolateRef.getId(), new VmServiceConsumers.EmptyResumeConsumer() {
-                @Override
-                public void onError(RPCError error) {
-                  LOG.error(error);
-                }
-              });
-            }
-          }
-
-          @Override
-          public void onError(RPCError error) {
-            LOG.error(error);
-          }
-        });
+        vmService = VmService.connect(url);
       }
       catch (IOException | RuntimeException e) {
-        LOG.error("Failed to connect to the VM observatory service at: " + url + "\n"
-                  + e.toString());
+        if (!launcher.isTerminated()) {
+          launcher.notifyTextAvailable(
+            "Failed to connect to the VM service at: " + url + "\n" + e.toString() + "\n",
+            ProcessOutputTypes.STDERR);
+        }
+        return;
       }
+
+      // Listen for debug 'PauseStart' events for isolates after the initial connect and resume those isolates.
+      vmService.streamListen(VmService.DEBUG_STREAM_ID, VmServiceConsumers.EMPTY_SUCCESS_CONSUMER);
+      vmService.addVmServiceListener(new VmServiceListenerAdapter() {
+        @Override
+        public void received(String streamId, Event event) {
+          if (EventKind.PauseStart.equals(event.getKind())) {
+            resumePausedAtStartIsolate(launcher, vmService, event.getIsolate());
+          }
+        }
+      });
+
+      // Resume any isolates paused at the initial connect.
+      vmService.getVM(new VMConsumer() {
+        @Override
+        public void received(VM response) {
+          final ElementList<IsolateRef> isolates = response.getIsolates();
+          for (IsolateRef isolateRef : isolates) {
+            resumePausedAtStartIsolate(launcher, vmService, isolateRef);
+          }
+        }
+
+        @Override
+        public void onError(RPCError error) {
+          if (!launcher.isTerminated()) {
+            launcher.notifyTextAvailable(
+              "Error connecting to VM: " + error.getCode() + " " + error.getMessage() + "\n",
+              ProcessOutputTypes.STDERR);
+          }
+        }
+      });
     });
 
     return new RunContentBuilder(executionResult, env).showRunContent(env.getContentToReuse());
+  }
+
+  private void resumePausedAtStartIsolate(@NotNull TestLaunchState launcher, @NotNull VmService vmService, @NotNull IsolateRef isolateRef) {
+    if (isolateRef.getIsSystemIsolate()) {
+      return;
+    }
+
+    vmService.getIsolate(isolateRef.getId(), new VmServiceConsumers.GetIsolateConsumerWrapper() {
+      @Override
+      public void received(Isolate isolate) {
+        final Event event = isolate.getPauseEvent();
+        final EventKind eventKind = event.getKind();
+
+        if (eventKind == EventKind.PauseStart) {
+          vmService.resume(isolateRef.getId(), new EmptyResumeConsumer() {
+            @Override
+            public void onError(RPCError error) {
+              if (!launcher.isTerminated()) {
+                launcher.notifyTextAvailable(
+                  "Error resuming isolate " + isolateRef.getId() + ": " + error.getCode() + " " + error.getMessage() + "\n",
+                  ProcessOutputTypes.STDERR);
+              }
+            }
+          });
+        }
+      }
+    });
   }
 
   protected RunContentDescriptor runInDebugger(@NotNull TestLaunchState launcher, @NotNull ExecutionEnvironment env)

--- a/src/io/flutter/run/test/FlutterTestRunner.java
+++ b/src/io/flutter/run/test/FlutterTestRunner.java
@@ -42,7 +42,13 @@ import io.flutter.vmService.VmServiceConsumers;
 import io.flutter.vmService.VmServiceConsumers.EmptyResumeConsumer;
 import org.dartlang.vm.service.VmService;
 import org.dartlang.vm.service.consumer.VMConsumer;
-import org.dartlang.vm.service.element.*;
+import org.dartlang.vm.service.element.ElementList;
+import org.dartlang.vm.service.element.Event;
+import org.dartlang.vm.service.element.EventKind;
+import org.dartlang.vm.service.element.Isolate;
+import org.dartlang.vm.service.element.IsolateRef;
+import org.dartlang.vm.service.element.RPCError;
+import org.dartlang.vm.service.element.VM;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 

--- a/src/io/flutter/run/test/TestLaunchState.java
+++ b/src/io/flutter/run/test/TestLaunchState.java
@@ -19,6 +19,7 @@ import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleUtil;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Key;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.jetbrains.lang.dart.ide.runner.DartConsoleFilter;
 import com.jetbrains.lang.dart.ide.runner.DartRelativePathsConsoleFilter;
@@ -152,5 +153,11 @@ class TestLaunchState extends CommandLineState {
 
   public boolean isTerminated() {
     return processHandler != null && processHandler.isProcessTerminated();
+  }
+
+  public void notifyTextAvailable(@NotNull String text, @NotNull Key<?> outputType) {
+    if (processHandler != null) {
+      processHandler.notifyTextAvailable(text, outputType);
+    }
   }
 }


### PR DESCRIPTION
- fix an issue resuming isolates at the start of running tests
- fix https://github.com/flutter/flutter-intellij/issues/4967
- fix https://github.com/flutter/flutter-intellij/issues/4960

From the reported issue, and looking at the code, I believe the problem was that we were resuming all known isolates (reported by the VM object) at test start. However, there's a chance the test isolate might not be executable yet. I believe the state changes that isolates go through are (https://github.com/dart-lang/sdk/blob/master/runtime/vm/service/service.md#streamlisten) `IsolateStart`, `IsolateRunnable`, and `PauseStart`. If you try and resume an isolate that's not yet runnable (or paused) the VM will return an error.

This changes to resuming all isolates that are `'PauseStart'` when we first connect, and all isolates for which we later received `'PauseStart'` events.

This alos changes from reporting issues via `LOG.error()` - which look like crashes to the user - to writing error messages to the run / test console.

@helin24 - this is for the `FlutterTestRunner` program runner. I haven't looked to see if we'll need similar changes for the bazel test runner as well.
