### PR TITLE
Handle time-out when getting Flutter SDK

### DIFF
--- a/src/io/flutter/inspector/EvalOnDartLibrary.java
+++ b/src/io/flutter/inspector/EvalOnDartLibrary.java
@@ -23,10 +23,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
+import java.util.concurrent.*;
 import java.util.function.Supplier;
 
 /**
@@ -89,8 +86,12 @@ public class EvalOnDartLibrary implements Disposable {
         response.complete(null);
         return;
       }
-      // No need to timeout until the request has actually started.
-      timeoutAfter(response, DEFAULT_REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS, requestName);
+      try {
+        // No need to timeout until the request has actually started.
+        timeoutAfter(response, DEFAULT_REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS, requestName);
+      } catch (CompletionException ex) {
+        response.completeExceptionally(ex);
+      }
       final CompletableFuture<T> future = request.get();
       future.whenCompleteAsync((v, t) -> {
         if (t != null) {


### PR DESCRIPTION
Fixes #4946. Maybe.

I think what happens is the Flutter SDK decides to download a bunch of stuff, causing a time-out. The exception is being reported to the user. This just hides it. I'm not sure if that will break something upstream, though.