### PR TITLE
Use OFF_SCREEN render mode for windows

### DIFF
--- a/src/io/flutter/jxbrowser/EmbeddedBrowser.java
+++ b/src/io/flutter/jxbrowser/EmbeddedBrowser.java
@@ -9,6 +9,7 @@ import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.SystemInfo;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.ui.content.Content;
 import com.intellij.ui.content.ContentManager;
@@ -27,6 +28,7 @@ import java.nio.file.Paths;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.teamdev.jxbrowser.engine.RenderingMode.HARDWARE_ACCELERATED;
+import static com.teamdev.jxbrowser.engine.RenderingMode.OFF_SCREEN;
 
 public class EmbeddedBrowser {
   private static final Logger LOG = Logger.getInstance(JxBrowserManager.class);
@@ -43,7 +45,7 @@ public class EmbeddedBrowser {
     LOG.info("JxBrowser user data path: " + dataPath);
 
     final EngineOptions options =
-      EngineOptions.newBuilder(HARDWARE_ACCELERATED)
+      EngineOptions.newBuilder(SystemInfo.isWindows ? OFF_SCREEN : HARDWARE_ACCELERATED)
         .userDataDir(Paths.get(dataPath))
         .build();
     final Engine engine = Engine.newInstance(options);


### PR DESCRIPTION
This render mode has comparable FPS performance to hardware-accelerated: https://jxbrowser-support.teamdev.com/docs/guides/browser-view.html#off-screen

Hopefully this fixes the issues where the embedded browser shows up in the wrong place (e.g. https://github.com/flutter/flutter-intellij/issues/5042)