### PR TITLE
Drop eap

### DIFF
--- a/product-matrix.json
+++ b/product-matrix.json
@@ -50,6 +50,7 @@
       "untilBuild": "213.*"
     },
     {
+      "channel": "dev",
       "comments": "Android Studio 2021.3 Canary",
       "name": "Dolphin",
       "version": "AS.213",

--- a/product-matrix.json
+++ b/product-matrix.json
@@ -51,6 +51,7 @@
     },
     {
       "channel": "dev",
+<<<<<<< Updated upstream
       "comments": "IntelliJ 2022.1",
       "name": "2022.1",
       "version": "2022.1",
@@ -60,6 +61,18 @@
       "dartPluginVersion": "221.3427.93",
       "sinceBuild": "221.3427.89",
       "untilBuild": "221.*"
+=======
+      "comments": "Android Studio 2021.3 Canary",
+      "name": "Dolphin",
+      "version": "AS.213",
+      "isUnitTestTarget": "true",
+      "ideaProduct": "android-studio",
+      "ideaVersion": "2021.3.1.1",
+      "baseVersion": "213.5744.223",
+      "dartPluginVersion": "213.5744.122",
+      "sinceBuild": "213.5744.223",
+      "untilBuild": "213.5744.223"
+>>>>>>> Stashed changes
     }
   ]
 }

--- a/product-matrix.json
+++ b/product-matrix.json
@@ -50,18 +50,6 @@
       "untilBuild": "213.*"
     },
     {
-      "channel": "dev",
-<<<<<<< Updated upstream
-      "comments": "IntelliJ 2022.1",
-      "name": "2022.1",
-      "version": "2022.1",
-      "ideaProduct": "ideaIC",
-      "ideaVersion": "221.3427.89",
-      "baseVersion": "221.3427.89",
-      "dartPluginVersion": "221.3427.93",
-      "sinceBuild": "221.3427.89",
-      "untilBuild": "221.*"
-=======
       "comments": "Android Studio 2021.3 Canary",
       "name": "Dolphin",
       "version": "AS.213",
@@ -72,7 +60,6 @@
       "dartPluginVersion": "213.5744.122",
       "sinceBuild": "213.5744.223",
       "untilBuild": "213.5744.223"
->>>>>>> Stashed changes
     }
   ]
 }

--- a/tool/plugin/test/plugin_test.dart
+++ b/tool/plugin/test/plugin_test.dart
@@ -47,7 +47,7 @@ void main() {
               'android-studio',
               'android-studio',
               'ideaIC',
-              'ideaIC',
+              'android-studio',
             ]));
       });
     });
@@ -64,7 +64,7 @@ void main() {
               'android-studio',
               'android-studio',
               'ideaIC',
-              'ideaIC',
+              'android-studio',
             ]));
       });
     });
@@ -81,7 +81,7 @@ void main() {
               'android-studio',
               'android-studio',
               'ideaIC',
-              'ideaIC',
+              'android-studio',
             ]));
       });
     });


### PR DESCRIPTION
For now, drop the EAP build spec. It doesn't work and just causes the dev channel build to fail. This will enable canary support on the dev channel this weekend.