### PR TITLE
Complete exceptionally if DevTools is taking too long

### DIFF
--- a/src/io/flutter/run/SdkFields.java
+++ b/src/io/flutter/run/SdkFields.java
@@ -170,7 +170,7 @@ public class SdkFields {
             devToolsFuture.complete(DevToolsService.getInstance(project).getDevToolsInstance().get(30, TimeUnit.SECONDS));
           }
           catch (Exception e) {
-            LOG.error(e);
+            devToolsFuture.completeExceptionally(e);
           }
         }, "Starting DevTools", false, project);
         final DevToolsInstance instance = devToolsFuture.get();


### PR DESCRIPTION
The future outside the progress indicator has to be completed with an exception if DevTools exceeds the max waiting time allowed; otherwise flutter run can't resume.