### PR TITLE
Show option to open DevTools in browser during JxBrowser installation

### DIFF
--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -433,10 +433,7 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
     final JxBrowserManager jxBrowserManager = JxBrowserManager.getInstance();
     final DevToolsManager devToolsManager = DevToolsManager.getInstance(app.getProject());
 
-    final List<LabelInput> inputs = new ArrayList<>();
-    inputs.add(new LabelInput(INSTALLATION_IN_PROGRESS_LABEL));
-    inputs.add(openDevToolsLabel(app, inspectorService, toolWindow));
-    presentClickableLabel(toolWindow, inputs);
+    presentOpenDevToolsOptionWithMessage(app, inspectorService, toolWindow, INSTALLATION_IN_PROGRESS_LABEL);
 
     // Start devtools while waiting for JxBrowser download.
     devToolsManager.installDevTools();
@@ -468,17 +465,11 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
       }
       else {
         // newStatus can be null if installation is interrupted or stopped for another reason.
-        final List<LabelInput> inputs = new ArrayList<>();
-        inputs.add(new LabelInput(INSTALLATION_STOPPED_LABEL));
-        inputs.add(openDevToolsLabel(app, inspectorService, toolWindow));
-        presentClickableLabel(toolWindow, inputs);
+        presentOpenDevToolsOptionWithMessage(app, inspectorService, toolWindow, INSTALLATION_STOPPED_LABEL);
       }
     }
     catch (TimeoutException e) {
-      final List<LabelInput> inputs = new ArrayList<>();
-      inputs.add(new LabelInput(INSTALLATION_TIMED_OUT_LABEL));
-      inputs.add(openDevToolsLabel(app, inspectorService, toolWindow));
-      presentClickableLabel(toolWindow, inputs);
+      presentOpenDevToolsOptionWithMessage(app, inspectorService, toolWindow, INSTALLATION_TIMED_OUT_LABEL);
 
       FlutterInitializer.getAnalytics().sendEvent(JxBrowserManager.ANALYTICS_CATEGORY, "timedOut");
     }
@@ -533,6 +524,16 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
     final JPanel center = new JPanel(new VerticalFlowLayout(VerticalFlowLayout.CENTER));
     center.add(panel);
     replacePanelLabel(toolWindow, center);
+  }
+
+  protected void presentOpenDevToolsOptionWithMessage(FlutterApp app,
+                                                      InspectorService inspectorService,
+                                                      ToolWindow toolWindow,
+                                                      String message) {
+    final List<LabelInput> inputs = new ArrayList<>();
+    inputs.add(new LabelInput(message));
+    inputs.add(openDevToolsLabel(app, inspectorService, toolWindow));
+    presentClickableLabel(toolWindow, inputs);
   }
 
   private void replacePanelLabel(ToolWindow toolWindow, JComponent label) {

--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -91,8 +91,7 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
   protected static final String INSTALLATION_IN_PROGRESS_LABEL = "Installing JxBrowser and DevTools...";
   protected static final String INSTALLATION_TIMED_OUT_LABEL =
     "Waiting for JxBrowser installation timed out. Restart your IDE to try again.";
-  protected static final String INSTALLATION_STOPPED_LABEL =
-    "The JxBrowser installation was stopped for unknown reasons. Restart your IDE to try again.";
+  protected static final String INSTALLATION_WAIT_FAILED = "The JxBrowser installation failed unexpectedly. Restart your IDE to try again.";
   protected static final String INSTALLING_DEVTOOLS_LABEL = "Installing DevTools...";
   protected static final String DEVTOOLS_FAILED_LABEL = "Setting up DevTools failed.";
   protected static final int INSTALLATION_WAIT_LIMIT_SECONDS = 2000;
@@ -465,7 +464,7 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
       }
       else {
         // newStatus can be null if installation is interrupted or stopped for another reason.
-        presentOpenDevToolsOptionWithMessage(app, inspectorService, toolWindow, INSTALLATION_STOPPED_LABEL);
+        presentOpenDevToolsOptionWithMessage(app, inspectorService, toolWindow, INSTALLATION_WAIT_FAILED);
       }
     }
     catch (TimeoutException e) {

--- a/testSrc/unit/io/flutter/view/FlutterViewTest.java
+++ b/testSrc/unit/io/flutter/view/FlutterViewTest.java
@@ -151,7 +151,8 @@ public class FlutterViewTest {
     when(mockJxBrowserManager.getStatus()).thenReturn(JxBrowserStatus.INSTALLED);
 
     partialMockFlutterView.handleJxBrowserInstallationInProgress(mockApp, mockInspectorService, mockToolWindow);
-    verify(partialMockFlutterView, times(1)).presentLabel(mockToolWindow, INSTALLATION_IN_PROGRESS_LABEL);
+    verify(partialMockFlutterView, times(1))
+      .presentOpenDevToolsOptionWithMessage(mockApp, mockInspectorService, mockToolWindow, INSTALLATION_IN_PROGRESS_LABEL);
     verify(partialMockFlutterView, times(1)).handleJxBrowserInstalled(mockApp, mockInspectorService, mockToolWindow);
   }
 
@@ -171,7 +172,8 @@ public class FlutterViewTest {
     when(mockJxBrowserManager.getStatus()).thenReturn(JxBrowserStatus.INSTALLATION_IN_PROGRESS);
 
     partialMockFlutterView.handleJxBrowserInstallationInProgress(mockApp, mockInspectorService, mockToolWindow);
-    verify(partialMockFlutterView, times(1)).presentLabel(mockToolWindow, INSTALLATION_IN_PROGRESS_LABEL);
+    verify(partialMockFlutterView, times(1))
+      .presentOpenDevToolsOptionWithMessage(mockApp, mockInspectorService, mockToolWindow, INSTALLATION_IN_PROGRESS_LABEL);
     verify(partialMockFlutterView, times(1)).startJxBrowserInstallationWaitingThread(mockApp, mockInspectorService, mockToolWindow);
   }
 
@@ -215,7 +217,8 @@ public class FlutterViewTest {
     when(FlutterInitializer.getAnalytics()).thenReturn(mockAnalytics);
 
     partialMockFlutterView.waitForJxBrowserInstallation(mockApp, mockInspectorService, mockToolWindow);
-    verify(partialMockFlutterView, times(1)).presentLabel(mockToolWindow, INSTALLATION_TIMED_OUT_LABEL);
+    verify(partialMockFlutterView, times(1))
+      .presentOpenDevToolsOptionWithMessage(mockApp, mockInspectorService, mockToolWindow, INSTALLATION_TIMED_OUT_LABEL);
   }
 
   private void setUpInstallationInProgress() {


### PR DESCRIPTION
If an app is started while JxBrowser is still installing, we present:
![Screen Shot 2020-10-19 at 11 22 59 AM](https://user-images.githubusercontent.com/6379305/96498632-28943180-1201-11eb-85e1-64f604799807.png)

If the installation times out:
![Screen Shot 2020-10-19 at 11 22 16 AM](https://user-images.githubusercontent.com/6379305/96498637-2af68b80-1201-11eb-885f-ece5b1a4675d.png)

If something else goes wrong, like installation is interrupted:
![Screen Shot 2020-10-19 at 11 15 46 AM](https://user-images.githubusercontent.com/6379305/96498644-2cc04f00-1201-11eb-8917-6ca2e8967b5b.png)
