### PR TITLE
Enable embedded browser by default

### DIFF
--- a/src/io/flutter/settings/FlutterSettings.java
+++ b/src/io/flutter/settings/FlutterSettings.java
@@ -269,7 +269,7 @@ public class FlutterSettings {
   }
 
   public boolean isEnableEmbeddedBrowsers() {
-    return getPropertiesComponent().getBoolean(enableEmbeddedBrowsersKey, isPluginVersionDev());
+    return getPropertiesComponent().getBoolean(enableEmbeddedBrowsersKey, true);
   }
 
   public void setEnableEmbeddedBrowsers(boolean value) {


### PR DESCRIPTION
Analytics are already logged for settings on IntelliJ startup.