### PR TITLE
Fix FakeWorkspaceFactory for test

### DIFF
--- a/flutter-idea/testSrc/unit/io/flutter/bazel/FakeWorkspaceFactory.java
+++ b/flutter-idea/testSrc/unit/io/flutter/bazel/FakeWorkspaceFactory.java
@@ -7,6 +7,7 @@ package io.flutter.bazel;
 
 import com.intellij.mock.MockVirtualFileSystem;
 import com.intellij.openapi.util.Pair;
+import org.dartlang.vm.service.element.Null;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -25,7 +26,8 @@ public class FakeWorkspaceFactory {
     @Nullable String versionFile,
     @Nullable String requiredIJPluginID,
     @Nullable String requiredIJPluginMessage,
-    @Nullable String configWarningMessage
+    @Nullable String configWarningMessage,
+    @Nullable String updatedIosRunMessage
   ) {
     final MockVirtualFileSystem fs = new MockVirtualFileSystem();
     fs.file("/workspace/WORKSPACE", "");
@@ -70,7 +72,7 @@ public class FakeWorkspaceFactory {
           requiredIJPluginID,
           requiredIJPluginMessage,
           configWarningMessage,
-          ""
+          updatedIosRunMessage
         )
       )
     );
@@ -93,7 +95,8 @@ public class FakeWorkspaceFactory {
       "flutter-version",
       "some.ij.plugin.id",
       "Some IJ Plugin ID Message",
-      "Config warning message"
+      "Config warning message",
+      "Updated iOS run message"
     );
   }
 }

--- a/flutter-idea/testSrc/unit/io/flutter/run/bazel/LaunchCommandsTest.java
+++ b/flutter-idea/testSrc/unit/io/flutter/run/bazel/LaunchCommandsTest.java
@@ -382,11 +382,12 @@ public class LaunchCommandsTest {
                     @Nullable String versionFile,
                     @Nullable String requiredIJPluginID,
                     @Nullable String requiredIJPluginMessage,
-                    @Nullable String configWarningMessage) {
+                    @Nullable String configWarningMessage,
+                    @Nullable String updatedIosRunMessage) {
       super(template);
       final Pair.NonNull<MockVirtualFileSystem, Workspace> pair = FakeWorkspaceFactory
         .createWorkspaceAndFilesystem(daemonScript, doctorScript, testScript, runScript, syncScript, sdkHome, versionFile,
-                                      requiredIJPluginID, requiredIJPluginMessage, configWarningMessage);
+                                      requiredIJPluginID, requiredIJPluginMessage, configWarningMessage, updatedIosRunMessage);
       fs = pair.first;
       fakeWorkspace = pair.second;
     }

--- a/flutter-idea/testSrc/unit/io/flutter/run/bazelTest/LaunchCommandsTest.java
+++ b/flutter-idea/testSrc/unit/io/flutter/run/bazelTest/LaunchCommandsTest.java
@@ -184,6 +184,7 @@ public class LaunchCommandsTest {
       null,
       null,
       null,
+      null,
       null
     );
     boolean didThrow = false;
@@ -209,6 +210,7 @@ public class LaunchCommandsTest {
       null,
       null,
       null,
+      null,
       null
     );
     boolean didThrow = false;
@@ -227,6 +229,7 @@ public class LaunchCommandsTest {
       new BazelTestFields(null, "/workspace/foo/test/foo_test.dart", "//foo:test", "--ignored-args"),
       "scripts/daemon.sh",
       "scripts/doctor.sh",
+      null,
       null,
       null,
       null,
@@ -299,10 +302,11 @@ public class LaunchCommandsTest {
                         @Nullable String versionFile,
                         @Nullable String requiredIJPluginID,
                         @Nullable String requiredIJPluginMessage,
-                        @Nullable String configWarningMessage) {
+                        @Nullable String configWarningMessage,
+                        @Nullable String updatedIosRunMessage) {
       super(template);
       final Pair.NonNull<MockVirtualFileSystem, Workspace> pair = FakeWorkspaceFactory
-        .createWorkspaceAndFilesystem(daemonScript, doctorScript, testScript, runScript, syncScript, sdkHome, versionFile, requiredIJPluginID, requiredIJPluginMessage, configWarningMessage);
+        .createWorkspaceAndFilesystem(daemonScript, doctorScript, testScript, runScript, syncScript, sdkHome, versionFile, requiredIJPluginID, requiredIJPluginMessage, configWarningMessage, updatedIosRunMessage);
       fs = pair.first;
       fakeWorkspace = pair.second;
     }


### PR DESCRIPTION
It's annoying to have to change these for every Bazel workspace change, but I think this is marginally better so that we don't have to suddenly add a bunch of lines the next time we have a bazel item that we do want to actively test.