### PR TITLE
Persist tool window open states during project open/close

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -1565,6 +1565,14 @@
               topic="com.intellij.openapi.project.ProjectManagerListener"/>
   </applicationListeners>
 
+  <projectListeners>
+    <listener class="io.flutter.view.FlutterViewFactory$FlutterViewListener" topic="com.intellij.openapi.wm.ex.ToolWindowManagerListener"/>
+    <listener class="io.flutter.performance.FlutterPerformanceViewFactory$FlutterPerformanceViewListener"
+              topic="com.intellij.openapi.wm.ex.ToolWindowManagerListener"/>
+    <listener class="io.flutter.preview.PreviewViewFactory$PreviewViewListener"
+              topic="com.intellij.openapi.wm.ex.ToolWindowManagerListener"/>
+  </projectListeners>
+
   <extensionPoints>
     <extensionPoint name="gradleSyncProvider" interface="io.flutter.android.GradleSyncProvider"/>
     <extensionPoint name="colorPickerProvider" interface="io.flutter.editor.ColorPickerProvider"/>

--- a/resources/META-INF/plugin_template.xml
+++ b/resources/META-INF/plugin_template.xml
@@ -246,6 +246,14 @@
               topic="com.intellij.openapi.project.ProjectManagerListener"/>
   </applicationListeners>
 
+  <projectListeners>
+    <listener class="io.flutter.view.FlutterViewFactory$FlutterViewListener" topic="com.intellij.openapi.wm.ex.ToolWindowManagerListener"/>
+    <listener class="io.flutter.performance.FlutterPerformanceViewFactory$FlutterPerformanceViewListener"
+              topic="com.intellij.openapi.wm.ex.ToolWindowManagerListener"/>
+    <listener class="io.flutter.preview.PreviewViewFactory$PreviewViewListener"
+              topic="com.intellij.openapi.wm.ex.ToolWindowManagerListener"/>
+  </projectListeners>
+
   <extensionPoints>
     <extensionPoint name="gradleSyncProvider" interface="io.flutter.android.GradleSyncProvider"/>
     <extensionPoint name="colorPickerProvider" interface="io.flutter.editor.ColorPickerProvider"/>

--- a/src/io/flutter/performance/FlutterPerformanceViewFactory.java
+++ b/src/io/flutter/performance/FlutterPerformanceViewFactory.java
@@ -5,6 +5,7 @@
  */
 package io.flutter.performance;
 
+import com.intellij.ide.util.PropertiesComponent;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.project.DumbAware;
@@ -13,10 +14,13 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowFactory;
 import com.intellij.openapi.wm.ToolWindowManager;
+import com.intellij.openapi.wm.ex.ToolWindowManagerListener;
 import io.flutter.view.FlutterViewMessages;
 import org.jetbrains.annotations.NotNull;
 
 public class FlutterPerformanceViewFactory implements ToolWindowFactory, DumbAware {
+  private static final String TOOL_WINDOW_VISIBLE_PROPERTY = "flutter.performance.tool.window.visible";
+
   public static void init(@NotNull Project project) {
     project.getMessageBus().connect().subscribe(
       FlutterViewMessages.FLUTTER_DEBUG_TOPIC, (event) -> initPerfView(project, event)
@@ -24,6 +28,10 @@ public class FlutterPerformanceViewFactory implements ToolWindowFactory, DumbAwa
     final ToolWindow window = ToolWindowManager.getInstance(project).getToolWindow(FlutterPerformanceView.TOOL_WINDOW_ID);
     if (window != null) {
       window.setAvailable(true);
+
+      if (PropertiesComponent.getInstance(project).getBoolean(TOOL_WINDOW_VISIBLE_PROPERTY, false)) {
+        window.activate(null, false);
+      }
     }
   }
 
@@ -46,5 +54,24 @@ public class FlutterPerformanceViewFactory implements ToolWindowFactory, DumbAwa
   @Override
   public boolean shouldBeAvailable(@NotNull Project project) {
     return false;
+  }
+
+  /**
+   * Helps to initialize tool window with the same visibility state as it was when the project was previously closed.
+   */
+  public static class FlutterPerformanceViewListener implements ToolWindowManagerListener {
+    private final @NotNull Project myProject;
+
+    public FlutterPerformanceViewListener(@NotNull Project project) {
+      myProject = project;
+    }
+
+    @Override
+    public void stateChanged(@NotNull ToolWindowManager toolWindowManager) {
+      ToolWindow toolWindow = toolWindowManager.getToolWindow(FlutterPerformanceView.TOOL_WINDOW_ID);
+      if (toolWindow != null && toolWindow.isAvailable()) {
+        PropertiesComponent.getInstance(myProject).setValue(TOOL_WINDOW_VISIBLE_PROPERTY, toolWindow.isVisible(), false);
+      }
+    }
   }
 }

--- a/src/io/flutter/performance/FlutterPerformanceViewFactory.java
+++ b/src/io/flutter/performance/FlutterPerformanceViewFactory.java
@@ -14,7 +14,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowFactory;
 import com.intellij.openapi.wm.ToolWindowManager;
-import com.intellij.openapi.wm.ex.ToolWindowManagerListener;
+import io.flutter.utils.ViewListener;
 import io.flutter.view.FlutterViewMessages;
 import org.jetbrains.annotations.NotNull;
 
@@ -56,22 +56,9 @@ public class FlutterPerformanceViewFactory implements ToolWindowFactory, DumbAwa
     return false;
   }
 
-  /**
-   * Helps to initialize tool window with the same visibility state as it was when the project was previously closed.
-   */
-  public static class FlutterPerformanceViewListener implements ToolWindowManagerListener {
-    private final @NotNull Project myProject;
-
+  public static class FlutterPerformanceViewListener extends ViewListener {
     public FlutterPerformanceViewListener(@NotNull Project project) {
-      myProject = project;
-    }
-
-    @Override
-    public void stateChanged(@NotNull ToolWindowManager toolWindowManager) {
-      ToolWindow toolWindow = toolWindowManager.getToolWindow(FlutterPerformanceView.TOOL_WINDOW_ID);
-      if (toolWindow != null && toolWindow.isAvailable()) {
-        PropertiesComponent.getInstance(myProject).setValue(TOOL_WINDOW_VISIBLE_PROPERTY, toolWindow.isVisible(), false);
-      }
+      super(project, FlutterPerformanceView.TOOL_WINDOW_ID, TOOL_WINDOW_VISIBLE_PROPERTY);
     }
   }
 }

--- a/src/io/flutter/preview/PreviewViewFactory.java
+++ b/src/io/flutter/preview/PreviewViewFactory.java
@@ -5,6 +5,7 @@
  */
 package io.flutter.preview;
 
+import com.intellij.ide.util.PropertiesComponent;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.DumbService;
@@ -12,13 +13,20 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowFactory;
 import com.intellij.openapi.wm.ToolWindowManager;
+import com.intellij.openapi.wm.ex.ToolWindowManagerListener;
 import org.jetbrains.annotations.NotNull;
 
 public class PreviewViewFactory implements ToolWindowFactory, DumbAware {
+  private static final String TOOL_WINDOW_VISIBLE_PROPERTY = "flutter.preview.tool.window.visible";
+
   public static void init(@NotNull Project project) {
     final ToolWindow window = ToolWindowManager.getInstance(project).getToolWindow(PreviewView.TOOL_WINDOW_ID);
     if (window != null) {
       window.setAvailable(true);
+
+      if (PropertiesComponent.getInstance(project).getBoolean(TOOL_WINDOW_VISIBLE_PROPERTY, false)) {
+        window.activate(null, false);
+      }
     }
   }
 
@@ -33,5 +41,24 @@ public class PreviewViewFactory implements ToolWindowFactory, DumbAware {
   @Override
   public boolean shouldBeAvailable(@NotNull Project project) {
     return false;
+  }
+
+  /**
+   * Helps to initialize tool window with the same visibility state as it was when the project was previously closed.
+   */
+  public static class PreviewViewListener implements ToolWindowManagerListener {
+    private final @NotNull Project myProject;
+
+    public PreviewViewListener(@NotNull Project project) {
+      myProject = project;
+    }
+
+    @Override
+    public void stateChanged(@NotNull ToolWindowManager toolWindowManager) {
+      ToolWindow toolWindow = toolWindowManager.getToolWindow(PreviewView.TOOL_WINDOW_ID);
+      if (toolWindow != null && toolWindow.isAvailable()) {
+        PropertiesComponent.getInstance(myProject).setValue(TOOL_WINDOW_VISIBLE_PROPERTY, toolWindow.isVisible(), false);
+      }
+    }
   }
 }

--- a/src/io/flutter/preview/PreviewViewFactory.java
+++ b/src/io/flutter/preview/PreviewViewFactory.java
@@ -14,6 +14,8 @@ import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowFactory;
 import com.intellij.openapi.wm.ToolWindowManager;
 import com.intellij.openapi.wm.ex.ToolWindowManagerListener;
+import io.flutter.performance.FlutterPerformanceView;
+import io.flutter.utils.ViewListener;
 import org.jetbrains.annotations.NotNull;
 
 public class PreviewViewFactory implements ToolWindowFactory, DumbAware {
@@ -43,22 +45,9 @@ public class PreviewViewFactory implements ToolWindowFactory, DumbAware {
     return false;
   }
 
-  /**
-   * Helps to initialize tool window with the same visibility state as it was when the project was previously closed.
-   */
-  public static class PreviewViewListener implements ToolWindowManagerListener {
-    private final @NotNull Project myProject;
-
+  public static class PreviewViewListener extends ViewListener {
     public PreviewViewListener(@NotNull Project project) {
-      myProject = project;
-    }
-
-    @Override
-    public void stateChanged(@NotNull ToolWindowManager toolWindowManager) {
-      ToolWindow toolWindow = toolWindowManager.getToolWindow(PreviewView.TOOL_WINDOW_ID);
-      if (toolWindow != null && toolWindow.isAvailable()) {
-        PropertiesComponent.getInstance(myProject).setValue(TOOL_WINDOW_VISIBLE_PROPERTY, toolWindow.isVisible(), false);
-      }
+      super(project, PreviewView.TOOL_WINDOW_ID, TOOL_WINDOW_VISIBLE_PROPERTY);
     }
   }
 }

--- a/src/io/flutter/utils/ViewListener.java
+++ b/src/io/flutter/utils/ViewListener.java
@@ -1,0 +1,31 @@
+package io.flutter.utils;
+
+import com.intellij.ide.util.PropertiesComponent;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.wm.ToolWindow;
+import com.intellij.openapi.wm.ToolWindowManager;
+import com.intellij.openapi.wm.ex.ToolWindowManagerListener;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Helps to initialize a tool window with the same visibility state as when the project was previously closed.
+ */
+public abstract class ViewListener implements ToolWindowManagerListener {
+  private final @NotNull Project project;
+  private final String toolWindowId;
+  private final String toolWindowVisibleProperty;
+
+  public ViewListener(@NotNull Project project, String toolWindowId, String toolWindowVisibleProperty) {
+    this.project = project;
+    this.toolWindowId = toolWindowId;
+    this.toolWindowVisibleProperty = toolWindowVisibleProperty;
+  }
+
+  @Override
+  public void stateChanged(@NotNull ToolWindowManager toolWindowManager) {
+    ToolWindow toolWindow = toolWindowManager.getToolWindow(toolWindowId);
+    if (toolWindow != null && toolWindow.isAvailable()) {
+      PropertiesComponent.getInstance(project).setValue(toolWindowVisibleProperty, toolWindow.isVisible(), false);
+    }
+  }
+}

--- a/src/io/flutter/utils/ViewListener.java
+++ b/src/io/flutter/utils/ViewListener.java
@@ -24,6 +24,7 @@ public abstract class ViewListener implements ToolWindowManagerListener {
   @Override
   public void stateChanged(@NotNull ToolWindowManager toolWindowManager) {
     ToolWindow toolWindow = toolWindowManager.getToolWindow(toolWindowId);
+    // We only make tool windows available once we've found a Flutter project, so we want to avoid setting the visible property until then.
     if (toolWindow != null && toolWindow.isAvailable()) {
       PropertiesComponent.getInstance(project).setValue(toolWindowVisibleProperty, toolWindow.isVisible(), false);
     }

--- a/src/io/flutter/view/FlutterViewFactory.java
+++ b/src/io/flutter/view/FlutterViewFactory.java
@@ -5,6 +5,7 @@
  */
 package io.flutter.view;
 
+import com.intellij.ide.util.PropertiesComponent;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.project.DumbAware;
@@ -13,9 +14,12 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowFactory;
 import com.intellij.openapi.wm.ToolWindowManager;
+import com.intellij.openapi.wm.ex.ToolWindowManagerListener;
 import org.jetbrains.annotations.NotNull;
 
 public class FlutterViewFactory implements ToolWindowFactory, DumbAware {
+  private static final String TOOL_WINDOW_VISIBLE_PROPERTY = "flutter.view.tool.window.visible";
+
   public static void init(@NotNull Project project) {
     project.getMessageBus().connect().subscribe(
       FlutterViewMessages.FLUTTER_DEBUG_TOPIC, (event) -> initFlutterView(project, event)
@@ -24,6 +28,10 @@ public class FlutterViewFactory implements ToolWindowFactory, DumbAware {
     final ToolWindow window = ToolWindowManager.getInstance(project).getToolWindow(FlutterView.TOOL_WINDOW_ID);
     if (window != null) {
       window.setAvailable(true);
+
+      if (PropertiesComponent.getInstance(project).getBoolean(TOOL_WINDOW_VISIBLE_PROPERTY, false)) {
+        window.activate(null, false);
+      }
     }
   }
 
@@ -45,5 +53,24 @@ public class FlutterViewFactory implements ToolWindowFactory, DumbAware {
     DumbService.getInstance(project).runWhenSmart(() -> {
       (ServiceManager.getService(project, FlutterView.class)).initToolWindow(toolWindow);
     });
+  }
+
+  /**
+   * Helps to initialize tool window with the same visibility state as it was when the project was previously closed.
+   */
+  public static class FlutterViewListener implements ToolWindowManagerListener {
+    private final @NotNull Project myProject;
+
+    public FlutterViewListener(@NotNull Project project) {
+      myProject = project;
+    }
+
+    @Override
+    public void stateChanged(@NotNull ToolWindowManager toolWindowManager) {
+      ToolWindow toolWindow = toolWindowManager.getToolWindow(FlutterView.TOOL_WINDOW_ID);
+      if (toolWindow != null && toolWindow.isAvailable()) {
+        PropertiesComponent.getInstance(myProject).setValue(TOOL_WINDOW_VISIBLE_PROPERTY, toolWindow.isVisible(), false);
+      }
+    }
   }
 }

--- a/src/io/flutter/view/FlutterViewFactory.java
+++ b/src/io/flutter/view/FlutterViewFactory.java
@@ -14,7 +14,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowFactory;
 import com.intellij.openapi.wm.ToolWindowManager;
-import com.intellij.openapi.wm.ex.ToolWindowManagerListener;
+import io.flutter.utils.ViewListener;
 import org.jetbrains.annotations.NotNull;
 
 public class FlutterViewFactory implements ToolWindowFactory, DumbAware {
@@ -55,22 +55,9 @@ public class FlutterViewFactory implements ToolWindowFactory, DumbAware {
     });
   }
 
-  /**
-   * Helps to initialize tool window with the same visibility state as it was when the project was previously closed.
-   */
-  public static class FlutterViewListener implements ToolWindowManagerListener {
-    private final @NotNull Project myProject;
-
+  public static class FlutterViewListener extends ViewListener {
     public FlutterViewListener(@NotNull Project project) {
-      myProject = project;
-    }
-
-    @Override
-    public void stateChanged(@NotNull ToolWindowManager toolWindowManager) {
-      ToolWindow toolWindow = toolWindowManager.getToolWindow(FlutterView.TOOL_WINDOW_ID);
-      if (toolWindow != null && toolWindow.isAvailable()) {
-        PropertiesComponent.getInstance(myProject).setValue(TOOL_WINDOW_VISIBLE_PROPERTY, toolWindow.isVisible(), false);
-      }
+      super(project, FlutterView.TOOL_WINDOW_ID, TOOL_WINDOW_VISIBLE_PROPERTY);
     }
   }
 }


### PR DESCRIPTION
Follow up to https://github.com/flutter/flutter-intellij/pull/5622

We want to save the state of whether a tool window is open or closed between project open and close (the previous change made it so that tool windows were always closed/not "activated" on project open since the tool windows would all be newly available).

This change can be tested by:
1. Open a Flutter project
2. Open one of the Flutter tool windows
3. Close the project
4. Reopen the project -> the previously opened Flutter tool window should be opened again once the project is loaded.