### PR TITLE
Use devtools script to launch bazel devtools

### DIFF
--- a/flutter-idea/src/io/flutter/analytics/DartCompletionTimerListener.java
+++ b/flutter-idea/src/io/flutter/analytics/DartCompletionTimerListener.java
@@ -3,7 +3,7 @@ package io.flutter.analytics;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
 
-import com.jetbrains.lang.dart.ide.completion.DartCompletionTimerExtension;
+
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -13,7 +13,7 @@ import java.time.Instant;
  * Implementation of the {@link DartCompletionTimerExtension} which allows the Flutter plugin to
  * measure the total time to present a code completion to the user.
  */
-public class DartCompletionTimerListener extends DartCompletionTimerExtension {
+public class DartCompletionTimerListener  {
   @Nullable FlutterAnalysisServerListener dasListener;
   @Nullable Long startTimeMS;
 

--- a/flutter-idea/src/io/flutter/analytics/DartCompletionTimerListener.java
+++ b/flutter-idea/src/io/flutter/analytics/DartCompletionTimerListener.java
@@ -3,7 +3,6 @@ package io.flutter.analytics;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
 
-
 import com.jetbrains.lang.dart.ide.completion.DartCompletionTimerExtension;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;

--- a/flutter-idea/src/io/flutter/analytics/DartCompletionTimerListener.java
+++ b/flutter-idea/src/io/flutter/analytics/DartCompletionTimerListener.java
@@ -4,6 +4,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
 
 
+import com.jetbrains.lang.dart.ide.completion.DartCompletionTimerExtension;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -13,7 +14,7 @@ import java.time.Instant;
  * Implementation of the {@link DartCompletionTimerExtension} which allows the Flutter plugin to
  * measure the total time to present a code completion to the user.
  */
-public class DartCompletionTimerListener  {
+public class DartCompletionTimerListener extends DartCompletionTimerExtension {
   @Nullable FlutterAnalysisServerListener dasListener;
   @Nullable Long startTimeMS;
 

--- a/flutter-idea/src/io/flutter/bazel/PluginConfig.java
+++ b/flutter-idea/src/io/flutter/bazel/PluginConfig.java
@@ -40,6 +40,10 @@ public class PluginConfig {
   }
 
   @Nullable
+  String getDevToolsScript() {
+    return fields.devToolsScript;
+  }
+  @Nullable
   String getDoctorScript() {
     return fields.doctorScript;
   }
@@ -135,6 +139,7 @@ public class PluginConfig {
   @VisibleForTesting
   public static PluginConfig forTest(
     @Nullable String daemonScript,
+    @Nullable String devToolsScript,
     @Nullable String doctorScript,
     @Nullable String testScript,
     @Nullable String runScript,
@@ -147,6 +152,7 @@ public class PluginConfig {
   ) {
     final Fields fields = new Fields(
       daemonScript,
+      devToolsScript,
       doctorScript,
       testScript,
       runScript,
@@ -169,6 +175,9 @@ public class PluginConfig {
      */
     @SerializedName("daemonScript")
     private String daemonScript;
+
+    @SerializedName("devToolsScript")
+    private String devToolsScript;
 
     /**
      * The script to run to start 'flutter doctor'.
@@ -231,6 +240,7 @@ public class PluginConfig {
      * Convenience constructor that takes all parameters.
      */
     Fields(String daemonScript,
+           String devToolsScript,
            String doctorScript,
            String testScript,
            String runScript,
@@ -241,6 +251,7 @@ public class PluginConfig {
            String configWarningPrefix,
            String updatedIosRunMessage) {
       this.daemonScript = daemonScript;
+      this.devToolsScript = devToolsScript;
       this.doctorScript = doctorScript;
       this.testScript = testScript;
       this.runScript = runScript;
@@ -257,6 +268,7 @@ public class PluginConfig {
       if (!(obj instanceof Fields)) return false;
       final Fields other = (Fields)obj;
       return Objects.equal(daemonScript, other.daemonScript)
+             && Objects.equal(devToolsScript, other.devToolsScript)
              && Objects.equal(doctorScript, other.doctorScript)
              && Objects.equal(testScript, other.testScript)
              && Objects.equal(runScript, other.runScript)
@@ -270,7 +282,7 @@ public class PluginConfig {
 
     @Override
     public int hashCode() {
-      return Objects.hashCode(daemonScript, doctorScript, testScript, runScript, syncScript, sdkHome, requiredIJPluginID,
+      return Objects.hashCode(daemonScript, devToolsScript, doctorScript, testScript, runScript, syncScript, sdkHome, requiredIJPluginID,
                               requiredIJPluginMessage, configWarningPrefix, updatedIosRunMessage);
     }
   }

--- a/flutter-idea/src/io/flutter/bazel/Workspace.java
+++ b/flutter-idea/src/io/flutter/bazel/Workspace.java
@@ -40,6 +40,7 @@ public class Workspace {
   @NotNull private final VirtualFile root;
   @Nullable private final PluginConfig config;
   @Nullable private final String daemonScript;
+  @Nullable private final String devToolsScript;
   @Nullable private final String doctorScript;
   @Nullable private final String testScript;
   @Nullable private final String runScript;
@@ -53,6 +54,7 @@ public class Workspace {
   private Workspace(@NotNull VirtualFile root,
                     @Nullable PluginConfig config,
                     @Nullable String daemonScript,
+                    @Nullable String devToolsScript,
                     @Nullable String doctorScript,
                     @Nullable String testScript,
                     @Nullable String runScript,
@@ -65,6 +67,7 @@ public class Workspace {
     this.root = root;
     this.config = config;
     this.daemonScript = daemonScript;
+    this.devToolsScript = devToolsScript;
     this.doctorScript = doctorScript;
     this.testScript = testScript;
     this.runScript = runScript;
@@ -131,6 +134,14 @@ public class Workspace {
   @Nullable
   public String getDaemonScript() {
     return daemonScript;
+  }
+
+  /**
+   * Returns the script that starts DevTools, or null if not configured.
+   */
+  @Nullable
+  public String getDevToolsScript() {
+    return devToolsScript;
   }
 
   /**
@@ -267,6 +278,8 @@ public class Workspace {
 
     final String daemonScript = config == null ? null : getScriptFromPath(root, readonlyPath, config.getDaemonScript());
 
+    final String devToolsScript = config == null ? null : getScriptFromPath(root, readonlyPath, config.getDevToolsScript());
+
     final String doctorScript = config == null ? null : getScriptFromPath(root, readonlyPath, config.getDoctorScript());
 
     final String testScript = config == null ? null : getScriptFromPath(root, readonlyPath, config.getTestScript());
@@ -285,7 +298,7 @@ public class Workspace {
 
     final String updatedIosRunMessage = config == null ? null : config.getUpdatedIosRunMessage();
 
-    return new Workspace(root, config, daemonScript, doctorScript, testScript, runScript, syncScript, sdkHome, requiredIJPluginID, requiredIJPluginMessage, configWarningPrefix, updatedIosRunMessage);
+    return new Workspace(root, config, daemonScript, devToolsScript, doctorScript, testScript, runScript, syncScript, sdkHome, requiredIJPluginID, requiredIJPluginMessage, configWarningPrefix, updatedIosRunMessage);
   }
 
   @VisibleForTesting
@@ -294,6 +307,7 @@ public class Workspace {
       workspaceRoot,
       pluginConfig,
       pluginConfig.getDaemonScript(),
+      pluginConfig.getDevToolsScript(),
       pluginConfig.getDoctorScript(),
       pluginConfig.getTestScript(),
       pluginConfig.getRunScript(),

--- a/flutter-idea/src/io/flutter/run/bazel/BazelFields.java
+++ b/flutter-idea/src/io/flutter/run/bazel/BazelFields.java
@@ -301,17 +301,22 @@ public class BazelFields {
         progress.getProgressIndicator().setIndeterminate(true);
         try {
           final DevToolsService service = this.devToolsService == null ? DevToolsService.getInstance(project) : this.devToolsService;
-          devToolsFuture.complete(service.getDevToolsInstance().get(30, TimeUnit.SECONDS));
+          final DevToolsInstance instance = service.getDevToolsInstance().get(30, TimeUnit.SECONDS);
+          if (instance != null) {
+            devToolsFuture.complete(instance);
+          } else {
+            devToolsFuture.completeExceptionally(new Exception("DevTools instance not available."));
+          }
         }
         catch (Exception e) {
-          LOG.error(e);
+          devToolsFuture.completeExceptionally(e);
         }
       }, "Starting DevTools", false, project);
       final DevToolsInstance instance = devToolsFuture.get();
       commandLine.addParameter("--devtools-server-address=http://" + instance.host + ":" + instance.port);
     }
     catch (Exception e) {
-      LOG.error(e);
+      LOG.info(e);
     }
 
     commandLine.addParameter(target);

--- a/flutter-idea/src/io/flutter/run/daemon/DevToolsService.java
+++ b/flutter-idea/src/io/flutter/run/daemon/DevToolsService.java
@@ -182,7 +182,7 @@ public class DevToolsService {
       });
     }
     catch (ExecutionException e) {
-      throw new RuntimeException(e);
+      logExceptionAndComplete(e);
     }
   }
 

--- a/flutter-idea/src/io/flutter/run/daemon/DevToolsService.java
+++ b/flutter-idea/src/io/flutter/run/daemon/DevToolsService.java
@@ -22,7 +22,6 @@ import com.intellij.openapi.util.Key;
 import com.intellij.openapi.util.Version;
 import com.intellij.openapi.util.io.FileUtil;
 import com.jetbrains.lang.dart.sdk.DartSdk;
-import com.jetbrains.lang.dart.sdk.DartSdkUtil;
 import io.flutter.FlutterInitializer;
 import io.flutter.FlutterUtils;
 import io.flutter.bazel.Workspace;
@@ -118,9 +117,16 @@ public class DevToolsService {
       }
 
       if (dartDevToolsSupported) {
-        setUpWithDart();
+        final WorkspaceCache workspaceCache = WorkspaceCache.getInstance(project);
+        if (workspaceCache.isBazel()) {
+          setUpWithDart(createCommand(workspaceCache.get().getRoot().getPath(), workspaceCache.get().getDevToolsScript(),
+                                      ImmutableList.of("--machine")));
+        }
+        else {
+          setUpWithDart(createCommand(DartSdk.getDartSdk(project).getHomePath(), "dart", ImmutableList.of("devtools", "--machine")));
+        }
       }
-      else if (WorkspaceCache.getInstance(project).isBazel() || (sdk != null && sdk.getVersion().useDaemonForDevTools())) {
+      else if (sdk != null && sdk.getVersion().useDaemonForDevTools()) {
         setUpWithDaemon();
       }
       else {
@@ -130,9 +136,7 @@ public class DevToolsService {
     });
   }
 
-  private void setUpWithDart() {
-    final GeneralCommandLine command =
-      createCommand(DartSdk.getDartSdk(project).getHomePath(), "dart", ImmutableList.of("devtools", "--machine"));
+  private void setUpWithDart(GeneralCommandLine command) {
     try {
       this.process = new MostlySilentColoredProcessHandler(command);
       this.process.addProcessListener(new ProcessAdapter() {

--- a/flutter-idea/testSrc/unit/io/flutter/bazel/FakeWorkspaceFactory.java
+++ b/flutter-idea/testSrc/unit/io/flutter/bazel/FakeWorkspaceFactory.java
@@ -18,6 +18,7 @@ public class FakeWorkspaceFactory {
   @NotNull
   public static Pair.NonNull<MockVirtualFileSystem, Workspace> createWorkspaceAndFilesystem(
     @Nullable String daemonScript,
+    @Nullable String devToolsScript,
     @Nullable String doctorScript,
     @Nullable String testScript,
     @Nullable String runScript,
@@ -33,6 +34,9 @@ public class FakeWorkspaceFactory {
     fs.file("/workspace/WORKSPACE", "");
     if (daemonScript != null) {
       fs.file("/workspace/" + daemonScript, "");
+    }
+    if (devToolsScript != null) {
+      fs.file("/workspace/" + devToolsScript, "");
     }
     if (doctorScript != null) {
       fs.file("/workspace/" + doctorScript, "");
@@ -64,6 +68,7 @@ public class FakeWorkspaceFactory {
         fs.findFileByPath("/workspace/"),
         PluginConfig.forTest(
           daemonScript,
+          devToolsScript,
           doctorScript,
           testScript,
           runScript,
@@ -87,6 +92,7 @@ public class FakeWorkspaceFactory {
   public static Pair.NonNull<MockVirtualFileSystem, Workspace> createWorkspaceAndFilesystem() {
     return createWorkspaceAndFilesystem(
       "scripts/flutter-daemon.sh",
+      "scripts/flutter-devtools.sh",
       "scripts/flutter-doctor.sh",
       "scripts/flutter-test.sh",
       "scripts/flutter-run.sh",

--- a/flutter-idea/testSrc/unit/io/flutter/run/bazel/LaunchCommandsTest.java
+++ b/flutter-idea/testSrc/unit/io/flutter/run/bazel/LaunchCommandsTest.java
@@ -374,6 +374,7 @@ public class LaunchCommandsTest {
 
     FakeBazelFields(@NotNull BazelFields template,
                     @Nullable String daemonScript,
+                    @Nullable String devToolsScript,
                     @Nullable String doctorScript,
                     @Nullable String testScript,
                     @Nullable String runScript,
@@ -386,7 +387,7 @@ public class LaunchCommandsTest {
                     @Nullable String updatedIosRunMessage) {
       super(template);
       final Pair.NonNull<MockVirtualFileSystem, Workspace> pair = FakeWorkspaceFactory
-        .createWorkspaceAndFilesystem(daemonScript, doctorScript, testScript, runScript, syncScript, sdkHome, versionFile,
+        .createWorkspaceAndFilesystem(daemonScript, devToolsScript, doctorScript, testScript, runScript, syncScript, sdkHome, versionFile,
                                       requiredIJPluginID, requiredIJPluginMessage, configWarningMessage, updatedIosRunMessage);
       fs = pair.first;
       fakeWorkspace = pair.second;

--- a/flutter-idea/testSrc/unit/io/flutter/run/bazelTest/BazelTestConfigProducerTest.java
+++ b/flutter-idea/testSrc/unit/io/flutter/run/bazelTest/BazelTestConfigProducerTest.java
@@ -166,7 +166,7 @@ public class BazelTestConfigProducerTest extends AbstractDartElementTest {
       fs.file("/workspace/WORKSPACE", "");
       fakeWorkspace = Workspace.forTest(
         fs.findFileByPath("/workspace/"),
-        PluginConfig.forTest("", "", "", "", "", "", "", "", "", "")
+        PluginConfig.forTest("", "", "", "", "", "", "", "", "", "", "")
       );
       this.hasWorkspace = hasWorkspace;
       this.hasValidTestFile = hasValidTestFile;

--- a/flutter-idea/testSrc/unit/io/flutter/run/bazelTest/LaunchCommandsTest.java
+++ b/flutter-idea/testSrc/unit/io/flutter/run/bazelTest/LaunchCommandsTest.java
@@ -176,6 +176,7 @@ public class LaunchCommandsTest {
     final BazelTestFields fields = new FakeBazelTestFields(
       BazelTestFields.forFile("/workspace/foo/test/foo_test.dart", null),
       "scripts/daemon.sh",
+      "scripts/devtools.sh",
       "scripts/doctor.sh",
       null,
       null,
@@ -202,6 +203,7 @@ public class LaunchCommandsTest {
     final BazelTestFields fields = new FakeBazelTestFields(
       BazelTestFields.forTestName("first test", "/workspace/foo/test/foo_test.dart", null),
       "scripts/daemon.sh",
+      "scripts/devtools.sh",
       "scripts/doctor.sh",
       null,
       null,
@@ -228,6 +230,7 @@ public class LaunchCommandsTest {
     final BazelTestFields fields = new FakeBazelTestFields(
       new BazelTestFields(null, "/workspace/foo/test/foo_test.dart", "//foo:test", "--ignored-args"),
       "scripts/daemon.sh",
+      "scripts/devtools.sh",
       "scripts/doctor.sh",
       null,
       null,
@@ -294,6 +297,7 @@ public class LaunchCommandsTest {
 
     FakeBazelTestFields(@NotNull BazelTestFields template,
                         @Nullable String daemonScript,
+                        @Nullable String devToolsScript,
                         @Nullable String doctorScript,
                         @Nullable String testScript,
                         @Nullable String runScript,
@@ -306,7 +310,8 @@ public class LaunchCommandsTest {
                         @Nullable String updatedIosRunMessage) {
       super(template);
       final Pair.NonNull<MockVirtualFileSystem, Workspace> pair = FakeWorkspaceFactory
-        .createWorkspaceAndFilesystem(daemonScript, doctorScript, testScript, runScript, syncScript, sdkHome, versionFile, requiredIJPluginID, requiredIJPluginMessage, configWarningMessage, updatedIosRunMessage);
+        .createWorkspaceAndFilesystem(daemonScript, devToolsScript, doctorScript, testScript, runScript, syncScript, sdkHome, versionFile,
+                                      requiredIJPluginID, requiredIJPluginMessage, configWarningMessage, updatedIosRunMessage);
       fs = pair.first;
       fakeWorkspace = pair.second;
     }


### PR DESCRIPTION
We've been using the daemon to request DevTools server start, but I changed over external DevTools to use `dart devtools` directly instead since that's a little faster and less indirection. This is the equivalent change for bazel workspaces