### PR TITLE
Add a parameter to Project.initProject() for canary

### DIFF
--- a/flutter-studio/src/io/flutter/android/AndroidModuleLibraryManager.java
+++ b/flutter-studio/src/io/flutter/android/AndroidModuleLibraryManager.java
@@ -48,7 +48,6 @@ import com.intellij.openapi.roots.libraries.Library;
 import com.intellij.openapi.roots.libraries.LibraryTable;
 import com.intellij.openapi.roots.libraries.LibraryTablesRegistrar;
 import com.intellij.openapi.roots.libraries.PersistentLibraryKind;
-import com.intellij.openapi.ui.popup.Balloon;
 import com.intellij.openapi.util.Disposer;
 import com.intellij.openapi.util.io.FileUtilRt;
 import com.intellij.openapi.vfs.LocalFileSystem;

--- a/flutter-studio/src/io/flutter/android/AndroidModuleLibraryManager.java
+++ b/flutter-studio/src/io/flutter/android/AndroidModuleLibraryManager.java
@@ -5,6 +5,7 @@
  */
 package io.flutter.android;
 
+import static com.android.tools.idea.gradle.util.GradleUtil.GRADLE_SYSTEM_ID;
 import static com.google.wireless.android.sdk.stats.GradleSyncStats.Trigger.TRIGGER_PROJECT_MODIFIED;
 import static io.flutter.android.AndroidModuleLibraryType.LIBRARY_KIND;
 import static io.flutter.android.AndroidModuleLibraryType.LIBRARY_NAME;
@@ -15,6 +16,9 @@ import com.intellij.ProjectTopics;
 import com.intellij.facet.FacetManager;
 import com.intellij.ide.plugins.IdeaPluginDescriptorImpl;
 import com.intellij.ide.plugins.PluginManagerCore;
+import com.intellij.notification.Notification;
+import com.intellij.notification.NotificationType;
+import com.intellij.notification.Notifications;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ModalityState;
@@ -44,6 +48,7 @@ import com.intellij.openapi.roots.libraries.Library;
 import com.intellij.openapi.roots.libraries.LibraryTable;
 import com.intellij.openapi.roots.libraries.LibraryTablesRegistrar;
 import com.intellij.openapi.roots.libraries.PersistentLibraryKind;
+import com.intellij.openapi.ui.popup.Balloon;
 import com.intellij.openapi.util.Disposer;
 import com.intellij.openapi.util.io.FileUtilRt;
 import com.intellij.openapi.vfs.LocalFileSystem;
@@ -55,6 +60,7 @@ import com.intellij.util.ReflectionUtil;
 import com.intellij.util.modules.CircularModuleDependenciesDetector;
 import io.flutter.sdk.AbstractLibraryManager;
 import io.flutter.sdk.FlutterSdkUtil;
+import io.flutter.settings.FlutterSettings;
 import io.flutter.utils.FlutterModuleUtils;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -90,6 +96,7 @@ public class AndroidModuleLibraryManager extends AbstractLibraryManager<AndroidM
   private static final Logger LOG = Logger.getInstance(AndroidModuleLibraryManager.class);
   private static final String BUILD_FILE_NAME = "build.gradle";
   private final AtomicBoolean isUpdating = new AtomicBoolean(false);
+  private final AtomicBoolean isDisabled = new AtomicBoolean(false);
 
   public AndroidModuleLibraryManager(@NotNull Project project) {
     super(project);
@@ -198,7 +205,7 @@ public class AndroidModuleLibraryManager extends AbstractLibraryManager<AndroidM
   }
 
   private void scheduleUpdate() {
-    if (isUpdating.get()) {
+    if (isUpdating.get() || isDisabled.get()) {
       return;
     }
 
@@ -219,7 +226,7 @@ public class AndroidModuleLibraryManager extends AbstractLibraryManager<AndroidM
     if (dir == null) dir = flutterProject.getBaseDir().findChild(".android"); // For modules.
     if (dir == null) return;
     EmbeddedAndroidProject androidProject = new EmbeddedAndroidProject(Paths.get(FileUtilRt.toSystemIndependentName(dir.getPath())));
-    androidProject.init41(null);
+    androidProject.init42(null);
     Disposer.register(flutterProject, androidProject);
 
     GradleSyncListener listener = new GradleSyncListener() {
@@ -362,6 +369,34 @@ public class AndroidModuleLibraryManager extends AbstractLibraryManager<AndroidM
       return null;
     }
 
+    public void init42(@Nullable ProgressIndicator indicator) {
+      boolean finished = false;
+      try {
+        //ProjectManagerImpl.initProject(path, this, true, true, null, null);
+        Method method = ReflectionUtil
+          .getDeclaredMethod(ProjectManagerImpl.class, "initProject", Path.class, ProjectImpl.class, boolean.class, boolean.class,
+                             Project.class, ProgressIndicator.class);
+        assert (method != null);
+        try {
+          method.invoke(null, path, this, true, true, null, null);
+        }
+        catch (IllegalAccessException | InvocationTargetException e) {
+          disableGradleSyncAndNotifyUser();
+          return;
+        }
+        finished = true;
+      }
+      finally {
+        if (!finished) {
+          TransactionGuard.submitTransaction(this, () -> WriteAction.run(() -> {
+            if (isDisposed() && !isDisabled.get()) {
+              Disposer.dispose(this);
+            }
+          }));
+        }
+      }
+    }
+
     public void init41(@Nullable ProgressIndicator indicator) {
       boolean finished = false;
       try {
@@ -374,14 +409,15 @@ public class AndroidModuleLibraryManager extends AbstractLibraryManager<AndroidM
           method.invoke(null, path, this, true, null, null);
         }
         catch (IllegalAccessException | InvocationTargetException e) {
-          throw new RuntimeException(e);
+          disableGradleSyncAndNotifyUser();
+          return;
         }
         finished = true;
       }
       finally {
         if (!finished) {
           TransactionGuard.submitTransaction(this, () -> WriteAction.run(() -> {
-            if (isDisposed()) {
+            if (isDisposed() && !isDisabled.get()) {
               Disposer.dispose(this);
             }
           }));
@@ -400,12 +436,25 @@ public class AndroidModuleLibraryManager extends AbstractLibraryManager<AndroidM
       finally {
         if (!finished) {
           TransactionGuard.submitTransaction(this, () -> WriteAction.run(() -> {
-            if (isDisposed()) {
+            if (isDisposed() && !isDisabled.get()) {
               Disposer.dispose(this);
             }
           }));
         }
       }
+    }
+
+    private void disableGradleSyncAndNotifyUser() {
+      final FlutterSettings instance = FlutterSettings.getInstance();
+      instance.setSyncingAndroidLibraries(false);
+      isDisabled.set(true);
+      final Notification notification = new Notification(
+        GRADLE_SYSTEM_ID.getReadableName() + " sync",
+        "Gradle sync disabled",
+        "An internal error prevents Gradle from analyzing the Android module at " + path,
+        NotificationType.WARNING,
+        null);
+      Notifications.Bus.notify(notification, this);
     }
   }
 }

--- a/tool/plugin/lib/edit.dart
+++ b/tool/plugin/lib/edit.dart
@@ -155,11 +155,13 @@ class EditAndroidModuleLibraryManager extends EditCommand {
             "");
         source = source.replaceAll("IProjectStore", "Object");
         source = source.replaceAll(
-            "androidProject.init41", "androidProject.initPre41");
+            "androidProject.init42", "androidProject.initPre41");
         source = source.replaceAll("PluginManagerCore.getLoadedPlugins(), null",
             "PluginManagerCore.getLoadedPlugins(), false");
       }
       if (spec.version.startsWith('4.2')) {
+        source = source.replaceAll(
+            "androidProject.init42", "androidProject.init41");
         source = source.replaceAll("PluginManagerCore.getLoadedPlugins(), null",
             "PluginManagerCore.getLoadedPlugins()");
         source = source.replaceAll("getStateStore1", "getStateStore");


### PR DESCRIPTION
This helps with #5335 but is not a complete fix. Gradle sync will work in the current Android Studio stable (4.1) and canary builds but does not work in beta. I added a notification that the feature is unavailable in the case where we get an internal error that prevents Gradle sync from running.

<img width="374" alt="Screen Shot 2021-03-23 at 3 52 54 PM" src="https://user-images.githubusercontent.com/8518285/112231046-2e000880-8bf3-11eb-9bba-b2152c866200.png">

Since this used to work in beta I'm hoping the next beta update will fix it. If not, some heroics will be required because I don't expect 4.2 to be in beta too much longer.