### PR TITLE
Refresh devices

### DIFF
--- a/src/io/flutter/actions/DeviceSelectorAction.java
+++ b/src/io/flutter/actions/DeviceSelectorAction.java
@@ -113,7 +113,7 @@ public class DeviceSelectorAction extends ComboBoxAction implements DumbAware {
     });
   }
 
-  private void updateVisibility(final Project project, final Presentation presentation) {
+  private static void updateVisibility(final Project project, final Presentation presentation) {
     final boolean visible = isSelectorVisible(project);
     presentation.setVisible(visible);
 
@@ -127,7 +127,7 @@ public class DeviceSelectorAction extends ComboBoxAction implements DumbAware {
     }
   }
 
-  private boolean isSelectorVisible(@Nullable Project project) {
+  private static boolean isSelectorVisible(@Nullable Project project) {
     if (project == null || !FlutterModuleUtils.hasFlutterModule(project)) {
       return false;
     }

--- a/src/io/flutter/actions/DeviceSelectorAction.java
+++ b/src/io/flutter/actions/DeviceSelectorAction.java
@@ -182,8 +182,10 @@ public class DeviceSelectorAction extends ComboBoxAction implements DumbAware {
       actions.add(new Separator());
       actions.addAll(emulatorActions);
     }
-    actions.add(new Separator());
-    actions.add(new RestartFlutterDaemonAction());
+    if (!FlutterModuleUtils.hasInternalDartSdkPath(project)) {
+      actions.add(new Separator());
+      actions.add(new RestartFlutterDaemonAction());
+    }
     ActivityTracker.getInstance().inc();
   }
 

--- a/src/io/flutter/actions/RestartFlutterDaemonAction.java
+++ b/src/io/flutter/actions/RestartFlutterDaemonAction.java
@@ -12,6 +12,10 @@ import io.flutter.FlutterInitializer;
 import io.flutter.run.daemon.DeviceService;
 
 public class RestartFlutterDaemonAction extends AnAction {
+  public RestartFlutterDaemonAction() {
+    super("Refresh");
+  }
+
   @Override
   public void actionPerformed(AnActionEvent event) {
     FlutterInitializer.sendAnalyticsAction(this);


### PR DESCRIPTION
Add a `Refresh` item to the device list. `DeviceService.isRefreshInProgress` was added to eliminate the flashing caused by the widget being hidden while the device service was inactive.

<img width="355" alt="Screen Shot 2021-03-18 at 9 53 12 AM" src="https://user-images.githubusercontent.com/8518285/111670245-d9b0ef00-87d4-11eb-99eb-91478e5c704b.png">

Fixes #5221 
Fixes #4801 
Fixes #4208

To be fair, this is not the "fix" requested in some of those issues, but is a work-around for the problem described. Automatically updating the device list after a new emulator is created isn't practical. Alternatively, recreating the list every time it is shown isn't performant.