### PR TITLE
Add dispatch events to run actions

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -5,7 +5,7 @@
 # found in the LICENSE file.
 
 name: presubmit
-on: [push]
+on: [push, pull_request_target, workflow_dispatch]
 jobs:
   presubmit:
     runs-on: ubuntu-latest

--- a/.github/workflows/presubmit.yaml.template
+++ b/.github/workflows/presubmit.yaml.template
@@ -3,7 +3,7 @@
 # found in the LICENSE file.
 
 name: presubmit
-on: [push]
+on: [push, pull_request_target, workflow_dispatch]
 jobs:
   presubmit:
     runs-on: ubuntu-latest

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -5,7 +5,7 @@
 # Use separate workflow for Windows so it can be disabled if needed.
 # https://docs.github.com/en/free-pro-team@latest/actions/managing-workflow-runs/disabling-and-enabling-a-workflow
 name: windows
-on: [push]
+on: [push, pull_request_target, workflow_dispatch]
 jobs:
   unit-tests:
     runs-on: windows-latest

--- a/src/io/flutter/module/settings/PlatformsForm.kt
+++ b/src/io/flutter/module/settings/PlatformsForm.kt
@@ -1,0 +1,2 @@
+package io.flutter.module.settings
+

--- a/src/io/flutter/module/settings/PlatformsForm.kt
+++ b/src/io/flutter/module/settings/PlatformsForm.kt
@@ -1,2 +1,0 @@
-package io.flutter.module.settings
-


### PR DESCRIPTION
The `pull_request_target` should allow actions to run as expected on repo forks. The `workflow_dispatch` is supposed to enable manual triggering from the github UI.