### PR TITLE
Disable bazel hot restart by default

### DIFF
--- a/src/io/flutter/FlutterBundle.properties
+++ b/src/io/flutter/FlutterBundle.properties
@@ -207,6 +207,7 @@ settings.flutter.version=Version:
 settings.open.inspector.on.launch=Open Flutter Inspector view on app launch
 settings.hot.reload.on.save=Perform hot reload on save
 settings.enable.embedding.devtools=Enable embedding DevTools in the Flutter Inspector tool window
+settings.enable.bazel.hot.restart=Enable Bazel hot restart (refreshes generated files)
 
 action.new.project.title=New Flutter Project...
 welcome.new.project.title=Create New Flutter Project

--- a/src/io/flutter/run/bazel/BazelFields.java
+++ b/src/io/flutter/run/bazel/BazelFields.java
@@ -285,7 +285,7 @@ public class BazelFields {
     if (!FlutterSettings.getInstance().isEnableBazelHotRestart() && hasDisabledArg) {
       final Notification notification = new Notification(
         FlutterMessages.FLUTTER_NOTIFICATION_GROUP_ID,
-        "Google3 hot restart is disabled by default",
+        "Google3-specific hot restart is disabled by default",
         "You can now remove this flag from your configuration's additional args: " + disableBazelHotRestartParam,
         NotificationType.INFORMATION);
       Notifications.Bus.notify(notification, project);

--- a/src/io/flutter/run/bazel/BazelFields.java
+++ b/src/io/flutter/run/bazel/BazelFields.java
@@ -28,6 +28,7 @@ import io.flutter.run.FlutterDevice;
 import io.flutter.run.common.RunMode;
 import io.flutter.run.daemon.DevToolsInstance;
 import io.flutter.run.daemon.DevToolsService;
+import io.flutter.settings.FlutterSettings;
 import io.flutter.utils.ElementIO;
 import org.jdom.Element;
 import org.jetbrains.annotations.NotNull;
@@ -91,7 +92,11 @@ public class BazelFields {
     this(bazelTarget, bazelArgs, additionalArgs, enableReleaseMode, null);
   }
 
-  BazelFields(@Nullable String bazelTarget, @Nullable String bazelArgs, @Nullable String additionalArgs, boolean enableReleaseMode, DevToolsService devToolsService) {
+  BazelFields(@Nullable String bazelTarget,
+              @Nullable String bazelArgs,
+              @Nullable String additionalArgs,
+              boolean enableReleaseMode,
+              DevToolsService devToolsService) {
     this.bazelTarget = bazelTarget;
     this.bazelArgs = bazelArgs;
     this.additionalArgs = additionalArgs;
@@ -267,6 +272,12 @@ public class BazelFields {
       StringUtil.notNullize(additionalArgs));
     while (additionalArgsTokenizer.hasMoreTokens()) {
       commandLine.addParameter(additionalArgsTokenizer.nextToken());
+    }
+
+    final String disableBazelHotRestartParam = "--no-enable-google3-hot-reload";
+    if (!FlutterSettings.getInstance().isEnableBazelHotRestart() &&
+        !StringUtil.notNullize(additionalArgs).contains(disableBazelHotRestartParam)) {
+      commandLine.addParameter(disableBazelHotRestartParam);
     }
 
     // Send in the deviceId.

--- a/src/io/flutter/run/bazel/BazelFields.java
+++ b/src/io/flutter/run/bazel/BazelFields.java
@@ -293,6 +293,8 @@ public class BazelFields {
       commandLine.addParameter(enableBazelHotRestartParam);
     }
 
+
+
     // Send in the deviceId.
     if (device != null) {
       commandLine.addParameter("-d");

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.form
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.form
@@ -98,7 +98,7 @@
           </component>
         </children>
       </grid>
-      <grid id="919ec" layout-manager="GridLayoutManager" row-count="3" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="919ec" layout-manager="GridLayoutManager" row-count="4" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -129,6 +129,14 @@
             </constraints>
             <properties>
               <text value="Show structured errors for Flutter framework issues"/>
+            </properties>
+          </component>
+          <component id="475be" class="javax.swing.JCheckBox" binding="myEnableBazelHotRestartCheckBox">
+            <constraints>
+              <grid row="3" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text resource-bundle="io/flutter/FlutterBundle" key="settings.enable.bazel.hot.restart"/>
             </properties>
           </component>
         </children>

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.java
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.java
@@ -68,6 +68,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
   private JCheckBox mySyncAndroidLibrariesCheckBox;
   private JCheckBox myEnableHotUiCheckBox;
   private JCheckBox myEnableEmbeddedBrowsersCheckBox;
+  private JCheckBox myEnableBazelHotRestartCheckBox;
 
   private JCheckBox myShowAllRunConfigurationsInContextCheckBox;
 
@@ -137,6 +138,8 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     mySyncAndroidLibrariesCheckBox.setVisible(FlutterUtils.isAndroidStudio());
 
     myEnableEmbeddedBrowsersCheckBox.setVisible(true);
+
+    myEnableBazelHotRestartCheckBox.setVisible(WorkspaceCache.getInstance(myProject).isBazel());
   }
 
   private void createUIComponents() {
@@ -220,6 +223,10 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
       return true;
     }
 
+    if (settings.isEnableBazelHotRestart() != myEnableBazelHotRestartCheckBox.isSelected()) {
+      return true;
+    }
+
     //noinspection RedundantIfStatement
     if (settings.showAllRunConfigurationsInContext() != myShowAllRunConfigurationsInContextCheckBox.isSelected()) {
       return true;
@@ -268,6 +275,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     settings.setSyncingAndroidLibraries(mySyncAndroidLibrariesCheckBox.isSelected());
     settings.setEnableHotUi(myEnableHotUiCheckBox.isSelected());
     settings.setEnableEmbeddedBrowsers(myEnableEmbeddedBrowsersCheckBox.isSelected());
+    settings.setEnableBazelHotRestart(myEnableBazelHotRestartCheckBox.isSelected());
     settings.setShowAllRunConfigurationsInContext(myShowAllRunConfigurationsInContextCheckBox.isSelected());
 
     reset(); // because we rely on remembering initial state
@@ -310,6 +318,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     myEnableHotUiCheckBox.setSelected(settings.isEnableHotUi());
 
     myEnableEmbeddedBrowsersCheckBox.setSelected(settings.isEnableEmbeddedBrowsers());
+    myEnableBazelHotRestartCheckBox.setSelected(settings.isEnableBazelHotRestart());
 
     myOrganizeImportsOnSaveCheckBox.setEnabled(myFormatCodeOnSaveCheckBox.isSelected());
 

--- a/src/io/flutter/settings/FlutterSettings.java
+++ b/src/io/flutter/settings/FlutterSettings.java
@@ -31,6 +31,7 @@ public class FlutterSettings {
   private static final String enableHotUiKey = "io.flutter.editor.enableHotUi";
   private static final String enableEmbeddedBrowsersKey = "io.flutter.editor.enableEmbeddedBrowsers";
   private static final String enableBazelHotRestart = "io.flutter.editor.enableBazelHotRestart";
+  private static final String showBazelHotRestartWarning = "io.flutter.showBazelHotRestartWarning";
 
   /**
    * Registry key to suggest all run configurations instead of just one.
@@ -119,6 +120,10 @@ public class FlutterSettings {
 
     if (isEnableHotUi()) {
       analytics.sendEvent("settings", afterLastPeriod(enableHotUiKey));
+    }
+
+    if (isShowBazelHotRestartWarning()) {
+      analytics.sendEvent("settings", afterLastPeriod(showBazelHotRestartWarning));
     }
   }
 
@@ -284,6 +289,15 @@ public class FlutterSettings {
 
   public void setEnableBazelHotRestart(boolean value) {
     getPropertiesComponent().setValue(enableBazelHotRestart, value, false);
+    fireEvent();
+  }
+
+  public boolean isShowBazelHotRestartWarning() {
+    return getPropertiesComponent().getBoolean(showBazelHotRestartWarning, true);
+  }
+
+  public void setShowBazelHotRestartWarning(boolean value) {
+    getPropertiesComponent().setValue(showBazelHotRestartWarning, value, true);
     fireEvent();
   }
 

--- a/src/io/flutter/settings/FlutterSettings.java
+++ b/src/io/flutter/settings/FlutterSettings.java
@@ -30,6 +30,7 @@ public class FlutterSettings {
   private static final String showBuildMethodGuidesKey = "io.flutter.editor.showBuildMethodGuides";
   private static final String enableHotUiKey = "io.flutter.editor.enableHotUi";
   private static final String enableEmbeddedBrowsersKey = "io.flutter.editor.enableEmbeddedBrowsers";
+  private static final String enableBazelHotRestart = "io.flutter.editor.enableBazelHotRestart";
 
   /**
    * Registry key to suggest all run configurations instead of just one.
@@ -274,6 +275,15 @@ public class FlutterSettings {
 
   public void setEnableEmbeddedBrowsers(boolean value) {
     getPropertiesComponent().setValue(enableEmbeddedBrowsersKey, value, true);
+    fireEvent();
+  }
+
+  public boolean isEnableBazelHotRestart() {
+    return getPropertiesComponent().getBoolean(enableBazelHotRestart, false);
+  }
+
+  public void setEnableBazelHotRestart(boolean value) {
+    getPropertiesComponent().setValue(enableBazelHotRestart, value, false);
     fireEvent();
   }
 

--- a/testSrc/unit/io/flutter/run/bazel/LaunchCommandsTest.java
+++ b/testSrc/unit/io/flutter/run/bazel/LaunchCommandsTest.java
@@ -63,6 +63,7 @@ public class LaunchCommandsTest {
     expectedCommandLine.add("/workspace/scripts/flutter-run.sh");
     expectedCommandLine.add("--bazel-options=--define=flutter_build_mode=release");
     expectedCommandLine.add("--machine");
+    expectedCommandLine.add("--no-enable-google3-hot-reload");
     expectedCommandLine.add("-d");
     expectedCommandLine.add("flutter-tester");
     expectedCommandLine.add("--devtools-server-address=http://http://localhost:1234");
@@ -89,6 +90,7 @@ public class LaunchCommandsTest {
     expectedCommandLine.add("/workspace/scripts/flutter-run.sh");
     expectedCommandLine.add("--bazel-options=--define=flutter_build_mode=debug");
     expectedCommandLine.add("--machine");
+    expectedCommandLine.add("--no-enable-google3-hot-reload");
     expectedCommandLine.add("-d");
     expectedCommandLine.add("flutter-tester");
     expectedCommandLine.add("--devtools-server-address=http://http://localhost:1234");
@@ -112,6 +114,7 @@ public class LaunchCommandsTest {
     expectedCommandLine.add("/workspace/scripts/flutter-run.sh");
     expectedCommandLine.add("--bazel-options=--define=bazel_args --define=flutter_build_mode=debug");
     expectedCommandLine.add("--machine");
+    expectedCommandLine.add("--no-enable-google3-hot-reload");
     expectedCommandLine.add("-d");
     expectedCommandLine.add("flutter-tester");
     expectedCommandLine.add("--devtools-server-address=http://http://localhost:1234");
@@ -135,6 +138,7 @@ public class LaunchCommandsTest {
     expectedCommandLine.add("/workspace/scripts/flutter-run.sh");
     expectedCommandLine.add("--bazel-options=--define=flutter_build_mode=release");
     expectedCommandLine.add("--machine");
+    expectedCommandLine.add("--no-enable-google3-hot-reload");
     expectedCommandLine.add("-d");
     expectedCommandLine.add("flutter-tester");
     expectedCommandLine.add("--devtools-server-address=http://http://localhost:1234");
@@ -155,6 +159,7 @@ public class LaunchCommandsTest {
     expectedCommandLine.add("/workspace/scripts/flutter-run.sh");
     expectedCommandLine.add("--bazel-options=--define flutter_build_mode=profile");
     expectedCommandLine.add("--machine");
+    expectedCommandLine.add("--no-enable-google3-hot-reload");
     expectedCommandLine.add("-d");
     expectedCommandLine.add("flutter-tester");
     expectedCommandLine.add("--devtools-server-address=http://http://localhost:1234");
@@ -175,6 +180,7 @@ public class LaunchCommandsTest {
     expectedCommandLine.add("/workspace/scripts/flutter-run.sh");
     expectedCommandLine.add("--bazel-options=--define param1=2 --define=param2=2 --define=flutter_build_mode=profile");
     expectedCommandLine.add("--machine");
+    expectedCommandLine.add("--no-enable-google3-hot-reload");
     expectedCommandLine.add("-d");
     expectedCommandLine.add("flutter-tester");
     expectedCommandLine.add("--devtools-server-address=http://http://localhost:1234");
@@ -199,6 +205,7 @@ public class LaunchCommandsTest {
     expectedCommandLine.add("--bazel-options=--define=flutter_build_mode=debug");
     expectedCommandLine.add("--machine");
     expectedCommandLine.add("additional_args");
+    expectedCommandLine.add("--no-enable-google3-hot-reload");
     expectedCommandLine.add("-d");
     expectedCommandLine.add("flutter-tester");
     expectedCommandLine.add("--devtools-server-address=http://http://localhost:1234");
@@ -211,7 +218,7 @@ public class LaunchCommandsTest {
     final BazelFields fields = setupBazelFields(
       "bazel_target",
       "--define=bazel_args0 --define bazel_args1=value",
-      "--additional_args1 --additional_args2 value_of_arg2",
+      "--additional_args1 --additional_args2 value_of_arg2 --no-enable-google3-hot-reload",
       false
     );
 
@@ -225,6 +232,7 @@ public class LaunchCommandsTest {
     expectedCommandLine.add("--additional_args1");
     expectedCommandLine.add("--additional_args2");
     expectedCommandLine.add("value_of_arg2");
+    expectedCommandLine.add("--no-enable-google3-hot-reload");
     expectedCommandLine.add("-d");
     expectedCommandLine.add("flutter-tester");
     expectedCommandLine.add("--devtools-server-address=http://http://localhost:1234");
@@ -245,6 +253,7 @@ public class LaunchCommandsTest {
     expectedCommandLine.add("--bazel-options=--define=flutter_build_mode=debug");
     expectedCommandLine.add("--machine");
     expectedCommandLine.add("--start-paused");
+    expectedCommandLine.add("--no-enable-google3-hot-reload");
     expectedCommandLine.add("-d");
     expectedCommandLine.add("flutter-tester");
     expectedCommandLine.add("--devtools-server-address=http://http://localhost:1234");
@@ -264,6 +273,7 @@ public class LaunchCommandsTest {
     expectedCommandLine.add("/workspace/scripts/flutter-run.sh");
     expectedCommandLine.add("--bazel-options=--define=flutter_build_mode=profile");
     expectedCommandLine.add("--machine");
+    expectedCommandLine.add("--no-enable-google3-hot-reload");
     expectedCommandLine.add("-d");
     expectedCommandLine.add("flutter-tester");
     expectedCommandLine.add("--devtools-server-address=http://http://localhost:1234");
@@ -282,6 +292,7 @@ public class LaunchCommandsTest {
     expectedCommandLine.add("/workspace/scripts/flutter-run.sh");
     expectedCommandLine.add("--bazel-options=--define=flutter_build_mode=debug");
     expectedCommandLine.add("--machine");
+    expectedCommandLine.add("--no-enable-google3-hot-reload");
     expectedCommandLine.add("-d");
     expectedCommandLine.add("android-tester");
     expectedCommandLine.add("--devtools-server-address=http://http://localhost:1234");
@@ -301,6 +312,7 @@ public class LaunchCommandsTest {
     expectedCommandLine.add("/workspace/scripts/flutter-run.sh");
     expectedCommandLine.add("--bazel-options=--define=flutter_build_mode=debug");
     expectedCommandLine.add("--machine");
+    expectedCommandLine.add("--no-enable-google3-hot-reload");
     expectedCommandLine.add("-d");
     expectedCommandLine.add("android-tester");
     expectedCommandLine.add("--devtools-server-address=http://http://localhost:1234");
@@ -319,6 +331,7 @@ public class LaunchCommandsTest {
     expectedCommandLine.add("/workspace/scripts/flutter-run.sh");
     expectedCommandLine.add("--bazel-options=--define=flutter_build_mode=debug");
     expectedCommandLine.add("--machine");
+    expectedCommandLine.add("--no-enable-google3-hot-reload");
     expectedCommandLine.add("-d");
     expectedCommandLine.add("ios-tester");
     expectedCommandLine.add("--devtools-server-address=http://http://localhost:1234");
@@ -337,6 +350,7 @@ public class LaunchCommandsTest {
     expectedCommandLine.add("/workspace/scripts/flutter-run.sh");
     expectedCommandLine.add("--bazel-options=--define=flutter_build_mode=debug");
     expectedCommandLine.add("--machine");
+    expectedCommandLine.add("--no-enable-google3-hot-reload");
     expectedCommandLine.add("-d");
     expectedCommandLine.add("ios-tester");
     expectedCommandLine.add("--devtools-server-address=http://http://localhost:1234");

--- a/testSrc/unit/io/flutter/run/bazel/LaunchCommandsTest.java
+++ b/testSrc/unit/io/flutter/run/bazel/LaunchCommandsTest.java
@@ -63,7 +63,6 @@ public class LaunchCommandsTest {
     expectedCommandLine.add("/workspace/scripts/flutter-run.sh");
     expectedCommandLine.add("--bazel-options=--define=flutter_build_mode=release");
     expectedCommandLine.add("--machine");
-    expectedCommandLine.add("--no-enable-google3-hot-reload");
     expectedCommandLine.add("-d");
     expectedCommandLine.add("flutter-tester");
     expectedCommandLine.add("--devtools-server-address=http://http://localhost:1234");
@@ -90,7 +89,6 @@ public class LaunchCommandsTest {
     expectedCommandLine.add("/workspace/scripts/flutter-run.sh");
     expectedCommandLine.add("--bazel-options=--define=flutter_build_mode=debug");
     expectedCommandLine.add("--machine");
-    expectedCommandLine.add("--no-enable-google3-hot-reload");
     expectedCommandLine.add("-d");
     expectedCommandLine.add("flutter-tester");
     expectedCommandLine.add("--devtools-server-address=http://http://localhost:1234");
@@ -114,7 +112,6 @@ public class LaunchCommandsTest {
     expectedCommandLine.add("/workspace/scripts/flutter-run.sh");
     expectedCommandLine.add("--bazel-options=--define=bazel_args --define=flutter_build_mode=debug");
     expectedCommandLine.add("--machine");
-    expectedCommandLine.add("--no-enable-google3-hot-reload");
     expectedCommandLine.add("-d");
     expectedCommandLine.add("flutter-tester");
     expectedCommandLine.add("--devtools-server-address=http://http://localhost:1234");
@@ -138,7 +135,6 @@ public class LaunchCommandsTest {
     expectedCommandLine.add("/workspace/scripts/flutter-run.sh");
     expectedCommandLine.add("--bazel-options=--define=flutter_build_mode=release");
     expectedCommandLine.add("--machine");
-    expectedCommandLine.add("--no-enable-google3-hot-reload");
     expectedCommandLine.add("-d");
     expectedCommandLine.add("flutter-tester");
     expectedCommandLine.add("--devtools-server-address=http://http://localhost:1234");
@@ -159,7 +155,6 @@ public class LaunchCommandsTest {
     expectedCommandLine.add("/workspace/scripts/flutter-run.sh");
     expectedCommandLine.add("--bazel-options=--define flutter_build_mode=profile");
     expectedCommandLine.add("--machine");
-    expectedCommandLine.add("--no-enable-google3-hot-reload");
     expectedCommandLine.add("-d");
     expectedCommandLine.add("flutter-tester");
     expectedCommandLine.add("--devtools-server-address=http://http://localhost:1234");
@@ -180,7 +175,6 @@ public class LaunchCommandsTest {
     expectedCommandLine.add("/workspace/scripts/flutter-run.sh");
     expectedCommandLine.add("--bazel-options=--define param1=2 --define=param2=2 --define=flutter_build_mode=profile");
     expectedCommandLine.add("--machine");
-    expectedCommandLine.add("--no-enable-google3-hot-reload");
     expectedCommandLine.add("-d");
     expectedCommandLine.add("flutter-tester");
     expectedCommandLine.add("--devtools-server-address=http://http://localhost:1234");
@@ -205,7 +199,6 @@ public class LaunchCommandsTest {
     expectedCommandLine.add("--bazel-options=--define=flutter_build_mode=debug");
     expectedCommandLine.add("--machine");
     expectedCommandLine.add("additional_args");
-    expectedCommandLine.add("--no-enable-google3-hot-reload");
     expectedCommandLine.add("-d");
     expectedCommandLine.add("flutter-tester");
     expectedCommandLine.add("--devtools-server-address=http://http://localhost:1234");
@@ -253,7 +246,6 @@ public class LaunchCommandsTest {
     expectedCommandLine.add("--bazel-options=--define=flutter_build_mode=debug");
     expectedCommandLine.add("--machine");
     expectedCommandLine.add("--start-paused");
-    expectedCommandLine.add("--no-enable-google3-hot-reload");
     expectedCommandLine.add("-d");
     expectedCommandLine.add("flutter-tester");
     expectedCommandLine.add("--devtools-server-address=http://http://localhost:1234");
@@ -273,7 +265,6 @@ public class LaunchCommandsTest {
     expectedCommandLine.add("/workspace/scripts/flutter-run.sh");
     expectedCommandLine.add("--bazel-options=--define=flutter_build_mode=profile");
     expectedCommandLine.add("--machine");
-    expectedCommandLine.add("--no-enable-google3-hot-reload");
     expectedCommandLine.add("-d");
     expectedCommandLine.add("flutter-tester");
     expectedCommandLine.add("--devtools-server-address=http://http://localhost:1234");
@@ -292,7 +283,6 @@ public class LaunchCommandsTest {
     expectedCommandLine.add("/workspace/scripts/flutter-run.sh");
     expectedCommandLine.add("--bazel-options=--define=flutter_build_mode=debug");
     expectedCommandLine.add("--machine");
-    expectedCommandLine.add("--no-enable-google3-hot-reload");
     expectedCommandLine.add("-d");
     expectedCommandLine.add("android-tester");
     expectedCommandLine.add("--devtools-server-address=http://http://localhost:1234");
@@ -312,7 +302,6 @@ public class LaunchCommandsTest {
     expectedCommandLine.add("/workspace/scripts/flutter-run.sh");
     expectedCommandLine.add("--bazel-options=--define=flutter_build_mode=debug");
     expectedCommandLine.add("--machine");
-    expectedCommandLine.add("--no-enable-google3-hot-reload");
     expectedCommandLine.add("-d");
     expectedCommandLine.add("android-tester");
     expectedCommandLine.add("--devtools-server-address=http://http://localhost:1234");
@@ -331,7 +320,6 @@ public class LaunchCommandsTest {
     expectedCommandLine.add("/workspace/scripts/flutter-run.sh");
     expectedCommandLine.add("--bazel-options=--define=flutter_build_mode=debug");
     expectedCommandLine.add("--machine");
-    expectedCommandLine.add("--no-enable-google3-hot-reload");
     expectedCommandLine.add("-d");
     expectedCommandLine.add("ios-tester");
     expectedCommandLine.add("--devtools-server-address=http://http://localhost:1234");
@@ -350,7 +338,6 @@ public class LaunchCommandsTest {
     expectedCommandLine.add("/workspace/scripts/flutter-run.sh");
     expectedCommandLine.add("--bazel-options=--define=flutter_build_mode=debug");
     expectedCommandLine.add("--machine");
-    expectedCommandLine.add("--no-enable-google3-hot-reload");
     expectedCommandLine.add("-d");
     expectedCommandLine.add("ios-tester");
     expectedCommandLine.add("--devtools-server-address=http://http://localhost:1234");


### PR DESCRIPTION
We want to default to disabling updating generated files during hot restart and add an option to turn this on for all projects if desired. (A user could enable this feature globally in settings but manually add a flag to disable for a particular project)

This setting is only visible for bazel projects.