### PR TITLE
Add additional args field to test config

### DIFF
--- a/flutter-studio/flutter-studio.iml
+++ b/flutter-studio/flutter-studio.iml
@@ -23,7 +23,6 @@
     <orderEntry type="module" module-name="intellij.android.adt.ui.model" />
     <orderEntry type="module" module-name="intellij.android.observable" />
     <orderEntry type="module" module-name="intellij.android.observable.ui" />
-    <orderEntry type="module" module-name="Dart-community" />
     <orderEntry type="module" module-name="intellij.platform.ide" />
     <orderEntry type="module" module-name="intellij.platform.lang" />
     <orderEntry type="module" module-name="intellij.platform.lang.impl" />
@@ -39,6 +38,7 @@
     <orderEntry type="module" module-name="intellij.android.designer" scope="TEST" />
     <orderEntry type="library" scope="TEST" name="truth" level="project" />
     <orderEntry type="module" module-name="flutter-intellij-community" />
+    <orderEntry type="module" module-name="Dart-community" />
     <orderEntry type="module" module-name="intellij.android.common" />
     <orderEntry type="module" module-name="intellij.android.projectSystem" />
     <orderEntry type="module" module-name="intellij.android.projectSystem.gradle" />

--- a/src/io/flutter/run/test/TestFields.java
+++ b/src/io/flutter/run/test/TestFields.java
@@ -36,7 +36,10 @@ public class TestFields {
   @Nullable
   private final String testDir;
 
-  private TestFields(@Nullable String testName, @Nullable String testFile, @Nullable String testDir) {
+  @Nullable
+  private String additionalArgs;
+
+  private TestFields(@Nullable String testName, @Nullable String testFile, @Nullable String testDir, @Nullable String additionalArgs) {
     if (testFile == null && testDir == null) {
       throw new IllegalArgumentException("either testFile or testDir must be non-null");
     }
@@ -49,27 +52,28 @@ public class TestFields {
     this.testName = testName;
     this.testFile = testFile;
     this.testDir = testDir;
+    this.additionalArgs = additionalArgs;
   }
 
   /**
    * Creates settings for running tests with the given name within a Dart file.
    */
   public static TestFields forTestName(String testName, String path) {
-    return new TestFields(testName, path, null);
+    return new TestFields(testName, path, null, null);
   }
 
   /**
    * Creates settings for running all the tests in a Dart file.
    */
   public static TestFields forFile(String path) {
-    return new TestFields(null, path, null);
+    return new TestFields(null, path, null, null);
   }
 
   /**
    * Creates settings for running all the tests in directory.
    */
   public static TestFields forDir(String path) {
-    return new TestFields(null, null, path);
+    return new TestFields(null, null, path, null);
   }
 
   /**
@@ -110,6 +114,18 @@ public class TestFields {
   @Nullable
   public String getTestDir() {
     return testDir;
+  }
+
+  /**
+   * The additional arguments to pass to the test runner.
+   */
+  @Nullable
+  public String getAdditionalArgs() {
+    return additionalArgs;
+  }
+
+  public void setAdditionalArgs(String args) {
+    additionalArgs = args;
   }
 
   /**
@@ -184,6 +200,7 @@ public class TestFields {
     ElementIO.addOption(elt, "testName", testName);
     ElementIO.addOption(elt, "testFile", testFile);
     ElementIO.addOption(elt, "testDir", testDir);
+    ElementIO.addOption(elt, "additionalArgs", additionalArgs);
   }
 
   /**
@@ -196,8 +213,9 @@ public class TestFields {
     final String testName = options.get("testName");
     final String testFile = options.get("testFile");
     final String testDir = options.get("testDir");
+    final String additionalArgs = options.get("additionalArgs");
     try {
-      return new TestFields(testName, testFile, testDir);
+      return new TestFields(testName, testFile, testDir, additionalArgs);
     }
     catch (IllegalArgumentException e) {
       throw new InvalidDataException(e.getMessage());
@@ -236,7 +254,7 @@ public class TestFields {
       throw new ExecutionException("Test file isn't within a Flutter pub root");
     }
 
-    return sdk.flutterTest(root, fileOrDir, testName, mode, getScope()).startProcess(project);
+    return sdk.flutterTest(root, fileOrDir, testName, mode, additionalArgs, getScope()).startProcess(project);
   }
 
   private void checkSdk(@NotNull Project project) throws RuntimeConfigurationError {

--- a/src/io/flutter/run/test/TestForm.form
+++ b/src/io/flutter/run/test/TestForm.form
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="io.flutter.run.test.TestForm">
-  <grid id="27dc6" binding="form" layout-manager="GridLayoutManager" row-count="9" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="form" layout-manager="GridLayoutManager" row-count="11" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="602" height="400"/>
+      <xy x="20" y="20" width="619" height="400"/>
     </constraints>
     <properties/>
     <border type="none"/>
     <children>
       <vspacer id="fff30">
         <constraints>
-          <grid row="8" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="10" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
       <component id="3abe7" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="testFile">
@@ -42,6 +42,7 @@
           </grid>
         </constraints>
         <properties>
+          <labelFor value="a65c8"/>
           <text value="Test &amp;scope:"/>
         </properties>
       </component>
@@ -64,6 +65,7 @@
           <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
+          <labelFor value="d2c23"/>
           <text value="Test &amp;name:"/>
         </properties>
       </component>
@@ -75,9 +77,9 @@
         </constraints>
         <properties/>
       </component>
-      <component id="1da83" class="javax.swing.JLabel" binding="scopeLabelHint">
+      <component id="1da83" class="javax.swing.JLabel">
         <constraints>
-          <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="1" use-parent-layout="false"/>
         </constraints>
         <properties>
           <enabled value="false"/>
@@ -109,6 +111,32 @@
         <properties>
           <enabled value="false"/>
           <text value="Some pattern to match test names by."/>
+        </properties>
+      </component>
+      <component id="c35e" class="javax.swing.JLabel">
+        <constraints>
+          <grid row="8" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <labelFor value="94628"/>
+          <text value="Additional args:"/>
+        </properties>
+      </component>
+      <component id="94628" class="javax.swing.JTextField" binding="additionalArgs">
+        <constraints>
+          <grid row="8" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+            <preferred-size width="150" height="-1"/>
+          </grid>
+        </constraints>
+        <properties/>
+      </component>
+      <component id="ff408" class="javax.swing.JLabel">
+        <constraints>
+          <grid row="9" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <enabled value="false"/>
+          <text value="Additional arguments to pass to the test runner."/>
         </properties>
       </component>
     </children>

--- a/src/io/flutter/run/test/TestForm.java
+++ b/src/io/flutter/run/test/TestForm.java
@@ -28,7 +28,6 @@ public class TestForm extends SettingsEditor<TestConfig> {
   private JPanel form;
 
   private JComboBox<Scope> scope;
-  private JLabel scopeLabelHint;
 
   private JLabel testDirLabel;
   private TextFieldWithBrowseButton testDir;
@@ -41,6 +40,8 @@ public class TestForm extends SettingsEditor<TestConfig> {
   private JLabel testNameLabel;
   private JTextField testName;
   private JLabel testNameHintLabel;
+
+  private JTextField additionalArgs;
 
   private Scope displayedScope;
 
@@ -89,6 +90,7 @@ public class TestForm extends SettingsEditor<TestConfig> {
         testDir.setText(fields.getTestDir());
         break;
     }
+    additionalArgs.setText(fields.getAdditionalArgs());
     render(next);
   }
 
@@ -108,6 +110,7 @@ public class TestForm extends SettingsEditor<TestConfig> {
       default:
         throw new ConfigurationException("unexpected scope: " + scope.getSelectedItem());
     }
+    fields.setAdditionalArgs(additionalArgs.getText().trim());
     config.setFields(fields);
   }
 

--- a/src/io/flutter/sdk/FlutterSdk.java
+++ b/src/io/flutter/sdk/FlutterSdk.java
@@ -318,7 +318,7 @@ public class FlutterSdk {
   }
 
   public FlutterCommand flutterTest(@NotNull PubRoot root, @NotNull VirtualFile fileOrDir, @Nullable String testNameSubstring,
-                                    @NotNull RunMode mode, TestFields.Scope scope) {
+                                    @NotNull RunMode mode, @Nullable String additionalArgs, TestFields.Scope scope) {
 
     final List<String> args = new ArrayList<>();
     if (myVersion.flutterTestSupportsMachineMode()) {
@@ -344,6 +344,10 @@ public class FlutterSdk {
       }
       args.add("--plain-name");
       args.add(testNameSubstring);
+    }
+
+    if (additionalArgs != null && !additionalArgs.trim().isEmpty()) {
+      args.addAll(Arrays.asList(additionalArgs.trim().split(" ")));
     }
 
     if (!root.getRoot().equals(fileOrDir)) {


### PR DESCRIPTION
Add a field to the test config that allows definition of additional arguments to be passed to the test runner.

<img width="852" alt="Screen Shot 2020-12-15 at 3 31 11 PM" src="https://user-images.githubusercontent.com/8518285/102285207-a5364a00-3eea-11eb-8f0c-fb7bcad53277.png">

The change in `flutter-studio.iml` adjusts the class path to put the Flutter plugin source ahead of the Dart plugin source. No idea how it got out of order but this allows use of our version of the analysis server protocol.

Fixes #3570, #3835, #4987, #5089