### PR TITLE
Fix edit.dart to clean up its changes

### DIFF
--- a/tool/plugin/lib/edit.dart
+++ b/tool/plugin/lib/edit.dart
@@ -138,14 +138,8 @@ List<EditCommand> editCommands = [
   ),
   Subst(
     path: 'src/io/flutter/utils/JxBrowserUtils.java',
-    initial: 'return false; // return SystemInfo.isMac && CpuArch.isArm64();',
+    initial: 'return false; // return SystemInfo.isMac && com.intellij.util.system.CpuArch.isArm64();',
     replacement: 'return SystemInfo.isMac && CpuArch.isArm64();',
-    versions: ['2021.1'],
-  ),
-  Subst(
-    path: 'src/io/flutter/utils/JxBrowserUtils.java',
-    initial: '// import com.intellij.util.system.CpuArch;',
-    replacement: 'import com.intellij.util.system.CpuArch;',
     versions: ['2021.1'],
   ),
 ];


### PR DESCRIPTION
The `Subst` edit is only for a single change per file. You can use `MultiSubst` for multiple changes. I should have caught this during the code review.