### PR TITLE
Add IDE font size to embedded browser URL

### DIFF
--- a/src/io/flutter/devtools/DevToolsUrl.java
+++ b/src/io/flutter/devtools/DevToolsUrl.java
@@ -20,14 +20,16 @@ public class DevToolsUrl {
   private boolean embed;
   public String colorHexCode;
   public String widgetId;
+  public Float fontSize;
 
-  public DevToolsUrl(String devtoolsHost, int devtoolsPort, String vmServiceUri, String page, boolean embed, String colorHexCode) {
+  public DevToolsUrl(String devtoolsHost, int devtoolsPort, String vmServiceUri, String page, boolean embed, String colorHexCode, Float fontSize) {
     this.devtoolsHost = devtoolsHost;
     this.devtoolsPort = devtoolsPort;
     this.vmServiceUri = vmServiceUri;
     this.page = page;
     this.embed = embed;
     this.colorHexCode = colorHexCode;
+    this.fontSize = fontSize;
   }
 
   public String getUrlString() {
@@ -42,6 +44,9 @@ public class DevToolsUrl {
     }
     if (embed) {
       params.add("embed=true");
+    }
+    if (fontSize != null) {
+      params.add("fontSize=" + fontSize);
     }
 
     if (vmServiceUri != null) {

--- a/src/io/flutter/devtools/DevToolsUtils.java
+++ b/src/io/flutter/devtools/DevToolsUtils.java
@@ -5,13 +5,6 @@
  */
 package io.flutter.devtools;
 
-import io.flutter.sdk.FlutterSdkUtil;
-
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
-import java.util.ArrayList;
-import java.util.List;
-
 public class DevToolsUtils {
   public static String generateDevToolsUrl(
     String devtoolsHost,
@@ -31,7 +24,7 @@ public class DevToolsUtils {
     boolean embed,
     String colorHexCode
   ) {
-    final DevToolsUrl devToolsUrl = new DevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, embed, colorHexCode);
+    final DevToolsUrl devToolsUrl = new DevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, embed, colorHexCode, null);
     return devToolsUrl.getUrlString();
   }
 

--- a/src/io/flutter/jxbrowser/EmbeddedBrowser.java
+++ b/src/io/flutter/jxbrowser/EmbeddedBrowser.java
@@ -165,6 +165,16 @@ public class EmbeddedBrowser {
     });
   }
 
+  public void updateFontSize(float newFontSize) {
+    updateUrlAndReload(devToolsUrl -> {
+      if (devToolsUrl.fontSize.equals(newFontSize)) {
+        return null;
+      }
+      devToolsUrl.fontSize = newFontSize;
+      return devToolsUrl;
+    });
+  }
+
   private void updateUrlAndReload(Function<DevToolsUrl, DevToolsUrl> newDevToolsUrlFn) {
     final CompletableFuture<DevToolsUrl> updatedUrlFuture = devToolsUrlFuture.thenApply(devToolsUrl -> {
       if (devToolsUrl == null) {

--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -10,6 +10,7 @@ import com.intellij.execution.runners.ExecutionUtil;
 import com.intellij.execution.ui.layout.impl.JBRunnerTabs;
 import com.intellij.icons.AllIcons;
 import com.intellij.ide.browsers.BrowserLauncher;
+import com.intellij.ide.ui.UISettingsListener;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.actionSystem.*;
 import com.intellij.openapi.application.ApplicationManager;
@@ -119,6 +120,8 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
   private final Project myProject;
 
   private final Map<FlutterApp, PerAppState> perAppViewState = new HashMap<>();
+  private final MessageBusConnection busConnection = ApplicationManager.getApplication().getMessageBus().connect();
+  private boolean busSubscribed = false;
 
   private Content emptyContent;
 
@@ -158,6 +161,7 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
 
   @Override
   public void dispose() {
+    busConnection.disconnect();
     Disposer.dispose(this);
   }
 
@@ -282,10 +286,15 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
         });
       });
 
-      final MessageBusConnection busConnection = ApplicationManager.getApplication().getMessageBus().connect();
-      busConnection.subscribe(EditorColorsManager.TOPIC, scheme ->
-        EmbeddedBrowser.getInstance(myProject).updateColor(ColorUtil.toHex(UIUtil.getEditorPaneBackground()))
-      );
+      if (!busSubscribed) {
+        busConnection.subscribe(EditorColorsManager.TOPIC, scheme ->
+                EmbeddedBrowser.getInstance(myProject).updateColor(ColorUtil.toHex(UIUtil.getEditorPaneBackground()))
+        );
+        busConnection.subscribe(UISettingsListener.TOPIC, scheme ->
+                EmbeddedBrowser.getInstance(myProject).updateFontSize(UIUtil.getFontSize(UIUtil.FontSize.NORMAL))
+        );
+        busSubscribed = true;
+      }
     } else {
       BrowserLauncher.getInstance().browse(
         DevToolsUtils.generateDevToolsUrl(devToolsInstance.host, devToolsInstance.port, browserUrl, "inspector", false),

--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -260,7 +260,15 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
 
     if (isEmbedded) {
       final String color = ColorUtil.toHex(UIUtil.getEditorPaneBackground());
-      final DevToolsUrl devToolsUrl = new DevToolsUrl(devToolsInstance.host, devToolsInstance.port, browserUrl, "inspector", true, color);
+      final DevToolsUrl devToolsUrl = new DevToolsUrl(
+              devToolsInstance.host,
+              devToolsInstance.port,
+              browserUrl,
+              "inspector",
+              true,
+              color,
+              UIUtil.getFontSize(UIUtil.FontSize.NORMAL)
+      );
 
       //noinspection CodeBlock2Expr
       ApplicationManager.getApplication().invokeLater(() -> {


### PR DESCRIPTION
Passing a `fontSize=<size>` param in the DevTools URL will result in no change until https://github.com/flutter/devtools/pull/3054 is deployed.

I also cleaned up how the listener is set up because a new one was being created for every run of the app.