### PR TITLE
avoid the use of a deprecated member

### DIFF
--- a/src/io/flutter/actions/FlutterDoctorAction.java
+++ b/src/io/flutter/actions/FlutterDoctorAction.java
@@ -12,7 +12,6 @@ import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.io.FileUtil;
-import com.intellij.openapi.vfs.CharsetToolkit;
 import io.flutter.FlutterUtils;
 import io.flutter.bazel.Workspace;
 import io.flutter.console.FlutterConsoles;
@@ -20,6 +19,8 @@ import io.flutter.pub.PubRoot;
 import io.flutter.sdk.FlutterSdk;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.nio.charset.StandardCharsets;
 
 public class FlutterDoctorAction extends FlutterSdkAction {
 
@@ -47,7 +48,7 @@ public class FlutterDoctorAction extends FlutterSdkAction {
 
   private void runWorkspaceFlutterDoctorScript(@NotNull Project project, @NotNull String workDir, @NotNull String doctorScript) {
     final GeneralCommandLine cmdLine = new GeneralCommandLine().withWorkDirectory(workDir);
-    cmdLine.setCharset(CharsetToolkit.UTF8_CHARSET);
+    cmdLine.setCharset(StandardCharsets.UTF_8);
     cmdLine.setExePath(FileUtil.toSystemDependentName(doctorScript));
 
     final ColoredProcessHandler handler;

--- a/src/io/flutter/run/FlutterReloadManager.java
+++ b/src/io/flutter/run/FlutterReloadManager.java
@@ -31,7 +31,6 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.popup.Balloon;
 import com.intellij.openapi.util.Computable;
 import com.intellij.openapi.util.io.FileUtil;
-import com.intellij.openapi.vfs.CharsetToolkit;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowId;
 import com.intellij.openapi.wm.ToolWindowManager;
@@ -61,6 +60,7 @@ import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 import javax.swing.event.HyperlinkEvent;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -220,7 +220,7 @@ public class FlutterReloadManager {
 
     final String script = workspace.getRoot().getPath() + "/" + workspace.getSyncScript();
     final GeneralCommandLine commandLine = new GeneralCommandLine().withWorkDirectory(workspace.getRoot().getPath());
-    commandLine.setCharset(CharsetToolkit.UTF8_CHARSET);
+    commandLine.setCharset(StandardCharsets.UTF_8);
     commandLine.setExePath(FileUtil.toSystemDependentName(script));
 
     try {

--- a/src/io/flutter/run/bazel/BazelFields.java
+++ b/src/io/flutter/run/bazel/BazelFields.java
@@ -18,7 +18,6 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.InvalidDataException;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.util.text.StringUtil;
-import com.intellij.openapi.vfs.CharsetToolkit;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.jetbrains.lang.dart.sdk.DartConfigurable;
@@ -38,6 +37,7 @@ import org.jdom.Element;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -100,7 +100,7 @@ public class BazelFields {
               @Nullable String bazelArgs,
               @Nullable String additionalArgs,
               boolean enableReleaseMode,
-              DevToolsService devToolsService) {
+              @Nullable DevToolsService devToolsService) {
     this.target = target;
     this.bazelArgs = bazelArgs;
     this.additionalArgs = additionalArgs;
@@ -227,7 +227,7 @@ public class BazelFields {
 
     final GeneralCommandLine commandLine = new GeneralCommandLine()
       .withWorkDirectory(workspace.getRoot().getPath());
-    commandLine.setCharset(CharsetToolkit.UTF8_CHARSET);
+    commandLine.setCharset(StandardCharsets.UTF_8);
     commandLine.setExePath(FileUtil.toSystemDependentName(launchingScript));
 
     // Potentially add build mode to user-specified bazel arguments.

--- a/src/io/flutter/run/bazelTest/BazelTestFields.java
+++ b/src/io/flutter/run/bazelTest/BazelTestFields.java
@@ -14,7 +14,6 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.InvalidDataException;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.util.text.StringUtil;
-import com.intellij.openapi.vfs.CharsetToolkit;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.jetbrains.lang.dart.sdk.DartConfigurable;
@@ -33,6 +32,7 @@ import org.jdom.Element;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 /**
@@ -188,7 +188,7 @@ public class BazelTestFields {
     assert launchingScript != null; // already checked
 
     final GeneralCommandLine commandLine = new GeneralCommandLine().withWorkDirectory(workspace.getRoot().getPath());
-    commandLine.setCharset(CharsetToolkit.UTF8_CHARSET);
+    commandLine.setCharset(StandardCharsets.UTF_8);
     commandLine.setExePath(FileUtil.toSystemDependentName(launchingScript));
 
     final String nonNullArgs = StringUtil.notNullize(additionalArgs);

--- a/src/io/flutter/run/daemon/DevToolsService.java
+++ b/src/io/flutter/run/daemon/DevToolsService.java
@@ -11,11 +11,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonSyntaxException;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configurations.GeneralCommandLine;
-import com.intellij.execution.process.ColoredProcessHandler;
-import com.intellij.execution.process.ProcessAdapter;
-import com.intellij.execution.process.ProcessEvent;
-import com.intellij.execution.process.ProcessHandler;
-import com.intellij.execution.process.ProcessOutput;
+import com.intellij.execution.process.*;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.diagnostic.Logger;
@@ -24,7 +20,6 @@ import com.intellij.openapi.project.ProjectManager;
 import com.intellij.openapi.project.ProjectManagerListener;
 import com.intellij.openapi.util.Key;
 import com.intellij.openapi.util.io.FileUtil;
-import com.intellij.openapi.vfs.CharsetToolkit;
 import io.flutter.FlutterInitializer;
 import io.flutter.FlutterUtils;
 import io.flutter.bazel.Workspace;
@@ -37,6 +32,7 @@ import io.flutter.utils.JsonUtils;
 import io.flutter.utils.MostlySilentColoredProcessHandler;
 import org.jetbrains.annotations.NotNull;
 
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -71,7 +67,8 @@ public class DevToolsService {
     if (devToolsFutureRef.updateAndGet((future) -> {
       if (future.isCompletedExceptionally()) {
         return null;
-      } else {
+      }
+      else {
         return future;
       }
     }) == null) {
@@ -95,7 +92,8 @@ public class DevToolsService {
     if (futureInstance == null) {
       devToolsFutureRef.set(new CompletableFuture<>());
       startServer();
-    } else if (!futureInstance.isDone()) {
+    }
+    else if (!futureInstance.isDone()) {
       futureInstance.cancel(true);
       devToolsFutureRef.set(new CompletableFuture<>());
       startServer();
@@ -172,7 +170,8 @@ public class DevToolsService {
     pubActivateDevTools(sdk).thenAccept(success -> {
       if (success) {
         pubRunDevTools(sdk);
-      } else {
+      }
+      else {
         logExceptionAndComplete("pub activate of DevTools failed");
       }
     });
@@ -297,7 +296,7 @@ public class DevToolsService {
 
   private static GeneralCommandLine createCommand(String workDir, String command, ImmutableList<String> arguments) {
     final GeneralCommandLine result = new GeneralCommandLine().withWorkDirectory(workDir);
-    result.setCharset(CharsetToolkit.UTF8_CHARSET);
+    result.setCharset(StandardCharsets.UTF_8);
     result.setExePath(FileUtil.toSystemDependentName(command));
     result.withEnvironment(FlutterSdkUtil.FLUTTER_HOST_ENV, FlutterSdkUtil.getFlutterHostEnvValue());
 

--- a/src/io/flutter/run/daemon/DeviceDaemon.java
+++ b/src/io/flutter/run/daemon/DeviceDaemon.java
@@ -14,7 +14,6 @@ import com.intellij.execution.process.ProcessHandler;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.io.FileUtil;
-import com.intellij.openapi.vfs.CharsetToolkit;
 import io.flutter.FlutterMessages;
 import io.flutter.FlutterUtils;
 import io.flutter.android.IntelliJAndroidSdk;
@@ -28,6 +27,7 @@ import io.flutter.utils.MostlySilentColoredProcessHandler;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -286,7 +286,7 @@ class DeviceDaemon {
 
     private GeneralCommandLine toCommandLine() {
       final GeneralCommandLine result = new GeneralCommandLine().withWorkDirectory(workDir);
-      result.setCharset(CharsetToolkit.UTF8_CHARSET);
+      result.setCharset(StandardCharsets.UTF_8);
       result.setExePath(FileUtil.toSystemDependentName(command));
       result.withEnvironment(FlutterSdkUtil.FLUTTER_HOST_ENV, FlutterSdkUtil.getFlutterHostEnvValue());
       if (androidHome != null) {

--- a/src/io/flutter/sdk/FlutterCommand.java
+++ b/src/io/flutter/sdk/FlutterCommand.java
@@ -13,7 +13,6 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.io.FileUtil;
-import com.intellij.openapi.vfs.CharsetToolkit;
 import com.intellij.openapi.vfs.VirtualFile;
 import io.flutter.FlutterBundle;
 import io.flutter.FlutterInitializer;
@@ -25,6 +24,7 @@ import io.flutter.utils.MostlySilentColoredProcessHandler;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.function.Consumer;
 
@@ -248,7 +248,7 @@ public class FlutterCommand {
   @NotNull
   public GeneralCommandLine createGeneralCommandLine(@Nullable Project project) {
     final GeneralCommandLine line = new GeneralCommandLine();
-    line.setCharset(CharsetToolkit.UTF8_CHARSET);
+    line.setCharset(StandardCharsets.UTF_8);
     line.withEnvironment(FlutterSdkUtil.FLUTTER_HOST_ENV, FlutterSdkUtil.getFlutterHostEnvValue());
     final String androidHome = IntelliJAndroidSdk.chooseAndroidHome(project, false);
     if (androidHome != null) {


### PR DESCRIPTION
- avoid the use of a deprecated member (move from using `CharsetToolkit.UTF8_CHARSET` to `StandardCharsets.UTF_8`)
