### PR TITLE
Ignore errors reported when Android Studio is launched

### DIFF
--- a/src/io/flutter/actions/OpenInAndroidStudioAction.java
+++ b/src/io/flutter/actions/OpenInAndroidStudioAction.java
@@ -230,13 +230,6 @@ public class OpenInAndroidStudioAction extends AnAction {
       final ColoredProcessHandler handler = new ColoredProcessHandler(cmd);
       handler.addProcessListener(new ProcessAdapter() {
         @Override
-        public void onTextAvailable(@NotNull ProcessEvent event, @NotNull Key outputType) {
-          if (ProcessOutputType.isStderr(outputType)) {
-            LOG.error(event.getText());
-          }
-        }
-
-        @Override
         public void processTerminated(@NotNull final ProcessEvent event) {
           if (event.getExitCode() != 0) {
             FlutterMessages.showError("Error Opening", projectPath, project);


### PR DESCRIPTION
These errors are getting logged, and there's nothing we can do about them, so let's stop logging them.
```java
java.lang.Throwable: 2021-08-22 18:16:31,068 [  11060]   WARN - Container.ComponentManagerImpl - Do not use constructor injection (requestorClass=com.android.tools.idea.AndroidInitialConfigurator) 

	at c.i.o.diagnostic.Logger.error(Logger.java:182)
	at io.flutter.actions.OpenInAndroidStudioAction$1.onTextAvailable(OpenInAndroidStudioAction.java:235)```

@jwren