### PR TITLE
Update live templates to null safety

### DIFF
--- a/resources/liveTemplates/flutter_miscellaneous.xml
+++ b/resources/liveTemplates/flutter_miscellaneous.xml
@@ -11,14 +11,14 @@
       <option name="DART_TOPLEVEL" value="true" />
     </context>
   </template>
-  <template name="inh" value="class $NAME$ extends InheritedWidget {&#10;  const $NAME$({&#10;    Key key,&#10;    @required Widget child,&#10;  }) : assert(child != null),&#10;       super(key: key, child: child);&#10;&#10;  static $NAME$ of(BuildContext context) {&#10;    return context.dependOnInheritedWidgetOfExactType&lt;$NAME$&gt;();&#10;  }&#10;&#10;  @override&#10;  bool updateShouldNotify($NAME$ old) {&#10;    return $SHOULD_NOTIFY$;&#10;  }&#10;}" description="New Inherited widget" toReformat="true" toShortenFQNames="true">
+  <template name="inh" value="class $NAME$ extends InheritedWidget {&#10;  const $NAME$({&#10;    Key? key,&#10;    required Widget child,&#10;  }) : super(key: key, child: child);&#10;&#10;  static $NAME$ of(BuildContext context) {&#10;    final $NAME$? result = context.dependOnInheritedWidgetOfExactType&lt;$NAME$&gt;();&#10;    return result!;&#10;  }&#10;&#10;  @override&#10;  bool updateShouldNotify($NAME$ old) {&#10;    return $SHOULD_NOTIFY$;&#10;  }&#10;}" description="New Inherited widget" toReformat="true" toShortenFQNames="true">
     <variable name="NAME" expression="" defaultValue="" alwaysStopAt="true" />
     <variable name="SHOULD_NOTIFY" expression="" defaultValue="" alwaysStopAt="true" />
     <context>
       <option name="DART_TOPLEVEL" value="true" />
     </context>
   </template>
-  <template name="stanim" value="class $NAME$ extends StatefulWidget {&#10;  @override&#10;  _$NAME$State createState() =&gt; _$NAME$State();&#10;}&#10;&#10;class _$NAME$State extends State&lt;$NAME$&gt; with SingleTickerProviderStateMixin {&#10;  AnimationController _controller;&#10;&#10;  @override&#10;  void initState() {&#10;    super.initState();&#10;    _controller = AnimationController(vsync: this);&#10;  }&#10;&#10;  @override&#10;  void dispose() {&#10;    _controller.dispose();&#10;    super.dispose();&#10;  }&#10;  &#10;  @override&#10;  Widget build(BuildContext context) {&#10;    return Container($END$);&#10;  }&#10;}&#10;" description="New Stateful widget with AnimationController" toReformat="false" toShortenFQNames="true">
+  <template name="stanim" value="class $NAME$ extends StatefulWidget {&#10;  @override&#10;  _$NAME$State createState() =&gt; _$NAME$State();&#10;}&#10;&#10;class _$NAME$State extends State&lt;$NAME$&gt; with SingleTickerProviderStateMixin {&#10;  late AnimationController _controller;&#10;&#10;  @override&#10;  void initState() {&#10;    super.initState();&#10;    _controller = AnimationController(vsync: this);&#10;  }&#10;&#10;  @override&#10;  void dispose() {&#10;    _controller.dispose();&#10;    super.dispose();&#10;  }&#10;  &#10;  @override&#10;  Widget build(BuildContext context) {&#10;    return Container($END$);&#10;  }&#10;}&#10;" description="New Stateful widget with AnimationController" toReformat="false" toShortenFQNames="true">
     <variable name="NAME" expression="" defaultValue="" alwaysStopAt="true" />
     <context>
       <option name="DART_TOPLEVEL" value="true" />

--- a/resources/liveTemplates/inh.txt
+++ b/resources/liveTemplates/inh.txt
@@ -1,12 +1,12 @@
 class $NAME$ extends InheritedWidget {
   const $NAME$({
-    Key key,
-    @required Widget child,
-  }) : assert(child != null),
-       super(key: key, child: child);
+    Key? key,
+    required Widget child,
+  }) : super(key: key, child: child);
 
   static $NAME$ of(BuildContext context) {
-    return context.dependOnInheritedWidgetOfExactType<$NAME$>();
+    final $NAME$? result = context.dependOnInheritedWidgetOfExactType<$NAME$>();
+    return result!;
   }
 
   @override

--- a/resources/liveTemplates/stanim.txt
+++ b/resources/liveTemplates/stanim.txt
@@ -4,7 +4,7 @@ class $NAME$ extends StatefulWidget {
 }
 
 class _$NAME$State extends State<$NAME$> with SingleTickerProviderStateMixin {
-  AnimationController _controller;
+  late AnimationController _controller;
 
   @override
   void initState() {


### PR DESCRIPTION
This pull request updates current live templates to null safety.

1. Update `inh`(Inherited widget)  live template to null safety.
  (skeleton code referenced from https://api.flutter.dev/flutter/widgets/InheritedWidget-class.html#widgets.InheritedWidget.1)

https://user-images.githubusercontent.com/33684401/114266212-0d77e100-9a30-11eb-88cf-06a73e7341f8.mov


2. Update `stanim`(Stateful widget with AnimationController) to null safety.
    * Mark `AnimationController` as `late`.
    (https://api.flutter.dev/flutter/animation/AnimationController-class.html#animation.AnimationController.1)


https://user-images.githubusercontent.com/33684401/114266220-1a94d000-9a30-11eb-92e4-79ef3ddee52e.mov

