### PR TITLE
Start DevTools server and pass address to run

### DIFF
--- a/src/io/flutter/run/SdkFields.java
+++ b/src/io/flutter/run/SdkFields.java
@@ -19,11 +19,15 @@ import io.flutter.dart.DartPlugin;
 import io.flutter.pub.PubRoot;
 import io.flutter.pub.PubRootCache;
 import io.flutter.run.common.RunMode;
+import io.flutter.run.daemon.DevToolsInstance;
+import io.flutter.run.daemon.DevToolsService;
 import io.flutter.sdk.FlutterCommand;
 import io.flutter.sdk.FlutterSdk;
 import io.flutter.settings.FlutterSettings;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.concurrent.TimeUnit;
 
 /**
  * Fields used when launching an app using the Flutter SDK (non-bazel).
@@ -149,6 +153,16 @@ public class SdkFields {
     }
     if (FlutterSettings.getInstance().isShowStructuredErrors() && flutterSdk.getVersion().isDartDefineSupported()) {
       args = ArrayUtil.append(args, "--dart-define=flutter.inspector.structuredErrors=true");
+    }
+
+    if (flutterSdk.getVersion().flutterRunSupportsDevToolsUrl()) {
+      try {
+        final DevToolsInstance instance = DevToolsService.getInstance(project).getDevToolsInstance().get(30, TimeUnit.SECONDS);
+        args = ArrayUtil.append(args, "--devtools-server-address=http://" + instance.host + ":" + instance.port);
+      }
+      catch (Exception e) {
+        e.printStackTrace();
+      }
     }
     command = flutterSdk.flutterRun(root, main.getFile(), device, runMode, flutterLaunchMode, project, args);
     return command.createGeneralCommandLine(project);

--- a/src/io/flutter/run/SdkFields.java
+++ b/src/io/flutter/run/SdkFields.java
@@ -8,6 +8,7 @@ package io.flutter.run;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configurations.GeneralCommandLine;
 import com.intellij.execution.configurations.RuntimeConfigurationError;
+import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -35,6 +36,7 @@ import java.util.concurrent.TimeUnit;
  * Fields used when launching an app using the Flutter SDK (non-bazel).
  */
 public class SdkFields {
+  private static final Logger LOG = Logger.getInstance(SdkFields.class);
   private @Nullable String filePath;
   private @Nullable String buildFlavor;
   private @Nullable String additionalArgs;
@@ -168,14 +170,14 @@ public class SdkFields {
             devToolsFuture.complete(DevToolsService.getInstance(project).getDevToolsInstance().get(30, TimeUnit.SECONDS));
           }
           catch (Exception e) {
-            e.printStackTrace();
+            LOG.error(e);
           }
         }, "Starting DevTools", false, project);
         final DevToolsInstance instance = devToolsFuture.get();
         args = ArrayUtil.append(args, "--devtools-server-address=http://" + instance.host + ":" + instance.port);
       }
       catch (Exception e) {
-        e.printStackTrace();
+        LOG.error(e);
       }
     }
     command = flutterSdk.flutterRun(root, main.getFile(), device, runMode, flutterLaunchMode, project, args);

--- a/src/io/flutter/run/daemon/DevToolsService.java
+++ b/src/io/flutter/run/daemon/DevToolsService.java
@@ -85,9 +85,8 @@ public class DevToolsService {
 
   private void startServer() {
     ApplicationManager.getApplication().executeOnPooledThread(() -> {
-      // TODO(helinx): Also use `setUpWithDaemon` for later flutter SDK versions where the daemon request `devtools.serve` has been changed
-      //  to use the latest DevTools server.
-      if (WorkspaceCache.getInstance(project).isBazel()) {
+      final FlutterSdk sdk = FlutterSdk.getFlutterSdk(project);
+      if (WorkspaceCache.getInstance(project).isBazel() || (sdk != null && sdk.getVersion().flutterRunSupportsDevToolsUrl())) {
         setUpWithDaemon();
       }
       else {

--- a/src/io/flutter/sdk/FlutterSdkVersion.java
+++ b/src/io/flutter/sdk/FlutterSdkVersion.java
@@ -43,6 +43,12 @@ public class FlutterSdkVersion implements Comparable<FlutterSdkVersion> {
    */
   private static final FlutterSdkVersion MIN_CREATE_PLATFORMS_SDK = new FlutterSdkVersion("1.20.0");
 
+  /**
+   * The version that supports --devtools-server-address in flutter run.
+   */
+  // TODO:(helinx): Check in with Patrick about the final version number.
+  private static final FlutterSdkVersion MIN_PASS_DEVTOOLS_SDK = new FlutterSdkVersion("1.26.0");
+
   @Nullable
   private final Version version;
   @Nullable
@@ -130,6 +136,11 @@ public class FlutterSdkVersion implements Comparable<FlutterSdkVersion> {
   public boolean flutterCreateSupportsPlatforms() {
     //noinspection ConstantConditions
     return version != null && version.compareTo(MIN_CREATE_PLATFORMS_SDK.version) >= 0;
+  }
+
+  public boolean flutterRunSupportsDevToolsUrl() {
+    //noinspection ConstantConditions
+    return version != null && version.compareTo(MIN_PASS_DEVTOOLS_SDK.version) >= 0;
   }
 
   public boolean flutterTestSupportsMachineMode() {

--- a/src/io/flutter/sdk/FlutterSdkVersion.java
+++ b/src/io/flutter/sdk/FlutterSdkVersion.java
@@ -47,7 +47,7 @@ public class FlutterSdkVersion implements Comparable<FlutterSdkVersion> {
    * The version that supports --devtools-server-address in flutter run.
    */
   // TODO:(helinx): Check in with Patrick about the final version number.
-  private static final FlutterSdkVersion MIN_PASS_DEVTOOLS_SDK = new FlutterSdkVersion("1.26.0");
+  private static final FlutterSdkVersion MIN_PASS_DEVTOOLS_SDK = new FlutterSdkVersion("1.26.0-11.0.pre");
 
   @Nullable
   private final Version version;
@@ -139,8 +139,7 @@ public class FlutterSdkVersion implements Comparable<FlutterSdkVersion> {
   }
 
   public boolean flutterRunSupportsDevToolsUrl() {
-    //noinspection ConstantConditions
-    return version != null && version.compareTo(MIN_PASS_DEVTOOLS_SDK.version) >= 0;
+    return this.compareTo(MIN_PASS_DEVTOOLS_SDK) >= 0;
   }
 
   public boolean flutterTestSupportsMachineMode() {

--- a/src/io/flutter/sdk/FlutterSdkVersion.java
+++ b/src/io/flutter/sdk/FlutterSdkVersion.java
@@ -46,7 +46,6 @@ public class FlutterSdkVersion implements Comparable<FlutterSdkVersion> {
   /**
    * The version that supports --devtools-server-address in flutter run.
    */
-  // TODO:(helinx): Check in with Patrick about the final version number.
   private static final FlutterSdkVersion MIN_PASS_DEVTOOLS_SDK = new FlutterSdkVersion("1.26.0-11.0.pre");
 
   @Nullable


### PR DESCRIPTION
We want to keep using a DevTools server that persists across app runs (associated with an open project instead), but we also want to pass the address of this server to flutter_tools during `flutter run` so that upcoming features like DevTools links generated in flutter_tools can use the same server.

However, I'm not sure when we should start the project DevTools server:
- If we should start it right before a user wants to run an application, this introduces a delay for the run process starting, and this runs on the UI thread (maybe there's a way to move to other thread?)
- If we start it when a project is opened, this is unnecessary if the user isn't running an app. If the user tries to run an app quickly, this could still result in a delay
- If we don't change the start time, then it will start when the embedded browser tries to display, which would cause the first app run to create an app-affiliated DevTools server (later app runs would use the project-affiliated server)
- (resolved)

We decided to use a modal dialog while waiting for DevTools server to start (shown the first time an app is run):
https://user-images.githubusercontent.com/6379305/105253671-c830cb00-5b34-11eb-8d0b-c43eda84e8bf.mov



(This is the flutter_tools change I'll be gating on: https://github.com/flutter/flutter/pull/73903)
CC @kenzieschmoll 