### PR TITLE
Make embedded browser default enabled, not version-specific

### DIFF
--- a/src/io/flutter/settings/FlutterSettings.java
+++ b/src/io/flutter/settings/FlutterSettings.java
@@ -273,7 +273,7 @@ public class FlutterSettings {
   }
 
   public void setEnableEmbeddedBrowsers(boolean value) {
-    getPropertiesComponent().setValue(enableEmbeddedBrowsersKey, value, isPluginVersionDev());
+    getPropertiesComponent().setValue(enableEmbeddedBrowsersKey, value, true);
 
     fireEvent();
   }


### PR DESCRIPTION
I changed the default value in `isEnableEmbeddedBrowsers` (the method above this change) but neglected to update the set method as well, so non-dev users would have been unable to disable the embedded browsers setting.

I verified with a non-dev version that the embedded browser option can be both enabled and disabled.