### PR TITLE
Remove launch script and devtools script

### DIFF
--- a/src/io/flutter/bazel/PluginConfig.java
+++ b/src/io/flutter/bazel/PluginConfig.java
@@ -45,11 +45,6 @@ public class PluginConfig {
   }
 
   @Nullable
-  String getLaunchScript() {
-    return fields.launchScript;
-  }
-
-  @Nullable
   String getTestScript() {
     return fields.testScript;
   }
@@ -72,11 +67,6 @@ public class PluginConfig {
   @Nullable
   String getVersionFile() {
     return fields.versionFile;
-  }
-
-  @Nullable
-  String getDevtoolsScript() {
-    return fields.devtoolsScript;
   }
 
   @Override
@@ -131,24 +121,20 @@ public class PluginConfig {
   public static PluginConfig forTest(
     @Nullable String daemonScript,
     @Nullable String doctorScript,
-    @Nullable String launchScript,
     @Nullable String testScript,
     @Nullable String runScript,
     @Nullable String syncScript,
     @Nullable String sdkHome,
-    @Nullable String versionFile,
-    @Nullable String devtoolsScript
+    @Nullable String versionFile
   ) {
     final Fields fields = new Fields(
       daemonScript,
       doctorScript,
-      launchScript,
       testScript,
       runScript,
       syncScript,
       sdkHome,
-      versionFile,
-      devtoolsScript
+      versionFile
     );
     return new PluginConfig(fields);
   }
@@ -168,12 +154,6 @@ public class PluginConfig {
      */
     @SerializedName("doctorScript")
     private String doctorScript;
-
-    /**
-     * The script to run to start 'bazel'
-     */
-    @SerializedName("launchScript")
-    private String launchScript;
 
     /**
      * The script to run to start 'flutter test'
@@ -205,12 +185,6 @@ public class PluginConfig {
     @SerializedName("versionFile")
     private String versionFile;
 
-    /**
-     * The bazel command to run to launch DevTools.
-     */
-    @SerializedName("devtoolsScript")
-    private String devtoolsScript;
-
     Fields() {
     }
 
@@ -219,22 +193,18 @@ public class PluginConfig {
      */
     Fields(String daemonScript,
            String doctorScript,
-           String launchScript,
            String testScript,
            String runScript,
            String syncScript,
            String sdkHome,
-           String versionFile,
-           String devtoolsScript) {
+           String versionFile) {
       this.daemonScript = daemonScript;
       this.doctorScript = doctorScript;
-      this.launchScript = launchScript;
       this.testScript = testScript;
       this.runScript = runScript;
       this.syncScript = syncScript;
       this.sdkHome = sdkHome;
       this.versionFile = versionFile;
-      this.devtoolsScript = devtoolsScript;
     }
 
     @Override
@@ -243,18 +213,16 @@ public class PluginConfig {
       final Fields other = (Fields)obj;
       return Objects.equal(daemonScript, other.daemonScript)
              && Objects.equal(doctorScript, other.doctorScript)
-             && Objects.equal(launchScript, other.launchScript)
              && Objects.equal(testScript, other.testScript)
              && Objects.equal(runScript, other.runScript)
              && Objects.equal(syncScript, other.syncScript)
              && Objects.equal(sdkHome, other.sdkHome)
-             && Objects.equal(versionFile, other.versionFile)
-             && Objects.equal(devtoolsScript, other.devtoolsScript);
+             && Objects.equal(versionFile, other.versionFile);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hashCode(daemonScript, doctorScript, launchScript, testScript, runScript, syncScript, sdkHome, versionFile, devtoolsScript);
+      return Objects.hashCode(daemonScript, doctorScript, testScript, runScript, syncScript, sdkHome, versionFile);
     }
   }
 

--- a/src/io/flutter/bazel/Workspace.java
+++ b/src/io/flutter/bazel/Workspace.java
@@ -45,7 +45,6 @@ public class Workspace {
   @Nullable private final String syncScript;
   @Nullable private final String sdkHome;
   @Nullable private final String versionFile;
-  @Nullable private final String devtoolsScript;
 
   private Workspace(@NotNull VirtualFile root,
                     @Nullable PluginConfig config,
@@ -55,8 +54,7 @@ public class Workspace {
                     @Nullable String runScript,
                     @Nullable String syncScript,
                     @Nullable String sdkHome,
-                    @Nullable String versionFile,
-                    @Nullable String devtoolsScript) {
+                    @Nullable String versionFile) {
     this.root = root;
     this.config = config;
     this.daemonScript = daemonScript;
@@ -66,7 +64,6 @@ public class Workspace {
     this.syncScript = syncScript;
     this.sdkHome = sdkHome;
     this.versionFile = versionFile;
-    this.devtoolsScript = devtoolsScript;
   }
 
   /**
@@ -135,14 +132,6 @@ public class Workspace {
   }
 
   /**
-   * Returns the script that runs the bazel target for a Flutter app, or null if not configured.
-   */
-  @Nullable
-  public String getLaunchScript() {
-    return (config == null) ? null : config.getLaunchScript();
-  }
-
-  /**
    * Returns the script that starts 'flutter test', or null if not configured.
    */
   @Nullable
@@ -180,14 +169,6 @@ public class Workspace {
   @Nullable
   public String getVersionFile() {
     return versionFile;
-  }
-
-  /**
-   * Returns the bazel target to be run with {@link Workspace#getLaunchScript} to launch DevTools.
-   */
-  @Nullable
-  public String getDevtoolsScript() {
-    return devtoolsScript;
   }
 
   /**
@@ -263,9 +244,7 @@ public class Workspace {
 
     final String versionFile = config == null ? null : getScriptFromPath(root, readonlyPath, config.getVersionFile());
 
-    final String devtoolsScript = config == null ? null : config.getDevtoolsScript();
-
-    return new Workspace(root, config, daemonScript, doctorScript, testScript, runScript, syncScript, sdkHome, versionFile, devtoolsScript);
+    return new Workspace(root, config, daemonScript, doctorScript, testScript, runScript, syncScript, sdkHome, versionFile);
   }
 
   @VisibleForTesting
@@ -279,8 +258,7 @@ public class Workspace {
       pluginConfig.getRunScript(),
       pluginConfig.getSyncScript(),
       pluginConfig.getSdkHome(),
-      pluginConfig.getVersionFile(),
-      pluginConfig.getDevtoolsScript());
+      pluginConfig.getVersionFile());
   }
 
   /**

--- a/src/io/flutter/run/bazelTest/BazelTestFields.java
+++ b/src/io/flutter/run/bazelTest/BazelTestFields.java
@@ -63,14 +63,10 @@ public class BazelTestFields {
 
   private String getTestScriptFromWorkspace(@NotNull Project project) {
     final Workspace workspace = getWorkspace(project);
+    assert workspace != null;
     String testScript = workspace.getTestScript();
-    // Fall back on the regular launch script if the test script is not available.
-    if (testScript == null) {
-      testScript = workspace.getLaunchScript();
-    }
-    if (testScript != null) {
-      testScript = workspace.getRoot().getPath() + "/" + testScript;
-    }
+    assert testScript != null;
+    testScript = workspace.getRoot().getPath() + "/" + testScript;
     return testScript;
   }
 

--- a/testSrc/unit/io/flutter/bazel/FakeWorkspaceFactory.java
+++ b/testSrc/unit/io/flutter/bazel/FakeWorkspaceFactory.java
@@ -18,13 +18,11 @@ public class FakeWorkspaceFactory {
   public static Pair.NonNull<MockVirtualFileSystem, Workspace> createWorkspaceAndFilesystem(
     @Nullable String daemonScript,
     @Nullable String doctorScript,
-    @Nullable String launchScript,
     @Nullable String testScript,
     @Nullable String runScript,
     @Nullable String syncScript,
     @Nullable String sdkHome,
-    @Nullable String versionFile,
-    @Nullable String devtoolsScript
+    @Nullable String versionFile
   ) {
     final MockVirtualFileSystem fs = new MockVirtualFileSystem();
     fs.file("/workspace/WORKSPACE", "");
@@ -33,9 +31,6 @@ public class FakeWorkspaceFactory {
     }
     if (doctorScript != null) {
       fs.file("/workspace/" + doctorScript, "");
-    }
-    if (launchScript != null) {
-      fs.file("/workspace/" + launchScript, "");
     }
     if (testScript != null) {
       fs.file("/workspace/" + testScript, "");
@@ -59,13 +54,11 @@ public class FakeWorkspaceFactory {
         PluginConfig.forTest(
           daemonScript,
           doctorScript,
-          launchScript,
           testScript,
           runScript,
           syncScript,
           sdkHome,
-          versionFile,
-          devtoolsScript
+          versionFile
         )
       )
     );
@@ -81,13 +74,11 @@ public class FakeWorkspaceFactory {
     return createWorkspaceAndFilesystem(
       "scripts/flutter-daemon.sh",
       "scripts/flutter-doctor.sh",
-      "scripts/bazel-run.sh",
       "scripts/flutter-test.sh",
       "scripts/flutter-run.sh",
       "scripts/flutter-sync.sh",
       "scripts/",
-      "flutter-version",
-      "scripts/devtools:server"
+      "flutter-version"
     );
   }
 }

--- a/testSrc/unit/io/flutter/run/bazel/LaunchCommandsTest.java
+++ b/testSrc/unit/io/flutter/run/bazel/LaunchCommandsTest.java
@@ -345,7 +345,6 @@ public class LaunchCommandsTest {
     FakeBazelFields(@NotNull BazelFields template,
                     @Nullable String daemonScript,
                     @Nullable String doctorScript,
-                    @Nullable String launchScript,
                     @Nullable String testScript,
                     @Nullable String runScript,
                     @Nullable String syncScript,
@@ -353,7 +352,7 @@ public class LaunchCommandsTest {
                     @Nullable String versionFile) {
       super(template);
       final Pair.NonNull<MockVirtualFileSystem, Workspace> pair = FakeWorkspaceFactory
-        .createWorkspaceAndFilesystem(daemonScript, doctorScript, launchScript, testScript, runScript, syncScript, sdkHome, versionFile, null);
+        .createWorkspaceAndFilesystem(daemonScript, doctorScript, testScript, runScript, syncScript, sdkHome, versionFile);
       fs = pair.first;
       fakeWorkspace = pair.second;
     }

--- a/testSrc/unit/io/flutter/run/bazelTest/BazelTestConfigProducerTest.java
+++ b/testSrc/unit/io/flutter/run/bazelTest/BazelTestConfigProducerTest.java
@@ -166,7 +166,7 @@ public class BazelTestConfigProducerTest extends AbstractDartElementTest {
       fs.file("/workspace/WORKSPACE", "");
       fakeWorkspace = Workspace.forTest(
         fs.findFileByPath("/workspace/"),
-        PluginConfig.forTest("", "", "", "", "", "", "", "", "")
+        PluginConfig.forTest("", "", "", "", "", "", "")
       );
       this.hasWorkspace = hasWorkspace;
       this.hasValidTestFile = hasValidTestFile;

--- a/testSrc/unit/io/flutter/run/bazelTest/LaunchCommandsTest.java
+++ b/testSrc/unit/io/flutter/run/bazelTest/LaunchCommandsTest.java
@@ -171,62 +171,12 @@ public class LaunchCommandsTest {
     assertThat(launchCommand.getCommandLineList(null), equalTo(expectedCommandLine));
   }
 
-
-  @Test
-  public void producesCorrectCommandLineForBazelTargetWithoutTestScript() throws ExecutionException {
-    final BazelTestFields fields = new FakeBazelTestFields(
-      BazelTestFields.forTarget("//foo:test", null),
-      "scripts/daemon.sh",
-      "scripts/doctor.sh",
-      "scripts/launch.sh",
-      null,
-      null,
-      null,
-      null,
-      null
-    );
-    final GeneralCommandLine launchCommand = fields.getLaunchCommand(projectFixture.getProject(), RunMode.RUN);
-
-    final List<String> expectedCommandLine = new ArrayList<>();
-    expectedCommandLine.add("/workspace/scripts/launch.sh");
-    expectedCommandLine.add("--no-color");
-    expectedCommandLine.add("--machine");
-    expectedCommandLine.add("//foo:test");
-    assertThat(launchCommand.getCommandLineList(null), equalTo(expectedCommandLine));
-  }
-
-  @Test
-  public void producesCorrectCommandLineForBazelTargetWithoutTestScriptInDebugMode() throws ExecutionException {
-    final BazelTestFields fields = new FakeBazelTestFields(
-      BazelTestFields.forTarget("//foo:test", null),
-      "scripts/daemon.sh",
-      "scripts/doctor.sh",
-      "scripts/launch.sh",
-      null,
-      null,
-      null,
-      null,
-      null
-    );
-    final GeneralCommandLine launchCommand = fields.getLaunchCommand(projectFixture.getProject(), RunMode.DEBUG);
-
-    final List<String> expectedCommandLine = new ArrayList<>();
-    expectedCommandLine.add("/workspace/scripts/launch.sh");
-    expectedCommandLine.add("--no-color");
-    expectedCommandLine.add("--machine");
-    expectedCommandLine.add("//foo:test");
-    expectedCommandLine.add("--");
-    expectedCommandLine.add("--enable-debugging");
-    assertThat(launchCommand.getCommandLineList(null), equalTo(expectedCommandLine));
-  }
-
   @Test
   public void failsForFileWithoutTestScript() {
     final BazelTestFields fields = new FakeBazelTestFields(
       BazelTestFields.forFile("/workspace/foo/test/foo_test.dart", null),
       "scripts/daemon.sh",
       "scripts/doctor.sh",
-      "scripts/launch.sh",
       null,
       null,
       null,
@@ -249,7 +199,6 @@ public class LaunchCommandsTest {
       BazelTestFields.forTestName("first test", "/workspace/foo/test/foo_test.dart", null),
       "scripts/daemon.sh",
       "scripts/doctor.sh",
-      "scripts/launch.sh",
       null,
       null,
       null,
@@ -272,7 +221,6 @@ public class LaunchCommandsTest {
       new BazelTestFields(null, "/workspace/foo/test/foo_test.dart", "//foo:test", "--ignored-args"),
       "scripts/daemon.sh",
       "scripts/doctor.sh",
-      "scripts/launch.sh",
       null,
       null,
       null,
@@ -331,7 +279,6 @@ public class LaunchCommandsTest {
     FakeBazelTestFields(@NotNull BazelTestFields template,
                         @Nullable String daemonScript,
                         @Nullable String doctorScript,
-                        @Nullable String launchScript,
                         @Nullable String testScript,
                         @Nullable String runScript,
                         @Nullable String syncScript,
@@ -339,7 +286,7 @@ public class LaunchCommandsTest {
                         @Nullable String versionFile) {
       super(template);
       final Pair.NonNull<MockVirtualFileSystem, Workspace> pair = FakeWorkspaceFactory
-        .createWorkspaceAndFilesystem(daemonScript, doctorScript, launchScript, testScript, runScript, syncScript, sdkHome, versionFile, null);
+        .createWorkspaceAndFilesystem(daemonScript, doctorScript, testScript, runScript, syncScript, sdkHome, versionFile);
       fs = pair.first;
       fakeWorkspace = pair.second;
     }


### PR DESCRIPTION
We don't expect the test script to not be available, so this part has been changed to an assert instead of using a backup launch script.

With this change and a previous change to use `runScript` instead of `launchScript` to run apps, the launch script is no longer used.

Similarly, the devtools script is no longer being used, since bazel projects now use a daemon action to launch devtools.