### PR TITLE
XCode -> Xcode casing

### DIFF
--- a/src/io/flutter/run/FlutterConfigurationEditorForm.form
+++ b/src/io/flutter/run/FlutterConfigurationEditorForm.form
@@ -38,7 +38,7 @@
         </constraints>
         <properties>
           <text value="Build flavor:"/>
-          <toolTipText value="The build flavor. This is either a gradle product flavor or an XCode custom scheme."/>
+          <toolTipText value="The build flavor. This is either a gradle product flavor or an Xcode custom scheme."/>
         </properties>
       </component>
       <component id="14837" class="javax.swing.JTextField" binding="myBuildFlavorField">
@@ -55,7 +55,7 @@
         </constraints>
         <properties>
           <enabled value="false"/>
-          <text value="An optional build flavor; either a Gradle product flavor or an XCode custom scheme."/>
+          <text value="An optional build flavor; either a Gradle product flavor or an Xcode custom scheme."/>
         </properties>
       </component>
       <component id="45360" class="javax.swing.JLabel">

--- a/src/io/flutter/utils/FlutterModuleUtils.java
+++ b/src/io/flutter/utils/FlutterModuleUtils.java
@@ -141,7 +141,7 @@ public class FlutterModuleUtils {
   public static VirtualFile findXcodeProjectFile(@NotNull Project project) {
     if (project.isDisposed()) return null;
 
-    // Look for XCode metadata file in `ios/`.
+    // Look for Xcode metadata file in `ios/`.
     for (PubRoot root : PubRoots.forProject(project)) {
       final VirtualFile dir = root.getiOsDir();
       final VirtualFile file = findPreferedXcodeMetadataFile(dir);
@@ -150,7 +150,7 @@ public class FlutterModuleUtils {
       }
     }
 
-    // Look for XCode metadata in `example/ios/`.
+    // Look for Xcode metadata in `example/ios/`.
     for (PubRoot root : PubRoots.forProject(project)) {
       final VirtualFile exampleDir = root.getExampleDir();
       if (exampleDir != null) {


### PR DESCRIPTION
Change from "XCode" to "Xcode" to match the app's correct casing.  See in docs: https://developer.apple.com/xcode/

<img width="550" alt="Screen Shot 2021-02-05 at 3 59 22 PM" src="https://user-images.githubusercontent.com/682784/107308211-14d53b00-6a3d-11eb-8001-49fcc4e79594.png">

Introduced in #1321