### PR TITLE
Stop adding --platforms for packages

### DIFF
--- a/src/io/flutter/module/settings/FlutterCreateAdditionalSettingsFields.java
+++ b/src/io/flutter/module/settings/FlutterCreateAdditionalSettingsFields.java
@@ -110,6 +110,7 @@ public class FlutterCreateAdditionalSettingsFields {
       orgField.setEnabled(projectType != FlutterProjectType.PACKAGE);
       UIUtil.setEnabled(androidLanguageRadios.getComponent(), areLanguageFeaturesVisible, true, true);
       UIUtil.setEnabled(iosLanguageRadios.getComponent(), areLanguageFeaturesVisible, true, true);
+      UIUtil.setEnabled(platformsForm.getComponent(), areLanguageFeaturesVisible, true, true);
     }
   }
 
@@ -193,13 +194,21 @@ public class FlutterCreateAdditionalSettingsFields {
       .setOrg(!orgField.getText().trim().isEmpty() ? orgField.getText().trim() : null)
       .setSwift(iosLanguageRadios.isRadio2Selected() ? true : null)
       .setOffline(createParams.isOfflineSelected())
-      .setPlatformAndroid(platformsForm.shouldBeVisible() ? settings.getPlatformAndroid() : Boolean.TRUE)
-      .setPlatformIos(platformsForm.shouldBeVisible() ? settings.getPlatformIos() : Boolean.TRUE)
-      .setPlatformLinux(platformsForm.shouldBeVisible() ? settings.getPlatformLinux() : null)
-      .setPlatformMacos(platformsForm.shouldBeVisible() ? settings.getPlatformMacos() : null)
-      .setPlatformWeb(platformsForm.shouldBeVisible() ? settings.getPlatformWeb() : null)
-      .setPlatformWindows(platformsForm.shouldBeVisible() ? settings.getPlatformWindows() : null)
+      .setPlatformAndroid(shouldIncludPlatforms() ? settings.getPlatformAndroid() : Boolean.TRUE)
+      .setPlatformIos(shouldIncludPlatforms() ? settings.getPlatformIos() : Boolean.TRUE)
+      .setPlatformLinux(shouldIncludPlatforms() ? settings.getPlatformLinux() : null)
+      .setPlatformMacos(shouldIncludPlatforms() ? settings.getPlatformMacos() : null)
+      .setPlatformWeb(shouldIncludPlatforms() ? settings.getPlatformWeb() : null)
+      .setPlatformWindows(shouldIncludPlatforms() ? settings.getPlatformWindows() : null)
       .build();
+  }
+
+  private boolean shouldIncludPlatforms() {
+    switch (projectTypeForm.getType()) {
+      case APP: // fall through
+      case PLUGIN: return platformsForm.shouldBeVisible();
+      default: return false;
+    }
   }
 
   public FlutterCreateAdditionalSettings getSettings() {

--- a/src/io/flutter/module/settings/FlutterCreateAdditionalSettingsFields.java
+++ b/src/io/flutter/module/settings/FlutterCreateAdditionalSettingsFields.java
@@ -194,16 +194,16 @@ public class FlutterCreateAdditionalSettingsFields {
       .setOrg(!orgField.getText().trim().isEmpty() ? orgField.getText().trim() : null)
       .setSwift(iosLanguageRadios.isRadio2Selected() ? true : null)
       .setOffline(createParams.isOfflineSelected())
-      .setPlatformAndroid(shouldIncludPlatforms() ? settings.getPlatformAndroid() : Boolean.TRUE)
-      .setPlatformIos(shouldIncludPlatforms() ? settings.getPlatformIos() : Boolean.TRUE)
-      .setPlatformLinux(shouldIncludPlatforms() ? settings.getPlatformLinux() : null)
-      .setPlatformMacos(shouldIncludPlatforms() ? settings.getPlatformMacos() : null)
-      .setPlatformWeb(shouldIncludPlatforms() ? settings.getPlatformWeb() : null)
-      .setPlatformWindows(shouldIncludPlatforms() ? settings.getPlatformWindows() : null)
+      .setPlatformAndroid(shouldIncludePlatforms() ? settings.getPlatformAndroid() : Boolean.TRUE)
+      .setPlatformIos(shouldIncludePlatforms() ? settings.getPlatformIos() : Boolean.TRUE)
+      .setPlatformLinux(shouldIncludePlatforms() ? settings.getPlatformLinux() : null)
+      .setPlatformMacos(shouldIncludePlatforms() ? settings.getPlatformMacos() : null)
+      .setPlatformWeb(shouldIncludePlatforms() ? settings.getPlatformWeb() : null)
+      .setPlatformWindows(shouldIncludePlatforms() ? settings.getPlatformWindows() : null)
       .build();
   }
 
-  private boolean shouldIncludPlatforms() {
+  private boolean shouldIncludePlatforms() {
     switch (projectTypeForm.getType()) {
       case APP: // fall through
       case PLUGIN: return platformsForm.shouldBeVisible();

--- a/src/io/flutter/module/settings/PlatformsForm.kt
+++ b/src/io/flutter/module/settings/PlatformsForm.kt
@@ -5,6 +5,7 @@
  */
 package io.flutter.module.settings
 
+import com.intellij.openapi.ui.DialogPanel
 import com.intellij.ui.layout.Cell
 import com.intellij.ui.layout.panel
 import io.flutter.FlutterBundle
@@ -24,6 +25,7 @@ class PlatformsForm(getSdk: Supplier<out FlutterSdk>) {
   var configMacos: Boolean? = null
   var configWeb: Boolean? = null
   var configWindows: Boolean? = null
+  var component: DialogPanel? = null
 
   fun initChannel() {
     val sdk = sdkGetter.get()
@@ -46,28 +48,29 @@ class PlatformsForm(getSdk: Supplier<out FlutterSdk>) {
     return ch.id > ID.STABLE
   }
 
-  fun panel(settings: FlutterCreateAdditionalSettings) = panel {
-    assert(channel != null)
-    val ch = channel!!.id
-    row {
-      cell(isVerticalFlow = false) {
-        makeCheckBox(this, FlutterBundle.message("npw_platform_android"), settings.platformAndroidProperty, configAndroid, ch, ID.STABLE)
-        makeCheckBox(this, FlutterBundle.message("npw_platform_ios"), settings.platformIosProperty, configIos, ch, ID.STABLE)
-        makeCheckBox(this, FlutterBundle.message("npw_platform_linux"), settings.platformLinuxProperty, configLinux, ch, ID.DEV)
-        makeCheckBox(this, FlutterBundle.message("npw_platform_macos"), settings.platformMacosProperty, configMacos, ch, ID.DEV)
-        makeCheckBox(this, FlutterBundle.message("npw_platform_web"), settings.platformWebProperty, configWeb, ch, ID.BETA)
-        makeCheckBox(this, FlutterBundle.message("npw_platform_windows"), settings.platformWindowsProperty, configWindows, ch, ID.DEV)
-      }
-    }
-    row {
-      label(FlutterBundle.message("npw_platform_availability_help")).apply {
-        comment(FlutterBundle.message("npw_platform_availability_comment"))
-      }
-    }
-    row {
-      label(FlutterBundle.message("npw_platform_selection_help"))
-    }
-  }
+  fun panel(settings: FlutterCreateAdditionalSettings) =
+      panel {
+        assert(channel != null)
+        val ch = channel!!.id
+        row {
+          cell(isVerticalFlow = false) {
+            makeCheckBox(this, FlutterBundle.message("npw_platform_android"), settings.platformAndroidProperty, configAndroid, ch, ID.STABLE)
+            makeCheckBox(this, FlutterBundle.message("npw_platform_ios"), settings.platformIosProperty, configIos, ch, ID.STABLE)
+            makeCheckBox(this, FlutterBundle.message("npw_platform_linux"), settings.platformLinuxProperty, configLinux, ch, ID.DEV)
+            makeCheckBox(this, FlutterBundle.message("npw_platform_macos"), settings.platformMacosProperty, configMacos, ch, ID.DEV)
+            makeCheckBox(this, FlutterBundle.message("npw_platform_web"), settings.platformWebProperty, configWeb, ch, ID.BETA)
+            makeCheckBox(this, FlutterBundle.message("npw_platform_windows"), settings.platformWindowsProperty, configWindows, ch, ID.DEV)
+          }
+        }
+        row {
+          label(FlutterBundle.message("npw_platform_availability_help")).apply {
+            comment(FlutterBundle.message("npw_platform_availability_comment"))
+          }
+        }
+        row {
+          label(FlutterBundle.message("npw_platform_selection_help"))
+        }
+      }.apply { component = this }
 
   private fun makeCheckBox(context: Cell,
                            name: String,
@@ -79,14 +82,14 @@ class PlatformsForm(getSdk: Supplier<out FlutterSdk>) {
       val wasSelected = chan >= min && config == true
       property.initialize(wasSelected)
       checkBox(name,
-               property.get(),
-               actionListener = { _, checkBox ->
-                 property.set(checkBox.isSelected)
-               }).apply {
+          property.get(),
+          actionListener = { _, checkBox ->
+            property.set(checkBox.isSelected)
+          }).apply {
         val names: List<String> = listOf(
-          FlutterBundle.message("npw_platform_android"),
-          FlutterBundle.message("npw_platform_ios"),
-          FlutterBundle.message("npw_platform_web"))
+            FlutterBundle.message("npw_platform_android"),
+            FlutterBundle.message("npw_platform_ios"),
+            FlutterBundle.message("npw_platform_web"))
         enabled(names.contains(name) || wasSelected)
       }
     }


### PR DESCRIPTION
PlatformsForm.kt changed a lot less than it looks. The formatter changed a lot of indents. My change added a field `component` and an assignment to initialize it. That's so it can be disabled when `Package` type is selected.

Fixes #5252