### PR TITLE
Enable embedded browser (once) for Big Sur users

### DIFF
--- a/src/io/flutter/settings/FlutterSettings.java
+++ b/src/io/flutter/settings/FlutterSettings.java
@@ -14,6 +14,7 @@ import com.intellij.openapi.util.SystemInfo;
 import com.intellij.openapi.util.registry.Registry;
 import com.intellij.util.EventDispatcher;
 import com.jetbrains.lang.dart.analyzer.DartClosingLabelManager;
+import io.flutter.FlutterMessages;
 import io.flutter.FlutterUtils;
 import io.flutter.analytics.Analytics;
 
@@ -303,6 +304,12 @@ public class FlutterSettings {
     if (SystemInfo.isMac && (SystemInfo.isOsVersionAtLeast("11.0") || SystemInfo.isOsVersionAtLeast("10.16")) &&
             !getPropertiesComponent().getBoolean(enableEmbeddedBrowsersKey, true) &&
             isChangeBigSurToTrue()) {
+      FlutterMessages.showInfo(
+              "Embedded DevTools Inspector",
+              "The embedded inspector is now supported for MacOS Big Sur and is enabled by default. To disable, go to Preferences > Flutter.",
+              null
+      );
+
       // We do not want to set it back to true again in the future (e.g. if a user decides to set to false).
       setChangeBigSurToTrue(false);
       return true;


### PR DESCRIPTION
When we disabled the embedded browser option for Big Sur users (back when JxBrowser did not support Big Sur yet - see https://github.com/flutter/flutter-intellij/pull/5065), this caused embedded browser to stay disabled if users adjusted unrelated settings (See https://github.com/flutter/flutter-intellij/pull/5487#issuecomment-842517418 for more detail). 

We want to enable embedded browser for Big Sur users by default now, but only once (if a user elects to disable embedded browser in the future, we want to allow this).