### PR TITLE
Allow devtools to run remotely for bazel (WIP)

### DIFF
--- a/src/io/flutter/run/bazel/BazelFields.java
+++ b/src/io/flutter/run/bazel/BazelFields.java
@@ -24,12 +24,15 @@ import io.flutter.bazel.WorkspaceCache;
 import io.flutter.dart.DartPlugin;
 import io.flutter.run.FlutterDevice;
 import io.flutter.run.common.RunMode;
+import io.flutter.run.daemon.DevToolsInstance;
+import io.flutter.run.daemon.DevToolsService;
 import io.flutter.utils.ElementIO;
 import org.jdom.Element;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 import static io.flutter.run.common.RunMode.DEBUG;
 
@@ -254,6 +257,16 @@ public class BazelFields {
     if (device != null) {
       commandLine.addParameter("-d");
       commandLine.addParameter(device.deviceId());
+    }
+
+    final CompletableFuture<DevToolsInstance> devToolsFuture = DevToolsService.getInstance(project).getDevToolsInstance();
+    if (devToolsFuture.isDone() && !devToolsFuture.isCompletedExceptionally()) {
+      try {
+        commandLine.addParameter("--devtools-port=" + devToolsFuture.get().port);
+      }
+      catch (Exception e) {
+        e.printStackTrace();
+      }
     }
 
     commandLine.addParameter(target);

--- a/src/io/flutter/run/daemon/DevToolsService.java
+++ b/src/io/flutter/run/daemon/DevToolsService.java
@@ -59,6 +59,11 @@ public class DevToolsService {
 
   private DevToolsService(@NotNull final Project project) {
     this.project = project;
+
+    // Start the server earlier for bazel projects so the port is available at app runtime.
+    if (WorkspaceCache.getInstance(project).isBazel() && devToolsFutureRef.compareAndSet(null, new CompletableFuture<>())) {
+      startServer();
+    }
   }
 
   public CompletableFuture<DevToolsInstance> getDevToolsInstance() {
@@ -252,7 +257,7 @@ public class DevToolsService {
     if (workspace != null) {
       final String script = workspace.getDaemonScript();
       if (script != null) {
-        return createCommand(workspace.getRoot().getPath(), script, ImmutableList.of());
+        return createCommand(workspace.getRoot().getPath(), script, ImmutableList.of("--remote-allowed"));
       }
     }
 


### PR DESCRIPTION
Instead of lazy loading the DevTools server, I'm instead starting one on project open (for bazel only) so that the port will be available at runtime.

This is suboptimal though (someone could run an app before DevTools starts). Alternatives:
- add a separate script (like `runScript`) to manage any port setup and call this after the server starts (more divergence between bazel and regular flutter tools, too many scripts?)
- wait for DevTools to finish (app running could be slower, would have to move to a pooled thread)