### PR TITLE
Stop running the Android framework detector

### DIFF
--- a/src/io/flutter/ProjectOpenActivity.java
+++ b/src/io/flutter/ProjectOpenActivity.java
@@ -5,6 +5,8 @@
  */
 package io.flutter;
 
+import com.intellij.framework.detection.DetectionExcludesConfiguration;
+import com.intellij.framework.detection.impl.exclude.DetectionExcludesConfigurationImpl;
 import com.intellij.notification.Notification;
 import com.intellij.notification.NotificationType;
 import com.intellij.notification.Notifications;
@@ -27,6 +29,7 @@ import io.flutter.sdk.FlutterSdk;
 import io.flutter.settings.FlutterSettings;
 import io.flutter.utils.AndroidUtils;
 import io.flutter.utils.FlutterModuleUtils;
+import org.jetbrains.android.facet.AndroidFrameworkDetector;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -56,6 +59,7 @@ public class ProjectOpenActivity implements StartupActivity, DumbAware {
       // We can't do anything without a Flutter SDK.
       return;
     }
+    excludeAndroidFrameworkDetector(project);
 
     // Set up JxBrowser listening and check if it's already enabled.
     JxBrowserManager.getInstance().listenForSettingChanges(project);
@@ -84,6 +88,14 @@ public class ProjectOpenActivity implements StartupActivity, DumbAware {
     }
   }
 
+  private static void excludeAndroidFrameworkDetector(@NotNull Project project) {
+    DetectionExcludesConfigurationImpl
+      excludesConfiguration = (DetectionExcludesConfigurationImpl)DetectionExcludesConfiguration.getInstance(project);
+    AndroidFrameworkDetector detector = new AndroidFrameworkDetector();
+    if (!excludesConfiguration.isExcludedFromDetection(detector.getFrameworkType())) {
+      excludesConfiguration.addExcludedFramework(detector.getFrameworkType());
+    }
+  }
   private static class PackagesOutOfDateNotification extends Notification {
     @NotNull private final Project myProject;
     @NotNull private final PubRoot myRoot;

--- a/src/io/flutter/ProjectOpenActivity.java
+++ b/src/io/flutter/ProjectOpenActivity.java
@@ -5,8 +5,8 @@
  */
 package io.flutter;
 
+import com.intellij.framework.FrameworkType;
 import com.intellij.framework.detection.DetectionExcludesConfiguration;
-import com.intellij.framework.detection.impl.exclude.DetectionExcludesConfigurationImpl;
 import com.intellij.notification.Notification;
 import com.intellij.notification.NotificationType;
 import com.intellij.notification.Notifications;
@@ -89,13 +89,13 @@ public class ProjectOpenActivity implements StartupActivity, DumbAware {
   }
 
   private static void excludeAndroidFrameworkDetector(@NotNull Project project) {
-    DetectionExcludesConfigurationImpl
-      excludesConfiguration = (DetectionExcludesConfigurationImpl)DetectionExcludesConfiguration.getInstance(project);
-    AndroidFrameworkDetector detector = new AndroidFrameworkDetector();
-    if (!excludesConfiguration.isExcludedFromDetection(detector.getFrameworkType())) {
-      excludesConfiguration.addExcludedFramework(detector.getFrameworkType());
+    DetectionExcludesConfiguration excludesConfiguration = DetectionExcludesConfiguration.getInstance(project);
+    FrameworkType type = new AndroidFrameworkDetector().getFrameworkType();
+    if (!excludesConfiguration.isExcludedFromDetection(type)) {
+      excludesConfiguration.addExcludedFramework(type);
     }
   }
+
   private static class PackagesOutOfDateNotification extends Notification {
     @NotNull private final Project myProject;
     @NotNull private final PubRoot myRoot;


### PR DESCRIPTION
Creating a new project with IntelliJ caused a notification to appear (which disappeared before I could capture the image). I would click its "Configure" button then deselect the items in this window. 

<img width="262" alt="Screen Shot 2020-10-23 at 3 17 08 PM" src="https://user-images.githubusercontent.com/8518285/97058510-e2add500-1542-11eb-856c-50e6019c6f8a.png">

If you did nothing the notification would appear next time you open the project. If you allow the configuration to proceed your Android module is ruined.

This just stops the detector from running on Flutter projects.

Fixes #989