### PR TITLE
Use runScript for bazel run

### DIFF
--- a/src/io/flutter/bazel/PluginConfig.java
+++ b/src/io/flutter/bazel/PluginConfig.java
@@ -55,6 +55,11 @@ public class PluginConfig {
   }
 
   @Nullable
+  String getRunScript() {
+    return fields.runScript;
+  }
+
+  @Nullable
   String getSdkHome() {
     return fields.sdkHome;
   }
@@ -123,6 +128,7 @@ public class PluginConfig {
     @Nullable String doctorScript,
     @Nullable String launchScript,
     @Nullable String testScript,
+    @Nullable String runScript,
     @Nullable String sdkHome,
     @Nullable String versionFile,
     @Nullable String devtoolsScript
@@ -132,6 +138,7 @@ public class PluginConfig {
       doctorScript,
       launchScript,
       testScript,
+      runScript,
       sdkHome,
       versionFile,
       devtoolsScript
@@ -168,6 +175,12 @@ public class PluginConfig {
     private String testScript;
 
     /**
+     * The script to run to start 'flutter run'
+     */
+    @SerializedName("runScript")
+    private String runScript;
+
+    /**
      * The directory containing the SDK tools.
      */
     @SerializedName("sdkHome")
@@ -195,6 +208,7 @@ public class PluginConfig {
            String doctorScript,
            String launchScript,
            String testScript,
+           String runScript,
            String sdkHome,
            String versionFile,
            String devtoolsScript) {
@@ -202,6 +216,7 @@ public class PluginConfig {
       this.doctorScript = doctorScript;
       this.launchScript = launchScript;
       this.testScript = testScript;
+      this.runScript = runScript;
       this.sdkHome = sdkHome;
       this.versionFile = versionFile;
       this.devtoolsScript = devtoolsScript;
@@ -215,6 +230,7 @@ public class PluginConfig {
              && Objects.equal(doctorScript, other.doctorScript)
              && Objects.equal(launchScript, other.launchScript)
              && Objects.equal(testScript, other.testScript)
+             && Objects.equal(runScript, other.runScript)
              && Objects.equal(sdkHome, other.sdkHome)
              && Objects.equal(versionFile, other.versionFile)
              && Objects.equal(devtoolsScript, other.devtoolsScript);
@@ -222,7 +238,7 @@ public class PluginConfig {
 
     @Override
     public int hashCode() {
-      return Objects.hashCode(daemonScript, doctorScript, launchScript, testScript, sdkHome, versionFile, devtoolsScript);
+      return Objects.hashCode(daemonScript, doctorScript, launchScript, testScript, runScript, sdkHome, versionFile, devtoolsScript);
     }
   }
 

--- a/src/io/flutter/bazel/Workspace.java
+++ b/src/io/flutter/bazel/Workspace.java
@@ -41,6 +41,7 @@ public class Workspace {
   @Nullable private final String daemonScript;
   @Nullable private final String doctorScript;
   @Nullable private final String testScript;
+  @Nullable private final String runScript;
   @Nullable private final String sdkHome;
   @Nullable private final String versionFile;
   @Nullable private final String devtoolsScript;
@@ -50,6 +51,7 @@ public class Workspace {
                     @Nullable String daemonScript,
                     @Nullable String doctorScript,
                     @Nullable String testScript,
+                    @Nullable String runScript,
                     @Nullable String sdkHome,
                     @Nullable String versionFile,
                     @Nullable String devtoolsScript) {
@@ -58,6 +60,7 @@ public class Workspace {
     this.daemonScript = daemonScript;
     this.doctorScript = doctorScript;
     this.testScript = testScript;
+    this.runScript = runScript;
     this.sdkHome = sdkHome;
     this.versionFile = versionFile;
     this.devtoolsScript = devtoolsScript;
@@ -142,6 +145,14 @@ public class Workspace {
   @Nullable
   public String getTestScript() {
     return testScript;
+  }
+
+  /**
+   * Returns the script that starts 'flutter run', or null if not configured.
+   */
+  @Nullable
+  public String getRunScript() {
+    return runScript;
   }
 
   /**
@@ -233,13 +244,15 @@ public class Workspace {
 
     final String testScript = config == null ? null : getScriptFromPath(root, readonlyPath, config.getTestScript());
 
+    final String runScript = config == null ? null : getScriptFromPath(root, readonlyPath, config.getRunScript());
+
     final String sdkHome = config == null ? null : getScriptFromPath(root, readonlyPath, config.getSdkHome());
 
     final String versionFile = config == null ? null : getScriptFromPath(root, readonlyPath, config.getVersionFile());
 
     final String devtoolsScript = config == null ? null : config.getDevtoolsScript();
 
-    return new Workspace(root, config, daemonScript, doctorScript, testScript, sdkHome, versionFile, devtoolsScript);
+    return new Workspace(root, config, daemonScript, doctorScript, testScript, runScript, sdkHome, versionFile, devtoolsScript);
   }
 
   @VisibleForTesting
@@ -250,6 +263,7 @@ public class Workspace {
       pluginConfig.getDaemonScript(),
       pluginConfig.getDoctorScript(),
       pluginConfig.getTestScript(),
+      pluginConfig.getRunScript(),
       pluginConfig.getSdkHome(),
       pluginConfig.getVersionFile(),
       pluginConfig.getDevtoolsScript());

--- a/src/io/flutter/run/bazel/BazelFields.java
+++ b/src/io/flutter/run/bazel/BazelFields.java
@@ -116,13 +116,13 @@ public class BazelFields {
   }
 
   @Nullable
-  private String getLaunchScriptFromWorkspace(@NotNull final Project project) {
+  private String getRunScriptFromWorkspace(@NotNull final Project project) {
     final Workspace workspace = getWorkspace(project);
-    String launchScript = workspace == null ? null : workspace.getLaunchScript();
-    if (launchScript != null) {
-      launchScript = workspace.getRoot().getPath() + "/" + launchScript;
+    String runScript = workspace == null ? null : workspace.getRunScript();
+    if (runScript != null) {
+      runScript = workspace.getRoot().getPath() + "/" + runScript;
     }
-    return launchScript;
+    return runScript;
   }
 
   // TODO(djshuckerow): this is dependency injection; switch this to a framework as we need more DI.
@@ -150,15 +150,15 @@ public class BazelFields {
                                           () -> DartConfigurable.openDartSettings(project));
     }
 
-    final String launchScript = getLaunchScriptFromWorkspace(project);
-    if (launchScript == null) {
+    final String runScript = getRunScriptFromWorkspace(project);
+    if (runScript == null) {
       throw new RuntimeConfigurationError(FlutterBundle.message("flutter.run.bazel.noLaunchingScript"));
     }
 
-    final VirtualFile scriptFile = LocalFileSystem.getInstance().findFileByPath(launchScript);
+    final VirtualFile scriptFile = LocalFileSystem.getInstance().findFileByPath(runScript);
     if (scriptFile == null) {
       throw new RuntimeConfigurationError(
-        FlutterBundle.message("flutter.run.bazel.launchingScriptNotFound", FileUtil.toSystemDependentName(launchScript)));
+        FlutterBundle.message("flutter.run.bazel.launchingScriptNotFound", FileUtil.toSystemDependentName(runScript)));
     }
 
     // check that bazel target is not empty
@@ -187,7 +187,7 @@ public class BazelFields {
 
     final Workspace workspace = getWorkspace(project);
 
-    final String launchingScript = getLaunchScriptFromWorkspace(project);
+    final String launchingScript = getRunScriptFromWorkspace(project);
     assert launchingScript != null; // already checked
     assert workspace != null; // if the workspace is null, then so is the launching script, therefore this was already checked.
 
@@ -201,17 +201,24 @@ public class BazelFields {
     commandLine.setCharset(CharsetToolkit.UTF8_CHARSET);
     commandLine.setExePath(FileUtil.toSystemDependentName(launchingScript));
 
+    // Potentially add build mode to user-specified bazel arguments.
+    final String inputBazelArgs = StringUtil.notNullize(bazelArgs);
+    final StringBuilder fullBazelArgs = new StringBuilder(inputBazelArgs);
+
     // If the user hasn't overridden the flutter_build_mode, then
     if (!StringUtil.notNullize(bazelArgs).matches(".*--define[ =]flutter_build_mode.*")) {
+      if (!inputBazelArgs.isEmpty()) {
+        fullBazelArgs.append(" ");
+      }
 
       // Set the mode. This section needs to match the bazel versions of the flutter_build_mode parameters.
       if (enableReleaseMode) {
-        commandLine.addParameters("--define", "flutter_build_mode=release");
+        fullBazelArgs.append("--define=flutter_build_mode=release");
       }
       else {
         switch (mode) {
           case PROFILE:
-            commandLine.addParameters("--define", "flutter_build_mode=profile");
+            fullBazelArgs.append("--define=flutter_build_mode=profile");
             break;
           case RUN:
           case DEBUG:
@@ -219,57 +226,13 @@ public class BazelFields {
             // The default mode of a flutter app is debug mode. This is the mode that supports hot reloading.
             // So far as flutter is concerned, there is no difference between debug mode and run mode;
             // the only difference is that a debug mode app will --start-paused.
-            commandLine.addParameters("--define", "flutter_build_mode=debug");
+            fullBazelArgs.append("--define=flutter_build_mode=debug");
             break;
         }
       }
     }
 
-    // User specified additional bazel arguments.
-    final CommandLineTokenizer bazelArgsTokenizer = new CommandLineTokenizer(
-      StringUtil.notNullize(bazelArgs));
-    while (bazelArgsTokenizer.hasMoreTokens()) {
-      commandLine.addParameter(bazelArgsTokenizer.nextToken());
-    }
-    // (the implicit else here is the debug case)
-
-    // Send in platform architecture based in the device info.
-    if (device != null) {
-
-      if (device.isIOS()) {
-        // --ios_cpu=[arm64, x86_64]
-        final String arch = device.emulator() ? "x86_64" : "arm64";
-        commandLine.addParameter("--ios_multi_cpus=" + arch);
-      }
-      else {
-        // --android_cpu=[armeabi-v7a, x86, x86_64]
-        String arch = null;
-        final String platform = device.platform();
-        if (platform != null) {
-          switch (platform) {
-            case "android-arm":
-              arch = "armeabi-v7a";
-              break;
-            case "android-x86":
-              arch = "x86";
-              break;
-            case "android-x64":
-            case "linux-x64":
-              arch = "x86_64";
-              break;
-          }
-        }
-
-        if (arch != null) {
-          commandLine.addParameter("--fat_apk_cpu=" + arch);
-        }
-      }
-    }
-
-    commandLine.addParameter(target);
-
-    // Pass additional args to bazel (we currently don't pass --device-id with bazel targets).
-    commandLine.addParameter("--");
+    commandLine.addParameter(String.format("--bazel-options=%s", fullBazelArgs.toString()));
 
     // Tell the flutter command-line tools that we want a machine interface on stdio.
     commandLine.addParameter("--machine");
@@ -291,6 +254,8 @@ public class BazelFields {
       commandLine.addParameter("-d");
       commandLine.addParameter(device.deviceId());
     }
+
+    commandLine.addParameter(target);
 
     return commandLine;
   }

--- a/src/io/flutter/run/bazel/BazelFields.java
+++ b/src/io/flutter/run/bazel/BazelFields.java
@@ -205,6 +205,7 @@ public class BazelFields {
     final String inputBazelArgs = StringUtil.notNullize(bazelArgs);
     final StringBuilder fullBazelArgs = new StringBuilder(inputBazelArgs);
 
+    // TODO(helinx): Have run script handle this bazel arg instead.
     // If the user hasn't overridden the flutter_build_mode, then
     if (!StringUtil.notNullize(bazelArgs).matches(".*--define[ =]flutter_build_mode.*")) {
       if (!inputBazelArgs.isEmpty()) {

--- a/testSrc/unit/io/flutter/bazel/FakeWorkspaceFactory.java
+++ b/testSrc/unit/io/flutter/bazel/FakeWorkspaceFactory.java
@@ -20,6 +20,7 @@ public class FakeWorkspaceFactory {
     @Nullable String doctorScript,
     @Nullable String launchScript,
     @Nullable String testScript,
+    @Nullable String runScript,
     @Nullable String sdkHome,
     @Nullable String versionFile,
     @Nullable String devtoolsScript
@@ -53,6 +54,7 @@ public class FakeWorkspaceFactory {
           doctorScript,
           launchScript,
           testScript,
+          runScript,
           sdkHome,
           versionFile,
           devtoolsScript
@@ -73,6 +75,7 @@ public class FakeWorkspaceFactory {
       "scripts/flutter-doctor.sh",
       "scripts/bazel-run.sh",
       "scripts/flutter-test.sh",
+      "scripts/flutter-run.sh",
       "scripts/",
       "flutter-version",
       "scripts/devtools:server"

--- a/testSrc/unit/io/flutter/run/bazel/LaunchCommandsTest.java
+++ b/testSrc/unit/io/flutter/run/bazel/LaunchCommandsTest.java
@@ -44,14 +44,12 @@ public class LaunchCommandsTest {
     GeneralCommandLine launchCommand = fields.getLaunchCommand(projectFixture.getProject(), device, RunMode.RUN);
 
     final List<String> expectedCommandLine = new ArrayList<>();
-    expectedCommandLine.add("/workspace/scripts/bazel-run.sh");
-    expectedCommandLine.add("--define");
-    expectedCommandLine.add("flutter_build_mode=release");
-    expectedCommandLine.add("bazel_target");
-    expectedCommandLine.add("--");
+    expectedCommandLine.add("/workspace/scripts/flutter-run.sh");
+    expectedCommandLine.add("--bazel-options=--define=flutter_build_mode=release");
     expectedCommandLine.add("--machine");
     expectedCommandLine.add("-d");
     expectedCommandLine.add("flutter-tester");
+    expectedCommandLine.add("bazel_target");
     assertThat(launchCommand.getCommandLineString(), equalTo(String.join(" ", expectedCommandLine)));
 
     // When release mode is enabled, using different RunModes has no effect.
@@ -71,14 +69,12 @@ public class LaunchCommandsTest {
     final GeneralCommandLine launchCommand = fields.getLaunchCommand(projectFixture.getProject(), device, RunMode.RUN);
 
     final List<String> expectedCommandLine = new ArrayList<>();
-    expectedCommandLine.add("/workspace/scripts/bazel-run.sh");
-    expectedCommandLine.add("--define");
-    expectedCommandLine.add("flutter_build_mode=debug");
-    expectedCommandLine.add("bazel_target");
-    expectedCommandLine.add("--");
+    expectedCommandLine.add("/workspace/scripts/flutter-run.sh");
+    expectedCommandLine.add("--bazel-options=--define=flutter_build_mode=debug");
     expectedCommandLine.add("--machine");
     expectedCommandLine.add("-d");
     expectedCommandLine.add("flutter-tester");
+    expectedCommandLine.add("bazel_target");
     assertThat(launchCommand.getCommandLineList(null), equalTo(expectedCommandLine));
   }
 
@@ -95,15 +91,12 @@ public class LaunchCommandsTest {
     final GeneralCommandLine launchCommand = fields.getLaunchCommand(projectFixture.getProject(), device, RunMode.RUN);
 
     final List<String> expectedCommandLine = new ArrayList<>();
-    expectedCommandLine.add("/workspace/scripts/bazel-run.sh");
-    expectedCommandLine.add("--define");
-    expectedCommandLine.add("flutter_build_mode=debug");
-    expectedCommandLine.add("--define=bazel_args");
-    expectedCommandLine.add("bazel_target");
-    expectedCommandLine.add("--");
+    expectedCommandLine.add("/workspace/scripts/flutter-run.sh");
+    expectedCommandLine.add("--bazel-options=--define=bazel_args --define=flutter_build_mode=debug");
     expectedCommandLine.add("--machine");
     expectedCommandLine.add("-d");
     expectedCommandLine.add("flutter-tester");
+    expectedCommandLine.add("bazel_target");
     assertThat(launchCommand.getCommandLineList(null), equalTo(expectedCommandLine));
   }
 
@@ -120,13 +113,12 @@ public class LaunchCommandsTest {
     GeneralCommandLine launchCommand = fields.getLaunchCommand(projectFixture.getProject(), device, RunMode.RUN);
 
     List<String> expectedCommandLine = new ArrayList<>();
-    expectedCommandLine.add("/workspace/scripts/bazel-run.sh");
-    expectedCommandLine.add("--define=flutter_build_mode=release");
-    expectedCommandLine.add("bazel_target");
-    expectedCommandLine.add("--");
+    expectedCommandLine.add("/workspace/scripts/flutter-run.sh");
+    expectedCommandLine.add("--bazel-options=--define=flutter_build_mode=release");
     expectedCommandLine.add("--machine");
     expectedCommandLine.add("-d");
     expectedCommandLine.add("flutter-tester");
+    expectedCommandLine.add("bazel_target");
     assertThat(launchCommand.getCommandLineList(null), equalTo(expectedCommandLine));
 
     // With a space instead of an =
@@ -140,14 +132,12 @@ public class LaunchCommandsTest {
     launchCommand = fields.getLaunchCommand(projectFixture.getProject(), device, RunMode.RUN);
 
     expectedCommandLine = new ArrayList<>();
-    expectedCommandLine.add("/workspace/scripts/bazel-run.sh");
-    expectedCommandLine.add("--define");
-    expectedCommandLine.add("flutter_build_mode=profile");
-    expectedCommandLine.add("bazel_target");
-    expectedCommandLine.add("--");
+    expectedCommandLine.add("/workspace/scripts/flutter-run.sh");
+    expectedCommandLine.add("--bazel-options=--define flutter_build_mode=profile");
     expectedCommandLine.add("--machine");
     expectedCommandLine.add("-d");
     expectedCommandLine.add("flutter-tester");
+    expectedCommandLine.add("bazel_target");
     assertThat(launchCommand.getCommandLineList(null), equalTo(expectedCommandLine));
 
     // With multiple params
@@ -161,16 +151,12 @@ public class LaunchCommandsTest {
     launchCommand = fields.getLaunchCommand(projectFixture.getProject(), device, RunMode.RUN);
 
     expectedCommandLine = new ArrayList<>();
-    expectedCommandLine.add("/workspace/scripts/bazel-run.sh");
-    expectedCommandLine.add("--define");
-    expectedCommandLine.add("param1=2");
-    expectedCommandLine.add("--define=param2=2");
-    expectedCommandLine.add("--define=flutter_build_mode=profile");
-    expectedCommandLine.add("bazel_target");
-    expectedCommandLine.add("--");
+    expectedCommandLine.add("/workspace/scripts/flutter-run.sh");
+    expectedCommandLine.add("--bazel-options=--define param1=2 --define=param2=2 --define=flutter_build_mode=profile");
     expectedCommandLine.add("--machine");
     expectedCommandLine.add("-d");
     expectedCommandLine.add("flutter-tester");
+    expectedCommandLine.add("bazel_target");
     assertThat(launchCommand.getCommandLineList(null), equalTo(expectedCommandLine));
   }
 
@@ -187,15 +173,13 @@ public class LaunchCommandsTest {
     final GeneralCommandLine launchCommand = fields.getLaunchCommand(projectFixture.getProject(), device, RunMode.RUN);
 
     final List<String> expectedCommandLine = new ArrayList<>();
-    expectedCommandLine.add("/workspace/scripts/bazel-run.sh");
-    expectedCommandLine.add("--define");
-    expectedCommandLine.add("flutter_build_mode=debug");
-    expectedCommandLine.add("bazel_target");
-    expectedCommandLine.add("--");
+    expectedCommandLine.add("/workspace/scripts/flutter-run.sh");
+    expectedCommandLine.add("--bazel-options=--define=flutter_build_mode=debug");
     expectedCommandLine.add("--machine");
     expectedCommandLine.add("additional_args");
     expectedCommandLine.add("-d");
     expectedCommandLine.add("flutter-tester");
+    expectedCommandLine.add("bazel_target");
     assertThat(launchCommand.getCommandLineList(null), equalTo(expectedCommandLine));
   }
 
@@ -212,20 +196,15 @@ public class LaunchCommandsTest {
     final GeneralCommandLine launchCommand = fields.getLaunchCommand(projectFixture.getProject(), device, RunMode.RUN);
 
     final List<String> expectedCommandLine = new ArrayList<>();
-    expectedCommandLine.add("/workspace/scripts/bazel-run.sh");
-    expectedCommandLine.add("--define");
-    expectedCommandLine.add("flutter_build_mode=debug");
-    expectedCommandLine.add("--define=bazel_args0");
-    expectedCommandLine.add("--define");
-    expectedCommandLine.add("bazel_args1=value");
-    expectedCommandLine.add("bazel_target");
-    expectedCommandLine.add("--");
+    expectedCommandLine.add("/workspace/scripts/flutter-run.sh");
+    expectedCommandLine.add("--bazel-options=--define=bazel_args0 --define bazel_args1=value --define=flutter_build_mode=debug");
     expectedCommandLine.add("--machine");
     expectedCommandLine.add("--additional_args1");
     expectedCommandLine.add("--additional_args2");
     expectedCommandLine.add("value_of_arg2");
     expectedCommandLine.add("-d");
     expectedCommandLine.add("flutter-tester");
+    expectedCommandLine.add("bazel_target");
     assertThat(launchCommand.getCommandLineList(null), equalTo(expectedCommandLine));
   }
 
@@ -238,15 +217,13 @@ public class LaunchCommandsTest {
       fields.getLaunchCommand(projectFixture.getProject(), device, RunMode.DEBUG);
 
     final List<String> expectedCommandLine = new ArrayList<>();
-    expectedCommandLine.add("/workspace/scripts/bazel-run.sh");
-    expectedCommandLine.add("--define");
-    expectedCommandLine.add("flutter_build_mode=debug");
-    expectedCommandLine.add("bazel_target");
-    expectedCommandLine.add("--");
+    expectedCommandLine.add("/workspace/scripts/flutter-run.sh");
+    expectedCommandLine.add("--bazel-options=--define=flutter_build_mode=debug");
     expectedCommandLine.add("--machine");
     expectedCommandLine.add("--start-paused");
     expectedCommandLine.add("-d");
     expectedCommandLine.add("flutter-tester");
+    expectedCommandLine.add("bazel_target");
     assertThat(launchCommand.getCommandLineList(null), equalTo(expectedCommandLine));
   }
 
@@ -259,14 +236,12 @@ public class LaunchCommandsTest {
       fields.getLaunchCommand(projectFixture.getProject(), device, RunMode.PROFILE);
 
     final List<String> expectedCommandLine = new ArrayList<>();
-    expectedCommandLine.add("/workspace/scripts/bazel-run.sh");
-    expectedCommandLine.add("--define");
-    expectedCommandLine.add("flutter_build_mode=profile");
-    expectedCommandLine.add("bazel_target");
-    expectedCommandLine.add("--");
+    expectedCommandLine.add("/workspace/scripts/flutter-run.sh");
+    expectedCommandLine.add("--bazel-options=--define=flutter_build_mode=profile");
     expectedCommandLine.add("--machine");
     expectedCommandLine.add("-d");
     expectedCommandLine.add("flutter-tester");
+    expectedCommandLine.add("bazel_target");
     assertThat(launchCommand.getCommandLineList(null), equalTo(expectedCommandLine));
   }
 
@@ -278,14 +253,12 @@ public class LaunchCommandsTest {
     final GeneralCommandLine launchCommand = fields.getLaunchCommand(projectFixture.getProject(), device, RunMode.RUN);
 
     final List<String> expectedCommandLine = new ArrayList<>();
-    expectedCommandLine.add("/workspace/scripts/bazel-run.sh");
-    expectedCommandLine.add("--define");
-    expectedCommandLine.add("flutter_build_mode=debug");
-    expectedCommandLine.add("bazel_target");
-    expectedCommandLine.add("--");
+    expectedCommandLine.add("/workspace/scripts/flutter-run.sh");
+    expectedCommandLine.add("--bazel-options=--define=flutter_build_mode=debug");
     expectedCommandLine.add("--machine");
     expectedCommandLine.add("-d");
     expectedCommandLine.add("android-tester");
+    expectedCommandLine.add("bazel_target");
     assertThat(launchCommand.getCommandLineList(null), equalTo(expectedCommandLine));
   }
 
@@ -298,14 +271,12 @@ public class LaunchCommandsTest {
     final GeneralCommandLine launchCommand = fields.getLaunchCommand(projectFixture.getProject(), device, RunMode.RUN);
 
     final List<String> expectedCommandLine = new ArrayList<>();
-    expectedCommandLine.add("/workspace/scripts/bazel-run.sh");
-    expectedCommandLine.add("--define");
-    expectedCommandLine.add("flutter_build_mode=debug");
-    expectedCommandLine.add("bazel_target");
-    expectedCommandLine.add("--");
+    expectedCommandLine.add("/workspace/scripts/flutter-run.sh");
+    expectedCommandLine.add("--bazel-options=--define=flutter_build_mode=debug");
     expectedCommandLine.add("--machine");
     expectedCommandLine.add("-d");
     expectedCommandLine.add("android-tester");
+    expectedCommandLine.add("bazel_target");
     assertThat(launchCommand.getCommandLineList(null), equalTo(expectedCommandLine));
   }
 
@@ -317,15 +288,12 @@ public class LaunchCommandsTest {
     final GeneralCommandLine launchCommand = fields.getLaunchCommand(projectFixture.getProject(), device, RunMode.RUN);
 
     final List<String> expectedCommandLine = new ArrayList<>();
-    expectedCommandLine.add("/workspace/scripts/bazel-run.sh");
-    expectedCommandLine.add("--define");
-    expectedCommandLine.add("flutter_build_mode=debug");
-    expectedCommandLine.add("--ios_multi_cpus=arm64");
-    expectedCommandLine.add("bazel_target");
-    expectedCommandLine.add("--");
+    expectedCommandLine.add("/workspace/scripts/flutter-run.sh");
+    expectedCommandLine.add("--bazel-options=--define=flutter_build_mode=debug");
     expectedCommandLine.add("--machine");
     expectedCommandLine.add("-d");
     expectedCommandLine.add("ios-tester");
+    expectedCommandLine.add("bazel_target");
     assertThat(launchCommand.getCommandLineList(null), equalTo(expectedCommandLine));
   }
 
@@ -337,15 +305,12 @@ public class LaunchCommandsTest {
     final GeneralCommandLine launchCommand = fields.getLaunchCommand(projectFixture.getProject(), device, RunMode.RUN);
 
     final List<String> expectedCommandLine = new ArrayList<>();
-    expectedCommandLine.add("/workspace/scripts/bazel-run.sh");
-    expectedCommandLine.add("--define");
-    expectedCommandLine.add("flutter_build_mode=debug");
-    expectedCommandLine.add("--ios_multi_cpus=x86_64");
-    expectedCommandLine.add("bazel_target");
-    expectedCommandLine.add("--");
+    expectedCommandLine.add("/workspace/scripts/flutter-run.sh");
+    expectedCommandLine.add("--bazel-options=--define=flutter_build_mode=debug");
     expectedCommandLine.add("--machine");
     expectedCommandLine.add("-d");
     expectedCommandLine.add("ios-tester");
+    expectedCommandLine.add("bazel_target");
     assertThat(launchCommand.getCommandLineList(null), equalTo(expectedCommandLine));
   }
 
@@ -382,11 +347,12 @@ public class LaunchCommandsTest {
                     @Nullable String doctorScript,
                     @Nullable String launchScript,
                     @Nullable String testScript,
+                    @Nullable String runScript,
                     @Nullable String sdkHome,
                     @Nullable String versionFile) {
       super(template);
       final Pair.NonNull<MockVirtualFileSystem, Workspace> pair = FakeWorkspaceFactory
-        .createWorkspaceAndFilesystem(daemonScript, doctorScript, launchScript, testScript, sdkHome, versionFile, null);
+        .createWorkspaceAndFilesystem(daemonScript, doctorScript, launchScript, testScript, runScript, sdkHome, versionFile, null);
       fs = pair.first;
       fakeWorkspace = pair.second;
     }

--- a/testSrc/unit/io/flutter/run/bazelTest/BazelTestConfigProducerTest.java
+++ b/testSrc/unit/io/flutter/run/bazelTest/BazelTestConfigProducerTest.java
@@ -166,7 +166,7 @@ public class BazelTestConfigProducerTest extends AbstractDartElementTest {
       fs.file("/workspace/WORKSPACE", "");
       fakeWorkspace = Workspace.forTest(
         fs.findFileByPath("/workspace/"),
-        PluginConfig.forTest("", "", "", "", "", "", "")
+        PluginConfig.forTest("", "", "", "", "", "", "", "")
       );
       this.hasWorkspace = hasWorkspace;
       this.hasValidTestFile = hasValidTestFile;

--- a/testSrc/unit/io/flutter/run/bazelTest/LaunchCommandsTest.java
+++ b/testSrc/unit/io/flutter/run/bazelTest/LaunchCommandsTest.java
@@ -181,6 +181,7 @@ public class LaunchCommandsTest {
       "scripts/launch.sh",
       null,
       null,
+      null,
       null
     );
     final GeneralCommandLine launchCommand = fields.getLaunchCommand(projectFixture.getProject(), RunMode.RUN);
@@ -200,6 +201,7 @@ public class LaunchCommandsTest {
       "scripts/daemon.sh",
       "scripts/doctor.sh",
       "scripts/launch.sh",
+      null,
       null,
       null,
       null
@@ -225,6 +227,7 @@ public class LaunchCommandsTest {
       "scripts/launch.sh",
       null,
       null,
+      null,
       null
     );
     boolean didThrow = false;
@@ -246,6 +249,7 @@ public class LaunchCommandsTest {
       "scripts/launch.sh",
       null,
       null,
+      null,
       null
     );
     boolean didThrow = false;
@@ -265,6 +269,7 @@ public class LaunchCommandsTest {
       "scripts/daemon.sh",
       "scripts/doctor.sh",
       "scripts/launch.sh",
+      null,
       null,
       null,
       null
@@ -323,11 +328,12 @@ public class LaunchCommandsTest {
                         @Nullable String doctorScript,
                         @Nullable String launchScript,
                         @Nullable String testScript,
+                        @Nullable String runScript,
                         @Nullable String sdkHome,
                         @Nullable String versionFile) {
       super(template);
       final Pair.NonNull<MockVirtualFileSystem, Workspace> pair = FakeWorkspaceFactory
-        .createWorkspaceAndFilesystem(daemonScript, doctorScript, launchScript, testScript, sdkHome, versionFile, null);
+        .createWorkspaceAndFilesystem(daemonScript, doctorScript, launchScript, testScript, runScript, sdkHome, versionFile, null);
       fs = pair.first;
       fakeWorkspace = pair.second;
     }


### PR DESCRIPTION
This uses the updated `runScript`, which:
- Processes `bazel-options` as a string of all of the bazel arguments
- Handles the device-specific logic internally (so we can remove from the plugin)