### PR TITLE
Add the new skeleton template to the New Project Wizard

### DIFF
--- a/src/io/flutter/module/FlutterModuleBuilder.java
+++ b/src/io/flutter/module/FlutterModuleBuilder.java
@@ -5,8 +5,6 @@
  */
 package io.flutter.module;
 
-import static java.util.Arrays.asList;
-
 import com.intellij.execution.OutputListener;
 import com.intellij.execution.process.ProcessListener;
 import com.intellij.ide.util.projectWizard.ModuleBuilder;
@@ -16,11 +14,8 @@ import com.intellij.ide.util.projectWizard.WizardContext;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.application.WriteAction;
 import com.intellij.openapi.diagnostic.Logger;
-import com.intellij.openapi.module.ModifiableModuleModel;
 import com.intellij.openapi.module.Module;
-import com.intellij.openapi.module.ModuleManager;
-import com.intellij.openapi.module.ModuleType;
-import com.intellij.openapi.module.ModuleWithNameAlreadyExists;
+import com.intellij.openapi.module.*;
 import com.intellij.openapi.options.ConfigurationException;
 import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.project.Project;
@@ -44,16 +39,17 @@ import io.flutter.sdk.FlutterSdk;
 import io.flutter.sdk.FlutterSdkUtil;
 import io.flutter.utils.AndroidUtils;
 import io.flutter.utils.FlutterModuleUtils;
+import org.apache.commons.lang.StringUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.atomic.AtomicReference;
-import javax.swing.ComboBoxEditor;
-import javax.swing.Icon;
-import javax.swing.JComponent;
-import org.apache.commons.lang.StringUtils;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+
+import static java.util.Arrays.asList;
 
 public class FlutterModuleBuilder extends ModuleBuilder {
   private static final Logger LOG = Logger.getInstance(FlutterModuleBuilder.class);
@@ -337,7 +333,7 @@ public class FlutterModuleBuilder extends ModuleBuilder {
     return mySettingsFields;
   }
 
-  public static class FlutterModuleWizardStep extends ModuleWizardStep implements Disposable {
+  public class FlutterModuleWizardStep extends ModuleWizardStep implements Disposable {
     private final FlutterGeneratorPeer myPeer;
 
     public FlutterModuleWizardStep(@NotNull WizardContext context) {
@@ -359,6 +355,7 @@ public class FlutterModuleBuilder extends ModuleBuilder {
 
     @Override
     public void updateDataModel() {
+      mySettingsFields.updateProjectTypes();
     }
 
     @Override

--- a/src/io/flutter/module/FlutterProjectType.java
+++ b/src/io/flutter/module/FlutterProjectType.java
@@ -12,6 +12,7 @@ public enum FlutterProjectType {
   PLUGIN(FlutterBundle.message("flutter.module.create.settings.type.plugin"), "plugin", true),
   PACKAGE(FlutterBundle.message("flutter.module.create.settings.type.package"), "package", false),
   MODULE(FlutterBundle.message("flutter.module.create.settings.type.module"), "module", false),
+  SKELETON("Skeleton", "skeleton", false),
   IMPORT(FlutterBundle.message("flutter.module.create.settings.type.import_module"), "module", false);
 
   final public String title;

--- a/src/io/flutter/module/settings/FlutterCreateAdditionalSettingsFields.java
+++ b/src/io/flutter/module/settings/FlutterCreateAdditionalSettingsFields.java
@@ -15,15 +15,14 @@ import io.flutter.FlutterUtils;
 import io.flutter.module.FlutterProjectType;
 import io.flutter.sdk.FlutterCreateAdditionalSettings;
 import io.flutter.sdk.FlutterSdk;
-import java.awt.Component;
-import java.awt.Insets;
-import java.awt.event.ItemEvent;
-import java.util.function.Supplier;
-import javax.swing.JComponent;
-import javax.swing.JTextField;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
 import javax.swing.border.AbstractBorder;
 import javax.swing.event.DocumentEvent;
-import org.jetbrains.annotations.NotNull;
+import java.awt.*;
+import java.awt.event.ItemEvent;
+import java.util.function.Supplier;
 
 public class FlutterCreateAdditionalSettingsFields {
   private final FlutterCreateAdditionalSettings settings;
@@ -165,7 +164,18 @@ public class FlutterCreateAdditionalSettingsFields {
   }
 
   private boolean projectTypeHasPlatforms() {
-    return settings.getType() == FlutterProjectType.APP || settings.getType() == FlutterProjectType.PLUGIN;
+    final FlutterProjectType type = settings.getType();
+    if (type != null) {
+      switch (type) {
+        case APP:
+        case PLUGIN:
+        case SKELETON:
+          return true;
+        default:
+          return false;
+      }
+    }
+    return false;
   }
 
   public void updateProjectType(FlutterProjectType projectType) {
@@ -193,8 +203,11 @@ public class FlutterCreateAdditionalSettingsFields {
   private boolean shouldIncludePlatforms() {
     switch (projectTypeForm.getType()) {
       case APP: // fall through
-      case PLUGIN: return platformsForm.shouldBeVisible();
-      default: return false;
+      case SKELETON:
+      case PLUGIN:
+        return platformsForm.shouldBeVisible();
+      default:
+        return false;
     }
   }
 
@@ -210,5 +223,9 @@ public class FlutterCreateAdditionalSettingsFields {
 
   public boolean isShowingPlatforms() {
     return projectTypeHasPlatforms() && platformsForm.shouldBeVisible();
+  }
+
+  public void updateProjectTypes() {
+    projectTypeForm.updateProjectTypes();
   }
 }

--- a/src/io/flutter/module/settings/ProjectType.java
+++ b/src/io/flutter/module/settings/ProjectType.java
@@ -10,17 +10,15 @@ import io.flutter.FlutterBundle;
 import io.flutter.FlutterUtils;
 import io.flutter.module.FlutterProjectType;
 import io.flutter.sdk.FlutterSdk;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
 import java.awt.event.ItemListener;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.function.Supplier;
-import javax.swing.AbstractListModel;
-import javax.swing.ComboBoxModel;
-import javax.swing.JComponent;
-import javax.swing.JPanel;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 public class ProjectType {
   private static final class ProjectTypeComboBoxModel extends AbstractListModel<FlutterProjectType>
@@ -62,6 +60,16 @@ public class ProjectType {
       mySelected = item;
       fireContentsChanged(this, 0, getSize());
     }
+
+    void addSkeleton() {
+      if (!myList.contains(FlutterProjectType.SKELETON)) {
+        myList.add(FlutterProjectType.SKELETON);
+      }
+    }
+
+    void removeSkeleton() {
+      myList.remove(FlutterProjectType.SKELETON);
+    }
   }
 
   private Supplier<? extends FlutterSdk> getSdk;
@@ -80,7 +88,6 @@ public class ProjectType {
 
   private void createUIComponents() {
     projectTypeCombo = new ComboBox<>();
-    //noinspection unchecked
     projectTypeCombo.setModel(new ProjectTypeComboBoxModel());
     projectTypeCombo.setToolTipText(FlutterBundle.message("flutter.module.create.settings.type.tip"));
   }
@@ -104,5 +111,14 @@ public class ProjectType {
 
   public void addListener(ItemListener listener) {
     projectTypeCombo.addItemListener(listener);
+  }
+
+  public void updateProjectTypes() {
+    if (getSdk.get().getVersion().isSkeletonTemplateAvailable()) {
+      ((ProjectTypeComboBoxModel)projectTypeCombo.getModel()).addSkeleton();
+    }
+    else {
+      ((ProjectTypeComboBoxModel)projectTypeCombo.getModel()).removeSkeleton();
+    }
   }
 }

--- a/src/io/flutter/sdk/FlutterSdkVersion.java
+++ b/src/io/flutter/sdk/FlutterSdkVersion.java
@@ -58,6 +58,11 @@ public class FlutterSdkVersion implements Comparable<FlutterSdkVersion> {
    */
   private static final FlutterSdkVersion MIN_PASS_DEVTOOLS_SDK = new FlutterSdkVersion("1.26.0-11.0.pre");
 
+  /**
+   * The version that includes the skeleton template.
+   */
+  private static final FlutterSdkVersion MIN_SKELETON_TEMPLATE = new FlutterSdkVersion("2.5.0");
+
   @Nullable
   private final Version version;
   @Nullable
@@ -77,11 +82,13 @@ public class FlutterSdkVersion implements Comparable<FlutterSdkVersion> {
         betaVersion = Version.parseVersion(split[1]);
         final String[] parts = split[1].split("\\.");
         masterVersion = parts.length > 3 ? Integer.parseInt(parts[3]) : 0;
-      } else {
+      }
+      else {
         betaVersion = null;
         masterVersion = 0;
       }
-    } else {
+    }
+    else {
       version = null;
       betaVersion = null;
       masterVersion = 0;
@@ -173,6 +180,10 @@ public class FlutterSdkVersion implements Comparable<FlutterSdkVersion> {
     return version != null && version.compareTo(MIN_PUB_OUTDATED_SDK.version) >= 0;
   }
 
+  public boolean isSkeletonTemplateAvailable() {
+    return version != null && version.compareTo(MIN_SKELETON_TEMPLATE.version) >= 0;
+  }
+
   public boolean isValid() {
     return version != null;
   }
@@ -206,9 +217,11 @@ public class FlutterSdkVersion implements Comparable<FlutterSdkVersion> {
     // Check for beta version strings if standard versions are equivalent.
     if (betaVersion == null && otherVersion.betaVersion == null) {
       return 0;
-    } else if (betaVersion == null) {
+    }
+    else if (betaVersion == null) {
       return 1;
-    } else if (otherVersion.betaVersion == null) {
+    }
+    else if (otherVersion.betaVersion == null) {
       return -1;
     }
 
@@ -222,11 +235,14 @@ public class FlutterSdkVersion implements Comparable<FlutterSdkVersion> {
     // Otherwise, the version without a master version is further ahead.
     if (masterVersion != 0 && otherVersion.masterVersion != 0) {
       return Integer.compare(masterVersion, otherVersion.masterVersion);
-    } else if (masterVersion != 0) {
+    }
+    else if (masterVersion != 0) {
       return -1;
-    } else if (otherVersion.masterVersion != 0) {
+    }
+    else if (otherVersion.masterVersion != 0) {
       return 1;
-    } else {
+    }
+    else {
       return 0;
     }
   }

--- a/src/io/flutter/utils/FlutterModuleUtils.java
+++ b/src/io/flutter/utils/FlutterModuleUtils.java
@@ -257,7 +257,7 @@ public class FlutterModuleUtils {
     fields.setFilePath(main.getPath());
     config.setFields(fields);
 
-    settings.storeInDotIdeaFolder();
+    runManager.addConfiguration(settings);
     runManager.setSelectedConfiguration(settings);
   }
 


### PR DESCRIPTION
The change to FlutterModuleUtils fixes a problem I introduced last week. FlutterSdkVersion has a number of formatting changes, but I did add a method to check if the skeleton is available.