### PR TITLE
Fix the lost SDK on start up problem

### DIFF
--- a/src/io/flutter/editor/WidgetIndentsHighlightingPassFactory.java
+++ b/src/io/flutter/editor/WidgetIndentsHighlightingPassFactory.java
@@ -169,6 +169,7 @@ public class WidgetIndentsHighlightingPassFactory implements TextEditorHighlight
     // analysis server updates not IntelliJ's default assumptions about how a
     // text highlighting pass should work. See runWidgetIndentsPass for the
     // logic that handles the actual widget indent guide pass.
+    if (file.getVirtualFile() == null) return null;
     if (!FlutterUtils.isDartFile(file.getVirtualFile())) {
       return null;
     }

--- a/src/io/flutter/pub/PubRoot.java
+++ b/src/io/flutter/pub/PubRoot.java
@@ -256,7 +256,21 @@ public class PubRoot {
   }
 
   @Nullable
+  public VirtualFile getPackageConfigFile() {
+    final VirtualFile tools = root.findChild(".dart_tool");
+    if (tools == null || !tools.isDirectory()) {
+      return null;
+    }
+    final VirtualFile config = tools.findChild("package_config.json");
+    if (config != null && !config.isDirectory()) {
+      return config;
+    }
+    return null;
+  }
+
+  @Nullable
   public VirtualFile getPackagesFile() {
+    // Obsolete by Flutter 2.0
     final VirtualFile packages = root.findChild(".packages");
     if (packages != null && !packages.isDirectory()) {
       return packages;

--- a/src/io/flutter/sdk/FlutterSdkUtil.java
+++ b/src/io/flutter/sdk/FlutterSdkUtil.java
@@ -19,8 +19,6 @@ import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
-import com.intellij.openapi.roots.ModuleRootManager;
-import com.intellij.openapi.roots.OrderEntry;
 import com.intellij.openapi.util.SystemInfo;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.vfs.LocalFileSystem;
@@ -28,7 +26,6 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.util.ArrayUtil;
 import com.intellij.util.Url;
 import com.intellij.util.Urls;
-import com.jetbrains.lang.dart.sdk.DartSdk;
 import com.jetbrains.lang.dart.sdk.DartSdkUpdateOption;
 import io.flutter.FlutterBundle;
 import io.flutter.dart.DartPlugin;
@@ -47,9 +44,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
-
-import static com.jetbrains.lang.dart.sdk.DartSdkLibUtil.isDartSdkOrderEntry;
-import com.intellij.openapi.roots.*;
 
 public class FlutterSdkUtil {
   /**

--- a/src/io/flutter/sdk/FlutterSdkUtil.java
+++ b/src/io/flutter/sdk/FlutterSdkUtil.java
@@ -376,15 +376,4 @@ public class FlutterSdkUtil {
     final File flutterBinFile = new File(flutterBinPath);
     return flutterBinFile.getParentFile().getParentFile().getPath();
   }
-
-  public static boolean flutterSdkEnabled(Module module) {
-    DartSdk.getDartSdk(module.getProject());
-    for (final OrderEntry orderEntry : ModuleRootManager.getInstance(module).getOrderEntries()) {
-      if (isDartSdkOrderEntry(orderEntry)) {
-        ((LibraryOrderEntry)orderEntry).getFiles(OrderRootType.DOCUMENTATION);
-        return true;
-      }
-    }
-    return false;
-  }
 }

--- a/src/io/flutter/sdk/FlutterSdkUtil.java
+++ b/src/io/flutter/sdk/FlutterSdkUtil.java
@@ -268,7 +268,7 @@ public class FlutterSdkUtil {
       // parse it
       try {
         final String contents = new String(packagesFile.contentsToByteArray(true /* cache contents */));
-        final JsonElement element = JsonParser.parseString(contents);
+        final JsonElement element = new JsonParser().parse(contents);
         if (element == null) {
           continue;
         }
@@ -285,7 +285,7 @@ public class FlutterSdkUtil {
             if (uri == null) {
               continue;
             }
-            final String path = extractSdkPathFromUri(uri);
+            final String path = extractSdkPathFromUri(uri, false);
             if (path == null) {
               continue;
             }
@@ -328,7 +328,7 @@ public class FlutterSdkUtil {
       final String flutterPrefix = "flutter:";
       if (line.startsWith(flutterPrefix)) {
         final String urlString = line.substring(flutterPrefix.length());
-        final String path = extractSdkPathFromUri(urlString);
+        final String path = extractSdkPathFromUri(urlString, true);
         if (path == null) {
           continue;
         }
@@ -339,7 +339,7 @@ public class FlutterSdkUtil {
     return null;
   }
 
-  private static String extractSdkPathFromUri(String urlString) {
+  private static String extractSdkPathFromUri(String urlString, boolean isLibIncluded) {
     if (urlString.startsWith("file:")) {
       final Url url = Urls.parseEncoded(urlString);
       if (url == null) {
@@ -349,7 +349,7 @@ public class FlutterSdkUtil {
       // go up three levels for .packages or two for .dart_tool/package_config.json
       File file = new File(url.getPath());
       file = file.getParentFile().getParentFile();
-      if (path.endsWith("lib/") || path.endsWith("lib")) {
+      if (isLibIncluded) {
         file = file.getParentFile();
       }
       return file.getPath();

--- a/src/io/flutter/utils/FlutterModuleUtils.java
+++ b/src/io/flutter/utils/FlutterModuleUtils.java
@@ -361,11 +361,7 @@ public class FlutterModuleUtils {
   }
 
   public static void enableDartSDK(@NotNull Module module) {
-    if (DartPlugin.isDartSdkEnabled(module)) {
-      return;
-    }
-
-    // parse the .packages file
+    // parse the .dart_tool/flutter_config.json or .packages file
     String sdkPath = FlutterSdkUtil.guessFlutterSdkFromPackagesFile(module);
     if (sdkPath != null) {
       FlutterSdkUtil.updateKnownSdkPaths(sdkPath);

--- a/src/io/flutter/utils/FlutterModuleUtils.java
+++ b/src/io/flutter/utils/FlutterModuleUtils.java
@@ -361,6 +361,9 @@ public class FlutterModuleUtils {
   }
 
   public static void enableDartSDK(@NotNull Module module) {
+    if (FlutterSdk.getFlutterSdk(module.getProject()) != null) {
+      return;
+    }
     // parse the .dart_tool/flutter_config.json or .packages file
     String sdkPath = FlutterSdkUtil.guessFlutterSdkFromPackagesFile(module);
     if (sdkPath != null) {

--- a/tool/plugin/lib/edit.dart
+++ b/tool/plugin/lib/edit.dart
@@ -110,6 +110,12 @@ List<EditCommand> editCommands = [
     replacement: 'cannotWriteToFiles(List<? extends File> files)',
     versions: ['4.1', '4.2'],
   ),
+  Subst(
+    path: 'src/io/flutter/sdk/FlutterSdkUtil.java',
+    initial: 'JsonParser.parseString(contents)',
+    replacement: 'new JsonParser().parse(contents)',
+    version: 'AF.3.1',
+  ),
 ];
 
 // Used to test checkAndClearAppliedEditCommands()


### PR DESCRIPTION
Fixes #5313 

We used to use `DartPlugin.isDartSdkEnabled(module)` as a quick short-circuit for checking if the Flutter SDK was configured. That isn't reliable (not sure why) anymore. The result is that the first time a project is created after IntelliJ is launched, the project does not have its SDK configured. Projects created after the first one do, however.

This also adds support for the new `.dart_tool/package_config.json` file.

Since the Dart SDK is configured, I tried to find a way to determine its location on disk. You can see in External Libraries that it knows about its content, so the path has to be somewhere. The IntelliJ API does not appear to reveal that information.

@alexander-doroshko If you can take a minute to look at this I'd appreciate any tips on finding the Dart SDK on disk. This approach works, and seems fast enough, but I can't help thinking it is redundant.