### PR TITLE
Show device menu for bazel projects

### DIFF
--- a/src/io/flutter/actions/DeviceSelectorAction.java
+++ b/src/io/flutter/actions/DeviceSelectorAction.java
@@ -15,7 +15,6 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
 import com.intellij.openapi.project.ProjectManagerListener;
 import com.intellij.openapi.util.Condition;
-import com.intellij.openapi.util.Disposer;
 import com.intellij.openapi.util.SystemInfo;
 import icons.FlutterIcons;
 import io.flutter.FlutterBundle;
@@ -135,7 +134,7 @@ public class DeviceSelectorAction extends ComboBoxAction implements DumbAware {
   }
 
   private static boolean isSelectorVisible(@Nullable Project project) {
-    if (project == null || !FlutterModuleUtils.hasFlutterModule(project)) {
+    if (project == null || (!FlutterModuleUtils.hasFlutterModule(project) && !FlutterModuleUtils.isFlutterBazelProject(project))) {
       return false;
     }
     final DeviceService deviceService = DeviceService.getInstance(project);


### PR DESCRIPTION
This menu disappeared for me yesterday, but oddly it was working a few days before. And I can't find what change caused this problem (e.g. when I install a v54.0 plugin I still see this problem, even though I'm pretty confident I had this menu for the past couple months).

Regardless, it seems like the check here should include bazel projects and this change fixes the problem.