### PR TITLE
Handle if embedded browser load fails

### DIFF
--- a/src/io/flutter/jxbrowser/EmbeddedBrowser.java
+++ b/src/io/flutter/jxbrowser/EmbeddedBrowser.java
@@ -107,7 +107,16 @@ public class EmbeddedBrowser {
     // Multiple LoadFinished events can occur, but we only need to add content the first time.
     final AtomicBoolean contentLoaded = new AtomicBoolean(false);
 
-    browser.navigation().loadUrl(devToolsUrl.getUrlString());
+    try {
+      browser.navigation().loadUrl(devToolsUrl.getUrlString());
+    } catch (Exception ex) {
+      devToolsUrlFuture.completeExceptionally(ex);
+      onBrowserUnavailable.run();
+      LOG.info(ex);
+      FlutterInitializer.getAnalytics().sendException(StringUtil.getThrowableText(ex), false);
+      return;
+    }
+
     devToolsUrlFuture.complete(devToolsUrl);
     browser.navigation().on(LoadFinished.class, event -> {
       if (!contentLoaded.compareAndSet(false, true)) {


### PR DESCRIPTION
If the embedded browser is created but it fails to load the DevTools URL, we want to show users an option to open in the normal browser and report the issue to analytics.

Fixes https://github.com/flutter/flutter-intellij/issues/5507