### PR TITLE
Show notification on error with deep link 

### DIFF
--- a/src/io/flutter/devtools/DevToolsUtils.java
+++ b/src/io/flutter/devtools/DevToolsUtils.java
@@ -54,4 +54,15 @@ public class DevToolsUtils {
     }
     return "http://" + devtoolsHost + ":" + devtoolsPort + "/?" + String.join("&", params);
   }
+
+  public static String findWidgetId(String url) {
+    final String searchFor = "inspectorRef=";
+    final String[] split = url.split("&");
+    for (String part : split) {
+      if (part.startsWith(searchFor)) {
+        return part.substring(searchFor.length());
+      }
+    }
+    return null;
+  }
 }

--- a/src/io/flutter/inspector/DiagnosticsNode.java
+++ b/src/io/flutter/inspector/DiagnosticsNode.java
@@ -194,9 +194,13 @@ public class DiagnosticsNode {
     return getLevelMember("level", DiagnosticLevel.info);
   }
 
+  /**
+   * Returns a value associated with the node. This is a URL for DevToolsDeepLinkProperty nodes.
+   */
   public String getValue() {
     return getStringMember("value");
   }
+
   /**
    * Whether the name of the property should be shown when showing the default
    * view of the tree.

--- a/src/io/flutter/inspector/DiagnosticsNode.java
+++ b/src/io/flutter/inspector/DiagnosticsNode.java
@@ -194,6 +194,9 @@ public class DiagnosticsNode {
     return getLevelMember("level", DiagnosticLevel.info);
   }
 
+  public String getValue() {
+    return getStringMember("value");
+  }
   /**
    * Whether the name of the property should be shown when showing the default
    * view of the tree.

--- a/src/io/flutter/jxbrowser/EmbeddedBrowser.java
+++ b/src/io/flutter/jxbrowser/EmbeddedBrowser.java
@@ -23,9 +23,6 @@ import com.teamdev.jxbrowser.browser.event.ConsoleMessageReceived;
 import com.teamdev.jxbrowser.engine.Engine;
 import com.teamdev.jxbrowser.js.ConsoleMessage;
 import com.teamdev.jxbrowser.navigation.event.LoadFinished;
-import com.teamdev.jxbrowser.navigation.event.LoadStarted;
-import com.teamdev.jxbrowser.navigation.event.NavigationFinished;
-import com.teamdev.jxbrowser.navigation.event.NavigationStarted;
 import com.teamdev.jxbrowser.view.swing.BrowserView;
 import com.teamdev.jxbrowser.view.swing.callback.DefaultAlertCallback;
 import com.teamdev.jxbrowser.view.swing.callback.DefaultConfirmCallback;
@@ -34,7 +31,7 @@ import io.flutter.FlutterInitializer;
 import io.flutter.settings.FlutterSettings;
 import org.jetbrains.annotations.NotNull;
 
-import java.awt.Dimension;
+import java.awt.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class EmbeddedBrowser {
@@ -132,17 +129,5 @@ public class EmbeddedBrowser {
 
   public void updatePanelToWidget(String widgetId) {
     browser.navigation().loadUrl(mainUrl + "&inspectorRef=" + widgetId);
-    browser.navigation().on(LoadStarted.class, event -> {
-      System.out.println("in load started");
-    });
-    browser.navigation().on(NavigationStarted.class, event -> {
-      System.out.println("in navigation started");
-    });
-    browser.navigation().on(LoadFinished.class, event -> {
-      System.out.println("in load finished");
-    });
-    browser.navigation().on(NavigationFinished.class, event -> {
-      System.out.println("in navigation finished");
-    });
   }
 }

--- a/src/io/flutter/jxbrowser/EmbeddedBrowser.java
+++ b/src/io/flutter/jxbrowser/EmbeddedBrowser.java
@@ -23,6 +23,9 @@ import com.teamdev.jxbrowser.browser.event.ConsoleMessageReceived;
 import com.teamdev.jxbrowser.engine.Engine;
 import com.teamdev.jxbrowser.js.ConsoleMessage;
 import com.teamdev.jxbrowser.navigation.event.LoadFinished;
+import com.teamdev.jxbrowser.navigation.event.LoadStarted;
+import com.teamdev.jxbrowser.navigation.event.NavigationFinished;
+import com.teamdev.jxbrowser.navigation.event.NavigationStarted;
 import com.teamdev.jxbrowser.view.swing.BrowserView;
 import com.teamdev.jxbrowser.view.swing.callback.DefaultAlertCallback;
 import com.teamdev.jxbrowser.view.swing.callback.DefaultConfirmCallback;
@@ -43,6 +46,7 @@ public class EmbeddedBrowser {
   }
 
   private Browser browser;
+  private String mainUrl;
 
   private EmbeddedBrowser(Project project) {
     System.setProperty("jxbrowser.force.dpi.awareness", "1.0");
@@ -98,6 +102,7 @@ public class EmbeddedBrowser {
     // Multiple LoadFinished events can occur, but we only need to add content the first time.
     final AtomicBoolean contentLoaded = new AtomicBoolean(false);
 
+    this.mainUrl = url;
     browser.navigation().loadUrl(url);
     browser.navigation().on(LoadFinished.class, event -> {
       if (!contentLoaded.compareAndSet(false, true)) {
@@ -122,6 +127,22 @@ public class EmbeddedBrowser {
         content.setIcon(FlutterIcons.Phone);
         contentManager.addContent(content);
       });
+    });
+  }
+
+  public void updatePanelToWidget(String widgetId) {
+    browser.navigation().loadUrl(mainUrl + "&inspectorRef=" + widgetId);
+    browser.navigation().on(LoadStarted.class, event -> {
+      System.out.println("in load started");
+    });
+    browser.navigation().on(NavigationStarted.class, event -> {
+      System.out.println("in navigation started");
+    });
+    browser.navigation().on(LoadFinished.class, event -> {
+      System.out.println("in load finished");
+    });
+    browser.navigation().on(NavigationFinished.class, event -> {
+      System.out.println("in navigation finished");
     });
   }
 }

--- a/src/io/flutter/logging/FlutterConsoleLogManager.java
+++ b/src/io/flutter/logging/FlutterConsoleLogManager.java
@@ -402,7 +402,7 @@ public class FlutterConsoleLogManager {
   private void showDeepLinkNotification(DiagnosticsNode property, String errorSummary) {
     final Notification notification = new Notification(
       FlutterMessages.FLUTTER_NOTIFICATION_GROUP_ID,
-      "Inspect widget",
+      "Inspect error-causing widget",
       errorSummary,
       NotificationType.INFORMATION);
     notification.setIcon(FlutterIcons.Flutter);

--- a/src/io/flutter/logging/FlutterConsoleLogManager.java
+++ b/src/io/flutter/logging/FlutterConsoleLogManager.java
@@ -333,20 +333,7 @@ public class FlutterConsoleLogManager {
       }
 
       if (StringUtil.equals("DevToolsDeepLinkProperty", property.getType()) && FlutterSettings.getInstance().isEnableEmbeddedBrowsers()) {
-        final Notification notification = new Notification(
-          FlutterMessages.FLUTTER_NOTIFICATION_GROUP_ID,
-          "Inspect this widget",
-          "Click below to inspect this exception-causing widget in Flutter DevTools",
-          NotificationType.INFORMATION);
-        notification.setIcon(FlutterIcons.Flutter);
-        notification.addAction(new AnAction("Inspect") {
-          @Override
-          public void actionPerformed(@NotNull AnActionEvent event) {
-            final String widgetId = DevToolsUtils.findWidgetId(property.getValue());
-            EmbeddedBrowser.getInstance(app.getProject()).updatePanelToWidget(widgetId);
-          }
-        });
-        Notifications.Bus.notify(notification, app.getProject());
+        showDeepLinkNotification(property);
         return;
       }
     }
@@ -407,6 +394,23 @@ public class FlutterConsoleLogManager {
     if (property.getLevel() == DiagnosticLevel.summary) {
       console.print("\n", contentType);
     }
+  }
+
+  private void showDeepLinkNotification(DiagnosticsNode property) {
+    final Notification notification = new Notification(
+      FlutterMessages.FLUTTER_NOTIFICATION_GROUP_ID,
+      "Inspect this widget",
+      "Click below to inspect this exception-causing widget in Flutter DevTools",
+      NotificationType.INFORMATION);
+    notification.setIcon(FlutterIcons.Flutter);
+    notification.addAction(new AnAction("Inspect") {
+      @Override
+      public void actionPerformed(@NotNull AnActionEvent event) {
+        final String widgetId = DevToolsUtils.findWidgetId(property.getValue());
+        EmbeddedBrowser.getInstance(app.getProject()).updatePanelToWidget(widgetId);
+      }
+    });
+    Notifications.Bus.notify(notification, app.getProject());
   }
 
   private String getChildIndent(String indent, DiagnosticsNode property) {

--- a/src/io/flutter/logging/FlutterConsoleLogManager.java
+++ b/src/io/flutter/logging/FlutterConsoleLogManager.java
@@ -249,6 +249,7 @@ public class FlutterConsoleLogManager {
     }
     else {
       DiagnosticLevel lastLevel = null;
+      String errorSummary = null;
 
       for (DiagnosticsNode property : diagnosticsNode.getInlineProperties()) {
         // Add blank line between hint and non-hint properties.
@@ -259,6 +260,13 @@ public class FlutterConsoleLogManager {
         }
 
         lastLevel = property.getLevel();
+
+        if (StringUtil.equals("ErrorSummary", property.getType())) {
+          errorSummary = property.getDescription();
+        } else if (StringUtil.equals("DevToolsDeepLinkProperty", property.getType()) && FlutterSettings.getInstance().isEnableEmbeddedBrowsers()) {
+          showDeepLinkNotification(property, errorSummary);
+          continue;
+        }
 
         printDiagnosticsNodeProperty(console, "", property, null, false);
       }
@@ -331,11 +339,6 @@ public class FlutterConsoleLogManager {
       if (StringUtil.equals("ErrorSpacer", property.getType())) {
         return;
       }
-
-      if (StringUtil.equals("DevToolsDeepLinkProperty", property.getType()) && FlutterSettings.getInstance().isEnableEmbeddedBrowsers()) {
-        showDeepLinkNotification(property);
-        return;
-      }
     }
 
     if (contentType == null) {
@@ -396,14 +399,14 @@ public class FlutterConsoleLogManager {
     }
   }
 
-  private void showDeepLinkNotification(DiagnosticsNode property) {
+  private void showDeepLinkNotification(DiagnosticsNode property, String errorSummary) {
     final Notification notification = new Notification(
       FlutterMessages.FLUTTER_NOTIFICATION_GROUP_ID,
-      "Inspect this widget",
-      "Click below to inspect this exception-causing widget in Flutter DevTools",
+      "Inspect widget",
+      errorSummary,
       NotificationType.INFORMATION);
     notification.setIcon(FlutterIcons.Flutter);
-    notification.addAction(new AnAction("Inspect") {
+    notification.addAction(new AnAction("Inspect Widget") {
       @Override
       public void actionPerformed(@NotNull AnActionEvent event) {
         final String widgetId = DevToolsUtils.findWidgetId(property.getValue());


### PR DESCRIPTION
When an app throws a render overflow error and sends a URL with a deep link to DevTools, we want to parse the widget ID and open in the embedded DevTools window (if the user has enabled this).

![Jan-25-2021 15-36-02](https://user-images.githubusercontent.com/6379305/105779461-4caf8f00-5f23-11eb-8030-55f3cadd0b38.gif)

I think we were under the impression that navigating to the same URL but with one param changed should not cause a full page refresh, but I haven't found a way to avoid this. 