### PR TITLE
Add some NotNull annotations in the FlutterWidgetPerf classes; rev to the latest VM service protocol lib

### DIFF
--- a/src/io/flutter/perf/FlutterWidgetPerf.java
+++ b/src/io/flutter/perf/FlutterWidgetPerf.java
@@ -24,6 +24,7 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.util.ui.EdtInvocationManager;
 import gnu.trove.TIntObjectHashMap;
 import io.flutter.utils.AsyncUtils;
+import org.jetbrains.annotations.NotNull;
 
 import javax.swing.Timer;
 import java.awt.event.ActionEvent;
@@ -76,14 +77,15 @@ public class FlutterWidgetPerf implements Disposable, WidgetPerfListener {
   final Set<TextEditor> currentEditors = new HashSet<>();
   private boolean profilingEnabled;
   final Timer uiAnimationTimer;
-  private final WidgetPerfProvider perfProvider;
+  @NotNull private final WidgetPerfProvider perfProvider;
   private boolean isDisposed = false;
   private final FilePerfModelFactory perfModelFactory;
   private final FileLocationMapperFactory fileLocationMapperFactory;
   private volatile long lastLocalPerfEventTime;
   private final WidgetPerfLinter perfLinter;
 
-  FlutterWidgetPerf(boolean profilingEnabled, WidgetPerfProvider perfProvider,
+  FlutterWidgetPerf(boolean profilingEnabled,
+                    @NotNull WidgetPerfProvider perfProvider,
                     FilePerfModelFactory perfModelFactory,
                     FileLocationMapperFactory fileLocationMapperFactory) {
     this.profilingEnabled = profilingEnabled;

--- a/src/io/flutter/perf/VmServiceWidgetPerfProvider.java
+++ b/src/io/flutter/perf/VmServiceWidgetPerfProvider.java
@@ -111,10 +111,9 @@ public class VmServiceWidgetPerfProvider implements WidgetPerfProvider {
     isDisposed = true;
     connected = false;
 
-    // TODO(devoncarew): This method will be available in a future version of the service protocol library.
-    //if (vmServiceListener != null) {
-    //  app.getVmService().removeEventListener(vmServiceListener);
-    //}
+    if (vmServiceListener != null && app.getVmService() != null) {
+      app.getVmService().removeVmServiceListener(vmServiceListener);
+    }
   }
 
   private void setupConnection(@NotNull VmService vmService) {

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/VmServiceBase.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/VmServiceBase.java
@@ -572,6 +572,10 @@ abstract class VmServiceBase implements VmServiceConst {
     }
   }
 
+  protected String removeNewLines(String str) {
+    return str.replaceAll("\r\n", " ").replaceAll("\n", " ");
+  }
+
   void processResponse(JsonObject json) {
     JsonElement idElem = json.get(ID);
     if (idElem == null) {

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/consumer/ClientNameConsumer.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/consumer/ClientNameConsumer.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2015, the Dart project authors.
+ *
+ * Licensed under the Eclipse Public License v1.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.dartlang.vm.service.consumer;
+
+// This is a generated file.
+
+import org.dartlang.vm.service.element.ClientName;
+
+@SuppressWarnings({"WeakerAccess", "unused"})
+public interface ClientNameConsumer extends Consumer {
+    void received(ClientName response);
+}

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/consumer/PortListConsumer.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/consumer/PortListConsumer.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2015, the Dart project authors.
+ *
+ * Licensed under the Eclipse Public License v1.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.dartlang.vm.service.consumer;
+
+// This is a generated file.
+
+import org.dartlang.vm.service.element.PortList;
+
+@SuppressWarnings({"WeakerAccess", "unused"})
+public interface PortListConsumer extends Consumer {
+
+  void received(PortList response);
+}

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/consumer/SetTraceClassAllocationConsumer.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/consumer/SetTraceClassAllocationConsumer.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2015, the Dart project authors.
+ *
+ * Licensed under the Eclipse Public License v1.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.dartlang.vm.service.consumer;
+
+// This is a generated file.
+
+import org.dartlang.vm.service.element.Sentinel;
+import org.dartlang.vm.service.element.Success;
+
+@SuppressWarnings({"WeakerAccess", "unused"})
+public interface SetTraceClassAllocationConsumer extends Consumer {
+
+  void received(Sentinel response);
+
+  void received(Success response);
+}

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/consumer/WebSocketTargetConsumer.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/consumer/WebSocketTargetConsumer.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2015, the Dart project authors.
+ *
+ * Licensed under the Eclipse Public License v1.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.dartlang.vm.service.consumer;
+
+// This is a generated file.
+
+import org.dartlang.vm.service.element.WebSocketTarget;
+
+@SuppressWarnings({"WeakerAccess", "unused"})
+public interface WebSocketTargetConsumer extends Consumer {
+    void received(WebSocketTarget response);
+}

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/element/Breakpoint.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/element/Breakpoint.java
@@ -35,6 +35,13 @@ public class Breakpoint extends Obj {
   }
 
   /**
+   * Is this breakpoint enabled?
+   */
+  public boolean getEnabled() {
+    return getAsBoolean("enabled");
+  }
+
+  /**
    * Is this a breakpoint that was added synthetically as part of a step OverAsyncSuspension resume
    * command?
    *

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/element/ClassObj.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/element/ClassObj.java
@@ -167,6 +167,13 @@ public class ClassObj extends Obj {
   }
 
   /**
+   * Are allocations of this class being traced?
+   */
+  public boolean getTraceAllocations() {
+    return getAsBoolean("traceAllocations");
+  }
+
+  /**
    * Is this an abstract class?
    */
   public boolean isAbstract() {

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/element/ClassRef.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/element/ClassRef.java
@@ -28,6 +28,29 @@ public class ClassRef extends ObjRef {
   }
 
   /**
+   * The library which contains this class.
+   */
+  public LibraryRef getLibrary() {
+    return new LibraryRef((JsonObject) json.get("library"));
+  }
+
+  /**
+   * The location of this class in the source code.
+   *
+   * Can return <code>null</code>.
+   */
+  public SourceLocation getLocation() {
+    JsonObject obj = (JsonObject) json.get("location");
+    if (obj == null) return null;
+    final String type = json.get("type").getAsString();
+    if ("Instance".equals(type) || "@Instance".equals(type)) {
+      final String kind = json.get("kind").getAsString();
+      if ("Null".equals(kind)) return null;
+    }
+    return new SourceLocation(obj);
+  }
+
+  /**
    * The name of this class.
    */
   public String getName() {

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/element/ClientName.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/element/ClientName.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2015, the Dart project authors.
+ *
+ * Licensed under the Eclipse Public License v1.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.dartlang.vm.service.element;
+
+// This is a generated file.
+
+import com.google.gson.JsonObject;
+
+/**
+ * See getClientName and setClientName.
+ */
+@SuppressWarnings({"WeakerAccess", "unused"})
+public class ClientName extends Response {
+    public ClientName(JsonObject json) {
+        super(json);
+    }
+
+    /**
+   * The name of the currently connected VM service client.
+   */
+    public String getName() {
+        return getAsString("name");
+    }
+}

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/element/Context.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/element/Context.java
@@ -40,7 +40,7 @@ public class Context extends Obj {
    *
    * Can return <code>null</code>.
    */
-  public Context getParent() {
+  public ContextRef getParent() {
     JsonObject obj = (JsonObject) json.get("parent");
     if (obj == null) return null;
     final String type = json.get("type").getAsString();
@@ -48,7 +48,7 @@ public class Context extends Obj {
       final String kind = json.get("kind").getAsString();
       if ("Null".equals(kind)) return null;
     }
-    return new Context(obj);
+    return new ContextRef(obj);
   }
 
   /**

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/element/CpuSample.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/element/CpuSample.java
@@ -29,6 +29,27 @@ public class CpuSample extends Element {
   }
 
   /**
+   * Matches the index of a class in HeapSnapshot.classes. Provided for CpuSample instances
+   * returned from a getAllocationTraces().
+   *
+   * Can return <code>null</code>.
+   */
+  public int getClassId() {
+    return getAsInt("classId");
+  }
+
+  /**
+   * The identityHashCode assigned to the allocated object. This hash code is the same as the hash
+   * code provided in HeapSnapshot. Provided for CpuSample instances returned from a
+   * getAllocationTraces().
+   *
+   * Can return <code>null</code>.
+   */
+  public int getIdentityHashCode() {
+    return getAsInt("identityHashCode");
+  }
+
+  /**
    * The call stack at the time this sample was collected. The stack is to be interpreted as top to
    * bottom. Each element in this array is a key into the `functions` array in `CpuSamples`.
    *

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/element/CpuSamples.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/element/CpuSamples.java
@@ -97,7 +97,9 @@ public class CpuSamples extends Response {
   }
 
   /**
-   * The timespan the set of returned samples covers, in microseconds.
+   * The timespan the set of returned samples covers, in microseconds (deprecated).
+   *
+   * Note: this property is deprecated and will always return -1. Use `timeExtentMicros` instead.
    */
   public int getTimeSpan() {
     return getAsInt("timeSpan");

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/element/Event.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/element/Event.java
@@ -64,6 +64,7 @@ public class Event extends Response {
    *  - BreakpointAdded
    *  - BreakpointRemoved
    *  - BreakpointResolved
+   *  - BreakpointUpdated
    *
    * Can return <code>null</code>.
    */

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/element/EventKind.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/element/EventKind.java
@@ -38,6 +38,11 @@ public enum EventKind {
   BreakpointResolved,
 
   /**
+   * A breakpoint has been updated.
+   */
+  BreakpointUpdated,
+
+  /**
    * Event from dart:developer.postEvent.
    */
   Extension,

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/element/Field.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/element/Field.java
@@ -15,6 +15,7 @@ package org.dartlang.vm.service.element;
 
 // This is a generated file.
 
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
 /**
@@ -67,14 +68,20 @@ public class Field extends Obj {
   }
 
   /**
-   * The value of this field, if the field is static.
+   * The value of this field, if the field is static. If uninitialized, this will take the value of
+   * an uninitialized Sentinel.
+   *
+   * @return one of <code>InstanceRef</code> or <code>Sentinel</code>
    *
    * Can return <code>null</code>.
    */
   public InstanceRef getStaticValue() {
-    JsonObject obj = (JsonObject) json.get("staticValue");
-    if (obj == null) return null;
-    return new InstanceRef(obj);
+    final JsonElement elem = json.get("staticValue");
+    if (!elem.isJsonObject()) return null;
+    final JsonObject child = elem.getAsJsonObject();
+    final String type = child.get("type").getAsString();
+    if ("Sentinel".equals(type)) return null;
+    return new InstanceRef(child);
   }
 
   /**

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/element/FieldRef.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/element/FieldRef.java
@@ -37,6 +37,22 @@ public class FieldRef extends ObjRef {
   }
 
   /**
+   * The location of this field in the source code.
+   *
+   * Can return <code>null</code>.
+   */
+  public SourceLocation getLocation() {
+    JsonObject obj = (JsonObject) json.get("location");
+    if (obj == null) return null;
+    final String type = json.get("type").getAsString();
+    if ("Instance".equals(type) || "@Instance".equals(type)) {
+      final String kind = json.get("kind").getAsString();
+      if ("Null".equals(kind)) return null;
+    }
+    return new SourceLocation(obj);
+  }
+
+  /**
    * The name of this field.
    */
   public String getName() {

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/element/FuncRef.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/element/FuncRef.java
@@ -28,6 +28,22 @@ public class FuncRef extends ObjRef {
   }
 
   /**
+   * The location of this function in the source code.
+   *
+   * Can return <code>null</code>.
+   */
+  public SourceLocation getLocation() {
+    JsonObject obj = (JsonObject) json.get("location");
+    if (obj == null) return null;
+    final String type = json.get("type").getAsString();
+    if ("Instance".equals(type) || "@Instance".equals(type)) {
+      final String kind = json.get("kind").getAsString();
+      if ("Null".equals(kind)) return null;
+    }
+    return new SourceLocation(obj);
+  }
+
+  /**
    * The name of this function.
    */
   public String getName() {

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/element/Instance.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/element/Instance.java
@@ -30,6 +30,20 @@ public class Instance extends Obj {
   }
 
   /**
+   * The stack trace associated with the allocation of a ReceivePort.
+   *
+   * Provided for instance kinds:
+   *  - ReceivePort
+   *
+   * Can return <code>null</code>.
+   */
+  public InstanceRef getAllocationLocation() {
+    JsonObject obj = (JsonObject) json.get("allocationLocation");
+    if (obj == null) return null;
+    return new InstanceRef(obj);
+  }
+
+  /**
    * The elements of a Map instance.
    *
    * Provided for instance kinds:
@@ -168,6 +182,18 @@ public class Instance extends Obj {
   }
 
   /**
+   * A name associated with a ReceivePort used for debugging purposes.
+   *
+   * Provided for instance kinds:
+   *  - ReceivePort
+   *
+   * Can return <code>null</code>.
+   */
+  public String getDebugName() {
+    return getAsString("debugName");
+  }
+
+  /**
    * The elements of a List instance.
    *
    * Provided for instance kinds:
@@ -202,6 +228,14 @@ public class Instance extends Obj {
         return new BoundField(array.get(index).getAsJsonObject());
       }
     };
+  }
+
+  /**
+   * The identityHashCode assigned to the allocated object. This hash code is the same as the hash
+   * code provided in HeapSnapshot and CpuSample's returned by getAllocationTraces().
+   */
+  public int getIdentityHashCode() {
+    return getAsInt("identityHashCode");
   }
 
   /**
@@ -370,6 +404,18 @@ public class Instance extends Obj {
   }
 
   /**
+   * The port ID for a ReceivePort.
+   *
+   * Provided for instance kinds:
+   *  - ReceivePort
+   *
+   * Can return <code>null</code>.
+   */
+  public int getPortId() {
+    return getAsInt("portId");
+  }
+
+  /**
    * The key for a WeakProperty instance.
    *
    * Provided for instance kinds:
@@ -460,6 +506,7 @@ public class Instance extends Obj {
    *  - Double (suitable for passing to Double.parse())
    *  - Int (suitable for passing to int.parse())
    *  - String (value may be truncated)
+   *  - StackTrace
    *
    * Can return <code>null</code>.
    */

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/element/InstanceKind.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/element/InstanceKind.java
@@ -101,6 +101,11 @@ public enum InstanceKind {
   PlainInstance,
 
   /**
+   * An instance of the Dart class ReceivePort.
+   */
+  ReceivePort,
+
+  /**
    * An instance of the Dart class RegExp.
    */
   RegExp,

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/element/InstanceRef.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/element/InstanceRef.java
@@ -29,6 +29,20 @@ public class InstanceRef extends ObjRef {
   }
 
   /**
+   * The stack trace associated with the allocation of a ReceivePort.
+   *
+   * Provided for instance kinds:
+   *  - ReceivePort
+   *
+   * Can return <code>null</code>.
+   */
+  public InstanceRef getAllocationLocation() {
+    JsonObject obj = (JsonObject) json.get("allocationLocation");
+    if (obj == null) return null;
+    return new InstanceRef(obj);
+  }
+
+  /**
    * Instance references always include their class.
    */
   public ClassRef getClassRef() {
@@ -71,6 +85,26 @@ public class InstanceRef extends ObjRef {
       if ("Null".equals(kind)) return null;
     }
     return new FuncRef(obj);
+  }
+
+  /**
+   * A name associated with a ReceivePort used for debugging purposes.
+   *
+   * Provided for instance kinds:
+   *  - ReceivePort
+   *
+   * Can return <code>null</code>.
+   */
+  public String getDebugName() {
+    return getAsString("debugName");
+  }
+
+  /**
+   * The identityHashCode assigned to the allocated object. This hash code is the same as the hash
+   * code provided in HeapSnapshot and CpuSample's returned by getAllocationTraces().
+   */
+  public int getIdentityHashCode() {
+    return getAsInt("identityHashCode");
   }
 
   /**
@@ -159,6 +193,18 @@ public class InstanceRef extends ObjRef {
     JsonObject obj = (JsonObject) json.get("pattern");
     if (obj == null) return null;
     return new InstanceRef(obj);
+  }
+
+  /**
+   * The port ID for a ReceivePort.
+   *
+   * Provided for instance kinds:
+   *  - ReceivePort
+   *
+   * Can return <code>null</code>.
+   */
+  public int getPortId() {
+    return getAsInt("portId");
   }
 
   /**

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/element/Isolate.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/element/Isolate.java
@@ -95,6 +95,19 @@ public class Isolate extends Response {
   }
 
   /**
+   * The list of isolate flags provided to this isolate. See Dart_IsolateFlags in dart_api.h for
+   * the list of accepted isolate flags.
+   */
+  public ElementList<IsolateFlag> getIsolateFlags() {
+    return new ElementList<IsolateFlag>(json.get("isolateFlags").getAsJsonArray()) {
+      @Override
+      protected IsolateFlag basicGet(JsonArray array, int index) {
+        return new IsolateFlag(array.get(index).getAsJsonObject());
+      }
+    };
+  }
+
+  /**
    * A list of all libraries for this isolate.
    *
    * Guaranteed to be initialized when the IsolateRunnable event fires.

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/element/IsolateFlag.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/element/IsolateFlag.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2015, the Dart project authors.
+ *
+ * Licensed under the Eclipse Public License v1.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.dartlang.vm.service.element;
+
+// This is a generated file.
+
+import com.google.gson.JsonObject;
+
+/**
+ * Represents the value of a single isolate flag. See Isolate.
+ */
+@SuppressWarnings({"WeakerAccess", "unused"})
+public class IsolateFlag extends Element {
+
+  public IsolateFlag(JsonObject json) {
+    super(json);
+  }
+
+  /**
+   * The name of the flag.
+   */
+  public String getName() {
+    return getAsString("name");
+  }
+
+  /**
+   * The value of this flag as a string.
+   */
+  public String getValueAsString() {
+    return getAsString("valueAsString");
+  }
+}

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/element/LibraryDependency.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/element/LibraryDependency.java
@@ -16,6 +16,7 @@ package org.dartlang.vm.service.element;
 // This is a generated file.
 
 import com.google.gson.JsonObject;
+import java.util.List;
 
 /**
  * A {@link LibraryDependency} provides information about an import or export.
@@ -25,6 +26,15 @@ public class LibraryDependency extends Element {
 
   public LibraryDependency(JsonObject json) {
     super(json);
+  }
+
+  /**
+   * The list of symbols hidden from this dependency.
+   *
+   * Can return <code>null</code>.
+   */
+  public List<String> getHides() {
+    return json.get("hides") == null ? null : getListString("hides");
   }
 
   /**
@@ -46,6 +56,15 @@ public class LibraryDependency extends Element {
    */
   public String getPrefix() {
     return getAsString("prefix");
+  }
+
+  /**
+   * The list of symbols made visible from this dependency.
+   *
+   * Can return <code>null</code>.
+   */
+  public List<String> getShows() {
+    return json.get("shows") == null ? null : getListString("shows");
   }
 
   /**

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/element/PortList.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/element/PortList.java
@@ -18,36 +18,21 @@ package org.dartlang.vm.service.element;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 
+/**
+ * A {@link PortList} contains a list of ports associated with some isolate.
+ */
 @SuppressWarnings({"WeakerAccess", "unused"})
-public class Timeline extends Response {
+public class PortList extends Response {
 
-  public Timeline(JsonObject json) {
+  public PortList(JsonObject json) {
     super(json);
   }
 
-  /**
-   * The duration of time covered by the timeline.
-   */
-  public int getTimeExtentMicros() {
-    return getAsInt("timeExtentMicros");
-  }
-
-  /**
-   * The start of the period of time in which traceEvents were collected.
-   */
-  public int getTimeOriginMicros() {
-    return getAsInt("timeOriginMicros");
-  }
-
-  /**
-   * A list of timeline events. No order is guaranteed for these events; in particular, these
-   * events may be unordered with respect to their timestamps.
-   */
-  public ElementList<TimelineEvent> getTraceEvents() {
-    return new ElementList<TimelineEvent>(json.get("traceEvents").getAsJsonArray()) {
+  public ElementList<InstanceRef> getPorts() {
+    return new ElementList<InstanceRef>(json.get("ports").getAsJsonArray()) {
       @Override
-      protected TimelineEvent basicGet(JsonArray array, int index) {
-        return new TimelineEvent(array.get(index).getAsJsonObject());
+      protected InstanceRef basicGet(JsonArray array, int index) {
+        return new InstanceRef(array.get(index).getAsJsonObject());
       }
     };
   }

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/element/Stack.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/element/Stack.java
@@ -18,6 +18,10 @@ package org.dartlang.vm.service.element;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 
+/**
+ * The {@link Stack} class represents the various components of a Dart stack trace for a given
+ * isolate.
+ */
 @SuppressWarnings({"WeakerAccess", "unused"})
 public class Stack extends Response {
 
@@ -26,6 +30,9 @@ public class Stack extends Response {
   }
 
   /**
+   * A list of frames representing the asynchronous path. Comparable to `awaiterFrames`, if
+   * provided, although some frames may be different.
+   *
    * Can return <code>null</code>.
    */
   public ElementList<Frame> getAsyncCausalFrames() {
@@ -40,6 +47,9 @@ public class Stack extends Response {
   }
 
   /**
+   * A list of frames representing the asynchronous path. Comparable to `asyncCausalFrames`, if
+   * provided, although some frames may be different.
+   *
    * Can return <code>null</code>.
    */
   public ElementList<Frame> getAwaiterFrames() {
@@ -53,6 +63,10 @@ public class Stack extends Response {
     };
   }
 
+  /**
+   * A list of frames that make up the synchronous stack, rooted at the message loop (i.e., the
+   * frames since the last asynchronous gap or the isolate's entrypoint).
+   */
   public ElementList<Frame> getFrames() {
     return new ElementList<Frame>(json.get("frames").getAsJsonArray()) {
       @Override
@@ -62,6 +76,9 @@ public class Stack extends Response {
     };
   }
 
+  /**
+   * A list of messages in the isolate's message queue.
+   */
   public ElementList<Message> getMessages() {
     return new ElementList<Message>(json.get("messages").getAsJsonArray()) {
       @Override
@@ -69,5 +86,12 @@ public class Stack extends Response {
         return new Message(array.get(index).getAsJsonObject());
       }
     };
+  }
+
+  /**
+   * Specifies whether or not this stack is complete or has been artificially truncated.
+   */
+  public boolean getTruncated() {
+    return getAsBoolean("truncated");
   }
 }

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/element/WebSocketTarget.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/element/WebSocketTarget.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2015, the Dart project authors.
+ *
+ * Licensed under the Eclipse Public License v1.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.dartlang.vm.service.element;
+
+// This is a generated file.
+
+import com.google.gson.JsonObject;
+
+/**
+ * See getWebSocketTarget
+ */
+@SuppressWarnings({"WeakerAccess", "unused"})
+public class WebSocketTarget extends Response {
+    public WebSocketTarget(JsonObject json) {
+        super(json);
+    }
+
+    /**
+   * The web socket URI that should be used to connect to the service.
+   */
+    public String getUri() {
+        return getAsString("uri");
+    }
+}


### PR DESCRIPTION
- add some NotNull annotations in the FlutterWidgetPerf classes
- rev to the latest VM service protocol lib

This PR is in response to https://github.com/flutter/flutter-intellij/issues/5587. The case of the stack trace wasn't immediately clear (in fact, nothing in that stack trace should have been null). This PR adds some NotNull annotations to clarify some if the intent of the variables.

```
	at com.intellij.openapi.util.Disposer.dispose(Disposer.java:120)
	at io.flutter.perf.FlutterWidgetPerf.dispose(FlutterWidgetPerf.java:461)
	at io.flutter.perf.FlutterWidgetPerfManager.updateCurrentAppChanged(FlutterWidgetPerfManager.java:276)
```

When in here, I also addressed an old TODO in terms of unregistering an event listener. As well, I updated to the latest version of the VM service protocol lib (upstreaming a change we'd made to the generated code (https://dart-review.googlesource.com/c/sdk/+/204260).

The library upgrade was done in two commits in order to make the review a little easier.