### PR TITLE
Skip waiting for DevTools after first run

### DIFF
--- a/src/io/flutter/run/SdkRunConfig.java
+++ b/src/io/flutter/run/SdkRunConfig.java
@@ -58,6 +58,7 @@ public class SdkRunConfig extends LocatableConfigurationBase<LaunchState>
   implements LaunchState.RunConfig, RefactoringListenerProvider, RunConfigurationWithSuppressedDefaultRunAction {
 
   private static final Logger LOG = Logger.getInstance(SdkRunConfig.class);
+  private boolean firstRun = true;
 
   private @NotNull SdkFields fields = new SdkFields();
 
@@ -233,7 +234,9 @@ public class SdkRunConfig extends LocatableConfigurationBase<LaunchState>
     final SdkFields launchFields = fields.copy();
     final Project project = env.getProject();
     final RunMode mode = RunMode.fromEnv(env);
-    return fields.createFlutterSdkRunCommand(project, mode, FlutterLaunchMode.fromEnv(env), device);
+    final boolean initialFirstRun = firstRun;
+    firstRun = false;
+    return fields.createFlutterSdkRunCommand(project, mode, FlutterLaunchMode.fromEnv(env), device, initialFirstRun);
   }
 
   @Override


### PR DESCRIPTION
If DevTools fails to start, we don't want to wait for it on every run. I think waiting the first time is okay since we want the same experience across runs (e.g. we don't want deep links to not be available only on the first run). But if DevTools hasn't started by the time an app is run for the second time, there probably isn't an easy way to fix DevTools and we should proceed without it. ﻿