### PR TITLE
Use app daemon to start DevTools

### DIFF
--- a/src/io/flutter/performance/FlutterPerformanceView.java
+++ b/src/io/flutter/performance/FlutterPerformanceView.java
@@ -204,7 +204,7 @@ public class FlutterPerformanceView implements Disposable {
 
     final LinkLabel<String> openDevtools = new LinkLabel<>("Open DevTools...", null);
     openDevtools.setListener((linkLabel, data) -> {
-      AsyncUtils.whenCompleteUiThread(DevToolsService.getInstance(app.getProject()).getDevToolsInstance(), (instance, ex) -> {
+      AsyncUtils.whenCompleteUiThread(DevToolsService.getInstance(app.getProject()).getDevToolsInstance(app), (instance, ex) -> {
         if (app.getProject().isDisposed()) {
           return;
         }

--- a/src/io/flutter/run/OpenDevToolsAction.java
+++ b/src/io/flutter/run/OpenDevToolsAction.java
@@ -62,7 +62,7 @@ public class OpenDevToolsAction extends DumbAwareAction {
     }
 
 
-    AsyncUtils.whenCompleteUiThread(DevToolsService.getInstance(project).getDevToolsInstance(), (instance, ex) -> {
+    AsyncUtils.whenCompleteUiThread(DevToolsService.getInstance(project).getDevToolsInstance(myApp), (instance, ex) -> {
       if (project.isDisposed()) {
         return;
       }

--- a/src/io/flutter/run/daemon/FlutterApp.java
+++ b/src/io/flutter/run/daemon/FlutterApp.java
@@ -611,6 +611,7 @@ public class FlutterApp implements Disposable {
       myProcessHandler.destroyProcess();
       myDaemonApi.cancelPending();
       done.run();
+      DevToolsService.getInstance(myProject).endAppDevToolsInstance();
     });
     return done;
   }

--- a/src/io/flutter/sdk/FlutterSdkVersion.java
+++ b/src/io/flutter/sdk/FlutterSdkVersion.java
@@ -8,10 +8,11 @@ package io.flutter.sdk;
 import com.google.common.annotations.VisibleForTesting;
 import com.intellij.openapi.util.Version;
 import com.intellij.openapi.vfs.VirtualFile;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 public class FlutterSdkVersion {
   /**
@@ -41,6 +42,11 @@ public class FlutterSdkVersion {
    * The version that supports --platform in flutter create.
    */
   private static final FlutterSdkVersion MIN_CREATE_PLATFORMS_SDK = new FlutterSdkVersion("1.20.0");
+
+  /**
+   * The version that supports opening DevTools using the daemon API.
+   */
+  private static final FlutterSdkVersion MIN_DEVTOOLS_FROM_DAEMON = new FlutterSdkVersion("1.26.0-8.0.pre");
 
   @Nullable
   private final Version version;
@@ -122,6 +128,11 @@ public class FlutterSdkVersion {
   public boolean isPubOutdatedSupported() {
     //noinspection ConstantConditions
     return version != null && version.compareTo(MIN_PUB_OUTDATED_SDK.version) >= 0;
+  }
+
+  // TODO: Use beta version comparing function.
+  public boolean isDevToolsFromDaemon() {
+    return true;
   }
 
   public boolean isValid() {

--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -452,7 +452,7 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
   }
 
   protected void openInspectorWithDevTools(FlutterApp app, InspectorService inspectorService, ToolWindow toolWindow, boolean isEmbedded) {
-    AsyncUtils.whenCompleteUiThread(DevToolsService.getInstance(myProject).getDevToolsInstance(), (instance, error) -> {
+    AsyncUtils.whenCompleteUiThread(DevToolsService.getInstance(myProject).getDevToolsInstance(app), (instance, error) -> {
       // Skip displaying if the project has been closed.
       if (!myProject.isOpen()) {
         return;
@@ -824,7 +824,7 @@ class FlutterViewDevToolsAction extends FlutterViewAction {
         return;
       }
 
-      AsyncUtils.whenCompleteUiThread(DevToolsService.getInstance(app.getProject()).getDevToolsInstance(), (instance, ex) -> {
+      AsyncUtils.whenCompleteUiThread(DevToolsService.getInstance(app.getProject()).getDevToolsInstance(app), (instance, ex) -> {
         if (app.getProject().isDisposed()) {
           return;
         }


### PR DESCRIPTION
We want to use an instance of the DevTools server associated with an app so that only one instance of the server will be present at a time and references from flutter_tools will all use the same instance.