### PR TITLE
Add log and run callback if the embedded browser fails

### DIFF
--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -231,7 +231,8 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
   private void addBrowserInspectorViewContent(FlutterApp app,
                                               @Nullable InspectorService inspectorService,
                                               ToolWindow toolWindow,
-                                              boolean isEmbedded, DevToolsInstance devToolsInstance) {
+                                              boolean isEmbedded,
+                                              DevToolsInstance devToolsInstance) {
     assert(SwingUtilities.isEventDispatchThread());
 
     final ContentManager contentManager = toolWindow.getContentManager();
@@ -256,7 +257,14 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
 
       //noinspection CodeBlock2Expr
       ApplicationManager.getApplication().invokeLater(() -> {
-        EmbeddedBrowser.getInstance(myProject).openPanel(contentManager, tabName, url);
+        EmbeddedBrowser.getInstance(myProject).openPanel(contentManager, tabName, url, () -> {
+          // If the embedded browser doesn't work, offer a link to open in the regular browser.
+          final List<LabelInput> inputs = Arrays.asList(
+            new LabelInput("The embedded browser failed to load."),
+            openDevToolsLabel(app, inspectorService, toolWindow)
+          );
+          presentClickableLabel(toolWindow, inputs);
+        });
       });
     } else {
       BrowserLauncher.getInstance().browse(


### PR DESCRIPTION
We want to log error messages to analytics if the embedded browser doesn't load and provide an alternative link to open DevTools in the browser:
<img width="797" alt="Screen Shot 2020-12-16 at 7 35 20 PM" src="https://user-images.githubusercontent.com/6379305/102441068-667dbe00-3fd6-11eb-9b7b-3cd96b09e822.png">

Fixes https://github.com/flutter/flutter-intellij/issues/5073