### PR TITLE
Restart DevTools and browser on inspector window reopen

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -21,7 +21,7 @@
 
   <category>Custom Languages</category>
   <version>SNAPSHOT</version>
-  <idea-version since-build="201.7223" until-build="203.8194.7"/>
+  <idea-version since-build="201.7223" until-build="202.8194.7"/>
 
   <depends>Dart</depends>
   <depends>Git4Idea</depends>

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -21,7 +21,7 @@
 
   <category>Custom Languages</category>
   <version>SNAPSHOT</version>
-  <idea-version since-build="201.7223" until-build="202.8194.7"/>
+  <idea-version since-build="201.7223" until-build="203.8194.7"/>
 
   <depends>Dart</depends>
   <depends>Git4Idea</depends>

--- a/src/io/flutter/FlutterBundle.properties
+++ b/src/io/flutter/FlutterBundle.properties
@@ -228,3 +228,5 @@ flutter.module.create.settings.platforms.label=Platforms:
 flutter.sdk.invalid.json.error=Invalid Json from flutter config
 change.color.command.text=Change Color
 fluitter.icon.preview.title=Icon preview
+flutter.devtools.installing=Installing DevTools... <br><br>If this takes more than 15 seconds, you can restart with these steps:<br>1. \
+  Remove this window from the sidebar<br>2. Open it again from View -> Tool Windows -> Flutter Inspector<br><br>Attempts: {0}

--- a/src/io/flutter/run/daemon/DevToolsService.java
+++ b/src/io/flutter/run/daemon/DevToolsService.java
@@ -83,6 +83,28 @@ public class DevToolsService {
     return devToolsFutureRef.get();
   }
 
+  public CompletableFuture<DevToolsInstance> getDevToolsInstanceWithForcedRestart() {
+    final CompletableFuture<DevToolsInstance> futureInstance = devToolsFutureRef.updateAndGet((future) -> {
+      if (future.isCompletedExceptionally() || future.isCancelled()) {
+        return null;
+      }
+      else {
+        return future;
+      }
+    });
+
+    if (futureInstance == null) {
+      devToolsFutureRef.set(new CompletableFuture<>());
+      startServer();
+    } else if (!futureInstance.isDone()) {
+      futureInstance.cancel(true);
+      devToolsFutureRef.set(new CompletableFuture<>());
+      startServer();
+    }
+
+    return devToolsFutureRef.get();
+  }
+
   private void startServer() {
     ApplicationManager.getApplication().executeOnPooledThread(() -> {
       final FlutterSdk sdk = FlutterSdk.getFlutterSdk(project);

--- a/src/io/flutter/toolwindow/FlutterViewToolWindowManagerListener.java
+++ b/src/io/flutter/toolwindow/FlutterViewToolWindowManagerListener.java
@@ -20,7 +20,7 @@ public class FlutterViewToolWindowManagerListener implements ToolWindowManagerLi
     project.getMessageBus().connect().subscribe(ToolWindowManagerListener.TOPIC, this);
   }
 
-  public void update(Runnable onWindowOpen) {
+  public void updateOnWindowOpen(Runnable onWindowOpen) {
     this.onWindowOpen = onWindowOpen;
   }
 

--- a/src/io/flutter/toolwindow/FlutterViewToolWindowManagerListener.java
+++ b/src/io/flutter/toolwindow/FlutterViewToolWindowManagerListener.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2021 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.toolwindow;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.wm.ToolWindow;
+import com.intellij.openapi.wm.ToolWindowManager;
+import com.intellij.openapi.wm.ex.ToolWindowManagerListener;
+import io.flutter.view.FlutterView;
+import org.jetbrains.annotations.NotNull;
+
+public class FlutterViewToolWindowManagerListener implements ToolWindowManagerListener {
+  private boolean inspectorIsOpen = false;
+  private Runnable onWindowOpen;
+
+  public FlutterViewToolWindowManagerListener(Project project) {
+    project.getMessageBus().connect().subscribe(ToolWindowManagerListener.TOPIC, this);
+  }
+
+  public void update(Runnable onWindowOpen) {
+    this.onWindowOpen = onWindowOpen;
+  }
+
+  @Override
+  public void stateChanged(@NotNull ToolWindowManager toolWindowManager) {
+    final ToolWindow inspectorWindow = toolWindowManager.getToolWindow(FlutterView.TOOL_WINDOW_ID);
+    if (inspectorWindow == null) {
+      return;
+    }
+
+    final boolean newIsOpen = inspectorWindow.isShowStripeButton();
+    if (newIsOpen != inspectorIsOpen) {
+      inspectorIsOpen = newIsOpen;
+      if (newIsOpen && onWindowOpen != null) {
+        onWindowOpen.run();
+      }
+    }
+  }
+}

--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -5,6 +5,7 @@
  */
 package io.flutter.view;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.intellij.execution.runners.ExecutionUtil;
 import com.intellij.execution.ui.layout.impl.JBRunnerTabs;
 import com.intellij.icons.AllIcons;
@@ -33,7 +34,10 @@ import com.intellij.ui.SimpleTextAttributes;
 import com.intellij.ui.components.JBLabel;
 import com.intellij.ui.components.labels.LinkLabel;
 import com.intellij.ui.components.labels.LinkListener;
-import com.intellij.ui.content.*;
+import com.intellij.ui.content.Content;
+import com.intellij.ui.content.ContentManager;
+import com.intellij.ui.content.ContentManagerAdapter;
+import com.intellij.ui.content.ContentManagerEvent;
 import com.intellij.ui.tabs.TabInfo;
 import com.intellij.util.ui.JBUI;
 import com.intellij.util.ui.UIUtil;
@@ -456,6 +460,11 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
 
     openInspectorWithDevTools(app, inspectorService, toolWindow, isEmbedded);
 
+    setUpToolWindowListener(app, inspectorService, toolWindow, isEmbedded);
+  }
+
+  @VisibleForTesting
+  protected void setUpToolWindowListener(FlutterApp app, InspectorService inspectorService, ToolWindow toolWindow, boolean isEmbedded) {
     if (this.toolWindowListener == null) {
       this.toolWindowListener = new FlutterViewToolWindowManagerListener(myProject);
     }
@@ -472,11 +481,12 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
            "Inspector<br><br>Attempts: " + devToolsInstallCount + "</body></html>";
   }
 
+  @VisibleForTesting
   protected void openInspectorWithDevTools(FlutterApp app, InspectorService inspectorService, ToolWindow toolWindow, boolean isEmbedded) {
     openInspectorWithDevTools(app, inspectorService, toolWindow, isEmbedded, false);
   }
 
-  protected void openInspectorWithDevTools(FlutterApp app,
+  private void openInspectorWithDevTools(FlutterApp app,
                                            InspectorService inspectorService,
                                            ToolWindow toolWindow,
                                            boolean isEmbedded,

--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -33,10 +33,7 @@ import com.intellij.ui.SimpleTextAttributes;
 import com.intellij.ui.components.JBLabel;
 import com.intellij.ui.components.labels.LinkLabel;
 import com.intellij.ui.components.labels.LinkListener;
-import com.intellij.ui.content.Content;
-import com.intellij.ui.content.ContentManager;
-import com.intellij.ui.content.ContentManagerAdapter;
-import com.intellij.ui.content.ContentManagerEvent;
+import com.intellij.ui.content.*;
 import com.intellij.ui.tabs.TabInfo;
 import com.intellij.util.ui.JBUI;
 import com.intellij.util.ui.UIUtil;
@@ -57,6 +54,7 @@ import io.flutter.run.daemon.DevToolsInstance;
 import io.flutter.run.daemon.DevToolsService;
 import io.flutter.run.daemon.FlutterApp;
 import io.flutter.settings.FlutterSettings;
+import io.flutter.toolwindow.FlutterViewToolWindowManagerListener;
 import io.flutter.utils.AsyncUtils;
 import io.flutter.utils.EventStream;
 import io.flutter.utils.JxBrowserUtils;
@@ -118,6 +116,8 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
   private final Map<FlutterApp, PerAppState> perAppViewState = new HashMap<>();
 
   private Content emptyContent;
+
+  private FlutterViewToolWindowManagerListener toolWindowListener;
 
   public FlutterView(@NotNull Project project) {
     myProject = project;
@@ -454,6 +454,13 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
     presentLabel(toolWindow, INSTALLING_DEVTOOLS_LABEL);
 
     openInspectorWithDevTools(app, inspectorService, toolWindow, isEmbedded);
+
+    if (this.toolWindowListener == null) {
+      this.toolWindowListener = new FlutterViewToolWindowManagerListener(myProject);
+    }
+    this.toolWindowListener.update(() -> {
+      openInspectorWithDevTools(app, inspectorService, toolWindow, isEmbedded);
+    });
   }
 
   protected void openInspectorWithDevTools(FlutterApp app, InspectorService inspectorService, ToolWindow toolWindow, boolean isEmbedded) {

--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -43,6 +43,7 @@ import com.intellij.util.ui.JBUI;
 import com.intellij.util.ui.UIUtil;
 import com.intellij.xdebugger.XSourcePosition;
 import icons.FlutterIcons;
+import io.flutter.FlutterBundle;
 import io.flutter.FlutterInitializer;
 import io.flutter.FlutterUtils;
 import io.flutter.devtools.DevToolsUtils;
@@ -476,9 +477,8 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
   }
 
   private String getInstallingDevtoolsLabel() {
-    return "<html><body style=\"text-align: center;\">Installing DevTools... <br><br>If this takes more than 15 seconds, you can restart " +
-           "with these steps:<br>1. Remove this window from the sidebar<br>2. Open it again from View -> Tool Windows -> Flutter " +
-           "Inspector<br><br>Attempts: " + devToolsInstallCount + "</body></html>";
+    return "<html><body style=\"text-align: center;\">" +
+           FlutterBundle.message("flutter.devtools.installing", devToolsInstallCount) + "</body></html>";
   }
 
   @VisibleForTesting

--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -99,8 +99,6 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
   protected static final String INSTALLATION_TIMED_OUT_LABEL =
     "Waiting for JxBrowser installation timed out. Restart your IDE to try again.";
   protected static final String INSTALLATION_WAIT_FAILED = "The JxBrowser installation failed unexpectedly. Restart your IDE to try again.";
-  protected static final String INSTALLING_DEVTOOLS_LABEL = "Installing DevTools...";
-  protected static final String RESTARTING_DEVTOOLS_LABEL = "Restarting DevTools...";
   protected static final String DEVTOOLS_FAILED_LABEL = "Setting up DevTools failed.";
   protected static final int INSTALLATION_WAIT_LIMIT_SECONDS = 2000;
 
@@ -119,6 +117,7 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
   private Content emptyContent;
 
   private FlutterViewToolWindowManagerListener toolWindowListener;
+  private int devToolsInstallCount = 0;
 
   public FlutterView(@NotNull Project project) {
     myProject = project;
@@ -452,7 +451,8 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
   private void presentDevTools(FlutterApp app, InspectorService inspectorService, ToolWindow toolWindow, boolean isEmbedded) {
     assert(SwingUtilities.isEventDispatchThread());
 
-    presentLabel(toolWindow, INSTALLING_DEVTOOLS_LABEL);
+    devToolsInstallCount += 1;
+    presentLabel(toolWindow, getInstallingDevtoolsLabel());
 
     openInspectorWithDevTools(app, inspectorService, toolWindow, isEmbedded);
 
@@ -460,9 +460,16 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
       this.toolWindowListener = new FlutterViewToolWindowManagerListener(myProject);
     }
     this.toolWindowListener.update(() -> {
-      presentLabel(toolWindow, RESTARTING_DEVTOOLS_LABEL);
+      devToolsInstallCount += 1;
+      presentLabel(toolWindow, getInstallingDevtoolsLabel());
       openInspectorWithDevTools(app, inspectorService, toolWindow, isEmbedded, true);
     });
+  }
+
+  private String getInstallingDevtoolsLabel() {
+    return "<html><body style=\"text-align: center;\">Installing DevTools... <br><br>If this takes more than 15 seconds, you can restart " +
+           "with these steps:<br>1. Remove this window from the sidebar<br>2. Open it again from View -> Tool Windows -> Flutter " +
+           "Inspector<br><br>Attempts: " + devToolsInstallCount + "</body></html>";
   }
 
   protected void openInspectorWithDevTools(FlutterApp app, InspectorService inspectorService, ToolWindow toolWindow, boolean isEmbedded) {

--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -459,7 +459,7 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
     if (this.toolWindowListener == null) {
       this.toolWindowListener = new FlutterViewToolWindowManagerListener(myProject);
     }
-    this.toolWindowListener.update(() -> {
+    this.toolWindowListener.updateOnWindowOpen(() -> {
       devToolsInstallCount += 1;
       presentLabel(toolWindow, getInstallingDevtoolsLabel());
       openInspectorWithDevTools(app, inspectorService, toolWindow, isEmbedded, true);

--- a/testSrc/unit/io/flutter/view/FlutterViewTest.java
+++ b/testSrc/unit/io/flutter/view/FlutterViewTest.java
@@ -54,6 +54,7 @@ public class FlutterViewTest {
 
     partialMockFlutterView.handleJxBrowserInstalled(mockApp, mockInspectorService, mockToolWindow);
     verify(partialMockFlutterView, times(1)).openInspectorWithDevTools(mockApp, mockInspectorService, mockToolWindow, true);
+    verify(partialMockFlutterView, times(1)).setUpToolWindowListener(mockApp, mockInspectorService, mockToolWindow, true);
   }
 
   @Test


### PR DESCRIPTION
There have been cases where DevTools installation gets stuck. This may be fixed with our change to having one DevTools instance per project, but we wanted to offer a way to restart DevTools if users are waiting a long time. 

![Jan-27-2021 11-46-00](https://user-images.githubusercontent.com/6379305/106044973-43deca80-6095-11eb-8f7b-97a16f0d36ae.gif)

The logic when a user closes and reopens the window:
- If the DevTools instance has successfully been created, the same instance is returned but the browser is refreshed (this may be useful if users see the frozen wheel or another issue within DevTools)
- If DevTools has completed with a failure, we try to start a new instance
- If DevTools is still in progress, we force a restart by canceling the existing future and trying to start a new instance

Fixes https://github.com/flutter/flutter-intellij/issues/5162