### PR TITLE
Check for NoClassDefFoundError before setting JxBrowser enabled

### DIFF
--- a/src/io/flutter/jxbrowser/JxBrowserManager.java
+++ b/src/io/flutter/jxbrowser/JxBrowserManager.java
@@ -19,6 +19,9 @@ import com.intellij.util.containers.ContainerUtil;
 import com.intellij.util.download.DownloadableFileDescription;
 import com.intellij.util.download.DownloadableFileService;
 import com.intellij.util.download.FileDownloader;
+import com.teamdev.jxbrowser.browser.UnsupportedRenderingModeException;
+import com.teamdev.jxbrowser.callback.Callback;
+import com.teamdev.jxbrowser.engine.RenderingMode;
 import io.flutter.FlutterInitializer;
 import io.flutter.settings.FlutterSettings;
 import io.flutter.utils.FileUtils;
@@ -264,6 +267,13 @@ public class JxBrowserManager {
 
       }
       LOG.info("Loaded JxBrowser file successfully: " + fullPath);
+    }
+    try {
+      final UnsupportedRenderingModeException test = new UnsupportedRenderingModeException(RenderingMode.HARDWARE_ACCELERATED);
+    } catch (NoClassDefFoundError e) {
+      LOG.info("Failed to find JxBrowser class");
+      setStatusFailed("NoClassDefFoundError");
+      return;
     }
     FlutterInitializer.getAnalytics().sendEvent(ANALYTICS_CATEGORY, "installed");
     status.set(JxBrowserStatus.INSTALLED);

--- a/src/io/flutter/logging/FlutterConsoleLogManager.java
+++ b/src/io/flutter/logging/FlutterConsoleLogManager.java
@@ -39,6 +39,8 @@ import io.flutter.inspector.DiagnosticsNode;
 import io.flutter.inspector.DiagnosticsTreeStyle;
 import io.flutter.inspector.InspectorService;
 import io.flutter.jxbrowser.EmbeddedBrowser;
+import io.flutter.jxbrowser.JxBrowserManager;
+import io.flutter.jxbrowser.JxBrowserStatus;
 import io.flutter.run.daemon.FlutterApp;
 import io.flutter.sdk.FlutterSdk;
 import io.flutter.settings.FlutterSettings;
@@ -270,7 +272,9 @@ public class FlutterConsoleLogManager {
 
         if (StringUtil.equals("ErrorSummary", property.getType())) {
           errorSummary = property.getDescription();
-        } else if (StringUtil.equals("DevToolsDeepLinkProperty", property.getType()) && FlutterSettings.getInstance().isEnableEmbeddedBrowsers()) {
+        } else if (StringUtil.equals("DevToolsDeepLinkProperty", property.getType()) &&
+                FlutterSettings.getInstance().isEnableEmbeddedBrowsers() &&
+                JxBrowserManager.getInstance().getStatus().equals(JxBrowserStatus.INSTALLED)) {
           showDeepLinkNotification(property, errorSummary);
           continue;
         }


### PR DESCRIPTION
This ameliorates https://github.com/flutter/flutter-intellij/issues/5376 by marking JxBrowser installation as failed and reporting the error.