### PR TITLE
Close embedded browser engine on application close

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -1424,6 +1424,7 @@
                         serviceImplementation="io.flutter.settings.FlutterSettings"
                         overrides="false"/>
 
+    <applicationService serviceImplementation="io.flutter.jxbrowser.EmbeddedBrowserEngine" overrides="false" />
     <console.folding implementation="io.flutter.console.FlutterConsoleFolding"/>
     <console.folding implementation="io.flutter.logging.FlutterConsoleLogFolding"/>
 

--- a/resources/META-INF/plugin_template.xml
+++ b/resources/META-INF/plugin_template.xml
@@ -284,6 +284,7 @@
                         serviceImplementation="io.flutter.settings.FlutterSettings"
                         overrides="false"/>
 
+    <applicationService serviceImplementation="io.flutter.jxbrowser.EmbeddedBrowserEngine" overrides="false" />
     <console.folding implementation="io.flutter.console.FlutterConsoleFolding"/>
     <console.folding implementation="io.flutter.logging.FlutterConsoleLogFolding"/>
 

--- a/src/io/flutter/jxbrowser/EmbeddedBrowser.java
+++ b/src/io/flutter/jxbrowser/EmbeddedBrowser.java
@@ -9,6 +9,8 @@ import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectManager;
+import com.intellij.openapi.project.ProjectManagerListener;
 import com.intellij.openapi.util.SystemInfo;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.wm.ToolWindow;
@@ -61,6 +63,16 @@ public class EmbeddedBrowser {
       LOG.error(ex);
       FlutterInitializer.getAnalytics().sendException(StringUtil.getThrowableText(ex), false);
     }
+
+    ProjectManager.getInstance().addProjectManagerListener(project, new ProjectManagerListener() {
+      @Override
+      public void projectClosing(@NotNull Project project) {
+        if (browser != null) {
+          browser.close();
+          browser = null;
+        }
+      }
+    });
   }
 
   public void openPanel(ContentManager contentManager, String tabName, String url) {

--- a/src/io/flutter/jxbrowser/EmbeddedBrowser.java
+++ b/src/io/flutter/jxbrowser/EmbeddedBrowser.java
@@ -42,6 +42,7 @@ public class EmbeddedBrowser {
     return ServiceManager.getService(project, EmbeddedBrowser.class);
   }
 
+  private Engine engine;
   private Browser browser;
 
   private EmbeddedBrowser(Project project) {
@@ -54,7 +55,7 @@ public class EmbeddedBrowser {
         .build();
 
     try {
-      final Engine engine = Engine.newInstance(options);
+      this.engine = Engine.newInstance(options);
       this.browser = engine.newBrowser();
       browser.settings().enableTransparentBackground();
     } catch (UnsupportedRenderingModeException ex) {
@@ -69,7 +70,9 @@ public class EmbeddedBrowser {
       public void projectClosing(@NotNull Project project) {
         if (browser != null) {
           browser.close();
+          engine.close();
           browser = null;
+          engine = null;
         }
       }
     });

--- a/src/io/flutter/jxbrowser/EmbeddedBrowserEngine.java
+++ b/src/io/flutter/jxbrowser/EmbeddedBrowserEngine.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.jxbrowser;
+
+import com.intellij.openapi.application.ApplicationListener;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.util.SystemInfo;
+import com.intellij.openapi.util.text.StringUtil;
+import com.teamdev.jxbrowser.engine.Engine;
+import com.teamdev.jxbrowser.engine.EngineOptions;
+import io.flutter.FlutterInitializer;
+
+import java.io.File;
+import java.nio.file.Paths;
+
+import static com.teamdev.jxbrowser.engine.RenderingMode.HARDWARE_ACCELERATED;
+import static com.teamdev.jxbrowser.engine.RenderingMode.OFF_SCREEN;
+
+public class EmbeddedBrowserEngine {
+  private static final Logger LOG = Logger.getInstance(EmbeddedBrowserEngine.class);
+  private final Engine engine;
+
+  public static EmbeddedBrowserEngine getInstance() {
+    return ServiceManager.getService(EmbeddedBrowserEngine.class);
+  }
+
+  public EmbeddedBrowserEngine() {
+    final String dataPath = JxBrowserManager.DOWNLOAD_PATH + File.separatorChar + "user-data";
+    LOG.info("JxBrowser user data path: " + dataPath);
+
+    final EngineOptions options =
+      EngineOptions.newBuilder(SystemInfo.isWindows ? OFF_SCREEN : HARDWARE_ACCELERATED)
+        .userDataDir(Paths.get(dataPath))
+        .build();
+
+    Engine temp;
+    try {
+      temp = Engine.newInstance(options);
+    } catch (Exception ex) {
+      temp = null;
+      LOG.error(ex);
+      FlutterInitializer.getAnalytics().sendException(StringUtil.getThrowableText(ex), false);
+    }
+    engine = temp;
+
+    ApplicationManager.getApplication().addApplicationListener(new ApplicationListener() {
+      @Override
+      public boolean canExitApplication() {
+        if (engine != null) {
+          engine.close();
+        }
+        return true;
+      }
+    });
+  }
+
+  public Engine getEngine() {
+    return engine;
+  }
+}


### PR DESCRIPTION
May fix https://github.com/flutter/flutter-intellij/issues/5119, https://github.com/flutter/flutter-intellij/issues/5139

It seems that sometimes the browser fails to start because the directory assigned to JxBrowser is already in use. Closing the engine should stop the use of the directory.