### PR TITLE
Revert "Use runScript for bazel run"

### DIFF
--- a/src/io/flutter/bazel/PluginConfig.java
+++ b/src/io/flutter/bazel/PluginConfig.java
@@ -55,11 +55,6 @@ public class PluginConfig {
   }
 
   @Nullable
-  String getRunScript() {
-    return fields.runScript;
-  }
-
-  @Nullable
   String getSdkHome() {
     return fields.sdkHome;
   }
@@ -128,7 +123,6 @@ public class PluginConfig {
     @Nullable String doctorScript,
     @Nullable String launchScript,
     @Nullable String testScript,
-    @Nullable String runScript,
     @Nullable String sdkHome,
     @Nullable String versionFile,
     @Nullable String devtoolsScript
@@ -138,7 +132,6 @@ public class PluginConfig {
       doctorScript,
       launchScript,
       testScript,
-      runScript,
       sdkHome,
       versionFile,
       devtoolsScript
@@ -175,12 +168,6 @@ public class PluginConfig {
     private String testScript;
 
     /**
-     * The script to run to start 'flutter run'
-     */
-    @SerializedName("runScript")
-    private String runScript;
-
-    /**
      * The directory containing the SDK tools.
      */
     @SerializedName("sdkHome")
@@ -208,7 +195,6 @@ public class PluginConfig {
            String doctorScript,
            String launchScript,
            String testScript,
-           String runScript,
            String sdkHome,
            String versionFile,
            String devtoolsScript) {
@@ -216,7 +202,6 @@ public class PluginConfig {
       this.doctorScript = doctorScript;
       this.launchScript = launchScript;
       this.testScript = testScript;
-      this.runScript = runScript;
       this.sdkHome = sdkHome;
       this.versionFile = versionFile;
       this.devtoolsScript = devtoolsScript;
@@ -230,7 +215,6 @@ public class PluginConfig {
              && Objects.equal(doctorScript, other.doctorScript)
              && Objects.equal(launchScript, other.launchScript)
              && Objects.equal(testScript, other.testScript)
-             && Objects.equal(runScript, other.runScript)
              && Objects.equal(sdkHome, other.sdkHome)
              && Objects.equal(versionFile, other.versionFile)
              && Objects.equal(devtoolsScript, other.devtoolsScript);
@@ -238,7 +222,7 @@ public class PluginConfig {
 
     @Override
     public int hashCode() {
-      return Objects.hashCode(daemonScript, doctorScript, launchScript, testScript, runScript, sdkHome, versionFile, devtoolsScript);
+      return Objects.hashCode(daemonScript, doctorScript, launchScript, testScript, sdkHome, versionFile, devtoolsScript);
     }
   }
 

--- a/src/io/flutter/bazel/Workspace.java
+++ b/src/io/flutter/bazel/Workspace.java
@@ -41,7 +41,6 @@ public class Workspace {
   @Nullable private final String daemonScript;
   @Nullable private final String doctorScript;
   @Nullable private final String testScript;
-  @Nullable private final String runScript;
   @Nullable private final String sdkHome;
   @Nullable private final String versionFile;
   @Nullable private final String devtoolsScript;
@@ -51,7 +50,6 @@ public class Workspace {
                     @Nullable String daemonScript,
                     @Nullable String doctorScript,
                     @Nullable String testScript,
-                    @Nullable String runScript,
                     @Nullable String sdkHome,
                     @Nullable String versionFile,
                     @Nullable String devtoolsScript) {
@@ -60,7 +58,6 @@ public class Workspace {
     this.daemonScript = daemonScript;
     this.doctorScript = doctorScript;
     this.testScript = testScript;
-    this.runScript = runScript;
     this.sdkHome = sdkHome;
     this.versionFile = versionFile;
     this.devtoolsScript = devtoolsScript;
@@ -145,14 +142,6 @@ public class Workspace {
   @Nullable
   public String getTestScript() {
     return testScript;
-  }
-
-  /**
-   * Returns the script that starts 'flutter run', or null if not configured.
-   */
-  @Nullable
-  public String getRunScript() {
-    return runScript;
   }
 
   /**
@@ -244,15 +233,13 @@ public class Workspace {
 
     final String testScript = config == null ? null : getScriptFromPath(root, readonlyPath, config.getTestScript());
 
-    final String runScript = config == null ? null : getScriptFromPath(root, readonlyPath, config.getRunScript());
-
     final String sdkHome = config == null ? null : getScriptFromPath(root, readonlyPath, config.getSdkHome());
 
     final String versionFile = config == null ? null : getScriptFromPath(root, readonlyPath, config.getVersionFile());
 
     final String devtoolsScript = config == null ? null : config.getDevtoolsScript();
 
-    return new Workspace(root, config, daemonScript, doctorScript, testScript, runScript, sdkHome, versionFile, devtoolsScript);
+    return new Workspace(root, config, daemonScript, doctorScript, testScript, sdkHome, versionFile, devtoolsScript);
   }
 
   @VisibleForTesting
@@ -263,7 +250,6 @@ public class Workspace {
       pluginConfig.getDaemonScript(),
       pluginConfig.getDoctorScript(),
       pluginConfig.getTestScript(),
-      pluginConfig.getRunScript(),
       pluginConfig.getSdkHome(),
       pluginConfig.getVersionFile(),
       pluginConfig.getDevtoolsScript());

--- a/testSrc/unit/io/flutter/bazel/FakeWorkspaceFactory.java
+++ b/testSrc/unit/io/flutter/bazel/FakeWorkspaceFactory.java
@@ -20,7 +20,6 @@ public class FakeWorkspaceFactory {
     @Nullable String doctorScript,
     @Nullable String launchScript,
     @Nullable String testScript,
-    @Nullable String runScript,
     @Nullable String sdkHome,
     @Nullable String versionFile,
     @Nullable String devtoolsScript
@@ -54,7 +53,6 @@ public class FakeWorkspaceFactory {
           doctorScript,
           launchScript,
           testScript,
-          runScript,
           sdkHome,
           versionFile,
           devtoolsScript
@@ -75,7 +73,6 @@ public class FakeWorkspaceFactory {
       "scripts/flutter-doctor.sh",
       "scripts/bazel-run.sh",
       "scripts/flutter-test.sh",
-      "scripts/flutter-run.sh",
       "scripts/",
       "flutter-version",
       "scripts/devtools:server"

--- a/testSrc/unit/io/flutter/run/bazel/LaunchCommandsTest.java
+++ b/testSrc/unit/io/flutter/run/bazel/LaunchCommandsTest.java
@@ -44,12 +44,14 @@ public class LaunchCommandsTest {
     GeneralCommandLine launchCommand = fields.getLaunchCommand(projectFixture.getProject(), device, RunMode.RUN);
 
     final List<String> expectedCommandLine = new ArrayList<>();
-    expectedCommandLine.add("/workspace/scripts/flutter-run.sh");
-    expectedCommandLine.add("--bazel-options=--define=flutter_build_mode=release");
+    expectedCommandLine.add("/workspace/scripts/bazel-run.sh");
+    expectedCommandLine.add("--define");
+    expectedCommandLine.add("flutter_build_mode=release");
+    expectedCommandLine.add("bazel_target");
+    expectedCommandLine.add("--");
     expectedCommandLine.add("--machine");
     expectedCommandLine.add("-d");
     expectedCommandLine.add("flutter-tester");
-    expectedCommandLine.add("bazel_target");
     assertThat(launchCommand.getCommandLineString(), equalTo(String.join(" ", expectedCommandLine)));
 
     // When release mode is enabled, using different RunModes has no effect.
@@ -69,12 +71,14 @@ public class LaunchCommandsTest {
     final GeneralCommandLine launchCommand = fields.getLaunchCommand(projectFixture.getProject(), device, RunMode.RUN);
 
     final List<String> expectedCommandLine = new ArrayList<>();
-    expectedCommandLine.add("/workspace/scripts/flutter-run.sh");
-    expectedCommandLine.add("--bazel-options=--define=flutter_build_mode=debug");
+    expectedCommandLine.add("/workspace/scripts/bazel-run.sh");
+    expectedCommandLine.add("--define");
+    expectedCommandLine.add("flutter_build_mode=debug");
+    expectedCommandLine.add("bazel_target");
+    expectedCommandLine.add("--");
     expectedCommandLine.add("--machine");
     expectedCommandLine.add("-d");
     expectedCommandLine.add("flutter-tester");
-    expectedCommandLine.add("bazel_target");
     assertThat(launchCommand.getCommandLineList(null), equalTo(expectedCommandLine));
   }
 
@@ -91,12 +95,15 @@ public class LaunchCommandsTest {
     final GeneralCommandLine launchCommand = fields.getLaunchCommand(projectFixture.getProject(), device, RunMode.RUN);
 
     final List<String> expectedCommandLine = new ArrayList<>();
-    expectedCommandLine.add("/workspace/scripts/flutter-run.sh");
-    expectedCommandLine.add("--bazel-options=--define=bazel_args --define=flutter_build_mode=debug");
+    expectedCommandLine.add("/workspace/scripts/bazel-run.sh");
+    expectedCommandLine.add("--define");
+    expectedCommandLine.add("flutter_build_mode=debug");
+    expectedCommandLine.add("--define=bazel_args");
+    expectedCommandLine.add("bazel_target");
+    expectedCommandLine.add("--");
     expectedCommandLine.add("--machine");
     expectedCommandLine.add("-d");
     expectedCommandLine.add("flutter-tester");
-    expectedCommandLine.add("bazel_target");
     assertThat(launchCommand.getCommandLineList(null), equalTo(expectedCommandLine));
   }
 
@@ -113,12 +120,13 @@ public class LaunchCommandsTest {
     GeneralCommandLine launchCommand = fields.getLaunchCommand(projectFixture.getProject(), device, RunMode.RUN);
 
     List<String> expectedCommandLine = new ArrayList<>();
-    expectedCommandLine.add("/workspace/scripts/flutter-run.sh");
-    expectedCommandLine.add("--bazel-options=--define=flutter_build_mode=release");
+    expectedCommandLine.add("/workspace/scripts/bazel-run.sh");
+    expectedCommandLine.add("--define=flutter_build_mode=release");
+    expectedCommandLine.add("bazel_target");
+    expectedCommandLine.add("--");
     expectedCommandLine.add("--machine");
     expectedCommandLine.add("-d");
     expectedCommandLine.add("flutter-tester");
-    expectedCommandLine.add("bazel_target");
     assertThat(launchCommand.getCommandLineList(null), equalTo(expectedCommandLine));
 
     // With a space instead of an =
@@ -132,12 +140,14 @@ public class LaunchCommandsTest {
     launchCommand = fields.getLaunchCommand(projectFixture.getProject(), device, RunMode.RUN);
 
     expectedCommandLine = new ArrayList<>();
-    expectedCommandLine.add("/workspace/scripts/flutter-run.sh");
-    expectedCommandLine.add("--bazel-options=--define flutter_build_mode=profile");
+    expectedCommandLine.add("/workspace/scripts/bazel-run.sh");
+    expectedCommandLine.add("--define");
+    expectedCommandLine.add("flutter_build_mode=profile");
+    expectedCommandLine.add("bazel_target");
+    expectedCommandLine.add("--");
     expectedCommandLine.add("--machine");
     expectedCommandLine.add("-d");
     expectedCommandLine.add("flutter-tester");
-    expectedCommandLine.add("bazel_target");
     assertThat(launchCommand.getCommandLineList(null), equalTo(expectedCommandLine));
 
     // With multiple params
@@ -151,12 +161,16 @@ public class LaunchCommandsTest {
     launchCommand = fields.getLaunchCommand(projectFixture.getProject(), device, RunMode.RUN);
 
     expectedCommandLine = new ArrayList<>();
-    expectedCommandLine.add("/workspace/scripts/flutter-run.sh");
-    expectedCommandLine.add("--bazel-options=--define param1=2 --define=param2=2 --define=flutter_build_mode=profile");
+    expectedCommandLine.add("/workspace/scripts/bazel-run.sh");
+    expectedCommandLine.add("--define");
+    expectedCommandLine.add("param1=2");
+    expectedCommandLine.add("--define=param2=2");
+    expectedCommandLine.add("--define=flutter_build_mode=profile");
+    expectedCommandLine.add("bazel_target");
+    expectedCommandLine.add("--");
     expectedCommandLine.add("--machine");
     expectedCommandLine.add("-d");
     expectedCommandLine.add("flutter-tester");
-    expectedCommandLine.add("bazel_target");
     assertThat(launchCommand.getCommandLineList(null), equalTo(expectedCommandLine));
   }
 
@@ -173,13 +187,15 @@ public class LaunchCommandsTest {
     final GeneralCommandLine launchCommand = fields.getLaunchCommand(projectFixture.getProject(), device, RunMode.RUN);
 
     final List<String> expectedCommandLine = new ArrayList<>();
-    expectedCommandLine.add("/workspace/scripts/flutter-run.sh");
-    expectedCommandLine.add("--bazel-options=--define=flutter_build_mode=debug");
+    expectedCommandLine.add("/workspace/scripts/bazel-run.sh");
+    expectedCommandLine.add("--define");
+    expectedCommandLine.add("flutter_build_mode=debug");
+    expectedCommandLine.add("bazel_target");
+    expectedCommandLine.add("--");
     expectedCommandLine.add("--machine");
     expectedCommandLine.add("additional_args");
     expectedCommandLine.add("-d");
     expectedCommandLine.add("flutter-tester");
-    expectedCommandLine.add("bazel_target");
     assertThat(launchCommand.getCommandLineList(null), equalTo(expectedCommandLine));
   }
 
@@ -196,15 +212,20 @@ public class LaunchCommandsTest {
     final GeneralCommandLine launchCommand = fields.getLaunchCommand(projectFixture.getProject(), device, RunMode.RUN);
 
     final List<String> expectedCommandLine = new ArrayList<>();
-    expectedCommandLine.add("/workspace/scripts/flutter-run.sh");
-    expectedCommandLine.add("--bazel-options=--define=bazel_args0 --define bazel_args1=value --define=flutter_build_mode=debug");
+    expectedCommandLine.add("/workspace/scripts/bazel-run.sh");
+    expectedCommandLine.add("--define");
+    expectedCommandLine.add("flutter_build_mode=debug");
+    expectedCommandLine.add("--define=bazel_args0");
+    expectedCommandLine.add("--define");
+    expectedCommandLine.add("bazel_args1=value");
+    expectedCommandLine.add("bazel_target");
+    expectedCommandLine.add("--");
     expectedCommandLine.add("--machine");
     expectedCommandLine.add("--additional_args1");
     expectedCommandLine.add("--additional_args2");
     expectedCommandLine.add("value_of_arg2");
     expectedCommandLine.add("-d");
     expectedCommandLine.add("flutter-tester");
-    expectedCommandLine.add("bazel_target");
     assertThat(launchCommand.getCommandLineList(null), equalTo(expectedCommandLine));
   }
 
@@ -217,13 +238,15 @@ public class LaunchCommandsTest {
       fields.getLaunchCommand(projectFixture.getProject(), device, RunMode.DEBUG);
 
     final List<String> expectedCommandLine = new ArrayList<>();
-    expectedCommandLine.add("/workspace/scripts/flutter-run.sh");
-    expectedCommandLine.add("--bazel-options=--define=flutter_build_mode=debug");
+    expectedCommandLine.add("/workspace/scripts/bazel-run.sh");
+    expectedCommandLine.add("--define");
+    expectedCommandLine.add("flutter_build_mode=debug");
+    expectedCommandLine.add("bazel_target");
+    expectedCommandLine.add("--");
     expectedCommandLine.add("--machine");
     expectedCommandLine.add("--start-paused");
     expectedCommandLine.add("-d");
     expectedCommandLine.add("flutter-tester");
-    expectedCommandLine.add("bazel_target");
     assertThat(launchCommand.getCommandLineList(null), equalTo(expectedCommandLine));
   }
 
@@ -236,12 +259,14 @@ public class LaunchCommandsTest {
       fields.getLaunchCommand(projectFixture.getProject(), device, RunMode.PROFILE);
 
     final List<String> expectedCommandLine = new ArrayList<>();
-    expectedCommandLine.add("/workspace/scripts/flutter-run.sh");
-    expectedCommandLine.add("--bazel-options=--define=flutter_build_mode=profile");
+    expectedCommandLine.add("/workspace/scripts/bazel-run.sh");
+    expectedCommandLine.add("--define");
+    expectedCommandLine.add("flutter_build_mode=profile");
+    expectedCommandLine.add("bazel_target");
+    expectedCommandLine.add("--");
     expectedCommandLine.add("--machine");
     expectedCommandLine.add("-d");
     expectedCommandLine.add("flutter-tester");
-    expectedCommandLine.add("bazel_target");
     assertThat(launchCommand.getCommandLineList(null), equalTo(expectedCommandLine));
   }
 
@@ -253,12 +278,14 @@ public class LaunchCommandsTest {
     final GeneralCommandLine launchCommand = fields.getLaunchCommand(projectFixture.getProject(), device, RunMode.RUN);
 
     final List<String> expectedCommandLine = new ArrayList<>();
-    expectedCommandLine.add("/workspace/scripts/flutter-run.sh");
-    expectedCommandLine.add("--bazel-options=--define=flutter_build_mode=debug");
+    expectedCommandLine.add("/workspace/scripts/bazel-run.sh");
+    expectedCommandLine.add("--define");
+    expectedCommandLine.add("flutter_build_mode=debug");
+    expectedCommandLine.add("bazel_target");
+    expectedCommandLine.add("--");
     expectedCommandLine.add("--machine");
     expectedCommandLine.add("-d");
     expectedCommandLine.add("android-tester");
-    expectedCommandLine.add("bazel_target");
     assertThat(launchCommand.getCommandLineList(null), equalTo(expectedCommandLine));
   }
 
@@ -271,12 +298,14 @@ public class LaunchCommandsTest {
     final GeneralCommandLine launchCommand = fields.getLaunchCommand(projectFixture.getProject(), device, RunMode.RUN);
 
     final List<String> expectedCommandLine = new ArrayList<>();
-    expectedCommandLine.add("/workspace/scripts/flutter-run.sh");
-    expectedCommandLine.add("--bazel-options=--define=flutter_build_mode=debug");
+    expectedCommandLine.add("/workspace/scripts/bazel-run.sh");
+    expectedCommandLine.add("--define");
+    expectedCommandLine.add("flutter_build_mode=debug");
+    expectedCommandLine.add("bazel_target");
+    expectedCommandLine.add("--");
     expectedCommandLine.add("--machine");
     expectedCommandLine.add("-d");
     expectedCommandLine.add("android-tester");
-    expectedCommandLine.add("bazel_target");
     assertThat(launchCommand.getCommandLineList(null), equalTo(expectedCommandLine));
   }
 
@@ -288,12 +317,15 @@ public class LaunchCommandsTest {
     final GeneralCommandLine launchCommand = fields.getLaunchCommand(projectFixture.getProject(), device, RunMode.RUN);
 
     final List<String> expectedCommandLine = new ArrayList<>();
-    expectedCommandLine.add("/workspace/scripts/flutter-run.sh");
-    expectedCommandLine.add("--bazel-options=--define=flutter_build_mode=debug");
+    expectedCommandLine.add("/workspace/scripts/bazel-run.sh");
+    expectedCommandLine.add("--define");
+    expectedCommandLine.add("flutter_build_mode=debug");
+    expectedCommandLine.add("--ios_multi_cpus=arm64");
+    expectedCommandLine.add("bazel_target");
+    expectedCommandLine.add("--");
     expectedCommandLine.add("--machine");
     expectedCommandLine.add("-d");
     expectedCommandLine.add("ios-tester");
-    expectedCommandLine.add("bazel_target");
     assertThat(launchCommand.getCommandLineList(null), equalTo(expectedCommandLine));
   }
 
@@ -305,12 +337,15 @@ public class LaunchCommandsTest {
     final GeneralCommandLine launchCommand = fields.getLaunchCommand(projectFixture.getProject(), device, RunMode.RUN);
 
     final List<String> expectedCommandLine = new ArrayList<>();
-    expectedCommandLine.add("/workspace/scripts/flutter-run.sh");
-    expectedCommandLine.add("--bazel-options=--define=flutter_build_mode=debug");
+    expectedCommandLine.add("/workspace/scripts/bazel-run.sh");
+    expectedCommandLine.add("--define");
+    expectedCommandLine.add("flutter_build_mode=debug");
+    expectedCommandLine.add("--ios_multi_cpus=x86_64");
+    expectedCommandLine.add("bazel_target");
+    expectedCommandLine.add("--");
     expectedCommandLine.add("--machine");
     expectedCommandLine.add("-d");
     expectedCommandLine.add("ios-tester");
-    expectedCommandLine.add("bazel_target");
     assertThat(launchCommand.getCommandLineList(null), equalTo(expectedCommandLine));
   }
 
@@ -347,12 +382,11 @@ public class LaunchCommandsTest {
                     @Nullable String doctorScript,
                     @Nullable String launchScript,
                     @Nullable String testScript,
-                    @Nullable String runScript,
                     @Nullable String sdkHome,
                     @Nullable String versionFile) {
       super(template);
       final Pair.NonNull<MockVirtualFileSystem, Workspace> pair = FakeWorkspaceFactory
-        .createWorkspaceAndFilesystem(daemonScript, doctorScript, launchScript, testScript, runScript, sdkHome, versionFile, null);
+        .createWorkspaceAndFilesystem(daemonScript, doctorScript, launchScript, testScript, sdkHome, versionFile, null);
       fs = pair.first;
       fakeWorkspace = pair.second;
     }

--- a/testSrc/unit/io/flutter/run/bazelTest/BazelTestConfigProducerTest.java
+++ b/testSrc/unit/io/flutter/run/bazelTest/BazelTestConfigProducerTest.java
@@ -166,7 +166,7 @@ public class BazelTestConfigProducerTest extends AbstractDartElementTest {
       fs.file("/workspace/WORKSPACE", "");
       fakeWorkspace = Workspace.forTest(
         fs.findFileByPath("/workspace/"),
-        PluginConfig.forTest("", "", "", "", "", "", "", "")
+        PluginConfig.forTest("", "", "", "", "", "", "")
       );
       this.hasWorkspace = hasWorkspace;
       this.hasValidTestFile = hasValidTestFile;

--- a/testSrc/unit/io/flutter/run/bazelTest/LaunchCommandsTest.java
+++ b/testSrc/unit/io/flutter/run/bazelTest/LaunchCommandsTest.java
@@ -181,7 +181,6 @@ public class LaunchCommandsTest {
       "scripts/launch.sh",
       null,
       null,
-      null,
       null
     );
     final GeneralCommandLine launchCommand = fields.getLaunchCommand(projectFixture.getProject(), RunMode.RUN);
@@ -201,7 +200,6 @@ public class LaunchCommandsTest {
       "scripts/daemon.sh",
       "scripts/doctor.sh",
       "scripts/launch.sh",
-      null,
       null,
       null,
       null
@@ -227,7 +225,6 @@ public class LaunchCommandsTest {
       "scripts/launch.sh",
       null,
       null,
-      null,
       null
     );
     boolean didThrow = false;
@@ -249,7 +246,6 @@ public class LaunchCommandsTest {
       "scripts/launch.sh",
       null,
       null,
-      null,
       null
     );
     boolean didThrow = false;
@@ -269,7 +265,6 @@ public class LaunchCommandsTest {
       "scripts/daemon.sh",
       "scripts/doctor.sh",
       "scripts/launch.sh",
-      null,
       null,
       null,
       null
@@ -328,12 +323,11 @@ public class LaunchCommandsTest {
                         @Nullable String doctorScript,
                         @Nullable String launchScript,
                         @Nullable String testScript,
-                        @Nullable String runScript,
                         @Nullable String sdkHome,
                         @Nullable String versionFile) {
       super(template);
       final Pair.NonNull<MockVirtualFileSystem, Workspace> pair = FakeWorkspaceFactory
-        .createWorkspaceAndFilesystem(daemonScript, doctorScript, launchScript, testScript, runScript, sdkHome, versionFile, null);
+        .createWorkspaceAndFilesystem(daemonScript, doctorScript, launchScript, testScript, sdkHome, versionFile, null);
       fs = pair.first;
       fakeWorkspace = pair.second;
     }


### PR DESCRIPTION
Reverts flutter/flutter-intellij#5046

I need to temporarily revert this because the compiled version of the runScript hasn't been updated for necessary changes yet. The changes will be included in the next compiled version sometime this week.

TBR @jacob314 @stevemessick 