### PR TITLE
Log any exceptions on jxbrowser close and check closed status

### DIFF
--- a/src/io/flutter/jxbrowser/EmbeddedBrowserEngine.java
+++ b/src/io/flutter/jxbrowser/EmbeddedBrowserEngine.java
@@ -53,8 +53,12 @@ public class EmbeddedBrowserEngine {
     ApplicationManager.getApplication().addApplicationListener(new ApplicationListener() {
       @Override
       public boolean canExitApplication() {
-        if (engine != null) {
-          engine.close();
+        try {
+          if (engine != null && !engine.isClosed()) {
+            engine.close();
+          }
+        } catch (Exception ex) {
+          LOG.error(ex);
         }
         return true;
       }


### PR DESCRIPTION
`engine.close()` can throw an error, potentially because there wasn't a check of whether the engine was already closed. I'm also wrapping all of this in a try/catch since this function should always return true.﻿

Fixes https://github.com/flutter/flutter-intellij/issues/5299