### PR TITLE
Fix indent delta to match change to IntelliJ.

### DIFF
--- a/src/io/flutter/editor/FilteredIndentsHighlightingPass.java
+++ b/src/io/flutter/editor/FilteredIndentsHighlightingPass.java
@@ -157,7 +157,7 @@ public class FilteredIndentsHighlightingPass extends TextEditorHighlightingPass 
     //     1. Show only active indent if it crosses soft wrap-introduced text;
     //     2. Show indent as is if it doesn't intersect with soft wrap-introduced text;
     if (selected) {
-      LinePainter2D.paint((Graphics2D)g, start.x + 2, start.y, start.x + 2, maxY - 1);
+      LinePainter2D.paint((Graphics2D)g, start.x + WidgetIndentsHighlightingPass.INDENT_GUIDE_DELTA, start.y, start.x + WidgetIndentsHighlightingPass.INDENT_GUIDE_DELTA, maxY - 1);
     }
     else {
       int y = start.y;
@@ -172,7 +172,7 @@ public class FilteredIndentsHighlightingPass extends TextEditorHighlightingPass 
         }
         if (!softWraps.isEmpty() && softWraps.get(0).getIndentInColumns() < indentColumn) {
           if (y < newY || i > startLine + lineShift) { // There is a possible case that soft wrap is located on indent start line.
-            LinePainter2D.paint((Graphics2D)g, start.x + 2, y, start.x + 2, newY + lineHeight - 1);
+            LinePainter2D.paint((Graphics2D)g, start.x + WidgetIndentsHighlightingPass.INDENT_GUIDE_DELTA, y, start.x + WidgetIndentsHighlightingPass.INDENT_GUIDE_DELTA, newY + lineHeight - 1);
           }
           newY += logicalLineHeight;
           y = newY;
@@ -188,7 +188,7 @@ public class FilteredIndentsHighlightingPass extends TextEditorHighlightingPass 
       }
 
       if (y < maxY) {
-        LinePainter2D.paint((Graphics2D)g, start.x + 2, y, start.x + 2, maxY - 1);
+        LinePainter2D.paint((Graphics2D)g, start.x + WidgetIndentsHighlightingPass.INDENT_GUIDE_DELTA, y, start.x + WidgetIndentsHighlightingPass.INDENT_GUIDE_DELTA, maxY - 1);
       }
     }
   };

--- a/src/io/flutter/editor/WidgetIndentsHighlightingPass.java
+++ b/src/io/flutter/editor/WidgetIndentsHighlightingPass.java
@@ -97,6 +97,8 @@ import static java.lang.Math.*;
 public class WidgetIndentsHighlightingPass {
   private static final Logger LOG = Logger.getInstance(WidgetIndentsHighlightingPass.class);
 
+  // Delta between the start of a column and where indent guides should start;
+  public static int INDENT_GUIDE_DELTA = -2;
   private final static Stroke SOLID_STROKE = new BasicStroke(1);
   private final static JBColor VERY_LIGHT_GRAY = new JBColor(Gray._224, Gray._80);
   private final static JBColor SHADOW_GRAY = new JBColor(Gray._192, Gray._100);
@@ -346,7 +348,7 @@ public class WidgetIndentsHighlightingPass {
               // This is the normal case where we draw a foward line to the connected child.
               LinePainter2D.paint(
                 g2d,
-                start.x + 2,
+                start.x + INDENT_GUIDE_DELTA,
                 newY + lineHeight * 0.5,
                 //start.x + charWidth  * childIndent - padding,
                 widgetPoint.x - padding,
@@ -371,7 +373,7 @@ public class WidgetIndentsHighlightingPass {
               final int endX = widgetPoint.x - padding;
               LinePainter2D.paint(
                 g2d,
-                start.x + 2,
+                start.x + INDENT_GUIDE_DELTA,
                 newY,
                 endX,
                 newY
@@ -424,11 +426,11 @@ public class WidgetIndentsHighlightingPass {
         if (splitY != -1) {
           drawVerticalLineHelper(g2d, lineColor, start.x, y, splitY, childLines);
           g2d.setColor(pastBlockColor);
-          g2d.drawLine(start.x + 2, (int)splitY + 1, start.x + 2, maxY);
+          g2d.drawLine(start.x + INDENT_GUIDE_DELTA, (int)splitY + 1, start.x + INDENT_GUIDE_DELTA, maxY);
         }
         else {
           g2d.setColor(pastBlockColor);
-          g2d.drawLine(start.x + 2, y, start.x + 2, maxY);
+          g2d.drawLine(start.x + INDENT_GUIDE_DELTA, y, start.x + INDENT_GUIDE_DELTA, maxY);
         }
       }
       g2d.dispose();
@@ -510,7 +512,7 @@ public class WidgetIndentsHighlightingPass {
     ArrayList<OutlineLocation> childLines
   ) {
     g.setColor(lineColor);
-    g.drawLine(x + 2, (int)yStart, x + 2, (int)yEnd + 1);
+    g.drawLine(x + INDENT_GUIDE_DELTA, (int)yStart, x + INDENT_GUIDE_DELTA, (int)yEnd + 1);
   }
 
   public static int compare(@NotNull TextRangeDescriptorPair r, @NotNull RangeHighlighter h) {


### PR DESCRIPTION
We could diverge from the IntelliJ default but the new default
seems fine and I like that the lines are now to the left of the cursor which is a bit clearer than when they were to the right.
Before:
<img width="560" alt="Screen Shot 2020-10-29 at 10 00 20 AM" src="https://user-images.githubusercontent.com/1226812/97639488-e38bae80-19fb-11eb-88d4-e7798e5ff8c2.png">
After:
<img width="572" alt="Screen Shot 2020-10-29 at 3 33 00 PM" src="https://user-images.githubusercontent.com/1226812/97639574-146be380-19fc-11eb-8325-ddcaf9aa3963.png">

This is related to https://github.com/flutter/flutter-intellij/issues/4982
An existing CL already resolved the doubling aspect by ensuring our indent renderer wins but we still have the issue that our widget indent guides had diverged from the default indent guides in terms of where lines were drawn.