### PR TITLE
Add devtools service

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -1380,6 +1380,8 @@
     <postStartupActivity implementation="io.flutter.FlutterInitializer"/>
     <projectService serviceInterface="io.flutter.run.daemon.DeviceService"
                     serviceImplementation="io.flutter.run.daemon.DeviceService"/>
+    <projectService serviceInterface="io.flutter.run.daemon.DevToolsService"
+                    serviceImplementation="io.flutter.run.daemon.DevToolsService"/>
     <projectService serviceInterface="io.flutter.dart.FlutterDartAnalysisServer"
                     serviceImplementation="io.flutter.dart.FlutterDartAnalysisServer"/>
     <projectService serviceInterface="io.flutter.bazel.WorkspaceCache"

--- a/resources/META-INF/plugin_template.xml
+++ b/resources/META-INF/plugin_template.xml
@@ -244,6 +244,8 @@
     <postStartupActivity implementation="io.flutter.FlutterInitializer"/>
     <projectService serviceInterface="io.flutter.run.daemon.DeviceService"
                     serviceImplementation="io.flutter.run.daemon.DeviceService"/>
+    <projectService serviceInterface="io.flutter.run.daemon.DevToolsService"
+                    serviceImplementation="io.flutter.run.daemon.DevToolsService"/>
     <projectService serviceInterface="io.flutter.dart.FlutterDartAnalysisServer"
                     serviceImplementation="io.flutter.dart.FlutterDartAnalysisServer"/>
     <projectService serviceInterface="io.flutter.bazel.WorkspaceCache"

--- a/src/io/flutter/FlutterInitializer.java
+++ b/src/io/flutter/FlutterInitializer.java
@@ -32,6 +32,7 @@ import io.flutter.pub.PubRoot;
 import io.flutter.pub.PubRoots;
 import io.flutter.run.FlutterReloadManager;
 import io.flutter.run.FlutterRunNotifications;
+import io.flutter.run.daemon.DevToolsService;
 import io.flutter.run.daemon.DeviceService;
 import io.flutter.sdk.FlutterPluginsLibraryManager;
 import io.flutter.settings.FlutterSettings;
@@ -74,6 +75,9 @@ public class FlutterInitializer implements StartupActivity {
 
     // Start watching for devices.
     DeviceService.getInstance(project);
+
+    // Start a DevTools server
+    DevToolsService.getInstance(project);
 
     // Start watching for Flutter debug active events.
     FlutterViewFactory.init(project);

--- a/src/io/flutter/run/daemon/DaemonApi.java
+++ b/src/io/flutter/run/daemon/DaemonApi.java
@@ -73,6 +73,10 @@ public class DaemonApi {
     return send("daemon.getSupportedPlatforms", new DaemonGetSupportedPlatforms(projectRoot));
   }
 
+  CompletableFuture<Boolean> daemonShutdown() {
+    return send("daemon.shutdown", new DaemonShutdown());
+  }
+
   CompletableFuture<RestartResult> restartApp(@NotNull String appId, boolean fullRestart, boolean pause, @NotNull String reason) {
     return send("app.restart", new AppRestart(appId, fullRestart, pause, reason));
   }
@@ -401,6 +405,14 @@ public class DaemonApi {
     @Override
     RestartResult parseResult(JsonElement result) {
       return GSON.fromJson(result, RestartResult.class);
+    }
+  }
+
+  private static class DaemonShutdown extends Params<Boolean> {
+    @Nullable
+    @Override
+    Boolean parseResult(@Nullable JsonElement result) {
+      return true;
     }
   }
 

--- a/src/io/flutter/run/daemon/DaemonApi.java
+++ b/src/io/flutter/run/daemon/DaemonApi.java
@@ -74,13 +74,7 @@ public class DaemonApi {
   }
 
   CompletableFuture<Boolean> daemonShutdown() {
-    return send("daemon.shutdown", new Params<Boolean>() {
-      @Nullable
-      @Override
-      Boolean parseResult(@Nullable JsonElement result) {
-        return true;
-      }
-    });
+    return send("daemon.shutdown", new DaemonShutdown());
   }
 
   CompletableFuture<RestartResult> restartApp(@NotNull String appId, boolean fullRestart, boolean pause, @NotNull String reason) {

--- a/src/io/flutter/run/daemon/DaemonApi.java
+++ b/src/io/flutter/run/daemon/DaemonApi.java
@@ -74,7 +74,13 @@ public class DaemonApi {
   }
 
   CompletableFuture<Boolean> daemonShutdown() {
-    return send("daemon.shutdown", new DaemonShutdown());
+    return send("daemon.shutdown", new Params<Boolean>() {
+      @Nullable
+      @Override
+      Boolean parseResult(@Nullable JsonElement result) {
+        return true;
+      }
+    });
   }
 
   CompletableFuture<RestartResult> restartApp(@NotNull String appId, boolean fullRestart, boolean pause, @NotNull String reason) {

--- a/src/io/flutter/run/daemon/DevToolsService.java
+++ b/src/io/flutter/run/daemon/DevToolsService.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2020 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.run.daemon;
+
+import com.google.common.collect.ImmutableList;
+import com.intellij.execution.ExecutionException;
+import com.intellij.execution.configurations.GeneralCommandLine;
+import com.intellij.execution.process.ProcessHandler;
+import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectManager;
+import com.intellij.openapi.project.ProjectManagerListener;
+import com.intellij.openapi.util.io.FileUtil;
+import com.intellij.openapi.vfs.CharsetToolkit;
+import io.flutter.FlutterUtils;
+import io.flutter.android.IntelliJAndroidSdk;
+import io.flutter.bazel.Workspace;
+import io.flutter.bazel.WorkspaceCache;
+import io.flutter.sdk.FlutterSdk;
+import io.flutter.sdk.FlutterSdkUtil;
+import io.flutter.utils.MostlySilentOsProcessHandler;
+import org.jetbrains.annotations.NotNull;
+
+import static com.jetbrains.lang.dart.ide.runner.server.vmService.VmServiceWrapper.LOG;
+
+public class DevToolsService {
+  private class DevToolsServiceListener implements DaemonEvent.Listener {
+  }
+
+  @NotNull private final Project project;
+  private DaemonApi daemonApi;
+  private ProcessHandler process;
+  private DevToolsInstance devToolsInstance;
+
+  @NotNull
+  public static DevToolsService getInstance(@NotNull final Project project) {
+    return ServiceManager.getService(project, DevToolsService.class);
+  }
+
+  private DevToolsService(@NotNull final Project project) {
+    this.project = project;
+    try {
+      final GeneralCommandLine command = chooseCommand(project);
+      assert command != null;
+      this.process = new MostlySilentOsProcessHandler(command);
+      daemonApi = new DaemonApi(process);
+      daemonApi.listen(process, new DevToolsServiceListener());
+      daemonApi.devToolsServe().thenAccept((DaemonApi.DevToolsAddress address) -> {
+        if (!project.isOpen()) {
+          // We should skip starting DevTools (and doing any UI work) if the project has been closed.
+          return;
+        }
+        if (address == null) {
+          LOG.error("DevTools address was null");
+        }
+        else {
+          devToolsInstance = new DevToolsInstance(address.host, address.port);
+        }
+      });
+    }
+    catch (ExecutionException e) {
+      e.printStackTrace();
+    }
+
+    ProjectManager.getInstance().addProjectManagerListener(project, new ProjectManagerListener() {
+      @Override
+      public void projectClosing(@NotNull Project project) {
+        daemonApi.daemonShutdown();
+        if (!process.isProcessTerminated()) {
+          process.destroyProcess();
+        }
+      }
+    });
+  }
+
+  private static GeneralCommandLine chooseCommand(@NotNull final Project project) {
+    final String androidHome = IntelliJAndroidSdk.chooseAndroidHome(project, false);
+
+    // Use daemon script if this is a bazel project.
+    final Workspace workspace = WorkspaceCache.getInstance(project).get();
+    if (workspace != null) {
+      final String script = workspace.getDaemonScript();
+      if (script != null) {
+        return createCommand(workspace.getRoot().getPath(), script, ImmutableList.of(), androidHome);
+      }
+
+    }
+
+    // Otherwise, use the Flutter SDK.
+    final FlutterSdk sdk = FlutterSdk.getFlutterSdk(project);
+    if (sdk == null) {
+      return null;
+    }
+
+    try {
+      final String path = FlutterSdkUtil.pathToFlutterTool(sdk.getHomePath());
+      return createCommand(sdk.getHomePath(), path, ImmutableList.of("daemon"), androidHome);
+    }
+    catch (ExecutionException e) {
+      FlutterUtils.warn(LOG, "Unable to calculate command to start Flutter daemon", e);
+      return null;
+    }
+  }
+
+  private static GeneralCommandLine createCommand(String workDir, String command, ImmutableList<String> arguments, String androidHome) {
+    final GeneralCommandLine result = new GeneralCommandLine().withWorkDirectory(workDir);
+    result.setCharset(CharsetToolkit.UTF8_CHARSET);
+    result.setExePath(FileUtil.toSystemDependentName(command));
+    result.withEnvironment(FlutterSdkUtil.FLUTTER_HOST_ENV, FlutterSdkUtil.getFlutterHostEnvValue());
+
+    if (androidHome != null) {
+      result.withEnvironment("ANDROID_HOME", androidHome);
+    }
+
+    for (String argument : arguments) {
+      result.addParameter(argument);
+    }
+
+    return result;
+  }
+}
+
+class DevToolsInstance {
+  final String host;
+  final int port;
+
+  DevToolsInstance(String host, int port) {
+    this.host = host;
+    this.port = port;
+  }
+}

--- a/src/io/flutter/run/daemon/DevToolsService.java
+++ b/src/io/flutter/run/daemon/DevToolsService.java
@@ -16,7 +16,6 @@ import com.intellij.openapi.project.ProjectManagerListener;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.vfs.CharsetToolkit;
 import io.flutter.FlutterUtils;
-import io.flutter.android.IntelliJAndroidSdk;
 import io.flutter.bazel.Workspace;
 import io.flutter.bazel.WorkspaceCache;
 import io.flutter.sdk.FlutterSdk;
@@ -24,16 +23,20 @@ import io.flutter.sdk.FlutterSdkUtil;
 import io.flutter.utils.MostlySilentOsProcessHandler;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
 import static com.jetbrains.lang.dart.ide.runner.server.vmService.VmServiceWrapper.LOG;
 
 public class DevToolsService {
-  private class DevToolsServiceListener implements DaemonEvent.Listener {
+  private static class DevToolsServiceListener implements DaemonEvent.Listener {
   }
 
   @NotNull private final Project project;
   private DaemonApi daemonApi;
   private ProcessHandler process;
-  private DevToolsInstance devToolsInstance;
+  private CompletableFuture<DevToolsInstance> devToolsInstance = new CompletableFuture<>();
 
   @NotNull
   public static DevToolsService getInstance(@NotNull final Project project) {
@@ -57,7 +60,7 @@ public class DevToolsService {
           LOG.error("DevTools address was null");
         }
         else {
-          devToolsInstance = new DevToolsInstance(address.host, address.port);
+          devToolsInstance.complete(new DevToolsInstance(address.host, address.port));
         }
       });
     }
@@ -68,23 +71,28 @@ public class DevToolsService {
     ProjectManager.getInstance().addProjectManagerListener(project, new ProjectManagerListener() {
       @Override
       public void projectClosing(@NotNull Project project) {
-        daemonApi.daemonShutdown();
-        if (!process.isProcessTerminated()) {
-          process.destroyProcess();
+        devToolsInstance = new CompletableFuture<>();
+
+        try {
+          daemonApi.daemonShutdown().get(5, TimeUnit.SECONDS);
+        }
+        catch (InterruptedException | java.util.concurrent.ExecutionException | TimeoutException e) {
+          LOG.error("DevTools daemon did not shut down normally: " + e);
+          if (!process.isProcessTerminated()) {
+            process.destroyProcess();
+          }
         }
       }
     });
   }
 
   private static GeneralCommandLine chooseCommand(@NotNull final Project project) {
-    final String androidHome = IntelliJAndroidSdk.chooseAndroidHome(project, false);
-
     // Use daemon script if this is a bazel project.
     final Workspace workspace = WorkspaceCache.getInstance(project).get();
     if (workspace != null) {
       final String script = workspace.getDaemonScript();
       if (script != null) {
-        return createCommand(workspace.getRoot().getPath(), script, ImmutableList.of(), androidHome);
+        return createCommand(workspace.getRoot().getPath(), script, ImmutableList.of());
       }
 
     }
@@ -97,7 +105,7 @@ public class DevToolsService {
 
     try {
       final String path = FlutterSdkUtil.pathToFlutterTool(sdk.getHomePath());
-      return createCommand(sdk.getHomePath(), path, ImmutableList.of("daemon"), androidHome);
+      return createCommand(sdk.getHomePath(), path, ImmutableList.of("daemon"));
     }
     catch (ExecutionException e) {
       FlutterUtils.warn(LOG, "Unable to calculate command to start Flutter daemon", e);
@@ -105,15 +113,11 @@ public class DevToolsService {
     }
   }
 
-  private static GeneralCommandLine createCommand(String workDir, String command, ImmutableList<String> arguments, String androidHome) {
+  private static GeneralCommandLine createCommand(String workDir, String command, ImmutableList<String> arguments) {
     final GeneralCommandLine result = new GeneralCommandLine().withWorkDirectory(workDir);
     result.setCharset(CharsetToolkit.UTF8_CHARSET);
     result.setExePath(FileUtil.toSystemDependentName(command));
     result.withEnvironment(FlutterSdkUtil.FLUTTER_HOST_ENV, FlutterSdkUtil.getFlutterHostEnvValue());
-
-    if (androidHome != null) {
-      result.withEnvironment("ANDROID_HOME", androidHome);
-    }
 
     for (String argument : arguments) {
       result.addParameter(argument);

--- a/src/io/flutter/run/daemon/DevToolsService.java
+++ b/src/io/flutter/run/daemon/DevToolsService.java
@@ -48,7 +48,7 @@ public class DevToolsService {
     try {
       final GeneralCommandLine command = chooseCommand(project);
       if (command == null) {
-        LOG.error("Unable to find daemon command for project: " + project);
+        LOG.info("Unable to find daemon command for project: " + project);
         return;
       }
       this.process = new MostlySilentOsProcessHandler(command);

--- a/src/io/flutter/run/daemon/DevToolsService.java
+++ b/src/io/flutter/run/daemon/DevToolsService.java
@@ -47,7 +47,10 @@ public class DevToolsService {
     this.project = project;
     try {
       final GeneralCommandLine command = chooseCommand(project);
-      assert command != null;
+      if (command == null) {
+        LOG.error("Unable to find daemon command for project: " + project);
+        return;
+      }
       this.process = new MostlySilentOsProcessHandler(command);
       daemonApi = new DaemonApi(process);
       daemonApi.listen(process, new DevToolsServiceListener());


### PR DESCRIPTION
This change is to start running a DevTools server for the duration of a project instead of having it associated with an application. 

Currently we don't use the daemon to serve DevTools for non-bazel projects, but this should be okay once we're using `pub global run devtools` in flutter tools.