### PR TITLE
Compare master versions with beta

### DIFF
--- a/src/io/flutter/sdk/FlutterSdkVersion.java
+++ b/src/io/flutter/sdk/FlutterSdkVersion.java
@@ -184,38 +184,31 @@ public class FlutterSdkVersion implements Comparable<FlutterSdkVersion> {
       return standardComparisonResult;
     }
 
-    // If both versions are on master, we can compare with the beta version and the master version.
-    if (masterVersion > 0 && otherVersion.masterVersion > 0) {
-      assert betaVersion != null;
-      assert otherVersion.betaVersion != null;
-      final int betaComparisonResult = betaVersion.compareTo(otherVersion.betaVersion);
-      return betaComparisonResult == 0 ? Integer.compare(masterVersion, otherVersion.masterVersion) : betaComparisonResult;
-    }
-
-    // TODO(helin24): Implement more thorough/correct comparison for master versions against non-master beta versions.
-    // This recognizes all master versions as later than non-master beta versions if the standard version is equal, because a later master
-    // version can have smaller beta version numbers than a preceding beta/dev version.
-    if (masterVersion > 0 && otherVersion.masterVersion == 0) {
-      return 1;
-    }
-
-    if (masterVersion == 0 && otherVersion.masterVersion > 0) {
-      return -1;
-    }
-
     // Check for beta version strings if standard versions are equivalent.
     if (betaVersion == null && otherVersion.betaVersion == null) {
       return 0;
-    }
-
-    if (betaVersion != null && otherVersion.betaVersion != null) {
-      return betaVersion.compareTo(otherVersion.betaVersion);
-    }
-
-    if (betaVersion == null) {
+    } else if (betaVersion == null) {
       return 1;
+    } else if (otherVersion.betaVersion == null) {
+      return -1;
     }
 
-    return -1;
+    final int betaComparisonResult = betaVersion.compareTo(otherVersion.betaVersion);
+
+    if (betaComparisonResult != 0) {
+      return betaComparisonResult;
+    }
+
+    // Check master version ints if both have master version ints and versions are otherwise equivalent.
+    // Otherwise, the version without a master version is further ahead.
+    if (masterVersion != 0 && otherVersion.masterVersion != 0) {
+      return Integer.compare(masterVersion, otherVersion.masterVersion);
+    } else if (masterVersion != 0) {
+      return -1;
+    } else if (otherVersion.masterVersion != 0) {
+      return 1;
+    } else {
+      return 0;
+    }
   }
 }

--- a/testSrc/unit/io/flutter/sdk/FlutterSdkVersionTest.java
+++ b/testSrc/unit/io/flutter/sdk/FlutterSdkVersionTest.java
@@ -50,9 +50,14 @@ public class FlutterSdkVersionTest {
       new FlutterSdkVersion("1.0.1").compareTo(new FlutterSdkVersion("1.0.0")),
       1
     );
+    // Stable version is ahead of all beta versions with the same major/minor/patch numbers.
     assertEquals(
       new FlutterSdkVersion("1.0.0").compareTo(new FlutterSdkVersion("1.0.0-1.0.pre")),
       1
+    );
+    assertEquals(
+      new FlutterSdkVersion("1.0.0-1.1.pre").compareTo(new FlutterSdkVersion("1.0.0")),
+      -1
     );
     assertEquals(
       new FlutterSdkVersion("1.0.0-1.1.pre").compareTo(new FlutterSdkVersion("1.0.0-1.0.pre")),
@@ -71,15 +76,9 @@ public class FlutterSdkVersionTest {
       -1
     );
     assertEquals(
-      new FlutterSdkVersion("1.0.0-1.1.pre").compareTo(new FlutterSdkVersion("1.0.0")),
-      -1
-    );
-    assertEquals(
       new FlutterSdkVersion("1.0.0-1.1.pre").compareTo(new FlutterSdkVersion("1.0.0-1.1.pre")),
       0
     );
-
-    // TODO:(helin24): Update with correct comparisons involving the master branch.
     assertEquals(
       new FlutterSdkVersion("1.0.0-1.1.pre.123").compareTo(new FlutterSdkVersion("1.0.0-1.1.pre.123")),
       0
@@ -92,23 +91,24 @@ public class FlutterSdkVersionTest {
       new FlutterSdkVersion("1.0.0-1.1.pre.124").compareTo(new FlutterSdkVersion("1.0.0-1.1.pre.123")),
       1
     );
-
+    // Master versions will be aware of the latest preceding dev version and have a version number higher than the preceding dev version.
+    // e.g. the next commit to master after cutting dev version 2.0.0-2.0.pre would be 2.0.0-3.0.pre.1, with the number 1 signifying 1
+    // commit after the previous version.
     assertEquals(
       new FlutterSdkVersion("1.0.0-1.1.pre.123").compareTo(new FlutterSdkVersion("1.0.0-1.1.pre")),
-      1
+      -1
     );
-    assertEquals(
-      new FlutterSdkVersion("1.0.0-1.0.pre.123").compareTo(new FlutterSdkVersion("1.0.0-2.0.pre")),
-      1
-    );
-
     assertEquals(
       new FlutterSdkVersion("1.0.0-1.1.pre").compareTo(new FlutterSdkVersion("1.0.0-1.1.pre.123")),
-      -1
+      1
+    );
+    assertEquals(
+      new FlutterSdkVersion("1.0.0-2.0.pre.123").compareTo(new FlutterSdkVersion("1.0.0-1.0.pre")),
+      1
     );
     assertEquals(
       new FlutterSdkVersion("1.0.0-2.0.pre").compareTo(new FlutterSdkVersion("1.0.0-1.0.pre.123")),
-      -1
+      1
     );
   }
 }


### PR DESCRIPTION
Versioning has been adjusted in flutter so that master versions are aware of the preceding dev release, so I'm updating our versioning check to fully consider all types (stable, beta, dev, and master channels).

CC @christopherfujino 