### PR TITLE
Add option to display all stack traces in debugger log

### DIFF
--- a/src/io/flutter/logging/FlutterConsoleLogManager.java
+++ b/src/io/flutter/logging/FlutterConsoleLogManager.java
@@ -232,7 +232,7 @@ public class FlutterConsoleLogManager {
   private void processFlutterErrorEvent(@NotNull DiagnosticsNode diagnosticsNode) {
     final String description = " " + diagnosticsNode.toString() + " ";
 
-    final boolean terseError = !isFirstErrorForFrame();
+    final boolean terseError = !isFirstErrorForFrame() && !FlutterSettings.getInstance().isIncludeAllStackTraces();
 
     frameErrorCount++;
 

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.form
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.form
@@ -98,7 +98,7 @@
           </component>
         </children>
       </grid>
-      <grid id="919ec" layout-manager="GridLayoutManager" row-count="4" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="919ec" layout-manager="GridLayoutManager" row-count="5" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -108,7 +108,7 @@
         <children>
           <component id="356a" class="javax.swing.JCheckBox" binding="myOpenInspectorOnAppLaunchCheckBox">
             <constraints>
-              <grid row="2" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="3" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text resource-bundle="io/flutter/FlutterBundle" key="settings.open.inspector.on.launch"/>
@@ -133,10 +133,19 @@
           </component>
           <component id="475be" class="javax.swing.JCheckBox" binding="myEnableBazelHotRestartCheckBox">
             <constraints>
-              <grid row="3" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="4" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text resource-bundle="io/flutter/FlutterBundle" key="settings.enable.bazel.hot.restart"/>
+            </properties>
+          </component>
+          <component id="6cf1f" class="javax.swing.JCheckBox" binding="myIncludeAllStackTraces">
+            <constraints>
+              <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="3" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Include all stack traces"/>
+              <toolTipText value="If checked, only the first exception will include a stack trace."/>
             </properties>
           </component>
         </children>

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.java
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.java
@@ -65,6 +65,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
   private JCheckBox myFormatCodeOnSaveCheckBox;
   private JCheckBox myOrganizeImportsOnSaveCheckBox;
   private JCheckBox myShowStructuredErrors;
+  private JCheckBox myIncludeAllStackTraces;
   private JCheckBox mySyncAndroidLibrariesCheckBox;
   private JCheckBox myEnableHotUiCheckBox;
   private JCheckBox myEnableEmbeddedBrowsersCheckBox;
@@ -129,6 +130,8 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
 
     myFormatCodeOnSaveCheckBox.addChangeListener(
       (e) -> myOrganizeImportsOnSaveCheckBox.setEnabled(myFormatCodeOnSaveCheckBox.isSelected()));
+    myShowStructuredErrors.addChangeListener(
+      (e) -> myIncludeAllStackTraces.setEnabled(myShowStructuredErrors.isSelected()));
 
     // There are other experiments so it is alright to show the experiments
     // panel even if the syncAndroidLibraries experiment is hidden.
@@ -203,6 +206,10 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
       return true;
     }
 
+    if (settings.isIncludeAllStackTraces() != myIncludeAllStackTraces.isSelected()) {
+      return true;
+    }
+
     if (settings.isOpenInspectorOnAppLaunch() != myOpenInspectorOnAppLaunchCheckBox.isSelected()) {
       return true;
     }
@@ -270,6 +277,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     settings.setShowBuildMethodGuides(myShowBuildMethodGuides.isSelected());
     settings.setShowClosingLabels(myShowClosingLabels.isSelected());
     settings.setShowStructuredErrors(myShowStructuredErrors.isSelected());
+    settings.setIncludeAllStackTraces(myIncludeAllStackTraces.isSelected());
     settings.setOpenInspectorOnAppLaunch(myOpenInspectorOnAppLaunchCheckBox.isSelected());
     settings.setVerboseLogging(myEnableVerboseLoggingCheckBox.isSelected());
     settings.setSyncingAndroidLibraries(mySyncAndroidLibrariesCheckBox.isSelected());
@@ -311,6 +319,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     myShowClosingLabels.setSelected(settings.isShowClosingLabels());
 
     myShowStructuredErrors.setSelected(settings.isShowStructuredErrors());
+    myIncludeAllStackTraces.setSelected(settings.isIncludeAllStackTraces());
     myOpenInspectorOnAppLaunchCheckBox.setSelected(settings.isOpenInspectorOnAppLaunch());
     myEnableVerboseLoggingCheckBox.setSelected(settings.isVerboseLogging());
     mySyncAndroidLibrariesCheckBox.setSelected(settings.isSyncingAndroidLibraries());
@@ -321,6 +330,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     myEnableBazelHotRestartCheckBox.setSelected(settings.isEnableBazelHotRestart());
 
     myOrganizeImportsOnSaveCheckBox.setEnabled(myFormatCodeOnSaveCheckBox.isSelected());
+    myIncludeAllStackTraces.setEnabled(myShowStructuredErrors.isSelected());
 
     myShowAllRunConfigurationsInContextCheckBox.setSelected(settings.showAllRunConfigurationsInContext());
   }

--- a/src/io/flutter/settings/FlutterSettings.java
+++ b/src/io/flutter/settings/FlutterSettings.java
@@ -27,6 +27,7 @@ public class FlutterSettings {
   private static final String showOnlyWidgetsKey = "io.flutter.showOnlyWidgets";
   private static final String syncAndroidLibrariesKey = "io.flutter.syncAndroidLibraries";
   private static final String showStructuredErrors = "io.flutter.showStructuredErrors";
+  private static final String includeAllStackTraces = "io.flutter.ncludeAllStackTraces";
   private static final String showBuildMethodGuidesKey = "io.flutter.editor.showBuildMethodGuides";
   private static final String enableHotUiKey = "io.flutter.editor.enableHotUi";
   private static final String enableEmbeddedBrowsersKey = "io.flutter.editor.enableEmbeddedBrowsers";
@@ -108,6 +109,10 @@ public class FlutterSettings {
 
     if (isShowStructuredErrors()) {
       analytics.sendEvent("settings", afterLastPeriod(showStructuredErrors));
+
+      if (isIncludeAllStackTraces()) {
+        analytics.sendEvent("settings", afterLastPeriod(includeAllStackTraces));
+      }
     }
 
     if (showAllRunConfigurationsInContext()) {
@@ -191,6 +196,16 @@ public class FlutterSettings {
 
   public void setShowStructuredErrors(boolean value) {
     getPropertiesComponent().setValue(showStructuredErrors, value, true);
+
+    fireEvent();
+  }
+
+  public boolean isIncludeAllStackTraces() {
+    return getPropertiesComponent().getBoolean(includeAllStackTraces, true);
+  }
+
+  public void setIncludeAllStackTraces(boolean value) {
+    getPropertiesComponent().setValue(includeAllStackTraces, value, true);
 
     fireEvent();
   }

--- a/src/io/flutter/settings/FlutterSettings.java
+++ b/src/io/flutter/settings/FlutterSettings.java
@@ -26,13 +26,13 @@ public class FlutterSettings {
   private static final String organizeImportsOnSaveKey = "io.flutter.organizeImportsOnSave";
   private static final String showOnlyWidgetsKey = "io.flutter.showOnlyWidgets";
   private static final String syncAndroidLibrariesKey = "io.flutter.syncAndroidLibraries";
-  private static final String showStructuredErrors = "io.flutter.showStructuredErrors";
-  private static final String includeAllStackTraces = "io.flutter.ncludeAllStackTraces";
+  private static final String showStructuredErrorsKey = "io.flutter.showStructuredErrors";
+  private static final String includeAllStackTracesKey = "io.flutter.includeAllStackTraces";
   private static final String showBuildMethodGuidesKey = "io.flutter.editor.showBuildMethodGuides";
   private static final String enableHotUiKey = "io.flutter.editor.enableHotUi";
   private static final String enableEmbeddedBrowsersKey = "io.flutter.editor.enableEmbeddedBrowsers";
-  private static final String enableBazelHotRestart = "io.flutter.editor.enableBazelHotRestart";
-  private static final String showBazelHotRestartWarning = "io.flutter.showBazelHotRestartWarning";
+  private static final String enableBazelHotRestartKey = "io.flutter.editor.enableBazelHotRestart";
+  private static final String showBazelHotRestartWarningKey = "io.flutter.showBazelHotRestartWarning";
 
   /**
    * Registry key to suggest all run configurations instead of just one.
@@ -108,10 +108,10 @@ public class FlutterSettings {
     }
 
     if (isShowStructuredErrors()) {
-      analytics.sendEvent("settings", afterLastPeriod(showStructuredErrors));
+      analytics.sendEvent("settings", afterLastPeriod(showStructuredErrorsKey));
 
       if (isIncludeAllStackTraces()) {
-        analytics.sendEvent("settings", afterLastPeriod(includeAllStackTraces));
+        analytics.sendEvent("settings", afterLastPeriod(includeAllStackTracesKey));
       }
     }
 
@@ -128,7 +128,7 @@ public class FlutterSettings {
     }
 
     if (isShowBazelHotRestartWarning()) {
-      analytics.sendEvent("settings", afterLastPeriod(showBazelHotRestartWarning));
+      analytics.sendEvent("settings", afterLastPeriod(showBazelHotRestartWarningKey));
     }
   }
 
@@ -191,21 +191,21 @@ public class FlutterSettings {
   }
 
   public boolean isShowStructuredErrors() {
-    return getPropertiesComponent().getBoolean(showStructuredErrors, true);
+    return getPropertiesComponent().getBoolean(showStructuredErrorsKey, true);
   }
 
   public void setShowStructuredErrors(boolean value) {
-    getPropertiesComponent().setValue(showStructuredErrors, value, true);
+    getPropertiesComponent().setValue(showStructuredErrorsKey, value, true);
 
     fireEvent();
   }
 
   public boolean isIncludeAllStackTraces() {
-    return getPropertiesComponent().getBoolean(includeAllStackTraces, true);
+    return getPropertiesComponent().getBoolean(includeAllStackTracesKey, true);
   }
 
   public void setIncludeAllStackTraces(boolean value) {
-    getPropertiesComponent().setValue(includeAllStackTraces, value, true);
+    getPropertiesComponent().setValue(includeAllStackTracesKey, value, true);
 
     fireEvent();
   }
@@ -299,20 +299,20 @@ public class FlutterSettings {
   }
 
   public boolean isEnableBazelHotRestart() {
-    return getPropertiesComponent().getBoolean(enableBazelHotRestart, false);
+    return getPropertiesComponent().getBoolean(enableBazelHotRestartKey, false);
   }
 
   public void setEnableBazelHotRestart(boolean value) {
-    getPropertiesComponent().setValue(enableBazelHotRestart, value, false);
+    getPropertiesComponent().setValue(enableBazelHotRestartKey, value, false);
     fireEvent();
   }
 
   public boolean isShowBazelHotRestartWarning() {
-    return getPropertiesComponent().getBoolean(showBazelHotRestartWarning, true);
+    return getPropertiesComponent().getBoolean(showBazelHotRestartWarningKey, true);
   }
 
   public void setShowBazelHotRestartWarning(boolean value) {
-    getPropertiesComponent().setValue(showBazelHotRestartWarning, value, true);
+    getPropertiesComponent().setValue(showBazelHotRestartWarningKey, value, true);
     fireEvent();
   }
 


### PR DESCRIPTION
Fixes #5421 by adding an option to display all stack traces in the console log.