### PR TITLE
Catch class loading exceptions and log full path

### DIFF
--- a/src/io/flutter/jxbrowser/JxBrowserManager.java
+++ b/src/io/flutter/jxbrowser/JxBrowserManager.java
@@ -253,12 +253,13 @@ public class JxBrowserManager {
 
   private void loadClasses(String[] fileNames) {
     for (String fileName : fileNames) {
-      final boolean success = FileUtils.getInstance().loadClass(this.getClass().getClassLoader(), getFilePath(fileName));
+      final String fullPath = getFilePath(fileName);
+      final boolean success = FileUtils.getInstance().loadClass(this.getClass().getClassLoader(), fullPath);
       if (success) {
-        LOG.info("Loaded JxBrowser file successfully: " + fileName);
+        LOG.info("Loaded JxBrowser file successfully: " + fullPath);
       }
       else {
-        LOG.info("Failed to load JxBrowser file: " + fileName);
+        LOG.info("Failed to load JxBrowser file: " + fullPath);
         setStatusFailed("classLoadFailed");
         return;
       }

--- a/src/io/flutter/utils/FileUtils.java
+++ b/src/io/flutter/utils/FileUtils.java
@@ -62,7 +62,12 @@ public class FileUtils {
     catch (MalformedURLException e) {
       return false;
     }
-    urlClassLoader.addURL(url);
+    try {
+      urlClassLoader.addURL(url);
+    }
+    catch (Exception e) {
+      return false;
+    }
     return true;
   }
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter-intellij/issues/5327#issuecomment-801129734

This will get rid of the error message but I'm not sure why this error occurs in the first place. I can't reproduce it on windows myself, but I actually see other similar errors when running on Windows that don't come from our plugin. I'll check with Alex to see if there's something I can change in our path logic to make this more consistent for Windows.