### PR TITLE
Change embedded browser setting

### DIFF
--- a/src/io/flutter/settings/FlutterSettings.java
+++ b/src/io/flutter/settings/FlutterSettings.java
@@ -38,7 +38,7 @@ public class FlutterSettings {
 
   // TODO(helin24): This is to change the embedded browser setting back to true only once for Big Sur users. If we
   // switch to enabling the embedded browser for everyone, then delete this key.
-  private static final String changeBigSurToTrueKey = "io.flutter.setBigSurToTrueKey";
+  private static final String changeBigSurToTrueKey = "io.flutter.setBigSurToTrueKey2";
 
   /**
    * Registry key to suggest all run configurations instead of just one.
@@ -312,6 +312,7 @@ public class FlutterSettings {
 
       // We do not want to set it back to true again in the future (e.g. if a user decides to set to false).
       setChangeBigSurToTrue(false);
+      setEnableEmbeddedBrowsers(true);
       return true;
     }
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter-intellij/issues/5557

It looks like the previous change was returning `true` for the embedded browser status once, but not saving it. I'm not sure how I missed this in testing last month; it's possible I built an earlier version with this line while testing the change and then accidentally deleted it before submitting. I verified with this current version that the embedded browser status is set to true.