### PR TITLE
Send internal errors to analytics for disconnections

### DIFF
--- a/flutter-idea/src/io/flutter/run/daemon/DaemonConsoleView.java
+++ b/flutter-idea/src/io/flutter/run/daemon/DaemonConsoleView.java
@@ -30,7 +30,6 @@ import org.jetbrains.annotations.NotNull;
  */
 public class DaemonConsoleView extends ConsoleViewImpl {
   private static final Logger LOG = Logger.getInstance(DaemonConsoleView.class);
-  private boolean sendErrorsToAnalytics = false;
   private final Analytics analytics = FlutterInitializer.getAnalytics();
 
   /**
@@ -72,7 +71,9 @@ public class DaemonConsoleView extends ConsoleViewImpl {
     if (contentType != ConsoleViewContentType.NORMAL_OUTPUT) {
       writeAvailableLines();
 
-      if (sendErrorsToAnalytics && text.length() > 0) {
+      // TODO(helin24): We want to log only disconnection messages, but we aren't sure what those are yet.
+      // Until then, only log error messages for internal users.
+      if (WorkspaceCache.getInstance(getProject()).isBazel() && contentType.equals(ConsoleViewContentType.ERROR_OUTPUT) && text.length() > 0) {
         analytics.sendEvent("potential-disconnect", text);
       }
       super.print(text, contentType);
@@ -81,10 +82,6 @@ public class DaemonConsoleView extends ConsoleViewImpl {
       stdoutParser.appendOutput(text);
       writeAvailableLines();
     }
-  }
-
-  public void maybeSendErrorsToAnalytics() {
-    this.sendErrorsToAnalytics = WorkspaceCache.getInstance(getProject()).isBazel();
   }
 
   private void writeAvailableLines() {

--- a/flutter-idea/src/io/flutter/run/daemon/FlutterApp.java
+++ b/flutter-idea/src/io/flutter/run/daemon/FlutterApp.java
@@ -887,6 +887,9 @@ class FlutterAppDaemonEventListener implements DaemonEvent.Listener {
   @Override
   public void onAppStarted(DaemonEvent.AppStarted started) {
     app.changeState(FlutterApp.State.STARTED);
+    if (app.getConsole() instanceof DaemonConsoleView) {
+      ((DaemonConsoleView)app.getConsole()).maybeSendErrorsToAnalytics();
+    }
   }
 
   @Override

--- a/flutter-idea/src/io/flutter/run/daemon/FlutterApp.java
+++ b/flutter-idea/src/io/flutter/run/daemon/FlutterApp.java
@@ -887,9 +887,6 @@ class FlutterAppDaemonEventListener implements DaemonEvent.Listener {
   @Override
   public void onAppStarted(DaemonEvent.AppStarted started) {
     app.changeState(FlutterApp.State.STARTED);
-    if (app.getConsole() instanceof DaemonConsoleView) {
-      ((DaemonConsoleView)app.getConsole()).maybeSendErrorsToAnalytics();
-    }
   }
 
   @Override


### PR DESCRIPTION
This is to help us track internal disconnection errors. Not all errors caught here will be truly the types of errors we'll be looking for, ~but this at least filters out startup messages as an app compiles (the startup messages are intended to go to stderr,~ as stdout is intended to be only what should be parsed by the flutter daemon).

Once we have a sense of what types of post-startup error exist, then we can further refine what messages represent different types of disconnections if needed.