### PR TITLE
Add version null check for DevTools URL support

### DIFF
--- a/src/io/flutter/sdk/FlutterSdkVersion.java
+++ b/src/io/flutter/sdk/FlutterSdkVersion.java
@@ -138,7 +138,7 @@ public class FlutterSdkVersion implements Comparable<FlutterSdkVersion> {
   }
 
   public boolean flutterRunSupportsDevToolsUrl() {
-    return this.compareTo(MIN_PASS_DEVTOOLS_SDK) >= 0;
+    return version != null && this.compareTo(MIN_PASS_DEVTOOLS_SDK) >= 0;
   }
 
   public boolean flutterTestSupportsMachineMode() {


### PR DESCRIPTION
The SDK version seems to be null if flutter has just been updated.