### PR TITLE
Add link to install docs to first page of NPW

### DIFF
--- a/src/io/flutter/module/FlutterModuleBuilder.java
+++ b/src/io/flutter/module/FlutterModuleBuilder.java
@@ -334,6 +334,9 @@ public class FlutterModuleBuilder extends ModuleBuilder {
     public FlutterModuleWizardStep(@NotNull WizardContext context) {
       //TODO(pq): find a way to listen to wizard cancelation and propagate to peer.
       myPeer = new FlutterGeneratorPeer(context);
+      if (!FlutterUtils.isAndroidStudio()) {
+        myPeer.getHelpForm().showGettingStarted();
+      }
     }
 
     public SettingsHelpForm getHelpForm() {

--- a/src/io/flutter/module/settings/SettingsHelpForm.form
+++ b/src/io/flutter/module/settings/SettingsHelpForm.form
@@ -59,7 +59,7 @@
             </properties>
           </component>
           <grid id="a8d23" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
-            <margin top="5" left="0" bottom="0" right="0"/>
+            <margin top="0" left="0" bottom="0" right="0"/>
             <constraints>
               <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
             </constraints>

--- a/src/io/flutter/module/settings/SettingsHelpForm.java
+++ b/src/io/flutter/module/settings/SettingsHelpForm.java
@@ -59,6 +59,15 @@ public class SettingsHelpForm {
       .setListener((label, linkUrl) -> BrowserLauncher.getInstance().browse(FlutterConstants.URL_GETTING_STARTED, null), null);
   }
 
+  public void showGettingStarted() {
+    projectTypeLabel.setVisible(false);
+    projectTypeDescriptionForApp.setVisible(false);
+    projectTypeDescriptionForModule.setVisible(false);
+    projectTypeDescriptionForPlugin.setVisible(false);
+    projectTypeDescriptionForPackage.setVisible(false);
+    mainPanel.setVisible(true);
+    gettingStartedUrl.setVisible(true);
+  }
 
   @NotNull
   public JComponent getComponent() {


### PR DESCRIPTION
Re-use the help screen link on the first page. This is only for IntelliJ; the whole help screen appears for Android Studio.

<img width="673" alt="Screen Shot 2021-01-05 at 9 41 53 AM" src="https://user-images.githubusercontent.com/8518285/103680274-c82caa80-4f3a-11eb-9d86-e2e728c1b48f.png">
