### PR TITLE
Detect M1 mac and skip JxBrowser

### DIFF
--- a/src/io/flutter/jxbrowser/EmbeddedBrowser.java
+++ b/src/io/flutter/jxbrowser/EmbeddedBrowser.java
@@ -69,7 +69,7 @@ public class EmbeddedBrowser {
       });
     } catch (UnsupportedRenderingModeException ex) {
       // Skip using a transparent background if an exception is thrown.
-    } catch (Exception ex) {
+    } catch (Exception | Error ex) {
       LOG.info(ex);
       FlutterInitializer.getAnalytics().sendException(StringUtil.getThrowableText(ex), false);
     }

--- a/src/io/flutter/jxbrowser/FailureType.java
+++ b/src/io/flutter/jxbrowser/FailureType.java
@@ -1,0 +1,11 @@
+package io.flutter.jxbrowser;
+
+public enum FailureType {
+    SYSTEM_INCOMPATIBLE,
+    FILE_DOWNLOAD_FAILED,
+    MISSING_KEY,
+    DIRECTORY_CREATION_FAILED,
+    MISSING_PLATFORM_FILES,
+    CLASS_LOAD_FAILED,
+    CLASS_NOT_FOUND,
+}

--- a/src/io/flutter/jxbrowser/InstallationFailedReason.java
+++ b/src/io/flutter/jxbrowser/InstallationFailedReason.java
@@ -4,7 +4,7 @@ public class InstallationFailedReason {
     public FailureType failureType;
     public String detail;
 
-    InstallationFailedReason(FailureType failureType) {
+    public InstallationFailedReason(FailureType failureType) {
         this(failureType, null);
     }
 

--- a/src/io/flutter/jxbrowser/InstallationFailedReason.java
+++ b/src/io/flutter/jxbrowser/InstallationFailedReason.java
@@ -1,0 +1,15 @@
+package io.flutter.jxbrowser;
+
+public class InstallationFailedReason {
+    public FailureType failureType;
+    public String detail;
+
+    InstallationFailedReason(FailureType failureType) {
+        this(failureType, null);
+    }
+
+    InstallationFailedReason(FailureType failureType, String detail) {
+        this.failureType = failureType;
+        this.detail = detail;
+    }
+}

--- a/src/io/flutter/jxbrowser/JxBrowserManager.java
+++ b/src/io/flutter/jxbrowser/JxBrowserManager.java
@@ -174,7 +174,7 @@ public class JxBrowserManager {
     }
 
     // Check that user is not on M1 mac.
-    if (JxBrowserUtils.isM1MacLegacy()) {
+    if (JxBrowserUtils.isM1Mac()) {
       LOG.info(project.getName() + ": Skipping downloads due to M1");
       setStatusFailed(new InstallationFailedReason(
               FailureType.SYSTEM_INCOMPATIBLE,

--- a/src/io/flutter/utils/JxBrowserUtils.java
+++ b/src/io/flutter/utils/JxBrowserUtils.java
@@ -6,6 +6,7 @@
 package io.flutter.utils;
 
 import com.intellij.openapi.util.SystemInfo;
+import com.intellij.util.system.CpuArch;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -73,5 +74,15 @@ public class JxBrowserUtils {
 
   public static boolean licenseIsSet() {
     return System.getProperty(JxBrowserUtils.LICENSE_PROPERTY_NAME) != null;
+  }
+
+  public static boolean isM1Mac() {
+    //noinspection MissingRecentApi
+    return SystemInfo.isMac && CpuArch.isArm64();
+  }
+
+  // Return default false value for earlier IntelliJ versions that do not have the CpuArch method (211.4961.30).
+  public static boolean isM1MacLegacy() {
+    return false;
   }
 }

--- a/src/io/flutter/utils/JxBrowserUtils.java
+++ b/src/io/flutter/utils/JxBrowserUtils.java
@@ -6,7 +6,6 @@
 package io.flutter.utils;
 
 import com.intellij.openapi.util.SystemInfo;
-import com.intellij.util.system.CpuArch;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -77,14 +76,9 @@ public class JxBrowserUtils {
   }
 
   public static boolean isM1Mac() {
-    //noinspection MissingRecentApi
-    return SystemInfo.isMac && CpuArch.isArm64();
-  }
-
-  // Return default false value for earlier IntelliJ versions that do not have the CpuArch method (211.4961.30).
-  // It's possible a user could be using an earlier IntelliJ version with an M1 mac, but for that case we can't detect
-  // that the system is the problem and will serve a more generic error message.
-  public static boolean isM1MacLegacy() {
-    return false;
+    // Return default false value for earlier IntelliJ versions that do not have the CpuArch method (211.4961.30).
+    // It's possible a user could be using an earlier IntelliJ version with an M1 mac, but for that case we can't detect
+    // that the system is the problem and will serve a more generic error message.
+    return false; // return SystemInfo.isMac && CpuArch.isArm64();
   }
 }

--- a/src/io/flutter/utils/JxBrowserUtils.java
+++ b/src/io/flutter/utils/JxBrowserUtils.java
@@ -82,6 +82,8 @@ public class JxBrowserUtils {
   }
 
   // Return default false value for earlier IntelliJ versions that do not have the CpuArch method (211.4961.30).
+  // It's possible a user could be using an earlier IntelliJ version with an M1 mac, but for that case we can't detect
+  // that the system is the problem and will serve a more generic error message.
   public static boolean isM1MacLegacy() {
     return false;
   }

--- a/src/io/flutter/utils/JxBrowserUtils.java
+++ b/src/io/flutter/utils/JxBrowserUtils.java
@@ -6,6 +6,7 @@
 package io.flutter.utils;
 
 import com.intellij.openapi.util.SystemInfo;
+// import com.intellij.util.system.CpuArch;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;

--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -54,9 +54,7 @@ import io.flutter.inspector.DiagnosticsNode;
 import io.flutter.inspector.InspectorGroupManagerService;
 import io.flutter.inspector.InspectorService;
 import io.flutter.inspector.InspectorSourceLocation;
-import io.flutter.jxbrowser.EmbeddedBrowser;
-import io.flutter.jxbrowser.JxBrowserManager;
-import io.flutter.jxbrowser.JxBrowserStatus;
+import io.flutter.jxbrowser.*;
 import io.flutter.run.FlutterDevice;
 import io.flutter.run.daemon.DevToolsInstance;
 import io.flutter.run.daemon.DevToolsService;
@@ -594,9 +592,15 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
     final List<LabelInput> inputs = new ArrayList<>();
     final LabelInput openDevToolsLabel = openDevToolsLabel(app, inspectorService, toolWindow);
 
+    final InstallationFailedReason latestFailureReason = JxBrowserManager.getInstance().getLatestFailureReason();
+
     if (!JxBrowserUtils.licenseIsSet()) {
       // If the license isn't available, allow the user to open the equivalent page in a non-embedded browser window.
       inputs.add(new LabelInput("The JxBrowser license could not be found."));
+      inputs.add(openDevToolsLabel);
+    } else if (latestFailureReason.failureType.equals(FailureType.SYSTEM_INCOMPATIBLE)) {
+      // If we know the system is incompatible, skip retry link and offer to open in browser.
+      inputs.add(new LabelInput(latestFailureReason.detail));
       inputs.add(openDevToolsLabel);
     }
     else {

--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -627,12 +627,12 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
 
     for (LabelInput input : labels) {
       if (input.listener == null) {
-        final JLabel descriptionLabel = new JLabel(input.text);
+        final JLabel descriptionLabel = new JLabel("<html>" + input.text + "</html>");
         descriptionLabel.setBorder(JBUI.Borders.empty(5));
         descriptionLabel.setHorizontalAlignment(SwingConstants.CENTER);
         panel.add(descriptionLabel, BorderLayout.NORTH);
       } else {
-        final LinkLabel<String> linkLabel = new LinkLabel<>(input.text, null);
+        final LinkLabel<String> linkLabel = new LinkLabel<>("<html>" + input.text + "</html>", null);
         linkLabel.setBorder(JBUI.Borders.empty(5));
         linkLabel.setListener(input.listener, null);
         linkLabel.setHorizontalAlignment(SwingConstants.CENTER);

--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -598,7 +598,7 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
       // If the license isn't available, allow the user to open the equivalent page in a non-embedded browser window.
       inputs.add(new LabelInput("The JxBrowser license could not be found."));
       inputs.add(openDevToolsLabel);
-    } else if (latestFailureReason.failureType.equals(FailureType.SYSTEM_INCOMPATIBLE)) {
+    } else if (latestFailureReason != null && latestFailureReason.failureType.equals(FailureType.SYSTEM_INCOMPATIBLE)) {
       // If we know the system is incompatible, skip retry link and offer to open in browser.
       inputs.add(new LabelInput(latestFailureReason.detail));
       inputs.add(openDevToolsLabel);

--- a/testSrc/unit/io/flutter/view/FlutterViewTest.java
+++ b/testSrc/unit/io/flutter/view/FlutterViewTest.java
@@ -12,6 +12,8 @@ import io.flutter.ObservatoryConnector;
 import io.flutter.analytics.Analytics;
 import io.flutter.inspector.InspectorGroupManagerService;
 import io.flutter.inspector.InspectorService;
+import io.flutter.jxbrowser.FailureType;
+import io.flutter.jxbrowser.InstallationFailedReason;
 import io.flutter.jxbrowser.JxBrowserManager;
 import io.flutter.jxbrowser.JxBrowserStatus;
 import io.flutter.run.daemon.FlutterApp;
@@ -61,6 +63,10 @@ public class FlutterViewTest {
   public void testHandleJxBrowserInstallationFailed() {
     PowerMockito.mockStatic(JxBrowserUtils.class);
     when(JxBrowserUtils.licenseIsSet()).thenReturn(true);
+
+    PowerMockito.mockStatic(JxBrowserManager.class);
+    when(JxBrowserManager.getInstance()).thenReturn(mockJxBrowserManager);
+    when(mockJxBrowserManager.getLatestFailureReason()).thenReturn(new InstallationFailedReason(FailureType.FILE_DOWNLOAD_FAILED));
 
     // If JxBrowser failed to install, we should show a failure message that allows the user to manually retry.
     final FlutterView partialMockFlutterView = mock(FlutterView.class);

--- a/tool/plugin/lib/edit.dart
+++ b/tool/plugin/lib/edit.dart
@@ -142,6 +142,12 @@ List<EditCommand> editCommands = [
     replacement: 'return SystemInfo.isMac && CpuArch.isArm64();',
     versions: ['2021.1'],
   ),
+  Subst(
+    path: 'src/io/flutter/utils/JxBrowserUtils.java',
+    initial: '// import com.intellij.util.system.CpuArch;',
+    replacement: 'import com.intellij.util.system.CpuArch;',
+    versions: ['2021.1'],
+  ),
 ];
 
 // Used to test checkAndClearAppliedEditCommands()

--- a/tool/plugin/lib/edit.dart
+++ b/tool/plugin/lib/edit.dart
@@ -137,9 +137,9 @@ List<EditCommand> editCommands = [
     versions: ['2021.1'],
   ),
   Subst(
-    path: 'src/io/flutter/jxbrowser/JxBrowserManager.java',
-    initial: 'JxBrowserUtils.isM1MacLegacy',
-    replacement: 'JxBrowserUtils.isM1Mac',
+    path: 'src/io/flutter/utils/JxBrowserUtils.java',
+    initial: 'return false; // return SystemInfo.isMac && CpuArch.isArm64();',
+    replacement: 'return SystemInfo.isMac && CpuArch.isArm64();',
     versions: ['2021.1'],
   ),
 ];

--- a/tool/plugin/lib/edit.dart
+++ b/tool/plugin/lib/edit.dart
@@ -136,6 +136,12 @@ List<EditCommand> editCommands = [
     replacement: 'urlClassLoader.addFiles(paths)',
     versions: ['2021.1'],
   ),
+  Subst(
+    path: 'src/io/flutter/jxbrowser/JxBrowserManager.java',
+    initial: 'JxBrowserUtils.isM1MacLegacy',
+    replacement: 'JxBrowserUtils.isM1Mac',
+    versions: ['2021.1'],
+  ),
 ];
 
 // Used to test checkAndClearAppliedEditCommands()


### PR DESCRIPTION
If a user is using an M1 mac and the version of IntelliJ native to this chip, then JxBrowser is not currently supported. If we detect this combination then show users the option to open DevTools in the browser instead.

It seems that automatically disabling embedded browser for situations where JxBrowser is not supported results in the setting being somewhat sticky once it is supported, e.g. it seems previously disabling for Big Sur resulted in a much higher proportion of users staying disabled despite no additional errors that would suggest a poorer user experience (maybe this setting sticks around as long as users keep their version of IntelliJ? I'm not sure). So I'm inclined to try prompting users to open in the browser instead. This should be a smaller proportion of users anyway.

Fixes https://github.com/flutter/flutter-intellij/issues/5472