### PR TITLE
Update live template to not use double underscores

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -16,3 +16,4 @@ Letticia Nicoli <letticia.nicoli@gmail.com>
 Alex Li <google@alexv525.com>
 Marcus Tomlinson <themarcustomlinson@gmail.com>
 Juyeong Lee <juyeonglee0413@gmail.com>
+Sander Kersten <spkersten@gmail.com>

--- a/resources/liveTemplates/flutter_miscellaneous.xml
+++ b/resources/liveTemplates/flutter_miscellaneous.xml
@@ -5,8 +5,9 @@
       <option name="DART_TOPLEVEL" value="true" />
     </context>
   </template>
-  <template name="stful" value="class $NAME$ extends StatefulWidget {&#10;  const $NAME$({Key? key}) : super(key: key);&#10;&#10;  @override&#10;  _$NAME$State createState() =&gt; _$NAME$State();&#10;}&#10;&#10;class _$NAME$State extends State&lt;$NAME$&gt; {&#10;  @override&#10;  Widget build(BuildContext context) {&#10;    return Container($END$);&#10;  }&#10;}&#10;" description="New Stateful widget" toReformat="false" toShortenFQNames="true">
+  <template name="stful" value="class $NAME$ extends StatefulWidget {&#10;  const $NAME$({Key? key}) : super(key: key);&#10;&#10;  @override&#10;  $SNAME$ createState() =&gt; $SNAME$();&#10;}&#10;&#10;class $SNAME$ extends State&lt;$NAME$&gt; {&#10;  @override&#10;  Widget build(BuildContext context) {&#10;    return Container($END$);&#10;  }&#10;}&#10;" description="New Stateful widget" toReformat="false" toShortenFQNames="true">
     <variable name="NAME" expression="" defaultValue="" alwaysStopAt="true" />
+    <variable name="SNAME" expression="regularExpression(concat(&quot;_&quot;, NAME, &quot;State&quot;), &quot;^__&quot;, &quot;_&quot;)" defaultValue="" alwaysStopAt="false" />
     <context>
       <option name="DART_TOPLEVEL" value="true" />
     </context>


### PR DESCRIPTION
When using the live template to create a stateful widget whose name starts with an underscore, don't let the associated state class name start with double underscores

Fixes #4577