### PR TITLE
Fix analytics

### DIFF
--- a/flutter-idea/src/io/flutter/analytics/FlutterAnalysisServerListener.java
+++ b/flutter-idea/src/io/flutter/analytics/FlutterAnalysisServerListener.java
@@ -308,7 +308,6 @@ public final class FlutterAnalysisServerListener implements Disposable, Analysis
 
   @Override
   public void computedLaunchData(String s, String s1, String[] strings) {
-    int length = strings.length;
   }
 
   @Override
@@ -351,7 +350,7 @@ public final class FlutterAnalysisServerListener implements Disposable, Analysis
     maybeReport(true, (analytics) -> {
       String method = details.method();
       long duration = generalTimestamp - details.startTime().toEpochMilli();
-      LOG.info(ROUND_TRIP_TIME + " " + method + " " + duration);
+      LOG.debug(ROUND_TRIP_TIME + " " + method + " " + duration);
       analytics.sendTiming(ROUND_TRIP_TIME, method, duration); // test: computedSearchResults()
     });
   }
@@ -371,7 +370,7 @@ public final class FlutterAnalysisServerListener implements Disposable, Analysis
       }
       String stack = requestError.getStackTrace();
       String exception = composeException(ERROR_TYPE_REQUEST, code, stack);
-      LOG.info(exception);
+      LOG.debug(exception);
       analytics.sendException(exception, false); // test: requestError()
     });
   }
@@ -412,7 +411,7 @@ public final class FlutterAnalysisServerListener implements Disposable, Analysis
   public void serverError(boolean isFatal, String message, String stackTraceString) {
     maybeReport(true, (analytics) -> {
       String exception = composeException(ERROR_TYPE_SERVER, message, stackTraceString);
-      LOG.info(exception + " fatal");
+      LOG.debug(exception + " fatal");
       analytics.sendException(exception, isFatal); // test: serverError()
     });
   }
@@ -460,7 +459,7 @@ public final class FlutterAnalysisServerListener implements Disposable, Analysis
     if (errorsTimestamp == 0L || currentTimestamp - errorsTimestamp > ERROR_REPORT_INTERVAL || IS_TESTING) {
       errorsTimestamp = currentTimestamp;
       Analytics analytics = FlutterInitializer.getAnalytics();
-      LOG.info(DAS_STATUS_EVENT_TYPE + " " + errorCount + " " + warningCount + " " + hintCount + " " + lintCount);
+      LOG.debug(DAS_STATUS_EVENT_TYPE + " " + errorCount + " " + warningCount + " " + hintCount + " " + lintCount);
       if (errorCount > 0) {
         analytics.sendEventMetric(DAS_STATUS_EVENT_TYPE, ERRORS, errorCount); // test: serverStatus()
       }
@@ -489,21 +488,21 @@ public final class FlutterAnalysisServerListener implements Disposable, Analysis
 
   private void logCompletion(@NotNull String selection, int prefixLength, @NotNull String eventType) {
     maybeReport(true, (analytics) -> {
-      LOG.info(eventType + " " + selection + " " + prefixLength);
+      LOG.debug(eventType + " " + selection + " " + prefixLength);
       analytics.sendEventMetric(eventType, selection, prefixLength); // test: acceptedCompletion(), lookupCanceled()
     });
   }
 
   void logE2ECompletionSuccessMS(long e2eCompletionMS) {
     maybeReport(true, (analytics) -> {
-      LOG.info(E2E_IJ_COMPLETION_TIME + " " + SUCCESS + " " + e2eCompletionMS);
+      LOG.debug(E2E_IJ_COMPLETION_TIME + " " + SUCCESS + " " + e2eCompletionMS);
       analytics.sendTiming(E2E_IJ_COMPLETION_TIME, SUCCESS, e2eCompletionMS); // test: logE2ECompletionSuccessMS()
     });
   }
 
   void logE2ECompletionErrorMS(long e2eCompletionMS) {
     maybeReport(true, (analytics) -> {
-      LOG.info(E2E_IJ_COMPLETION_TIME + " " + FAILURE + " " + e2eCompletionMS);
+      LOG.debug(E2E_IJ_COMPLETION_TIME + " " + FAILURE + " " + e2eCompletionMS);
       analytics.sendTiming(E2E_IJ_COMPLETION_TIME, FAILURE, e2eCompletionMS); // test: logE2ECompletionErrorMS()
     });
   }
@@ -520,7 +519,7 @@ public final class FlutterAnalysisServerListener implements Disposable, Analysis
 
   private void logFileAnalysisTime(@NotNull String kind, String path, long analysisTime) {
     maybeReport(false, (analytics) -> {
-      LOG.info(kind + " " + DURATION + " " + analysisTime);
+      LOG.debug(kind + " " + DURATION + " " + analysisTime);
       analytics.sendEvent(kind, DURATION, "", Long.toString(analysisTime)); // test: computedErrors()
     });
   }
@@ -591,7 +590,7 @@ public final class FlutterAnalysisServerListener implements Disposable, Analysis
         List<String> errorsOnLine =
           pathToErrors.containsKey(path) ? pathToErrors.get(path).stream().filter(error -> error.getLocation().getStartLine() == lineNumber)
             .map(AnalysisError::getCode).collect(Collectors.toList()) : ImmutableList.of();
-        LOG.info(QUICK_FIX + " " + intention.getText() + " " + errorsOnLine.size());
+        LOG.debug(QUICK_FIX + " " + intention.getText() + " " + errorsOnLine.size());
         analytics.sendEventMetric(QUICK_FIX, intention.getText(), errorsOnLine.size()); // test: quickFix()
       });
     }
@@ -629,7 +628,7 @@ public final class FlutterAnalysisServerListener implements Disposable, Analysis
                             LOG_ENTRY_KIND, serverLogEntry.get(LOG_ENTRY_KIND).getAsString(), LOG_ENTRY_DATA,
                             serverLogEntry.get(LOG_ENTRY_DATA).getAsString());
             assert logEntry != null;
-            LOG.info(ANALYSIS_SERVER_LOG + " " + logEntry);
+            LOG.debug(ANALYSIS_SERVER_LOG + " " + logEntry);
             // Log the "sdkVersion" only if it was provided in the event
             if (StringUtil.isEmpty(sdkVersionValue)) {
               FlutterInitializer.getAnalytics().sendEvent(ANALYSIS_SERVER_LOG, logEntry); // test: dasListenerLogging()
@@ -655,7 +654,7 @@ public final class FlutterAnalysisServerListener implements Disposable, Analysis
         // Throttle to one report per interval for each distinct details.method().
         if (timestamp == null || currentTimestamp - timestamp > GENERAL_REPORT_INTERVAL) {
           methodTimestamps.put(details.method(), currentTimestamp);
-          LOG.info(ROUND_TRIP_TIME + " " + details.method() + " " + Duration.between(details.startTime(), Instant.now()).toMillis());
+          LOG.debug(ROUND_TRIP_TIME + " " + details.method() + " " + Duration.between(details.startTime(), Instant.now()).toMillis());
           FlutterInitializer.getAnalytics()
             .sendTiming(ROUND_TRIP_TIME, details.method(), // test: dasListenerTiming()
                         Objects.requireNonNull(Duration.between(details.startTime(), Instant.now())).toMillis());

--- a/flutter-idea/src/io/flutter/analytics/FlutterAnalysisServerListener.java
+++ b/flutter-idea/src/io/flutter/analytics/FlutterAnalysisServerListener.java
@@ -2,6 +2,8 @@ package io.flutter.analytics;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Sets;
+import com.google.dart.server.AnalysisServerListener;
 import com.google.dart.server.AnalysisServerListenerAdapter;
 import com.google.dart.server.RequestListener;
 import com.google.dart.server.ResponseListener;
@@ -43,7 +45,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 @SuppressWarnings("LocalCanBeFinal")
-public final class FlutterAnalysisServerListener extends AnalysisServerListenerAdapter implements Disposable {
+public final class FlutterAnalysisServerListener implements Disposable, AnalysisServerListener {
   // statics
   static final String INITIAL_COMPUTE_ERRORS_TIME = "initialComputeErrorsTime";
   static final String INITIAL_HIGHLIGHTS_TIME = "initialHighlightsTime";
@@ -55,6 +57,9 @@ public final class FlutterAnalysisServerListener extends AnalysisServerListenerA
   static final String ACCEPTED_COMPLETION = "acceptedCompletion";
   static final String REJECTED_COMPLETION = "rejectedCompletion";
   static final String E2E_IJ_COMPLETION_TIME = "e2eIJCompletionTime";
+  static final String GET_SUGGESTIONS = "completion.getSuggestions";
+  static final String FIND_REFERENCES = "search.findElementReferences";
+  static final Set<String> MANUALLY_MANAGED_METHODS = Sets.newHashSet(GET_SUGGESTIONS, FIND_REFERENCES);
   static final String ERRORS = "errors";
   static final String WARNINGS = "warnings";
   static final String HINTS = "hints";
@@ -86,8 +91,8 @@ public final class FlutterAnalysisServerListener extends AnalysisServerListenerA
   private static final Logger LOG = Logger.getInstance(FlutterAnalysisServerListener.class);
   private static final boolean IS_TESTING = ApplicationManager.getApplication().isUnitTestMode();
 
-  @NotNull final RequestListener requestListener;
-  @NotNull final ResponseListener responseListener;
+  @NotNull final FlutterRequestListener requestListener;
+  @NotNull final FlutterResponseListener responseListener;
   @NotNull final DartQuickFixListener quickFixListener;
   // instance members
   @NotNull private final Project project;
@@ -181,10 +186,12 @@ public final class FlutterAnalysisServerListener extends AnalysisServerListenerA
 
   @Override
   public void computedAnalyzedFiles(List<String> list) {
+    // No start time is recorded.
   }
 
   @Override
   public void computedAvailableSuggestions(@NotNull List<AvailableSuggestionSet> list, int[] ints) {
+    // No start time is recorded.
   }
 
   @Override
@@ -197,6 +204,36 @@ public final class FlutterAnalysisServerListener extends AnalysisServerListenerA
                                  List<IncludedSuggestionRelevanceTag> includedSuggestionRelevanceTags,
                                  boolean isLast,
                                  String libraryFilePathSD) {
+    long currentTimestamp = System.currentTimeMillis();
+    String id = getIdForMethod(GET_SUGGESTIONS);
+    if (id == null) {
+      return;
+    }
+    RequestDetails details = requestToDetails.remove(id);
+    if (!isLast) {
+      // TODO(messick) Do we want only the first results or all results? If only the first, remove this check.
+      return;
+    }
+    if (details == null) {
+      return;
+    }
+    maybeReport(true, (analytics) -> {
+      long startTime = details.startTime().toEpochMilli();
+      analytics.sendTiming(ROUND_TRIP_TIME, GET_SUGGESTIONS, currentTimestamp - startTime); // test: computedCompletion
+    });
+  }
+
+  @Nullable
+  private String getIdForMethod(@NotNull String method) {
+    Set<String> keys = requestToDetails.keySet();
+    for (String id : keys) {
+      RequestDetails details = requestToDetails.get(id);
+      assert details != null;
+      if ("completion.getSuggestions".equals(details.method())) {
+        return id;
+      }
+    };
+    return null;
   }
 
   @Override
@@ -266,18 +303,22 @@ public final class FlutterAnalysisServerListener extends AnalysisServerListenerA
 
   @Override
   public void computedImplemented(String s, List<ImplementedClass> list, List<ImplementedMember> list1) {
+    // No start time is recorded.
   }
 
   @Override
   public void computedLaunchData(String s, String s1, String[] strings) {
+    int length = strings.length;
   }
 
   @Override
   public void computedNavigation(String s, List<NavigationRegion> list) {
+    // No start time is recorded.
   }
 
   @Override
   public void computedOccurrences(String s, List<Occurrences> list) {
+    // No start time is recorded.
   }
 
   @Override
@@ -288,18 +329,36 @@ public final class FlutterAnalysisServerListener extends AnalysisServerListenerA
 
   @Override
   public void computedOverrides(String s, List<OverrideMember> list) {
+    // No start time is recorded.
   }
 
   @Override
   public void computedClosingLabels(String s, List<ClosingLabel> list) {
+    // No start time is recorded.
   }
 
   @Override
-  public void computedSearchResults(String s, List<SearchResult> list, boolean b) {
+  public void computedSearchResults(String searchId, List<SearchResult> results, boolean isLast) {
+    if (!isLast) {
+      // TODO(messick) Do we want only the first results or all results? If only the first, remove this check.
+      return;
+    }
+    RequestDetails details = requestToDetails.get(searchId);
+    if (details == null) {
+      return;
+    }
+    requestToDetails.remove(searchId);
+    maybeReport(true, (analytics) -> {
+      String method = details.method();
+      long duration = generalTimestamp - details.startTime().toEpochMilli();
+      LOG.info(ROUND_TRIP_TIME + " " + method + " " + duration);
+      analytics.sendTiming(ROUND_TRIP_TIME, method, duration); // test: computedSearchResults()
+    });
   }
 
   @Override
   public void flushedResults(List<String> list) {
+    // Timing info not valid.
   }
 
   @Override
@@ -417,6 +476,7 @@ public final class FlutterAnalysisServerListener extends AnalysisServerListenerA
       errorCount = warningCount = hintCount = lintCount = 0;
     }
   }
+
   private static int extractCount(@NotNull Map<String, Integer> errorCounts, String name) {
     //noinspection Java8MapApi,ConstantConditions
     return errorCounts.containsKey(name) ? errorCounts.get(name) : 0;
@@ -424,6 +484,7 @@ public final class FlutterAnalysisServerListener extends AnalysisServerListenerA
 
   @Override
   public void computedExistingImports(String file, Map<String, Map<String, Set<String>>> existingImports) {
+    // No start time is recorded.
   }
 
   private void logCompletion(@NotNull String selection, int prefixLength, @NotNull String eventType) {
@@ -549,7 +610,8 @@ public final class FlutterAnalysisServerListener extends AnalysisServerListenerA
 
   @SuppressWarnings("LocalCanBeFinal")
   class FlutterResponseListener implements ResponseListener {
-    private final Map<String, Long> methodTimestamps = new HashMap<>();
+    final Map<String, Long> methodTimestamps = new HashMap<>();
+
     @Override
     public void onResponse(String jsonString) {
       JsonObject response = new Gson().fromJson(jsonString, JsonObject.class);
@@ -585,6 +647,9 @@ public final class FlutterAnalysisServerListener extends AnalysisServerListenerA
       String id = response.get("id").getAsString();
       RequestDetails details = requestToDetails.get(id);
       if (details != null) {
+        if (MANUALLY_MANAGED_METHODS.contains(details.method())) {
+          return;
+        }
         Long timestamp = methodTimestamps.get(details.method());
         timestamp = null; // TODO
         long currentTimestamp = System.currentTimeMillis();

--- a/flutter-idea/src/io/flutter/analytics/FlutterAnalysisServerListener.java
+++ b/flutter-idea/src/io/flutter/analytics/FlutterAnalysisServerListener.java
@@ -446,9 +446,9 @@ public final class FlutterAnalysisServerListener implements Disposable, Analysis
     if (observeThrottling && !IS_TESTING) {
       long currentTimestamp = System.currentTimeMillis();
       // Throttle to one report per interval.
-      //if (currentTimestamp - generalTimestamp < GENERAL_REPORT_INTERVAL) { // TODO
-      //  return;
-      //}
+      if (currentTimestamp - generalTimestamp < GENERAL_REPORT_INTERVAL) {
+        return;
+      }
       generalTimestamp = currentTimestamp;
     }
     func.accept(FlutterInitializer.getAnalytics());
@@ -651,7 +651,6 @@ public final class FlutterAnalysisServerListener implements Disposable, Analysis
           return;
         }
         Long timestamp = methodTimestamps.get(details.method());
-        timestamp = null; // TODO
         long currentTimestamp = System.currentTimeMillis();
         // Throttle to one report per interval for each distinct details.method().
         if (timestamp == null || currentTimestamp - timestamp > GENERAL_REPORT_INTERVAL) {

--- a/flutter-idea/src/io/flutter/analytics/RequestDetails.java
+++ b/flutter-idea/src/io/flutter/analytics/RequestDetails.java
@@ -22,4 +22,9 @@ public class RequestDetails {
   public Instant startTime() {
     return startTime;
   }
+
+  @NotNull
+  public String toString() {
+    return method + ": " + startTime.toEpochMilli();
+  }
 }

--- a/flutter-idea/testSrc/unit/io/flutter/analytics/FlutterAnalysisServerListenerTest.java
+++ b/flutter-idea/testSrc/unit/io/flutter/analytics/FlutterAnalysisServerListenerTest.java
@@ -195,9 +195,23 @@ public class FlutterAnalysisServerListenerTest {
   }
 
   @Test
-  public void dasListenerTiming() throws Exception {
+  public void computedSearchResults() throws Exception {
     fasl.requestListener.onRequest("{\"method\":\"test\",\"id\":\"2\"}");
     fasl.responseListener.onResponse("{\"event\":\"none\",\"id\":\"2\"}");
+    fasl.computedSearchResults("2", new ArrayList<>(), true);
+    assertEquals(1, transport.sentValues.size());
+    Map<String, String> map = transport.sentValues.get(0);
+    assertEquals(ROUND_TRIP_TIME, map.get("utc"));
+    assertEquals("test", map.get("utv"));
+    assertNotNull(map.get("utt")); // Not checking a computed value, duration.
+  }
+
+  @Test
+  public void computedCompletion() throws Exception {
+    fasl.requestListener.onRequest("{\"method\":\"test\",\"id\":\"2\"}");
+    fasl.responseListener.onResponse("{\"event\":\"none\",\"id\":\"2\"}");
+    List none = new ArrayList();
+    fasl.computedCompletion("2", 0, 0, none, none, none, none, true, "");
     assertEquals(1, transport.sentValues.size());
     Map<String, String> map = transport.sentValues.get(0);
     assertEquals(ROUND_TRIP_TIME, map.get("utc"));

--- a/flutter-idea/testSrc/unit/io/flutter/analytics/FlutterAnalysisServerListenerTest.java
+++ b/flutter-idea/testSrc/unit/io/flutter/analytics/FlutterAnalysisServerListenerTest.java
@@ -196,13 +196,13 @@ public class FlutterAnalysisServerListenerTest {
 
   @Test
   public void computedSearchResults() throws Exception {
-    fasl.requestListener.onRequest("{\"method\":\"test\",\"id\":\"2\"}");
+    fasl.requestListener.onRequest("{\"method\":\"" + FIND_REFERENCES + "\",\"id\":\"2\"}");
     fasl.responseListener.onResponse("{\"event\":\"none\",\"id\":\"2\"}");
     fasl.computedSearchResults("2", new ArrayList<>(), true);
     assertEquals(1, transport.sentValues.size());
     Map<String, String> map = transport.sentValues.get(0);
     assertEquals(ROUND_TRIP_TIME, map.get("utc"));
-    assertEquals("test", map.get("utv"));
+    assertEquals(FIND_REFERENCES, map.get("utv"));
     assertNotNull(map.get("utt")); // Not checking a computed value, duration.
   }
 


### PR DESCRIPTION
This fixes the calculation of timings for completions and references. The old version was incorrect because it measured the time to get a response, but no work was done before the response was sent.