### PR TITLE
Remove old bazel test file mapping code

### DIFF
--- a/flutter-idea/src/io/flutter/FlutterInitializer.java
+++ b/flutter-idea/src/io/flutter/FlutterInitializer.java
@@ -76,11 +76,6 @@ public class FlutterInitializer implements StartupActivity {
         project);
     }
 
-    System.out.println("get path of project root");
-    if (WorkspaceCache.getInstance(project).isBazel()) {
-      System.out.println(WorkspaceCache.getInstance(project).get().getRoot().getPath());
-    }
-
     // Disable the 'Migrate Project to Gradle' notification.
     FlutterUtils.disableGradleProjectMigrationNotification(project);
 

--- a/flutter-idea/src/io/flutter/run/bazelTest/BazelTestRunner.java
+++ b/flutter-idea/src/io/flutter/run/bazelTest/BazelTestRunner.java
@@ -270,26 +270,6 @@ public class BazelTestRunner extends GenericProgramRunner {
       this.connector = connector;
     }
 
-    @NotNull
-    public Collection<String> getBreakpointUris(@NotNull final VirtualFile file) {
-      // Get the results from superclass
-      final Collection<String> results = super.getBreakpointUris(file);
-
-      // Get the workspace directory name provided by the test harness.
-      final String workspaceDirName = connector.getWorkspaceDirName();
-
-      // Verify the returned workspace directory name
-      if (StringUtils.isEmpty(workspaceDirName)) return results;
-
-      final String filePath = file.getPath();
-      int workspaceEndOffset = filePath.lastIndexOf(workspaceDirName + "/");
-      if (workspaceEndOffset != -1) {
-        workspaceEndOffset += workspaceDirName.length();
-        results.add(workspaceDirName + "://" + filePath.substring(workspaceEndOffset));
-      }
-      return results;
-    }
-
     /**
      * Attempt to find a local Dart file corresponding to a script in Observatory.
      */


### PR DESCRIPTION
We're now using the VM service instead for file mapping during debugging, so this bazel test code is no longer needed for test breakpoints to work.