### PR TITLE
Add analytics for null analyzer during add breakpoint

### DIFF
--- a/src/io/flutter/run/FlutterPositionMapper.java
+++ b/src/io/flutter/run/FlutterPositionMapper.java
@@ -23,7 +23,9 @@ import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService;
 import com.jetbrains.lang.dart.util.DartResolveUtil;
 import com.jetbrains.lang.dart.util.DartUrlResolver;
 import gnu.trove.THashMap;
+import io.flutter.FlutterInitializer;
 import io.flutter.FlutterUtils;
+import io.flutter.bazel.WorkspaceCache;
 import io.flutter.dart.DartPlugin;
 import io.flutter.vmService.DartVmServiceDebugProcess;
 import org.dartlang.vm.service.element.LibraryRef;
@@ -195,6 +197,10 @@ public class FlutterPositionMapper implements DartVmServiceDebugProcess.Position
     else {
       results.add(uriByIde);
       results.add(threeSlashize(new File(file.getPath()).toURI().toString()));
+    }
+
+    if (WorkspaceCache.getInstance(project).isBazel()) {
+      FlutterInitializer.getAnalytics().sendEvent("breakpoint", analyzer == null ? "analyzer-found" : "analyzer-null");
     }
 
     // package: (if applicable)

--- a/src/io/flutter/vmService/VmServiceWrapper.java
+++ b/src/io/flutter/vmService/VmServiceWrapper.java
@@ -367,6 +367,7 @@ public class VmServiceWrapper implements Disposable {
                 final Set<String> mappedCanonicalBreakpoints = new HashSet<>();
                 for (Breakpoint breakpoint : breakpoints) {
                   Object location = breakpoint.getLocation();
+                  // In JIT mode, locations will be unresolved at this time since files aren't compiled until they are used.
                   if (location instanceof  UnresolvedSourceLocation) {
                     final ScriptRef script = ((UnresolvedSourceLocation)location).getScript();
                     if (script != null && libraryUris.contains(script.getUri())) {

--- a/src/io/flutter/vmService/VmServiceWrapper.java
+++ b/src/io/flutter/vmService/VmServiceWrapper.java
@@ -358,8 +358,10 @@ public class VmServiceWrapper implements Disposable {
                 final Set<String> libraryUris = new HashSet<>();
                 final Set<String> fileNames = new HashSet<>();
                 for (LibraryRef library : response.getLibraries()) {
-                  libraryUris.add(library.getUri());
-                  fileNames.add(library.getName());
+                  final String uri = library.getUri();
+                  libraryUris.add(uri);
+                  final String[] split = uri.split("/");
+                  fileNames.add(split[split.length - 1]);
                 }
 
                 final ElementList<Breakpoint> breakpoints = response.getBreakpoints();
@@ -401,7 +403,7 @@ public class VmServiceWrapper implements Disposable {
                   for (CanonicalBreakpoint canonicalBreakpoint : finalDifference) {
                     if (canonicalBreakpoint.path.contains("google3")) {
                       analytics.sendEvent(category,
-                                          String.format("unmapped-file_%s_%s", response.getRootLib().getUri(), canonicalBreakpoint.path));
+                                          String.format("unmapped-file|%s|%s", response.getRootLib().getUri(), canonicalBreakpoint.path));
                     }
                   }
                 }


### PR DESCRIPTION
This will log events about analyzer availability while setting breakpoints in bazel projects. This is only one specific case where we suspect there could be breakpoint setting issues, so perhaps there's a more general way to check if a breakpoint has been set successfully?