### PR TITLE
Report flutter SDK version on startup

### DIFF
--- a/flutter-idea/src/io/flutter/ProjectOpenActivity.java
+++ b/flutter-idea/src/io/flutter/ProjectOpenActivity.java
@@ -84,7 +84,8 @@ public class ProjectOpenActivity implements StartupActivity, DumbAware {
       FlutterInitializer.getAnalytics().sendEventMetric(
         "startup",
         "indexingFinished",
-        project.getService(TimeTracker.class).millisSinceProjectOpen()
+        project.getService(TimeTracker.class).millisSinceProjectOpen(),
+        FlutterSdk.getFlutterSdk(project)
       );
     });
 

--- a/flutter-idea/src/io/flutter/analytics/Analytics.java
+++ b/flutter-idea/src/io/flutter/analytics/Analytics.java
@@ -104,11 +104,15 @@ public class Analytics {
   }
 
   public void sendEventMetric(@NotNull String category, @NotNull String action, int value) {
+    sendEventMetric(category, action, value, null);
+  }
+
+  public void sendEventMetric(@NotNull String category, @NotNull String action, int value, @Nullable FlutterSdk flutterSdk) {
     final Map<String, String> args = new HashMap<>();
     args.put("ec", category);
     args.put("ea", action);
     args.put("ev", Integer.toString(value));
-    sendPayload("event", args, null);
+    sendPayload("event", args, flutterSdk);
   }
 
   public void sendEvent(@NotNull String category, @NotNull String action, @NotNull String label, @NotNull String value) {


### PR DESCRIPTION
We have a custom field defined for the Flutter SDK version, but we don't seem to be reporting it. This adds it to an analytics event that happens on startup.