### PR TITLE
Modify password store to avoid keyring prompts

### DIFF
--- a/src/io/flutter/jxbrowser/EmbeddedBrowserEngine.java
+++ b/src/io/flutter/jxbrowser/EmbeddedBrowserEngine.java
@@ -13,6 +13,7 @@ import com.intellij.openapi.util.SystemInfo;
 import com.intellij.openapi.util.text.StringUtil;
 import com.teamdev.jxbrowser.engine.Engine;
 import com.teamdev.jxbrowser.engine.EngineOptions;
+import com.teamdev.jxbrowser.engine.PasswordStore;
 import io.flutter.FlutterInitializer;
 
 import java.io.File;
@@ -36,6 +37,8 @@ public class EmbeddedBrowserEngine {
     final EngineOptions options =
       EngineOptions.newBuilder(SystemInfo.isWindows ? OFF_SCREEN : HARDWARE_ACCELERATED)
         .userDataDir(Paths.get(dataPath))
+        .passwordStore(PasswordStore.BASIC)
+        .addSwitch("--use-mock-keychain")
         .build();
 
     Engine temp;

--- a/src/io/flutter/jxbrowser/EmbeddedBrowserEngine.java
+++ b/src/io/flutter/jxbrowser/EmbeddedBrowserEngine.java
@@ -38,7 +38,6 @@ public class EmbeddedBrowserEngine {
       EngineOptions.newBuilder(SystemInfo.isWindows ? OFF_SCREEN : HARDWARE_ACCELERATED)
         .userDataDir(Paths.get(dataPath))
         .passwordStore(PasswordStore.BASIC)
-        .addSwitch("--use-mock-keychain")
         .build();
 
     Engine temp;


### PR DESCRIPTION
Since JxBrowser uses Chromium we have some situations where a user opens the embedded browser and is prompted to unlock the keyring in Linux if Chrome hasn't been opened already. We're hoping to avoid this by passing a Chrome option.