### PR TITLE
Use existing devtools for bazel in panel and remove opening devtools for tests

### DIFF
--- a/src/io/flutter/FlutterUtils.java
+++ b/src/io/flutter/FlutterUtils.java
@@ -37,7 +37,6 @@ import com.jetbrains.lang.dart.DartFileType;
 import com.jetbrains.lang.dart.psi.DartFile;
 import io.flutter.pub.PubRoot;
 import io.flutter.pub.PubRootCache;
-import io.flutter.run.daemon.FlutterApp;
 import io.flutter.utils.AndroidUtils;
 import io.flutter.utils.FlutterModuleUtils;
 import org.jetbrains.annotations.NotNull;
@@ -55,7 +54,6 @@ import java.io.InputStreamReader;
 import java.nio.file.Paths;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Properties;
 import java.util.regex.Pattern;
 
@@ -572,9 +570,5 @@ public class FlutterUtils {
   // SystemInfo check for Big Sur is not available for earlier IntelliJ versions.
   public static boolean isMacOsBigSur() {
     return SystemInfo.isMac && (SystemInfo.isOsVersionAtLeast("11.0") || SystemInfo.isOsVersionAtLeast("10.16"));
-  }
-
-  public static Optional<FlutterApp> findFlutterAppFromProject(@NotNull Project project) {
-    return FlutterApp.allFromProjectProcess(project).stream().filter((FlutterApp app) -> app.getProject() == project).findFirst();
   }
 }

--- a/src/io/flutter/FlutterUtils.java
+++ b/src/io/flutter/FlutterUtils.java
@@ -37,6 +37,7 @@ import com.jetbrains.lang.dart.DartFileType;
 import com.jetbrains.lang.dart.psi.DartFile;
 import io.flutter.pub.PubRoot;
 import io.flutter.pub.PubRootCache;
+import io.flutter.run.daemon.FlutterApp;
 import io.flutter.utils.AndroidUtils;
 import io.flutter.utils.FlutterModuleUtils;
 import org.jetbrains.annotations.NotNull;
@@ -54,6 +55,7 @@ import java.io.InputStreamReader;
 import java.nio.file.Paths;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.regex.Pattern;
 
@@ -570,5 +572,9 @@ public class FlutterUtils {
   // SystemInfo check for Big Sur is not available for earlier IntelliJ versions.
   public static boolean isMacOsBigSur() {
     return SystemInfo.isMac && (SystemInfo.isOsVersionAtLeast("11.0") || SystemInfo.isOsVersionAtLeast("10.16"));
+  }
+
+  public static Optional<FlutterApp> findFlutterAppFromProject(@NotNull Project project) {
+    return FlutterApp.allFromProjectProcess(project).stream().filter((FlutterApp app) -> app.getProject() == project).findFirst();
   }
 }

--- a/src/io/flutter/devtools/DevToolsManager.java
+++ b/src/io/flutter/devtools/DevToolsManager.java
@@ -190,18 +190,19 @@ public class DevToolsManager {
   public void openBrowserIntoPanel(String uri, ContentManager contentManager, String tabName, String pageName) {
     final String screen = null;
 
-    if (devToolsInstance != null) {
-      devToolsInstance.openPanel(project, uri, contentManager, tabName, pageName);
+    if (isBazel(project)) {
+      try {
+        getDevToolsInstance().get(15, TimeUnit.SECONDS).openPanel(project, uri, contentManager, tabName, pageName);
+      }
+      catch (Exception e) {
+        LOG.info("Failed to get existing devToolsInstance");
+      }
     }
     else {
-      if (isBazel(project)) {
-        try {
-          devToolsInstance = getDevToolsInstance().get(15, TimeUnit.SECONDS);
-          devToolsInstance.openPanel(project, uri, contentManager, tabName, pageName);
-        } catch (Exception e) {
-          LOG.info("Failed to get existing devToolsInstance");
-        }
-      } else {
+      if (devToolsInstance != null) {
+        devToolsInstance.openPanel(project, uri, contentManager, tabName, pageName);
+      }
+      else {
         @Nullable final OSProcessHandler handler = getProcessHandlerForPub();
 
         if (handler != null) {
@@ -220,20 +221,19 @@ public class DevToolsManager {
   }
 
   private void openBrowserImpl(String uri, String screen) {
-    if (devToolsInstance != null) {
-      devToolsInstance.openBrowserAndConnect(uri, screen);
+    // For internal users, we can connect to the DevTools server started by flutter daemon. For external users, the flutter daemon has an
+    // older version of DevTools, so we launch the server using `pub global run` instead.
+    if (isBazel(project)) {
+      try {
+        getDevToolsInstance().get(15, TimeUnit.SECONDS).openBrowserAndConnect(uri, screen);
+      }
+      catch (Exception e) {
+        LOG.info("Failed to get existing devToolsInstance");
+      }
     }
     else {
-      // For internal users, we can connect to the DevTools server started by flutter daemon. For external users, the flutter daemon has an
-      // older version of DevTools, so we launch the server using `pub global run` instead.
-      if (isBazel(project)) {
-        try {
-          devToolsInstance = getDevToolsInstance().get(15, TimeUnit.SECONDS);
-          devToolsInstance.openBrowserAndConnect(uri, screen);
-        }
-        catch (Exception e) {
-          LOG.info("Failed to get existing devToolsInstance");
-        }
+      if (devToolsInstance != null) {
+        devToolsInstance.openBrowserAndConnect(uri, screen);
       }
       else {
         @Nullable final OSProcessHandler handler = getProcessHandlerForPub();

--- a/src/io/flutter/devtools/DevToolsManager.java
+++ b/src/io/flutter/devtools/DevToolsManager.java
@@ -221,6 +221,10 @@ public class DevToolsManager {
   }
 
   private void openBrowserImpl(Optional<FlutterApp> appOptional, String uri, String screen) {
+    // do it differently for test - maybe just launch other way?
+    // make sure daemon is separate and not using daemon from app if app/test running simultaneously
+    // are people running devtools from test (should we support at all?) ask on devexp
+
     // For internal users, we can connect to the DevTools server started by flutter daemon. For external users, the flutter daemon has an
     // older version of DevTools, so we launch the server using `pub global run` instead.
     if (isBazel(project)) {

--- a/src/io/flutter/devtools/DevToolsManager.java
+++ b/src/io/flutter/devtools/DevToolsManager.java
@@ -247,7 +247,7 @@ public class DevToolsManager {
     final Optional<FlutterApp> appsOptional =
       FlutterApp.allFromProjectProcess(project).stream().filter((FlutterApp app) -> app.getProject() == project).findFirst();
 
-    if (appsOptional.isEmpty()) {
+    if (!appsOptional.isPresent()) {
       LOG.error("DevTools cannot be opened because the app has been closed");
       instance.complete(null);
       return instance;

--- a/src/io/flutter/run/FlutterDebugProcess.java
+++ b/src/io/flutter/run/FlutterDebugProcess.java
@@ -124,7 +124,7 @@ public class FlutterDebugProcess extends DartVmServiceDebugProcess {
     topToolbar.addAction(new ReloadFlutterApp(app, canReload));
     topToolbar.addAction(new RestartFlutterApp(app, canReload));
     topToolbar.addSeparator();
-    topToolbar.addAction(new OpenDevToolsAction(app.getConnector(), debugUrlAvailable));
+    topToolbar.addAction(new OpenDevToolsAction(app, debugUrlAvailable));
 
     settings.addAction(new ReloadAllFlutterApps(app, canReload));
     settings.addAction(new RestartAllFlutterApps(app, canReload));

--- a/src/io/flutter/run/LaunchState.java
+++ b/src/io/flutter/run/LaunchState.java
@@ -234,7 +234,7 @@ public class LaunchState extends CommandLineState {
     final List<AnAction> actions = new ArrayList<>(Arrays.asList(
       super.createActions(console, app.getProcessHandler(), getEnvironment().getExecutor())));
     actions.add(new Separator());
-    actions.add(new OpenDevToolsAction(app.getConnector(), observatoryAvailable));
+    actions.add(new OpenDevToolsAction(app, observatoryAvailable));
 
     return new DefaultExecutionResult(console, app.getProcessHandler(), actions.toArray(new AnAction[0]));
   }

--- a/src/io/flutter/run/OpenDevToolsAction.java
+++ b/src/io/flutter/run/OpenDevToolsAction.java
@@ -10,11 +10,14 @@ import com.intellij.openapi.project.DumbAwareAction;
 import com.intellij.openapi.util.Computable;
 import icons.FlutterIcons;
 import io.flutter.FlutterInitializer;
+import io.flutter.FlutterUtils;
 import io.flutter.ObservatoryConnector;
 import io.flutter.devtools.DevToolsManager;
+import io.flutter.run.daemon.FlutterApp;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 public class OpenDevToolsAction extends DumbAwareAction {
@@ -53,13 +56,15 @@ public class OpenDevToolsAction extends DumbAwareAction {
 
     final DevToolsManager devToolsManager = DevToolsManager.getInstance(event.getProject());
 
+    final Optional<FlutterApp> appOptional = FlutterUtils.findFlutterAppFromProject(event.getProject());
+
     if (myConnector == null) {
       if (devToolsManager.hasInstalledDevTools()) {
-        devToolsManager.openBrowser();
+        devToolsManager.openBrowser(appOptional);
       }
       else {
         final CompletableFuture<Boolean> result = devToolsManager.installDevTools();
-        result.thenAccept(o -> devToolsManager.openBrowser());
+        result.thenAccept(o -> devToolsManager.openBrowser(appOptional));
       }
     }
     else {
@@ -69,11 +74,11 @@ public class OpenDevToolsAction extends DumbAwareAction {
       }
 
       if (devToolsManager.hasInstalledDevTools()) {
-        devToolsManager.openBrowserAndConnect(urlString);
+        devToolsManager.openBrowserAndConnect(appOptional, urlString);
       }
       else {
         final CompletableFuture<Boolean> result = devToolsManager.installDevTools();
-        result.thenAccept(o -> devToolsManager.openBrowserAndConnect(urlString));
+        result.thenAccept(o -> devToolsManager.openBrowserAndConnect(appOptional, urlString));
       }
     }
   }

--- a/src/io/flutter/run/bazelTest/BazelTestDebugProcess.java
+++ b/src/io/flutter/run/bazelTest/BazelTestDebugProcess.java
@@ -39,7 +39,6 @@ public class BazelTestDebugProcess extends DartVmServiceDebugProcess {
                                         @NotNull DefaultActionGroup settings) {
     topToolbar.addSeparator();
     topToolbar.addAction(new FlutterPopFrameAction());
-    topToolbar.addAction(new OpenDevToolsAction(connector, this::isActive));
   }
 
   private boolean isActive() {

--- a/src/io/flutter/run/test/TestDebugProcess.java
+++ b/src/io/flutter/run/test/TestDebugProcess.java
@@ -39,7 +39,6 @@ public class TestDebugProcess extends DartVmServiceDebugProcess {
                                         @NotNull DefaultActionGroup settings) {
     topToolbar.addSeparator();
     topToolbar.addAction(new FlutterPopFrameAction());
-    topToolbar.addAction(new OpenDevToolsAction(connector, this::isActive));
   }
 
   private boolean isActive() {

--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -249,10 +249,10 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
     final String browserUrl = app.getConnector().getBrowserUrl();
 
     if (isEmbedded) {
-      DevToolsManager.getInstance(app.getProject()).openBrowserIntoPanel(browserUrl, contentManager, tabName, "inspector");
+      DevToolsManager.getInstance(app.getProject()).openBrowserIntoPanel(Optional.of(app), browserUrl, contentManager, tabName, "inspector");
     }
     else {
-      DevToolsManager.getInstance(app.getProject()).openBrowserAndConnect(browserUrl, "inspector");
+      DevToolsManager.getInstance(app.getProject()).openBrowserAndConnect(Optional.of(app), browserUrl, "inspector");
       presentLabel(toolWindow, "DevTools inspector has been opened in the browser.");
     }
   }
@@ -804,11 +804,11 @@ class FlutterViewDevToolsAction extends FlutterViewAction {
       final DevToolsManager devToolsManager = DevToolsManager.getInstance(app.getProject());
 
       if (devToolsManager.hasInstalledDevTools()) {
-        devToolsManager.openBrowserAndConnect(urlString);
+        devToolsManager.openBrowserAndConnect(Optional.of(app), urlString);
       }
       else {
         final CompletableFuture<Boolean> result = devToolsManager.installDevTools();
-        result.thenAccept(o -> devToolsManager.openBrowserAndConnect(urlString));
+        result.thenAccept(o -> devToolsManager.openBrowserAndConnect(Optional.of(app), urlString));
       }
     }
   }

--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -249,10 +249,10 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
     final String browserUrl = app.getConnector().getBrowserUrl();
 
     if (isEmbedded) {
-      DevToolsManager.getInstance(app.getProject()).openBrowserIntoPanel(Optional.of(app), browserUrl, contentManager, tabName, "inspector");
+      DevToolsManager.getInstance(app.getProject()).openBrowserIntoPanel(app, browserUrl, contentManager, tabName, "inspector");
     }
     else {
-      DevToolsManager.getInstance(app.getProject()).openBrowserAndConnect(Optional.of(app), browserUrl, "inspector");
+      DevToolsManager.getInstance(app.getProject()).openBrowserAndConnect(app, browserUrl, "inspector");
       presentLabel(toolWindow, "DevTools inspector has been opened in the browser.");
     }
   }
@@ -804,11 +804,11 @@ class FlutterViewDevToolsAction extends FlutterViewAction {
       final DevToolsManager devToolsManager = DevToolsManager.getInstance(app.getProject());
 
       if (devToolsManager.hasInstalledDevTools()) {
-        devToolsManager.openBrowserAndConnect(Optional.of(app), urlString);
+        devToolsManager.openBrowserAndConnect(app, urlString);
       }
       else {
         final CompletableFuture<Boolean> result = devToolsManager.installDevTools();
-        result.thenAccept(o -> devToolsManager.openBrowserAndConnect(Optional.of(app), urlString));
+        result.thenAccept(o -> devToolsManager.openBrowserAndConnect(app, urlString));
       }
     }
   }

--- a/testSrc/unit/io/flutter/view/FlutterViewTest.java
+++ b/testSrc/unit/io/flutter/view/FlutterViewTest.java
@@ -25,7 +25,6 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeoutException;
 
@@ -69,7 +68,7 @@ public class FlutterViewTest {
     when(mockProject.getName()).thenReturn(projectName);
 
     flutterView.handleJxBrowserInstalled(mockApp, mockInspectorService, mockToolWindow);
-    verify(mockDevToolsManager, times(1)).openBrowserIntoPanel(Optional.of(mockApp), testUrl, null, projectName, "inspector");
+    verify(mockDevToolsManager, times(1)).openBrowserIntoPanel(mockApp, testUrl, null, projectName, "inspector");
   }
 
   @Test
@@ -98,7 +97,7 @@ public class FlutterViewTest {
 
     partialMockFlutterView.handleJxBrowserInstalled(mockApp, mockInspectorService, mockToolWindow);
     verify(partialMockFlutterView, times(1)).presentLabel(mockToolWindow, INSTALLING_DEVTOOLS_LABEL);
-    verify(mockDevToolsManager, times(1)).openBrowserIntoPanel(Optional.of(mockApp), testUrl, null, projectName, "inspector");
+    verify(mockDevToolsManager, times(1)).openBrowserIntoPanel(mockApp, testUrl, null, projectName, "inspector");
   }
 
   @Test

--- a/testSrc/unit/io/flutter/view/FlutterViewTest.java
+++ b/testSrc/unit/io/flutter/view/FlutterViewTest.java
@@ -25,6 +25,7 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeoutException;
 
@@ -68,7 +69,7 @@ public class FlutterViewTest {
     when(mockProject.getName()).thenReturn(projectName);
 
     flutterView.handleJxBrowserInstalled(mockApp, mockInspectorService, mockToolWindow);
-    verify(mockDevToolsManager, times(1)).openBrowserIntoPanel(testUrl, null, projectName, "inspector");
+    verify(mockDevToolsManager, times(1)).openBrowserIntoPanel(Optional.of(mockApp), testUrl, null, projectName, "inspector");
   }
 
   @Test
@@ -97,7 +98,7 @@ public class FlutterViewTest {
 
     partialMockFlutterView.handleJxBrowserInstalled(mockApp, mockInspectorService, mockToolWindow);
     verify(partialMockFlutterView, times(1)).presentLabel(mockToolWindow, INSTALLING_DEVTOOLS_LABEL);
-    verify(mockDevToolsManager, times(1)).openBrowserIntoPanel(testUrl, null, projectName, "inspector");
+    verify(mockDevToolsManager, times(1)).openBrowserIntoPanel(Optional.of(mockApp), testUrl, null, projectName, "inspector");
   }
 
   @Test


### PR DESCRIPTION
We're currently launching a new devtools server when opening the embedded browser, but for bazel projects it is faster to use the existing devtools server.