### PR TITLE
Platform selector bug

### DIFF
--- a/product-matrix.json
+++ b/product-matrix.json
@@ -35,8 +35,8 @@
       "ideaProduct": "android-studio",
       "ideaVersion": "2020.3.1.5",
       "dartPluginVersion": "203.6912",
-      "sinceBuild": "203.6682.168",
-      "untilBuild": "203.6682.168",
+      "sinceBuild": "203.7148.57",
+      "untilBuild": "203.7148.57",
       "filesToSkip": ["src/io/flutter/utils/AndroidLocationProvider.java"]
     },
     {

--- a/src/io/flutter/module/FlutterModuleBuilder.java
+++ b/src/io/flutter/module/FlutterModuleBuilder.java
@@ -145,7 +145,7 @@ public class FlutterModuleBuilder extends ModuleBuilder {
     return flutter;
   }
 
-  private static String validateSettings(FlutterCreateAdditionalSettings settings) {
+  private String validateSettings(FlutterCreateAdditionalSettings settings) {
     final String description = settings.getDescription();
     if (description != null && description.contains(": ")) {
       return FlutterBundle.message("npw_invalid_desc_error");
@@ -157,7 +157,7 @@ public class FlutterModuleBuilder extends ModuleBuilder {
     if (StringUtils.endsWith(org, ".")) {
       return FlutterBundle.message("npw_invalid_org_error");
     }
-    if (!settings.isSomePlatformSelected()) {
+    if (mySettingsFields.isShowingPlatforms() && !settings.isSomePlatformSelected()) {
       return FlutterBundle.message("npw_none_selected_error");
     }
     // Invalid package names will cause issues down the line.

--- a/src/io/flutter/module/FlutterProjectType.java
+++ b/src/io/flutter/module/FlutterProjectType.java
@@ -8,18 +8,20 @@ package io.flutter.module;
 import io.flutter.FlutterBundle;
 
 public enum FlutterProjectType {
-  APP(FlutterBundle.message("flutter.module.create.settings.type.application"), "app"),
-  PLUGIN(FlutterBundle.message("flutter.module.create.settings.type.plugin"), "plugin"),
-  PACKAGE(FlutterBundle.message("flutter.module.create.settings.type.package"), "package"),
-  MODULE(FlutterBundle.message("flutter.module.create.settings.type.module"), "module"),
-  IMPORT(FlutterBundle.message("flutter.module.create.settings.type.import_module"), "module");
+  APP(FlutterBundle.message("flutter.module.create.settings.type.application"), "app", true),
+  PLUGIN(FlutterBundle.message("flutter.module.create.settings.type.plugin"), "plugin", true),
+  PACKAGE(FlutterBundle.message("flutter.module.create.settings.type.package"), "package", false),
+  MODULE(FlutterBundle.message("flutter.module.create.settings.type.module"), "module", false),
+  IMPORT(FlutterBundle.message("flutter.module.create.settings.type.import_module"), "module", false);
 
   final public String title;
   final public String arg;
+  final public boolean requiresPlatform;
 
-  FlutterProjectType(String title, String arg) {
+  FlutterProjectType(String title, String arg, boolean requiresPlatform) {
     this.title = title;
     this.arg = arg;
+    this.requiresPlatform = requiresPlatform;
   }
 
   public String toString() {

--- a/src/io/flutter/module/settings/FlutterCreateAdditionalSettingsFields.java
+++ b/src/io/flutter/module/settings/FlutterCreateAdditionalSettingsFields.java
@@ -110,7 +110,9 @@ public class FlutterCreateAdditionalSettingsFields {
       orgField.setEnabled(projectType != FlutterProjectType.PACKAGE);
       UIUtil.setEnabled(androidLanguageRadios.getComponent(), areLanguageFeaturesVisible, true, true);
       UIUtil.setEnabled(iosLanguageRadios.getComponent(), areLanguageFeaturesVisible, true, true);
-      UIUtil.setEnabled(platformsForm.getComponent(), areLanguageFeaturesVisible, true, true);
+      if (isShowingPlatforms()) {
+        UIUtil.setEnabled(platformsForm.getComponent(), areLanguageFeaturesVisible, true, true);
+      }
     }
   }
 
@@ -194,8 +196,8 @@ public class FlutterCreateAdditionalSettingsFields {
       .setOrg(!orgField.getText().trim().isEmpty() ? orgField.getText().trim() : null)
       .setSwift(iosLanguageRadios.isRadio2Selected() ? true : null)
       .setOffline(createParams.isOfflineSelected())
-      .setPlatformAndroid(shouldIncludePlatforms() ? settings.getPlatformAndroid() : Boolean.TRUE)
-      .setPlatformIos(shouldIncludePlatforms() ? settings.getPlatformIos() : Boolean.TRUE)
+      .setPlatformAndroid(shouldIncludePlatforms() ? settings.getPlatformAndroid() : null)
+      .setPlatformIos(shouldIncludePlatforms() ? settings.getPlatformIos() : null)
       .setPlatformLinux(shouldIncludePlatforms() ? settings.getPlatformLinux() : null)
       .setPlatformMacos(shouldIncludePlatforms() ? settings.getPlatformMacos() : null)
       .setPlatformWeb(shouldIncludePlatforms() ? settings.getPlatformWeb() : null)
@@ -219,5 +221,9 @@ public class FlutterCreateAdditionalSettingsFields {
   // The help form appears on the first page of the wizard.
   public void linkHelpForm(SettingsHelpForm form) {
     helpForm = form;
+  }
+
+  public boolean isShowingPlatforms() {
+    return projectTypeHasPlatforms() && platformsForm.shouldBeVisible();
   }
 }

--- a/src/io/flutter/sdk/FlutterCreateAdditionalSettings.java
+++ b/src/io/flutter/sdk/FlutterCreateAdditionalSettings.java
@@ -149,6 +149,9 @@ public class FlutterCreateAdditionalSettings {
     if (platformWindows.get()) {
       platforms.append("windows,");
     }
+    if (type.requiresPlatform && platforms.length() == 0) {
+      platforms.append("android,ios,");
+    }
 
     int lastComma = platforms.lastIndexOf(",");
     if (lastComma > 0) {

--- a/src/io/flutter/sdk/FlutterCreateAdditionalSettings.java
+++ b/src/io/flutter/sdk/FlutterCreateAdditionalSettings.java
@@ -254,8 +254,8 @@ public class FlutterCreateAdditionalSettings {
   public static class Builder {
     @Nullable
     private Boolean includeDriverTest;
-    @Nullable
-    private FlutterProjectType type;
+    @NotNull
+    private FlutterProjectType type = FlutterProjectType.APP;
     @Nullable
     private String description;
     @Nullable

--- a/testSrc/unit/io/flutter/sdk/FlutterCreateAdditionalSettingsTest.java
+++ b/testSrc/unit/io/flutter/sdk/FlutterCreateAdditionalSettingsTest.java
@@ -38,22 +38,19 @@ public class FlutterCreateAdditionalSettingsTest {
       new FlutterCreateAdditionalSettings.Builder().setType(FlutterProjectType.PLUGIN).build();
     final FlutterCreateAdditionalSettings additionalSettings3 =
       new FlutterCreateAdditionalSettings.Builder().setType(FlutterProjectType.PACKAGE).build();
-    final FlutterCreateAdditionalSettings additionalSettings4 =
-      new FlutterCreateAdditionalSettings.Builder().setType(null).build();
 
     final List<String> args1 = additionalSettings1.getArgs();
     final List<String> args2 = additionalSettings2.getArgs();
     final List<String> args3 = additionalSettings3.getArgs();
-    final List<String> args4 = additionalSettings4.getArgs();
 
-    final int base = args4.size();
+    final int base = 6;
     assertEquals(base + 2, args1.size());
     assertEquals("app", args1.get(1));
 
     assertEquals(base + 2, args2.size());
     assertEquals("plugin", args2.get(1));
 
-    assertEquals(base + 2, args3.size());
+    assertEquals(base, args3.size());
     assertEquals("package", args3.get(1));
   }
 
@@ -69,8 +66,8 @@ public class FlutterCreateAdditionalSettingsTest {
     final List<String> args3 = additionalSettings3.getArgs();
 
     assertEquals(args2.size() + 2, args1.size());
-    assertEquals("--description", args1.get(0));
-    assertEquals(d, args1.get(1));
+    assertEquals("--template", args1.get(0));
+    assertEquals(d, args1.get(3));
 
     assertEquals(args2.size(), args3.size());
   }
@@ -87,8 +84,8 @@ public class FlutterCreateAdditionalSettingsTest {
     final List<String> args3 = additionalSettings3.getArgs();
 
     assertEquals(args2.size() + 2, args1.size());
-    assertEquals("--org", args1.get(0));
-    assertEquals(d, args1.get(1));
+    assertEquals("--org", args1.get(2));
+    assertEquals(d, args1.get(3));
 
     assertEquals(args2.size(), args3.size());
   }
@@ -103,8 +100,8 @@ public class FlutterCreateAdditionalSettingsTest {
     final List<String> args2 = additionalSettings2.getArgs();
     final List<String> args3 = additionalSettings3.getArgs();
 
-    assertEquals(2, args1.size());
-    assertNotEquals("--ios-language", args1.get(0));
+    assertEquals(6, args1.size());
+    assertNotEquals("--ios-language", args1.get(2));
 
     assertEquals(args2.size(), args3.size());
   }
@@ -137,9 +134,9 @@ public class FlutterCreateAdditionalSettingsTest {
       .setPlatformWindows(true)
       .build();
     final List<String> args = additionalSettings.getArgs();
-    assertEquals(6, args.size());
-    assertEquals("--platforms", args.get(4));
-    assertEquals("android,ios,web,linux,macos,windows", args.get(5));
+    assertEquals(8, args.size());
+    assertEquals("--platforms", args.get(6));
+    assertEquals("android,ios,web,linux,macos,windows", args.get(7));
   }
 
   @Test
@@ -150,9 +147,9 @@ public class FlutterCreateAdditionalSettingsTest {
       .setPlatformWindows(true)
       .build();
     final List<String> args = additionalSettings.getArgs();
-    assertEquals(6, args.size());
-    assertEquals("--platforms", args.get(4));
-    assertEquals("ios,macos,windows", args.get(5));
+    assertEquals(8, args.size());
+    assertEquals("--platforms", args.get(6));
+    assertEquals("ios,macos,windows", args.get(7));
   }
 
   @Test
@@ -161,9 +158,9 @@ public class FlutterCreateAdditionalSettingsTest {
       .setPlatformAndroid(true)
       .build();
     final List<String> args = additionalSettings.getArgs();
-    assertEquals(6, args.size());
-    assertEquals("--platforms", args.get(4));
-    assertEquals("android", args.get(5));
+    assertEquals(8, args.size());
+    assertEquals("--platforms", args.get(6));
+    assertEquals("android", args.get(7));
   }
 
   @Test
@@ -172,7 +169,7 @@ public class FlutterCreateAdditionalSettingsTest {
       .setPlatformAndroid(false)
       .build();
     final List<String> args = additionalSettings.getArgs();
-    assertEquals(4, args.size());
+    assertEquals(8, args.size());
   }
 
   @Test
@@ -189,7 +186,7 @@ public class FlutterCreateAdditionalSettingsTest {
 
     final String line = String.join(" ", args);
 
-    assertEquals(6, args.size());
-    assertEquals("--template plugin --description a b c --org tld.domain", line);
+    assertEquals(8, args.size());
+    assertEquals("--template plugin --description a b c --org tld.domain --platforms android,ios", line);
   }
 }


### PR DESCRIPTION
This fixes a problem I discovered during testing. The support for platforms is complex because it depends on the selected Flutter SDK, which can change while the new project wizard is running. And it depends on the platforms the user has chosen to configure for use via the CLI tool. And on the project type; only apps and plugins allow the `--platforms` option.

I also bumped the version to work with the latest canary, which is now built on the latest stable IJ.