### PR TITLE
Set user-data folder for embedded browser

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -1474,6 +1474,9 @@
                     serviceImplementation="io.flutter.editor.WidgetIndentsHighlightingPassFactory"
                     overrides="false"/>
     <highlightingPassFactory implementation="io.flutter.editor.WidgetIndentsHighlightingPassFactoryRegistrar"/>
+    <projectService serviceInterface="io.flutter.jxbrowser.EmbeddedBrowser"
+                    serviceImplementation="io.flutter.jxbrowser.EmbeddedBrowser"
+                    overrides="false"/>
   </extensions>
 
   <!-- Dart Plugin extensions -->

--- a/resources/META-INF/plugin_template.xml
+++ b/resources/META-INF/plugin_template.xml
@@ -354,6 +354,9 @@
                     serviceImplementation="io.flutter.editor.WidgetIndentsHighlightingPassFactory"
                     overrides="false"/>
     <highlightingPassFactory implementation="io.flutter.editor.WidgetIndentsHighlightingPassFactoryRegistrar"/>
+    <projectService serviceInterface="io.flutter.jxbrowser.EmbeddedBrowser"
+                    serviceImplementation="io.flutter.jxbrowser.EmbeddedBrowser"
+                    overrides="false"/>
   </extensions>
 
   <!-- Dart Plugin extensions -->

--- a/src/io/flutter/devtools/DevToolsManager.java
+++ b/src/io/flutter/devtools/DevToolsManager.java
@@ -404,7 +404,7 @@ class DevToolsInstance {
 
     //noinspection CodeBlock2Expr
     ApplicationManager.getApplication().invokeLater(() -> {
-      new EmbeddedBrowser().openPanel(contentManager, tabName, url);
+      EmbeddedBrowser.getInstance().openPanel(contentManager, tabName, url);
     });
   }
 }

--- a/src/io/flutter/devtools/DevToolsManager.java
+++ b/src/io/flutter/devtools/DevToolsManager.java
@@ -234,7 +234,7 @@ public class DevToolsManager {
     final String screen = null;
 
     if (devToolsInstance != null) {
-      devToolsInstance.openPanel(uri, contentManager, tabName, pageName);
+      devToolsInstance.openPanel(project, uri, contentManager, tabName, pageName);
     }
     else {
       @Nullable final OSProcessHandler handler =
@@ -245,7 +245,7 @@ public class DevToolsManager {
         DevToolsInstance.startServer(handler, instance -> {
           devToolsInstance = instance;
 
-          devToolsInstance.openPanel(uri, contentManager, tabName, pageName);
+          devToolsInstance.openPanel(project, uri, contentManager, tabName, pageName);
         }, () -> {
           // Listen for closing; null out the devToolsInstance.
           devToolsInstance = null;
@@ -398,13 +398,13 @@ class DevToolsInstance {
     );
   }
 
-  public void openPanel(String serviceProtocolUri, ContentManager contentManager, String tabName, String pageName) {
+  public void openPanel(Project project, String serviceProtocolUri, ContentManager contentManager, String tabName, String pageName) {
     final String color = ColorUtil.toHex(UIUtil.getEditorPaneBackground());
     final String url = DevToolsUtils.generateDevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, pageName, true, color);
 
     //noinspection CodeBlock2Expr
     ApplicationManager.getApplication().invokeLater(() -> {
-      EmbeddedBrowser.getInstance().openPanel(contentManager, tabName, url);
+      EmbeddedBrowser.getInstance(project).openPanel(contentManager, tabName, url);
     });
   }
 }

--- a/src/io/flutter/jxbrowser/EmbeddedBrowser.java
+++ b/src/io/flutter/jxbrowser/EmbeddedBrowser.java
@@ -16,25 +16,46 @@ import com.teamdev.jxbrowser.engine.EngineOptions;
 import com.teamdev.jxbrowser.navigation.event.LoadFinished;
 import com.teamdev.jxbrowser.view.swing.BrowserView;
 import icons.FlutterIcons;
+import org.jetbrains.annotations.NotNull;
 
 import java.awt.*;
+import java.io.File;
+import java.nio.file.Paths;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.teamdev.jxbrowser.engine.RenderingMode.HARDWARE_ACCELERATED;
 
 public class EmbeddedBrowser {
-  public void openPanel(ContentManager contentManager, String tabName, String url) {
+  private static EmbeddedBrowser embeddedBrowser;
+
+  @NotNull
+  public static EmbeddedBrowser getInstance() {
+    if (embeddedBrowser == null) {
+      embeddedBrowser = new EmbeddedBrowser();
+    }
+    return embeddedBrowser;
+  }
+
+  private Browser browser;
+
+  private EmbeddedBrowser() {
+    System.out.println(Paths.get(JxBrowserManager.DOWNLOAD_PATH + File.separatorChar + "user-data"));
+
     final EngineOptions options =
-      EngineOptions.newBuilder(HARDWARE_ACCELERATED).build();
+      EngineOptions.newBuilder(HARDWARE_ACCELERATED)
+        .userDataDir(Paths.get(JxBrowserManager.DOWNLOAD_PATH + File.separatorChar + "user-data"))
+        .build();
     final Engine engine = Engine.newInstance(options);
-    final Browser browser = engine.newBrowser();
+    this.browser = engine.newBrowser();
 
     try {
       browser.settings().enableTransparentBackground();
     } catch (UnsupportedRenderingModeException ex) {
       // Skip using a transparent background if an exception is thrown.
     }
+  }
 
+  public void openPanel(ContentManager contentManager, String tabName, String url) {
     // Multiple LoadFinished events can occur, but we only need to add content the first time.
     final AtomicBoolean contentLoaded = new AtomicBoolean(false);
 

--- a/src/io/flutter/jxbrowser/EmbeddedBrowser.java
+++ b/src/io/flutter/jxbrowser/EmbeddedBrowser.java
@@ -6,6 +6,9 @@
 package io.flutter.jxbrowser;
 
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.ui.content.Content;
 import com.intellij.ui.content.ContentManager;
@@ -18,7 +21,7 @@ import com.teamdev.jxbrowser.view.swing.BrowserView;
 import icons.FlutterIcons;
 import org.jetbrains.annotations.NotNull;
 
-import java.awt.*;
+import java.awt.Dimension;
 import java.io.File;
 import java.nio.file.Paths;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -26,24 +29,22 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static com.teamdev.jxbrowser.engine.RenderingMode.HARDWARE_ACCELERATED;
 
 public class EmbeddedBrowser {
-  private static EmbeddedBrowser embeddedBrowser;
+  private static final Logger LOG = Logger.getInstance(JxBrowserManager.class);
 
   @NotNull
-  public static EmbeddedBrowser getInstance() {
-    if (embeddedBrowser == null) {
-      embeddedBrowser = new EmbeddedBrowser();
-    }
-    return embeddedBrowser;
+  public static EmbeddedBrowser getInstance(Project project) {
+    return ServiceManager.getService(project, EmbeddedBrowser.class);
   }
 
   private Browser browser;
 
-  private EmbeddedBrowser() {
-    System.out.println(Paths.get(JxBrowserManager.DOWNLOAD_PATH + File.separatorChar + "user-data"));
+  private EmbeddedBrowser(Project project) {
+    final String dataPath = JxBrowserManager.DOWNLOAD_PATH + File.separatorChar + "user-data" + File.separatorChar + project.getName();
+    LOG.info("JxBrowser user data path: " + dataPath);
 
     final EngineOptions options =
       EngineOptions.newBuilder(HARDWARE_ACCELERATED)
-        .userDataDir(Paths.get(JxBrowserManager.DOWNLOAD_PATH + File.separatorChar + "user-data"))
+        .userDataDir(Paths.get(dataPath))
         .build();
     final Engine engine = Engine.newInstance(options);
     this.browser = engine.newBrowser();

--- a/src/io/flutter/jxbrowser/JxBrowserManager.java
+++ b/src/io/flutter/jxbrowser/JxBrowserManager.java
@@ -45,7 +45,6 @@ import java.util.concurrent.atomic.AtomicReference;
 public class JxBrowserManager {
   private static JxBrowserManager manager;
 
-  @VisibleForTesting
   protected static final String DOWNLOAD_PATH =
     PathManager.getPluginsPath() + File.separatorChar + "flutter-intellij" + File.separatorChar + "jxbrowser";
   private static final AtomicReference<JxBrowserStatus> status = new AtomicReference<>(JxBrowserStatus.NOT_INSTALLED);


### PR DESCRIPTION
(maybe) fixes https://github.com/flutter/flutter-intellij/issues/5025

This changes `EmbeddedBrowser` to a singleton class so that we can maintain one JxBrowser `Engine` and `Browser` with a folder for the browser data.
![Screen Shot 2020-11-10 at 10 09 58 AM](https://user-images.githubusercontent.com/6379305/98714064-4a369380-233d-11eb-921f-2e6bc7064db7.png)
