### PR TITLE
Add Flutter snap path to getKnownFlutterSdkPaths()

### DIFF
--- a/src/io/flutter/sdk/FlutterSdkUtil.java
+++ b/src/io/flutter/sdk/FlutterSdkUtil.java
@@ -48,6 +48,7 @@ public class FlutterSdkUtil {
 
   private static final String FLUTTER_SDK_KNOWN_PATHS = "FLUTTER_SDK_KNOWN_PATHS";
   private static final Logger LOG = Logger.getInstance(FlutterSdkUtil.class);
+  private static final String FLUTTER_SNAP_SDK_PATH = System.getenv("HOME") + "/snap/flutter/common/flutter";
 
   private FlutterSdkUtil() {
   }
@@ -140,7 +141,7 @@ public class FlutterSdkUtil {
     }
 
     // add the snap SDK path if it exists (standard on all Linux platforms)
-    final File snapSdkPath = new File(System.getenv("HOME") + "/snap/flutter/common/flutter");
+    final File snapSdkPath = new File(FLUTTER_SNAP_SDK_PATH);
     if (snapSdkPath.exists()) {
       paths.add(snapSdkPath.getAbsolutePath());
     }

--- a/src/io/flutter/sdk/FlutterSdkUtil.java
+++ b/src/io/flutter/sdk/FlutterSdkUtil.java
@@ -139,6 +139,12 @@ public class FlutterSdkUtil {
       paths.add(fromUserPath);
     }
 
+    // add the snap SDK path if it exists (standard on all Linux platforms)
+    final File snapSdkPath = new File(System.getenv("HOME") + "/snap/flutter/common/flutter");
+    if (snapSdkPath.exists()) {
+      paths.add(snapSdkPath.getAbsolutePath());
+    }
+
     return paths.toArray(new String[0]);
   }
 


### PR DESCRIPTION
Fixes: https://github.com/canonical/flutter-snap/issues/19.

Changes proposed in this pull request:

* If present, add the Flutter snap SDK path to the list returned from getKnownFlutterSdkPaths()
  * This path is well-known and standard on all Linux platforms.