### PR TITLE
use the same sdk constraint in the project pubspec files

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -7,5 +7,6 @@ analyzer:
 
 linter:
   rules:
-    - unawaited_futures
     - prefer_single_quotes
+    - type_annotate_public_apis
+    - unawaited_futures

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,13 @@
 name: flutter_intellij
 version: 0.1.0
+
 environment:
-  sdk: '>=2.9.0'
+  sdk: '>=2.10.0 <3.0.0'
+
 dependencies:
   args: any
   path: any
+
 dev_dependencies:
   grinder: ^0.8.0
   http: ^0.12.0

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -8,10 +8,10 @@ import 'package:grinder/grinder.dart';
 import 'package:http/http.dart' as http;
 import 'package:meta/meta.dart';
 
-main(List<String> args) => grind(args);
+void main(List<String> args) => grind(args);
 
 @Task('Check plugin URLs for liveness')
-checkUrls() async {
+void checkUrls() async {
   log('checking URLs in FlutterBundle.properties...');
   var lines =
       await new File('src/io/flutter/FlutterBundle.properties').readAsLines();
@@ -34,7 +34,7 @@ checkUrls() async {
 }
 
 @Task('Create Outline view icons from svgs')
-outlineIcons() async {
+void outlineIcons() async {
   Directory previewIconsDir = getDir('resources/icons/preview');
 
   log('using svgexport (npm install -g svgexport)');

--- a/tool/plugin/lib/edit.dart
+++ b/tool/plugin/lib/edit.dart
@@ -94,7 +94,8 @@ List<EditCommand> editCommands = [
   Subst(
     path: 'src/io/flutter/survey/FlutterSurveyService.java',
     initial: 'properties.getLong(FLUTTER_LAST_SURVEY_CONTENT_CHECK_KEY, 0)',
-    replacement: 'properties.getOrInitLong(FLUTTER_LAST_SURVEY_CONTENT_CHECK_KEY, 0)',
+    replacement:
+        'properties.getOrInitLong(FLUTTER_LAST_SURVEY_CONTENT_CHECK_KEY, 0)',
     version: '4.0',
   ),
   Subst(
@@ -111,7 +112,8 @@ List<EditCommand> editCommands = [
   ),
   Subst(
     path: 'src/io/flutter/preview/PreviewView.java',
-    initial: 'Arrays.asList(expandAllAction, collapseAllAction, showOnlyWidgetsAction)',
+    initial:
+        'Arrays.asList(expandAllAction, collapseAllAction, showOnlyWidgetsAction)',
     replacement: 'expandAllAction, collapseAllAction, showOnlyWidgetsAction',
     versions: ['4.0', '4.1'],
   ),
@@ -265,7 +267,12 @@ class Subst extends EditCommand {
   String replacement;
   List<String> versions;
 
-  Subst({this.versions, this.initial, this.replacement, this.path, version})
+  Subst(
+      {this.versions,
+      this.initial,
+      this.replacement,
+      this.path,
+      String version})
       : assert(initial != null),
         assert(replacement != null),
         assert(path != null) {

--- a/tool/plugin/pubspec.yaml
+++ b/tool/plugin/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin tool.
 version: 0.1.1
 
 environment:
-  sdk: '>=2.2.0 <3.0.0'
+  sdk: '>=2.10.0 <3.0.0'
 
 dependencies:
   args: ^1.5.2


### PR DESCRIPTION
- use the same sdk constraint in the project pubspec files
- require types in APIs (this will catch places where we unintentionally leave off types)
