### PR TITLE
Update AS modules for 212

### DIFF
--- a/flutter-intellij-community.iml
+++ b/flutter-intellij-community.iml
@@ -15,7 +15,6 @@
       <sourceFolder url="file://$MODULE_DIR$/flutter-idea/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/flutter-idea/testSrc/unit" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/flutter-idea/third_party/vmServiceDrivers" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/flutter-studio/src" isTestSource="false" />
       <excludeFolder url="file://$MODULE_DIR$/.dart_tool" />
       <excludeFolder url="file://$MODULE_DIR$/.pub" />
       <excludeFolder url="file://$MODULE_DIR$/artifacts" />
@@ -54,6 +53,7 @@
       <excludeFolder url="file://$MODULE_DIR$/flutter-idea/testSrc/integration" />
       <excludeFolder url="file://$MODULE_DIR$/flutter-studio/testSrc" />
       <excludeFolder url="file://$MODULE_DIR$/flutter-studio/src/io/flutter/module" />
+      <excludeFolder url="file://$MODULE_DIR$/flutter-studio/src" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
@@ -123,5 +123,9 @@
     <orderEntry type="library" name="Dart" level="project" />
     <orderEntry type="module" module-name="intellij.android.wizard" />
     <orderEntry type="module" module-name="intellij.android.wizard.model" />
+    <orderEntry type="library" name="json" level="project" />
+    <orderEntry type="library" name="weberknecht-0.1.5" level="project" />
+    <orderEntry type="library" name="jxbrowser-7.19" level="project" />
+    <orderEntry type="library" name="jxbrowser-swing-7.19" level="project" />
   </component>
 </module>

--- a/flutter-studio/flutter-studio.iml
+++ b/flutter-studio/flutter-studio.iml
@@ -15,27 +15,16 @@
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="module" module-name="intellij.android.adt.branding" />
     <orderEntry type="module" module-name="intellij.android.core" />
     <orderEntry type="module" module-name="intellij.android.wizard" />
     <orderEntry type="module" module-name="intellij.android.wizard.model" />
-    <orderEntry type="module" module-name="intellij.xml.dom" />
     <orderEntry type="module" module-name="intellij.android.adt.ui" />
     <orderEntry type="module" module-name="intellij.android.adt.ui.model" />
     <orderEntry type="module" module-name="intellij.android.observable" />
     <orderEntry type="module" module-name="intellij.android.observable.ui" />
-    <orderEntry type="module" module-name="intellij.platform.ide" />
-    <orderEntry type="module" module-name="intellij.platform.lang" />
-    <orderEntry type="module" module-name="intellij.platform.lang.impl" />
-    <orderEntry type="module" module-name="intellij.platform.debugger" />
-    <orderEntry type="module" module-name="intellij.java.ui" />
-    <orderEntry type="module" module-name="intellij.java.impl" />
-    <orderEntry type="module" module-name="intellij.gradle" />
     <orderEntry type="module" module-name="android.sdktools.flags" />
-    <orderEntry type="module" module-name="intellij.platform.testFramework" scope="TEST" />
     <orderEntry type="module" module-name="intellij.android.guiTestFramework" scope="TEST" />
     <orderEntry type="module" module-name="intellij.android.testFramework" scope="TEST" />
-    <orderEntry type="module" module-name="intellij.platform.externalSystem.rt" scope="TEST" />
     <orderEntry type="module" module-name="intellij.android.designer" scope="TEST" />
     <orderEntry type="library" scope="TEST" name="truth" level="project" />
     <orderEntry type="module" module-name="flutter-intellij-community" />
@@ -44,17 +33,8 @@
     <orderEntry type="module" module-name="intellij.android.projectSystem.gradle" />
     <orderEntry type="module" module-name="intellij.android.profilers" />
     <orderEntry type="module" module-name="intellij.android.profilers.ui" />
-    <orderEntry type="module" module-name="intellij.javascript.protocolModelGenerator" />
     <orderEntry type="module" module-name="intellij.android.artwork" />
-    <orderEntry type="module" module-name="intellij.java" />
-    <orderEntry type="library" name="protobuf" level="project" />
-    <orderEntry type="module" module-name="intellij.android.projectSystem.tests" />
-    <orderEntry type="library" name="com.android.tools:common" level="project" />
-    <orderEntry type="library" name="com.android.tools:repository" level="project" />
     <orderEntry type="library" name="studio-analytics-proto" level="project" />
-    <orderEntry type="module" module-name="intellij.groovy.psi" />
-    <orderEntry type="module" module-name="intellij.java.debugger.impl" />
-    <orderEntry type="module" module-name="intellij.platform.serviceContainer" />
     <orderEntry type="module" module-name="fest-swing" />
     <orderEntry type="module" module-name="android.sdktools.testutils" />
     <orderEntry type="module" module-name="intellij.android.gradle.dsl" />
@@ -63,18 +43,6 @@
     <orderEntry type="module" module-name="assistant" />
     <orderEntry type="library" name="studio-sdk" level="project" />
     <orderEntry type="library" name="studio-plugin-gradle" level="project" />
-    <orderEntry type="module-library">
-      <library>
-        <CLASSES>
-          <root url="jar://$MODULE_DIR$/../lib/dart-plugin/203.6912/Dart.jar!/" />
-        </CLASSES>
-        <JAVADOC />
-        <SOURCES />
-      </library>
-    </orderEntry>
-    <orderEntry type="module" module-name="intellij.android.assistant" />
-    <orderEntry type="module" module-name="intellij.platform.core.ui" />
-    <orderEntry type="module" module-name="intellij.platform.ide.util.io" />
-    <orderEntry type="library" name="jaxb-api" level="project" />
+    <orderEntry type="library" name="Dart" level="project" />
   </component>
 </module>


### PR DESCRIPTION
To work with Android Studio sources we still need to use `*.iml` modules (that is, not Gradle). Those were out of date.

This PR is the first step toward a rewrite of the New Project Wizard for AS. The current version does not work in the canary builds. See https://github.com/flutter/flutter-intellij/issues/5878 for more info.