### PR TITLE
Stop using DevTools URL util method, reorg tests

### DIFF
--- a/src/io/flutter/devtools/DevToolsUrl.java
+++ b/src/io/flutter/devtools/DevToolsUrl.java
@@ -22,7 +22,13 @@ public class DevToolsUrl {
   public String widgetId;
   public Float fontSize;
 
-  public DevToolsUrl(String devtoolsHost, int devtoolsPort, String vmServiceUri, String page, boolean embed, String colorHexCode, Float fontSize) {
+  public DevToolsUrl(String devtoolsHost,
+                     int devtoolsPort,
+                     String vmServiceUri,
+                     String page,
+                     boolean embed,
+                     String colorHexCode,
+                     Float fontSize) {
     this.devtoolsHost = devtoolsHost;
     this.devtoolsPort = devtoolsPort;
     this.vmServiceUri = vmServiceUri;

--- a/src/io/flutter/devtools/DevToolsUtils.java
+++ b/src/io/flutter/devtools/DevToolsUtils.java
@@ -6,28 +6,6 @@
 package io.flutter.devtools;
 
 public class DevToolsUtils {
-  public static String generateDevToolsUrl(
-    String devtoolsHost,
-    int devtoolsPort,
-    String serviceProtocolUri,
-    String page,
-    boolean embed
-  ) {
-    return generateDevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, embed, null);
-  }
-
-  public static String generateDevToolsUrl(
-    String devtoolsHost,
-    int devtoolsPort,
-    String serviceProtocolUri,
-    String page,
-    boolean embed,
-    String colorHexCode
-  ) {
-    final DevToolsUrl devToolsUrl = new DevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, embed, colorHexCode, null);
-    return devToolsUrl.getUrlString();
-  }
-
   public static String findWidgetId(String url) {
     final String searchFor = "inspectorRef=";
     final String[] split = url.split("&");

--- a/src/io/flutter/performance/FlutterPerformanceView.java
+++ b/src/io/flutter/performance/FlutterPerformanceView.java
@@ -29,7 +29,7 @@ import com.intellij.ui.content.ContentManager;
 import com.intellij.util.ui.JBUI;
 import com.intellij.util.ui.UIUtil;
 import icons.FlutterIcons;
-import io.flutter.devtools.DevToolsUtils;
+import io.flutter.devtools.DevToolsUrl;
 import io.flutter.run.FlutterDevice;
 import io.flutter.run.FlutterLaunchMode;
 import io.flutter.run.daemon.DevToolsService;
@@ -215,8 +215,8 @@ public class FlutterPerformanceView implements Disposable {
         }
 
         BrowserLauncher.getInstance().browse(
-          DevToolsUtils.generateDevToolsUrl(instance.host, instance.port, app.getConnector().getBrowserUrl(), null, false),
-          null
+                (new DevToolsUrl(instance.host, instance.port, app.getConnector().getBrowserUrl(), null, false, null, null)).getUrlString(),
+                null
         );
       });
     }, null);

--- a/src/io/flutter/run/OpenDevToolsAction.java
+++ b/src/io/flutter/run/OpenDevToolsAction.java
@@ -14,7 +14,7 @@ import com.intellij.openapi.util.Computable;
 import icons.FlutterIcons;
 import io.flutter.FlutterInitializer;
 import io.flutter.ObservatoryConnector;
-import io.flutter.devtools.DevToolsUtils;
+import io.flutter.devtools.DevToolsUrl;
 import io.flutter.run.daemon.DevToolsService;
 import io.flutter.run.daemon.FlutterApp;
 import io.flutter.utils.AsyncUtils;
@@ -75,7 +75,7 @@ public class OpenDevToolsAction extends DumbAwareAction {
       final String serviceUrl = myConnector != null && myConnector.getBrowserUrl() != null ? myConnector.getBrowserUrl() : null;
 
       BrowserLauncher.getInstance().browse(
-        DevToolsUtils.generateDevToolsUrl(instance.host, instance.port, serviceUrl, null, false),
+        (new DevToolsUrl(instance.host, instance.port, serviceUrl, null, false, null, null).getUrlString()),
         null
       );
     });

--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -50,7 +50,6 @@ import io.flutter.FlutterBundle;
 import io.flutter.FlutterInitializer;
 import io.flutter.FlutterUtils;
 import io.flutter.devtools.DevToolsUrl;
-import io.flutter.devtools.DevToolsUtils;
 import io.flutter.inspector.DiagnosticsNode;
 import io.flutter.inspector.InspectorGroupManagerService;
 import io.flutter.inspector.InspectorService;
@@ -297,7 +296,7 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
       }
     } else {
       BrowserLauncher.getInstance().browse(
-        DevToolsUtils.generateDevToolsUrl(devToolsInstance.host, devToolsInstance.port, browserUrl, "inspector", false),
+        (new DevToolsUrl(devToolsInstance.host, devToolsInstance.port, browserUrl, "inspector", false, null, null).getUrlString()),
         null
       );
       presentLabel(toolWindow, "DevTools inspector has been opened in the browser.");
@@ -950,7 +949,7 @@ class FlutterViewDevToolsAction extends FlutterViewAction {
         }
 
         BrowserLauncher.getInstance().browse(
-          DevToolsUtils.generateDevToolsUrl(instance.host, instance.port, urlString, null, false),
+          (new DevToolsUrl(instance.host, instance.port, urlString, null, false, null, null).getUrlString()),
           null
         );
       });

--- a/testSrc/unit/io/flutter/devtools/DevToolsUrlTest.java
+++ b/testSrc/unit/io/flutter/devtools/DevToolsUrlTest.java
@@ -1,0 +1,62 @@
+package io.flutter.devtools;
+
+import io.flutter.sdk.FlutterSdkUtil;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(FlutterSdkUtil.class)
+public class DevToolsUrlTest {
+    @Test
+    public void testGetUrlString() {
+        final String devtoolsHost = "127.0.0.1";
+        final int devtoolsPort = 9100;
+        final String serviceProtocolUri = "http://127.0.0.1:50224/WTFTYus3IPU=/";
+        final String page = "timeline";
+
+        PowerMockito.mockStatic(FlutterSdkUtil.class);
+        PowerMockito.when(FlutterSdkUtil.getFlutterHostEnvValue()).thenReturn("IntelliJ-IDEA");
+
+        assertEquals(
+                "http://127.0.0.1:9100/?ide=IntelliJ-IDEA&page=timeline&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F",
+                (new DevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false, null, null)).getUrlString()
+        );
+
+        assertEquals(
+                "http://127.0.0.1:9100/?ide=IntelliJ-IDEA&page=timeline&embed=true&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F",
+                (new DevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, true, null, null)).getUrlString()
+        );
+
+        assertEquals(
+                "http://127.0.0.1:9100/?ide=IntelliJ-IDEA",
+                (new DevToolsUrl(devtoolsHost, devtoolsPort, null, null, false, null, null).getUrlString())
+        );
+
+        assertEquals(
+                "http://127.0.0.1:9100/?ide=IntelliJ-IDEA&page=timeline&backgroundColor=ffffff&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F",
+                (new DevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false, "ffffff", null).getUrlString())
+        );
+
+        assertEquals(
+                "http://127.0.0.1:9100/?ide=IntelliJ-IDEA&page=timeline&backgroundColor=ffffff&fontSize=12.0&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F",
+                (new DevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false, "ffffff", 12.0f).getUrlString())
+        );
+
+        PowerMockito.when(FlutterSdkUtil.getFlutterHostEnvValue()).thenReturn("Android-Studio");
+
+        assertEquals(
+                "http://127.0.0.1:9100/?ide=Android-Studio&page=timeline&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F",
+                (new DevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false, null, null).getUrlString())
+        );
+
+        assertEquals(
+                "http://127.0.0.1:9100/?ide=Android-Studio&page=timeline&backgroundColor=3c3f41&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F",
+                (new DevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false, "3c3f41", null).getUrlString())
+        );
+    }
+}

--- a/testSrc/unit/io/flutter/devtools/DevToolsUrlTest.java
+++ b/testSrc/unit/io/flutter/devtools/DevToolsUrlTest.java
@@ -12,51 +12,51 @@ import static org.junit.Assert.assertEquals;
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(FlutterSdkUtil.class)
 public class DevToolsUrlTest {
-    @Test
-    public void testGetUrlString() {
-        final String devtoolsHost = "127.0.0.1";
-        final int devtoolsPort = 9100;
-        final String serviceProtocolUri = "http://127.0.0.1:50224/WTFTYus3IPU=/";
-        final String page = "timeline";
+  @Test
+  public void testGetUrlString() {
+    final String devtoolsHost = "127.0.0.1";
+    final int devtoolsPort = 9100;
+    final String serviceProtocolUri = "http://127.0.0.1:50224/WTFTYus3IPU=/";
+    final String page = "timeline";
 
-        PowerMockito.mockStatic(FlutterSdkUtil.class);
-        PowerMockito.when(FlutterSdkUtil.getFlutterHostEnvValue()).thenReturn("IntelliJ-IDEA");
+    PowerMockito.mockStatic(FlutterSdkUtil.class);
+    PowerMockito.when(FlutterSdkUtil.getFlutterHostEnvValue()).thenReturn("IntelliJ-IDEA");
 
-        assertEquals(
-                "http://127.0.0.1:9100/?ide=IntelliJ-IDEA&page=timeline&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F",
-                (new DevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false, null, null)).getUrlString()
-        );
+    assertEquals(
+      "http://127.0.0.1:9100/?ide=IntelliJ-IDEA&page=timeline&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F",
+      (new DevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false, null, null)).getUrlString()
+    );
 
-        assertEquals(
-                "http://127.0.0.1:9100/?ide=IntelliJ-IDEA&page=timeline&embed=true&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F",
-                (new DevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, true, null, null)).getUrlString()
-        );
+    assertEquals(
+      "http://127.0.0.1:9100/?ide=IntelliJ-IDEA&page=timeline&embed=true&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F",
+      (new DevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, true, null, null)).getUrlString()
+    );
 
-        assertEquals(
-                "http://127.0.0.1:9100/?ide=IntelliJ-IDEA",
-                (new DevToolsUrl(devtoolsHost, devtoolsPort, null, null, false, null, null).getUrlString())
-        );
+    assertEquals(
+      "http://127.0.0.1:9100/?ide=IntelliJ-IDEA",
+      (new DevToolsUrl(devtoolsHost, devtoolsPort, null, null, false, null, null).getUrlString())
+    );
 
-        assertEquals(
-                "http://127.0.0.1:9100/?ide=IntelliJ-IDEA&page=timeline&backgroundColor=ffffff&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F",
-                (new DevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false, "ffffff", null).getUrlString())
-        );
+    assertEquals(
+      "http://127.0.0.1:9100/?ide=IntelliJ-IDEA&page=timeline&backgroundColor=ffffff&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F",
+      (new DevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false, "ffffff", null).getUrlString())
+    );
 
-        assertEquals(
-                "http://127.0.0.1:9100/?ide=IntelliJ-IDEA&page=timeline&backgroundColor=ffffff&fontSize=12.0&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F",
-                (new DevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false, "ffffff", 12.0f).getUrlString())
-        );
+    assertEquals(
+      "http://127.0.0.1:9100/?ide=IntelliJ-IDEA&page=timeline&backgroundColor=ffffff&fontSize=12.0&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F",
+      (new DevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false, "ffffff", 12.0f).getUrlString())
+    );
 
-        PowerMockito.when(FlutterSdkUtil.getFlutterHostEnvValue()).thenReturn("Android-Studio");
+    PowerMockito.when(FlutterSdkUtil.getFlutterHostEnvValue()).thenReturn("Android-Studio");
 
-        assertEquals(
-                "http://127.0.0.1:9100/?ide=Android-Studio&page=timeline&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F",
-                (new DevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false, null, null).getUrlString())
-        );
+    assertEquals(
+      "http://127.0.0.1:9100/?ide=Android-Studio&page=timeline&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F",
+      (new DevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false, null, null).getUrlString())
+    );
 
-        assertEquals(
-                "http://127.0.0.1:9100/?ide=Android-Studio&page=timeline&backgroundColor=3c3f41&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F",
-                (new DevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false, "3c3f41", null).getUrlString())
-        );
-    }
+    assertEquals(
+      "http://127.0.0.1:9100/?ide=Android-Studio&page=timeline&backgroundColor=3c3f41&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F",
+      (new DevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false, "3c3f41", null).getUrlString())
+    );
+  }
 }

--- a/testSrc/unit/io/flutter/devtools/DevToolsUtilsTest.java
+++ b/testSrc/unit/io/flutter/devtools/DevToolsUtilsTest.java
@@ -8,62 +8,24 @@ package io.flutter.devtools;
 import io.flutter.sdk.FlutterSdkUtil;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import static io.flutter.devtools.DevToolsUtils.generateDevToolsUrl;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(FlutterSdkUtil.class)
 public class DevToolsUtilsTest {
   @Test
-  public void validDevToolsUrl() {
-    final String devtoolsHost = "127.0.0.1";
-    final int devtoolsPort = 9100;
-    final String serviceProtocolUri = "http://127.0.0.1:50224/WTFTYus3IPU=/";
-    final String page = "timeline";
-    final String pageName = "timeline";
-
-    PowerMockito.mockStatic(FlutterSdkUtil.class);
-    PowerMockito.when(FlutterSdkUtil.getFlutterHostEnvValue()).thenReturn("IntelliJ-IDEA");
-
+  public void testFindWidgetId() {
+    String url = "http://127.0.0.1:9102/#/inspector?uri=http%3A%2F%2F127.0.0.1%3A51805%2FP-f92tUS3r8%3D%2F&inspectorRef=inspector-238";
     assertEquals(
-      "http://127.0.0.1:9100/?ide=IntelliJ-IDEA&page=timeline&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F",
-      generateDevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false, null)
+            "inspector-238",
+            DevToolsUtils.findWidgetId(url)
     );
 
-    assertEquals(
-      "http://127.0.0.1:9100/?ide=IntelliJ-IDEA&page=timeline&embed=true&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F",
-      generateDevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, true, null)
-    );
-
-    assertEquals(
-      "http://127.0.0.1:9100/?ide=IntelliJ-IDEA&page=timeline&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F",
-      generateDevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false)
-    );
-
-    assertEquals(
-      "http://127.0.0.1:9100/?ide=IntelliJ-IDEA",
-      generateDevToolsUrl(devtoolsHost, devtoolsPort, null, null, false, null)
-    );
-
-    PowerMockito.when(FlutterSdkUtil.getFlutterHostEnvValue()).thenReturn("Android-Studio");
-
-    assertEquals(
-      generateDevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false, null),
-      "http://127.0.0.1:9100/?ide=Android-Studio&page=timeline&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F"
-    );
-
-    assertEquals(
-      generateDevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false, "3c3f41"),
-      "http://127.0.0.1:9100/?ide=Android-Studio&page=timeline&backgroundColor=3c3f41&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F"
-    );
-
-    assertEquals(
-      generateDevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false, "ffffff"),
-      "http://127.0.0.1:9100/?ide=Android-Studio&page=timeline&backgroundColor=ffffff&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F"
-    );
+    String noIdUrl = "http://127.0.0.1:9102/#/inspector?uri=http%3A%2F%2F127.0.0.1%3A51805%2FP-f92tUS3r8%3D%2F";
+    assertNull(DevToolsUtils.findWidgetId(noIdUrl));
   }
 }


### PR DESCRIPTION
This is to clean up an old util method that we don't really need since adding a `DevToolsUrl` class and move its associated tests.

Also adding a test for finding a widget ID since we didn't have one before.

(does not need to be part of v57)