### PR TITLE
Slight change to github actions

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -5,7 +5,13 @@
 # found in the LICENSE file.
 
 name: presubmit
-on: [push, pull_request_target, workflow_dispatch]
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
 jobs:
   presubmit:
     runs-on: ubuntu-latest
@@ -21,7 +27,7 @@ jobs:
         env:
           IDEA_VERSION: ${{ matrix.version }}
   checker:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
-      - name: linux ${{ matrix.bot }}
+      - name: MacOS ${{ matrix.bot }}
         run: ./tool/github.sh
         env:
           BOT: ${{ matrix.bot }}

--- a/.github/workflows/presubmit.yaml.template
+++ b/.github/workflows/presubmit.yaml.template
@@ -5,8 +5,6 @@
 name: presubmit
 on:
   pull_request:
-    branches:
-      - master
   push:
     branches:
       - master

--- a/.github/workflows/presubmit.yaml.template
+++ b/.github/workflows/presubmit.yaml.template
@@ -33,7 +33,7 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
-      - name: linux ${{ matrix.bot }}
+      - name: MacOS ${{ matrix.bot }}
         run: ./tool/github.sh
         env:
           BOT: ${{ matrix.bot }}

--- a/.github/workflows/presubmit.yaml.template
+++ b/.github/workflows/presubmit.yaml.template
@@ -3,7 +3,15 @@
 # found in the LICENSE file.
 
 name: presubmit
-on: [push, pull_request_target, workflow_dispatch]
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
 jobs:
   presubmit:
     runs-on: ubuntu-latest
@@ -19,7 +27,7 @@ jobs:
         env:
           IDEA_VERSION: ${{ matrix.version }}
   checker:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     strategy:
       fail-fast: true
       matrix:


### PR DESCRIPTION
This restricts Github actions to run on master only. It also switches the unit test bot to run on MacOS.

It is now the same as devtools, with the addition of `workflow_dispatch` to allow manual triggering.