### PR TITLE
Update plugin tool

### DIFF
--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -12,8 +12,8 @@ void main(List<String> args) => grind(args);
 @Task('Check plugin URLs for live-ness')
 void checkUrls() async {
   log('checking URLs in FlutterBundle.properties...');
-  var lines =
-      await File('flutter-idea/src/io/flutter/FlutterBundle.properties').readAsLines();
+  var lines = await File('flutter-idea/src/io/flutter/FlutterBundle.properties')
+      .readAsLines();
   for (var line in lines) {
     var split = line.split('=');
     if (split.length == 2) {

--- a/tool/plugin/lib/artifact.dart
+++ b/tool/plugin/lib/artifact.dart
@@ -134,8 +134,7 @@ class ArtifactManager {
       if (artifact.isZip) {
         if (artifact.bareArchive) {
           result = extractZip(artifact.file,
-              cwd: 'artifacts',
-              targetDirectory: artifact.output);
+              cwd: 'artifacts', targetDirectory: artifact.output);
 
           var files = Directory(artifact.outPath).listSync();
           if (files.length < 3) /* Might have .DS_Store */ {
@@ -154,8 +153,7 @@ class ArtifactManager {
         }
       } else {
         result = extractTar(artifact,
-            cwd: 'artifacts',
-            targetDirectory: artifact.output);
+            cwd: 'artifacts', targetDirectory: artifact.output);
       }
       if (result != 0) {
         log('unpacking failed');

--- a/tool/plugin/lib/artifact.dart
+++ b/tool/plugin/lib/artifact.dart
@@ -136,9 +136,10 @@ class ArtifactManager {
 
       if (artifact.isZip) {
         if (artifact.bareArchive) {
-          result = await exec(
-              'unzip', ['-q', '-d', artifact.output, artifact.file],
-              cwd: 'artifacts');
+          result = extractZip(artifact.file,
+              cwd: 'artifacts',
+              targetDirectory: artifact.output);
+
           var files = Directory(artifact.outPath).listSync();
           if (files.length < 3) /* Might have .DS_Store */ {
             // This is the Mac zip case.
@@ -152,7 +153,7 @@ class ArtifactManager {
             Directory("${artifact.outPath}Temp").renameSync(artifact.outPath);
           }
         } else {
-          result = await exec('unzip', ['-q', artifact.file], cwd: 'artifacts');
+          result = extractZip(artifact.file, cwd: 'artifacts');
         }
       } else {
         result = await exec(

--- a/tool/plugin/lib/artifact.dart
+++ b/tool/plugin/lib/artifact.dart
@@ -128,12 +128,6 @@ class ArtifactManager {
         continue;
       }
 
-      // expand
-      if (Directory(artifact.outPath).existsSync()) {
-        await removeAll(artifact.outPath);
-      }
-      createDir(artifact.outPath);
-
       if (artifact.isZip) {
         if (artifact.bareArchive) {
           result = extractZip(artifact.file,

--- a/tool/plugin/lib/artifact.dart
+++ b/tool/plugin/lib/artifact.dart
@@ -156,17 +156,9 @@ class ArtifactManager {
           result = extractZip(artifact.file, cwd: 'artifacts');
         }
       } else {
-        result = await exec(
-          'tar',
-          [
-            '--strip-components=1',
-            '-zxf',
-            artifact.file,
-            '-C',
-            artifact.output
-          ],
-          cwd: p.join(rootPath, 'artifacts'),
-        );
+        result = extractTar(artifact,
+            cwd: 'artifacts',
+            targetDirectory: artifact.output);
       }
       if (result != 0) {
         log('unpacking failed');

--- a/tool/plugin/lib/artifact.dart
+++ b/tool/plugin/lib/artifact.dart
@@ -122,7 +122,7 @@ class ArtifactManager {
 
       // clear unpacked cache
       if (rebuildCache || !FileSystemEntity.isDirectorySync(artifact.outPath)) {
-        await removeAll(artifact.outPath);
+        removeAll(artifact.outPath);
       }
       if (isCacheDirectoryValid(artifact)) {
         continue;
@@ -156,7 +156,7 @@ class ArtifactManager {
       }
       if (result != 0) {
         log('unpacking failed');
-        await removeAll(artifact.output);
+        removeAll(artifact.output);
         break;
       }
 

--- a/tool/plugin/lib/artifact.dart
+++ b/tool/plugin/lib/artifact.dart
@@ -85,7 +85,7 @@ class ArtifactManager {
         }
         if (doDownload) {
           log('downloading $path...');
-          result = await curl('$base/${artifact.file}', to: path);
+          result = await download('$base/${artifact.file}', to: path);
           if (result != 0) {
             log('download failed');
           }
@@ -99,7 +99,7 @@ class ArtifactManager {
             if (artifact.isZip) {
               artifact.convertToTar();
               path = 'artifacts/${artifact.file}';
-              result = await curl('$base/${artifact.file}', to: path);
+              result = await download('$base/${artifact.file}', to: path);
               if (result != 0) {
                 log('download failed');
                 artifacts.remove(artifact);

--- a/tool/plugin/lib/edit.dart
+++ b/tool/plugin/lib/edit.dart
@@ -10,6 +10,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:meta/meta.dart';
+import 'package:path/path.dart' as p;
 
 import 'build_spec.dart';
 import 'util.dart';
@@ -96,17 +97,22 @@ class Unused extends EditCommand {
 }
 
 class EditAndroidModuleLibraryManager extends EditCommand {
+
+  final _moduleManagerPath = p.join(
+      'flutter-studio', 'src', 'io', 'flutter', 'android', 'AndroidModuleLibraryManager.java'
+  );
+
   @override
-  String get path =>
-      'flutter-studio/src/io/flutter/android/AndroidModuleLibraryManager.java';
+  String get path => _moduleManagerPath;
 
   @override
   String convert(BuildSpec spec) {
     // Starting with 3.6 we need to call a simplified init().
     // This is where the $PROJECT_FILE$ macro is defined, #registerComponents.
+
+    var libMgrPath = _moduleManagerPath;
     if (spec.version.startsWith('4.2')) {
-      var processedFile = File(
-          'flutter-studio/src/io/flutter/android/AndroidModuleLibraryManager.java');
+      var processedFile = File(libMgrPath);
       var source = processedFile.readAsStringSync();
       var original = source;
       source = source.replaceAll("ProjectExImpl", "ProjectImpl");
@@ -133,8 +139,7 @@ class EditAndroidModuleLibraryManager extends EditCommand {
       return original;
     } else {
       if (spec.version.startsWith('2021.2')) {
-        var processedFile = File(
-            'flutter-studio/src/io/flutter/android/AndroidModuleLibraryManager.java');
+        var processedFile = File(libMgrPath);
         var source = processedFile.readAsStringSync();
         var original = source;
         source = source.replaceAll(

--- a/tool/plugin/lib/edit.dart
+++ b/tool/plugin/lib/edit.dart
@@ -97,10 +97,8 @@ class Unused extends EditCommand {
 }
 
 class EditAndroidModuleLibraryManager extends EditCommand {
-
-  final _moduleManagerPath = p.join(
-      'flutter-studio', 'src', 'io', 'flutter', 'android', 'AndroidModuleLibraryManager.java'
-  );
+  final _moduleManagerPath = p.join('flutter-studio', 'src', 'io', 'flutter',
+      'android', 'AndroidModuleLibraryManager.java');
 
   @override
   String get path => _moduleManagerPath;

--- a/tool/plugin/lib/globals.dart
+++ b/tool/plugin/lib/globals.dart
@@ -14,7 +14,7 @@ const int cloudErrorFileMaxSize = 1000; // In bytes.
 // Globals are initialized early in ProductCommand. These are used in various
 // top-level functions. This is not ideal, but the "proper" solution would be
 // to move nearly all the top-level functions to methods in ProductCommand.
-String rootPath;
+String rootPath = '';
 String lastReleaseName;
 DateTime lastReleaseDate;
 int pluginCount = 0;

--- a/tool/plugin/lib/plugin.dart
+++ b/tool/plugin/lib/plugin.dart
@@ -879,19 +879,19 @@ class RenamePackageCommand extends ProductCommand {
   }
 
   void moveFiles() {
-    final srcDir = Directory(p.join(baseDir, oldName.replaceAll('.', '/')));
-    final destDir = Directory(p.join(baseDir, newName.replaceAll('.', '/')));
+    final srcDir = Directory(p.joinAll([baseDir] + oldName.split('.')));
+    final destDir = Directory(p.joinAll([baseDir] + newName.split('.')));
     _editAndMoveAll(srcDir, destDir);
   }
 
   void editReferences() {
-    final srcDir = Directory(p.join(baseDir, oldName.replaceAll('.', '/')));
-    final destDir = Directory(p.join(baseDir, newName.replaceAll('.', '/')));
+    final srcDir = Directory(p.joinAll([baseDir] + oldName.split('.')));
+    final destDir = Directory(p.joinAll([baseDir] + newName.split('.')));
     _editAll(Directory(baseDir), skipOld: srcDir, skipNew: destDir);
   }
 
   Future<int> deleteDir() async {
-    final dir = Directory(p.join(baseDir, oldName.replaceAll('.', '/')));
+    final dir = Directory(p.joinAll([baseDir] + oldName.split('.')));
     await dir.delete(recursive: true);
     return 0;
   }

--- a/tool/plugin/lib/plugin.dart
+++ b/tool/plugin/lib/plugin.dart
@@ -505,7 +505,7 @@ abstract class BuildCommand extends ProductCommand {
       }
 
       separator('Building flutter-intellij.jar');
-      await removeAll('build');
+      removeAll('build');
 
       log('spec.version: ${spec.version}');
 

--- a/tool/plugin/lib/plugin.dart
+++ b/tool/plugin/lib/plugin.dart
@@ -60,10 +60,10 @@ List<BuildSpec> createBuildSpecs(ProductCommand command) {
 Future<int> deleteBuildContents() async {
   final dir = Directory(p.join(rootPath, 'build'));
   if (!dir.existsSync()) throw 'No build directory found';
-  var args = <String>[];
-  args.add('-rf');
-  args.add(p.join(rootPath, 'build', '*'));
-  return await exec('rm', args);
+  log('Deleting build contents from ${dir.path}');
+  dir.deleteSync(recursive: true);
+
+  return 0;
 }
 
 List<File> findJars(String path) {

--- a/tool/plugin/lib/plugin.dart
+++ b/tool/plugin/lib/plugin.dart
@@ -410,11 +410,7 @@ class GradleBuildCommand extends BuildCommand {
   }
 
   Future<int> _stopDaemon() async {
-    if (Platform.isWindows) {
-      return await exec('.\\gradlew.bat', ['--stop']);
-    } else {
-      return await exec('./gradlew', ['--stop']);
-    }
+    return execGradleCommand(['--stop']);
   }
 }
 

--- a/tool/plugin/lib/plugin.dart
+++ b/tool/plugin/lib/plugin.dart
@@ -158,10 +158,11 @@ Future<int> jar(String directory, String outFile) async {
   try {
     return await exec('jar', args, cwd: directory);
   } on ProcessException catch (e) {
-    if (e.message == 'No such file or directory'){
+    if (e.message == 'No such file or directory') {
       log(
-        '\nThe build command requires `java` to be installed.'
-        '\nPlease ensure `jar` is on your \$PATH.', indent: false);
+          '\nThe build command requires `java` to be installed.'
+          '\nPlease ensure `jar` is on your \$PATH.',
+          indent: false);
       exit(e.errorCode);
     } else {
       rethrow;
@@ -864,7 +865,8 @@ class RenamePackageCommand extends ProductCommand {
 
   @override
   Future<int> doit() async {
-    if (argResults['studio']) baseDir = p.join(baseDir, 'flutter-studio', 'src');
+    if (argResults['studio'])
+      baseDir = p.join(baseDir, 'flutter-studio', 'src');
     oldName = argResults['package'];
     newName = argResults.wasParsed('new-name')
         ? argResults['new-name']

--- a/tool/plugin/lib/plugin.dart
+++ b/tool/plugin/lib/plugin.dart
@@ -155,7 +155,18 @@ Future<int> jar(String directory, String outFile) async {
       .listSync(followLinks: false)
       .map((f) => p.basename(f.path)));
   args.remove('.DS_Store');
-  return await exec('jar', args, cwd: directory);
+  try {
+    return await exec('jar', args, cwd: directory);
+  } on ProcessException catch (e) {
+    if (e.message == 'No such file or directory'){
+      log(
+        '\nThe build command requires `java` to be installed.'
+        '\nPlease ensure `jar` is on your \$PATH.', indent: false);
+      exit(e.errorCode);
+    } else {
+      rethrow;
+    }
+  }
 }
 
 Future<int> moveToArtifacts(ProductCommand cmd, BuildSpec spec) async {

--- a/tool/plugin/lib/plugin.dart
+++ b/tool/plugin/lib/plugin.dart
@@ -161,11 +161,15 @@ Future<int> jar(String directory, String outFile) async {
 Future<int> moveToArtifacts(ProductCommand cmd, BuildSpec spec) async {
   final dir = Directory(p.join(rootPath, 'artifacts'));
   if (!dir.existsSync()) throw 'No artifacts directory found';
-  var file = pluginRegistryIds[spec.pluginId];
-  var args = <String>[];
-  args.add(p.join(rootPath, 'build', file));
-  args.add(cmd.releasesFilePath(spec));
-  return await exec('mv', args);
+
+  var targetFile =
+      File(p.join(rootPath, 'build', pluginRegistryIds[spec.pluginId]));
+  var newPath = cmd.releasesFilePath(spec);
+
+  log('Moving ${targetFile.path} to $newPath');
+  targetFile.renameSync(newPath);
+
+  return 0;
 }
 
 Future<bool> performReleaseChecks(ProductCommand cmd) async {

--- a/tool/plugin/lib/runner.dart
+++ b/tool/plugin/lib/runner.dart
@@ -100,19 +100,15 @@ baseVersion=${spec.baseVersion}
     // --daemon => Invalid byte 1 of 1-byte UTF-8 sequence, which is nonsense.
     // During instrumentation of FlutterProjectStep.form, which is a UTF-8 file.
     try {
-      if (Platform.isWindows) {
-        if (spec.version == '4.1') {
+      if (spec.version == '4.1') {
+        if (Platform.isWindows) {
           log('CANNOT BUILD ${spec.version} ON WINDOWS');
           return 0;
-        }
-        result = await exec('.\\gradlew.bat', command);
-      } else {
-        if (spec.version == '4.1') {
-          return await runShellScript(command, spec);
         } else {
-          result = await exec('./gradlew', command);
+          return await runShellScript(command, spec);
         }
       }
+      result = await execGradleCommand(command);
     } finally {
       propertiesFile.writeAsStringSync(source);
     }

--- a/tool/plugin/lib/runner.dart
+++ b/tool/plugin/lib/runner.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:args/command_runner.dart';
+import 'package:path/path.dart' as p;
 
 import 'build_spec.dart';
 import 'globals.dart';
@@ -59,7 +60,7 @@ compile
     final jxBrowserKey =
         readTokenFromKeystore('FLUTTER_KEYSTORE_JXBROWSER_KEY_NAME');
     final propertiesFile =
-        File("$rootPath/resources/jxbrowser/jxbrowser.properties");
+        File(p.join(rootPath, 'resources', 'jxbrowser', 'jxbrowser.properties'));
     if (jxBrowserKey.isNotEmpty) {
       final contents = '''
 jxbrowser.license.key=$jxBrowserKey
@@ -92,7 +93,7 @@ testing=$testing
 buildSpec=${spec.version}
 baseVersion=${spec.baseVersion}
 ''';
-    final propertiesFile = File("$rootPath/gradle.properties");
+    final propertiesFile = File(p.join(rootPath, 'gradle.properties'));
     final source = propertiesFile.readAsStringSync();
     propertiesFile.writeAsStringSync(contents);
     int result;

--- a/tool/plugin/lib/runner.dart
+++ b/tool/plugin/lib/runner.dart
@@ -59,8 +59,8 @@ compile
   void writeJxBrowserKeyToFile() {
     final jxBrowserKey =
         readTokenFromKeystore('FLUTTER_KEYSTORE_JXBROWSER_KEY_NAME');
-    final propertiesFile =
-        File(p.join(rootPath, 'resources', 'jxbrowser', 'jxbrowser.properties'));
+    final propertiesFile = File(
+        p.join(rootPath, 'resources', 'jxbrowser', 'jxbrowser.properties'));
     if (jxBrowserKey.isNotEmpty) {
       final contents = '''
 jxbrowser.license.key=$jxBrowserKey

--- a/tool/plugin/lib/util.dart
+++ b/tool/plugin/lib/util.dart
@@ -102,7 +102,7 @@ void log(String s, {bool indent = true}) {
 void createDir(String name) {
   final dir = Directory(name);
   if (!dir.existsSync()) {
-    log('creating $name/');
+    log('creating $name');
     dir.createSync(recursive: true);
   }
 }
@@ -233,7 +233,7 @@ String readTokenFromKeystore(String keyName) {
   var id = env['FLUTTER_KEYSTORE_ID'];
   var name = env[keyName];
 
-  var file = File('$base/${id}_$name');
+  var file = File(p.join(base, '${id}_$name'));
   return file.existsSync() ? file.readAsStringSync() : '';
 }
 

--- a/tool/plugin/lib/util.dart
+++ b/tool/plugin/lib/util.dart
@@ -244,7 +244,7 @@ int extractTar(Artifact artifact, {targetDirectory = '', cwd = ''}) {
         ..writeAsBytesSync(tarFile.content);
     }
   } on FileSystemException catch (e) {
-    log(e.osError.message);
+    log(e.osError?.message ?? e.message);
     return -1;
   } catch (e) {
     log('An unknown error occurred: $e');

--- a/tool/plugin/lib/util.dart
+++ b/tool/plugin/lib/util.dart
@@ -208,7 +208,9 @@ String stripComponents(String filePath, int i) {
 File getFileOrThrow(String filePath) {
   var file = File(filePath);
 
-  if (!file.existsSync()) throw "Unable to locate file '${file.path}'";
+  if (!file.existsSync()) {
+    throw FileSystemException("Unable to locate file '${file.path}'");
+  }
 
   return file;
 }

--- a/tool/plugin/lib/util.dart
+++ b/tool/plugin/lib/util.dart
@@ -186,3 +186,19 @@ String _nextRelease() {
   var val = int.parse(current) + 1;
   return '$val.0';
 }
+
+/// Replicates `tar` --strip-components=N behaviour
+///
+/// Returns [filePath] with the first [i] components removed.
+/// e.g. ('a/b/c/', 1) returns 'b/c'
+String stripComponents(String filePath, int i) {
+  List<String> components = p.split(filePath);
+
+  if (i < components.length - 1) {
+    components.removeRange(0, i);
+  } else {
+    components.removeRange(0, components.length - 1);
+  }
+
+  return p.joinAll(components);
+}

--- a/tool/plugin/lib/util.dart
+++ b/tool/plugin/lib/util.dart
@@ -289,3 +289,12 @@ int extractZip(Artifact artifact, {targetDirectory = '', cwd = ''}) {
 
   return 0;
 }
+
+/// Calls the platform specific gradle wrapper with the provided arguments
+Future<int> execGradleCommand(List<String> args) async {
+  if (Platform.isWindows) {
+    return await exec('.\\gradlew.bat', args);
+  } else {
+    return await exec('./gradlew', args);
+  }
+}

--- a/tool/plugin/lib/util.dart
+++ b/tool/plugin/lib/util.dart
@@ -255,15 +255,15 @@ int extractTar(Artifact artifact, {targetDirectory = '', cwd = ''}) {
 }
 
 
-/// Extract files from a zipped [artifact.file] to [artifact.output]
+/// Extract files from a zipped [artifactPath]
 ///
 /// The [artifact] file location can be specified using [cwd] and
 /// [targetDirectory] can be used to set a directory for the extracted files.
 ///
 /// An int is returned to match existing patterns of checking for an error ala
 /// the CLI
-int extractZip(Artifact artifact, {targetDirectory = '', cwd = ''}) {
-  var filePath = p.join(cwd, artifact.file);
+int extractZip(String artifactPath, {targetDirectory = '', cwd = ''}) {
+  var filePath = p.join(cwd, artifactPath);
   var outputPath = p.join(cwd, targetDirectory);
 
   try {

--- a/tool/plugin/lib/util.dart
+++ b/tool/plugin/lib/util.dart
@@ -25,7 +25,7 @@ Future<int> exec(String cmd, List<String> args, {String cwd}) async {
     log(_shorten('$cmd ${args.join(' ')}'));
   }
 
-  var codec = Platform.isWindows ? latin1: utf8;
+  var codec = Platform.isWindows ? latin1 : utf8;
   final process = await Process.start(cmd, args, workingDirectory: cwd);
   _toLineStream(process.stderr, codec).listen(log);
   _toLineStream(process.stdout, codec).listen(log);
@@ -237,7 +237,6 @@ String readTokenFromKeystore(String keyName) {
   return file.existsSync() ? file.readAsStringSync() : '';
 }
 
-
 int get devBuildNumber {
   // The dev channel is automatically refreshed weekly, so the build number
   // is just the number of weeks since the last stable release.
@@ -262,7 +261,7 @@ String buildVersionNumber(BuildSpec spec) {
 
 String _nextRelease() {
   var current =
-  RegExp(r'release_(\d+)').matchAsPrefix(lastReleaseName).group(1);
+      RegExp(r'release_(\d+)').matchAsPrefix(lastReleaseName).group(1);
   var val = int.parse(current) + 1;
   return '$val.0';
 }
@@ -302,21 +301,19 @@ File getFileOrThrow(String filePath) {
 /// An int is returned to match existing patterns of checking for an error ala
 /// the CLI
 int extractTar(Artifact artifact, {targetDirectory = '', cwd = ''}) {
-
   var artifactPath = p.join(cwd, artifact.file);
   var outputDir = p.join(cwd, targetDirectory, artifact.output);
 
   log('Extracting $artifactPath to $outputDir');
 
   try {
-
     var file = getFileOrThrow(artifactPath);
     var decodedGZipContent = GZipCodec().decode(file.readAsBytesSync());
     var iStream = InputStream(decodedGZipContent);
     var decodedArchive = TarDecoder().decodeBuffer(iStream);
 
     for (var tarFile in decodedArchive.files) {
-      if (!tarFile.isFile) continue;  // Don't need to create empty directories
+      if (!tarFile.isFile) continue; // Don't need to create empty directories
 
       File(p.join(outputDir, stripComponents(tarFile.name, 1)))
         ..createSync(recursive: true)
@@ -332,7 +329,6 @@ int extractTar(Artifact artifact, {targetDirectory = '', cwd = ''}) {
 
   return 0;
 }
-
 
 /// Extract files from a zipped [artifactPath]
 ///

--- a/tool/plugin/lib/util.dart
+++ b/tool/plugin/lib/util.dart
@@ -107,7 +107,7 @@ void createDir(String name) {
   }
 }
 
-Future<int> curl(String url, {String to}) async {
+Future<int> download(String url, {String to}) async {
   final File tmpFile = File('$to.tmp');
   final httpClient = Client();
   final request = Request('GET', Uri.parse(url));

--- a/tool/plugin/lib/util.dart
+++ b/tool/plugin/lib/util.dart
@@ -109,9 +109,26 @@ Future<int> curl(String url, {String to}) async {
   return await exec('curl', ['-o', to, url]);
 }
 
-Future<int> removeAll(String dir) async {
-  var args = ['-rf', dir];
-  return await exec('rm', args);
+int removeAll(String dir) {
+  var targetDirectory = Directory(dir);
+
+  log('Removing Directory $dir');
+
+  if (targetDirectory.existsSync()) {
+    try {
+      targetDirectory.deleteSync(recursive: true);
+    } on FileSystemException catch (e) {
+      log(e.osError.message);
+      return -1;
+    } catch (e) {
+      log("An error occurred while deleteing $dir");
+      log(e);
+
+      return -1;
+    }
+  }
+
+  return 0;
 }
 
 bool isCacheDirectoryValid(Artifact artifact) {

--- a/tool/plugin/lib/util.dart
+++ b/tool/plugin/lib/util.dart
@@ -229,9 +229,9 @@ Stream<String> _toLineStream(Stream<List<int>> s, Encoding encoding) =>
 
 String readTokenFromKeystore(String keyName) {
   var env = Platform.environment;
-  var base = env['KOKORO_KEYSTORE_DIR'];
-  var id = env['FLUTTER_KEYSTORE_ID'];
-  var name = env[keyName];
+  var base = env['KOKORO_KEYSTORE_DIR'] ?? '';
+  var id = env['FLUTTER_KEYSTORE_ID'] ?? '';
+  var name = env[keyName] ?? '';
 
   var file = File(p.join(base, '${id}_$name'));
   return file.existsSync() ? file.readAsStringSync() : '';

--- a/tool/plugin/pubspec.yaml
+++ b/tool/plugin/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   markdown: ^4.0.0
   path: ^1.7.0
   archive: ^3.2.2
+  http: ^0.13.4
 
 dev_dependencies:
   lints: ^1.0.0

--- a/tool/plugin/pubspec.yaml
+++ b/tool/plugin/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   git: ^2.0.0
   markdown: ^4.0.0
   path: ^1.7.0
+  archive: ^3.2.2
 
 dev_dependencies:
   lints: ^1.0.0

--- a/tool/plugin/test/artifact_test.dart
+++ b/tool/plugin/test/artifact_test.dart
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+// @dart = 2.10
+import 'package:path/path.dart' as p;
+import 'package:plugin_tool/util.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Validate `stripComponents` function', () {
+    test('Correct components are removed', () {
+      var testPath = p.join('a', 'b', 'c', 'd');
+      expect(stripComponents(testPath, 1), p.join('b', 'c', 'd'));
+      expect(stripComponents(testPath, 2), p.join('c', 'd'));
+      expect(stripComponents(testPath, 3), p.join('d'));
+    });
+
+    test('Last element is always returned', () {
+      var testPath = p.join('a', 'b', 'c', 'd');
+
+      expect(stripComponents(testPath, 4), p.join('d'));
+      expect(stripComponents(testPath, 5), p.join('d'));
+    });
+  });
+
+}

--- a/tool/plugin/test/artifact_test.dart
+++ b/tool/plugin/test/artifact_test.dart
@@ -24,5 +24,4 @@ void main() {
       expect(stripComponents(testPath, 5), p.join('d'));
     });
   });
-
 }


### PR DESCRIPTION
This PR brings the project closer to normalizing the tool across platforms. 

Previously, this plugin used OS specific calls like `rm`, `mv`, `curl` to complete. These calls have been replaced with platform-agnostic Dart.  Additionally, file pathing has been normalized to use Dart's `path` library.

#### Issues fixed:
- Addresses https://github.com/flutter/flutter-intellij/issues/6052

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
