### PR TITLE
Automate EAP build for dev channel

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,9 @@ buildscript {
   repositories {
     mavenCentral()
     maven {
+      url "https://www.jetbrains.com/intellij-repository/snapshots/"
+    }
+    maven {
       url "https://oss.sonatype.org/content/repositories/snapshots/"
     }
     maven {
@@ -59,7 +62,7 @@ intellij {
   updateSinceUntilBuild = false
   localPath "${project.rootDir.absolutePath}/artifacts/$ide"
   downloadSources false
-  def pluginList = [project(':flutter-idea'), "java", "Dart:$dartVersion", "properties", "junit",
+  def pluginList = [project(':flutter-idea'), "java", "Dart:$dartVersion", "properties", "junit", "Git4Idea",
                     "Kotlin", "gradle", "android", "Groovy", "smali", "IntelliLang"]
   if (ide == 'android-studio') {
     pluginList.add(project(':flutter-studio'))

--- a/flutter-idea/build.gradle
+++ b/flutter-idea/build.gradle
@@ -6,6 +6,10 @@
 
 repositories {
   mavenLocal()
+  maven {
+      url "https://www.jetbrains.com/intellij-repository/snapshots/"
+    }
+
   mavenCentral()
   maven {
     url "https://oss.sonatype.org/content/repositories/snapshots/"
@@ -45,7 +49,7 @@ intellij {
   updateSinceUntilBuild = false
   downloadSources false
   localPath "${project.rootDir.absolutePath}/artifacts/$ide"
-  plugins "java", "Dart:$dartVersion", "properties", "junit", "Kotlin",
+  plugins "java", "Dart:$dartVersion", "properties", "junit", "Kotlin", "Git4Idea",
           "gradle", "android", "Groovy", "smali", "IntelliLang"
 }
 

--- a/product-matrix.json
+++ b/product-matrix.json
@@ -61,7 +61,7 @@
       "ideaVersion": "211.6222.4",
       "dartPluginVersion": "211.6222.2",
       "sinceBuild": "211.6222.4",
-      "untilBuild": "211.6222.4"
+      "untilBuild": "211.6305.21"
     }
   ]
 }

--- a/tool/plugin/lib/edit.dart
+++ b/tool/plugin/lib/edit.dart
@@ -26,6 +26,18 @@ void checkAndClearAppliedEditCommands() {
 List<EditCommand> editCommands = [
   EditAndroidModuleLibraryManager(),
   Subst(
+    path: 'build.gradle',
+    initial: 'localPath "\${project.rootDir.absolutePath}/artifacts/\$ide"',
+    replacement: 'type = "IC"\n  version = "211.6222.4-EAP-SNAPSHOT"',
+    version: '2021.1',
+  ),
+  Subst(
+    path: 'flutter-idea/build.gradle',
+    initial: 'localPath "\${project.rootDir.absolutePath}/artifacts/\$ide"',
+    replacement: 'type = "IC"\n  version = "211.6222.4-EAP-SNAPSHOT"',
+    version: '2021.1',
+  ),
+  Subst(
     path: 'src/io/flutter/FlutterUtils.java',
     initial: 'ProjectUtil.isSameProject(Paths.get(path), project)',
     replacement: 'ProjectUtil.isSameProject(path, project)',


### PR DESCRIPTION
It appears that ideaIC-211.6305.21 is actually labeled internally as 211.6222.4. Upgrading the IDE asks to upgrade the Dart plugin. After restarting, there is an error due to the Dart plugin requiring a newer version and the about box still has the 6222.4 version.