### PR TITLE
Permit deep link to open embedded browser

### DIFF
--- a/src/io/flutter/jxbrowser/EmbeddedBrowser.java
+++ b/src/io/flutter/jxbrowser/EmbeddedBrowser.java
@@ -29,9 +29,11 @@ import com.teamdev.jxbrowser.view.swing.callback.DefaultConfirmCallback;
 import icons.FlutterIcons;
 import io.flutter.FlutterInitializer;
 import io.flutter.settings.FlutterSettings;
+import io.flutter.utils.AsyncUtils;
 import org.jetbrains.annotations.NotNull;
 
-import java.awt.*;
+import java.awt.Dimension;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class EmbeddedBrowser {
@@ -43,7 +45,7 @@ public class EmbeddedBrowser {
   }
 
   private Browser browser;
-  private String mainUrl;
+  private CompletableFuture<String> mainUrlFuture;
 
   private EmbeddedBrowser(Project project) {
     System.setProperty("jxbrowser.force.dpi.awareness", "1.0");
@@ -70,6 +72,8 @@ public class EmbeddedBrowser {
       FlutterInitializer.getAnalytics().sendException(StringUtil.getThrowableText(ex), false);
     }
 
+    resetUrl();
+
     ProjectManager.getInstance().addProjectManagerListener(project, new ProjectManagerListener() {
       @Override
       public void projectClosing(@NotNull Project project) {
@@ -79,6 +83,13 @@ public class EmbeddedBrowser {
         }
       }
     });
+  }
+
+  /**
+   * This is to clear out a potentially old URL, i.e. a URL from an app that's no longer running.
+   */
+  public void resetUrl() {
+    this.mainUrlFuture = new CompletableFuture<>();
   }
 
   public void openPanel(ContentManager contentManager, String tabName, String url) {
@@ -99,8 +110,8 @@ public class EmbeddedBrowser {
     // Multiple LoadFinished events can occur, but we only need to add content the first time.
     final AtomicBoolean contentLoaded = new AtomicBoolean(false);
 
-    this.mainUrl = url;
     browser.navigation().loadUrl(url);
+    mainUrlFuture.complete(url);
     browser.navigation().on(LoadFinished.class, event -> {
       if (!contentLoaded.compareAndSet(false, true)) {
         return;
@@ -128,6 +139,12 @@ public class EmbeddedBrowser {
   }
 
   public void updatePanelToWidget(String widgetId) {
-    browser.navigation().loadUrl(mainUrl + "&inspectorRef=" + widgetId);
+    AsyncUtils.whenCompleteUiThread(mainUrlFuture, (url, ex) -> {
+      if (ex != null) {
+        LOG.error(ex);
+        return;
+      }
+      browser.navigation().loadUrl(url + "&inspectorRef=" + widgetId);
+    });
   }
 }

--- a/src/io/flutter/jxbrowser/EmbeddedBrowser.java
+++ b/src/io/flutter/jxbrowser/EmbeddedBrowser.java
@@ -89,6 +89,9 @@ public class EmbeddedBrowser {
    * This is to clear out a potentially old URL, i.e. a URL from an app that's no longer running.
    */
   public void resetUrl() {
+    if (mainUrlFuture != null && !mainUrlFuture.isDone()) {
+      mainUrlFuture.completeExceptionally(new Exception("Embedded browser URL has been reset before previous URL completed."));
+    }
     this.mainUrlFuture = new CompletableFuture<>();
   }
 
@@ -142,6 +145,10 @@ public class EmbeddedBrowser {
     AsyncUtils.whenCompleteUiThread(mainUrlFuture, (url, ex) -> {
       if (ex != null) {
         LOG.error(ex);
+        return;
+      }
+      if (url == null) {
+        LOG.error("DevTools URL is null");
         return;
       }
       browser.navigation().loadUrl(url + "&inspectorRef=" + widgetId);

--- a/src/io/flutter/jxbrowser/EmbeddedBrowser.java
+++ b/src/io/flutter/jxbrowser/EmbeddedBrowser.java
@@ -90,7 +90,7 @@ public class EmbeddedBrowser {
    */
   public void resetUrl() {
     if (mainUrlFuture != null && !mainUrlFuture.isDone()) {
-      mainUrlFuture.completeExceptionally(new Exception("Embedded browser URL has been reset before previous URL completed."));
+      mainUrlFuture.complete(null);
     }
     this.mainUrlFuture = new CompletableFuture<>();
   }
@@ -148,7 +148,7 @@ public class EmbeddedBrowser {
         return;
       }
       if (url == null) {
-        LOG.error("DevTools URL is null");
+        // This happens if URL has already been reset (e.g. new app has started). We no longer need to update to a widget for the old app.
         return;
       }
       browser.navigation().loadUrl(url + "&inspectorRef=" + widgetId);

--- a/src/io/flutter/logging/FlutterConsoleLogManager.java
+++ b/src/io/flutter/logging/FlutterConsoleLogManager.java
@@ -419,10 +419,6 @@ public class FlutterConsoleLogManager {
     notification.addAction(new AnAction("Inspect Widget") {
       @Override
       public void actionPerformed(@NotNull AnActionEvent event) {
-        final String widgetId = DevToolsUtils.findWidgetId(property.getValue());
-        EmbeddedBrowser.getInstance(app.getProject()).updatePanelToWidget(widgetId);
-        notification.expire();
-
         // Show inspector window if it's not already visible.
         final ToolWindowManager toolWindowManager = ToolWindowManager.getInstance(app.getProject());
         if (!(toolWindowManager instanceof ToolWindowManagerEx)) {
@@ -433,6 +429,10 @@ public class FlutterConsoleLogManager {
         if (toolWindow != null && !toolWindow.isVisible()) {
           toolWindow.show();
         }
+
+        final String widgetId = DevToolsUtils.findWidgetId(property.getValue());
+        EmbeddedBrowser.getInstance(app.getProject()).updatePanelToWidget(widgetId);
+        notification.expire();
 
         FlutterInitializer.getAnalytics().sendEvent(
           "deep-link-clicked",

--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -671,6 +671,7 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
     toolWindow.setIcon(ExecutionUtil.getLiveIndicator(FlutterIcons.Flutter_13));
 
     if (FlutterSettings.getInstance().isEnableEmbeddedBrowsers()) {
+      // Reset the URL since we may have an outdated one from a previous app run.
       EmbeddedBrowser.getInstance(myProject).resetUrl();
       if (toolWindow.isVisible()) {
         displayEmbeddedBrowser(app, inspectorService, toolWindow);

--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -671,6 +671,7 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
     toolWindow.setIcon(ExecutionUtil.getLiveIndicator(FlutterIcons.Flutter_13));
 
     if (FlutterSettings.getInstance().isEnableEmbeddedBrowsers()) {
+      EmbeddedBrowser.getInstance(myProject).resetUrl();
       if (toolWindow.isVisible()) {
         displayEmbeddedBrowser(app, inspectorService, toolWindow);
       } else {


### PR DESCRIPTION
Since we now wait for the inspector window to be visible before navigating to DevTools in the embedded browser (instead of navigating on app start), there could be cases where a notification with a deep link is shown before the navigation happens. This change shows the tool window before trying to navigate and waits for the main URL to be set before navigating to the URL with a widget ID.

![Feb-19-2021 16-55-37](https://user-images.githubusercontent.com/6379305/108576711-76b26200-72d3-11eb-896d-d6a3276fd6a4.gif)
