### PR TITLE
Fix build issues and missing module problem

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,8 +20,8 @@ buildscript {
 }
 
 plugins {
-  id("org.jetbrains.intellij") version "1.2.0" // Latest is 1.4.0 but does not work: Unresolved reference testRuntime
-  id("org.jetbrains.kotlin.jvm") version "1.4.31"
+  id("org.jetbrains.intellij") version "1.2.0" // Do not upgrade until AF 3.1 has been dropped
+  id("org.jetbrains.kotlin.jvm") version "1.6.10"
 }
 
 repositories {
@@ -72,9 +72,9 @@ intellij {
   localPath.set("${project.rootDir.absolutePath}/artifacts/$ide")
   downloadSources.set(false)
   val pluginList = mutableListOf(
-    project(":flutter-idea"), "java", "Dart:$dartVersion", "properties",
+    project(":flutter-idea"), "java", "properties",
     "junit", "Git4Idea", "Kotlin", "gradle", "org.jetbrains.android",
-    "Groovy", "smali", "IntelliLang")
+    "Groovy", "smali", "IntelliLang", "Dart:$dartVersion")
   if (ide == "android-studio") {
     pluginList += listOf(project(":flutter-studio"))
   } else if ("$buildSpec" == "2020.3") {

--- a/flutter-idea/build.gradle.kts
+++ b/flutter-idea/build.gradle.kts
@@ -52,8 +52,8 @@ intellij {
   updateSinceUntilBuild.set(false)
   downloadSources.set(false)
   localPath.set("${project.rootDir.absolutePath}/artifacts/$ide")
-  val pluginList = mutableListOf("java", "Dart:$dartVersion", "properties", "junit", "Kotlin", "Git4Idea",
-             "gradle", "Groovy", "smali", "IntelliLang", "org.jetbrains.android", "yaml")
+  val pluginList = mutableListOf("java", "properties", "junit", "Kotlin", "Git4Idea",
+             "gradle", "Groovy", "smali", "IntelliLang", "org.jetbrains.android", "yaml", "Dart:$dartVersion")
   plugins.set(pluginList)
 }
 
@@ -62,10 +62,10 @@ dependencies {
   testImplementation("org.powermock:powermock-module-junit4:2.0.0")
   if (ide == "android-studio") {
     testImplementation(project(":flutter-studio"))
-    testRuntime(fileTree(mapOf("dir" to "${project.rootDir}/artifacts/android-studio/plugins",
+    testRuntimeOnly(fileTree(mapOf("dir" to "${project.rootDir}/artifacts/android-studio/plugins",
                          "include" to listOf("**/*.jar"),
-                         "exclude" to listOf("**/kotlin-compiler.jar", "**/kotlin-plugin.jar", "**/kotlin-stdlib-jdk8.jar"))))
-    testRuntime(fileTree(mapOf("dir" to "${project.rootDir}/artifacts/android-studio/lib",
+                         "exclude" to listOf("**/android-ndk.jar", "**/kotlin-compiler.jar", "**/kotlin-plugin.jar", "**/kotlin-stdlib-jdk8.jar"))))
+    testRuntimeOnly(fileTree(mapOf("dir" to "${project.rootDir}/artifacts/android-studio/lib",
                          "include" to listOf("*.jar"))))
     compileOnly(fileTree(mapOf("dir" to "${project.rootDir}/artifacts/android-studio/plugins/git4idea/lib",
                          "include" to listOf("*.jar"))))
@@ -89,12 +89,12 @@ sourceSets {
   main {
     java.srcDirs(listOf(
       "src",
-      "third_party/vmServiceDrivers",
+      "third_party/vmServiceDrivers"
     ))
     // Add kotlin.srcDirs if we start using Kotlin in the main plugin.
     resources.srcDirs(listOf(
       "src",
-      "resources",
+      "resources"
     ))
   }
   test {

--- a/flutter-idea/src/io/flutter/utils/FlutterModuleUtils.java
+++ b/flutter-idea/src/io/flutter/utils/FlutterModuleUtils.java
@@ -327,6 +327,20 @@ public class FlutterModuleUtils {
     return modulesConverted;
   }
 
+  public static boolean hasAndroidModule(@NotNull Project project) {
+    String moduleName = project.getName() + "_android";
+    for (Module module : FlutterModuleUtils.getModules(project)) {
+      if (moduleName.equals(module.getName())) {
+        for (Facet<?> facet : FacetManager.getInstance(module).getAllFacets()) {
+          if ("Android".equals(facet.getName())) {
+            return true;
+          }
+        }
+      }
+    }
+    return false;
+  }
+
   public static boolean isDeprecatedFlutterModuleType(@NotNull Module module) {
     if (!DEPRECATED_FLUTTER_MODULE_TYPE_ID.equals(module.getOptionValue("type"))) {
       return false;

--- a/flutter-studio/build.gradle.kts
+++ b/flutter-studio/build.gradle.kts
@@ -67,7 +67,7 @@ sourceSets {
   main {
     java.srcDirs(listOf(
       "src",
-      "third_party/vmServiceDrivers",
+      "third_party/vmServiceDrivers"
       //"resources"
     ))
     // Add kotlin.srcDirs if we start using Kotlin in the main plugin.

--- a/flutter-studio/src/io/flutter/android/AndroidModuleLibraryManager.java
+++ b/flutter-studio/src/io/flutter/android/AndroidModuleLibraryManager.java
@@ -258,7 +258,7 @@ public class AndroidModuleLibraryManager extends AbstractLibraryManager<AndroidM
 
     GradleSyncInvoker.Request request = new GradleSyncInvoker.Request(TRIGGER_PROJECT_MODIFIED);
     request.runInBackground = true;
-    GradleSyncInvoker gradleSyncInvoker = ServiceManager.getService(GradleSyncInvoker.class);
+    GradleSyncInvoker gradleSyncInvoker = ApplicationManager.getApplication().getService(GradleSyncInvoker.class);
     gradleSyncInvoker.requestProjectSync(androidProject, request, listener);
   }
 

--- a/product-matrix.json
+++ b/product-matrix.json
@@ -46,8 +46,20 @@
       "ideaVersion": "213.5744.223",
       "baseVersion": "213.5744.223",
       "dartPluginVersion": "213.5744.122",
-      "sinceBuild": "213.5744.223",
+      "sinceBuild": "213.6461.79",
       "untilBuild": "213.*"
+    },
+    {
+      "channel": "dev",
+      "comments": "IntelliJ 2022.1",
+      "name": "2022.1",
+      "version": "2022.1",
+      "ideaProduct": "ideaIC",
+      "ideaVersion": "221.3427.89",
+      "baseVersion": "221.3427.89",
+      "dartPluginVersion": "221.3427.93",
+      "sinceBuild": "221.3427.89",
+      "untilBuild": "221.*"
     }
   ]
 }

--- a/tool/plugin/lib/artifact.dart
+++ b/tool/plugin/lib/artifact.dart
@@ -140,7 +140,7 @@ class ArtifactManager {
               'unzip', ['-q', '-d', artifact.output, artifact.file],
               cwd: 'artifacts');
           var files = Directory(artifact.outPath).listSync();
-          if (files.length == 1) {
+          if (files.length < 3) /* Might have .DS_Store */ {
             // This is the Mac zip case.
             Directory("${files.first.path}/Contents")
                 .renameSync("${artifact.outPath}Temp");

--- a/tool/plugin/lib/edit.dart
+++ b/tool/plugin/lib/edit.dart
@@ -34,15 +34,17 @@ List<EditCommand> editCommands = [
   EditAndroidModuleLibraryManager(),
   Subst(
     path: 'build.gradle.kts',
-    initial: 'localPath "\${project.rootDir.absolutePath}/artifacts/\$ide"',
-    replacement: 'type.set("IC")\n  version.set("LATEST-EAP-SNAPSHOT")',
-    version: '2022.1.futureEAP',
+    initial:
+        'localPath.set("\${project.rootDir.absolutePath}/artifacts/\$ide")',
+    replacement: 'type.set("IC")\n  version.set("221.3427.89-EAP-SNAPSHOT")',
+    version: '2022.1',
   ),
   Subst(
-    path: 'flutter-idea/build.gradle',
-    initial: 'localPath.set("\${project.rootDir.absolutePath}/artifacts/\$ide")',
-    replacement: 'type = "IC"\n  version = "LATEST-EAP-SNAPSHOT"',
-    version: '2022.1.futureEAP',
+    path: 'flutter-idea/build.gradle.kts',
+    initial:
+        'localPath.set("\${project.rootDir.absolutePath}/artifacts/\$ide")',
+    replacement: 'type.set("IC")\n  version.set("221.3427.89-EAP-SNAPSHOT")',
+    version: '2022.1',
   ),
   Subst(
     path: 'flutter-idea/src/io/flutter/utils/CollectionUtils.java',

--- a/tool/plugin/test/plugin_test.dart
+++ b/tool/plugin/test/plugin_test.dart
@@ -47,6 +47,7 @@ void main() {
               'android-studio',
               'android-studio',
               'ideaIC',
+              'ideaIC',
             ]));
       });
     });
@@ -63,6 +64,7 @@ void main() {
               'android-studio',
               'android-studio',
               'ideaIC',
+              'ideaIC',
             ]));
       });
     });
@@ -78,6 +80,7 @@ void main() {
               'android-studio',
               'android-studio',
               'android-studio',
+              'ideaIC',
               'ideaIC',
             ]));
       });


### PR DESCRIPTION
Sorry, but things got mixed up dealing with the Bumblebee crises. This should have been two PRs.

It fixes a number of problems caused by upgrading the Gradle plugin for IntelliJ. Turns out, it couldn't be upgraded yet because the newer version won't work with the oldest Android Studio we support.

It also fixes the "missing Android module" problem that causes some AS features to be disabled in a Flutter project.
Fixes #5464