### PR TITLE
Get device list after indexing finishes

### DIFF
--- a/src/io/flutter/run/daemon/DeviceService.java
+++ b/src/io/flutter/run/daemon/DeviceService.java
@@ -10,8 +10,10 @@ import com.google.common.collect.ImmutableSet;
 import com.intellij.concurrency.JobScheduler;
 import com.intellij.execution.ExecutionException;
 import com.intellij.openapi.application.ApplicationInfo;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.project.DumbService;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ex.ProjectRootManagerEx;
 import com.intellij.openapi.util.Disposer;
@@ -162,8 +164,11 @@ public class DeviceService {
    * <p>This might mean starting it, stopping it, or restarting it.
    */
   private void refreshDeviceDaemon() {
-    if (project.isDisposed()) return;
-    deviceDaemon.refresh(this::chooseNextDaemon);
+    ApplicationManager.getApplication().executeOnPooledThread(() -> {
+      DumbService.getInstance(project).waitForSmartMode();
+      if (project.isDisposed()) return;
+      deviceDaemon.refresh(this::chooseNextDaemon);
+    });
   }
 
   private void daemonStopped(String details) {


### PR DESCRIPTION
Wait for indexing to finish before updating the device list. This change is going to affect all daemon state changes. I think it is OK but want someone to double-check that it is not causing downstream problems.

Fixes #5248
Fixes #5244