### PR TITLE
Fix some tests using non-static methods

### DIFF
--- a/flutter-intellij.iml
+++ b/flutter-intellij.iml
@@ -79,7 +79,7 @@
       <library name="org.apache.commons:commons-lang3:3.9" type="repository">
         <properties maven-id="org.apache.commons:commons-lang3:RELEASE" />
         <CLASSES>
-          <root url="jar://$USER_HOME$/.m2/repository/org/apache/commons/commons-lang3/3.12.0/commons-lang3-3.12.0.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/apache/commons/commons-lang3/3.12.0/commons-lang3-3.12.0.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES />
@@ -118,10 +118,9 @@
     <orderEntry type="library" name="android" level="project" />
     <orderEntry type="library" name="com.android.tools.build:gradle:3.6.0-alpha09" level="project" />
     <orderEntry type="library" name="gradle-common" level="project" />
-    <orderEntry type="library" name="org.powermock:powermock-module-junit4:2.0.2" level="project" />
-    <orderEntry type="library" name="org.powermock:powermock-api-mockito2:2.0.2" level="project" />
     <orderEntry type="library" name="com.google.protobuf:protobuf-java:3.5.1" level="project" />
     <orderEntry type="library" name="KotlinJavaRuntime" level="project" />
     <orderEntry type="library" name="Dart Packages" level="project" />
+    <orderEntry type="library" name="org.mockito:mockito-core:2.2.2" level="project" />
   </component>
 </module>

--- a/src/io/flutter/devtools/DevToolsUrl.java
+++ b/src/io/flutter/devtools/DevToolsUrl.java
@@ -21,6 +21,7 @@ public class DevToolsUrl {
   public String colorHexCode;
   public String widgetId;
   public Float fontSize;
+  private final FlutterSdkUtil sdkUtil;
 
   public DevToolsUrl(String devtoolsHost,
                      int devtoolsPort,
@@ -29,6 +30,17 @@ public class DevToolsUrl {
                      boolean embed,
                      String colorHexCode,
                      Float fontSize) {
+    this(devtoolsHost, devtoolsPort, vmServiceUri, page, embed, colorHexCode, fontSize, new FlutterSdkUtil());
+  }
+
+  public DevToolsUrl(String devtoolsHost,
+                     int devtoolsPort,
+                     String vmServiceUri,
+                     String page,
+                     boolean embed,
+                     String colorHexCode,
+                     Float fontSize,
+                     FlutterSdkUtil flutterSdkUtil) {
     this.devtoolsHost = devtoolsHost;
     this.devtoolsPort = devtoolsPort;
     this.vmServiceUri = vmServiceUri;
@@ -36,12 +48,13 @@ public class DevToolsUrl {
     this.embed = embed;
     this.colorHexCode = colorHexCode;
     this.fontSize = fontSize;
+    this.sdkUtil = flutterSdkUtil;
   }
 
   public String getUrlString() {
     final List<String> params = new ArrayList<>();
 
-    params.add("ide=" + FlutterSdkUtil.getFlutterHostEnvValue());
+    params.add("ide=" + sdkUtil.getFlutterHostEnvValue());
     if (page != null) {
       params.add("page=" + page);
     }

--- a/src/io/flutter/run/daemon/DevToolsService.java
+++ b/src/io/flutter/run/daemon/DevToolsService.java
@@ -298,7 +298,7 @@ public class DevToolsService {
     final GeneralCommandLine result = new GeneralCommandLine().withWorkDirectory(workDir);
     result.setCharset(StandardCharsets.UTF_8);
     result.setExePath(FileUtil.toSystemDependentName(command));
-    result.withEnvironment(FlutterSdkUtil.FLUTTER_HOST_ENV, FlutterSdkUtil.getFlutterHostEnvValue());
+    result.withEnvironment(FlutterSdkUtil.FLUTTER_HOST_ENV, (new FlutterSdkUtil()).getFlutterHostEnvValue());
 
     for (String argument : arguments) {
       result.addParameter(argument);

--- a/src/io/flutter/run/daemon/DeviceDaemon.java
+++ b/src/io/flutter/run/daemon/DeviceDaemon.java
@@ -288,7 +288,7 @@ class DeviceDaemon {
       final GeneralCommandLine result = new GeneralCommandLine().withWorkDirectory(workDir);
       result.setCharset(StandardCharsets.UTF_8);
       result.setExePath(FileUtil.toSystemDependentName(command));
-      result.withEnvironment(FlutterSdkUtil.FLUTTER_HOST_ENV, FlutterSdkUtil.getFlutterHostEnvValue());
+      result.withEnvironment(FlutterSdkUtil.FLUTTER_HOST_ENV, (new FlutterSdkUtil()).getFlutterHostEnvValue());
       if (androidHome != null) {
         result.withEnvironment("ANDROID_HOME", androidHome);
       }

--- a/src/io/flutter/sdk/FlutterCommand.java
+++ b/src/io/flutter/sdk/FlutterCommand.java
@@ -249,7 +249,7 @@ public class FlutterCommand {
   public GeneralCommandLine createGeneralCommandLine(@Nullable Project project) {
     final GeneralCommandLine line = new GeneralCommandLine();
     line.setCharset(StandardCharsets.UTF_8);
-    line.withEnvironment(FlutterSdkUtil.FLUTTER_HOST_ENV, FlutterSdkUtil.getFlutterHostEnvValue());
+    line.withEnvironment(FlutterSdkUtil.FLUTTER_HOST_ENV, (new FlutterSdkUtil()).getFlutterHostEnvValue());
     final String androidHome = IntelliJAndroidSdk.chooseAndroidHome(project, false);
     if (androidHome != null) {
       line.withEnvironment("ANDROID_HOME", androidHome);

--- a/src/io/flutter/sdk/FlutterSdkUtil.java
+++ b/src/io/flutter/sdk/FlutterSdkUtil.java
@@ -55,13 +55,13 @@ public class FlutterSdkUtil {
   private static final Logger LOG = Logger.getInstance(FlutterSdkUtil.class);
   private static final String FLUTTER_SNAP_SDK_PATH = "/snap/flutter/common/flutter";
 
-  private FlutterSdkUtil() {
+  public FlutterSdkUtil() {
   }
 
   /**
    * Return the environment variable value to use when shelling out to the Flutter command-line tool.
    */
-  public static String getFlutterHostEnvValue() {
+  public String getFlutterHostEnvValue() {
     final String clientId = ApplicationNamesInfo.getInstance().getFullProductName().replaceAll(" ", "-");
     final String existingVar = java.lang.System.getenv(FLUTTER_HOST_ENV);
     return existingVar == null ? clientId : (existingVar + ":" + clientId);

--- a/src/io/flutter/utils/JxBrowserUtils.java
+++ b/src/io/flutter/utils/JxBrowserUtils.java
@@ -18,7 +18,7 @@ public class JxBrowserUtils {
   private static final String JXBROWSER_FILE_SUFFIX = "jar";
   public static final String LICENSE_PROPERTY_NAME = "jxbrowser.license.key";
 
-  public static String getPlatformFileName() throws FileNotFoundException {
+  public String getPlatformFileName() throws FileNotFoundException {
     String name = "";
     if (SystemInfo.isMac) {
       name = "mac";
@@ -39,19 +39,19 @@ public class JxBrowserUtils {
     return String.format("%s-%s-%s.%s", JXBROWSER_FILE_PREFIX, name, JXBROWSER_FILE_VERSION, JXBROWSER_FILE_SUFFIX);
   }
 
-  public static String getApiFileName() {
+  public String getApiFileName() {
     return String.format("%s-%s.%s", JXBROWSER_FILE_PREFIX, JXBROWSER_FILE_VERSION, JXBROWSER_FILE_SUFFIX);
   }
 
-  public static String getSwingFileName() {
+  public String getSwingFileName() {
     return String.format("%s-swing-%s.%s", JXBROWSER_FILE_PREFIX, JXBROWSER_FILE_VERSION, JXBROWSER_FILE_SUFFIX);
   }
 
-  public static String getDistributionLink(String fileName) {
+  public String getDistributionLink(String fileName) {
     return "https://storage.googleapis.com/flutter_infra/flutter/intellij/jxbrowser/" + fileName;
   }
 
-  public static String getJxBrowserKey() throws FileNotFoundException {
+  public String getJxBrowserKey() throws FileNotFoundException {
     if (JxBrowserUtils.class.getResource("/jxbrowser/jxbrowser.properties") == null) {
       throw new FileNotFoundException("jxbrowser.properties file does not exist");
     }
@@ -72,11 +72,11 @@ public class JxBrowserUtils {
     return value;
   }
 
-  public static boolean licenseIsSet() {
+  public boolean licenseIsSet() {
     return System.getProperty(JxBrowserUtils.LICENSE_PROPERTY_NAME) != null;
   }
 
-  public static boolean isM1Mac() {
+  public boolean isM1Mac() {
     // Return default false value for earlier IntelliJ versions that do not have the CpuArch method (211.4961.30).
     // It's possible a user could be using an earlier IntelliJ version with an M1 mac, but for that case we can't detect
     // that the system is the problem and will serve a more generic error message.

--- a/src/io/flutter/view/FlutterView.java
+++ b/src/io/flutter/view/FlutterView.java
@@ -126,9 +126,11 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
 
   private FlutterViewToolWindowManagerListener toolWindowListener;
   private int devToolsInstallCount = 0;
+  private final JxBrowserUtils jxBrowserUtils;
 
   public FlutterView(@NotNull Project project) {
     myProject = project;
+    this.jxBrowserUtils = new JxBrowserUtils();
 
     shouldAutoHorizontalScroll.listen(state::setShouldAutoScroll);
     highlightNodesShownInBothTrees.listen(state::setHighlightNodesShownInBothTrees);
@@ -616,7 +618,7 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
 
     final InstallationFailedReason latestFailureReason = JxBrowserManager.getInstance().getLatestFailureReason();
 
-    if (!JxBrowserUtils.licenseIsSet()) {
+    if (!jxBrowserUtils.licenseIsSet()) {
       // If the license isn't available, allow the user to open the equivalent page in a non-embedded browser window.
       inputs.add(new LabelInput("The JxBrowser license could not be found."));
       inputs.add(openDevToolsLabel);

--- a/testSrc/unit/io/flutter/devtools/DevToolsUrlTest.java
+++ b/testSrc/unit/io/flutter/devtools/DevToolsUrlTest.java
@@ -1,18 +1,12 @@
 package io.flutter.devtools;
 
 import io.flutter.sdk.FlutterSdkUtil;
-import org.junit.Ignore;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
-@Ignore
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(FlutterSdkUtil.class)
 public class DevToolsUrlTest {
   @Test
   public void testGetUrlString() {
@@ -21,44 +15,44 @@ public class DevToolsUrlTest {
     final String serviceProtocolUri = "http://127.0.0.1:50224/WTFTYus3IPU=/";
     final String page = "timeline";
 
-    PowerMockito.mockStatic(FlutterSdkUtil.class);
-    PowerMockito.when(FlutterSdkUtil.getFlutterHostEnvValue()).thenReturn("IntelliJ-IDEA");
+    final FlutterSdkUtil mockSdkUtil = mock(FlutterSdkUtil.class);
+    when(mockSdkUtil.getFlutterHostEnvValue()).thenReturn("IntelliJ-IDEA");
 
     assertEquals(
       "http://127.0.0.1:9100/?ide=IntelliJ-IDEA&page=timeline&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F",
-      (new DevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false, null, null)).getUrlString()
+      (new DevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false, null, null, mockSdkUtil)).getUrlString()
     );
 
     assertEquals(
       "http://127.0.0.1:9100/?ide=IntelliJ-IDEA&page=timeline&embed=true&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F",
-      (new DevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, true, null, null)).getUrlString()
+      (new DevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, true, null, null, mockSdkUtil)).getUrlString()
     );
 
     assertEquals(
       "http://127.0.0.1:9100/?ide=IntelliJ-IDEA",
-      (new DevToolsUrl(devtoolsHost, devtoolsPort, null, null, false, null, null).getUrlString())
+      (new DevToolsUrl(devtoolsHost, devtoolsPort, null, null, false, null, null, mockSdkUtil).getUrlString())
     );
 
     assertEquals(
       "http://127.0.0.1:9100/?ide=IntelliJ-IDEA&page=timeline&backgroundColor=ffffff&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F",
-      (new DevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false, "ffffff", null).getUrlString())
+      (new DevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false, "ffffff", null, mockSdkUtil).getUrlString())
     );
 
     assertEquals(
       "http://127.0.0.1:9100/?ide=IntelliJ-IDEA&page=timeline&backgroundColor=ffffff&fontSize=12.0&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F",
-      (new DevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false, "ffffff", 12.0f).getUrlString())
+      (new DevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false, "ffffff", 12.0f, mockSdkUtil).getUrlString())
     );
 
-    PowerMockito.when(FlutterSdkUtil.getFlutterHostEnvValue()).thenReturn("Android-Studio");
+    when(mockSdkUtil.getFlutterHostEnvValue()).thenReturn("Android-Studio");
 
     assertEquals(
       "http://127.0.0.1:9100/?ide=Android-Studio&page=timeline&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F",
-      (new DevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false, null, null).getUrlString())
+      (new DevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false, null, null, mockSdkUtil).getUrlString())
     );
 
     assertEquals(
       "http://127.0.0.1:9100/?ide=Android-Studio&page=timeline&backgroundColor=3c3f41&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F",
-      (new DevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false, "3c3f41", null).getUrlString())
+      (new DevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false, "3c3f41", null, mockSdkUtil).getUrlString())
     );
   }
 }

--- a/testSrc/unit/io/flutter/devtools/DevToolsUtilsTest.java
+++ b/testSrc/unit/io/flutter/devtools/DevToolsUtilsTest.java
@@ -5,19 +5,11 @@
  */
 package io.flutter.devtools;
 
-import io.flutter.sdk.FlutterSdkUtil;
-import org.junit.Ignore;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
-@Ignore
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(FlutterSdkUtil.class)
 public class DevToolsUtilsTest {
   @Test
   public void testFindWidgetId() {

--- a/testSrc/unit/io/flutter/jxbrowser/JxBrowserManagerTest.java
+++ b/testSrc/unit/io/flutter/jxbrowser/JxBrowserManagerTest.java
@@ -6,33 +6,23 @@
 package io.flutter.jxbrowser;
 
 import com.intellij.openapi.project.Project;
-import io.flutter.FlutterInitializer;
 import io.flutter.analytics.Analytics;
 import io.flutter.utils.FileUtils;
 import io.flutter.utils.JxBrowserUtils;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.File;
 import java.io.FileNotFoundException;
 
 import static io.flutter.jxbrowser.JxBrowserManager.DOWNLOAD_PATH;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
-import static org.powermock.api.mockito.PowerMockito.when;
 
-@Ignore
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({FileUtils.class, JxBrowserUtils.class, FlutterInitializer.class})
 public class JxBrowserManagerTest {
-  @Mock Project mockProject;
+  final Project mockProject = mock(Project.class);
+  final Analytics mockAnalytics = mock(Analytics.class);
   final String PLATFORM_FILE_NAME = "test/platform/file/name";
   final String API_FILE_NAME = "test/api/file/name";
   final String SWING_FILE_NAME = "test/swing/file/name";
@@ -40,19 +30,15 @@ public class JxBrowserManagerTest {
   @Before
   public void setUp() {
     JxBrowserManager.resetForTest();
-
-    final Analytics mockAnalytics = mock(Analytics.class);
-    PowerMockito.mockStatic(FlutterInitializer.class);
-    when(FlutterInitializer.getAnalytics()).thenReturn(mockAnalytics);
   }
 
   @Test
   public void testSetUpIfKeyNotFound() throws FileNotFoundException {
-    // If the directory for JxBrowser files cannot be created, the installation should fail.
-    final JxBrowserManager manager = JxBrowserManager.getInstance();
+    final JxBrowserUtils mockUtils = mock(JxBrowserUtils.class);
+    when(mockUtils.getJxBrowserKey()).thenThrow(new FileNotFoundException("Key not found"));
 
-    PowerMockito.mockStatic(JxBrowserUtils.class);
-    when(JxBrowserUtils.getJxBrowserKey()).thenThrow(new FileNotFoundException("Key not found"));
+    // If the directory for JxBrowser files cannot be created, the installation should fail.
+    final JxBrowserManager manager = new JxBrowserManager(mockUtils, mockAnalytics, mock(FileUtils.class));
 
     manager.setUp(mockProject);
     Assert.assertEquals(JxBrowserStatus.INSTALLATION_FAILED, manager.getStatus());
@@ -60,16 +46,14 @@ public class JxBrowserManagerTest {
 
   @Test
   public void testSetUpIfDirectoryFails() throws FileNotFoundException {
-    // If the directory for JxBrowser files cannot be created, the installation should fail.
-    final JxBrowserManager manager = JxBrowserManager.getInstance();
-
-    PowerMockito.mockStatic(JxBrowserUtils.class);
-    when(JxBrowserUtils.getJxBrowserKey()).thenReturn("KEY");
+    final JxBrowserUtils mockUtils = mock(JxBrowserUtils.class);
+    when(mockUtils.getJxBrowserKey()).thenReturn("KEY");
 
     final FileUtils mockFileUtils = mock(FileUtils.class);
-    PowerMockito.mockStatic(FileUtils.class);
-    when(FileUtils.getInstance()).thenReturn(mockFileUtils);
     when(mockFileUtils.makeDirectory(DOWNLOAD_PATH)).thenReturn(false);
+
+    // If the directory for JxBrowser files cannot be created, the installation should fail.
+    final JxBrowserManager manager = new JxBrowserManager(mockUtils, mockAnalytics, mockFileUtils);
 
     manager.setUp(mockProject);
     Assert.assertEquals(JxBrowserStatus.INSTALLATION_FAILED, manager.getStatus());
@@ -77,17 +61,15 @@ public class JxBrowserManagerTest {
 
   @Test
   public void testSetUpIfPlatformFileNotFound() throws FileNotFoundException {
-    // If the system platform is not found among JxBrowser files, then the installation should fail.
-    final JxBrowserManager manager = JxBrowserManager.getInstance();
+    final JxBrowserUtils mockUtils = mock(JxBrowserUtils.class);
+    when(mockUtils.getJxBrowserKey()).thenReturn("KEY");
+    when(mockUtils.getPlatformFileName()).thenThrow(new FileNotFoundException());
 
     final FileUtils mockFileUtils = mock(FileUtils.class);
-    PowerMockito.mockStatic(FileUtils.class);
-    when(FileUtils.getInstance()).thenReturn(mockFileUtils);
     when(mockFileUtils.makeDirectory(DOWNLOAD_PATH)).thenReturn(true);
 
-    PowerMockito.mockStatic(JxBrowserUtils.class);
-    when(JxBrowserUtils.getJxBrowserKey()).thenReturn("KEY");
-    when(JxBrowserUtils.getPlatformFileName()).thenThrow(new FileNotFoundException());
+    // If the system platform is not found among JxBrowser files, then the installation should fail.
+    final JxBrowserManager manager = new JxBrowserManager(mockUtils, mockAnalytics, mockFileUtils);
 
     manager.setUp(mockProject);
     Assert.assertEquals(JxBrowserStatus.INSTALLATION_FAILED, manager.getStatus());
@@ -95,20 +77,18 @@ public class JxBrowserManagerTest {
 
   @Test
   public void testSetUpIfAllFilesExist() throws FileNotFoundException {
-    // If all of the files are already downloaded, we should load the existing files.
-    final JxBrowserManager manager = JxBrowserManager.getInstance();
+    final JxBrowserUtils mockUtils = mock(JxBrowserUtils.class);
+    when(mockUtils.getJxBrowserKey()).thenReturn("KEY");
+    when(mockUtils.getPlatformFileName()).thenReturn(PLATFORM_FILE_NAME);
+    when(mockUtils.getApiFileName()).thenReturn(API_FILE_NAME);
+    when(mockUtils.getSwingFileName()).thenReturn(SWING_FILE_NAME);
 
     final FileUtils mockFileUtils = mock(FileUtils.class);
-    PowerMockito.mockStatic(FileUtils.class);
-    when(FileUtils.getInstance()).thenReturn(mockFileUtils);
     when(mockFileUtils.makeDirectory(DOWNLOAD_PATH)).thenReturn(true);
     when(mockFileUtils.fileExists(anyString())).thenReturn(true);
 
-    PowerMockito.mockStatic(JxBrowserUtils.class);
-    when(JxBrowserUtils.getJxBrowserKey()).thenReturn("KEY");
-    when(JxBrowserUtils.getPlatformFileName()).thenReturn(PLATFORM_FILE_NAME);
-    when(JxBrowserUtils.getApiFileName()).thenReturn(API_FILE_NAME);
-    when(JxBrowserUtils.getSwingFileName()).thenReturn(SWING_FILE_NAME);
+    // If all of the files are already downloaded, we should load the existing files.
+    final JxBrowserManager manager = new JxBrowserManager(mockUtils, mockAnalytics, mockFileUtils);
 
     manager.setUp(mockProject);
     final String[] expectedFileNames = {PLATFORM_FILE_NAME, API_FILE_NAME, SWING_FILE_NAME};
@@ -117,32 +97,33 @@ public class JxBrowserManagerTest {
 
   @Test
   public void testSetUpIfFilesMissing() throws FileNotFoundException {
-    // If any of our required files do not exist, we want to delete any existing files and start a download of all of the required files.
-    final JxBrowserManager partialMockManager = mock(JxBrowserManager.class);
-    doCallRealMethod().when(partialMockManager).setUp(mockProject);
+    System.out.println("in testSetUpIfFilesMissing");
+    final JxBrowserUtils mockUtils = mock(JxBrowserUtils.class);
+    when(mockUtils.getJxBrowserKey()).thenReturn("KEY");
+    when(mockUtils.getPlatformFileName()).thenReturn(PLATFORM_FILE_NAME);
+    when(mockUtils.getApiFileName()).thenReturn(API_FILE_NAME);
+    when(mockUtils.getSwingFileName()).thenReturn(SWING_FILE_NAME);
 
     final FileUtils mockFileUtils = mock(FileUtils.class);
-    PowerMockito.mockStatic(FileUtils.class);
-    when(FileUtils.getInstance()).thenReturn(mockFileUtils);
     when(mockFileUtils.makeDirectory(DOWNLOAD_PATH)).thenReturn(true);
     when(mockFileUtils.fileExists(PLATFORM_FILE_NAME)).thenReturn(true);
     when(mockFileUtils.fileExists(API_FILE_NAME)).thenReturn(false);
     when(mockFileUtils.fileExists(SWING_FILE_NAME)).thenReturn(true);
     when(mockFileUtils.deleteFile(anyString())).thenReturn(true);
 
-    PowerMockito.mockStatic(JxBrowserUtils.class);
-    when(JxBrowserUtils.getJxBrowserKey()).thenReturn("KEY");
-    when(JxBrowserUtils.getPlatformFileName()).thenReturn(PLATFORM_FILE_NAME);
-    when(JxBrowserUtils.getApiFileName()).thenReturn(API_FILE_NAME);
-    when(JxBrowserUtils.getSwingFileName()).thenReturn(SWING_FILE_NAME);
+    // If any of our required files do not exist, we want to delete any existing files and start a download of all of the required files.
+    final JxBrowserManager manager = new JxBrowserManager(mockUtils, mockAnalytics, mockFileUtils);
+    final JxBrowserManager spy = spy(manager);
+    final String[] expectedFileNames = {PLATFORM_FILE_NAME, API_FILE_NAME, SWING_FILE_NAME};
+    doNothing().when(spy).downloadJxBrowser(mockProject, expectedFileNames);
 
-    partialMockManager.setUp(mockProject);
+    System.out.println("using spy");
+    spy.setUp(mockProject);
 
     verify(mockFileUtils, times(1)).deleteFile(DOWNLOAD_PATH + File.separatorChar + PLATFORM_FILE_NAME);
     verify(mockFileUtils, times(1)).deleteFile(DOWNLOAD_PATH + File.separatorChar + API_FILE_NAME);
     verify(mockFileUtils, times(1)).deleteFile(DOWNLOAD_PATH + File.separatorChar + SWING_FILE_NAME);
 
-    final String[] expectedFileNames = {PLATFORM_FILE_NAME, API_FILE_NAME, SWING_FILE_NAME};
-    verify(partialMockManager, times(1)).downloadJxBrowser(mockProject, expectedFileNames);
+    verify(spy, times(1)).downloadJxBrowser(mockProject, expectedFileNames);
   }
 }

--- a/testSrc/unit/io/flutter/view/FlutterViewTest.java
+++ b/testSrc/unit/io/flutter/view/FlutterViewTest.java
@@ -36,7 +36,7 @@ import static org.powermock.api.mockito.PowerMockito.when;
 
 @Ignore
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({JxBrowserManager.class, ThreadUtil.class, FlutterInitializer.class, JxBrowserUtils.class,
+@PrepareForTest({ThreadUtil.class, FlutterInitializer.class, JxBrowserUtils.class,
   InspectorGroupManagerService.class, SwingUtilities.class})
 public class FlutterViewTest {
   @Mock Project mockProject;
@@ -63,8 +63,8 @@ public class FlutterViewTest {
 
   @Test
   public void testHandleJxBrowserInstallationFailed() {
-    PowerMockito.mockStatic(JxBrowserUtils.class);
-    when(JxBrowserUtils.licenseIsSet()).thenReturn(true);
+    final JxBrowserUtils mockJxBrowserUtils = mock(JxBrowserUtils.class);
+    when(mockJxBrowserUtils.licenseIsSet()).thenReturn(true);
 
     PowerMockito.mockStatic(JxBrowserManager.class);
     when(JxBrowserManager.getInstance()).thenReturn(mockJxBrowserManager);


### PR DESCRIPTION
Powermock has not been reliable and is generally intended for mocking classes we don't control anyway, so I'm instead planning to change utility classes to have non-static methods so we can mock them more easily.

partially addresses https://github.com/flutter/flutter-intellij/issues/5585