### PR TITLE
Log console messages from embedded browser

### DIFF
--- a/src/io/flutter/jxbrowser/EmbeddedBrowser.java
+++ b/src/io/flutter/jxbrowser/EmbeddedBrowser.java
@@ -19,7 +19,9 @@ import com.teamdev.jxbrowser.browser.Browser;
 import com.teamdev.jxbrowser.browser.UnsupportedRenderingModeException;
 import com.teamdev.jxbrowser.browser.callback.AlertCallback;
 import com.teamdev.jxbrowser.browser.callback.ConfirmCallback;
+import com.teamdev.jxbrowser.browser.event.ConsoleMessageReceived;
 import com.teamdev.jxbrowser.engine.Engine;
+import com.teamdev.jxbrowser.js.ConsoleMessage;
 import com.teamdev.jxbrowser.navigation.event.LoadFinished;
 import com.teamdev.jxbrowser.view.swing.BrowserView;
 import com.teamdev.jxbrowser.view.swing.callback.DefaultAlertCallback;
@@ -55,6 +57,10 @@ public class EmbeddedBrowser {
 
       this.browser = engine.newBrowser();
       browser.settings().enableTransparentBackground();
+      browser.on(ConsoleMessageReceived.class, event -> {
+        final ConsoleMessage consoleMessage = event.consoleMessage();
+        LOG.info("Browser message(" + consoleMessage.level().name() + "): " + consoleMessage.message());
+      });
     } catch (UnsupportedRenderingModeException ex) {
       // Skip using a transparent background if an exception is thrown.
     } catch (Exception ex) {


### PR DESCRIPTION
This logs console messages from the embedded browser to idea.log. e.g.:
```
2021-01-15 14:55:17,559 [  82786]   INFO - ter.jxbrowser.JxBrowserManager - Browser message(LOG): PreferencesController: storage not initialized 
2021-01-15 14:55:17,575 [  82802]   INFO - ter.jxbrowser.JxBrowserManager - Browser message(LOG): DevTools version 0.9.6. 
```

Fixes https://github.com/flutter/devtools/issues/2606