### PR TITLE
Migrate to IntelliJ NPW for AS 4.3

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,9 +19,10 @@ file.
 * In the Project Structure dialog (`File | Project Structure`), select "Platform Settings > SDKs" click the "+" sign at the top "Add New SDK (Alt+Insert)" to configure an IntelliJ Platform Plugin SDK
   - Point it to the directory of your downloaded IntelliJ Community Edition installation (e.g, `IntelliJ IDEA CE.app/Contents` or `~/idea-IC-183.4886.37`)
   - Change the name to `IntelliJ IDEA Community Edition`
-  - Extend it with additional plugin libraries by adding to `Classpath` (only until Android Q is released):
+  - Extend it with additional plugin libraries by adding to `Classpath`:
     - plugins/android/lib/android.jar
     - plugins/gradle/lib/gradle-common.jar
+    - plugins/gradle-dsl-impl/lib/gradle-dsl-impl.jar
 * One-time Dart plugin install - first-time a new IDE is installed and run you will need to install the Dart plugin. Find `Plugins` (in Settings/Preferences) and install the Dart plugin, then restart the IDE
 * Open flutter-intellij project in IntelliJ (select and open the directory of the flutter-intellij repository). Build it using `Build` | `Build Project`
 * Try running the plugin; there is an existing launch config for "Flutter IntelliJ". This should open the "runtime workbench", a new intance of IntelliJ with the plugin installed.

--- a/flutter-intellij-community.iml
+++ b/flutter-intellij-community.iml
@@ -114,5 +114,8 @@
     </orderEntry>
     <orderEntry type="library" name="Trove4j" level="project" />
     <orderEntry type="library" name="Dart Packages" level="project" />
+    <orderEntry type="module" module-name="intellij.gradle.dsl.impl" />
+    <orderEntry type="library" name="studio-sdk" level="project" />
+    <orderEntry type="library" name="studio-plugin-gradle" level="project" />
   </component>
 </module>

--- a/flutter-studio/flutter-studio.iml
+++ b/flutter-studio/flutter-studio.iml
@@ -62,5 +62,7 @@
     <orderEntry type="module" module-name="intellij.android.projectSystem.gradle.psd" />
     <orderEntry type="module" module-name="intellij.android.deploy" />
     <orderEntry type="module" module-name="assistant" />
+    <orderEntry type="library" name="studio-sdk" level="project" />
+    <orderEntry type="library" name="studio-plugin-gradle" level="project" />
   </component>
 </module>

--- a/flutter-studio/src/org/jetbrains/kotlin/tools/projectWizard/wizard/NewProjectWizardModuleBuilder.java
+++ b/flutter-studio/src/org/jetbrains/kotlin/tools/projectWizard/wizard/NewProjectWizardModuleBuilder.java
@@ -1,0 +1,7 @@
+package org.jetbrains.kotlin.tools.projectWizard.wizard;
+
+import com.intellij.ide.util.projectWizard.EmptyModuleBuilder;
+
+// This class definition is required to prevent an exception during extension initialization.
+public class NewProjectWizardModuleBuilder extends EmptyModuleBuilder {
+}

--- a/src/io/flutter/FlutterBundle.properties
+++ b/src/io/flutter/FlutterBundle.properties
@@ -206,3 +206,7 @@ settings.flutter.version=Version:
 settings.open.inspector.on.launch=Open Flutter Inspector view on app launch
 settings.hot.reload.on.save=Perform hot reload on save
 settings.enable.embedding.devtools=Enable embedding DevTools in the Flutter Inspector tool window
+
+action.new.project.title=New Flutter Project...
+welcome.new.project.title=Create New Flutter Project
+welcome.new.project.compact=New Flutter Project


### PR DESCRIPTION
The main change is in `FlutterNewProjectAction.actionPerformed()`. The previous content has bee embedded in an if-statement detecting version 4.2 or earlier. If later, the IntelliJ new project wizard will be used.

In 4.2 the Welcome screen changes, and I thought a more compact title would be better (I stretched the screen a little so the search option shows).

<img width="897" alt="Screen Shot 2020-10-19 at 2 06 49 PM" src="https://user-images.githubusercontent.com/8518285/96514875-2d64df80-1219-11eb-80af-640aba30333e.png">
