### PR TITLE
Make reanalyze() work after packages are removed from icon package list

### DIFF
--- a/src/io/flutter/editor/FlutterIconLineMarkerProvider.java
+++ b/src/io/flutter/editor/FlutterIconLineMarkerProvider.java
@@ -51,6 +51,11 @@ public class FlutterIconLineMarkerProvider extends LineMarkerProviderDescriptor 
   private static final Logger LOG = Logger.getInstance(FlutterIconLineMarkerProvider.class);
 
   static {
+    initialize();
+  }
+
+  public static void initialize() {
+    KnownPaths.clear();
     KnownPaths.put("Icons", new THashSet<>(Collections.singleton("packages/flutter/lib/src/material")));
     KnownPaths.put("IconData", new THashSet<>(Collections.singleton("packages/flutter/lib/src/widgets")));
     KnownPaths.put("CupertinoIcons", new THashSet<>(Collections.singleton("packages/flutter/lib/src/cupertino")));


### PR DESCRIPTION
I added a lot of logging that I'm not sure I want to keep. The main thing is to clear KnownPaths.

The issue was that the icons were not disappearing after an icon package was removed from preferences.