### PR TITLE
Check for project disposal right before organize executes

### DIFF
--- a/src/io/flutter/editor/FlutterSaveActionsManager.java
+++ b/src/io/flutter/editor/FlutterSaveActionsManager.java
@@ -127,30 +127,32 @@ public class FlutterSaveActionsManager {
     final String filePath = file.getPath();
     final SourceFileEdit fileEdit = DartAnalysisServerService.getInstance(myProject).edit_organizeDirectives(filePath);
 
-    if (myProject.isDisposed()) {
-      return;
-    }
-
     if (fileEdit != null) {
-      ApplicationManager.getApplication().invokeLater(() -> new WriteCommandAction.Simple(myProject) {
-        @Override
-        protected void run() {
-          if (myProject.isDisposed()) {
-            return;
-          }
-
-          AssistUtils.applySourceEdits(myProject, file, document, fileEdit.getEdits(), Collections.emptySet());
-
-          // Committing a document here is required in order to guarantee that DartPostFormatProcessor.processText() is called afterwards.
-          PsiDocumentManager.getInstance(myProject).commitDocument(document);
-
-          // Run this in an invoke later so that we don't exeucte the initial part of performFormat in a write action.
-          //noinspection CodeBlock2Expr
-          ApplicationManager.getApplication().invokeLater(() -> {
-            performFormat(document, file, true);
-          });
+      ApplicationManager.getApplication().invokeLater(() -> {
+        if (myProject.isDisposed()) {
+          return;
         }
-      }.execute());
+
+        new WriteCommandAction.Simple(myProject) {
+          @Override
+          protected void run() {
+            if (myProject.isDisposed()) {
+              return;
+            }
+
+            AssistUtils.applySourceEdits(myProject, file, document, fileEdit.getEdits(), Collections.emptySet());
+
+            // Committing a document here is required in order to guarantee that DartPostFormatProcessor.processText() is called afterwards.
+            PsiDocumentManager.getInstance(myProject).commitDocument(document);
+
+            // Run this in an invoke later so that we don't exeucte the initial part of performFormat in a write action.
+            //noinspection CodeBlock2Expr
+            ApplicationManager.getApplication().invokeLater(() -> {
+              performFormat(document, file, true);
+            });
+          }
+        }.execute();
+      });
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter-intellij/issues/5621

It looks like since the `WriteCommandAction` is inside `invokeLater`, there's a chance the project could be disposed in between the earlier check and when `execute` is called.