### PR TITLE
Add jxbrowser log file for easier debugging

### DIFF
--- a/flutter-idea/src/io/flutter/jxbrowser/EmbeddedBrowser.java
+++ b/flutter-idea/src/io/flutter/jxbrowser/EmbeddedBrowser.java
@@ -6,6 +6,7 @@
 package io.flutter.jxbrowser;
 
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.PathManager;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
@@ -33,6 +34,7 @@ import io.flutter.utils.AsyncUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.awt.Dimension;
+import java.io.File;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
@@ -52,6 +54,7 @@ public class EmbeddedBrowser {
     System.setProperty("jxbrowser.force.dpi.awareness", "1.0");
     if (FlutterSettings.getInstance().isVerboseLogging()) {
       System.setProperty("jxbrowser.logging.level", "ALL");
+      System.setProperty("jxbrowser.logging.file", PathManager.getLogPath() + File.separatorChar + "jxbrowser.log");
     }
 
     try {


### PR DESCRIPTION
This seems to produce a different set of logs than when we have logs directed into the normal idea.log file, and these will be easier to send directly to JxBrowser developers who help us with debugging.