### PR TITLE
Add support for integration tests to the UI

### DIFF
--- a/src/io/flutter/FlutterUtils.java
+++ b/src/io/flutter/FlutterUtils.java
@@ -204,7 +204,7 @@ public class FlutterUtils {
 
     // Check that we're in a project path that starts with 'test/'.
     final String relativePath = root.getRelativePath(file.getVirtualFile());
-    if (relativePath == null || !relativePath.startsWith("test/")) {
+    if (relativePath == null || !(relativePath.startsWith("test/") || relativePath.startsWith("integration_test/"))) {
       return false;
     }
 

--- a/src/io/flutter/project/FlutterIconProvider.java
+++ b/src/io/flutter/project/FlutterIconProvider.java
@@ -55,6 +55,7 @@ public class FlutterIconProvider extends IconProvider {
 
       if (Objects.equals(dir, root.getAndroidDir())) return AllIcons.Nodes.KeymapTools;
       if (Objects.equals(dir, root.getiOsDir())) return AllIcons.Nodes.KeymapTools;
+      if (Objects.equals(dir, root.getIntegrationTestDir())) return AllIcons.Nodes.TestSourceFolder;
 
       if (dir.isDirectory() && dir.getName().equals(".idea")) return AllIcons.Modules.GeneratedFolder;
     }

--- a/src/io/flutter/pub/PubRoot.java
+++ b/src/io/flutter/pub/PubRoot.java
@@ -354,6 +354,11 @@ public class PubRoot {
   }
 
   @Nullable
+  public VirtualFile getIntegrationTestDir() {
+    return root.findChild("integration_test");
+  }
+
+  @Nullable
   public VirtualFile getExampleDir() {
     return root.findChild("example");
   }

--- a/src/io/flutter/run/common/TestLineMarkerContributor.java
+++ b/src/io/flutter/run/common/TestLineMarkerContributor.java
@@ -27,6 +27,8 @@ import com.jetbrains.lang.dart.psi.DartId;
 import java.util.Date;
 import java.util.Map;
 import javax.swing.Icon;
+
+import io.flutter.run.test.TestConfigUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -69,6 +71,12 @@ public abstract class TestLineMarkerContributor extends RunLineMarkerContributor
           }
         }
         else if (dartId.getParent().getParent() instanceof DartFunctionDeclarationWithBodyOrNative) {
+          if (testConfigUtils instanceof TestConfigUtils) {
+            // TODO(messick) Find a better way to eliminate duplicate pop-up menu entries.
+            // The issue is that there are two contributors, one for normal Flutter, one for Bazel,
+            // and they should not both produce contributions at the same time.
+            return null;
+          }
           if ("main".equals(dartId.getText())) {
             // There seems to be an intermittent timing issue that causes the first test call to not get marked.
             // Priming the cache here solves it.


### PR DESCRIPTION
This does a few things:
- Change the icon for `integration_test` to indicate it is a test source directory
- Change the icon for integration test files to indicate the file is a test source
- Add the device id to the flutter_tools command
- Stop displaying duplicate menu items on the `main()` test run button in the gutter

We also need to update the flutter_tools project templates to mark `integration_test` as a test source root.