### PR TITLE
Skip URL reset if JxBrowser not installed

### DIFF
--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -671,8 +671,10 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
     toolWindow.setIcon(ExecutionUtil.getLiveIndicator(FlutterIcons.Flutter_13));
 
     if (FlutterSettings.getInstance().isEnableEmbeddedBrowsers()) {
-      // Reset the URL since we may have an outdated one from a previous app run.
-      EmbeddedBrowser.getInstance(myProject).resetUrl();
+      if (JxBrowserManager.getInstance().getStatus().equals(JxBrowserStatus.INSTALLED)) {
+        // Reset the URL since we may have an outdated one from a previous app run.
+        EmbeddedBrowser.getInstance(myProject).resetUrl();
+      }
       if (toolWindow.isVisible()) {
         displayEmbeddedBrowser(app, inspectorService, toolWindow);
       } else {
@@ -751,7 +753,8 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
   }
 
   private void displayEmbeddedBrowser(FlutterApp app, InspectorService inspectorService, ToolWindow toolWindow) {
-    final JxBrowserStatus jxBrowserStatus = JxBrowserManager.getInstance().getStatus();
+    final JxBrowserManager manager = JxBrowserManager.getInstance();
+    final JxBrowserStatus jxBrowserStatus = manager.getStatus();
 
     if (jxBrowserStatus.equals(JxBrowserStatus.INSTALLED)) {
       handleJxBrowserInstalled(app, inspectorService, toolWindow);
@@ -761,6 +764,9 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
     }
     else if (jxBrowserStatus.equals(JxBrowserStatus.INSTALLATION_FAILED)) {
       handleJxBrowserInstallationFailed(app, inspectorService, toolWindow);
+    } else if (jxBrowserStatus.equals(JxBrowserStatus.NOT_INSTALLED)) {
+      manager.setUp(myProject);
+      handleJxBrowserInstallationInProgress(app, inspectorService, toolWindow);
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter-intellij/issues/5321

There are some cases where JxBrowser doesn't get set up from ProjectOpenActivity ([code pointer](https://github.com/flutter/flutter-intellij/blob/0ca51f4dd74dcb791d20285eab865abb6a798e20/src/io/flutter/ProjectOpenActivity.java#L62)). I'm not sure why this may be - in the issue linked, the user had a pubspec.yaml file with flutter as a dependency, and that seems to be the only condition checked.

However, even though I'm not sure why this would happen, it's definitely more correct to check for JxBrowser status before resetting the URL in case it's in another state. It also seems reasonable to set up JxBrowser if we haven't tried yet at the point that we're hoping to show the embedded DevTools.