### PR TITLE
Check for content manager disposed before replacing panel

### DIFF
--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -630,6 +630,9 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
   private void replacePanelLabel(ToolWindow toolWindow, JComponent label) {
     ApplicationManager.getApplication().invokeLater(() -> {
       final ContentManager contentManager = toolWindow.getContentManager();
+      if (contentManager.isDisposed()) {
+        return;
+      }
       contentManager.removeAllContents(true);
 
       final JPanel panel = new JPanel(new BorderLayout());


### PR DESCRIPTION
Hopefully fixes https://github.com/flutter/flutter-intellij/issues/5228

It looks like `myUI` within `ContentManagerImpl` can be set back to null after dispose, and we didn't have a check of dispose status here.﻿
