### PR TITLE
Make unit test name matching more strict

### DIFF
--- a/src/io/flutter/run/test/FlutterTestConfigProducer.java
+++ b/src/io/flutter/run/test/FlutterTestConfigProducer.java
@@ -17,6 +17,7 @@ import io.flutter.FlutterUtils;
 import io.flutter.dart.DartPlugin;
 import io.flutter.pub.PubRoot;
 import io.flutter.run.FlutterRunConfigurationProducer;
+import io.flutter.run.common.TestType;
 import io.flutter.sdk.FlutterSdk;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -59,8 +60,9 @@ public class FlutterTestConfigProducer extends RunConfigurationProducer<TestConf
 
     if (supportsFiltering(config.getSdk())) {
       final String testName = testConfigUtils.findTestName(elt);
-      if (testName != null) {
-        return setupForSingleTest(config, context, file, testName);
+      if (testName != null && elt != null) {
+        final boolean hasVariant = "testWidgets".equals(elt.getText());
+        return setupForSingleTest(config, context, file, testName, hasVariant);
       }
     }
 
@@ -71,11 +73,11 @@ public class FlutterTestConfigProducer extends RunConfigurationProducer<TestConf
     return sdk != null && sdk.getVersion().flutterTestSupportsFiltering();
   }
 
-  private boolean setupForSingleTest(TestConfig config, ConfigurationContext context, DartFile file, String testName) {
+  private boolean setupForSingleTest(TestConfig config, ConfigurationContext context, DartFile file, String testName, boolean hasVariant) {
     final VirtualFile testFile = verifyFlutterTestFile(config, context, file);
     if (testFile == null) return false;
 
-    config.setFields(TestFields.forTestName(testName, testFile.getPath()));
+    config.setFields(TestFields.forTestName(testName, testFile.getPath()).useRegexp(hasVariant));
     config.setGeneratedName();
 
     return true;

--- a/src/io/flutter/run/test/FlutterTestConfigProducer.java
+++ b/src/io/flutter/run/test/FlutterTestConfigProducer.java
@@ -17,7 +17,6 @@ import io.flutter.FlutterUtils;
 import io.flutter.dart.DartPlugin;
 import io.flutter.pub.PubRoot;
 import io.flutter.run.FlutterRunConfigurationProducer;
-import io.flutter.run.common.TestType;
 import io.flutter.sdk.FlutterSdk;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;

--- a/src/io/flutter/run/test/TestFields.java
+++ b/src/io/flutter/run/test/TestFields.java
@@ -61,12 +61,12 @@ public class TestFields {
     this.additionalArgs = additionalArgs;
   }
 
-  @VisibleForTesting
   public TestFields useRegexp(boolean useRegexp) {
     this.useRegexp = useRegexp;
     return this;
   }
 
+  @VisibleForTesting
   public boolean getUseRegexp() {
     return useRegexp;
   }

--- a/src/io/flutter/run/test/TestFields.java
+++ b/src/io/flutter/run/test/TestFields.java
@@ -5,6 +5,7 @@
  */
 package io.flutter.run.test;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configurations.RuntimeConfigurationError;
 import com.intellij.openapi.project.Project;
@@ -42,6 +43,7 @@ public class TestFields {
 
   @Nullable
   private String additionalArgs;
+  private boolean useRegexp = false;
 
   private TestFields(@Nullable String testName, @Nullable String testFile, @Nullable String testDir, @Nullable String additionalArgs) {
     if (testFile == null && testDir == null) {
@@ -59,8 +61,18 @@ public class TestFields {
     this.additionalArgs = additionalArgs;
   }
 
+  @VisibleForTesting
+  public TestFields useRegexp(boolean useRegexp) {
+    this.useRegexp = useRegexp;
+    return this;
+  }
+
+  public boolean getUseRegexp() {
+    return useRegexp;
+  }
+
   public TestFields copy() {
-    return new TestFields(testName, testFile, testDir, additionalArgs);
+    return new TestFields(testName, testFile, testDir, additionalArgs).useRegexp(useRegexp);
   }
 
   /**
@@ -208,6 +220,7 @@ public class TestFields {
     ElementIO.addOption(elt, "testName", testName);
     ElementIO.addOption(elt, "testFile", testFile);
     ElementIO.addOption(elt, "testDir", testDir);
+    ElementIO.addOption(elt, "useRegexp", useRegexp ? "true" : "false");
     ElementIO.addOption(elt, "additionalArgs", additionalArgs);
   }
 
@@ -221,9 +234,10 @@ public class TestFields {
     final String testName = options.get("testName");
     final String testFile = options.get("testFile");
     final String testDir = options.get("testDir");
+    final String useRegexp = options.get("useRegexp");
     final String additionalArgs = options.get("additionalArgs");
     try {
-      return new TestFields(testName, testFile, testDir, additionalArgs);
+      return new TestFields(testName, testFile, testDir, additionalArgs).useRegexp("true".equals(useRegexp));
     }
     catch (IllegalArgumentException e) {
       throw new InvalidDataException(e.getMessage());
@@ -263,7 +277,7 @@ public class TestFields {
     }
 
     final String args = adjustArgs(root, fileOrDir, project);
-    return sdk.flutterTest(root, fileOrDir, testName, mode, args, getScope()).startProcess(project);
+    return sdk.flutterTest(root, fileOrDir, testName, mode, args, getScope(), useRegexp).startProcess(project);
   }
 
   @Nullable

--- a/src/io/flutter/sdk/FlutterSdk.java
+++ b/src/io/flutter/sdk/FlutterSdk.java
@@ -20,6 +20,7 @@ import com.intellij.openapi.roots.libraries.LibraryTable;
 import com.intellij.openapi.roots.libraries.LibraryTablesRegistrar;
 import com.intellij.openapi.util.Key;
 import com.intellij.openapi.util.io.FileUtil;
+import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vcs.VcsException;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VfsUtil;
@@ -356,7 +357,7 @@ public class FlutterSdk {
   }
 
   public FlutterCommand flutterTest(@NotNull PubRoot root, @NotNull VirtualFile fileOrDir, @Nullable String testNameSubstring,
-                                    @NotNull RunMode mode, @Nullable String additionalArgs, TestFields.Scope scope) {
+                                    @NotNull RunMode mode, @Nullable String additionalArgs, TestFields.Scope scope, boolean useRegexp) {
 
     final List<String> args = new ArrayList<>();
     if (myVersion.flutterTestSupportsMachineMode()) {
@@ -380,8 +381,14 @@ public class FlutterSdk {
       if (!myVersion.flutterTestSupportsFiltering()) {
         throw new IllegalStateException("Flutter SDK is too old to select tests by name");
       }
-      args.add("--plain-name");
-      args.add(testNameSubstring);
+      if (useRegexp) {
+        args.add("--name");
+        args.add("^" + StringUtil.escapeToRegexp(testNameSubstring) + "( \\(variant: .*\\))?$");
+      }
+      else {
+        args.add("--plain-name");
+        args.add(testNameSubstring);
+      }
     }
 
     if (additionalArgs != null && !additionalArgs.trim().isEmpty()) {

--- a/testSrc/unit/io/flutter/run/test/TestFieldsTest.java
+++ b/testSrc/unit/io/flutter/run/test/TestFieldsTest.java
@@ -9,8 +9,7 @@ import io.flutter.run.test.TestFields.Scope;
 import org.jdom.Element;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.*;
 
 /**
  * Verifies that we can read and write test configurations.
@@ -61,6 +60,19 @@ public class TestFieldsTest {
     assertEquals(Scope.NAME, after.getScope());
     assertEquals("should work", after.getTestName());
     assertEquals("hello_test.dart", after.getTestFile());
+    assertNull(after.getTestDir());
+  }
+
+  @Test
+  public void roundTripShouldPreserveRegexpSettings() {
+    final Element elt = new Element("test");
+    TestFields.forTestName("should *", "hello_test.dart").useRegexp(true).writeTo(elt);
+
+    final TestFields after = TestFields.readFrom(elt);
+    assertEquals(Scope.NAME, after.getScope());
+    assertEquals("should *", after.getTestName());
+    assertEquals("hello_test.dart", after.getTestFile());
+    assertTrue(after.getUseRegexp());
     assertNull(after.getTestDir());
   }
 


### PR DESCRIPTION
This modifies how Flutter `testWidgets` unit tests are run when a run config is automatically created by clicking the 'Run' icon next to the test name in the editor. In this case, we should only run a single test.