### PR TITLE
Fix modules for working with AS sources

### DIFF
--- a/flutter-intellij-community.iml
+++ b/flutter-intellij-community.iml
@@ -4,7 +4,6 @@
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
-      <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/testSrc/unit" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/testSrc/integration" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/resources" type="java-resource" />

--- a/flutter-studio/flutter-studio.iml
+++ b/flutter-studio/flutter-studio.iml
@@ -13,6 +13,10 @@
       <excludeFolder url="file://$MODULE_DIR$/testSrc/system" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
     </content>
+    <content url="file://$MODULE_DIR$/resources" />
+    <content url="file://$MODULE_DIR$/src" />
+    <content url="file://$MODULE_DIR$/testData" />
+    <content url="file://$MODULE_DIR$/testSrc" />
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="module" module-name="intellij.android.core" />


### PR DESCRIPTION
The *.iml files were not correct for working with an Android Studio source-based project. This affects me, and probably no one else.