### PR TITLE
Modify deep link notification appearance

### DIFF
--- a/src/io/flutter/logging/FlutterConsoleLogManager.java
+++ b/src/io/flutter/logging/FlutterConsoleLogManager.java
@@ -15,6 +15,8 @@ import com.intellij.execution.ui.ConsoleView;
 import com.intellij.execution.ui.ConsoleViewContentType;
 import com.intellij.ide.util.PropertiesComponent;
 import com.intellij.notification.Notification;
+import com.intellij.notification.NotificationDisplayType;
+import com.intellij.notification.NotificationGroup;
 import com.intellij.notification.NotificationType;
 import com.intellij.notification.Notifications;
 import com.intellij.openapi.actionSystem.AnAction;
@@ -29,10 +31,9 @@ import com.intellij.openapi.wm.ToolWindowManager;
 import com.intellij.openapi.wm.ex.ToolWindowManagerEx;
 import com.intellij.ui.SimpleTextAttributes;
 import com.intellij.util.concurrency.QueueProcessor;
-import icons.FlutterIcons;
 import io.flutter.FlutterInitializer;
-import io.flutter.FlutterMessages;
 import io.flutter.devtools.DevToolsUtils;
+import io.flutter.editor.FlutterMaterialIcons;
 import io.flutter.inspector.DiagnosticLevel;
 import io.flutter.inspector.DiagnosticsNode;
 import io.flutter.inspector.DiagnosticsTreeStyle;
@@ -54,6 +55,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -65,6 +67,7 @@ public class FlutterConsoleLogManager {
   private static final Logger LOG = Logger.getInstance(FlutterConsoleLogManager.class);
 
   private static final String consolePreferencesSetKey = "io.flutter.console.preferencesSet";
+  private static final String DEEP_LINK_GROUP_ID = "deeplink";
 
   private static final ConsoleViewContentType TITLE_CONTENT_TYPE =
     new ConsoleViewContentType("title", SimpleTextAttributes.REGULAR_BOLD_ATTRIBUTES.toTextAttributes());
@@ -404,12 +407,15 @@ public class FlutterConsoleLogManager {
   }
 
   private void showDeepLinkNotification(DiagnosticsNode property, String errorSummary) {
+    // TODO(helin24): We can register a notification group in plugin.xml for 2020.3
+    // (see https://plugins.jetbrains.com/docs/intellij/notifications.html?from=jetbrains.org#top-level-notifications)
+    final NotificationGroup notificationGroup = new NotificationGroup(DEEP_LINK_GROUP_ID, NotificationDisplayType.STICKY_BALLOON);
     final Notification notification = new Notification(
-      FlutterMessages.FLUTTER_NOTIFICATION_GROUP_ID,
-      "Inspect error-causing widget",
+      DEEP_LINK_GROUP_ID,
+      "",
       errorSummary,
       NotificationType.INFORMATION);
-    notification.setIcon(FlutterIcons.Flutter);
+    notification.setIcon(FlutterMaterialIcons.getIconForName("error_outline"));
     notification.addAction(new AnAction("Inspect Widget") {
       @Override
       public void actionPerformed(@NotNull AnActionEvent event) {
@@ -429,6 +435,7 @@ public class FlutterConsoleLogManager {
       }
     });
     Notifications.Bus.notify(notification, app.getProject());
+    Executors.newSingleThreadScheduledExecutor().schedule(notification::expire, 25, TimeUnit.SECONDS);
   }
 
   private String getChildIndent(String indent, DiagnosticsNode property) {

--- a/src/io/flutter/logging/FlutterConsoleLogManager.java
+++ b/src/io/flutter/logging/FlutterConsoleLogManager.java
@@ -13,6 +13,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonSyntaxException;
 import com.intellij.execution.ui.ConsoleView;
 import com.intellij.execution.ui.ConsoleViewContentType;
+import com.intellij.icons.AllIcons;
 import com.intellij.ide.util.PropertiesComponent;
 import com.intellij.notification.Notification;
 import com.intellij.notification.NotificationDisplayType;
@@ -33,7 +34,6 @@ import com.intellij.ui.SimpleTextAttributes;
 import com.intellij.util.concurrency.QueueProcessor;
 import io.flutter.FlutterInitializer;
 import io.flutter.devtools.DevToolsUtils;
-import io.flutter.editor.FlutterMaterialIcons;
 import io.flutter.inspector.DiagnosticLevel;
 import io.flutter.inspector.DiagnosticsNode;
 import io.flutter.inspector.DiagnosticsTreeStyle;
@@ -415,7 +415,7 @@ public class FlutterConsoleLogManager {
       "",
       errorSummary,
       NotificationType.INFORMATION);
-    notification.setIcon(FlutterMaterialIcons.getIconForName("error_outline"));
+    notification.setIcon(AllIcons.General.BalloonWarning);
     notification.addAction(new AnAction("Inspect Widget") {
       @Override
       public void actionPerformed(@NotNull AnActionEvent event) {


### PR DESCRIPTION
- Removes title to be more similar to VS Code notification
- Notification persists for 25 seconds (unless clicked/removed)
- Icon denotes error instead of using the standard Flutter icon

<img width="377" alt="Screen Shot 2021-01-26 at 2 35 51 PM" src="https://user-images.githubusercontent.com/6379305/105914894-d9218680-5fe3-11eb-977e-c4135d8801c1.png">

CC @InMatrix 