### PR TITLE
[WIP] Remove non-Flutter projects from NPW

### DIFF
--- a/flutter-intellij-community.iml
+++ b/flutter-intellij-community.iml
@@ -53,7 +53,6 @@
       <excludeFolder url="file://$MODULE_DIR$/flutter-idea/testSrc/integration" />
       <excludeFolder url="file://$MODULE_DIR$/flutter-studio/testSrc" />
       <excludeFolder url="file://$MODULE_DIR$/flutter-studio/src/io/flutter/module" />
-      <excludeFolder url="file://$MODULE_DIR$/flutter-studio/src" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
@@ -127,5 +126,6 @@
     <orderEntry type="library" name="weberknecht-0.1.5" level="project" />
     <orderEntry type="library" name="jxbrowser-7.19" level="project" />
     <orderEntry type="library" name="jxbrowser-swing-7.19" level="project" />
+    <orderEntry type="module" module-name="fest-swing" />
   </component>
 </module>

--- a/flutter-studio/flutter-studio.iml
+++ b/flutter-studio/flutter-studio.iml
@@ -44,5 +44,7 @@
     <orderEntry type="library" name="studio-sdk" level="project" />
     <orderEntry type="library" name="studio-plugin-gradle" level="project" />
     <orderEntry type="library" name="Dart" level="project" />
+    <orderEntry type="module" module-name="intellij.android.newProjectWizard" />
+    <orderEntry type="module" module-name="intellij.android.wizardTemplate.plugin" />
   </component>
 </module>

--- a/flutter-studio/flutter-studio.iml
+++ b/flutter-studio/flutter-studio.iml
@@ -44,7 +44,5 @@
     <orderEntry type="library" name="studio-sdk" level="project" />
     <orderEntry type="library" name="studio-plugin-gradle" level="project" />
     <orderEntry type="library" name="Dart" level="project" />
-    <orderEntry type="module" module-name="intellij.android.newProjectWizard" />
-    <orderEntry type="module" module-name="intellij.android.wizardTemplate.plugin" />
   </component>
 </module>


### PR DESCRIPTION
This removes all project types except Flutter from the new project wizard in Android Studio. One of the concerns the AS group has is that the NPW we are using exposes things that don't make sense for Android.

Old
<img width="598" alt="Screen Shot 2022-01-14 at 2 53 40 PM" src="https://user-images.githubusercontent.com/8518285/149595651-bdba586a-03d6-4b7f-b51c-1d5028062d89.png">

New
<img width="639" alt="Screen Shot 2022-01-14 at 3 18 42 PM" src="https://user-images.githubusercontent.com/8518285/149597405-8cdd7bbb-ed58-4677-9d33-554796bb36d4.png">

This uses the `fest` library, which is normally used for functional testing. I'm not sure we want to distribute that as part of the plugin, so I'd like to get feedback on whether this seems like a PR we want to keep.

Until recently, I was trimming the project list when the NPW was constructed. Unfortunately, AS locked down the code I was re-using so I had to remove that.

WIP until the build system is modified to work with `fest`.