### PR TITLE
Notify bazel users to try running iOS apps

### DIFF
--- a/flutter-idea/src/io/flutter/bazel/PluginConfig.java
+++ b/flutter-idea/src/io/flutter/bazel/PluginConfig.java
@@ -79,6 +79,11 @@ public class PluginConfig {
     return fields.configWarningPrefix;
   }
 
+  @Nullable
+  String getUpdatedIosRunMessage() {
+    return fields.updatedIosRunMessage;
+  }
+
   @Override
   public boolean equals(Object obj) {
     if (!(obj instanceof PluginConfig)) return false;
@@ -137,7 +142,8 @@ public class PluginConfig {
     @Nullable String sdkHome,
     @Nullable String requiredIJPluginID,
     @Nullable String requiredIJPluginMessage,
-    @Nullable String configWarningPrefix
+    @Nullable String configWarningPrefix,
+    @Nullable String updatedIosRunMessage
   ) {
     final Fields fields = new Fields(
       daemonScript,
@@ -148,7 +154,8 @@ public class PluginConfig {
       sdkHome,
       requiredIJPluginID,
       requiredIJPluginMessage,
-      configWarningPrefix
+      configWarningPrefix,
+      updatedIosRunMessage
     );
     return new PluginConfig(fields);
   }
@@ -211,6 +218,12 @@ public class PluginConfig {
     @SerializedName("configWarningPrefix")
     private String configWarningPrefix;
 
+    /**
+     * The prefix that indicates a message about iOS run being updated.
+     */
+    @SerializedName("updatedIosRunMessage")
+    private String updatedIosRunMessage;
+
     Fields() {
     }
 
@@ -225,7 +238,8 @@ public class PluginConfig {
            String sdkHome,
            String requiredIJPluginID,
            String requiredIJPluginMessage,
-           String configWarningPrefix) {
+           String configWarningPrefix,
+           String updatedIosRunMessage) {
       this.daemonScript = daemonScript;
       this.doctorScript = doctorScript;
       this.testScript = testScript;
@@ -235,6 +249,7 @@ public class PluginConfig {
       this.requiredIJPluginID = requiredIJPluginID;
       this.requiredIJPluginMessage = requiredIJPluginMessage;
       this.configWarningPrefix = configWarningPrefix;
+      this.updatedIosRunMessage = updatedIosRunMessage;
     }
 
     @Override
@@ -249,13 +264,14 @@ public class PluginConfig {
              && Objects.equal(sdkHome, other.sdkHome)
              && Objects.equal(requiredIJPluginID, other.requiredIJPluginID)
              && Objects.equal(requiredIJPluginMessage, other.requiredIJPluginMessage)
-             && Objects.equal(configWarningPrefix, other.configWarningPrefix);
+             && Objects.equal(configWarningPrefix, other.configWarningPrefix)
+             && Objects.equal(updatedIosRunMessage, other.updatedIosRunMessage);
     }
 
     @Override
     public int hashCode() {
       return Objects.hashCode(daemonScript, doctorScript, testScript, runScript, syncScript, sdkHome, requiredIJPluginID,
-                              requiredIJPluginMessage, configWarningPrefix);
+                              requiredIJPluginMessage, configWarningPrefix, updatedIosRunMessage);
     }
   }
 

--- a/flutter-idea/src/io/flutter/bazel/Workspace.java
+++ b/flutter-idea/src/io/flutter/bazel/Workspace.java
@@ -48,6 +48,7 @@ public class Workspace {
   @Nullable private final String requiredIJPluginID;
   @Nullable private final String requiredIJPluginMessage;
   @Nullable private final String configWarningPrefix;
+  @Nullable private final String updatedIosRunMessage;
 
   private Workspace(@NotNull VirtualFile root,
                     @Nullable PluginConfig config,
@@ -59,7 +60,8 @@ public class Workspace {
                     @Nullable String sdkHome,
                     @Nullable String requiredIJPluginID,
                     @Nullable String requiredIJPluginMessage,
-                    @Nullable String configWarningPrefix) {
+                    @Nullable String configWarningPrefix,
+                    @Nullable String updatedIosRunMessage) {
     this.root = root;
     this.config = config;
     this.daemonScript = daemonScript;
@@ -71,6 +73,7 @@ public class Workspace {
     this.requiredIJPluginID = requiredIJPluginID;
     this.requiredIJPluginMessage = requiredIJPluginMessage;
     this.configWarningPrefix = configWarningPrefix;
+    this.updatedIosRunMessage = updatedIosRunMessage;
   }
 
   /**
@@ -195,6 +198,15 @@ public class Workspace {
   }
 
   /**
+   * Returns the message notifying users that running iOS apps has improved.
+   */
+  @Nullable
+  public String getUpdatedIosRunMessage() {
+    return updatedIosRunMessage;
+  }
+
+
+  /**
    * Returns true if the plugin config was loaded.
    */
   public boolean hasPluginConfig() {
@@ -271,7 +283,9 @@ public class Workspace {
 
     final String configWarningPrefix = config == null ? null : config.getConfigWarningPrefix();
 
-    return new Workspace(root, config, daemonScript, doctorScript, testScript, runScript, syncScript, sdkHome, requiredIJPluginID, requiredIJPluginMessage, configWarningPrefix);
+    final String updatedIosRunMessage = config == null ? null : config.getUpdatedIosRunMessage();
+
+    return new Workspace(root, config, daemonScript, doctorScript, testScript, runScript, syncScript, sdkHome, requiredIJPluginID, requiredIJPluginMessage, configWarningPrefix, updatedIosRunMessage);
   }
 
   @VisibleForTesting
@@ -287,7 +301,8 @@ public class Workspace {
       pluginConfig.getSdkHome(),
       pluginConfig.getRequiredIJPluginID(),
       pluginConfig.getRequiredIJPluginMessage(),
-      pluginConfig.getConfigWarningPrefix());
+      pluginConfig.getConfigWarningPrefix(),
+      pluginConfig.getUpdatedIosRunMessage());
   }
 
   /**

--- a/flutter-idea/src/io/flutter/run/bazel/BazelFields.java
+++ b/flutter-idea/src/io/flutter/run/bazel/BazelFields.java
@@ -279,6 +279,18 @@ public class BazelFields {
     if (device != null) {
       commandLine.addParameter("-d");
       commandLine.addParameter(device.deviceId());
+
+      //final String message = workspace.getUpdatedIosRunMessage();
+      final String message = "test message";
+      if (message != null) {
+        final String title = device.isIOS() ? "Running iOS apps has improved!" : "Try running an iOS app!";
+        final Notification notification = new Notification(
+          FlutterMessages.FLUTTER_NOTIFICATION_GROUP_ID,
+          title,
+          message,
+          NotificationType.INFORMATION);
+        Notifications.Bus.notify(notification, project);
+      }
     }
 
     try {

--- a/flutter-idea/src/io/flutter/run/bazel/BazelFields.java
+++ b/flutter-idea/src/io/flutter/run/bazel/BazelFields.java
@@ -280,8 +280,7 @@ public class BazelFields {
       commandLine.addParameter("-d");
       commandLine.addParameter(device.deviceId());
 
-      //final String message = workspace.getUpdatedIosRunMessage();
-      final String message = "test message";
+      final String message = workspace.getUpdatedIosRunMessage();
       if (message != null && FlutterSettings.getInstance().isShowBazelIosRunNotification()) {
         final String title = device.isIOS() ? "Running iOS apps has improved!" : "Try running an iOS app!";
         final Notification notification = new Notification(

--- a/flutter-idea/src/io/flutter/run/bazel/BazelFields.java
+++ b/flutter-idea/src/io/flutter/run/bazel/BazelFields.java
@@ -282,7 +282,7 @@ public class BazelFields {
 
       //final String message = workspace.getUpdatedIosRunMessage();
       final String message = "test message";
-      if (message != null) {
+      if (message != null && FlutterSettings.getInstance().isShowBazelIosRunNotification()) {
         final String title = device.isIOS() ? "Running iOS apps has improved!" : "Try running an iOS app!";
         final Notification notification = new Notification(
           FlutterMessages.FLUTTER_NOTIFICATION_GROUP_ID,
@@ -290,6 +290,7 @@ public class BazelFields {
           message,
           NotificationType.INFORMATION);
         Notifications.Bus.notify(notification, project);
+        FlutterSettings.getInstance().setShowBazelIosRunNotification(false);
       }
     }
 

--- a/flutter-idea/src/io/flutter/settings/FlutterSettings.java
+++ b/flutter-idea/src/io/flutter/settings/FlutterSettings.java
@@ -6,8 +6,6 @@
 package io.flutter.settings;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.intellij.ide.plugins.IdeaPluginDescriptor;
-import com.intellij.ide.plugins.PluginManagerCore;
 import com.intellij.ide.util.PropertiesComponent;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.util.SystemInfo;
@@ -15,7 +13,6 @@ import com.intellij.openapi.util.registry.Registry;
 import com.intellij.util.EventDispatcher;
 import com.jetbrains.lang.dart.analyzer.DartClosingLabelManager;
 import io.flutter.FlutterMessages;
-import io.flutter.FlutterUtils;
 import io.flutter.analytics.Analytics;
 
 import java.util.EventListener;
@@ -37,6 +34,7 @@ public class FlutterSettings {
   private static final String showBazelHotRestartWarningKey = "io.flutter.showBazelHotRestartWarning";
   private static final String fontPackagesKey = "io.flutter.fontPackages";
   private static final String allowTestsInSourcesRootKey = "io.flutter.allowTestsInSources";
+  private static final String showBazelIosRunNotificationKey = "io.flutter.hideBazelIosRunNotification";
 
   // TODO(helin24): This is to change the embedded browser setting back to true only once for Big Sur users. If we
   // switch to enabling the embedded browser for everyone, then delete this key.
@@ -148,6 +146,10 @@ public class FlutterSettings {
 
     if (!getFontPackages().isEmpty()) {
       analytics.sendEvent("settings", afterLastPeriod(fontPackagesKey));
+    }
+
+    if (isShowBazelIosRunNotification()) {
+      analytics.sendEvent("settings", afterLastPeriod(showBazelIosRunNotificationKey));
     }
   }
 
@@ -374,6 +376,15 @@ public class FlutterSettings {
 
   public void setAllowTestsInSourcesRoot(boolean value) {
     getPropertiesComponent().setValue(allowTestsInSourcesRootKey, value, false);
+    fireEvent();
+  }
+
+  public boolean isShowBazelIosRunNotification() {
+    return getPropertiesComponent().getBoolean(showBazelIosRunNotificationKey, true);
+  }
+
+  public void setShowBazelIosRunNotification(boolean value) {
+    getPropertiesComponent().setValue(showBazelIosRunNotificationKey, value, true);
     fireEvent();
   }
 }

--- a/flutter-idea/testSrc/unit/io/flutter/run/bazelTest/BazelTestConfigProducerTest.java
+++ b/flutter-idea/testSrc/unit/io/flutter/run/bazelTest/BazelTestConfigProducerTest.java
@@ -166,7 +166,7 @@ public class BazelTestConfigProducerTest extends AbstractDartElementTest {
       fs.file("/workspace/WORKSPACE", "");
       fakeWorkspace = Workspace.forTest(
         fs.findFileByPath("/workspace/"),
-        PluginConfig.forTest("", "", "", "", "", "", "", "", "")
+        PluginConfig.forTest("", "", "", "", "", "", "", "", "", "")
       );
       this.hasWorkspace = hasWorkspace;
       this.hasValidTestFile = hasValidTestFile;


### PR DESCRIPTION
This should show a notification only when bazel users haven't seen the notification before while running an app. If a user is running an iOS app, the notification title is about the process having improved; if running on another device, the notification title suggests trying out iOS. 