### PR TITLE
Add null check for manager

### DIFF
--- a/src/io/flutter/FlutterUtils.java
+++ b/src/io/flutter/FlutterUtils.java
@@ -219,7 +219,11 @@ public class FlutterUtils {
   }
 
   private static boolean isInTestOrSourceRoot(Module module, @NotNull DartFile file) {
-    final ContentEntry[] entries = ModuleRootManager.getInstance(module).getContentEntries();
+    final ModuleRootManager manager = ModuleRootManager.getInstance(module);
+    if (manager == null) {
+      return false;
+    }
+    final ContentEntry[] entries = manager.getContentEntries();
     final VirtualFile virtualFile = file.getContainingFile().getVirtualFile();
     boolean foundSourceRoot = false;
     for (ContentEntry entry : entries) {


### PR DESCRIPTION
Fixes #5797 

Significant enough to warrant a point release. #getInstance is not annotated with either @Nullable or @NotNull, and I forgot that implicitly means it is @Nullable.

@jwren

Had to start over. All commits must be signed and the first one previously was not.