### PR TITLE
Add attach args field to run config

### DIFF
--- a/src/io/flutter/actions/AttachDebuggerAction.java
+++ b/src/io/flutter/actions/AttachDebuggerAction.java
@@ -72,17 +72,6 @@ public class AttachDebuggerAction extends FlutterSdkAction {
     }
 
     final SdkAttachConfig sdkRunConfig = new SdkAttachConfig((SdkRunConfig)configuration);
-    final SdkFields fields = sdkRunConfig.getFields();
-    final String additionalArgs = fields.getAttachArgs();
-
-    final List<String> args = new ArrayList<>();
-    if (additionalArgs != null) {
-      args.add(additionalArgs);
-    }
-    if (!args.isEmpty()) {
-      fields.setAdditionalArgs(Joiner.on(" ").join(args));
-    }
-
     final Executor executor = RunFlutterAction.getExecutor(ToolWindowId.DEBUG);
     if (executor == null) {
       return;

--- a/src/io/flutter/actions/AttachDebuggerAction.java
+++ b/src/io/flutter/actions/AttachDebuggerAction.java
@@ -73,19 +73,11 @@ public class AttachDebuggerAction extends FlutterSdkAction {
 
     final SdkAttachConfig sdkRunConfig = new SdkAttachConfig((SdkRunConfig)configuration);
     final SdkFields fields = sdkRunConfig.getFields();
-    final String additionalArgs = fields.getAdditionalArgs();
-
-    String flavorArg = null;
-    if (fields.getBuildFlavor() != null) {
-      flavorArg = "--flavor=" + fields.getBuildFlavor();
-    }
+    final String additionalArgs = fields.getAttachArgs();
 
     final List<String> args = new ArrayList<>();
     if (additionalArgs != null) {
       args.add(additionalArgs);
-    }
-    if (flavorArg != null) {
-      args.add(flavorArg);
     }
     if (!args.isEmpty()) {
       fields.setAdditionalArgs(Joiner.on(" ").join(args));

--- a/src/io/flutter/run/FlutterConfigurationEditorForm.form
+++ b/src/io/flutter/run/FlutterConfigurationEditorForm.form
@@ -94,7 +94,7 @@
       </component>
       <component id="7a4a6" class="javax.swing.JTextField" binding="myAttachArgsField">
         <constraints>
-          <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="1" use-parent-layout="false"/>
+          <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
       </component>

--- a/src/io/flutter/run/FlutterConfigurationEditorForm.form
+++ b/src/io/flutter/run/FlutterConfigurationEditorForm.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="io.flutter.run.FlutterConfigurationEditorForm">
-  <grid id="27dc6" binding="myMainPanel" default-binding="true" layout-manager="GridLayoutManager" row-count="7" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="myMainPanel" default-binding="true" layout-manager="GridLayoutManager" row-count="9" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="698" height="320"/>
@@ -10,7 +10,7 @@
     <children>
       <vspacer id="3f5de">
         <constraints>
-          <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="8" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
       <component id="17e7a" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="myFileField">
@@ -34,7 +34,7 @@
       </component>
       <component id="efe47" class="javax.swing.JLabel">
         <constraints>
-          <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Build flavor:"/>
@@ -43,7 +43,7 @@
       </component>
       <component id="14837" class="javax.swing.JTextField" binding="myBuildFlavorField">
         <constraints>
-          <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+          <grid row="6" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
             <preferred-size width="150" height="-1"/>
           </grid>
         </constraints>
@@ -51,7 +51,7 @@
       </component>
       <component id="9a5c8" class="javax.swing.JLabel">
         <constraints>
-          <grid row="5" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="7" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <enabled value="false"/>
@@ -79,7 +79,7 @@
         </constraints>
         <properties>
           <labelFor value="e7876"/>
-          <text value="Additional &amp;arguments:"/>
+          <text value="Additional run &amp;args:"/>
           <toolTipText value="Additional command-line arguments to pass into 'flutter run'."/>
         </properties>
       </component>
@@ -89,7 +89,32 @@
         </constraints>
         <properties>
           <enabled value="false"/>
-          <text value="Additional arguments to flutter run."/>
+          <text value="Additional arguments to 'flutter run'."/>
+        </properties>
+      </component>
+      <component id="7a4a6" class="javax.swing.JTextField" binding="myAttachArgsField">
+        <constraints>
+          <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="1" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+      </component>
+      <component id="42996" class="javax.swing.JLabel">
+        <constraints>
+          <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <labelFor value="e7876"/>
+          <text value="Additional a&amp;ttach args:"/>
+          <toolTipText value="Additional command-line arguments to pass into 'flutter attach'."/>
+        </properties>
+      </component>
+      <component id="2171a" class="javax.swing.JLabel">
+        <constraints>
+          <grid row="5" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <enabled value="false"/>
+          <text value="Additional arguments to 'flutter attach'."/>
         </properties>
       </component>
     </children>

--- a/src/io/flutter/run/FlutterConfigurationEditorForm.java
+++ b/src/io/flutter/run/FlutterConfigurationEditorForm.java
@@ -23,6 +23,7 @@ public class FlutterConfigurationEditorForm extends SettingsEditor<SdkRunConfig>
   private TextFieldWithBrowseButton myFileField;
   private JTextField myAdditionalArgumentsField;
   private JTextField myBuildFlavorField;
+  private JTextField myAttachArgsField;
 
   public FlutterConfigurationEditorForm(final Project project) {
     initDartFileTextWithBrowse(project, myFileField);
@@ -34,6 +35,7 @@ public class FlutterConfigurationEditorForm extends SettingsEditor<SdkRunConfig>
     myFileField.setText(FileUtil.toSystemDependentName(StringUtil.notNullize(fields.getFilePath())));
     myBuildFlavorField.setText(fields.getBuildFlavor());
     myAdditionalArgumentsField.setText(fields.getAdditionalArgs());
+    myAttachArgsField.setText(fields.getAttachArgs());
   }
 
   @Override
@@ -42,6 +44,7 @@ public class FlutterConfigurationEditorForm extends SettingsEditor<SdkRunConfig>
     fields.setFilePath(StringUtil.nullize(FileUtil.toSystemIndependentName(myFileField.getText().trim()), true));
     fields.setBuildFlavor(StringUtil.nullize(myBuildFlavorField.getText().trim()));
     fields.setAdditionalArgs(StringUtil.nullize(myAdditionalArgumentsField.getText().trim()));
+    fields.setAttachArgs(StringUtil.nullize(myAttachArgsField.getText().trim()));
     config.setFields(fields);
   }
 

--- a/src/io/flutter/run/SdkFields.java
+++ b/src/io/flutter/run/SdkFields.java
@@ -40,6 +40,7 @@ public class SdkFields {
   private @Nullable String filePath;
   private @Nullable String buildFlavor;
   private @Nullable String additionalArgs;
+  private @Nullable String attachArgs;
 
   public SdkFields() {
   }
@@ -88,6 +89,26 @@ public class SdkFields {
       return ParametersListUtil.parse(additionalArgs, false, true, true).toArray(new String[0]);
     }
 
+    return new String[0];
+  }
+
+  public String getAttachArgs() {
+    return attachArgs;
+  }
+
+  public void setAttachArgs(@Nullable String attachArgs) {
+    this.attachArgs = attachArgs;
+  }
+
+  public boolean hasAttachArgs() {
+    return attachArgs != null;
+  }
+
+  public String[] getAttachArgsParsed() {
+    if (hasAttachArgs()) {
+      assert attachArgs != null;
+      return ParametersListUtil.parse(attachArgs, false, true, true).toArray(new String[0]);
+    }
     return new String[0];
   }
 
@@ -214,10 +235,7 @@ public class SdkFields {
       throw new ExecutionException("Entrypoint isn't within a Flutter pub root");
     }
 
-    String[] args = getAdditionalArgsParsed();
-    if (buildFlavor != null) {
-      args = ArrayUtil.append(args, "--flavor=" + buildFlavor);
-    }
+    String[] args = getAttachArgsParsed();
     final FlutterCommand command = flutterSdk.flutterAttach(root, main.getFile(), device, flutterLaunchMode, args);
     return command.createGeneralCommandLine(project);
   }

--- a/testSrc/unit/io/flutter/run/SdkFieldsTest.java
+++ b/testSrc/unit/io/flutter/run/SdkFieldsTest.java
@@ -75,6 +75,17 @@ public class SdkFieldsTest {
     }, sdkFields.getAdditionalArgsParsed());
   }
 
+  @Test
+  public void supportsSpacesInAttachArgs() {
+    final SdkFields sdkFields = new SdkFields();
+    sdkFields.setAttachArgs("--dart-define='VALUE=foo bar' --other=baz");
+
+    assertArrayEquals(new String[]{
+      "--dart-define=VALUE=foo bar",
+      "--other=baz"
+    }, sdkFields.getAttachArgsParsed());
+  }
+
   private void addOption(Element elt, String name, String value) {
     final Element child = new Element("option");
     child.setAttribute("name", name);


### PR DESCRIPTION
Add another field to the run config, for use by `flutter attach`.

<img width="945" alt="Screen Shot 2021-02-19 at 11 51 43 AM" src="https://user-images.githubusercontent.com/8518285/108554759-68e7e700-72a9-11eb-81ea-7ed0bab7d79b.png">

Fixes #5237