### PR TITLE
Use actual project name to find Android module

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -24,6 +24,7 @@ This might require a reboot. Start from the Welcome screen at least once.
 
 * Create a **simple project** (`File > New > Project...`, pick `Flutter`; on Android Studio, `File > New > New Flutter Project...`).
   * (select an `Application` type project)
+  * use a project name that contains a space -- project location must be lowercase_with_underscores
 * Confirm that:
   * Project contents are created.
     * Verify that a run configuration (`main.dart`) is enabled in the run/debug selector.

--- a/flutter-idea/src/io/flutter/FlutterInitializer.java
+++ b/flutter-idea/src/io/flutter/FlutterInitializer.java
@@ -147,7 +147,10 @@ public class FlutterInitializer implements StartupActivity {
           baseDir = baseDir.getParent();
         }
         boolean isModule = false;
-        FlutterModuleBuilder.addAndroidModule(project, null, baseDir.getPath(), module.getName(), isModule);
+        try { // TODO(messick) Rewrite this loop to eliminate the need for this try-catch
+          FlutterModuleBuilder.addAndroidModule(project, null, baseDir.getPath(), module.getName(), isModule);
+        } catch (IllegalStateException ignored) {
+        }
       }
 
       // Ensure a run config is selected and ready to go.

--- a/flutter-idea/src/io/flutter/utils/FlutterModuleUtils.java
+++ b/flutter-idea/src/io/flutter/utils/FlutterModuleUtils.java
@@ -24,6 +24,7 @@ import com.intellij.ui.EditorNotifications;
 import com.intellij.util.PlatformUtils;
 import com.jetbrains.lang.dart.DartFileType;
 import com.jetbrains.lang.dart.sdk.DartSdk;
+import com.jetbrains.lang.dart.util.PubspecYamlUtil;
 import io.flutter.FlutterUtils;
 import io.flutter.actions.FlutterBuildActionGroup;
 import io.flutter.bazel.Workspace;
@@ -341,13 +342,20 @@ public class FlutterModuleUtils {
   }
 
   public static boolean hasAndroidModule(@NotNull Project project) {
-    String moduleName = project.getName() + "_android";
-    for (Module module : FlutterModuleUtils.getModules(project)) {
-      if (moduleName.equals(module.getName())) {
-        return true;
+    boolean isAllMatch = true;
+    for (PubRoot root : PubRoots.forProject(project)) {
+      assert root != null;
+      String name = PubspecYamlUtil.getDartProjectName(root.getPubspec());
+      String moduleName = name + "_android";
+      boolean isMatch = false;
+      for (Module module : FlutterModuleUtils.getModules(project)) {
+        if (moduleName.equals(module.getName())) {
+          isMatch = true;
+        }
       }
+      isAllMatch = isAllMatch && isMatch;
     }
-    return false;
+    return isAllMatch;
   }
 
   public static boolean isDeprecatedFlutterModuleType(@NotNull Module module) {


### PR DESCRIPTION
The IntelliJ project name is not necessarily the same as the Flutter project name.

Also updates test script to account for the difference.

There is a configuration error that causes 2022.1 and unit tests to fail. None of them touch the code in this PR.

Fixes #6019