### PR TITLE
Use alternative JxBrowser class loading for 2021.1 

### DIFF
--- a/src/io/flutter/jxbrowser/JxBrowserManager.java
+++ b/src/io/flutter/jxbrowser/JxBrowserManager.java
@@ -196,7 +196,7 @@ public class JxBrowserManager {
 
     if (allDownloaded) {
       LOG.info(project.getName() + ": JxBrowser platform files already exist, skipping download");
-      loadClasses2021(fileNames);
+      loadClasses(fileNames);
       return;
     }
 
@@ -241,7 +241,7 @@ public class JxBrowserManager {
           }
 
           FlutterInitializer.getAnalytics().sendEvent(ANALYTICS_CATEGORY, "filesDownloaded");
-          loadClasses2021(fileNames);
+          loadClasses(fileNames);
         }
         catch (IOException e) {
           final long elapsedTime = System.currentTimeMillis() - startTime;
@@ -282,12 +282,11 @@ public class JxBrowserManager {
   }
 
   private void loadClasses2021(String[] fileNames) {
-    System.out.println("Using loadClasses2021");
     List<Path> paths = new ArrayList<>();
 
     try {
       for (String fileName: fileNames) {
-        paths.add(Paths.get(fileName));
+        paths.add(Paths.get(getFilePath(fileName)));
       }
       FileUtils.getInstance().loadPaths(this.getClass().getClassLoader(), paths);
     } catch (Exception ex) {

--- a/src/io/flutter/jxbrowser/JxBrowserManager.java
+++ b/src/io/flutter/jxbrowser/JxBrowserManager.java
@@ -20,7 +20,6 @@ import com.intellij.util.download.DownloadableFileDescription;
 import com.intellij.util.download.DownloadableFileService;
 import com.intellij.util.download.FileDownloader;
 import com.teamdev.jxbrowser.browser.UnsupportedRenderingModeException;
-import com.teamdev.jxbrowser.callback.Callback;
 import com.teamdev.jxbrowser.engine.RenderingMode;
 import io.flutter.FlutterInitializer;
 import io.flutter.settings.FlutterSettings;
@@ -31,6 +30,8 @@ import org.jetbrains.annotations.NotNull;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -195,7 +196,7 @@ public class JxBrowserManager {
 
     if (allDownloaded) {
       LOG.info(project.getName() + ": JxBrowser platform files already exist, skipping download");
-      loadClasses(fileNames);
+      loadClasses2021(fileNames);
       return;
     }
 
@@ -240,7 +241,7 @@ public class JxBrowserManager {
           }
 
           FlutterInitializer.getAnalytics().sendEvent(ANALYTICS_CATEGORY, "filesDownloaded");
-          loadClasses(fileNames);
+          loadClasses2021(fileNames);
         }
         catch (IOException e) {
           final long elapsedTime = System.currentTimeMillis() - startTime;
@@ -268,6 +269,33 @@ public class JxBrowserManager {
       }
       LOG.info("Loaded JxBrowser file successfully: " + fullPath);
     }
+    try {
+      final UnsupportedRenderingModeException test = new UnsupportedRenderingModeException(RenderingMode.HARDWARE_ACCELERATED);
+    } catch (NoClassDefFoundError e) {
+      LOG.info("Failed to find JxBrowser class");
+      setStatusFailed("NoClassDefFoundError");
+      return;
+    }
+    FlutterInitializer.getAnalytics().sendEvent(ANALYTICS_CATEGORY, "installed");
+    status.set(JxBrowserStatus.INSTALLED);
+    installation.complete(JxBrowserStatus.INSTALLED);
+  }
+
+  private void loadClasses2021(String[] fileNames) {
+    System.out.println("Using loadClasses2021");
+    List<Path> paths = new ArrayList<>();
+
+    try {
+      for (String fileName: fileNames) {
+        paths.add(Paths.get(fileName));
+      }
+      FileUtils.getInstance().loadPaths(this.getClass().getClassLoader(), paths);
+    } catch (Exception ex) {
+      LOG.info("Failed to load JxBrowser file", ex);
+      setStatusFailed("classLoadFailed");
+      return;
+    }
+
     try {
       final UnsupportedRenderingModeException test = new UnsupportedRenderingModeException(RenderingMode.HARDWARE_ACCELERATED);
     } catch (NoClassDefFoundError e) {

--- a/src/io/flutter/utils/FileUtils.java
+++ b/src/io/flutter/utils/FileUtils.java
@@ -74,6 +74,6 @@ public class FileUtils {
    */
   public void loadPaths(ClassLoader classLoader, List<Path> paths) {
     final UrlClassLoader urlClassLoader = (UrlClassLoader) classLoader;
-    urlClassLoader.addFiles(paths);
+    //urlClassLoader.addFiles(paths);
   }
 }

--- a/src/io/flutter/utils/FileUtils.java
+++ b/src/io/flutter/utils/FileUtils.java
@@ -9,6 +9,8 @@ import com.intellij.util.lang.UrlClassLoader;
 
 import java.io.File;
 import java.net.URL;
+import java.nio.file.Path;
+import java.util.List;
 
 public class FileUtils {
   private static FileUtils fileUtils;
@@ -61,5 +63,17 @@ public class FileUtils {
 
     final URL url = file.toURI().toURL();
     urlClassLoader.addURL(url);
+  }
+
+  /**
+   * Loads a list of file paths with a class loader.
+   *
+   * This is only available for versions 211.4961.30 and later.
+   * @param classLoader classloader that can be used as a UrlClassLoader to load the files.
+   * @param paths list of file paths to load.
+   */
+  public void loadPaths(ClassLoader classLoader, List<Path> paths) {
+    final UrlClassLoader urlClassLoader = (UrlClassLoader) classLoader;
+    urlClassLoader.addFiles(paths);
   }
 }

--- a/tool/plugin/lib/edit.dart
+++ b/tool/plugin/lib/edit.dart
@@ -123,11 +123,17 @@ List<EditCommand> editCommands = [
     version: 'AF.3.1',
   ),
   Subst(
-    path: 'src/io/flutter/jxbrowser/JxbrowserManager.java',
+    path: 'src/io/flutter/jxbrowser/JxBrowserManager.java',
     initial: 'loadClasses(fileNames)',
     replacement: 'loadClasses2021(fileNames)',
     versions: ['2021.1'],
-  )
+  ),
+  Subst(
+    path: 'src/io/flutter/utils/FileUtils.java',
+    initial: '//urlClassLoader.addFiles(paths)',
+    replacement: 'urlClassLoader.addFiles(paths)',
+    versions: ['2021.1'],
+  ),
 ];
 
 // Used to test checkAndClearAppliedEditCommands()

--- a/tool/plugin/lib/edit.dart
+++ b/tool/plugin/lib/edit.dart
@@ -122,6 +122,12 @@ List<EditCommand> editCommands = [
     replacement: 'new JsonParser().parse(contents)',
     version: 'AF.3.1',
   ),
+  Subst(
+    path: 'src/io/flutter/jxbrowser/JxbrowserManager.java',
+    initial: 'loadClasses(fileNames)',
+    replacement: 'loadClasses2021(fileNames)',
+    versions: ['2021.1'],
+  )
 ];
 
 // Used to test checkAndClearAppliedEditCommands()


### PR DESCRIPTION
The older (deprecated) URL class loading fails for 2021.1 on Mac, but there is now a new method for loading classes in 2021.1. This works for me locally (building the plugin and installing to 2021.1).