### PR TITLE
Add run icon to definition of main()

### DIFF
--- a/src/io/flutter/run/common/CommonTestConfigUtils.java
+++ b/src/io/flutter/run/common/CommonTestConfigUtils.java
@@ -5,6 +5,9 @@
  */
 package io.flutter.run.common;
 
+import static org.dartlang.analysis.server.protocol.ElementKind.UNIT_TEST_GROUP;
+import static org.dartlang.analysis.server.protocol.ElementKind.UNIT_TEST_TEST;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer;
 import com.intellij.openapi.application.ApplicationManager;
@@ -17,17 +20,13 @@ import com.jetbrains.lang.dart.psi.DartCallExpression;
 import com.jetbrains.lang.dart.psi.DartStringLiteralExpression;
 import io.flutter.dart.DartSyntax;
 import io.flutter.editor.ActiveEditorsOutlineService;
+import java.util.HashMap;
+import java.util.Map;
 import org.apache.commons.lang.StringEscapeUtils;
 import org.dartlang.analysis.server.protocol.ElementKind;
 import org.dartlang.analysis.server.protocol.FlutterOutline;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
-import java.util.HashMap;
-import java.util.Map;
-
-import static org.dartlang.analysis.server.protocol.ElementKind.UNIT_TEST_GROUP;
-import static org.dartlang.analysis.server.protocol.ElementKind.UNIT_TEST_TEST;
 
 /**
  * Common utilities for processing Flutter tests.
@@ -39,6 +38,10 @@ public abstract class CommonTestConfigUtils {
   public static String convertHttpServiceProtocolToWs(String url) {
     return StringUtil.trimTrailing(
       url.replaceFirst("http:", "ws:"), '/') + "/ws";
+  }
+
+  public void refreshOutline(@NotNull PsiElement element) {
+    getTestsFromOutline(element.getContainingFile());
   }
 
   /**


### PR DESCRIPTION
Add a run icon to the definition of main(). Works for both the app and its tests.

<img width="676" alt="Screen Shot 2021-01-21 at 3 54 23 PM" src="https://user-images.githubusercontent.com/8518285/105426962-fe3b8100-5c00-11eb-8e03-e7560bcec2bf.png">

Fixes #5000
