### PR TITLE
Change .packages file use to package config file

### DIFF
--- a/bin/plugin
+++ b/bin/plugin
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-# TODO(devoncarew): Warn if tool/plugin/.packages does not exist.
+# TODO: Warn if 'pub get' needs to be done.
 
 dart tool/plugin/bin/main.dart "$@"

--- a/flutter-idea/src/io/flutter/FlutterInitializer.java
+++ b/flutter-idea/src/io/flutter/FlutterInitializer.java
@@ -173,7 +173,7 @@ public class FlutterInitializer implements StartupActivity {
     // Watch save actions for format on save.
     FlutterSaveActionsManager.init(project);
 
-    // Start watching for project structure and .packages file changes.
+    // Start watching for project structure changes.
     final FlutterPluginsLibraryManager libraryManager = new FlutterPluginsLibraryManager(project);
     libraryManager.startWatching();
 

--- a/flutter-idea/src/io/flutter/run/MainFile.java
+++ b/flutter-idea/src/io/flutter/run/MainFile.java
@@ -58,7 +58,7 @@ public class MainFile {
   }
 
   /**
-   * Returns the closest ancestor directory containing a pubspec.yaml, BUILD, or .packages file.
+   * Returns the closest ancestor directory containing a pubspec.yaml, BUILD, or packages meta-data file.
    */
   @NotNull
   public VirtualFile getAppDir() {
@@ -137,6 +137,7 @@ public class MainFile {
     assert(!WorkspaceCache.getInstance(project).isBazel());
     return dir.isDirectory() && (
       dir.findChild("pubspec.yaml") != null ||
+      dir.findChild(".dart_tool") != null ||
       dir.findChild(".packages") != null
     );
   }

--- a/flutter-idea/src/io/flutter/sdk/FlutterSdk.java
+++ b/flutter-idea/src/io/flutter/sdk/FlutterSdk.java
@@ -467,7 +467,7 @@ public class FlutterSdk {
     if (module == null) return null;
     // Ensure pubspec is saved.
     FileDocumentManager.getInstance().saveAllDocuments();
-    // Refresh afterwards to ensure Dart Plugin sees .packages and doesn't mistakenly nag to run pub.
+    // Refresh afterwards to ensure Dart Plugin doesn't mistakenly nag to run pub.
     return flutterPackagesGet(root).startInModuleConsole(module, root::refresh, null);
   }
 

--- a/flutter-idea/src/io/flutter/sdk/FlutterSdkUtil.java
+++ b/flutter-idea/src/io/flutter/sdk/FlutterSdkUtil.java
@@ -254,7 +254,7 @@ public class FlutterSdkUtil {
   }
 
   /**
-   * Parse any .packages file and infer the location of the Flutter SDK from that.
+   * Parse packages meta-data file and infer the location of the Flutter SDK from that.
    */
   @Nullable
   public static String guessFlutterSdkFromPackagesFile(@NotNull Module module) {

--- a/flutter-idea/src/io/flutter/utils/JsonUtils.java
+++ b/flutter-idea/src/io/flutter/utils/JsonUtils.java
@@ -71,13 +71,13 @@ public class JsonUtils {
    * Parses the specified JSON string into a JsonElement.
    */
   public static JsonElement parseString(String json) throws JsonSyntaxException {
-    return new JsonParser().parse(json);
+    return JsonParser.parseString(json);
   }
 
   /**
    * Parses the specified JSON string into a JsonElement.
    */
   public static JsonElement parseReader(Reader reader) throws JsonIOException, JsonSyntaxException {
-    return new JsonParser().parse(reader);
+    return JsonParser.parseReader(reader);
   }
 }

--- a/flutter-idea/src/io/flutter/utils/JsonUtils.java
+++ b/flutter-idea/src/io/flutter/utils/JsonUtils.java
@@ -71,13 +71,13 @@ public class JsonUtils {
    * Parses the specified JSON string into a JsonElement.
    */
   public static JsonElement parseString(String json) throws JsonSyntaxException {
-    return JsonParser.parseString(json);
+    return new JsonParser().parse(json);
   }
 
   /**
    * Parses the specified JSON string into a JsonElement.
    */
   public static JsonElement parseReader(Reader reader) throws JsonIOException, JsonSyntaxException {
-    return JsonParser.parseReader(reader);
+    return new JsonParser().parse(reader);
   }
 }


### PR DESCRIPTION
Cleans up reliance on `.packages` file. Most places that use it had already been changed to look for the package config file instead. I added a fall-back option to the one place that hadn't. I expect the Dart plugin will be updated soon, and when it is this fall-back option can be removed.

We are not deleting the code that uses `.packages` yet because old projects could, possibly, not have the package config file. That seems unlikely, but at some point it should be safe to trim all references to `.packages`.

Fixes #5614 
