### PR TITLE
Simplify the new project wizard for AS 4.2+

### DIFF
--- a/flutter-intellij-community.iml
+++ b/flutter-intellij-community.iml
@@ -77,7 +77,6 @@
       </library>
     </orderEntry>
     <orderEntry type="library" exported="" name="Dart SDK" level="project" />
-    <orderEntry type="library" exported="" name="Dart Packages" level="project" />
     <orderEntry type="module" module-name="intellij.android.core" />
     <orderEntry type="module" module-name="intellij.platform.externalSystem" />
     <orderEntry type="module" module-name="intellij.gradle.common" />
@@ -113,9 +112,9 @@
       </library>
     </orderEntry>
     <orderEntry type="library" name="Trove4j" level="project" />
-    <orderEntry type="library" name="Dart Packages" level="project" />
     <orderEntry type="module" module-name="intellij.gradle.dsl.impl" />
     <orderEntry type="library" name="studio-sdk" level="project" />
     <orderEntry type="library" name="studio-plugin-gradle" level="project" />
+    <orderEntry type="library" name="Dart Packages" level="project" />
   </component>
 </module>

--- a/flutter-studio/src/io/flutter/actions/FlutterNewProjectAction.java
+++ b/flutter-studio/src/io/flutter/actions/FlutterNewProjectAction.java
@@ -11,9 +11,16 @@ import com.android.tools.idea.wizard.model.ModelWizardDialog;
 import com.intellij.icons.AllIcons;
 import com.intellij.ide.impl.NewProjectUtil;
 import com.intellij.ide.projectWizard.NewProjectWizard;
+import com.intellij.ide.projectWizard.ProjectCategory;
+import com.intellij.ide.util.projectWizard.ModuleBuilder;
+import com.intellij.ide.util.projectWizard.ModuleBuilderFactory;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.application.ApplicationInfo;
+import com.intellij.openapi.extensions.impl.ExtensionPointImpl;
+import com.intellij.openapi.module.ModuleType;
+import com.intellij.openapi.module.ModuleTypeEP;
+import com.intellij.openapi.module.ModuleTypeManager;
+import com.intellij.openapi.module.impl.ModuleTypeManagerImpl;
 import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.roots.ui.configuration.ModulesProvider;
 import com.intellij.openapi.ui.Messages;
@@ -21,16 +28,30 @@ import com.intellij.openapi.util.registry.Registry;
 import com.intellij.openapi.wm.impl.welcomeScreen.NewWelcomeScreen;
 import com.intellij.ui.LayeredIcon;
 import com.intellij.ui.OffsetIcon;
+import com.intellij.util.ReflectionUtil;
 import icons.FlutterIcons;
 import io.flutter.FlutterBundle;
+import io.flutter.FlutterUtils;
+import io.flutter.module.FlutterModuleBuilder;
+import io.flutter.module.FlutterModuleGroup;
 import io.flutter.module.FlutterProjectType;
 import io.flutter.project.ChoseProjectTypeStep;
 import io.flutter.project.FlutterProjectModel;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.NoSuchElementException;
 import javax.swing.Icon;
 import org.jetbrains.annotations.NotNull;
 
 public class FlutterNewProjectAction extends AnAction implements DumbAware {
+
+  ModuleBuilderFactory[] originalModuleBuilders;
+  ProjectCategory[] originalCategories;
+  List<ModuleType<?>> originalTypes;
+  ModuleType<?>[] originalModuleTypes;
+  LinkedHashMap<ModuleType<?>, Boolean> originalModuleMap;
 
   public FlutterNewProjectAction() {
     super(FlutterBundle.message("action.new.project.title"));
@@ -49,10 +70,7 @@ public class FlutterNewProjectAction extends AnAction implements DumbAware {
 
   @Override
   public void actionPerformed(@NotNull AnActionEvent e) {
-    ApplicationInfo info = ApplicationInfo.getInstance();
-    int major = Integer.parseInt(info.getMajorVersion());
-    int minor = Integer.parseInt(info.getMinorVersion());
-    if (major == 4 && minor < 3) {
+    if (!FlutterUtils.isNewAndroidStudioProjectWizard()) {
       FlutterProjectModel model = new FlutterProjectModel(FlutterProjectType.APP);
       try {
         ModelWizard wizard = new ModelWizard.Builder()
@@ -70,12 +88,21 @@ public class FlutterNewProjectAction extends AnAction implements DumbAware {
       catch (NoSuchMethodError x) {
         Messages.showMessageDialog("Android Studio canary is not supported", "Unsupported IDE", Messages.getErrorIcon());
       }
-    } else {
-      NewProjectWizard wizard = new NewProjectWizard(null, ModulesProvider.EMPTY_MODULES_PROVIDER, null);
+    }
+    else {
+      NewProjectWizard wizard;
+      replaceModuleBuilders();
+      try {
+        wizard = new NewProjectWizard(null, ModulesProvider.EMPTY_MODULES_PROVIDER, null);
+      }
+      finally {
+        restoreModuleBuilders();
+      }
       NewProjectUtil.createNewProject(wizard);
     }
   }
 
+  @NotNull
   Icon getFlutterDecoratedIcon() {
     Icon icon = AllIcons.Welcome.CreateNewProject;
     Icon badgeIcon = new OffsetIcon(0, FlutterIcons.Flutter_badge).scale(0.666f);
@@ -84,5 +111,130 @@ public class FlutterNewProjectAction extends AnAction implements DumbAware {
     decorated.setIcon(badgeIcon, 0, 7, 7);
     decorated.setIcon(icon, 1, 0, 0);
     return decorated;
+  }
+
+  @SuppressWarnings("UnstableApiUsage")
+  private void replaceModuleBuilders() {
+    ModuleBuilder.EP_NAME.getExtensions();
+    ProjectCategory.EXTENSION_POINT_NAME.getExtensions();
+    ModuleTypeManagerImpl.EP_NAME.getExtensionList();
+
+    ExtensionPointImpl<ModuleBuilderFactory> factoryExtensionPoint =
+      (ExtensionPointImpl<ModuleBuilderFactory>)ModuleBuilder.EP_NAME.getPoint();
+    Field arrayField = ReflectionUtil.getDeclaredField(ExtensionPointImpl.class, "myExtensionsCacheAsArray");
+    assert arrayField != null;
+    ModuleBuilderFactory[] originalArray = ReflectionUtil.getFieldValue(arrayField, factoryExtensionPoint);
+    assert originalArray != null;
+    originalModuleBuilders = originalArray;
+
+    ExtensionPointImpl<ModuleTypeEP> typeExtensionPoint =
+      (ExtensionPointImpl<ModuleTypeEP>)ModuleTypeManagerImpl.EP_NAME.getPoint();
+    Field listField = ReflectionUtil.getDeclaredField(ExtensionPointImpl.class, "myExtensionsCache");
+    assert listField != null;
+    List<ModuleType<?>> originalList = ReflectionUtil.getFieldValue(listField, typeExtensionPoint);
+    assert originalList != null;
+    originalTypes = originalList;
+
+    ExtensionPointImpl<ProjectCategory> categoryExtensionPoint =
+      (ExtensionPointImpl<ProjectCategory>)ProjectCategory.EXTENSION_POINT_NAME.getPoint();
+    Field categoryField = ReflectionUtil.getDeclaredField(ExtensionPointImpl.class, "myExtensionsCacheAsArray");
+    assert categoryField != null;
+    ProjectCategory[] categories = ReflectionUtil.getFieldValue(categoryField, categoryExtensionPoint);
+    assert categories != null;
+    originalCategories = categories;
+
+    Field mapField = ReflectionUtil.getDeclaredField(ModuleTypeManagerImpl.class, "myModuleTypes");
+    assert mapField != null;
+    LinkedHashMap<ModuleType<?>, Boolean> originalMap = ReflectionUtil.getFieldValue(mapField, ModuleTypeManager.getInstance());
+    assert originalMap != null;
+    originalModuleMap = originalMap;
+
+    ModuleTypeManager typeManager = ModuleTypeManager.getInstance();
+    originalModuleTypes = typeManager.getRegisteredTypes();
+    for (ModuleType<?> type : originalModuleTypes) {
+      typeManager.unregisterModuleType(type);
+    }
+
+    try {
+      arrayField.set(factoryExtensionPoint, getFlutterModuleBuilders());
+      listField.set(typeExtensionPoint, new ArrayList<ModuleType<?>>());
+      categoryField.set(categoryExtensionPoint, new ProjectCategory[0]);
+      mapField.set(ModuleTypeManager.getInstance(), new LinkedHashMap<ModuleType<?>, Boolean>());
+    }
+    catch (IllegalAccessException e) {
+      // not reached
+    }
+  }
+
+  @SuppressWarnings("UnstableApiUsage")
+  private void restoreModuleBuilders() {
+    ExtensionPointImpl<ModuleBuilderFactory> factoryExtensionPoint =
+      (ExtensionPointImpl<ModuleBuilderFactory>)ModuleBuilder.EP_NAME.getPoint();
+    Field arrayField = ReflectionUtil.getDeclaredField(ExtensionPointImpl.class, "myExtensionsCacheAsArray");
+    assert arrayField != null;
+
+    ExtensionPointImpl<ModuleTypeEP> typeExtensionPoint =
+      (ExtensionPointImpl<ModuleTypeEP>)ModuleTypeManagerImpl.EP_NAME.getPoint();
+    Field listField = ReflectionUtil.getDeclaredField(ExtensionPointImpl.class, "myExtensionsCache");
+    assert listField != null;
+
+    ExtensionPointImpl<ProjectCategory> categoryExtensionPoint =
+      (ExtensionPointImpl<ProjectCategory>)ProjectCategory.EXTENSION_POINT_NAME.getPoint();
+    Field categoryField = ReflectionUtil.getDeclaredField(ExtensionPointImpl.class, "myExtensionsCacheAsArray");
+    assert categoryField != null;
+
+    Field mapField = ReflectionUtil.getDeclaredField(ModuleTypeManagerImpl.class, "myModuleTypes");
+    assert mapField != null;
+
+    assert originalModuleBuilders != null;
+    assert originalTypes != null;
+    assert originalModuleTypes != null;
+    assert originalModuleMap != null;
+
+    try {
+      arrayField.set(factoryExtensionPoint, originalModuleBuilders);
+      listField.set(typeExtensionPoint, originalTypes);
+      categoryField.set(categoryExtensionPoint, originalCategories);
+      mapField.set(ModuleTypeManager.getInstance(), originalModuleMap);
+    }
+    catch (IllegalAccessException e) {
+      // not reached
+    }
+
+    ModuleTypeManager typeManager = ModuleTypeManager.getInstance();
+    for (ModuleType<?> type : originalModuleTypes) {
+      typeManager.registerModuleType(type);
+    }
+
+    originalModuleBuilders = null;
+    originalTypes = null;
+    originalModuleTypes = null;
+    originalModuleMap = null;
+  }
+
+  @NotNull
+  private ModuleBuilderFactory[] getFlutterModuleBuilders() {
+    // The order is not relevant. The builders are sorted by weight.
+    return new ModuleBuilderFactory[]{
+      w(new FlutterModuleGroup.App()),
+      w(new FlutterModuleGroup.Mod()),
+      w(new FlutterModuleGroup.Plugin()),
+      w(new FlutterModuleGroup.Package()),
+    };
+  }
+
+  @NotNull
+  private ModuleBuilderFactory w(@NotNull final FlutterModuleBuilder b) {
+    // For some unknown reason our FlutterModuleGroup classes are not in the class loader used by default.
+    // Unless the IDE is being run by the debugger.
+    // Instead of letting the factory fail to find the class just return the instance.
+    ModuleBuilderFactory f = new ModuleBuilderFactory() {
+      @Override
+      public ModuleBuilder createBuilder() {
+        return b;
+      }
+    };
+    f.builderClass = b.getClass().getName();
+    return f;
   }
 }

--- a/flutter-studio/src/io/flutter/actions/FlutterNewProjectAction.java_stub
+++ b/flutter-studio/src/io/flutter/actions/FlutterNewProjectAction.java_stub
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2017 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.actions;
+
+import com.android.tools.idea.ui.wizard.StudioWizardDialogBuilder;
+import com.android.tools.idea.wizard.model.ModelWizard;
+import com.android.tools.idea.wizard.model.ModelWizardDialog;
+import com.intellij.icons.AllIcons;
+import com.intellij.ide.impl.NewProjectUtil;
+import com.intellij.ide.projectWizard.NewProjectWizard;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.application.ApplicationInfo;
+import com.intellij.openapi.project.DumbAware;
+import com.intellij.openapi.roots.ui.configuration.ModulesProvider;
+import com.intellij.openapi.ui.Messages;
+import com.intellij.openapi.util.registry.Registry;
+import com.intellij.openapi.wm.impl.welcomeScreen.NewWelcomeScreen;
+import com.intellij.ui.LayeredIcon;
+import com.intellij.ui.OffsetIcon;
+import icons.FlutterIcons;
+import io.flutter.FlutterBundle;
+import io.flutter.module.FlutterProjectType;
+import io.flutter.project.ChoseProjectTypeStep;
+import io.flutter.project.FlutterProjectModel;
+import java.util.NoSuchElementException;
+import javax.swing.Icon;
+import org.jetbrains.annotations.NotNull;
+
+public class FlutterNewProjectAction extends AnAction implements DumbAware {
+
+  public FlutterNewProjectAction() {
+    super(FlutterBundle.message("action.new.project.title"));
+  }
+
+  @Override
+  public void update(@NotNull AnActionEvent e) {
+    if (NewWelcomeScreen.isNewWelcomeScreen(e)) {
+      e.getPresentation().setIcon(getFlutterDecoratedIcon());
+      e.getPresentation().setText(
+        Registry.is("use.tabbed.welcome.screen", false)
+        ? FlutterBundle.message("welcome.new.project.compact")
+        : FlutterBundle.message("welcome.new.project.title"));
+    }
+  }
+
+  @Override
+  public void actionPerformed(@NotNull AnActionEvent e) {
+    ApplicationInfo info = ApplicationInfo.getInstance();
+    int major = Integer.parseInt(info.getMajorVersion());
+    int minor = Integer.parseInt(info.getMinorVersion());
+    if (major == 4 && minor < 3) {
+      FlutterProjectModel model = new FlutterProjectModel(FlutterProjectType.APP);
+      try {
+        ModelWizard wizard = new ModelWizard.Builder()
+          .addStep(new ChoseProjectTypeStep(model))
+          .build();
+        StudioWizardDialogBuilder builder = new StudioWizardDialogBuilder(wizard, "Create New Flutter Project");
+        ModelWizardDialog dialog = builder.build();
+        try {
+          dialog.show();
+        }
+        catch (NoSuchElementException ex) {
+          // This happens if no Flutter SDK is installed and the user cancels the FlutterProjectStep.
+        }
+      }
+      catch (NoSuchMethodError x) {
+        Messages.showMessageDialog("Android Studio canary is not supported", "Unsupported IDE", Messages.getErrorIcon());
+      }
+    } else {
+      NewProjectWizard wizard = new NewProjectWizard(null, ModulesProvider.EMPTY_MODULES_PROVIDER, null);
+      NewProjectUtil.createNewProject(wizard);
+    }
+  }
+
+  Icon getFlutterDecoratedIcon() {
+    Icon icon = AllIcons.Welcome.CreateNewProject;
+    Icon badgeIcon = new OffsetIcon(0, FlutterIcons.Flutter_badge).scale(0.666f);
+
+    LayeredIcon decorated = new LayeredIcon(2);
+    decorated.setIcon(badgeIcon, 0, 7, 7);
+    decorated.setIcon(icon, 1, 0, 0);
+    return decorated;
+  }
+}

--- a/flutter-studio/src/io/flutter/module/FlutterModuleGroup.java
+++ b/flutter-studio/src/io/flutter/module/FlutterModuleGroup.java
@@ -1,0 +1,134 @@
+package io.flutter.module;
+
+import com.intellij.ide.util.projectWizard.ModuleWizardStep;
+import com.intellij.ide.util.projectWizard.SettingsStep;
+import com.intellij.ide.util.projectWizard.WizardContext;
+import com.intellij.openapi.Disposable;
+import io.flutter.FlutterBundle;
+import org.jetbrains.annotations.NotNull;
+
+// Define a group of Flutter project types for use in Android Studio 4.2 and later.
+// TODO (messick) DO NOT delete this during post-4.2 clean-up.
+public abstract class FlutterModuleGroup extends FlutterModuleBuilder {
+
+  abstract public FlutterProjectType getFlutterProjectType();
+
+  abstract public String getDescription();
+
+  @Override
+  public String getBuilderId() {
+    return super.getBuilderId() + getFlutterProjectType().arg;
+  }
+
+  @Override
+  public ModuleWizardStep getCustomOptionsStep(final WizardContext context, final Disposable parentDisposable) {
+    // This runs each time the project type selection changes.
+    FlutterModuleWizardStep step = (FlutterModuleWizardStep)super.getCustomOptionsStep(context, parentDisposable);
+    assert step!= null;
+    getSettingsField().linkHelpForm(step.getHelpForm());
+    getSettingsField().updateProjectType(getFlutterProjectType());
+    return step;
+  }
+
+  @Override
+  public ModuleWizardStep modifySettingsStep(@NotNull SettingsStep settingsStep) {
+    // This runs when the Next button takes the wizard to the second page.
+    ModuleWizardStep wizard = super.modifySettingsStep(settingsStep);
+    setProjectTypeInSettings();
+    return wizard;
+  }
+
+  // Using a parent group ensures there are no separators. The getWeight() in each subclass method controls sort order.
+  @Override
+  public String getParentGroup() {
+    return "Flutter";
+  }
+
+  protected void setProjectTypeInSettings() {
+    getSettingsField().updateProjectType(getFlutterProjectType());
+  }
+
+  public static class App extends FlutterModuleGroup {
+
+    @NotNull
+    public FlutterProjectType getFlutterProjectType() {
+      return FlutterProjectType.APP;
+    }
+
+    @Override
+    public String getPresentableName() {
+      return FlutterBundle.message("module.wizard.app_title_short");
+    }
+
+    public String getDescription() {
+      return FlutterBundle.message("flutter.module.create.settings.help.project_type.description.app");
+    }
+
+    public int getWeight() {
+      return 4;
+    }
+  }
+
+  public static class Mod extends FlutterModuleGroup {
+
+    @NotNull
+    public FlutterProjectType getFlutterProjectType() {
+      return FlutterProjectType.MODULE;
+    }
+
+    @Override
+    public String getPresentableName() {
+      return FlutterBundle.message("module.wizard.module_title");
+    }
+
+    public String getDescription() {
+      return FlutterBundle.message("flutter.module.create.settings.help.project_type.description.module");
+    }
+
+    public int getWeight() {
+      return 3;
+    }
+  }
+
+  public static class Plugin extends FlutterModuleGroup {
+
+    @NotNull
+    public FlutterProjectType getFlutterProjectType() {
+      return FlutterProjectType.PLUGIN;
+    }
+
+    @Override
+    public String getPresentableName() {
+      return FlutterBundle.message("module.wizard.plugin_title");
+    }
+
+    public String getDescription() {
+      return FlutterBundle.message("flutter.module.create.settings.help.project_type.description.plugin");
+    }
+
+    public int getWeight() {
+      return 2;
+    }
+  }
+
+  public static class Package extends FlutterModuleGroup {
+
+    @NotNull
+    public FlutterProjectType getFlutterProjectType() {
+      return FlutterProjectType.PACKAGE;
+    }
+
+    @Override
+    public String getPresentableName() {
+      return FlutterBundle.message("module.wizard.package_title");
+    }
+
+    public String getDescription() {
+      return FlutterBundle.message("flutter.module.create.settings.help.project_type.description.package");
+    }
+
+    public int getWeight() {
+      return 1;
+    }
+  }
+}

--- a/product-matrix.json
+++ b/product-matrix.json
@@ -10,7 +10,10 @@
       "dartPluginVersion": "201.7223.99",
       "sinceBuild": "201.7223",
       "untilBuild": "201.*",
-      "filesToSkip": ["src/io/flutter/utils/AndroidLocationProvider.java"]
+      "filesToSkip": [
+        "src/io/flutter/utils/AndroidLocationProvider.java",
+        "flutter-studio/src/io/flutter/actions/FlutterNewProjectAction.java"
+      ]
     },
     {
       "channel": "stable",

--- a/src/io/flutter/FlutterBundle.properties
+++ b/src/io/flutter/FlutterBundle.properties
@@ -146,6 +146,7 @@ module.wizard.language.name_kotlin=Include Kotlin support for Android code
 module.wizard.language.name_swift=Include Swift support for iOS code
 
 module.wizard.app_title=Flutter Application
+module.wizard.app_title_short=Flutter App
 module.wizard.app_description=Creates a Flutter application
 module.wizard.app_step_title=New Flutter Application
 module.wizard.app_step_body=Configure the new Flutter application

--- a/src/io/flutter/FlutterUtils.java
+++ b/src/io/flutter/FlutterUtils.java
@@ -38,6 +38,13 @@ import io.flutter.pub.PubRoot;
 import io.flutter.pub.PubRootCache;
 import io.flutter.utils.AndroidUtils;
 import io.flutter.utils.FlutterModuleUtils;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.regex.Pattern;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.SystemIndependent;
@@ -47,14 +54,6 @@ import org.yaml.snakeyaml.constructor.SafeConstructor;
 import org.yaml.snakeyaml.nodes.Tag;
 import org.yaml.snakeyaml.representer.Representer;
 import org.yaml.snakeyaml.resolver.Resolver;
-
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.nio.file.Paths;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Properties;
-import java.util.regex.Pattern;
 
 public class FlutterUtils {
   public static class FlutterPubspecInfo {
@@ -117,6 +116,17 @@ public class FlutterUtils {
 
   public static boolean isAndroidStudio() {
     return StringUtil.equals(PlatformUtils.getPlatformPrefix(), "AndroidStudio");
+  }
+
+  public static boolean isNewAndroidStudioProjectWizard() {
+    // TODO (messick) Remove this and its references when Android Studio 4.2 is stable.
+    if (isAndroidStudio()) {
+      ApplicationInfo info = ApplicationInfo.getInstance();
+      int major = Integer.parseInt(info.getMajorVersion());
+      int minor = Integer.parseInt(info.getMinorVersion());
+      return major >= 4 && minor >= 2;
+    }
+    return false;
   }
 
   /**

--- a/src/io/flutter/module/FlutterGeneratorPeer.form
+++ b/src/io/flutter/module/FlutterGeneratorPeer.form
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="io.flutter.module.FlutterGeneratorPeer">
-  <grid id="27dc6" binding="myMainPanel" layout-manager="GridLayoutManager" row-count="5" column-count="10" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="myMainPanel" layout-manager="GridLayoutManager" row-count="6" column-count="12" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="5" bottom="0" right="8"/>
     <constraints>
-      <xy x="20" y="20" width="565" height="335"/>
+      <xy x="20" y="20" width="565" height="367"/>
     </constraints>
     <properties/>
     <border type="none"/>
     <children>
       <component id="4e54c" class="com.intellij.ui.components.JBLabel">
         <constraints>
-          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="0" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <labelFor value="b09db"/>
@@ -19,13 +19,13 @@
       </component>
       <component id="b09db" class="com.intellij.ui.ComboboxWithBrowseButton" binding="mySdkPathComboWithBrowse" custom-create="true">
         <constraints>
-          <grid row="0" column="1" row-span="1" col-span="9" vsize-policy="0" hsize-policy="7" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="0" column="2" row-span="1" col-span="10" vsize-policy="0" hsize-policy="7" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
       </component>
       <component id="2c07c" class="com.intellij.ui.components.JBLabel" binding="myVersionContent">
         <constraints>
-          <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="2" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value=""/>
@@ -33,13 +33,13 @@
       </component>
       <vspacer id="e8033">
         <constraints>
-          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="4" column="0" row-span="1" col-span="2" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
       <grid id="91fa8" layout-manager="GridLayoutManager" row-count="1" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="0" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="4" column="0" row-span="1" col-span="10" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="5" column="0" row-span="1" col-span="12" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>
@@ -77,7 +77,7 @@
       <grid id="bdced" layout-manager="GridLayoutManager" row-count="2" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="32"/>
         <constraints>
-          <grid row="1" column="2" row-span="1" col-span="7" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="2" column="3" row-span="1" col-span="7" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>
@@ -134,6 +134,11 @@
           </component>
         </children>
       </grid>
+      <nested-form id="df11" form-file="io/flutter/module/settings/SettingsHelpForm.form" binding="myHelpForm">
+        <constraints>
+          <grid row="1" column="0" row-span="1" col-span="12" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+      </nested-form>
     </children>
   </grid>
 </form>

--- a/src/io/flutter/module/FlutterGeneratorPeer.java
+++ b/src/io/flutter/module/FlutterGeneratorPeer.java
@@ -22,18 +22,26 @@ import com.intellij.ui.components.labels.LinkLabel;
 import com.intellij.util.ui.UIUtil;
 import com.intellij.xml.util.XmlStringUtil;
 import io.flutter.FlutterBundle;
+import io.flutter.FlutterUtils;
 import io.flutter.actions.InstallSdkAction;
+import io.flutter.module.settings.SettingsHelpForm;
 import io.flutter.sdk.FlutterSdkUtil;
+import java.awt.Cursor;
+import java.awt.Font;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import javax.swing.ComboBoxEditor;
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JProgressBar;
+import javax.swing.JScrollPane;
+import javax.swing.JTextPane;
+import javax.swing.event.DocumentEvent;
+import javax.swing.text.JTextComponent;
 import org.apache.commons.lang.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
-import javax.swing.*;
-import javax.swing.event.DocumentEvent;
-import javax.swing.text.JTextComponent;
-import java.awt.*;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
 
 public class FlutterGeneratorPeer implements InstallSdkAction.Model {
   private final WizardContext myContext;
@@ -48,6 +56,7 @@ public class FlutterGeneratorPeer implements InstallSdkAction.Model {
   private JTextPane myProgressText;
   private JScrollPane myProgressScrollPane;
   private JLabel myCancelProgressButton;
+  private SettingsHelpForm myHelpForm;
 
   private final InstallSdkAction myInstallSdkAction;
   private InstallSdkAction.CancelActionListener myListener;
@@ -65,6 +74,10 @@ public class FlutterGeneratorPeer implements InstallSdkAction.Model {
     myProgressBar.setVisible(false);
     myProgressText.setVisible(false);
     myCancelProgressButton.setVisible(false);
+
+    if (!FlutterUtils.isNewAndroidStudioProjectWizard()) {
+      myHelpForm.getComponent().setVisible(false);
+    }
 
     init();
   }
@@ -217,5 +230,9 @@ public class FlutterGeneratorPeer implements InstallSdkAction.Model {
     if (wizard != null) {
       UIUtil.invokeAndWaitIfNeeded((Runnable)wizard::doNextAction);
     }
+  }
+
+  public SettingsHelpForm getHelpForm() {
+    return myHelpForm;
   }
 }

--- a/src/io/flutter/module/FlutterModuleBuilder.java
+++ b/src/io/flutter/module/FlutterModuleBuilder.java
@@ -32,6 +32,7 @@ import io.flutter.FlutterMessages;
 import io.flutter.FlutterUtils;
 import io.flutter.actions.FlutterDoctorAction;
 import io.flutter.module.settings.FlutterCreateAdditionalSettingsFields;
+import io.flutter.module.settings.SettingsHelpForm;
 import io.flutter.pub.PubRoot;
 import io.flutter.sdk.FlutterCreateAdditionalSettings;
 import io.flutter.sdk.FlutterSdk;
@@ -51,9 +52,9 @@ import static java.util.Arrays.asList;
 public class FlutterModuleBuilder extends ModuleBuilder {
   private static final Logger LOG = Logger.getInstance(FlutterModuleBuilder.class);
 
-  private FlutterModuleWizardStep myStep;
+  protected FlutterModuleWizardStep myStep;
   private FlutterCreateAdditionalSettingsFields mySettingsFields;
-  private Project myProject;
+  protected Project myProject;
 
   @Override
   public String getName() {
@@ -262,7 +263,6 @@ public class FlutterModuleBuilder extends ModuleBuilder {
     return null;
   }
 
-  @Nullable
   @Override
   public ModuleWizardStep getCustomOptionsStep(final WizardContext context, final Disposable parentDisposable) {
     if (!context.isCreatingNewProject()) {
@@ -275,7 +275,6 @@ public class FlutterModuleBuilder extends ModuleBuilder {
   }
 
   @Override
-  @NotNull
   public String getBuilderId() {
     // The builder id is used to distinguish between different builders with the same module type, see
     // com.intellij.ide.projectWizard.ProjectTypeStep for an example.
@@ -317,12 +316,20 @@ public class FlutterModuleBuilder extends ModuleBuilder {
     combo.setItem(s);
   }
 
-  public class FlutterModuleWizardStep extends ModuleWizardStep implements Disposable {
+  FlutterCreateAdditionalSettingsFields getSettingsField() {
+    return mySettingsFields;
+  }
+
+  public static class FlutterModuleWizardStep extends ModuleWizardStep implements Disposable {
     private final FlutterGeneratorPeer myPeer;
 
     public FlutterModuleWizardStep(@NotNull WizardContext context) {
       //TODO(pq): find a way to listen to wizard cancelation and propagate to peer.
       myPeer = new FlutterGeneratorPeer(context);
+    }
+
+    public SettingsHelpForm getHelpForm() {
+      return myPeer.getHelpForm();
     }
 
     @Override

--- a/src/io/flutter/module/settings/ProjectType.java
+++ b/src/io/flutter/module/settings/ProjectType.java
@@ -7,6 +7,7 @@ package io.flutter.module.settings;
 
 import com.intellij.openapi.ui.ComboBox;
 import io.flutter.FlutterBundle;
+import io.flutter.FlutterUtils;
 import io.flutter.module.FlutterProjectType;
 import io.flutter.sdk.FlutterSdk;
 import java.awt.event.ItemListener;
@@ -29,7 +30,9 @@ public class ProjectType {
 
     private ProjectTypeComboBoxModel() {
       if (System.getProperty("flutter.experimental.modules", null) == null) {
-        myList.remove(FlutterProjectType.MODULE);
+        if (!FlutterUtils.isAndroidStudio()) {
+          myList.remove(FlutterProjectType.MODULE);
+        }
         myList.remove(FlutterProjectType.IMPORT);
       }
       mySelected = myList.get(0);
@@ -64,7 +67,7 @@ public class ProjectType {
   private Supplier<? extends FlutterSdk> getSdk;
 
   private JPanel projectTypePanel;
-  private ComboBox projectTypeCombo;
+  private ComboBox<FlutterProjectType> projectTypeCombo;
 
   public ProjectType(@Nullable Supplier<? extends FlutterSdk> getSdk) {
     this.getSdk = getSdk;
@@ -91,7 +94,7 @@ public class ProjectType {
     return (FlutterProjectType)projectTypeCombo.getSelectedItem();
   }
 
-  public ComboBox getProjectTypeCombo() {
+  public ComboBox<FlutterProjectType> getProjectTypeCombo() {
     return projectTypeCombo;
   }
 

--- a/src/io/flutter/module/settings/SettingsHelpForm.form
+++ b/src/io/flutter/module/settings/SettingsHelpForm.form
@@ -8,7 +8,7 @@
     <properties/>
     <border type="none"/>
     <children>
-      <grid id="ec0ab" binding="helpPanel" layout-manager="GridLayoutManager" row-count="5" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="ec0ab" binding="helpPanel" layout-manager="GridLayoutManager" row-count="6" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="10" left="10" bottom="10" right="10"/>
         <constraints>
           <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -30,7 +30,7 @@
           </component>
           <vspacer id="d2ba8">
             <constraints>
-              <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+              <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
             </constraints>
           </vspacer>
           <component id="f2329" class="javax.swing.JLabel" binding="projectTypeLabel">
@@ -52,7 +52,7 @@
           </component>
           <component id="1706b" class="javax.swing.JLabel" binding="projectTypeDescriptionForPlugin">
             <constraints>
-              <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text value="Help for plugin..."/>
@@ -89,7 +89,7 @@
           <grid id="87380" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
             <margin top="0" left="0" bottom="0" right="0"/>
             <constraints>
-              <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+              <grid row="5" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties/>
             <border type="none"/>
@@ -97,10 +97,18 @@
           </grid>
           <component id="b3b85" class="javax.swing.JLabel" binding="projectTypeDescriptionForPackage">
             <constraints>
-              <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text value="Help for package..."/>
+            </properties>
+          </component>
+          <component id="aeed9" class="javax.swing.JLabel" binding="projectTypeDescriptionForModule">
+            <constraints>
+              <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Help for module..."/>
             </properties>
           </component>
         </children>

--- a/src/io/flutter/module/settings/SettingsHelpForm.java
+++ b/src/io/flutter/module/settings/SettingsHelpForm.java
@@ -6,16 +6,20 @@
 package io.flutter.module.settings;
 
 import com.intellij.ide.browsers.BrowserLauncher;
+import com.intellij.openapi.components.ServiceManager;
 import com.intellij.ui.components.labels.LinkLabel;
 import io.flutter.FlutterBundle;
 import io.flutter.FlutterConstants;
+import io.flutter.FlutterUtils;
+import io.flutter.module.FlutterProjectType;
+import java.awt.Cursor;
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
 import org.jetbrains.annotations.NotNull;
 
-import javax.swing.*;
-import java.awt.*;
-
 /**
- * The settings panel that list helps.
+ * The settings panel that lists help messages.
  */
 public class SettingsHelpForm {
   private JPanel mainPanel;
@@ -25,16 +29,27 @@ public class SettingsHelpForm {
 
   private JLabel projectTypeLabel;
   private JLabel projectTypeDescriptionForApp;
+  private JLabel projectTypeDescriptionForModule;
   private JLabel projectTypeDescriptionForPlugin;
   private JLabel projectTypeDescriptionForPackage;
 
+  @SuppressWarnings("rawtypes")
   private LinkLabel gettingStartedUrl;
+
+  public static SettingsHelpForm getInstance() {
+    return ServiceManager.getService(SettingsHelpForm.class);
+  }
 
   public SettingsHelpForm() {
     projectTypeLabel.setText(FlutterBundle.message("flutter.module.create.settings.help.project_type.label"));
     projectTypeDescriptionForApp.setText(FlutterBundle.message("flutter.module.create.settings.help.project_type.description.app"));
+    projectTypeDescriptionForModule.setText(FlutterBundle.message("flutter.module.create.settings.help.project_type.description.module"));
     projectTypeDescriptionForPlugin.setText(FlutterBundle.message("flutter.module.create.settings.help.project_type.description.plugin"));
     projectTypeDescriptionForPackage.setText(FlutterBundle.message("flutter.module.create.settings.help.project_type.description.package"));
+
+    if (!FlutterUtils.isAndroidStudio()) {
+      projectTypeDescriptionForModule.setVisible(false);
+    }
 
     gettingStartedUrl.setText(FlutterBundle.message("flutter.module.create.settings.help.getting_started_link_text"));
     gettingStartedUrl.setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
@@ -48,5 +63,28 @@ public class SettingsHelpForm {
   @NotNull
   public JComponent getComponent() {
     return mainPanel;
+  }
+
+  public void adjustContrast(FlutterProjectType type) {
+    projectTypeDescriptionForApp.setEnabled(false);
+    projectTypeDescriptionForModule.setEnabled(false);
+    projectTypeDescriptionForPlugin.setEnabled(false);
+    projectTypeDescriptionForPackage.setEnabled(false);
+    switch (type) {
+      case APP:
+        projectTypeDescriptionForApp.setEnabled(true);
+        break;
+      case MODULE:
+        projectTypeDescriptionForModule.setEnabled(true);
+        break;
+      case PACKAGE:
+        projectTypeDescriptionForPackage.setEnabled(true);
+        break;
+      case PLUGIN:
+        projectTypeDescriptionForPlugin.setEnabled(true);
+        break;
+      default:
+        break;
+    }
   }
 }

--- a/tool/plugin/lib/edit.dart
+++ b/tool/plugin/lib/edit.dart
@@ -26,20 +26,13 @@ void checkAndClearAppliedEditCommands() {
 List<EditCommand> editCommands = [
   EditAndroidModuleLibraryManager(),
   Subst(
-    path: 'flutter-studio/src/io/flutter/project/FlutterProjectSystem.java',
-    initial:
-        'gradleProjectSystem.getAndroidFacetsWithPackageName(project, packageName, scope)',
-    replacement: 'Collections.emptyList()',
-    version: '4.0',
-  ),
-  Subst(
     path:
         'flutter-studio/src/io/flutter/actions/FlutterShowStructureSettingsAction.java',
     initial:
         'import com.android.tools.idea.gradle.structure.actions.AndroidShowStructureSettingsAction;',
     replacement:
         'import com.android.tools.idea.gradle.actions.AndroidShowStructureSettingsAction;',
-    versions: ['4.0', '2020.2'],
+    versions: ['2020.2'],
   ),
   MultiSubst(
     path: 'flutter-studio/src/io/flutter/actions/OpenAndroidModule.java',
@@ -51,13 +44,13 @@ List<EditCommand> editCommands = [
       'findImportTarget',
       'importProjectCore(projectFile)',
     ],
-    versions: ['4.0', '2020.2'],
+    versions: ['2020.2'],
   ),
   Subst(
     path: 'flutter-studio/src/io/flutter/utils/AddToAppUtils.java',
     initial: '.project.importing.GradleProjectImporter',
     replacement: '.project.importing.NewProjectSetup',
-    versions: ['4.0', '2020.2'],
+    versions: ['2020.2'],
   ),
   Subst(
     path: 'src/io/flutter/utils/AndroidUtils.java',
@@ -68,58 +61,22 @@ List<EditCommand> editCommands = [
     versions: ['4.1', '4.2'],
   ),
   Subst(
-    path:
-        'flutter-studio/src/io/flutter/assistant/whatsnew/FlutterNewsBundleCreator.java',
-    initial: """
-    PluginManager pluginManager = PluginManager.getInstance();
-    IdeaPluginDescriptor descriptor = pluginManager.findEnabledPlugin(PluginId.getId("io.flutter"));
-""",
-    replacement: """
-    IdeaPluginDescriptor descriptor = PluginManager.getPlugin(PluginId.getId("io.flutter"));
-""",
-    version: '4.0',
-  ),
-  Subst(
     path: 'src/io/flutter/FlutterUtils.java',
     initial: 'ProjectUtil.isSameProject(Paths.get(path), project)',
     replacement: 'ProjectUtil.isSameProject(path, project)',
-    versions: ['4.0', '4.1'],
-  ),
-  Subst(
-    path: 'src/io/flutter/FlutterBundle.java',
-    initial: 'AbstractBundle',
-    replacement: 'CommonBundle',
-    version: '4.0',
-  ),
-  Subst(
-    path: 'src/io/flutter/survey/FlutterSurveyService.java',
-    initial: 'properties.getLong(FLUTTER_LAST_SURVEY_CONTENT_CHECK_KEY, 0)',
-    replacement: 'properties.getOrInitLong(FLUTTER_LAST_SURVEY_CONTENT_CHECK_KEY, 0)',
-    version: '4.0',
-  ),
-  Subst(
-    path: 'src/io/flutter/survey/FlutterSurveyNotifications.java',
-    initial: 'properties.getLong(FLUTTER_LAST_SURVEY_PROMPT_KEY, 0)',
-    replacement: 'properties.getOrInitLong(FLUTTER_LAST_SURVEY_PROMPT_KEY, 0)',
-    version: '4.0',
+    versions: ['4.1'],
   ),
   Subst(
     path: 'src/io/flutter/perf/EditorPerfDecorations.java',
     initial: 'highlighter.getTextAttributes(null)',
     replacement: 'highlighter.getTextAttributes()',
-    versions: ['4.0', '4.1'],
+    versions: ['4.1'],
   ),
   Subst(
     path: 'src/io/flutter/preview/PreviewView.java',
     initial: 'Arrays.asList(expandAllAction, collapseAllAction, showOnlyWidgetsAction)',
     replacement: 'expandAllAction, collapseAllAction, showOnlyWidgetsAction',
-    versions: ['4.0', '4.1'],
-  ),
-  Subst(
-    path: 'src/io/flutter/analytics/ToolWindowTracker.java',
-    initial: '@Override',
-    replacement: '',
-    version: '4.0',
+    versions: ['4.1'],
   ),
   Subst(
     path: 'src/io/flutter/FlutterErrorReportSubmitter.java',


### PR DESCRIPTION
For Android Studio 4.2 and later, change the new project wizard to this:

<img width="965" alt="Screen Shot 2020-11-12 at 1 12 39 PM" src="https://user-images.githubusercontent.com/8518285/98997091-ce794a00-24e8-11eb-8240-523146d83353.png">

This includes one goal for this quarter: adding a link on the first page of the wizard that points to the installation docs.

`FlutterNewProjectAction.replaceModuleBuilders()` (and `restoreModuleBuilders()`) does some tricky stuff with reflection. This could break, and our fallback is to simply stop using those methods. That would make the wizard look like it does in IntelliJ. There should be no changes to the IntelliJ wizard, although almost all the code is shared.

Android Studio has always highlighted the help message for the selected project type, so I found a way to do that here, too. 

FlutterNewProjectAction.java_stub is the previous version of `FlutterNewProjectAction`, which is required for AS 4.1 (see the change in product-matrix.json).

FYI @devoncarew @pq