### PR TITLE
Fix hang when opening a project if previous selection was a directory

### DIFF
--- a/src/io/flutter/pub/PubRoot.java
+++ b/src/io/flutter/pub/PubRoot.java
@@ -38,7 +38,6 @@ public class PubRoot {
   private final VirtualFile pubspec;
 
   private PubRoot(@NotNull VirtualFile root, @NotNull VirtualFile pubspec) {
-    assert (!root.getPath().endsWith("/"));
     this.root = root;
     this.pubspec = pubspec;
   }
@@ -134,7 +133,7 @@ public class PubRoot {
    */
   @Nullable
   public static PubRoot forDirectory(@Nullable VirtualFile dir) {
-    if (dir == null || !dir.isDirectory()) {
+    if (dir == null || !dir.isDirectory() || dir.getPath().endsWith("/")) {
       return null;
     }
 


### PR DESCRIPTION
@alexander-doroshko I can't reproduce the original problem but this ought to fix it.

Fixes #4979 