### PR TITLE
Make console stack traces expandable

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -384,8 +384,9 @@
 
     <applicationService serviceImplementation="io.flutter.jxbrowser.EmbeddedBrowserEngine" overrides="false" />
     <applicationService serviceImplementation="io.flutter.font.FontPreviewProcessor"/>
-    <console.folding implementation="io.flutter.console.FlutterConsoleFolding"/>
-    <console.folding implementation="io.flutter.logging.FlutterConsoleLogFolding"/>
+    <console.folding implementation="io.flutter.console.FlutterConsoleFolding" id="1"/>
+    <console.folding implementation="io.flutter.console.FlutterConsoleExceptionFolding" order="after 1"/>
+    <console.folding implementation="io.flutter.logging.FlutterConsoleLogFolding" order="last"/>
 
     <projectConfigurable groupId="language" instance="io.flutter.sdk.FlutterSettingsConfigurable"
                          id="flutter.settings" key="flutter.title" bundle="io.flutter.FlutterBundle" nonDefaultProject="true"/>

--- a/resources/META-INF/plugin_template.xml
+++ b/resources/META-INF/plugin_template.xml
@@ -310,8 +310,9 @@
 
     <applicationService serviceImplementation="io.flutter.jxbrowser.EmbeddedBrowserEngine" overrides="false" />
     <applicationService serviceImplementation="io.flutter.font.FontPreviewProcessor"/>
-    <console.folding implementation="io.flutter.console.FlutterConsoleFolding"/>
-    <console.folding implementation="io.flutter.logging.FlutterConsoleLogFolding"/>
+    <console.folding implementation="io.flutter.console.FlutterConsoleFolding" id="1"/>
+    <console.folding implementation="io.flutter.console.FlutterConsoleExceptionFolding" order="after 1"/>
+    <console.folding implementation="io.flutter.logging.FlutterConsoleLogFolding" order="last"/>
 
     <projectConfigurable groupId="language" instance="io.flutter.sdk.FlutterSettingsConfigurable"
                          id="flutter.settings" key="flutter.title" bundle="io.flutter.FlutterBundle" nonDefaultProject="true"/>

--- a/src/io/flutter/console/FlutterConsoleExceptionFolding.java
+++ b/src/io/flutter/console/FlutterConsoleExceptionFolding.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.console;
+
+import com.intellij.execution.ConsoleFolding;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.text.StringUtil;
+import io.flutter.settings.FlutterSettings;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+public class FlutterConsoleExceptionFolding extends ConsoleFolding {
+  private static final String EXCEPTION_PREFIX = "=======";
+  private boolean foldLines = false;
+  private boolean foldingInProgress = false;
+
+  @Override
+  public boolean shouldFoldLine(@NotNull Project project, @NotNull String line) {
+    final FlutterSettings settings = FlutterSettings.getInstance();
+    if (line.startsWith(EXCEPTION_PREFIX) && settings.isShowStructuredErrors() && !settings.isIncludeAllStackTraces()) {
+      foldingInProgress = true;
+      foldLines = !foldLines;
+      return true;
+    }
+    return foldLines;
+  }
+
+  @Override
+  public boolean shouldBeAttachedToThePreviousLine() {
+    return false;
+  }
+
+  @Nullable
+  @Override
+  public String getPlaceholderText(@NotNull Project project, @NotNull List<String> lines) {
+    if (foldingInProgress) {
+      foldingInProgress = false;
+      return lines.size() == 0 ? null : lines.get(0); // Newlines are removed, so we can only show one line.
+    }
+    return null;
+  }
+}


### PR DESCRIPTION
Fixes #5445 

If this is first in the list of foldings a stack trace collapses to a single line (the first line in the screen shot). If it is last, another folding may interfere. With it second in the list, a stack trace looks like this:
<img width="423" alt="Screen Shot 2021-09-27 at 2 30 52 PM" src="https://user-images.githubusercontent.com/8518285/134989023-88257e28-6483-4a71-8ae3-aaa22c810b4b.png">

That preserves the spirit of the structured stack traces option, I think, but we may need to iterate. If the option to include all stack traces is selected then no folding is done.
