### PR TITLE
Fix bugs in M53

### DIFF
--- a/.idea/libraries/KotlinJavaRuntime.xml
+++ b/.idea/libraries/KotlinJavaRuntime.xml
@@ -1,0 +1,19 @@
+<component name="libraryTable">
+  <library name="KotlinJavaRuntime">
+    <CLASSES>
+      <root url="jar://$PROJECT_DIR$/lib/kotlin-stdlib.jar!/" />
+      <root url="jar://$PROJECT_DIR$/lib/kotlin-reflect.jar!/" />
+      <root url="jar://$PROJECT_DIR$/lib/kotlin-test.jar!/" />
+      <root url="jar://$PROJECT_DIR$/lib/kotlin-stdlib-jdk7.jar!/" />
+      <root url="jar://$PROJECT_DIR$/lib/kotlin-stdlib-jdk8.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES>
+      <root url="jar://$PROJECT_DIR$/lib/kotlin-stdlib-sources.jar!/" />
+      <root url="jar://$PROJECT_DIR$/lib/kotlin-reflect-sources.jar!/" />
+      <root url="jar://$PROJECT_DIR$/lib/kotlin-test-sources.jar!/" />
+      <root url="jar://$PROJECT_DIR$/lib/kotlin-stdlib-jdk7-sources.jar!/" />
+      <root url="jar://$PROJECT_DIR$/lib/kotlin-stdlib-jdk8-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.java
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.java
@@ -243,10 +243,12 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
         ApplicationManager.getApplication().runWriteAction(() -> {
           FlutterSdkUtil.setFlutterSdkPath(myProject, sdkHomePath);
           FlutterSdkUtil.enableDartSdk(myProject);
-          final FlutterSdk sdk = FlutterSdk.forPath(sdkHomePath);
-          if (sdk != null) {
-            sdk.queryFlutterChannel(false);
-          }
+          ApplicationManager.getApplication().executeOnPooledThread(() -> {
+            final FlutterSdk sdk = FlutterSdk.forPath(sdkHomePath);
+            if (sdk != null) {
+              sdk.queryFlutterChannel(false);
+            }
+          });
         });
       }
     }

--- a/src/io/flutter/vmService/frame/DartVmServiceEvaluatorInFrame.java
+++ b/src/io/flutter/vmService/frame/DartVmServiceEvaluatorInFrame.java
@@ -24,15 +24,6 @@ public class DartVmServiceEvaluatorInFrame extends DartVmServiceEvaluator {
   public void evaluate(@NotNull final String expression,
                        @NotNull final XEvaluationCallback callback,
                        @Nullable final XSourcePosition expressionPosition) {
-    myDebugProcess.getVmServiceWrapper().evaluateInFrame(myIsolateId, myFrame, replaceNewlines(expression), callback);
-  }
-
-  private String replaceNewlines(String expr) {
-    if (SystemInfo.isWindows) {
-      // Doing separately in case we only have \n in this string.
-      return expr.replaceAll("\n", " ").replaceAll("\r", " ");
-    } else {
-      return expr.replaceAll("\n", " ");
-    }
+    myDebugProcess.getVmServiceWrapper().evaluateInFrame(myIsolateId, myFrame, expression, callback);
   }
 }

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/VmService.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/VmService.java
@@ -20,6 +20,8 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 import java.util.List;
 import java.util.Map;
+
+import com.intellij.openapi.util.SystemInfo;
 import org.dartlang.vm.service.consumer.*;
 import org.dartlang.vm.service.element.*;
 
@@ -169,7 +171,7 @@ public class VmService extends VmServiceBase {
     final JsonObject params = new JsonObject();
     params.addProperty("isolateId", isolateId);
     params.addProperty("targetId", targetId);
-    params.addProperty("expression", expression);
+    params.addProperty("expression", replaceNewlines(expression));
     request("evaluate", params, consumer);
   }
 
@@ -182,7 +184,7 @@ public class VmService extends VmServiceBase {
     final JsonObject params = new JsonObject();
     params.addProperty("isolateId", isolateId);
     params.addProperty("targetId", targetId);
-    params.addProperty("expression", expression);
+    params.addProperty("expression", replaceNewlines(expression));
     if (scope != null) params.add("scope", convertMapToJsonObject(scope));
     if (disableBreakpoints != null) params.addProperty("disableBreakpoints", disableBreakpoints);
     request("evaluate", params, consumer);
@@ -197,7 +199,7 @@ public class VmService extends VmServiceBase {
     final JsonObject params = new JsonObject();
     params.addProperty("isolateId", isolateId);
     params.addProperty("frameIndex", frameIndex);
-    params.addProperty("expression", expression);
+    params.addProperty("expression", replaceNewlines(expression));
     request("evaluateInFrame", params, consumer);
   }
 
@@ -212,7 +214,7 @@ public class VmService extends VmServiceBase {
     final JsonObject params = new JsonObject();
     params.addProperty("isolateId", isolateId);
     params.addProperty("frameIndex", frameIndex);
-    params.addProperty("expression", expression);
+    params.addProperty("expression", replaceNewlines(expression));
     if (scope != null) params.add("scope", convertMapToJsonObject(scope));
     if (disableBreakpoints != null) params.addProperty("disableBreakpoints", disableBreakpoints);
     request("evaluateInFrame", params, consumer);
@@ -1161,5 +1163,14 @@ public class VmService extends VmServiceBase {
       return;
     }
     logUnknownResponse(consumer, json);
+  }
+
+  private String replaceNewlines(String expr) {
+    if (SystemInfo.isWindows) {
+      // Doing separately in case we only have \n in this string.
+      return expr.replaceAll("\n", " ").replaceAll("\r", " ");
+    } else {
+      return expr.replaceAll("\n", " ");
+    }
   }
 }


### PR DESCRIPTION
The `flutter channel` query was being run on the EDT during start-up, so I moved that to run on a pooled thread.

I missed some expression evaluation paths, but I think this catches all of them.