### PR TITLE
Fix child lines when folding code

### DIFF
--- a/flutter-idea/src/io/flutter/editor/WidgetIndentsHighlightingPass.java
+++ b/flutter-idea/src/io/flutter/editor/WidgetIndentsHighlightingPass.java
@@ -396,6 +396,12 @@ public class WidgetIndentsHighlightingPass {
           }
         }
 
+        final FoldRegion foldRegion = foldingModel.getCollapsedRegionAtOffset(doc.getLineEndOffset(i));
+        if (foldRegion != null && foldRegion.getEndOffset() < doc.getTextLength()) {
+          i = doc.getLineNumber(foldRegion.getEndOffset()) - 1;
+          continue;
+        }
+
         final List<? extends SoftWrap> softWraps = softWrapModel.getSoftWrapsForLine(i);
         int logicalLineHeight = softWraps.size() * lineHeight;
         if (i > startLine + lineShift) {
@@ -412,10 +418,6 @@ public class WidgetIndentsHighlightingPass {
           newY += logicalLineHeight;
         }
 
-        final FoldRegion foldRegion = foldingModel.getCollapsedRegionAtOffset(doc.getLineEndOffset(i));
-        if (foldRegion != null && foldRegion.getEndOffset() < doc.getTextLength()) {
-          i = doc.getLineNumber(foldRegion.getEndOffset());
-        }
       }
 
       if (childLines != null && iChildLine < childLines.size() && splitY == -1) {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter-intellij/issues/6123 (and seems to not break other things)

Two issues here:
- We don't want to extend the left vertical line if a segment of code has been folded
- We want to evaluate the line immediately following the end of a folded segment; if we skip `continue;` then we will evaluate two lines after

I find this code really hard to follow and debug, so I posted https://github.com/flutter/flutter-intellij/issues/6127

No folding:
<img width="519" alt="Screen Shot 2022-04-21 at 1 37 57 PM" src="https://user-images.githubusercontent.com/6379305/164548370-996be6c9-3c2f-42cd-a5fb-2d36efd9c829.png">

First statement folded:
<img width="543" alt="Screen Shot 2022-04-21 at 1 38 22 PM" src="https://user-images.githubusercontent.com/6379305/164548417-d6663436-07b7-431f-a94f-6ee1a0273f02.png">

Both statements folded:
<img width="589" alt="Screen Shot 2022-04-21 at 1 38 37 PM" src="https://user-images.githubusercontent.com/6379305/164548446-67650e1b-a38d-49d7-a278-38ed1a13c71a.png">

