### PR TITLE
Log JxBrowser exceptions as info

### DIFF
--- a/src/io/flutter/jxbrowser/EmbeddedBrowser.java
+++ b/src/io/flutter/jxbrowser/EmbeddedBrowser.java
@@ -70,7 +70,7 @@ public class EmbeddedBrowser {
     } catch (UnsupportedRenderingModeException ex) {
       // Skip using a transparent background if an exception is thrown.
     } catch (Exception ex) {
-      LOG.error(ex);
+      LOG.info(ex);
       FlutterInitializer.getAnalytics().sendException(StringUtil.getThrowableText(ex), false);
     }
 
@@ -168,7 +168,8 @@ public class EmbeddedBrowser {
 
     AsyncUtils.whenCompleteUiThread(updatedUrlFuture, (devToolsUrl, ex) -> {
       if (ex != null) {
-        LOG.error(ex);
+        LOG.info(ex);
+        FlutterInitializer.getAnalytics().sendException(StringUtil.getThrowableText(ex), false);
         return;
       }
       if (devToolsUrl == null) {

--- a/src/io/flutter/jxbrowser/EmbeddedBrowserEngine.java
+++ b/src/io/flutter/jxbrowser/EmbeddedBrowserEngine.java
@@ -45,7 +45,7 @@ public class EmbeddedBrowserEngine {
       temp = Engine.newInstance(options);
     } catch (Exception ex) {
       temp = null;
-      LOG.error(ex);
+      LOG.info(ex);
       FlutterInitializer.getAnalytics().sendException(StringUtil.getThrowableText(ex), false);
     }
     engine = temp;
@@ -58,7 +58,8 @@ public class EmbeddedBrowserEngine {
             engine.close();
           }
         } catch (Exception ex) {
-          LOG.error(ex);
+          LOG.info(ex);
+          FlutterInitializer.getAnalytics().sendException(StringUtil.getThrowableText(ex), false);
         }
         return true;
       }


### PR DESCRIPTION
I think in all of these cases we don't need users to receive an error notification since the exceptions are handled (e.g. show a failure message). It's more important to send the exceptions to analytics so we have a sense of how often they occur and log in the idea.log file in case a user reports experiencing a problem. Otherwise we get error reports that tend to have no context and aren't particularly helpful.

Fixes https://github.com/flutter/flutter-intellij/issues/5424