### PR TITLE
Track time lapsed to start analysis server and finish indexing

### DIFF
--- a/src/io/flutter/ProjectOpenActivity.java
+++ b/src/io/flutter/ProjectOpenActivity.java
@@ -21,6 +21,7 @@ import com.intellij.openapi.project.ProjectTypeService;
 import com.intellij.openapi.startup.StartupActivity;
 import com.intellij.openapi.ui.Messages;
 import icons.FlutterIcons;
+import io.flutter.analytics.TimeTracker;
 import io.flutter.bazel.WorkspaceCache;
 import io.flutter.jxbrowser.JxBrowserManager;
 import io.flutter.pub.PubRoot;
@@ -46,6 +47,8 @@ public class ProjectOpenActivity implements StartupActivity, DumbAware {
 
   @Override
   public void runActivity(@NotNull Project project) {
+    project.getService(TimeTracker.class).setProjectOpenTime();
+
     // TODO(messick): Remove 'FlutterUtils.isAndroidStudio()' after Android Q sources are published.
     if (FlutterUtils.isAndroidStudio() && AndroidUtils.isAndroidProject(project)) {
       AndroidUtils.addGradleListeners(project);

--- a/src/io/flutter/analytics/TimeTracker.java
+++ b/src/io/flutter/analytics/TimeTracker.java
@@ -6,25 +6,32 @@
 package io.flutter.analytics;
 
 import com.intellij.openapi.components.Service;
+import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.project.Project;
+import org.jetbrains.annotations.NotNull;
 
 @Service
 public final class TimeTracker {
   private final Project project;
   private Long projectOpenTime;
 
+  @NotNull
+  public static TimeTracker getInstance(@NotNull final Project project) {
+    return ServiceManager.getService(project, TimeTracker.class);
+  }
+
   public TimeTracker(Project project) {
     this.project = project;
   }
 
-  public void setProjectOpenTime() {
+  public void onProjectOpen() {
     this.projectOpenTime = System.currentTimeMillis();
   }
 
-  public Long millisSinceProjectOpen() {
+  public int millisSinceProjectOpen() {
     if (projectOpenTime == null) {
-      return null;
+      return 0;
     }
-    return System.currentTimeMillis() - projectOpenTime;
+    return (int) (System.currentTimeMillis() - projectOpenTime);
   }
 }

--- a/src/io/flutter/analytics/TimeTracker.java
+++ b/src/io/flutter/analytics/TimeTracker.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.analytics;
+
+import com.intellij.openapi.components.Service;
+import com.intellij.openapi.project.Project;
+
+@Service
+public final class TimeTracker {
+  private final Project project;
+  private Long projectOpenTime;
+
+  public TimeTracker(Project project) {
+    this.project = project;
+  }
+
+  public void setProjectOpenTime() {
+    this.projectOpenTime = System.currentTimeMillis();
+  }
+
+  public Long millisSinceProjectOpen() {
+    if (projectOpenTime == null) {
+      return null;
+    }
+    return System.currentTimeMillis() - projectOpenTime;
+  }
+}

--- a/src/io/flutter/dart/FlutterDartAnalysisServer.java
+++ b/src/io/flutter/dart/FlutterDartAnalysisServer.java
@@ -88,7 +88,7 @@ public class FlutterDartAnalysisServer implements Disposable {
           FlutterInitializer.getAnalytics().sendEventMetric(
             "startup",
             "analysisComputedErrors",
-            project.getService(TimeTracker.class).millisSinceProjectOpen()
+            TimeTracker.getInstance(project).millisSinceProjectOpen()
           );
           hasComputedErrors = true;
         }

--- a/src/io/flutter/dart/FlutterDartAnalysisServer.java
+++ b/src/io/flutter/dart/FlutterDartAnalysisServer.java
@@ -84,22 +84,18 @@ public class FlutterDartAnalysisServer implements Disposable {
 
       @Override
       public void computedErrors(String file, List<AnalysisError> errors) {
-        if (!hasComputedErrors) {
-          final Long millisSinceProjectOpen = project.getService(TimeTracker.class).millisSinceProjectOpen();
-          if (millisSinceProjectOpen != null) {
-            FlutterInitializer.getAnalytics().sendEventMetric(
-              "startup",
-              "analysisComputedErrors",
-              millisSinceProjectOpen.intValue()
-            );
-          }
+        if (!hasComputedErrors && project.isOpen()) {
+          FlutterInitializer.getAnalytics().sendEventMetric(
+            "startup",
+            "analysisComputedErrors",
+            project.getService(TimeTracker.class).millisSinceProjectOpen()
+          );
           hasComputedErrors = true;
         }
 
         super.computedErrors(file, errors);
       }
     });
-    final Long time = project.getService(TimeTracker.class).millisSinceProjectOpen();
     Disposer.register(project, this);
   }
 

--- a/src/io/flutter/dart/FlutterDartAnalysisServer.java
+++ b/src/io/flutter/dart/FlutterDartAnalysisServer.java
@@ -23,6 +23,7 @@ import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.util.Consumer;
 import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService;
+import io.flutter.analytics.TimeTracker;
 import io.flutter.utils.JsonUtils;
 import org.dartlang.analysis.server.protocol.*;
 import org.jetbrains.annotations.NotNull;
@@ -78,6 +79,7 @@ public class FlutterDartAnalysisServer implements Disposable {
         }
       }
     });
+    final Long time = project.getService(TimeTracker.class).millisSinceProjectOpen();
     Disposer.register(project, this);
   }
 


### PR DESCRIPTION
We want to find the time lapsed to start the analysis server and finish indexing, and send these values to analytics.

 Example times:
```
Has computed errors: 6890
Indexing has finished: 28634
```