### PR TITLE
Run flutter channel if git is not available

### DIFF
--- a/src/io/flutter/sdk/FlutterSdk.java
+++ b/src/io/flutter/sdk/FlutterSdk.java
@@ -515,8 +515,12 @@ public class FlutterSdk {
       branch = git4idea.light.LightGitUtilKt.getLocation(dir, GitExecutableManager.getInstance().getExecutable((Project)null));
     }
     catch (VcsException e) {
-      LOG.error(e);
-      branch = "unknown";
+      String stdout = returnOutputOfQuery(flutterChannel());
+      if (stdout == null) {
+        branch = "unknown";
+      } else {
+        branch = FlutterSdkChannel.parseChannel(stdout);
+      }
     }
 
     cachedConfigValues.put("channel", branch);

--- a/src/io/flutter/sdk/FlutterSdkChannel.java
+++ b/src/io/flutter/sdk/FlutterSdkChannel.java
@@ -13,7 +13,7 @@ public class FlutterSdkChannel {
 
   public enum ID {
 
-    // Do not change this order. An unknown branch is assymed to be off master.
+    // Do not change this order. An unknown branch is assumed to be off master.
     STABLE("stable"), BETA("beta"), DEV("dev"), MASTER("master"), UNKNOWN("unknown");
 
     private final String name;
@@ -63,4 +63,16 @@ public class FlutterSdkChannel {
   public String toString() {
     return "channel " + channel.toString();
   }
+
+  @NotNull
+  public static String parseChannel(@NotNull String text) {
+    String[] lines = text.split("\n");
+    for (String line : lines) {
+      if (line.startsWith("*")) {
+        return line.substring(2);
+      }
+    }
+    return "unknown";
+  }
 }
+


### PR DESCRIPTION
There was no reason to log an error if `git` was not available. Now, we try running `flutter channel` if needed. It may have a better ability to find the channel, but if not it will still be classified as "unknown". Open question whether it should be "stable" instead. The channel is used to determine if platform selection should be shown when creating a new project.

Fixes #5232