### PR TITLE
Try SIGINT before SIGKILL for processes

### DIFF
--- a/flutter-idea/src/io/flutter/run/FlutterReloadManager.java
+++ b/flutter-idea/src/io/flutter/run/FlutterReloadManager.java
@@ -267,7 +267,7 @@ public class FlutterReloadManager {
     commandLine.setExePath(FileUtil.toSystemDependentName(script));
 
     try {
-      final MostlySilentColoredProcessHandler handler = new MostlySilentColoredProcessHandler(commandLine, true);
+      final MostlySilentColoredProcessHandler handler = new MostlySilentColoredProcessHandler(commandLine);
       handler.startNotify();
       if (!handler.getProcess().waitFor(10, TimeUnit.SECONDS)) {
         LOG.error("Syncing files timed out");

--- a/flutter-idea/src/io/flutter/run/bazelTest/BazelTestFields.java
+++ b/flutter-idea/src/io/flutter/run/bazelTest/BazelTestFields.java
@@ -166,7 +166,7 @@ public class BazelTestFields {
    */
   @NotNull
   ProcessHandler run(@NotNull final Project project, @NotNull final RunMode mode) throws ExecutionException {
-    return new MostlySilentColoredProcessHandler(getLaunchCommand(project, mode), true);
+    return new MostlySilentColoredProcessHandler(getLaunchCommand(project, mode));
   }
 
   /**

--- a/flutter-idea/src/io/flutter/run/daemon/FlutterApp.java
+++ b/flutter-idea/src/io/flutter/run/daemon/FlutterApp.java
@@ -265,7 +265,7 @@ public class FlutterApp implements Disposable {
       }
     }
 
-    final ProcessHandler process = new MostlySilentColoredProcessHandler(command, false, onTextAvailable);
+    final ProcessHandler process = new MostlySilentColoredProcessHandler(command, onTextAvailable);
     Disposer.register(project, process::destroyProcess);
 
     // Send analytics for the start and stop events.

--- a/flutter-idea/src/io/flutter/utils/MostlySilentColoredProcessHandler.java
+++ b/flutter-idea/src/io/flutter/utils/MostlySilentColoredProcessHandler.java
@@ -36,28 +36,17 @@ import java.util.function.Consumer;
  * for more information.
  */
 public class MostlySilentColoredProcessHandler extends ColoredProcessHandler {
-  /*
-  This determines whether a soft kill (SIGINT) is sent to the process on destroy, instead of the default SIGKILL. SIGKILL can't be routed
-  to remote processes spawned from the original one.
-   */
-  private boolean softKill;
   private GeneralCommandLine commandLine;
   private Consumer<String> onTextAvailable;
 
   public MostlySilentColoredProcessHandler(@NotNull GeneralCommandLine commandLine)
     throws ExecutionException {
-    this(commandLine, false);
+    this(commandLine, null);
   }
 
-  public MostlySilentColoredProcessHandler(@NotNull GeneralCommandLine commandLine, boolean softKill)
-    throws ExecutionException {
-    this(commandLine, softKill, null);
-  }
-
-  public MostlySilentColoredProcessHandler(@NotNull GeneralCommandLine commandLine, boolean softKill, Consumer<String> onTextAvailable)
+  public MostlySilentColoredProcessHandler(@NotNull GeneralCommandLine commandLine, Consumer<String> onTextAvailable)
           throws ExecutionException {
     super(commandLine);
-    this.softKill = softKill;
     this.commandLine = commandLine;
     this.onTextAvailable = onTextAvailable;
   }
@@ -71,7 +60,7 @@ public class MostlySilentColoredProcessHandler extends ColoredProcessHandler {
   @Override
   protected void doDestroyProcess() {
     final Process process = getProcess();
-    if (softKill && SystemInfo.isUnix && shouldDestroyProcessRecursively() && processCanBeKilledByOS(process)) {
+    if (SystemInfo.isUnix && shouldDestroyProcessRecursively() && processCanBeKilledByOS(process)) {
       final boolean result = UnixProcessManager.sendSigIntToProcessTree(process);
       if (!result) {
         FlutterInitializer.getAnalytics().sendEvent("process", "process kill failed");


### PR DESCRIPTION
We were sending SIGKILL for apps, which is preventing other work from being done that relies on trapping a signal.

CC @chingjun 