### PR TITLE
Allow open DevTools from tests

### DIFF
--- a/src/io/flutter/run/OpenDevToolsAction.java
+++ b/src/io/flutter/run/OpenDevToolsAction.java
@@ -26,19 +26,20 @@ public class OpenDevToolsAction extends DumbAwareAction {
   private static final String title = "Open Flutter DevTools";
   private final @Nullable ObservatoryConnector myConnector;
   private final Computable<Boolean> myIsApplicable;
-  private final FlutterApp myApp;
 
   public OpenDevToolsAction() {
-    myApp = null;
     myConnector = null;
     myIsApplicable = null;
   }
 
   public OpenDevToolsAction(@NotNull final FlutterApp app, @NotNull final Computable<Boolean> isApplicable) {
+    this(app.getConnector(), isApplicable);
+  }
+
+  public OpenDevToolsAction(@NotNull final ObservatoryConnector connector, @NotNull final Computable<Boolean> isApplicable) {
     super(title, title, FlutterIcons.Dart_16);
 
-    myApp = app;
-    myConnector = app.getConnector();
+    myConnector = connector;
     myIsApplicable = isApplicable;
   }
 

--- a/src/io/flutter/run/bazelTest/BazelTestDebugProcess.java
+++ b/src/io/flutter/run/bazelTest/BazelTestDebugProcess.java
@@ -39,6 +39,7 @@ public class BazelTestDebugProcess extends DartVmServiceDebugProcess {
                                         @NotNull DefaultActionGroup settings) {
     topToolbar.addSeparator();
     topToolbar.addAction(new FlutterPopFrameAction());
+    topToolbar.addAction(new OpenDevToolsAction(connector, this::isActive));
   }
 
   private boolean isActive() {

--- a/src/io/flutter/run/test/TestDebugProcess.java
+++ b/src/io/flutter/run/test/TestDebugProcess.java
@@ -39,6 +39,7 @@ public class TestDebugProcess extends DartVmServiceDebugProcess {
                                         @NotNull DefaultActionGroup settings) {
     topToolbar.addSeparator();
     topToolbar.addAction(new FlutterPopFrameAction());
+    topToolbar.addAction(new OpenDevToolsAction(connector, this::isActive));
   }
 
   private boolean isActive() {


### PR DESCRIPTION
I'm not sure if this is actually useful - I think opening DevTools from the console used to be available while running/debugging tests, but at some point we removed it when we were starting DevTools from an app (since tests don't have an associated app and we didn't want to add another way to start DevTools). Since we're serving DevTools separately from apps now, we can add back this option for tests.