### PR TITLE
Log perf dispose NPEs

### DIFF
--- a/flutter-idea/src/io/flutter/perf/FlutterWidgetPerf.java
+++ b/flutter-idea/src/io/flutter/perf/FlutterWidgetPerf.java
@@ -17,12 +17,14 @@ import com.intellij.concurrency.JobScheduler;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.application.Application;
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.fileEditor.TextEditor;
 import com.intellij.openapi.util.Disposer;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.util.ui.EdtInvocationManager;
 import gnu.trove.TIntObjectHashMap;
+import io.flutter.module.FlutterModuleBuilder;
 import io.flutter.utils.AsyncUtils;
 import org.jetbrains.annotations.NotNull;
 
@@ -45,6 +47,8 @@ import java.util.concurrent.TimeUnit;
  * production application.
  */
 public class FlutterWidgetPerf implements Disposable, WidgetPerfListener {
+
+  private static final Logger LOG = Logger.getInstance(FlutterWidgetPerf.class);
 
   public static final long IDLE_DELAY_MILISECONDS = 400;
 
@@ -510,7 +514,12 @@ public class FlutterWidgetPerf implements Disposable, WidgetPerfListener {
     if (uiAnimationTimer.isRunning()) {
       uiAnimationTimer.stop();
     }
-    Disposer.dispose(perfProvider);
+    try {
+      // We've had a number of NPEs reported from this line, and it is not obvious what's wrong.
+      Disposer.dispose(perfProvider);
+    } catch (NullPointerException ex) {
+      LOG.info("NPE during dispose of " + perfProvider + "/" + perfProvider.isStarted() + "/" + perfProvider.isConnected(), ex);
+    }
 
     AsyncUtils.invokeLater(() -> {
       clearModels();

--- a/flutter-idea/src/io/flutter/perf/FlutterWidgetPerf.java
+++ b/flutter-idea/src/io/flutter/perf/FlutterWidgetPerf.java
@@ -24,7 +24,6 @@ import com.intellij.openapi.util.TextRange;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.util.ui.EdtInvocationManager;
 import gnu.trove.TIntObjectHashMap;
-import io.flutter.module.FlutterModuleBuilder;
 import io.flutter.utils.AsyncUtils;
 import org.jetbrains.annotations.NotNull;
 


### PR DESCRIPTION
I suspect something gets disposed out-of-order and that causes NPEs where I added the logging. #5940 and #5945 provide some hints about possible causes.

This does not actually fix anything but will stop throwing the NPE. We can close a bunch of uninformative issues.
Fixes #5965
Fixes #5943
Fixes #5831
Fixes #5813
Fixes #5791
Fixes #5746
Fixes #5587
Fixes #5536

