### PR TITLE
Convert pack to iml-based project

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/flutter-intellij.iml" filepath="$PROJECT_DIR$/flutter-intellij.iml" />
+    </modules>
+  </component>
+</project>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,14 @@ file.
     - `flutter pub get`
     - `flutter doctor`
     - `flutter run`
+* Fork `https://github.com/flutter/flutter-intellij` into your own GitHub account. 
+  If you already have a fork, and are now installing a development environment on a new machine,
+  make sure you've updated your fork so that you don't use stale configuration options from long ago.
+* `git clone git@github.com:<your_name_here>/flutter-intellij.git`
+* `cd flutter-intellij`
+* `git remote add origin git@github.com:flutter/flutter-intellij.git`
+  (So that you fetch from the master repository, not your clone, when running git fetch et al.)
+  The name `origin` can be whatever you want
 
 ## Flutter plugin development on MacOS and Linux
 
@@ -48,30 +56,29 @@ file.
       - plugins/yaml/lib/yaml.jar
 * In the "Java Compiler" preference page, make sure that the "Project bytecode version" is set to `11` or `Same as language level`
 * In the "Kotlin Compiler" preference page, make sure that the "Target JVM Version" is set to `11` or `Same as language level`
-* One-time Dart plugin install - first-time a new IDE is installed and run you will need to install the Dart plugin. 
-  Find `Plugins` (in Settings/Preferences) and install the Dart plugin, then restart the IDE
-* Open flutter-intellij project in IntelliJ (select and open the directory of the flutter-intellij repository).
-  Note that as of version 60 the project must be opened as a Gradle project. Wait for Gradle sync to complete.
-  - Create an external tool named Provision. See the section below named `Provision Tool`
+* One-time Dart plugin install - first-time a new IDE is installed and run you will need to install the Dart plugin
+  - Find `Plugins` (in Settings/Preferences) and install the Dart plugin, then restart the IDE
+* Open the flutter-intellij project in IntelliJ (select and open the directory of the flutter-intellij repository).
+  - If you see a popup with "Gradle build scripts found", please "Skip" or ignore it since the project cannot be imported as a gradle project
   - Build the project using `Build` | `Build Project`
 * Run the tests from the command line:
   - `cd path/to/flutter-intellij`
   - `bin/plugin test`
-* Try running the plugin; there is an existing launch config for "Flutter IntelliJ". This should open the "runtime workbench", 
+* Try running the plugin; there is an existing launch config for "Flutter Plugin". This should open the "runtime workbench", 
   a new instance of IntelliJ with the plugin installed.
 * If the Flutter Plugin doesn't load (Dart code or files are unknown) see above "One-time Dart plugin install"
+  - Install the Dart plugin, exit, and launch again
 * Verify installation of the Flutter plugin:
-  - Select `Flutter Plugin` in the Run Configuration drop-down list.
-  - Click Debug button (to the right of that drop-down).
-  - In the new IntelliJ process that spawns, open the `path/to/flutter/examples/hello_world` project.
-  - Choose Edit Configuration in the Run Configuration drop-down list.
-  - Expand Defaults and verify that Flutter is present.
-  - Click [+] and verify that Flutter is present.
-* Note that as of version 60 the old `src` and `testSrc` trees in the root directory are no longer usable.
-  Edit code using the files in the `flutter-idea` and `flutter-studio` modules instead.
-  This change had to be made to allow debugging of tests in the IDE.
+  - Select `Flutter Plugin` in the Run Configuration drop-down list
+  - Click Debug button (to the right of that drop-down)
+  - In the new IntelliJ process that spawns, open the `path/to/flutter/examples/hello_world` project
+  - Choose `Edit Configurations...` in the Run Configuration drop-down list
+  - Expand `Edit configuration templates...` and verify that Flutter is present
+  - Click [+] and verify that Flutter is present
 
 ## Provision Tool
+
+This is not currently required. However, for debugging unit tests it may be handy; please ignore for now.
 
 The Gradle build script currently assumes that some dependencies are present in the `artifacts` directory.
 This project uses an External Tool in IntelliJ to ensure the dependencies are present. It appears that
@@ -138,7 +145,7 @@ creating a project.
 - Shut it down.
 
 - In Project Structure, import the module `flutter-intellij`
-  - *It must be imported as a Gradle module.*
+  - *Do not import it as a Gradle module.*
 - Add a dependency to it to `intellij.idea.community.main` using Project Structure
 - Move it above Dart-community. This sets the class path to use the Flutter plugin
 version of some code duplicated from the Dart plugin.
@@ -152,6 +159,10 @@ version of some code duplicated from the Dart plugin.
 ## Running plugin tests
 
 ### Using test run configurations in IntelliJ
+
+The IntelliJ test framework now requires unit tests to be run in a Gradle project. It is possible to
+import `flutter-intellij` as a Gradle project, but it is difficult, and not covered here. Instead,
+run tests using the plugin tool, as described below.
 
 The repository contains two pre-defined test run configurations. One is for "unit" tests; that is
 currently defined as tests that do not rely on the IntelliJ UI APIs. The other is for "integration"
@@ -187,6 +198,8 @@ It is also possible to run tests directly with Gradle, which would allow passing
 
 If you wanted to run a subset of the tests you could do so this way. See the 
 [Gradle docs](https://docs.gradle.org/current/userguide/java_testing.html) for more info about testing.
+*However*, you must have run the tests once using the plugin tool, to ensure all the dependencies have
+been configured.
 
 ## Adding platform sources
 Sometimes browsing the source code of IntelliJ is helpful for understanding platform details that aren't documented.
@@ -210,9 +223,9 @@ Sometimes browsing the source code of IntelliJ is helpful for understanding plat
 4. Checkout Dart plugin sources.
 5. Using the Project Structure editor, import
     - intellij-plugins/Dart/Dart-community.iml
-    - flutter-intellij -- Select the directory and choose `Import module from external model` and select `Gradle`
-6. In the Gradle tool window, click the refresh icon (top left) to ensure all Gradle modules are loaded properly
-7. Using the Project Structure editor, select the `studio` module and add a module dependency to all modules that begin with `flutter`
+    - flutter-intellij
+6. Using the Project Structure editor, select the `studio` module and add a module dependency to all modules
+   that begin with `flutter`, plus `Dart` (make sure `Dart` is at the bottom of the list)
 
 ## Working with Embedded DevTools (JxBrowser)
 

--- a/flutter-intellij-community.iml
+++ b/flutter-intellij-community.iml
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PLUGIN_MODULE" version="4">
+  <component name="DevKit.ModuleBuildProperties" url="file://$MODULE_DIR$/resources/META-INF/plugin.xml" />
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/testSrc/unit" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/testSrc/integration" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/resources" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/gen" isTestSource="false" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/third_party/intellij-plugins-dart/testSrc" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/third_party/vmServiceDrivers" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/testData" type="java-test-resource" />
+      <excludeFolder url="file://$MODULE_DIR$/.dart_tool" />
+      <excludeFolder url="file://$MODULE_DIR$/.pub" />
+      <excludeFolder url="file://$MODULE_DIR$/artifacts" />
+      <excludeFolder url="file://$MODULE_DIR$/build" />
+      <excludeFolder url="file://$MODULE_DIR$/flutter-idea" />
+      <excludeFolder url="file://$MODULE_DIR$/flutter-idea/testData/sample_tests/.dart_tool" />
+      <excludeFolder url="file://$MODULE_DIR$/flutter-idea/testData/sample_tests/.pub" />
+      <excludeFolder url="file://$MODULE_DIR$/flutter-idea/testData/sample_tests/build" />
+      <excludeFolder url="file://$MODULE_DIR$/flutter-idea/testData/sample_tests/test" />
+      <excludeFolder url="file://$MODULE_DIR$/out/production/flutter-intellij/.dart_tool" />
+      <excludeFolder url="file://$MODULE_DIR$/out/production/flutter-intellij/.pub" />
+      <excludeFolder url="file://$MODULE_DIR$/out/production/flutter-intellij/build" />
+      <excludeFolder url="file://$MODULE_DIR$/out/test/flutter-intellij/sample_tests/.dart_tool" />
+      <excludeFolder url="file://$MODULE_DIR$/out/test/flutter-intellij/sample_tests/.pub" />
+      <excludeFolder url="file://$MODULE_DIR$/out/test/flutter-intellij/sample_tests/build" />
+      <excludeFolder url="file://$MODULE_DIR$/src/main" />
+      <excludeFolder url="file://$MODULE_DIR$/testData" />
+      <excludeFolder url="file://$MODULE_DIR$/testData/sample_tests/.dart_tool" />
+      <excludeFolder url="file://$MODULE_DIR$/testData/sample_tests/.pub" />
+      <excludeFolder url="file://$MODULE_DIR$/testData/sample_tests/build" />
+      <excludeFolder url="file://$MODULE_DIR$/tool/icon_generator/.dart_tool" />
+      <excludeFolder url="file://$MODULE_DIR$/tool/icon_generator/.pub" />
+      <excludeFolder url="file://$MODULE_DIR$/tool/icon_generator/build" />
+      <excludeFolder url="file://$MODULE_DIR$/tool/plugin/.dart_tool" />
+      <excludeFolder url="file://$MODULE_DIR$/tool/plugin/.pub" />
+      <excludeFolder url="file://$MODULE_DIR$/tool/plugin/build" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="module" module-name="intellij.platform.ide" />
+    <orderEntry type="module" module-name="intellij.platform.lang" />
+    <orderEntry type="module" module-name="intellij.platform.lang.impl" />
+    <orderEntry type="module" module-name="intellij.platform.debugger" />
+    <orderEntry type="module" module-name="intellij.platform.debugger.impl" />
+    <orderEntry type="module" module-name="intellij.platform.externalSystem.impl" />
+    <orderEntry type="module" module-name="intellij.platform.externalSystem.rt" />
+    <orderEntry type="module" module-name="intellij.platform.testFramework" scope="TEST" />
+    <orderEntry type="library" name="Velocity" level="project" />
+    <orderEntry type="module" module-name="intellij.platform.smRunner" />
+    <orderEntry type="module" module-name="intellij.xml.impl" />
+    <orderEntry type="module" module-name="intellij.java.ui" />
+    <orderEntry type="module" module-name="intellij.java.psi.impl" />
+    <orderEntry type="module-library">
+      <library>
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/lib/dart-plugin/deps/weberknecht-0.1.5.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library">
+      <library name="org.apache.commons:commons-lang3:3.9" type="repository">
+        <properties maven-id="org.apache.commons:commons-lang3:3.9" />
+        <CLASSES>
+          <root url="jar://$MAVEN_REPOSITORY$/org/apache/commons/commons-lang3/3.9/commons-lang3-3.9.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES>
+          <root url="jar://$MAVEN_REPOSITORY$/org/apache/commons/commons-lang3/3.9/commons-lang3-3.9-sources.jar!/" />
+        </SOURCES>
+      </library>
+    </orderEntry>
+    <orderEntry type="library" exported="" name="Dart SDK" level="project" />
+    <orderEntry type="module" module-name="intellij.android.core" />
+    <orderEntry type="module" module-name="intellij.platform.externalSystem" />
+    <orderEntry type="module" module-name="intellij.gradle.common" />
+    <orderEntry type="module" module-name="intellij.java.compiler.impl" />
+    <orderEntry type="module" module-name="intellij.platform.serviceContainer" />
+    <orderEntry type="library" name="snakeyaml" level="project" />
+    <orderEntry type="library" name="miglayout-swing" level="project" />
+    <orderEntry type="library" name="commons-io" level="project" />
+    <orderEntry type="library" name="com.android.tools:common" level="project" />
+    <orderEntry type="library" name="studio-analytics-proto" level="project" />
+    <orderEntry type="library" name="protobuf" level="project" />
+    <orderEntry type="library" name="com.android.tools.analytics-library:protos" level="project" />
+    <orderEntry type="module" module-name="intellij.android.gradle.dsl" />
+    <orderEntry type="module" module-name="intellij.android.projectSystem" />
+    <orderEntry type="library" name="Trove4j" level="project" />
+    <orderEntry type="module" module-name="intellij.android.observable" />
+    <orderEntry type="library" name="jxbrowser-7.17" level="project" />
+    <orderEntry type="module-library">
+      <library>
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/lib/jxbrowser/jxbrowser-7.17.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library">
+      <library>
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/lib/jxbrowser/jxbrowser-swing-7.17.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+    <orderEntry type="library" name="Trove4j" level="project" />
+    <orderEntry type="module" module-name="intellij.android.observable" />
+    <orderEntry type="library" name="jxbrowser-7.17" level="project" />
+    <orderEntry type="library" name="studio-plugin-git4idea" level="project" />
+    <orderEntry type="library" name="studio-plugin-yaml" level="project" />
+    <orderEntry type="library" name="studio-plugin-gradle" level="project" />
+    <orderEntry type="library" name="studio-sdk" level="project" />
+    <orderEntry type="module-library">
+      <library>
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/lib/dart-plugin/deps/json.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library">
+      <library>
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/lib/dart-plugin/203.6912/Dart.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+    <orderEntry type="module" module-name="intellij.vcs.git.rt" />
+    <orderEntry type="module" module-name="intellij.platform.vcs" />
+    <orderEntry type="module" module-name="intellij.vcs.git" />
+    <orderEntry type="module" module-name="intellij.platform.ide.util.io" />
+    <orderEntry type="module" module-name="intellij.platform.core.ui" />
+    <orderEntry type="module" module-name="intellij.platform.util.classLoader" />
+    <orderEntry type="module" module-name="intellij.platform.coverage" />
+    <orderEntry type="module" module-name="intellij.android.common" />
+    <orderEntry type="library" name="KotlinJavaRuntime" level="project" />
+    <orderEntry type="module-library" scope="RUNTIME">
+      <library>
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/lib/dart-plugin/203.6912/resources_en.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+        <jarDirectory url="jar://$MODULE_DIR$/lib/dart-plugin/203.6912/resources_en.jar!/" recursive="false" />
+      </library>
+    </orderEntry>
+    <orderEntry type="library" name="Dart Packages" level="project" />
+    <orderEntry type="library" name="java-string-similarity-2.0.0" level="project" />
+    <orderEntry type="module" module-name="intellij.yaml" />
+    <orderEntry type="library" name="mockito" level="project" />
+  </component>
+</module>

--- a/flutter-intellij.iml
+++ b/flutter-intellij.iml
@@ -15,6 +15,7 @@
       <sourceFolder url="file://$MODULE_DIR$/testData" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/tool/icon_generator" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/tool/icon_generator/lib" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/tool/plugin/lib" isTestSource="false" />
       <excludeFolder url="file://$MODULE_DIR$/.dart_tool" />
       <excludeFolder url="file://$MODULE_DIR$/.pub" />
       <excludeFolder url="file://$MODULE_DIR$/.sandbox" />
@@ -35,6 +36,8 @@
       <excludeFolder url="file://$MODULE_DIR$/tool/plugin/.pub" />
       <excludeFolder url="file://$MODULE_DIR$/tool/plugin/build" />
       <excludeFolder url="file://$MODULE_DIR$/tool/plugin/.dart_tool" />
+      <excludeFolder url="file://$MODULE_DIR$/.gradle" />
+      <excludeFolder url="file://$MODULE_DIR$/flutter-studio/src/main" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/flutter-intellij.iml
+++ b/flutter-intellij.iml
@@ -1,4 +1,127 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module version="4">
+<module type="PLUGIN_MODULE" version="4">
   <component name="DevKit.ModuleBuildProperties" url="file://$MODULE_DIR$/resources/META-INF/plugin.xml" />
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/resources" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/gen" isTestSource="false" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/third_party/intellij-plugins-dart/testSrc" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/third_party/vmServiceDrivers" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/testSrc/unit" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/testSrc/integration" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/third_party/analysisServer/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/testData" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/tool/icon_generator" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/tool/icon_generator/lib" isTestSource="false" />
+      <excludeFolder url="file://$MODULE_DIR$/.dart_tool" />
+      <excludeFolder url="file://$MODULE_DIR$/.pub" />
+      <excludeFolder url="file://$MODULE_DIR$/.sandbox" />
+      <excludeFolder url="file://$MODULE_DIR$/artifacts" />
+      <excludeFolder url="file://$MODULE_DIR$/build" />
+      <excludeFolder url="file://$MODULE_DIR$/flutter-idea" />
+      <excludeFolder url="file://$MODULE_DIR$/flutter-idea/testData/sample_tests/.dart_tool" />
+      <excludeFolder url="file://$MODULE_DIR$/flutter-idea/testData/sample_tests/.pub" />
+      <excludeFolder url="file://$MODULE_DIR$/flutter-idea/testData/sample_tests/build" />
+      <excludeFolder url="file://$MODULE_DIR$/material-design-icons" />
+      <excludeFolder url="file://$MODULE_DIR$/releases" />
+      <excludeFolder url="file://$MODULE_DIR$/src/main" />
+      <excludeFolder url="file://$MODULE_DIR$/testData" />
+      <excludeFolder url="file://$MODULE_DIR$/testData/sample_tests/.dart_tool" />
+      <excludeFolder url="file://$MODULE_DIR$/testData/sample_tests/.pub" />
+      <excludeFolder url="file://$MODULE_DIR$/testData/sample_tests/build" />
+      <excludeFolder url="file://$MODULE_DIR$/tool/icon_generator" />
+      <excludeFolder url="file://$MODULE_DIR$/tool/plugin/.pub" />
+      <excludeFolder url="file://$MODULE_DIR$/tool/plugin/build" />
+      <excludeFolder url="file://$MODULE_DIR$/tool/plugin/.dart_tool" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="module-library" scope="PROVIDED">
+      <library>
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/lib/dart-plugin/203.6912/Dart.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library" scope="PROVIDED">
+      <library>
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/lib/dart-plugin/203.6912/resources_en.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+        <jarDirectory url="jar://$MODULE_DIR$/lib/dart-plugin/203.6912/resources_en.jar!/" recursive="false" />
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library" scope="PROVIDED">
+      <library>
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/lib/dart-plugin/deps/json.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library" scope="PROVIDED">
+      <library>
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/lib/dart-plugin/deps/weberknecht-0.1.5.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library">
+      <library name="org.apache.commons:commons-lang3:3.9" type="repository">
+        <properties maven-id="org.apache.commons:commons-lang3:RELEASE" />
+        <CLASSES>
+          <root url="jar://$MAVEN_REPOSITORY$/org/apache/commons/commons-lang3/3.12.0/commons-lang3-3.12.0.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library">
+      <library>
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/lib/jxbrowser/jxbrowser-7.17.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library">
+      <library>
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/lib/jxbrowser/jxbrowser-swing-7.17.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+    <orderEntry type="library" name="Dart SDK" level="project" />
+    <orderEntry type="module" module-name="intellij.platform.externalSystem" />
+    <orderEntry type="module" module-name="intellij.gradle.common" />
+    <orderEntry type="module" module-name="intellij.java.compiler.impl" />
+    <orderEntry type="module" module-name="plugin" />
+    <orderEntry type="module" module-name="intellij.platform.serviceContainer" />
+    <orderEntry type="library" name="com.android.tools:common" level="project" />
+    <orderEntry type="library" name="studio-analytics-proto" level="project" />
+    <orderEntry type="library" name="protobuf" level="project" />
+    <orderEntry type="library" name="com.android.tools.analytics-library:protos" level="project" />
+    <orderEntry type="library" name="com.android.tools:common:26.5.0" level="project" />
+    <orderEntry type="library" name="com.android.tools.analytics-library:protos:25.3.0" level="project" />
+    <orderEntry type="library" name="android" level="project" />
+    <orderEntry type="library" name="com.android.tools.build:gradle:3.6.0-alpha09" level="project" />
+    <orderEntry type="library" name="gradle-common" level="project" />
+    <orderEntry type="library" name="com.google.protobuf:protobuf-java:3.5.1" level="project" />
+    <orderEntry type="library" name="KotlinJavaRuntime" level="project" />
+    <orderEntry type="library" name="Dart Packages" level="project" />
+    <orderEntry type="library" name="java-string-similarity-2.0.0" level="project" />
+    <orderEntry type="library" name="org.mockito:mockito-core:2.2.2" level="project" />
+  </component>
 </module>

--- a/flutter-studio/flutter-studio.iml
+++ b/flutter-studio/flutter-studio.iml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/testSrc/unit" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/resources" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/testData" type="java-test-resource" />
+      <excludeFolder url="file://$MODULE_DIR$/src/main/java/io/flutter" />
+      <excludeFolder url="file://$MODULE_DIR$/testSrc/config" />
+      <excludeFolder url="file://$MODULE_DIR$/testSrc/failures" />
+      <excludeFolder url="file://$MODULE_DIR$/testSrc/system" />
+      <excludeFolder url="file://$MODULE_DIR$/build" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="module" module-name="intellij.android.adt.branding" />
+    <orderEntry type="module" module-name="intellij.android.core" />
+    <orderEntry type="module" module-name="intellij.android.wizard" />
+    <orderEntry type="module" module-name="intellij.android.wizard.model" />
+    <orderEntry type="module" module-name="intellij.xml.dom" />
+    <orderEntry type="module" module-name="intellij.android.adt.ui" />
+    <orderEntry type="module" module-name="intellij.android.adt.ui.model" />
+    <orderEntry type="module" module-name="intellij.android.observable" />
+    <orderEntry type="module" module-name="intellij.android.observable.ui" />
+    <orderEntry type="module" module-name="intellij.platform.ide" />
+    <orderEntry type="module" module-name="intellij.platform.lang" />
+    <orderEntry type="module" module-name="intellij.platform.lang.impl" />
+    <orderEntry type="module" module-name="intellij.platform.debugger" />
+    <orderEntry type="module" module-name="intellij.java.ui" />
+    <orderEntry type="module" module-name="intellij.java.impl" />
+    <orderEntry type="module" module-name="intellij.gradle" />
+    <orderEntry type="module" module-name="android.sdktools.flags" />
+    <orderEntry type="module" module-name="intellij.platform.testFramework" scope="TEST" />
+    <orderEntry type="module" module-name="intellij.android.guiTestFramework" scope="TEST" />
+    <orderEntry type="module" module-name="intellij.android.testFramework" scope="TEST" />
+    <orderEntry type="module" module-name="intellij.platform.externalSystem.rt" scope="TEST" />
+    <orderEntry type="module" module-name="intellij.android.designer" scope="TEST" />
+    <orderEntry type="library" scope="TEST" name="truth" level="project" />
+    <orderEntry type="module" module-name="flutter-intellij-community" />
+    <orderEntry type="module" module-name="intellij.android.common" />
+    <orderEntry type="module" module-name="intellij.android.projectSystem" />
+    <orderEntry type="module" module-name="intellij.android.projectSystem.gradle" />
+    <orderEntry type="module" module-name="intellij.android.profilers" />
+    <orderEntry type="module" module-name="intellij.android.profilers.ui" />
+    <orderEntry type="module" module-name="intellij.javascript.protocolModelGenerator" />
+    <orderEntry type="module" module-name="intellij.android.artwork" />
+    <orderEntry type="module" module-name="intellij.java" />
+    <orderEntry type="library" name="protobuf" level="project" />
+    <orderEntry type="module" module-name="intellij.android.projectSystem.tests" />
+    <orderEntry type="library" name="com.android.tools:common" level="project" />
+    <orderEntry type="library" name="com.android.tools:repository" level="project" />
+    <orderEntry type="library" name="studio-analytics-proto" level="project" />
+    <orderEntry type="module" module-name="intellij.groovy.psi" />
+    <orderEntry type="module" module-name="intellij.java.debugger.impl" />
+    <orderEntry type="module" module-name="intellij.platform.serviceContainer" />
+    <orderEntry type="module" module-name="fest-swing" />
+    <orderEntry type="module" module-name="android.sdktools.testutils" />
+    <orderEntry type="module" module-name="intellij.android.gradle.dsl" />
+    <orderEntry type="module" module-name="intellij.android.projectSystem.gradle.psd" />
+    <orderEntry type="module" module-name="intellij.android.deploy" />
+    <orderEntry type="module" module-name="assistant" />
+    <orderEntry type="library" name="studio-sdk" level="project" />
+    <orderEntry type="library" name="studio-plugin-gradle" level="project" />
+    <orderEntry type="module-library">
+      <library>
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/../lib/dart-plugin/203.6912/Dart.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+    <orderEntry type="module" module-name="intellij.android.assistant" />
+    <orderEntry type="module" module-name="intellij.platform.core.ui" />
+    <orderEntry type="module" module-name="intellij.platform.ide.util.io" />
+    <orderEntry type="library" name="jaxb-api" level="project" />
+  </component>
+</module>

--- a/src/WRONG_TREE.md
+++ b/src/WRONG_TREE.md
@@ -1,4 +1,0 @@
-Do not use this path to edit or run code. Use `flutter-idea/src/main/java` instead.
-
-Some day we need to find a way to move the sources to their proper location without losing history.
-That's an exercise for another day.


### PR DESCRIPTION
This effectively reverts #5720. I have not had success creating a Gradle-based project, with an optional module, that can launch the runtime workbench. It did, however, run unit tests in the IDE.

We lose git history for the *.iml files, I think. I don't think that was very useful, anyway.

Fixes #5733 

@jwren