### PR TITLE
Move launching of Android Studio off EDT onto a background thread

### DIFF
--- a/src/io/flutter/sdk/FlutterSdk.java
+++ b/src/io/flutter/sdk/FlutterSdk.java
@@ -501,11 +501,13 @@ public class FlutterSdk {
         }
 
         final JsonObject obj = elem.getAsJsonObject();
-        final JsonPrimitive primitive = obj.getAsJsonPrimitive(key);
-        if (primitive != null) {
-          cachedConfigValues.put(key, stdout);
-          return cachedConfigValues.get(key);
+        for (String jsonKey : obj.keySet()) {
+          final JsonPrimitive primitive = obj.getAsJsonPrimitive(jsonKey);
+          if (primitive != null) {
+            cachedConfigValues.put(jsonKey, primitive.getAsString());
+          }
         }
+        return cachedConfigValues.get(key);
       }
       catch (JsonSyntaxException ignored) {
       }


### PR DESCRIPTION
Also fixes a json parsing error I introduced in my previous PR, along with some logging to help decipher launch failures.