### PR TITLE
Follow up on the isFailure json attribute change, removal of the error attribute to match the Dart IJ Plugin

### DIFF
--- a/src/io/flutter/test/DartTestEventsConverterZ.java
+++ b/src/io/flutter/test/DartTestEventsConverterZ.java
@@ -348,7 +348,6 @@ public class DartTestEventsConverterZ extends OutputToGeneralTestEventsConverter
         }
       }
 
-      testError.addAttribute("error", "true");
       testError.addAttribute("message", appendLineBreakIfNeeded(failureMessage));
 
       result &= finishMessage(testError, test.getId(), test.getValidParentId());


### PR DESCRIPTION
Dart IJ Plugin change: https://github.com/JetBrains/intellij-plugins/commit/9bf7b23b8c8aa8e1ec19ec98c6248d413a84d629