### PR TITLE
Check that files exist during class load

### DIFF
--- a/src/io/flutter/jxbrowser/JxBrowserManager.java
+++ b/src/io/flutter/jxbrowser/JxBrowserManager.java
@@ -254,15 +254,16 @@ public class JxBrowserManager {
   private void loadClasses(String[] fileNames) {
     for (String fileName : fileNames) {
       final String fullPath = getFilePath(fileName);
-      final boolean success = FileUtils.getInstance().loadClass(this.getClass().getClassLoader(), fullPath);
-      if (success) {
-        LOG.info("Loaded JxBrowser file successfully: " + fullPath);
-      }
-      else {
-        LOG.info("Failed to load JxBrowser file: " + fullPath);
+
+      try {
+        FileUtils.getInstance().loadClass(this.getClass().getClassLoader(), fullPath);
+      } catch (Exception ex) {
+        LOG.error("Failed to load JxBrowser file", ex);
         setStatusFailed("classLoadFailed");
         return;
+
       }
+      LOG.info("Loaded JxBrowser file successfully: " + fullPath);
     }
     FlutterInitializer.getAnalytics().sendEvent(ANALYTICS_CATEGORY, "installed");
     status.set(JxBrowserStatus.INSTALLED);

--- a/src/io/flutter/jxbrowser/JxBrowserManager.java
+++ b/src/io/flutter/jxbrowser/JxBrowserManager.java
@@ -258,7 +258,7 @@ public class JxBrowserManager {
       try {
         FileUtils.getInstance().loadClass(this.getClass().getClassLoader(), fullPath);
       } catch (Exception ex) {
-        LOG.error("Failed to load JxBrowser file", ex);
+        LOG.info("Failed to load JxBrowser file", ex);
         setStatusFailed("classLoadFailed");
         return;
 

--- a/src/io/flutter/utils/FileUtils.java
+++ b/src/io/flutter/utils/FileUtils.java
@@ -8,7 +8,6 @@ package io.flutter.utils;
 import com.intellij.util.lang.UrlClassLoader;
 
 import java.io.File;
-import java.net.MalformedURLException;
 import java.net.URL;
 
 public class FileUtils {
@@ -52,22 +51,15 @@ public class FileUtils {
     return true;
   }
 
-  public boolean loadClass(ClassLoader classLoader, String path) {
+  public void loadClass(ClassLoader classLoader, String path) throws Exception {
     final UrlClassLoader urlClassLoader = (UrlClassLoader) classLoader;
+
     final File file = new File(path);
-    final URL url;
-    try {
-      url = file.toURI().toURL();
+    if (!file.exists()) {
+      throw new Exception("File does not exist: " + file.getAbsolutePath());
     }
-    catch (MalformedURLException e) {
-      return false;
-    }
-    try {
-      urlClassLoader.addURL(url);
-    }
-    catch (Exception e) {
-      return false;
-    }
-    return true;
+
+    final URL url = file.toURI().toURL();
+    urlClassLoader.addURL(url);
   }
 }

--- a/testSrc/unit/io/flutter/jxbrowser/JxBrowserManagerTest.java
+++ b/testSrc/unit/io/flutter/jxbrowser/JxBrowserManagerTest.java
@@ -101,9 +101,6 @@ public class JxBrowserManagerTest {
     when(FileUtils.getInstance()).thenReturn(mockFileUtils);
     when(mockFileUtils.makeDirectory(DOWNLOAD_PATH)).thenReturn(true);
     when(mockFileUtils.fileExists(anyString())).thenReturn(true);
-    when(mockFileUtils.loadClass(any(ClassLoader.class), endsWith(PLATFORM_FILE_NAME))).thenReturn(true);
-    when(mockFileUtils.loadClass(any(ClassLoader.class), endsWith(API_FILE_NAME))).thenReturn(true);
-    when(mockFileUtils.loadClass(any(ClassLoader.class), endsWith(SWING_FILE_NAME))).thenReturn(true);
 
     PowerMockito.mockStatic(JxBrowserUtils.class);
     when(JxBrowserUtils.getJxBrowserKey()).thenReturn("KEY");


### PR DESCRIPTION
I noticed while debugging another issue that a file can not exist and still seem to be "loaded" correctly because no exceptions are thrown during the `loadClass` function. I don't think this is actually happening (it shouldn't) but for completeness it seems like we should check for this since we're checking for other exceptions.