### PR TITLE
skip a flaky test

### DIFF
--- a/testSrc/unit/io/flutter/utils/AsyncRateLimiterTest.java
+++ b/testSrc/unit/io/flutter/utils/AsyncRateLimiterTest.java
@@ -11,6 +11,7 @@ import com.intellij.openapi.util.Computable;
 import com.intellij.openapi.util.Disposer;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import javax.swing.*;
@@ -82,6 +83,7 @@ public class AsyncRateLimiterTest {
   }
 
   @Test
+  @Ignore("generally flaky")
   public void rateLimited() {
     final long start = clock.millis();
     expectedEvents = 4;


### PR DESCRIPTION
- skip the `AsyncRateLimiterTest. rateLimited` test - it's flaky (see https://github.com/flutter/flutter-intellij/pull/5135#issuecomment-747751471 for a flake)
