### PR TITLE
Send caught exceptions as events

### DIFF
--- a/src/io/flutter/analytics/Analytics.java
+++ b/src/io/flutter/analytics/Analytics.java
@@ -32,6 +32,7 @@ import java.util.Map;
  */
 public class Analytics {
   public static final String GROUP_DISPLAY_ID = "Flutter Usage Statistics";
+  private static final String EXPECTED_EXCEPTION_CATEGORY = "expected-exception";
 
   private static final String analyticsUrl = "https://www.google-analytics.com/collect";
   private static final String applicationName = "Flutter IntelliJ Plugin";
@@ -112,8 +113,8 @@ public class Analytics {
     sendPayload("timing", args, null);
   }
 
-  public void sendCaughtException(String text) {
-    sendEvent("caught-exception", text);
+  public void sendExpectedException(String location, Throwable throwable) {
+    sendEvent(EXPECTED_EXCEPTION_CATEGORY, location + ":" + throwable.getClass().getName());
   }
 
   public void sendException(String throwableText, boolean isFatal) {

--- a/src/io/flutter/analytics/Analytics.java
+++ b/src/io/flutter/analytics/Analytics.java
@@ -32,7 +32,6 @@ import java.util.Map;
  */
 public class Analytics {
   public static final String GROUP_DISPLAY_ID = "Flutter Usage Statistics";
-  private static final String EXPECTED_EXCEPTION_CATEGORY = "expected-exception";
 
   private static final String analyticsUrl = "https://www.google-analytics.com/collect";
   private static final String applicationName = "Flutter IntelliJ Plugin";
@@ -114,7 +113,7 @@ public class Analytics {
   }
 
   public void sendExpectedException(String location, Throwable throwable) {
-    sendEvent(EXPECTED_EXCEPTION_CATEGORY, location + ":" + throwable.getClass().getName());
+    sendEvent("expected-exception", location + ":" + throwable.getClass().getName());
   }
 
   public void sendException(String throwableText, boolean isFatal) {

--- a/src/io/flutter/analytics/Analytics.java
+++ b/src/io/flutter/analytics/Analytics.java
@@ -112,6 +112,10 @@ public class Analytics {
     sendPayload("timing", args, null);
   }
 
+  public void sendCaughtException(String text) {
+    sendEvent("caught-exception", text);
+  }
+
   public void sendException(String throwableText, boolean isFatal) {
     String description = throwableText;
     description = description.replaceAll("com.intellij.openapi.", "c.i.o.");

--- a/src/io/flutter/jxbrowser/EmbeddedBrowser.java
+++ b/src/io/flutter/jxbrowser/EmbeddedBrowser.java
@@ -11,7 +11,6 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
 import com.intellij.openapi.project.ProjectManagerListener;
-import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.ui.content.Content;
 import com.intellij.ui.content.ContentManager;
@@ -71,7 +70,7 @@ public class EmbeddedBrowser {
       // Skip using a transparent background if an exception is thrown.
     } catch (Exception | Error ex) {
       LOG.info(ex);
-      FlutterInitializer.getAnalytics().sendException(StringUtil.getThrowableText(ex), false);
+      FlutterInitializer.getAnalytics().sendCaughtException("embedded-browser-setup: " + ex);
     }
 
     resetUrl();
@@ -113,7 +112,7 @@ public class EmbeddedBrowser {
       devToolsUrlFuture.completeExceptionally(ex);
       onBrowserUnavailable.run();
       LOG.info(ex);
-      FlutterInitializer.getAnalytics().sendException(StringUtil.getThrowableText(ex), false);
+      FlutterInitializer.getAnalytics().sendCaughtException("embedded-browser-load: " + ex);
       return;
     }
 
@@ -188,7 +187,7 @@ public class EmbeddedBrowser {
     AsyncUtils.whenCompleteUiThread(updatedUrlFuture, (devToolsUrl, ex) -> {
       if (ex != null) {
         LOG.info(ex);
-        FlutterInitializer.getAnalytics().sendException(StringUtil.getThrowableText(ex), false);
+        FlutterInitializer.getAnalytics().sendCaughtException("embedded-browser-update: " + ex);
         return;
       }
       if (devToolsUrl == null) {

--- a/src/io/flutter/jxbrowser/EmbeddedBrowser.java
+++ b/src/io/flutter/jxbrowser/EmbeddedBrowser.java
@@ -70,7 +70,7 @@ public class EmbeddedBrowser {
       // Skip using a transparent background if an exception is thrown.
     } catch (Exception | Error ex) {
       LOG.info(ex);
-      FlutterInitializer.getAnalytics().sendCaughtException("embedded-browser-setup: " + ex);
+      FlutterInitializer.getAnalytics().sendCaughtException("jxbrowser-setup: " + ex);
     }
 
     resetUrl();
@@ -112,7 +112,7 @@ public class EmbeddedBrowser {
       devToolsUrlFuture.completeExceptionally(ex);
       onBrowserUnavailable.run();
       LOG.info(ex);
-      FlutterInitializer.getAnalytics().sendCaughtException("embedded-browser-load: " + ex);
+      FlutterInitializer.getAnalytics().sendCaughtException("jxbrowser-load: " + ex);
       return;
     }
 
@@ -187,7 +187,7 @@ public class EmbeddedBrowser {
     AsyncUtils.whenCompleteUiThread(updatedUrlFuture, (devToolsUrl, ex) -> {
       if (ex != null) {
         LOG.info(ex);
-        FlutterInitializer.getAnalytics().sendCaughtException("embedded-browser-update: " + ex);
+        FlutterInitializer.getAnalytics().sendCaughtException("jxbrowser-update: " + ex);
         return;
       }
       if (devToolsUrl == null) {

--- a/src/io/flutter/jxbrowser/EmbeddedBrowser.java
+++ b/src/io/flutter/jxbrowser/EmbeddedBrowser.java
@@ -70,7 +70,7 @@ public class EmbeddedBrowser {
       // Skip using a transparent background if an exception is thrown.
     } catch (Exception | Error ex) {
       LOG.info(ex);
-      FlutterInitializer.getAnalytics().sendCaughtException("jxbrowser-setup: " + ex);
+      FlutterInitializer.getAnalytics().sendExpectedException("jxbrowser-setup", ex);
     }
 
     resetUrl();
@@ -112,7 +112,7 @@ public class EmbeddedBrowser {
       devToolsUrlFuture.completeExceptionally(ex);
       onBrowserUnavailable.run();
       LOG.info(ex);
-      FlutterInitializer.getAnalytics().sendCaughtException("jxbrowser-load: " + ex);
+      FlutterInitializer.getAnalytics().sendExpectedException("jxbrowser-load", ex);
       return;
     }
 
@@ -187,7 +187,7 @@ public class EmbeddedBrowser {
     AsyncUtils.whenCompleteUiThread(updatedUrlFuture, (devToolsUrl, ex) -> {
       if (ex != null) {
         LOG.info(ex);
-        FlutterInitializer.getAnalytics().sendCaughtException("jxbrowser-update: " + ex);
+        FlutterInitializer.getAnalytics().sendExpectedException("jxbrowser-update", ex);
         return;
       }
       if (devToolsUrl == null) {

--- a/src/io/flutter/jxbrowser/EmbeddedBrowserEngine.java
+++ b/src/io/flutter/jxbrowser/EmbeddedBrowserEngine.java
@@ -46,7 +46,7 @@ public class EmbeddedBrowserEngine {
     } catch (Exception ex) {
       temp = null;
       LOG.info(ex);
-      FlutterInitializer.getAnalytics().sendCaughtException("jxbrowser-engine: " + ex);
+      FlutterInitializer.getAnalytics().sendExpectedException("jxbrowser-engine", ex);
     }
     engine = temp;
 
@@ -59,7 +59,7 @@ public class EmbeddedBrowserEngine {
           }
         } catch (Exception ex) {
           LOG.info(ex);
-          FlutterInitializer.getAnalytics().sendCaughtException("jxbrowswer-engine-close: " + ex);
+          FlutterInitializer.getAnalytics().sendExpectedException("jxbrowswer-engine-close", ex);
         }
         return true;
       }

--- a/src/io/flutter/jxbrowser/EmbeddedBrowserEngine.java
+++ b/src/io/flutter/jxbrowser/EmbeddedBrowserEngine.java
@@ -46,7 +46,7 @@ public class EmbeddedBrowserEngine {
     } catch (Exception ex) {
       temp = null;
       LOG.info(ex);
-      FlutterInitializer.getAnalytics().sendCaughtException("embedded-browser-engine: " + ex);
+      FlutterInitializer.getAnalytics().sendCaughtException("jxbrowser-engine: " + ex);
     }
     engine = temp;
 
@@ -59,7 +59,7 @@ public class EmbeddedBrowserEngine {
           }
         } catch (Exception ex) {
           LOG.info(ex);
-          FlutterInitializer.getAnalytics().sendCaughtException("embedded-browswer-engine-close: " + ex);
+          FlutterInitializer.getAnalytics().sendCaughtException("jxbrowswer-engine-close: " + ex);
         }
         return true;
       }

--- a/src/io/flutter/jxbrowser/EmbeddedBrowserEngine.java
+++ b/src/io/flutter/jxbrowser/EmbeddedBrowserEngine.java
@@ -10,7 +10,6 @@ import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.util.SystemInfo;
-import com.intellij.openapi.util.text.StringUtil;
 import com.teamdev.jxbrowser.engine.Engine;
 import com.teamdev.jxbrowser.engine.EngineOptions;
 import com.teamdev.jxbrowser.engine.PasswordStore;
@@ -47,7 +46,7 @@ public class EmbeddedBrowserEngine {
     } catch (Exception ex) {
       temp = null;
       LOG.info(ex);
-      FlutterInitializer.getAnalytics().sendException(StringUtil.getThrowableText(ex), false);
+      FlutterInitializer.getAnalytics().sendCaughtException("embedded-browser-engine: " + ex);
     }
     engine = temp;
 
@@ -60,7 +59,7 @@ public class EmbeddedBrowserEngine {
           }
         } catch (Exception ex) {
           LOG.info(ex);
-          FlutterInitializer.getAnalytics().sendException(StringUtil.getThrowableText(ex), false);
+          FlutterInitializer.getAnalytics().sendCaughtException("embedded-browswer-engine-close: " + ex);
         }
         return true;
       }

--- a/src/io/flutter/run/SdkFields.java
+++ b/src/io/flutter/run/SdkFields.java
@@ -11,7 +11,6 @@ import com.intellij.execution.configurations.RuntimeConfigurationError;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.util.ArrayUtil;
 import com.intellij.util.execution.ParametersListUtil;
@@ -216,7 +215,7 @@ public class SdkFields {
       }
       catch (Exception e) {
         LOG.info(e);
-        FlutterInitializer.getAnalytics().sendException(StringUtil.getThrowableText(e), false);
+        FlutterInitializer.getAnalytics().sendCaughtException("devtools: " + e);
       }
     }
     command = flutterSdk.flutterRun(root, main.getFile(), device, runMode, flutterLaunchMode, project, args);

--- a/src/io/flutter/run/SdkFields.java
+++ b/src/io/flutter/run/SdkFields.java
@@ -215,7 +215,7 @@ public class SdkFields {
       }
       catch (Exception e) {
         LOG.info(e);
-        FlutterInitializer.getAnalytics().sendCaughtException("devtools: " + e);
+        FlutterInitializer.getAnalytics().sendExpectedException("devtools", e);
       }
     }
     command = flutterSdk.flutterRun(root, main.getFile(), device, runMode, flutterLaunchMode, project, args);

--- a/src/io/flutter/run/daemon/DevToolsService.java
+++ b/src/io/flutter/run/daemon/DevToolsService.java
@@ -262,7 +262,7 @@ public class DevToolsService {
 
   private void logExceptionAndComplete(Exception exception) {
     LOG.info(exception);
-    FlutterInitializer.getAnalytics().sendCaughtException("devtools-service: " + exception);
+    FlutterInitializer.getAnalytics().sendExpectedException("devtools-service", exception);
     final CompletableFuture<DevToolsInstance> future = devToolsFutureRef.get();
     if (future != null) {
       future.completeExceptionally(exception);

--- a/src/io/flutter/run/daemon/DevToolsService.java
+++ b/src/io/flutter/run/daemon/DevToolsService.java
@@ -24,7 +24,6 @@ import com.intellij.openapi.project.ProjectManager;
 import com.intellij.openapi.project.ProjectManagerListener;
 import com.intellij.openapi.util.Key;
 import com.intellij.openapi.util.io.FileUtil;
-import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.CharsetToolkit;
 import io.flutter.FlutterInitializer;
 import io.flutter.FlutterUtils;
@@ -262,7 +261,7 @@ public class DevToolsService {
   }
 
   private void logExceptionAndComplete(Exception exception) {
-    LOG.error(exception);
+    LOG.info(exception);
     FlutterInitializer.getAnalytics().sendCaughtException("devtools-service: " + exception);
     final CompletableFuture<DevToolsInstance> future = devToolsFutureRef.get();
     if (future != null) {

--- a/src/io/flutter/run/daemon/DevToolsService.java
+++ b/src/io/flutter/run/daemon/DevToolsService.java
@@ -263,7 +263,7 @@ public class DevToolsService {
 
   private void logExceptionAndComplete(Exception exception) {
     LOG.error(exception);
-    FlutterInitializer.getAnalytics().sendException(StringUtil.getThrowableText(exception), false);
+    FlutterInitializer.getAnalytics().sendCaughtException("devtools-service: " + exception);
     final CompletableFuture<DevToolsInstance> future = devToolsFutureRef.get();
     if (future != null) {
       future.completeExceptionally(exception);


### PR DESCRIPTION
We want to reserve `Analytics::sendException` for unexpected exceptions rather than for tracking how often different types of caught exceptions occur.

This may be a clumsy usage of the event fields, since I'm combining a label and the exception title into the event action. There is an `eventLabel` field that we don't seem to be using in analytics, but I'm not sure what the abbreviation for this field is - perhaps it would be better to make the event action a description of where the exception comes from (e.g. "embedded-browser-setup") and make the label store the exception title/details.