### PR TITLE
Add compare function that works for beta versions

### DIFF
--- a/testSrc/unit/io/flutter/sdk/FlutterSdkVersionTest.java
+++ b/testSrc/unit/io/flutter/sdk/FlutterSdkVersionTest.java
@@ -39,44 +39,76 @@ public class FlutterSdkVersionTest {
   @Test
   public void comparesBetaVersions() {
     assertEquals(
-      new FlutterSdkVersion("1.0.0").compareToWithBetaVersion(new FlutterSdkVersion("1.0.1")),
+      new FlutterSdkVersion("1.0.0").compareTo(new FlutterSdkVersion("1.0.1")),
       -1
     );
     assertEquals(
-      new FlutterSdkVersion("1.0.0").compareToWithBetaVersion(new FlutterSdkVersion("1.0.0")),
+      new FlutterSdkVersion("1.0.0").compareTo(new FlutterSdkVersion("1.0.0")),
       0
     );
     assertEquals(
-      new FlutterSdkVersion("1.0.1").compareToWithBetaVersion(new FlutterSdkVersion("1.0.0")),
+      new FlutterSdkVersion("1.0.1").compareTo(new FlutterSdkVersion("1.0.0")),
       1
     );
     assertEquals(
-      new FlutterSdkVersion("1.0.0").compareToWithBetaVersion(new FlutterSdkVersion("1.0.0-1.0.pre")),
+      new FlutterSdkVersion("1.0.0").compareTo(new FlutterSdkVersion("1.0.0-1.0.pre")),
       1
     );
     assertEquals(
-      new FlutterSdkVersion("1.0.0-1.1.pre").compareToWithBetaVersion(new FlutterSdkVersion("1.0.0-1.0.pre")),
+      new FlutterSdkVersion("1.0.0-1.1.pre").compareTo(new FlutterSdkVersion("1.0.0-1.0.pre")),
       1
     );
     assertEquals(
-      new FlutterSdkVersion("1.0.0-2.0.pre").compareToWithBetaVersion(new FlutterSdkVersion("1.0.0-1.0.pre")),
+      new FlutterSdkVersion("1.0.0-2.0.pre").compareTo(new FlutterSdkVersion("1.0.0-1.0.pre")),
       1
     );
     assertEquals(
-      new FlutterSdkVersion("1.0.0-1.1.pre").compareToWithBetaVersion(new FlutterSdkVersion("1.0.0-1.2.pre")),
+      new FlutterSdkVersion("1.0.0-1.1.pre").compareTo(new FlutterSdkVersion("1.0.0-1.2.pre")),
       -1
     );
     assertEquals(
-      new FlutterSdkVersion("1.0.0-1.1.pre").compareToWithBetaVersion(new FlutterSdkVersion("1.0.0-2.1.pre")),
+      new FlutterSdkVersion("1.0.0-1.1.pre").compareTo(new FlutterSdkVersion("1.0.0-2.1.pre")),
       -1
     );
     assertEquals(
-      new FlutterSdkVersion("1.0.0-1.1.pre").compareToWithBetaVersion(new FlutterSdkVersion("1.0.0")),
+      new FlutterSdkVersion("1.0.0-1.1.pre").compareTo(new FlutterSdkVersion("1.0.0")),
       -1
     );
     assertEquals(
-      new FlutterSdkVersion("1.0.0-1.1.pre").compareToWithBetaVersion(new FlutterSdkVersion("1.0.0-1.1.pre")),
+      new FlutterSdkVersion("1.0.0-1.1.pre").compareTo(new FlutterSdkVersion("1.0.0-1.1.pre")),
       0
+    );
+
+    // TODO:(helin24): Update with correct comparisons involving the master branch.
+    assertEquals(
+      new FlutterSdkVersion("1.0.0-1.1.pre.123").compareTo(new FlutterSdkVersion("1.0.0-1.1.pre.123")),
+      0
+    );
+    assertEquals(
+      new FlutterSdkVersion("1.0.0-1.1.pre.123").compareTo(new FlutterSdkVersion("1.0.0-1.1.pre.124")),
+      -1
+    );
+    assertEquals(
+      new FlutterSdkVersion("1.0.0-1.1.pre.124").compareTo(new FlutterSdkVersion("1.0.0-1.1.pre.123")),
+      1
+    );
+
+    assertEquals(
+      new FlutterSdkVersion("1.0.0-1.1.pre.123").compareTo(new FlutterSdkVersion("1.0.0-1.1.pre")),
+      1
+    );
+    assertEquals(
+      new FlutterSdkVersion("1.0.0-1.0.pre.123").compareTo(new FlutterSdkVersion("1.0.0-2.0.pre")),
+      1
+    );
+
+    assertEquals(
+      new FlutterSdkVersion("1.0.0-1.1.pre").compareTo(new FlutterSdkVersion("1.0.0-1.1.pre.123")),
+      -1
+    );
+    assertEquals(
+      new FlutterSdkVersion("1.0.0-2.0.pre").compareTo(new FlutterSdkVersion("1.0.0-1.0.pre.123")),
+      -1
     );
   }
 }

--- a/testSrc/unit/io/flutter/sdk/FlutterSdkVersionTest.java
+++ b/testSrc/unit/io/flutter/sdk/FlutterSdkVersionTest.java
@@ -7,8 +7,7 @@ package io.flutter.sdk;
 
 import org.junit.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class FlutterSdkVersionTest {
   @Test
@@ -35,5 +34,49 @@ public class FlutterSdkVersionTest {
   public void handlesBadVersion() {
     final FlutterSdkVersion version = new FlutterSdkVersion("unknown");
     assertFalse(version.isValid());
+  }
+
+  @Test
+  public void comparesBetaVersions() {
+    assertEquals(
+      new FlutterSdkVersion("1.0.0").compareToWithBetaVersion(new FlutterSdkVersion("1.0.1")),
+      -1
+    );
+    assertEquals(
+      new FlutterSdkVersion("1.0.0").compareToWithBetaVersion(new FlutterSdkVersion("1.0.0")),
+      0
+    );
+    assertEquals(
+      new FlutterSdkVersion("1.0.1").compareToWithBetaVersion(new FlutterSdkVersion("1.0.0")),
+      1
+    );
+    assertEquals(
+      new FlutterSdkVersion("1.0.0").compareToWithBetaVersion(new FlutterSdkVersion("1.0.0-1.0.pre")),
+      1
+    );
+    assertEquals(
+      new FlutterSdkVersion("1.0.0-1.1.pre").compareToWithBetaVersion(new FlutterSdkVersion("1.0.0-1.0.pre")),
+      1
+    );
+    assertEquals(
+      new FlutterSdkVersion("1.0.0-2.0.pre").compareToWithBetaVersion(new FlutterSdkVersion("1.0.0-1.0.pre")),
+      1
+    );
+    assertEquals(
+      new FlutterSdkVersion("1.0.0-1.1.pre").compareToWithBetaVersion(new FlutterSdkVersion("1.0.0-1.2.pre")),
+      -1
+    );
+    assertEquals(
+      new FlutterSdkVersion("1.0.0-1.1.pre").compareToWithBetaVersion(new FlutterSdkVersion("1.0.0-2.1.pre")),
+      -1
+    );
+    assertEquals(
+      new FlutterSdkVersion("1.0.0-1.1.pre").compareToWithBetaVersion(new FlutterSdkVersion("1.0.0")),
+      -1
+    );
+    assertEquals(
+      new FlutterSdkVersion("1.0.0-1.1.pre").compareToWithBetaVersion(new FlutterSdkVersion("1.0.0-1.1.pre")),
+      0
+    );
   }
 }


### PR DESCRIPTION
I think we need to use a beta version to gate the upcoming change for DevTools since the next major release of flutter to include the needed changes won't be out by the time we want the full setup to be working.

I didn't find a built in way to compare these versions, so added this. Let me know if there is an easier way though.