### PR TITLE
Add Android module when opening any project

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [AF.3.1, AS.211, AS.212, 2021.3]
+        version: [AF.3.1, AS.211, AS.212, 2021.3, 2022.1]
     steps:
       - name: checkout
         uses: actions/checkout@v2

--- a/flutter-idea/src/io/flutter/FlutterInitializer.java
+++ b/flutter-idea/src/io/flutter/FlutterInitializer.java
@@ -122,7 +122,8 @@ public class FlutterInitializer implements StartupActivity {
 
     if (hasFlutterModule || WorkspaceCache.getInstance(project).isBazel()) {
       initializeToolWindows(project);
-    } else {
+    }
+    else {
       project.getMessageBus().connect().subscribe(ProjectTopics.MODULES, new ModuleListener() {
         @Override
         public void moduleAdded(@NotNull Project project, @NotNull Module module) {
@@ -133,22 +134,20 @@ public class FlutterInitializer implements StartupActivity {
       });
     }
 
-    if (hasFlutterModule) {
-      if (PluginManagerCore.getPlugin(PluginId.getId("org.jetbrains.android")) != null) {
-        if (!FlutterModuleUtils.hasAndroidModule(project)) {
-          List<Module> modules = FlutterModuleUtils.findModulesWithFlutterContents(project);
-          for (Module module : modules) {
-            if (module.isDisposed() || !FlutterModuleUtils.isFlutterModule(module)) continue;
-            VirtualFile moduleFile = module.getModuleFile();
-            if (moduleFile == null) continue;
-            VirtualFile baseDir = moduleFile.getParent();
-            if (baseDir.getName().equals(".idea")) {
-              baseDir = baseDir.getParent();
-            }
-            boolean isModule = false;
-            FlutterModuleBuilder.addAndroidModule(project, null, baseDir.getPath(), module.getName(), isModule);
-          }
+    if (hasFlutterModule
+        && PluginManagerCore.getPlugin(PluginId.getId("org.jetbrains.android")) != null
+        && !FlutterModuleUtils.hasAndroidModule(project)) {
+      List<Module> modules = FlutterModuleUtils.findModulesWithFlutterContents(project);
+      for (Module module : modules) {
+        if (module.isDisposed() || !FlutterModuleUtils.isFlutterModule(module)) continue;
+        VirtualFile moduleFile = module.getModuleFile();
+        if (moduleFile == null) continue;
+        VirtualFile baseDir = moduleFile.getParent();
+        if (baseDir.getName().equals(".idea")) {
+          baseDir = baseDir.getParent();
         }
+        boolean isModule = false;
+        FlutterModuleBuilder.addAndroidModule(project, null, baseDir.getPath(), module.getName(), isModule);
       }
 
       // Ensure a run config is selected and ready to go.

--- a/flutter-idea/src/io/flutter/FlutterInitializer.java
+++ b/flutter-idea/src/io/flutter/FlutterInitializer.java
@@ -142,6 +142,9 @@ public class FlutterInitializer implements StartupActivity {
             VirtualFile moduleFile = module.getModuleFile();
             if (moduleFile == null) continue;
             VirtualFile baseDir = moduleFile.getParent();
+            if (baseDir.getName().equals(".idea")) {
+              baseDir = baseDir.getParent();
+            }
             boolean isModule = false;
             FlutterModuleBuilder.addAndroidModule(project, null, baseDir.getPath(), module.getName(), isModule);
           }

--- a/flutter-idea/src/io/flutter/ProjectOpenActivity.java
+++ b/flutter-idea/src/io/flutter/ProjectOpenActivity.java
@@ -7,6 +7,9 @@ package io.flutter;
 
 import com.intellij.framework.FrameworkType;
 import com.intellij.framework.detection.DetectionExcludesConfiguration;
+import com.intellij.ide.plugins.IdeaPluginDescriptor;
+import com.intellij.ide.plugins.PluginManager;
+import com.intellij.ide.plugins.PluginManagerCore;
 import com.intellij.notification.Notification;
 import com.intellij.notification.NotificationType;
 import com.intellij.notification.Notifications;
@@ -14,6 +17,8 @@ import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.extensions.PluginId;
+import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.DumbService;
 import com.intellij.openapi.project.Project;
@@ -21,10 +26,12 @@ import com.intellij.openapi.project.ProjectType;
 import com.intellij.openapi.project.ProjectTypeService;
 import com.intellij.openapi.startup.StartupActivity;
 import com.intellij.openapi.ui.Messages;
+import com.intellij.openapi.vfs.VirtualFile;
 import icons.FlutterIcons;
 import io.flutter.analytics.TimeTracker;
 import io.flutter.bazel.WorkspaceCache;
 import io.flutter.jxbrowser.JxBrowserManager;
+import io.flutter.module.FlutterModuleBuilder;
 import io.flutter.pub.PubRoot;
 import io.flutter.pub.PubRoots;
 import io.flutter.sdk.FlutterSdk;
@@ -33,6 +40,8 @@ import io.flutter.utils.AndroidUtils;
 import io.flutter.utils.FlutterModuleUtils;
 import org.jetbrains.android.facet.AndroidFrameworkDetector;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
 
 /**
  * Runs startup actions just after a project is opened, before it's indexed.
@@ -101,6 +110,13 @@ public class ProjectOpenActivity implements StartupActivity, DumbAware {
   }
 
   private static void excludeAndroidFrameworkDetector(@NotNull Project project) {
+    if (FlutterUtils.isAndroidStudio()) {
+      return;
+    }
+    IdeaPluginDescriptor desc;
+    if (PluginManagerCore.getPlugin(PluginId.getId("org.jetbrains.android")) == null) {
+      return;
+    }
     try {
       final DetectionExcludesConfiguration excludesConfiguration = DetectionExcludesConfiguration.getInstance(project);
       try {

--- a/flutter-idea/src/io/flutter/editor/WidgetIndentsHighlightingPassFactory.java
+++ b/flutter-idea/src/io/flutter/editor/WidgetIndentsHighlightingPassFactory.java
@@ -25,6 +25,7 @@ import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
+import com.intellij.util.ui.EdtInvocationManager;
 import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService;
 import io.flutter.FlutterUtils;
 import io.flutter.dart.FlutterDartAnalysisServer;
@@ -188,8 +189,13 @@ public class WidgetIndentsHighlightingPassFactory implements TextEditorHighlight
     // If we are showing build method guides we can never show the regular
     // IntelliJ indent guides for a file because they will overlap with the
     // widget indent guides in distracting ways.
-    e.getSettings().setIndentGuidesShown(false);
-
+    if (EdtInvocationManager.getInstance().isEventDispatchThread()) {
+      e.getSettings().setIndentGuidesShown(false);
+    } else {
+      ApplicationManager.getApplication().invokeLater(() -> {
+        e.getSettings().setIndentGuidesShown(false);
+      });
+    }
     // If regular indent guides should be shown we need to show the filtered
     // indents guides which look like the regular indent guides except that
     // guides that intersect with the widget guides are filtered out.

--- a/flutter-idea/src/io/flutter/module/FlutterModuleBuilder.java
+++ b/flutter-idea/src/io/flutter/module/FlutterModuleBuilder.java
@@ -11,6 +11,8 @@ import com.intellij.execution.OutputListener;
 import com.intellij.execution.process.ProcessListener;
 import com.intellij.facet.Facet;
 import com.intellij.facet.FacetManager;
+import com.intellij.ide.projectView.ProjectView;
+import com.intellij.ide.projectView.impl.ProjectViewPane;
 import com.intellij.ide.util.projectWizard.ModuleBuilder;
 import com.intellij.ide.util.projectWizard.ModuleWizardStep;
 import com.intellij.ide.util.projectWizard.SettingsStep;
@@ -26,6 +28,7 @@ import com.intellij.openapi.module.ModuleType;
 import com.intellij.openapi.module.ModuleWithNameAlreadyExists;
 import com.intellij.openapi.options.ConfigurationException;
 import com.intellij.openapi.progress.ProgressManager;
+import com.intellij.openapi.project.DumbService;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ModifiableRootModel;
 import com.intellij.openapi.ui.Messages;
@@ -33,6 +36,7 @@ import com.intellij.openapi.util.Disposer;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.openapi.wm.ToolWindowId;
 import icons.FlutterIcons;
 import io.flutter.FlutterBundle;
 import io.flutter.FlutterConstants;
@@ -143,11 +147,20 @@ public class FlutterModuleBuilder extends ModuleBuilder {
     }
 
     FlutterModuleUtils.autoShowMain(project, root);
-
-    if (!FlutterModuleUtils.hasAndroidModule(project)) { // TODO
-      //addAndroidModule(project, model, basePath, flutter.getName(), settings.getType() == FlutterProjectType.MODULE);
-    }
+    showProjectInProjectWindow(project);
     return flutter;
+  }
+
+  private void showProjectInProjectWindow(@NotNull Project project) {
+    ApplicationManager.getApplication().invokeLater(() -> {
+      DumbService.getInstance(project).runWhenSmart(() -> {
+        ApplicationManager.getApplication().invokeLater(() -> {
+          ProjectView view = ProjectView.getInstance(project);
+          if (view == null) return;
+          view.changeView(ProjectViewPane.ID);
+        });
+      });
+    });
   }
 
   private String validateSettings(FlutterCreateAdditionalSettings settings) {

--- a/flutter-idea/src/io/flutter/module/FlutterModuleBuilder.java
+++ b/flutter-idea/src/io/flutter/module/FlutterModuleBuilder.java
@@ -16,6 +16,7 @@ import com.intellij.ide.util.projectWizard.ModuleWizardStep;
 import com.intellij.ide.util.projectWizard.SettingsStep;
 import com.intellij.ide.util.projectWizard.WizardContext;
 import com.intellij.openapi.Disposable;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.WriteAction;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.module.ModifiableModuleModel;
@@ -143,8 +144,8 @@ public class FlutterModuleBuilder extends ModuleBuilder {
 
     FlutterModuleUtils.autoShowMain(project, root);
 
-    if (!FlutterModuleUtils.hasAndroidModule(project)) {
-      addAndroidModule(project, model, basePath, flutter.getName(), settings.getType() == FlutterProjectType.MODULE);
+    if (!FlutterModuleUtils.hasAndroidModule(project)) { // TODO
+      //addAndroidModule(project, model, basePath, flutter.getName(), settings.getType() == FlutterProjectType.MODULE);
     }
     return flutter;
   }
@@ -168,7 +169,7 @@ public class FlutterModuleBuilder extends ModuleBuilder {
     return AndroidUtils.validateAndroidPackageName(org);
   }
 
-  private static void addAndroidModule(@NotNull Project project,
+  public static void addAndroidModule(@NotNull Project project,
                                        @Nullable ModifiableModuleModel model,
                                        @NotNull String baseDirPath,
                                        @NotNull String flutterModuleName,
@@ -197,7 +198,9 @@ public class FlutterModuleBuilder extends ModuleBuilder {
       model.loadModule(androidFile.getPath());
 
       if (toCommit != null) {
-        WriteAction.run(toCommit::commit);
+        ApplicationManager.getApplication().invokeLater(() -> {
+          WriteAction.run(toCommit::commit);
+        });
       }
     }
     catch (ModuleWithNameAlreadyExists | IOException e) {

--- a/flutter-idea/src/io/flutter/utils/FlutterModuleUtils.java
+++ b/flutter-idea/src/io/flutter/utils/FlutterModuleUtils.java
@@ -10,6 +10,7 @@ import com.intellij.execution.RunnerAndConfigurationSettings;
 import com.intellij.facet.Facet;
 import com.intellij.facet.FacetManager;
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.fileEditor.FileEditor;
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.*;
@@ -21,6 +22,7 @@ import com.intellij.psi.PsiElement;
 import com.intellij.serviceContainer.AlreadyDisposedException;
 import com.intellij.ui.EditorNotifications;
 import com.intellij.util.PlatformUtils;
+import com.jetbrains.lang.dart.DartFileType;
 import com.jetbrains.lang.dart.sdk.DartSdk;
 import io.flutter.FlutterUtils;
 import io.flutter.actions.FlutterBuildActionGroup;
@@ -262,7 +264,7 @@ public class FlutterModuleUtils {
   }
 
   /**
-   * If no files are open, show lib/main.dart for the given PubRoot.
+   * If no files are open, or just the readme, show lib/main.dart for the given PubRoot.
    */
   public static void autoShowMain(@NotNull Project project, @NotNull PubRoot root) {
     if (project.isDisposed()) return;
@@ -272,9 +274,20 @@ public class FlutterModuleUtils {
 
     DumbService.getInstance(project).runWhenSmart(() -> {
       final FileEditorManager manager = FileEditorManager.getInstance(project);
-      if (manager.getAllEditors().length == 0) {
-        manager.openFile(main, true);
+      FileEditor[] editors = manager.getAllEditors();
+      if (editors.length > 1) {
+        return;
       }
+      for (FileEditor editor : editors) {
+        VirtualFile file = editor.getFile();
+        if (file.equals(main)) {
+          return;
+        }
+        if (file.getFileType().equals(DartFileType.INSTANCE)) {
+          return;
+        }
+      }
+      manager.openFile(main, editors.length == 0);
     });
   }
 

--- a/product-matrix.json
+++ b/product-matrix.json
@@ -50,6 +50,7 @@
       "untilBuild": "213.*"
     },
     {
+      "channel": "stable",
       "comments": "IntelliJ 2022.1",
       "name": "2022.1",
       "version": "2022.1",

--- a/product-matrix.json
+++ b/product-matrix.json
@@ -38,7 +38,7 @@
     },
     {
       "channel": "stable",
-      "comments": "IntelliJ 2021.3",
+      "comments": "IntelliJ 2021.3, Android Studio 2021.3 Canary",
       "name": "2021.3",
       "version": "2021.3",
       "isUnitTestTarget": "true",
@@ -50,20 +50,6 @@
       "untilBuild": "213.*"
     },
     {
-      "channel": "dev",
-      "comments": "Android Studio 2021.3 Canary",
-      "name": "Dolphin",
-      "version": "AS.213",
-      "isUnitTestTarget": "true",
-      "ideaProduct": "android-studio",
-      "ideaVersion": "2021.3.1.1",
-      "baseVersion": "213.5744.223",
-      "dartPluginVersion": "213.5744.122",
-      "sinceBuild": "213.5744.223",
-      "untilBuild": "213.5744.223"
-    },
-    {
-      "channel": "dev",
       "comments": "IntelliJ 2022.1",
       "name": "2022.1",
       "version": "2022.1",

--- a/tool/plugin/test/plugin_test.dart
+++ b/tool/plugin/test/plugin_test.dart
@@ -47,7 +47,6 @@ void main() {
               'android-studio',
               'android-studio',
               'ideaIC',
-              'android-studio',
               'ideaIC',
             ]));
       });
@@ -65,7 +64,6 @@ void main() {
               'android-studio',
               'android-studio',
               'ideaIC',
-              'android-studio',
               'ideaIC',
             ]));
       });
@@ -83,7 +81,6 @@ void main() {
               'android-studio',
               'android-studio',
               'ideaIC',
-              'android-studio',
               'ideaIC',
             ]));
       });


### PR DESCRIPTION
This actually does a few things, since I couldn't test initialization interactions separately.

- Add an Android module if needed
- Switch to showing "Project" in the project view (not "Android")
- Open `main.dart` for new projects if needed
- Merge preview builds into stable

Fixes #5932 
Fixes #5933 