### PR TITLE
Check for initial open state of embedded browser

### DIFF
--- a/src/io/flutter/toolwindow/FlutterViewToolWindowManagerListener.java
+++ b/src/io/flutter/toolwindow/FlutterViewToolWindowManagerListener.java
@@ -13,12 +13,14 @@ import io.flutter.view.FlutterView;
 import org.jetbrains.annotations.NotNull;
 
 public class FlutterViewToolWindowManagerListener implements ToolWindowManagerListener {
-  private boolean inspectorIsOpen = false;
+  private boolean inspectorIsOpen;
   private Runnable onWindowOpen;
   private Runnable onWindowFirstVisible;
 
-  public FlutterViewToolWindowManagerListener(Project project) {
+  public FlutterViewToolWindowManagerListener(Project project, ToolWindow toolWindow) {
     project.getMessageBus().connect().subscribe(ToolWindowManagerListener.TOPIC, this);
+
+    inspectorIsOpen = toolWindow.isShowStripeButton();
   }
 
   public void updateOnWindowOpen(Runnable onWindowOpen) {

--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -489,7 +489,7 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
   @VisibleForTesting
   protected void setUpToolWindowListener(FlutterApp app, InspectorService inspectorService, ToolWindow toolWindow, boolean isEmbedded) {
     if (this.toolWindowListener == null) {
-      this.toolWindowListener = new FlutterViewToolWindowManagerListener(myProject);
+      this.toolWindowListener = new FlutterViewToolWindowManagerListener(myProject, toolWindow);
     }
     this.toolWindowListener.updateOnWindowOpen(() -> {
       devToolsInstallCount += 1;
@@ -723,7 +723,7 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
         displayEmbeddedBrowser(app, inspectorService, toolWindow);
       } else {
         if (toolWindowListener == null) {
-          toolWindowListener = new FlutterViewToolWindowManagerListener(myProject);
+          toolWindowListener = new FlutterViewToolWindowManagerListener(myProject, toolWindow);
         }
         // If the window isn't visible yet, only executed embedded browser steps when it becomes visible.
         toolWindowListener.updateOnWindowFirstVisible(() -> {


### PR DESCRIPTION
Setting `inspectorIsOpen` to false caused the embedded browser to load twice if the inspector window is initially open when app is run. 