### PR TITLE
Allow slow op for 2021.2

### DIFF
--- a/src/io/flutter/font/FontPreviewProcessor.java
+++ b/src/io/flutter/font/FontPreviewProcessor.java
@@ -7,7 +7,6 @@ package io.flutter.font;
 
 import com.intellij.openapi.application.Application;
 import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
 import com.intellij.openapi.project.ProjectManagerListener;
@@ -80,9 +79,11 @@ public class FontPreviewProcessor {
     });
     final String packagesText = FlutterSettings.getInstance().getFontPackages();
     final String[] packages = packagesText.split(PACKAGE_SEPARATORS);
-    for (String pack : packages) {
-      findFontClasses(project, pack.trim());
-    }
+    //com.intellij.util.SlowOperations.allowSlowOperations(() -> { // 2021.2
+      for (String pack : packages) {
+        findFontClasses(project, pack.trim());
+      }
+    //}); //2021.2
   }
 
   private void clearProjectCaches(@NotNull Project project) {

--- a/tool/plugin/lib/edit.dart
+++ b/tool/plugin/lib/edit.dart
@@ -31,6 +31,18 @@ void checkAndClearAppliedEditCommands() {
 
 List<EditCommand> editCommands = [
   EditAndroidModuleLibraryManager(),
+  MultiSubst(
+    path: 'src/io/flutter/font/FontPreviewProcessor.java',
+    initials: [
+      '//com.intellij.util.SlowOperations.allowSlowOperations(() -> { // 2021.2',
+      '//}); //2021.2'
+    ],
+    replacements: [
+      'com.intellij.util.SlowOperations.allowSlowOperations(() -> { // 2021.2',
+      '}); //2021.2'
+    ],
+    versions: ['2021.2'],
+  ),
   Subst(
     path: 'src/io/flutter/editor/FlutterIconLineMarkerProvider.java',
     initial: '''


### PR DESCRIPTION
This avoids an error message in 2021.2. The refactoring I'm working on will eliminate the need for this hack.

TBR @helin24 