### PR TITLE
Add live template for `MediaQuery.of(context)`

### DIFF
--- a/resources/liveTemplates/flutter_miscellaneous.xml
+++ b/resources/liveTemplates/flutter_miscellaneous.xml
@@ -36,4 +36,9 @@
       <option name="DART_STATEMENT" value="true"/>
     </context>
   </template>
+  <template name="mdof" value="MediaQuery.of(context)" description="Create MediaQueryData from build context" toReformat="false" toShortenFQNames="true">
+    <context>
+      <option name="DART_STATEMENT" value="true"/>
+    </context>
+  </template>
 </templateSet>

--- a/resources/liveTemplates/mdof.txt
+++ b/resources/liveTemplates/mdof.txt
@@ -1,0 +1,1 @@
+MediaQuery.of(context)


### PR DESCRIPTION
I think this one deserves its own live template, it's probably used even more than `Theme.of(context)` due to the wider multi-platform support that Flutter now has.

Part of #3256