### PR TITLE
allow Instance fields to be nullable

### DIFF
--- a/src/io/flutter/vmService/frame/DartVmServiceValue.java
+++ b/src/io/flutter/vmService/frame/DartVmServiceValue.java
@@ -443,16 +443,21 @@ public class DartVmServiceValue extends XNamedValue {
     node.addChildren(childrenList, true);
   }
 
-  private void addFields(@NotNull final XCompositeNode node, @NotNull final ElementList<BoundField> fields) {
-    final XValueChildrenList childrenList = new XValueChildrenList(fields.size());
-    for (BoundField field : fields) {
-      final InstanceRef value = field.getValue();
-      if (value != null) {
-        childrenList
-          .add(new DartVmServiceValue(myDebugProcess, myIsolateId, field.getDecl().getName(), value, null, field.getDecl(), false));
-      }
+  private void addFields(@NotNull final XCompositeNode node, @Nullable final ElementList<BoundField> fields) {
+    if (fields == null) {
+      node.addChildren(new XValueChildrenList(0), true);
     }
-    node.addChildren(childrenList, true);
+    else {
+      final XValueChildrenList childrenList = new XValueChildrenList(fields.size());
+      for (BoundField field : fields) {
+        final InstanceRef value = field.getValue();
+        if (value != null) {
+          childrenList
+            .add(new DartVmServiceValue(myDebugProcess, myIsolateId, field.getDecl().getName(), value, null, field.getDecl(), false));
+        }
+      }
+      node.addChildren(childrenList, true);
+    }
   }
 
   @NotNull


### PR DESCRIPTION
- allow Instance fields to be nullable

When debugging a Fluter web app, I saw:

```
Argument for @NotNull parameter 'fields' of io/flutter/vmService/frame/DartVmServiceValue.addFields must not be null
```

when expanding a closure instance in the variables view. We were expecting the `fields` field to always be populated, but from the spec this field should be nullable (the VM impl had just always passed an empty list; the package:dwds impl. instead passes null).
