### PR TITLE
Add menu item to Open in AppCode

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -1429,6 +1429,9 @@
       <action id="flutter.xcode.open" class="io.flutter.actions.OpenInXcodeAction"
               text="Open iOS module in Xcode"
               description="Launch Xcode to edit the iOS module as a top-level project"/>
+      <action id="flutter.appcode.open" class="io.flutter.actions.OpenInAppCodeAction"
+              text="Open iOS module in AppCode"
+              description="Launch AppCode to edit the iOS module as a top-level project"/>
       <separator/>
       <action id="flutter.submitFeedback" class="io.flutter.actions.FlutterSubmitFeedback"
               text="Submit Feedback..."
@@ -1445,6 +1448,7 @@
         <separator/>
         <reference ref="flutter.androidstudio.open"/>
         <reference ref="flutter.xcode.open"/>
+        <reference ref="flutter.appcode.open"/>
         <separator/>
         <reference ref="flutter.upgrade"/>
         <reference ref="flutter.doctor"/>
@@ -1457,6 +1461,7 @@
       <group text="Flutter" description="Flutter Tools" icon="FlutterIcons.Flutter" popup="true">
         <reference ref="flutter.androidstudio.open"/>
         <reference ref="flutter.xcode.open"/>
+        <reference ref="flutter.appcode.open"/>
       </group>
       <separator/>
       <add-to-group group-id="ProjectViewPopupMenu" relative-to-action="AddToFavorites" anchor="before"/>

--- a/resources/META-INF/plugin_template.xml
+++ b/resources/META-INF/plugin_template.xml
@@ -110,6 +110,9 @@
       <action id="flutter.xcode.open" class="io.flutter.actions.OpenInXcodeAction"
               text="Open iOS module in Xcode"
               description="Launch Xcode to edit the iOS module as a top-level project"/>
+      <action id="flutter.appcode.open" class="io.flutter.actions.OpenInAppCodeAction"
+              text="Open iOS module in AppCode"
+              description="Launch AppCode to edit the iOS module as a top-level project"/>
       <separator/>
       <action id="flutter.submitFeedback" class="io.flutter.actions.FlutterSubmitFeedback"
               text="Submit Feedback..."
@@ -126,6 +129,7 @@
         <separator/>
         <reference ref="flutter.androidstudio.open"/>
         <reference ref="flutter.xcode.open"/>
+        <reference ref="flutter.appcode.open"/>
         <separator/>
         <reference ref="flutter.upgrade"/>
         <reference ref="flutter.doctor"/>
@@ -138,6 +142,7 @@
       <group text="Flutter" description="Flutter Tools" icon="FlutterIcons.Flutter" popup="true">
         <reference ref="flutter.androidstudio.open"/>
         <reference ref="flutter.xcode.open"/>
+        <reference ref="flutter.appcode.open"/>
       </group>
       <separator/>
       <add-to-group group-id="ProjectViewPopupMenu" relative-to-action="AddToFavorites" anchor="before"/>

--- a/src/io/flutter/actions/OpenInAppCodeAction.java
+++ b/src/io/flutter/actions/OpenInAppCodeAction.java
@@ -13,7 +13,6 @@ import com.intellij.execution.process.ProcessEvent;
 import com.intellij.execution.process.ProcessOutputTypes;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.actionSystem.CommonDataKeys;
 import com.intellij.openapi.actionSystem.Presentation;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectUtil;
@@ -21,9 +20,7 @@ import com.intellij.openapi.util.Key;
 import com.intellij.openapi.util.SystemInfo;
 import com.intellij.openapi.vfs.VirtualFile;
 import io.flutter.FlutterMessages;
-import io.flutter.FlutterUtils;
 import io.flutter.sdk.FlutterSdk;
-import io.flutter.utils.FlutterModuleUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 

--- a/src/io/flutter/actions/OpenInAppCodeAction.java
+++ b/src/io/flutter/actions/OpenInAppCodeAction.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2021 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.actions;
+
+import com.intellij.execution.ExecutionException;
+import com.intellij.execution.configurations.GeneralCommandLine;
+import com.intellij.execution.process.ColoredProcessHandler;
+import com.intellij.execution.process.ProcessAdapter;
+import com.intellij.execution.process.ProcessEvent;
+import com.intellij.execution.process.ProcessOutputTypes;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.CommonDataKeys;
+import com.intellij.openapi.actionSystem.Presentation;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectUtil;
+import com.intellij.openapi.util.Key;
+import com.intellij.openapi.util.SystemInfo;
+import com.intellij.openapi.vfs.VirtualFile;
+import io.flutter.FlutterMessages;
+import io.flutter.FlutterUtils;
+import io.flutter.sdk.FlutterSdk;
+import io.flutter.utils.FlutterModuleUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import static io.flutter.actions.OpenInXcodeAction.findProjectFile;
+
+public class OpenInAppCodeAction extends AnAction {
+
+  private static boolean IS_INITIALIZED = false;
+  private static boolean IS_APPCODE_INSTALLED = false;
+
+  static {
+    initialize();
+  }
+
+  private static void initialize() {
+    try {
+      // AppCode is installed if this shell command produces any output:
+      // mdfind "kMDItemContentType == 'com.apple.application-bundle'" | grep AppCode.app
+      final GeneralCommandLine cmd = new GeneralCommandLine().withExePath("/bin/bash")
+        .withParameters("-c", "mdfind \"kMDItemContentType == 'com.apple.application-bundle'\" | grep AppCode.app");
+      final ColoredProcessHandler handler = new ColoredProcessHandler(cmd);
+      handler.addProcessListener(new ProcessAdapter() {
+        @Override
+        public void onTextAvailable(@NotNull ProcessEvent event, @NotNull Key outputType) {
+          if (outputType == ProcessOutputTypes.STDOUT) {
+            IS_APPCODE_INSTALLED = true;
+          }
+        }
+      });
+      handler.startNotify();
+    }
+    catch (ExecutionException ex) {
+      // ignored
+    }
+    IS_INITIALIZED = true;
+  }
+
+  @Override
+  public void update(@NotNull AnActionEvent event) {
+    // Enable in global menu; action group controls context menu visibility.
+    if (!SystemInfo.isMac || !(IS_INITIALIZED && IS_APPCODE_INSTALLED)) {
+      event.getPresentation().setVisible(false);
+    }
+    else {
+      final Presentation presentation = event.getPresentation();
+      final boolean enabled = findProjectFile(event) != null;
+      presentation.setEnabledAndVisible(enabled);
+    }
+  }
+
+  @Override
+  public void actionPerformed(@NotNull AnActionEvent event) {
+    final VirtualFile projectFile = findProjectFile(event);
+    if (projectFile != null) {
+      openFile(projectFile);
+    }
+    else {
+      @Nullable final Project project = event.getProject();
+      FlutterMessages.showError("Error Opening AppCode", "Project not found.", project);
+    }
+  }
+
+  private static void openFile(@NotNull VirtualFile file) {
+    final Project project = ProjectUtil.guessProjectForFile(file);
+    final FlutterSdk sdk = project != null ? FlutterSdk.getFlutterSdk(project) : null;
+    if (sdk == null) {
+      FlutterSdkAction.showMissingSdkDialog(project);
+      return;
+    }
+    openInAppCode(project, file.getPath());
+  }
+
+  private static void openInAppCode(@Nullable Project project, @NotNull String path) {
+    try {
+      final GeneralCommandLine cmd = new GeneralCommandLine().withExePath("open").withParameters("-a", "AppCode.app", path);
+      final ColoredProcessHandler handler = new ColoredProcessHandler(cmd);
+      handler.addProcessListener(new ProcessAdapter() {
+        @Override
+        public void processTerminated(@NotNull final ProcessEvent event) {
+          if (event.getExitCode() != 0) {
+            FlutterMessages.showError("Error Opening", path, project);
+          }
+        }
+      });
+      handler.startNotify();
+    }
+    catch (ExecutionException ex) {
+      FlutterMessages.showError(
+        "Error Opening",
+        "Exception: " + ex.getMessage(),
+        project);
+    }
+  }
+}

--- a/src/io/flutter/actions/OpenInAppCodeAction.java
+++ b/src/io/flutter/actions/OpenInAppCodeAction.java
@@ -36,24 +36,26 @@ public class OpenInAppCodeAction extends AnAction {
   }
 
   private static void initialize() {
-    try {
-      // AppCode is installed if this shell command produces any output:
-      // mdfind "kMDItemContentType == 'com.apple.application-bundle'" | grep AppCode.app
-      final GeneralCommandLine cmd = new GeneralCommandLine().withExePath("/bin/bash")
-        .withParameters("-c", "mdfind \"kMDItemContentType == 'com.apple.application-bundle'\" | grep AppCode.app");
-      final ColoredProcessHandler handler = new ColoredProcessHandler(cmd);
-      handler.addProcessListener(new ProcessAdapter() {
-        @Override
-        public void onTextAvailable(@NotNull ProcessEvent event, @NotNull Key outputType) {
-          if (outputType == ProcessOutputTypes.STDOUT) {
-            IS_APPCODE_INSTALLED = true;
+    if (SystemInfo.isMac) {
+      try {
+        // AppCode is installed if this shell command produces any output:
+        // mdfind "kMDItemContentType == 'com.apple.application-bundle'" | grep AppCode.app
+        final GeneralCommandLine cmd = new GeneralCommandLine().withExePath("/bin/bash")
+          .withParameters("-c", "mdfind \"kMDItemContentType == 'com.apple.application-bundle'\" | grep AppCode.app");
+        final ColoredProcessHandler handler = new ColoredProcessHandler(cmd);
+        handler.addProcessListener(new ProcessAdapter() {
+          @Override
+          public void onTextAvailable(@NotNull ProcessEvent event, @NotNull Key outputType) {
+            if (outputType == ProcessOutputTypes.STDOUT) {
+              IS_APPCODE_INSTALLED = true;
+            }
           }
-        }
-      });
-      handler.startNotify();
-    }
-    catch (ExecutionException ex) {
-      // ignored
+        });
+        handler.startNotify();
+      }
+      catch (ExecutionException ex) {
+        // ignored
+      }
     }
     IS_INITIALIZED = true;
   }
@@ -90,7 +92,7 @@ public class OpenInAppCodeAction extends AnAction {
       FlutterSdkAction.showMissingSdkDialog(project);
       return;
     }
-    openInAppCode(project, file.getPath());
+    openInAppCode(project, file.getParent().getPath());
   }
 
   private static void openInAppCode(@Nullable Project project, @NotNull String path) {

--- a/src/io/flutter/actions/OpenInXcodeAction.java
+++ b/src/io/flutter/actions/OpenInXcodeAction.java
@@ -28,15 +28,16 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class OpenInXcodeAction extends AnAction {
+
   @Nullable
-  private static VirtualFile findProjectFile(@NotNull AnActionEvent event) {
+  static VirtualFile findProjectFile(@NotNull AnActionEvent event) {
     final VirtualFile file = event.getData(CommonDataKeys.VIRTUAL_FILE);
+    final Project project = event.getProject();
     if (file != null && file.exists()) {
       if (FlutterUtils.isXcodeFileName(file.getName())) {
         return file;
       }
 
-      final Project project = event.getProject();
       if (project == null) {
         return null;
       }
@@ -48,7 +49,6 @@ public class OpenInXcodeAction extends AnAction {
       }
     }
 
-    final Project project = event.getProject();
     if (project != null) {
       return FlutterModuleUtils.findXcodeProjectFile(project);
     }


### PR DESCRIPTION
Add `Open iOS module in AppCode` parallel to the Xcode item.

There are some caveats:
- It requires Spotlight indexing to be enabled.
- The iOS module must have previously been opened and trusted by AppCode

Fixes #5446 