### PR TITLE
Delay loading embedded browser until inspector visible

### DIFF
--- a/src/io/flutter/toolwindow/FlutterViewToolWindowManagerListener.java
+++ b/src/io/flutter/toolwindow/FlutterViewToolWindowManagerListener.java
@@ -15,6 +15,7 @@ import org.jetbrains.annotations.NotNull;
 public class FlutterViewToolWindowManagerListener implements ToolWindowManagerListener {
   private boolean inspectorIsOpen = false;
   private Runnable onWindowOpen;
+  private Runnable onWindowFirstVisible;
 
   public FlutterViewToolWindowManagerListener(Project project) {
     project.getMessageBus().connect().subscribe(ToolWindowManagerListener.TOPIC, this);
@@ -22,6 +23,10 @@ public class FlutterViewToolWindowManagerListener implements ToolWindowManagerLi
 
   public void updateOnWindowOpen(Runnable onWindowOpen) {
     this.onWindowOpen = onWindowOpen;
+  }
+
+  public void updateOnWindowFirstVisible(Runnable onWindowFirstVisible) {
+    this.onWindowFirstVisible = onWindowFirstVisible;
   }
 
   @Override
@@ -37,6 +42,11 @@ public class FlutterViewToolWindowManagerListener implements ToolWindowManagerLi
       if (newIsOpen && onWindowOpen != null) {
         onWindowOpen.run();
       }
+    }
+
+    if (inspectorWindow.isVisible() && onWindowFirstVisible != null) {
+      onWindowFirstVisible.run();
+      onWindowFirstVisible = null;
     }
   }
 }

--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -668,17 +668,18 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
     toolWindow.setIcon(ExecutionUtil.getLiveIndicator(FlutterIcons.Flutter_13));
 
     if (FlutterSettings.getInstance().isEnableEmbeddedBrowsers()) {
-      final JxBrowserStatus jxBrowserStatus = JxBrowserManager.getInstance().getStatus();
+      if (toolWindow.isVisible()) {
+        displayEmbeddedBrowser(app, inspectorService, toolWindow);
+      } else {
+        if (toolWindowListener == null) {
+          toolWindowListener = new FlutterViewToolWindowManagerListener(myProject);
+        }
+        // If the window isn't visible yet, only executed embedded browser steps when it becomes visible.
+        toolWindowListener.updateOnWindowFirstVisible(() -> {
+          displayEmbeddedBrowser(app, inspectorService, toolWindow);
+        });
+      }
 
-      if (jxBrowserStatus.equals(JxBrowserStatus.INSTALLED)) {
-        handleJxBrowserInstalled(app, inspectorService, toolWindow);
-      }
-      else if (jxBrowserStatus.equals(JxBrowserStatus.INSTALLATION_IN_PROGRESS)) {
-        handleJxBrowserInstallationInProgress(app, inspectorService, toolWindow);
-      }
-      else if (jxBrowserStatus.equals(JxBrowserStatus.INSTALLATION_FAILED)) {
-        handleJxBrowserInstallationFailed(app, inspectorService, toolWindow);
-      }
       return;
     }
 
@@ -742,6 +743,20 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
         }
       }
     });
+  }
+
+  private void displayEmbeddedBrowser(FlutterApp app, InspectorService inspectorService, ToolWindow toolWindow) {
+    final JxBrowserStatus jxBrowserStatus = JxBrowserManager.getInstance().getStatus();
+
+    if (jxBrowserStatus.equals(JxBrowserStatus.INSTALLED)) {
+      handleJxBrowserInstalled(app, inspectorService, toolWindow);
+    }
+    else if (jxBrowserStatus.equals(JxBrowserStatus.INSTALLATION_IN_PROGRESS)) {
+      handleJxBrowserInstallationInProgress(app, inspectorService, toolWindow);
+    }
+    else if (jxBrowserStatus.equals(JxBrowserStatus.INSTALLATION_FAILED)) {
+      handleJxBrowserInstallationFailed(app, inspectorService, toolWindow);
+    }
   }
 
   private void updateForEmptyContent(ToolWindow toolWindow) {


### PR DESCRIPTION
We've been loading the inspector embedded browser content on app run, but we can delay this until the inspector tool window is first made visible. 