### PR TITLE
Add build spec to configure IDE for debugging

### DIFF
--- a/.idea/kotlinScripting.xml
+++ b/.idea/kotlinScripting.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="KotlinScriptingSettings">
+    <option name="suppressDefinitionsCheck" value="true" />
+  </component>
+</project>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,7 @@ file.
     - `flutter pub get`
     - `(cd tool/plugin; flutter pub get)`
     - `bin/plugin test`
+    - `bin/plugin make -csetup -osetup -u` # configures the IDE used to launch the debugger
 * Start IntelliJ
 * In the "Project Structure" dialog (`File | Project Structure`):
   - Select "Platform Settings > SDKs" click the "+" sign at the top "Add New SDK (Alt+Insert)" to configure the JDK

--- a/product-matrix.json
+++ b/product-matrix.json
@@ -49,6 +49,18 @@
       "untilBuild": "213.*"
     },
     {
+      "channel": "setup",
+      "comments": "IntelliJ 2021.3",
+      "name": "setup",
+      "version": "setup",
+      "ideaProduct": "ideaIC",
+      "ideaVersion": "2021.3.1.1",
+      "baseVersion": "213.5744.223",
+      "dartPluginVersion": "213.5744.122",
+      "sinceBuild": "213.6461.79",
+      "untilBuild": "213.*"
+    },
+    {
       "channel": "stable",
       "comments": "IntelliJ 2022.1",
       "name": "2022.1",

--- a/tool/plugin/lib/build_spec.dart
+++ b/tool/plugin/lib/build_spec.dart
@@ -60,6 +60,8 @@ class BuildSpec {
 
   bool get isDevChannel => channel == 'dev';
 
+  bool get isStableChannel => channel == 'stable';
+
   bool get isReleaseMode => release != null;
 
   bool get isSynthetic => false;

--- a/tool/plugin/lib/plugin.dart
+++ b/tool/plugin/lib/plugin.dart
@@ -303,6 +303,13 @@ class AntBuildCommand extends BuildCommand {
   AntBuildCommand(BuildCommandRunner runner) : super(runner, 'build');
 
   @override
+  Future<int> doit() async {
+    // TODO Convert this to a synonym of 'make'
+    log('Use "make" not "build"');
+    return 1;
+  }
+
+  @override
   Future<int> externalBuildCommand(BuildSpec spec) async {
     var r = await runner.javac2(spec);
     if (r == 0) {
@@ -443,6 +450,9 @@ abstract class BuildCommand extends ProductCommand {
 
   @override
   Future<int> doit() async {
+    if (channel == 'setup') {
+      return 0;
+    }
     if (isReleaseMode) {
       if (argResults['unpack']) {
         separator('Release mode (--release) implies --unpack');

--- a/tool/plugin/test/plugin_test.dart
+++ b/tool/plugin/test/plugin_test.dart
@@ -48,6 +48,7 @@ void main() {
               'android-studio',
               'android-studio',
               'ideaIC',
+              'ideaIC',
             ]));
       });
     });
@@ -65,6 +66,7 @@ void main() {
               'android-studio',
               'android-studio',
               'ideaIC',
+              'ideaIC',
             ]));
       });
     });
@@ -81,6 +83,7 @@ void main() {
               'android-studio',
               'android-studio',
               'android-studio',
+              'ideaIC',
               'ideaIC',
             ]));
       });
@@ -155,7 +158,7 @@ void main() {
       await runner.run(["--release=19", "-d../..", "deploy"]).whenComplete(() {
         cmd = (runner.commands['deploy'] as TestDeployCommand);
       });
-      var specs = cmd.specs.where((s) => !s.isDevChannel).toList();
+      var specs = cmd.specs.where((s) => s.isStableChannel).toList();
       expect(cmd.paths.length, specs.length);
     });
   });


### PR DESCRIPTION
Run `bin/plugin make -csetup -osetup -u` before starting the IntelliJ debugger.