### PR TITLE
Fix disposer bug

### DIFF
--- a/flutter-idea/src/io/flutter/perf/FlutterWidgetPerf.java
+++ b/flutter-idea/src/io/flutter/perf/FlutterWidgetPerf.java
@@ -513,18 +513,20 @@ public class FlutterWidgetPerf implements Disposable, WidgetPerfListener {
     if (uiAnimationTimer.isRunning()) {
       uiAnimationTimer.stop();
     }
-    try {
-      // We've had a number of NPEs reported from this line, and it is not obvious what's wrong.
-      Disposer.dispose(perfProvider);
-    } catch (NullPointerException ex) {
-      LOG.info("NPE during dispose of " + perfProvider + "/" + perfProvider.isStarted() + "/" + perfProvider.isConnected(), ex);
-    }
-
+    // TODO(jacobr): WidgetPerfProvider implements Disposer but its dispose method
+    // needs to be called manually rather than using the Disposer API
+    // because it is not registered for disposal using
+    // Disposer.register
+    perfProvider.dispose();
     AsyncUtils.invokeLater(() -> {
       clearModels();
 
       for (EditorPerfModel decorations : editorDecorations.values()) {
-        Disposer.dispose(decorations);
+        // TODO(jacobr): EditorPerfModel implements Disposer but its dispose method
+        // needs to be called manually rather than using the Disposer API
+        // because it is not registered for disposal using
+        // Disposer.register
+        decorations.dispose();
       }
       editorDecorations.clear();
       perfListeners.clear();


### PR DESCRIPTION
This s a (signed) replacement for #6080.

Fixes https://github.com/flutter/flutter-intellij/issues/6042

Filed https://github.com/flutter/flutter-intellij/issues/6077 to track down the broader tech debt issue that we are manually calling dispose() on Disposable objects a fair amount which is a JetBrains anti-pattern.