### PR TITLE
Skip Flutter tool windows for non-Flutter projects (WIP)

### DIFF
--- a/src/io/flutter/FlutterInitializer.java
+++ b/src/io/flutter/FlutterInitializer.java
@@ -118,7 +118,6 @@ public class FlutterInitializer implements StartupActivity {
 
     if (hasFlutterModule || WorkspaceCache.getInstance(project).isBazel()) {
       initializeToolWindows(project);
-      toolWindowsInitialized = true;
     } else {
       project.getMessageBus().connect().subscribe(ProjectTopics.MODULES, new ModuleListener() {
         @Override
@@ -219,6 +218,7 @@ public class FlutterInitializer implements StartupActivity {
     FlutterViewFactory.init(project);
     FlutterPerformanceViewFactory.init(project);
     PreviewViewFactory.init(project);
+    toolWindowsInitialized = true;
   }
 
   /**

--- a/src/io/flutter/FlutterInitializer.java
+++ b/src/io/flutter/FlutterInitializer.java
@@ -122,7 +122,7 @@ public class FlutterInitializer implements StartupActivity {
       project.getMessageBus().connect().subscribe(ProjectTopics.MODULES, new ModuleListener() {
         @Override
         public void moduleAdded(@NotNull Project project, @NotNull Module module) {
-          if (!toolWindowsInitialized) {
+          if (!toolWindowsInitialized && FlutterModuleUtils.isFlutterModule(module)) {
             initializeToolWindows(project);
           }
         }

--- a/src/io/flutter/FlutterInitializer.java
+++ b/src/io/flutter/FlutterInitializer.java
@@ -24,10 +24,12 @@ import com.intellij.openapi.startup.StartupActivity;
 import io.flutter.analytics.Analytics;
 import io.flutter.analytics.ToolWindowTracker;
 import io.flutter.android.IntelliJAndroidSdk;
+import io.flutter.bazel.WorkspaceCache;
 import io.flutter.editor.FlutterSaveActionsManager;
 import io.flutter.logging.FlutterConsoleLogManager;
 import io.flutter.perf.FlutterWidgetPerfManager;
 import io.flutter.performance.FlutterPerformanceViewFactory;
+import io.flutter.preview.PreviewViewFactory;
 import io.flutter.pub.PubRoot;
 import io.flutter.pub.PubRoots;
 import io.flutter.run.FlutterReloadManager;
@@ -79,11 +81,6 @@ public class FlutterInitializer implements StartupActivity {
     // Start a DevTools server
     DevToolsService.getInstance(project);
 
-    // Start watching for Flutter debug active events.
-    FlutterViewFactory.init(project);
-
-    FlutterPerformanceViewFactory.init(project);
-
     // If the project declares a Flutter dependency, do some extra initialization.
     boolean hasFlutterModule = false;
 
@@ -113,6 +110,13 @@ public class FlutterInitializer implements StartupActivity {
           FlutterModuleUtils.autoShowMain(project, root);
         }
       }
+    }
+
+    if (hasFlutterModule || WorkspaceCache.getInstance(project).isBazel()) {
+      // Start watching for Flutter debug active events.
+      FlutterViewFactory.init(project);
+      FlutterPerformanceViewFactory.init(project);
+      PreviewViewFactory.init(project);
     }
 
     if (hasFlutterModule) {

--- a/src/io/flutter/performance/FlutterPerformanceView.java
+++ b/src/io/flutter/performance/FlutterPerformanceView.java
@@ -65,6 +65,7 @@ public class FlutterPerformanceView implements Disposable {
   }
 
   void initToolWindow(ToolWindow window) {
+    //window.setAvailable(false);
     if (window.isDisposed()) return;
 
     updateForEmptyContent(window);

--- a/src/io/flutter/performance/FlutterPerformanceView.java
+++ b/src/io/flutter/performance/FlutterPerformanceView.java
@@ -65,7 +65,6 @@ public class FlutterPerformanceView implements Disposable {
   }
 
   void initToolWindow(ToolWindow window) {
-    //window.setAvailable(false);
     if (window.isDisposed()) return;
 
     updateForEmptyContent(window);

--- a/src/io/flutter/performance/FlutterPerformanceViewFactory.java
+++ b/src/io/flutter/performance/FlutterPerformanceViewFactory.java
@@ -12,24 +12,25 @@ import com.intellij.openapi.project.DumbService;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowFactory;
+import com.intellij.openapi.wm.ToolWindowManager;
 import io.flutter.view.FlutterViewMessages;
 import org.jetbrains.annotations.NotNull;
 
 public class FlutterPerformanceViewFactory implements ToolWindowFactory, DumbAware {
-  @Override
-  public void init(ToolWindow window) {
-    window.setAvailable(true, null);
-  }
-
   public static void init(@NotNull Project project) {
     project.getMessageBus().connect().subscribe(
       FlutterViewMessages.FLUTTER_DEBUG_TOPIC, (event) -> initPerfView(project, event)
     );
+    final ToolWindow window = ToolWindowManager.getInstance(project).getToolWindow(FlutterPerformanceView.TOOL_WINDOW_ID);
+    if (window != null) {
+      window.setAvailable(true);
+    }
   }
 
   private static void initPerfView(@NotNull Project project, FlutterViewMessages.FlutterDebugEvent event) {
     ApplicationManager.getApplication().invokeLater(() -> {
       final FlutterPerformanceView flutterPerfView = ServiceManager.getService(project, FlutterPerformanceView.class);
+      ToolWindowManager.getInstance(project).getToolWindow(FlutterPerformanceView.TOOL_WINDOW_ID).setAvailable(true);
       flutterPerfView.debugActive(event);
     });
   }
@@ -40,5 +41,10 @@ public class FlutterPerformanceViewFactory implements ToolWindowFactory, DumbAwa
     DumbService.getInstance(project).runWhenSmart(() -> {
       (ServiceManager.getService(project, FlutterPerformanceView.class)).initToolWindow(toolWindow);
     });
+  }
+
+  @Override
+  public boolean shouldBeAvailable(@NotNull Project project) {
+    return false;
   }
 }

--- a/src/io/flutter/preview/PreviewViewFactory.java
+++ b/src/io/flutter/preview/PreviewViewFactory.java
@@ -11,14 +11,27 @@ import com.intellij.openapi.project.DumbService;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowFactory;
+import com.intellij.openapi.wm.ToolWindowManager;
 import org.jetbrains.annotations.NotNull;
 
 public class PreviewViewFactory implements ToolWindowFactory, DumbAware {
+  public static void init(@NotNull Project project) {
+    final ToolWindow window = ToolWindowManager.getInstance(project).getToolWindow(PreviewView.TOOL_WINDOW_ID);
+    if (window != null) {
+      window.setAvailable(true);
+    }
+  }
+
   @Override
   public void createToolWindowContent(@NotNull Project project, @NotNull ToolWindow toolWindow) {
     //noinspection CodeBlock2Expr
     DumbService.getInstance(project).runWhenSmart(() -> {
       (ServiceManager.getService(project, PreviewView.class)).initToolWindow(toolWindow);
     });
+  }
+
+  @Override
+  public boolean shouldBeAvailable(@NotNull Project project) {
+    return false;
   }
 }

--- a/src/io/flutter/view/FlutterViewFactory.java
+++ b/src/io/flutter/view/FlutterViewFactory.java
@@ -12,6 +12,7 @@ import com.intellij.openapi.project.DumbService;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowFactory;
+import com.intellij.openapi.wm.ToolWindowManager;
 import org.jetbrains.annotations.NotNull;
 
 public class FlutterViewFactory implements ToolWindowFactory, DumbAware {
@@ -19,11 +20,16 @@ public class FlutterViewFactory implements ToolWindowFactory, DumbAware {
     project.getMessageBus().connect().subscribe(
       FlutterViewMessages.FLUTTER_DEBUG_TOPIC, (event) -> initFlutterView(project, event)
     );
+
+    final ToolWindow window = ToolWindowManager.getInstance(project).getToolWindow(FlutterView.TOOL_WINDOW_ID);
+    if (window != null) {
+      window.setAvailable(true);
+    }
   }
 
   @Override
-  public void init(ToolWindow window) {
-    window.setAvailable(true, null);
+  public boolean shouldBeAvailable(@NotNull Project project) {
+    return false;
   }
 
   private static void initFlutterView(@NotNull Project project, FlutterViewMessages.FlutterDebugEvent event) {


### PR DESCRIPTION
From reading over https://github.com/flutter/flutter-intellij/pull/4281, it looks like these are the goals:
- Do not show any of the tool windows (outline, inspector, performance) for non-Flutter projects (defining this as having a Flutter module or being in a bazel workspace)
- Flutter outline should be available as soon as Flutter project is detected
- Flutter inspector and performance should be available when an app starts running, although they can also be open when app is not running. Once an app has run these tool windows should remain open
- Show windows if add to app module is created - Do we also want to remove tool windows if the only Flutter app module is deleted? (Can be done but maybe not worth the trouble)