### PR TITLE
Change run config to open one instance of workbench

### DIFF
--- a/.idea/runConfigurations/flutter_idea__runIde_.xml
+++ b/.idea/runConfigurations/flutter_idea__runIde_.xml
@@ -1,15 +1,17 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="flutter-intellij [runIde]" type="GradleRunConfiguration" factoryName="Gradle">
+  <configuration default="false" name="flutter-idea [runIde]" type="GradleRunConfiguration" factoryName="Gradle">
     <ExternalSystemSettings>
       <option name="executionName" />
-      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$/flutter-idea" />
       <option name="externalSystemIdString" value="GRADLE" />
-      <option name="scriptParameters" value="runIde" />
+      <option name="scriptParameters" value="" />
       <option name="taskDescriptions">
         <list />
       </option>
       <option name="taskNames">
-        <list />
+        <list>
+          <option value="runIde" />
+        </list>
       </option>
       <option name="vmOptions" />
     </ExternalSystemSettings>


### PR DESCRIPTION
Our run configuration was opening two instances of workbench, and only one of them would connect debug endpoints.