### PR TITLE
Open source file in Android Studio at exact cursor

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -16,3 +16,4 @@ Letticia Nicoli <letticia.nicoli@gmail.com>
 Alex Li <google@alexv525.com>
 Marcus Tomlinson <themarcustomlinson@gmail.com>
 Juyeong Lee <juyeonglee0413@gmail.com>
+Hrishikesh Kadam <hrkadam.92@gmail.com>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,7 @@ file.
     - Change the "Internal Java Platform" to `IntelliJ IDEA jbr 11`
     - Extend it with additional plugin libraries by adding to `Classpath`:
       - plugins/git4idea/lib/git4idea.jar
+      - plugins/android/lib/android.jar
 * In the "Java Compiler" preference page, make sure that the "Project bytecode version" is set to `11` or `Same as language level`
 * In the "Kotlin Compiler" preference page, make sure that the "Target JVM Version" is set to `11` or `Same as language level`
 * One-time Dart plugin install - first-time a new IDE is installed and run you will need to install the Dart plugin. 

--- a/src/io/flutter/actions/OpenInAndroidStudioAction.java
+++ b/src/io/flutter/actions/OpenInAndroidStudioAction.java
@@ -17,6 +17,11 @@ import com.intellij.openapi.actionSystem.CommonDataKeys;
 import com.intellij.openapi.actionSystem.Presentation;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.editor.CaretModel;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.fileEditor.FileEditor;
+import com.intellij.openapi.fileEditor.FileEditorManager;
+import com.intellij.openapi.fileEditor.TextEditor;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.Messages;
 import com.intellij.openapi.util.Key;
@@ -76,11 +81,38 @@ public class OpenInAndroidStudioAction extends AnAction {
       return;
     }
 
-    final VirtualFile file = event.getData(CommonDataKeys.VIRTUAL_FILE);
-    final String sourceFile = file == null ? null : file.isDirectory() ? null : file.getPath();
+    final VirtualFile sourceFile = event.getData(CommonDataKeys.VIRTUAL_FILE);
+    final String sourceFilePath = sourceFile == null ? null : sourceFile.isDirectory() ? null : sourceFile.getPath();
+
+    final Integer line;
+    final Integer column;
+    final Editor editor = getCurrentEditor(project, sourceFile);
+    if (editor != null) {
+      final CaretModel caretModel = editor.getCaretModel();
+      line = caretModel.getLogicalPosition().line + 1;
+      column = caretModel.getLogicalPosition().column;
+    }
+    else {
+      line = column = null;
+    }
+
     ApplicationManager.getApplication().executeOnPooledThread(() -> {
-      openFileInStudio(project, projectFile, androidStudioPath, sourceFile);
+      openFileInStudio(androidStudioPath, project, projectFile.getPath(), sourceFilePath, line, column);
     });
+  }
+
+  @Nullable
+  private static Editor getCurrentEditor(@NotNull Project project, @Nullable VirtualFile file) {
+    if (file == null) return null;
+    final FileEditor fileEditor = FileEditorManager.getInstance(project).getSelectedEditor(file);
+    if (fileEditor instanceof TextEditor) {
+      final TextEditor textEditor = (TextEditor)fileEditor;
+      final Editor editor = textEditor.getEditor();
+      if (!editor.isDisposed()) {
+        return editor;
+      }
+    }
+    return null;
   }
 
   private static void updatePresentation(AnActionEvent event, Presentation state) {
@@ -164,27 +196,36 @@ public class OpenInAndroidStudioAction extends AnAction {
     return null;
   }
 
-  private static void openFileInStudio(@Nullable Project project,
-                                       @NotNull VirtualFile projectFile,
-                                       @NotNull String androidStudioPath,
-                                       @Nullable String sourceFile) {
+  private static void openFileInStudio(@NotNull String androidStudioPath,
+                                       @NotNull Project project,
+                                       @NotNull String projectPath,
+                                       @Nullable String sourceFile,
+                                       @Nullable Integer line,
+                                       @Nullable Integer column) {
     try {
       final GeneralCommandLine cmd;
       if (SystemInfo.isMac) {
-        cmd = new GeneralCommandLine().withExePath("open").withParameters("-a", androidStudioPath, "--args", projectFile.getPath());
-        if (sourceFile != null) {
-          cmd.addParameter(sourceFile);
-        }
+        cmd = new GeneralCommandLine().withExePath("open")
+          .withParameters("-a", androidStudioPath, "--args", projectPath);
       }
       else {
-        // TODO Open editor on sourceFile for Linux, Windows
         if (SystemInfo.isWindows) {
           androidStudioPath += "\\bin\\studio.bat";
         }
         else {
           androidStudioPath += "/bin/studio.sh";
         }
-        cmd = new GeneralCommandLine().withExePath(androidStudioPath).withParameters(projectFile.getPath());
+        cmd = new GeneralCommandLine().withExePath(androidStudioPath)
+          .withParameters(projectPath);
+      }
+      if (sourceFile != null) {
+        if (line != null) {
+          cmd.addParameters("--line", line.toString());
+          if (column != null) {
+            cmd.addParameters("--column", column.toString());
+          }
+        }
+        cmd.addParameter(sourceFile);
       }
       final ColoredProcessHandler handler = new ColoredProcessHandler(cmd);
       handler.addProcessListener(new ProcessAdapter() {
@@ -194,10 +235,11 @@ public class OpenInAndroidStudioAction extends AnAction {
             LOG.error(event.getText());
           }
         }
+
         @Override
         public void processTerminated(@NotNull final ProcessEvent event) {
           if (event.getExitCode() != 0) {
-            FlutterMessages.showError("Error Opening", projectFile.getPath(), project);
+            FlutterMessages.showError("Error Opening", projectPath, project);
           }
         }
       });

--- a/src/io/flutter/actions/OpenInAndroidStudioAction.java
+++ b/src/io/flutter/actions/OpenInAndroidStudioAction.java
@@ -181,6 +181,9 @@ public class OpenInAndroidStudioAction extends AnAction {
         if (SystemInfo.isWindows) {
           androidStudioPath += "\\bin\\studio.bat";
         }
+        else {
+          androidStudioPath += "/bin/studio.sh";
+        }
         cmd = new GeneralCommandLine().withExePath(androidStudioPath).withParameters(projectFile.getPath());
       }
       final ColoredProcessHandler handler = new ColoredProcessHandler(cmd);


### PR DESCRIPTION
I have tested this on Linux.
Please test this on macOS and Windows.

I was not able to run the tests as explained in [Running plugin tests](https://github.com/flutter/flutter-intellij/blob/master/CONTRIBUTING.md#running-plugin-tests).

<details>
<summary>$ bin/plugin test</summary>

```terminal
  JAVA_HOME=/home/hrk/.sdkman/candidates/java/current
  
Getting artifacts
  artifacts/intellij-javac2.zip exists in cache
  rm -rf /mnt/common-data/study-material/flutter/flutter-intellij/artifacts/javac2
  creating /mnt/common-data/study-material/flutter/flutter-intellij/artifacts/javac2/
  unzip -q -d javac2 intellij-javac2.zip {cwd=artifacts}
  
  artifacts/Dart-212.4037.9.zip exists in cache
  rm -rf /mnt/common-data/study-material/flutter/flutter-intellij/artifacts/Dart
  creating /mnt/common-data/study-material/flutter/flutter-intellij/artifacts/Dart/
  unzip -q Dart-212.4037.9.zip {cwd=artifacts}
  
  renamed flutter-studio/src/io/flutter/actions/FlutterNewProjectAction.java_stub
  edited build.gradle
  edited flutter-idea/build.gradle
  ./gradlew test
  
  FAILURE: Build failed with an exception.
  
  * What went wrong:
  Could not determine the dependencies of task ':test'.
  > Could not resolve all dependencies for configuration ':testRuntimeClasspath'.
     > Cannot resolve plugin Dart version 212.4037.9 
  
  * Try:
  Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.
  
  * Get more help at https://help.gradle.org
  
  BUILD FAILED in 612ms
  Restoring flutter-studio/src/io/flutter/android/AndroidModuleLibraryManager.java
  Restoring build.gradle
  Restoring flutter-idea/build.gradle
```

</details>