### PR TITLE
Enable JxBrowser logging with verbose logging option

### DIFF
--- a/src/io/flutter/jxbrowser/EmbeddedBrowser.java
+++ b/src/io/flutter/jxbrowser/EmbeddedBrowser.java
@@ -22,6 +22,7 @@ import com.teamdev.jxbrowser.navigation.event.LoadFinished;
 import com.teamdev.jxbrowser.view.swing.BrowserView;
 import icons.FlutterIcons;
 import io.flutter.FlutterInitializer;
+import io.flutter.settings.FlutterSettings;
 import org.jetbrains.annotations.NotNull;
 
 import java.awt.Dimension;
@@ -38,6 +39,10 @@ public class EmbeddedBrowser {
   private Browser browser;
 
   private EmbeddedBrowser(Project project) {
+    if (FlutterSettings.getInstance().isVerboseLogging()) {
+      System.setProperty("jxbrowser.logging.level", "ALL");
+    }
+
     try {
       final Engine engine = EmbeddedBrowserEngine.getInstance().getEngine();
       if (engine == null) {


### PR DESCRIPTION
Sometimes verbose logs would be helpful to the JxBrowser team when they're debugging issues (e.g. for https://github.com/flutter/flutter-intellij/issues/5152)

These logs will be available in idea.log files (they will not be reported to our analytics).