### PR TITLE
Run devtools panel actions on UI thread

### DIFF
--- a/src/io/flutter/devtools/DevToolsManager.java
+++ b/src/io/flutter/devtools/DevToolsManager.java
@@ -251,13 +251,8 @@ public class DevToolsManager {
         }
       }
       else {
-        if (devToolsInstance != null) {
-          devToolsInstance.openBrowserAndConnect(uri, screen);
-        }
-        else {
-          @Nullable final OSProcessHandler handler = getProcessHandlerForPub();
-          startDevToolsServerAndConnect(handler, uri, screen);
-        }
+        @Nullable final OSProcessHandler handler = getProcessHandlerForPub();
+        startDevToolsServerAndConnect(handler, uri, screen);
       }
     });
   }

--- a/src/io/flutter/devtools/DevToolsManager.java
+++ b/src/io/flutter/devtools/DevToolsManager.java
@@ -190,6 +190,10 @@ public class DevToolsManager {
 
   public void openBrowserIntoPanel(FlutterApp app, String uri, ContentManager contentManager, String tabName, String pageName) {
     ApplicationManager.getApplication().executeOnPooledThread(() -> {
+      if (!project.isOpen()) {
+        return;
+      }
+
       final String screen = null;
 
       if (devToolsInstance != null) {
@@ -231,6 +235,10 @@ public class DevToolsManager {
     }
 
     ApplicationManager.getApplication().executeOnPooledThread(() -> {
+      if (!project.isOpen()) {
+        return;
+      }
+
       // For internal users, we can connect to the DevTools server started by flutter daemon. For external users, the flutter daemon has an
       // older version of DevTools, so we launch the server using `pub global run` instead.
       if (isBazel(project)) {
@@ -382,6 +390,10 @@ class DevToolsInstance {
   }
 
   public void openPanel(Project project, String serviceProtocolUri, ContentManager contentManager, String tabName, String pageName) {
+    if (!project.isOpen()) {
+      return;
+    }
+
     final String color = ColorUtil.toHex(UIUtil.getEditorPaneBackground());
     final String url = DevToolsUtils.generateDevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, pageName, true, color);
 

--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -428,15 +428,18 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
   }
 
   private void presentDevTools(FlutterApp app, InspectorService inspectorService, ToolWindow toolWindow, boolean isEmbedded) {
+    assert(SwingUtilities.isEventDispatchThread());
     final DevToolsManager devToolsManager = DevToolsManager.getInstance(app.getProject());
 
     if (devToolsManager.hasInstalledDevTools()) {
-      AsyncUtils.invokeLater(() -> addBrowserInspectorViewContent(app, inspectorService, toolWindow, isEmbedded));
+      addBrowserInspectorViewContent(app, inspectorService, toolWindow, isEmbedded);
     }
     else {
       presentLabel(toolWindow, INSTALLING_DEVTOOLS_LABEL);
-      final CompletableFuture<Boolean> result = devToolsManager.installDevTools();
-      awaitDevToolsInstall(app, inspectorService, toolWindow, isEmbedded, result);
+      ApplicationManager.getApplication().executeOnPooledThread(() -> {
+        final CompletableFuture<Boolean> result = devToolsManager.installDevTools();
+        awaitDevToolsInstall(app, inspectorService, toolWindow, isEmbedded, result);
+      });
     }
   }
 

--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -57,6 +57,7 @@ import io.flutter.utils.EventStream;
 import io.flutter.utils.JxBrowserUtils;
 import io.flutter.utils.VmServiceListenerAdapter;
 import io.flutter.vmService.ServiceExtensions;
+import org.apache.commons.lang3.BooleanUtils;
 import org.dartlang.vm.service.VmService;
 import org.dartlang.vm.service.element.Event;
 import org.jetbrains.annotations.NotNull;
@@ -441,14 +442,15 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
 
   protected void awaitDevToolsInstall(FlutterApp app, InspectorService inspectorService, ToolWindow toolWindow, boolean isEmbedded, CompletableFuture<Boolean> installResult) {
     AsyncUtils.whenCompleteUiThread(installResult, (succeeded, throwable) -> {
-      if (succeeded) {
+      if (throwable != null) {
+        LOG.error(throwable);
+        return;
+      }
+      if (BooleanUtils.isTrue(succeeded)) {
         addBrowserInspectorViewContent(app, inspectorService, toolWindow, isEmbedded);
       } else {
         // TODO(helin24): Handle with alternative instructions if devtools fails.
         presentLabel(toolWindow, DEVTOOLS_FAILED_LABEL);
-        if (throwable != null) {
-          LOG.error(throwable);
-        }
       }
     });
   }

--- a/testSrc/unit/io/flutter/view/FlutterViewTest.java
+++ b/testSrc/unit/io/flutter/view/FlutterViewTest.java
@@ -25,6 +25,7 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import javax.swing.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeoutException;
 
@@ -34,7 +35,7 @@ import static org.powermock.api.mockito.PowerMockito.when;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({DevToolsManager.class, JxBrowserManager.class, ThreadUtil.class, FlutterInitializer.class, JxBrowserUtils.class,
-  InspectorGroupManagerService.class})
+  InspectorGroupManagerService.class, SwingUtilities.class})
 public class FlutterViewTest {
   @Mock Project mockProject;
   @Mock FlutterApp mockApp;
@@ -56,6 +57,9 @@ public class FlutterViewTest {
 
     PowerMockito.mockStatic(InspectorGroupManagerService.class);
     when(InspectorGroupManagerService.getInstance(mockProject)).thenReturn(mockInspectorGroupManagerService);
+
+    PowerMockito.mockStatic(SwingUtilities.class);
+    when(SwingUtilities.isEventDispatchThread()).thenReturn(true);
 
     final FlutterView flutterView = new FlutterView(mockProject);
 
@@ -81,6 +85,9 @@ public class FlutterViewTest {
     final FlutterView partialMockFlutterView = mock(FlutterView.class);
     doCallRealMethod().when(partialMockFlutterView).handleJxBrowserInstalled(mockApp, mockInspectorService, mockToolWindow);
 
+    PowerMockito.mockStatic(SwingUtilities.class);
+    when(SwingUtilities.isEventDispatchThread()).thenReturn(true);
+
     PowerMockito.mockStatic(DevToolsManager.class);
     when(DevToolsManager.getInstance(mockProject)).thenReturn(mockDevToolsManager);
     when(mockDevToolsManager.hasInstalledDevTools()).thenReturn(false);
@@ -92,7 +99,7 @@ public class FlutterViewTest {
 
     partialMockFlutterView.handleJxBrowserInstalled(mockApp, mockInspectorService, mockToolWindow);
     verify(partialMockFlutterView, times(1)).presentLabel(mockToolWindow, INSTALLING_DEVTOOLS_LABEL);
-    verify(partialMockFlutterView, times(1)).awaitDevToolsInstall(mockApp, mockInspectorService, mockToolWindow, true, result);
+    verify(partialMockFlutterView, times(1)).awaitDevToolsInstall(mockApp, mockInspectorService, mockToolWindow, true, mockDevToolsManager);
   }
 
   @Test

--- a/testSrc/unit/io/flutter/view/FlutterViewTest.java
+++ b/testSrc/unit/io/flutter/view/FlutterViewTest.java
@@ -72,7 +72,7 @@ public class FlutterViewTest {
   }
 
   @Test
-  public void testHandleJxBrowserInstalledWithDevtoolsSucceeded() {
+  public void testHandleJxBrowserInstalledWithoutDevtools() {
     // If JxBrowser has been installed but we have to wait for DevTools to install, we should show a message about DevTools and then open
     // the embedded browser when DevTools is ready.
     final String testUrl = "http://www.testUrl.com";
@@ -88,44 +88,11 @@ public class FlutterViewTest {
     result.complete(true);
     when(mockDevToolsManager.installDevTools()).thenReturn(result);
 
-    when(mockApp.getConnector()).thenReturn(mockObservatoryConnector);
-    when(mockObservatoryConnector.getBrowserUrl()).thenReturn(testUrl);
-    when(mockToolWindow.getContentManager()).thenReturn(null);
-    when(mockApp.device()).thenReturn(null);
     when(mockApp.getProject()).thenReturn(mockProject);
-    when(mockProject.getName()).thenReturn(projectName);
 
     partialMockFlutterView.handleJxBrowserInstalled(mockApp, mockInspectorService, mockToolWindow);
     verify(partialMockFlutterView, times(1)).presentLabel(mockToolWindow, INSTALLING_DEVTOOLS_LABEL);
-    verify(mockDevToolsManager, times(1)).openBrowserIntoPanel(mockApp, testUrl, null, projectName, "inspector");
-  }
-
-  @Test
-  public void testHandleJxBrowserInstalledWithDevtoolsFailed() {
-    // If JxBrowser has been installed but DevTools fails to install, then we want to show a status message followed by a failure message.
-    final String testUrl = "http://www.testUrl.com";
-    final String projectName = "Test Project Name";
-
-    final FlutterView partialMockFlutterView = mock(FlutterView.class);
-    doCallRealMethod().when(partialMockFlutterView).handleJxBrowserInstalled(mockApp, mockInspectorService, mockToolWindow);
-
-    PowerMockito.mockStatic(DevToolsManager.class);
-    when(DevToolsManager.getInstance(mockProject)).thenReturn(mockDevToolsManager);
-    when(mockDevToolsManager.hasInstalledDevTools()).thenReturn(false);
-    final CompletableFuture<Boolean> result = new CompletableFuture<>();
-    result.complete(false);
-    when(mockDevToolsManager.installDevTools()).thenReturn(result);
-
-    when(mockApp.getConnector()).thenReturn(mockObservatoryConnector);
-    when(mockObservatoryConnector.getBrowserUrl()).thenReturn(testUrl);
-    when(mockToolWindow.getContentManager()).thenReturn(null);
-    when(mockApp.device()).thenReturn(null);
-    when(mockApp.getProject()).thenReturn(mockProject);
-    when(mockProject.getName()).thenReturn(projectName);
-
-    partialMockFlutterView.handleJxBrowserInstalled(mockApp, mockInspectorService, mockToolWindow);
-    verify(partialMockFlutterView, times(1)).presentLabel(mockToolWindow, INSTALLING_DEVTOOLS_LABEL);
-    verify(partialMockFlutterView, times(1)).presentLabel(mockToolWindow, DEVTOOLS_FAILED_LABEL);
+    verify(partialMockFlutterView, times(1)).awaitDevToolsInstall(mockApp, mockInspectorService, mockToolWindow, true, result);
   }
 
   @Test


### PR DESCRIPTION
May fix https://github.com/flutter/flutter-intellij/issues/5032

`addBrowserInspectorViewContent` should be run on the UI thread since it removes content from the panel and `app.getConnector().getBrowserUrl()` may be inaccurate when not run on the UI thread.

However, `DevToolsManager::openBrowserIntoPanel` has some actions that should be run on a non-UI thread since we have to wait for the devtools server to start.