### PR TITLE
Suggest invalidating caches if DevTools taking too long

### DIFF
--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -101,7 +101,7 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
   protected static final String INSTALLATION_TIMED_OUT_LABEL =
     "Waiting for JxBrowser installation timed out. Restart your IDE to try again.";
   protected static final String INSTALLATION_WAIT_FAILED = "The JxBrowser installation failed unexpectedly. Restart your IDE to try again.";
-  protected static final String INSTALLING_DEVTOOLS_LABEL = "Installing DevTools...";
+  protected static final String INSTALLING_DEVTOOLS_LABEL = "<html><body style=\"text-align: center;\">Installing DevTools... <br><br>(If this takes more than 15 seconds, please run File > Invalidate Caches & Restart.)</body></html>";
   protected static final String DEVTOOLS_FAILED_LABEL = "Setting up DevTools failed.";
   protected static final int INSTALLATION_WAIT_LIMIT_SECONDS = 2000;
 


### PR DESCRIPTION
I think we won't have this problem frequently since we've fixed a threading issue related to DevTools starting and we're now using an instance of the server that persists for a project. But providing an expectation of how long the loading should take and an action that is reported to help seems reasonable in case the problem persists.

![Screen Shot 2021-01-22 at 11 36 58 AM](https://user-images.githubusercontent.com/6379305/105537184-5f696000-5ca6-11eb-8924-162903ec4c40.png)


Fixes https://github.com/flutter/flutter-intellij/issues/5172

