### PR TITLE
Stop using a deprecated method

### DIFF
--- a/flutter-idea/src/io/flutter/analytics/DartCompletionTimerListener.java
+++ b/flutter-idea/src/io/flutter/analytics/DartCompletionTimerListener.java
@@ -3,7 +3,7 @@ package io.flutter.analytics;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
 
-import com.jetbrains.lang.dart.ide.completion.DartCompletionTimerExtension;
+
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -13,7 +13,7 @@ import java.time.Instant;
  * Implementation of the {@link DartCompletionTimerExtension} which allows the Flutter plugin to
  * measure the total time to present a code completion to the user.
  */
-public class DartCompletionTimerListener extends DartCompletionTimerExtension {
+public class DartCompletionTimerListener  {
   @Nullable FlutterAnalysisServerListener dasListener;
   @Nullable Long startTimeMS;
 

--- a/flutter-idea/src/io/flutter/analytics/DartCompletionTimerListener.java
+++ b/flutter-idea/src/io/flutter/analytics/DartCompletionTimerListener.java
@@ -3,7 +3,6 @@ package io.flutter.analytics;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
 
-
 import com.jetbrains.lang.dart.ide.completion.DartCompletionTimerExtension;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;

--- a/flutter-idea/src/io/flutter/analytics/DartCompletionTimerListener.java
+++ b/flutter-idea/src/io/flutter/analytics/DartCompletionTimerListener.java
@@ -4,6 +4,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
 
 
+import com.jetbrains.lang.dart.ide.completion.DartCompletionTimerExtension;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -13,7 +14,7 @@ import java.time.Instant;
  * Implementation of the {@link DartCompletionTimerExtension} which allows the Flutter plugin to
  * measure the total time to present a code completion to the user.
  */
-public class DartCompletionTimerListener  {
+public class DartCompletionTimerListener extends DartCompletionTimerExtension {
   @Nullable FlutterAnalysisServerListener dasListener;
   @Nullable Long startTimeMS;
 

--- a/flutter-idea/src/io/flutter/analytics/TimeTracker.java
+++ b/flutter-idea/src/io/flutter/analytics/TimeTracker.java
@@ -6,9 +6,10 @@
 package io.flutter.analytics;
 
 import com.intellij.openapi.components.Service;
-import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.project.Project;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
 
 @Service
 public final class TimeTracker {
@@ -17,7 +18,7 @@ public final class TimeTracker {
 
   @NotNull
   public static TimeTracker getInstance(@NotNull final Project project) {
-    return ServiceManager.getService(project, TimeTracker.class);
+    return Objects.requireNonNull(project.getService(TimeTracker.class));
   }
 
   public TimeTracker(Project project) {
@@ -32,6 +33,6 @@ public final class TimeTracker {
     if (projectOpenTime == null) {
       return 0;
     }
-    return (int) (System.currentTimeMillis() - projectOpenTime);
+    return (int)(System.currentTimeMillis() - projectOpenTime);
   }
 }

--- a/flutter-idea/src/io/flutter/bazel/WorkspaceCache.java
+++ b/flutter-idea/src/io/flutter/bazel/WorkspaceCache.java
@@ -7,7 +7,6 @@ package io.flutter.bazel;
 
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableSet;
-import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.registry.Registry;
@@ -21,6 +20,8 @@ import javax.swing.*;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
+
+import static java.util.Objects.requireNonNull;
 
 /**
  * Holds the current Bazel workspace for a Project.
@@ -79,7 +80,7 @@ public class WorkspaceCache {
 
   @NotNull
   public static WorkspaceCache getInstance(@NotNull final Project project) {
-    return ServiceManager.getService(project, WorkspaceCache.class);
+    return requireNonNull(project.getService(WorkspaceCache.class));
   }
 
   /**

--- a/flutter-idea/src/io/flutter/dart/DartPlugin.java
+++ b/flutter-idea/src/io/flutter/dart/DartPlugin.java
@@ -8,7 +8,6 @@ package io.flutter.dart;
 import com.intellij.execution.configurations.ConfigurationType;
 import com.intellij.ide.plugins.IdeaPluginDescriptor;
 import com.intellij.ide.plugins.PluginManagerCore;
-import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.extensions.PluginId;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
@@ -111,10 +110,10 @@ public class DartPlugin {
   }
 
   /**
-   * Return the DartAnalysisServerService instance. This handles the older case where the service was app
-   * based, and the newer case where the service is project based.
+   * Return the DartAnalysisServerService instance.
    */
+  @Nullable
   public DartAnalysisServerService getAnalysisService(@NotNull final Project project) {
-    return ServiceManager.getService(project, DartAnalysisServerService.class);
+    return project.getService(DartAnalysisServerService.class);
   }
 }

--- a/flutter-idea/src/io/flutter/dart/FlutterDartAnalysisServer.java
+++ b/flutter-idea/src/io/flutter/dart/FlutterDartAnalysisServer.java
@@ -16,7 +16,6 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Disposer;
 import com.intellij.openapi.util.io.FileUtil;
@@ -30,10 +29,7 @@ import org.dartlang.analysis.server.protocol.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -63,7 +59,7 @@ public class FlutterDartAnalysisServer implements Disposable {
 
   @NotNull
   public static FlutterDartAnalysisServer getInstance(@NotNull final Project project) {
-    return ServiceManager.getService(project, FlutterDartAnalysisServer.class);
+    return Objects.requireNonNull(project.getService(FlutterDartAnalysisServer.class));
   }
 
   @VisibleForTesting

--- a/flutter-idea/src/io/flutter/editor/ActiveEditorsOutlineService.java
+++ b/flutter-idea/src/io/flutter/editor/ActiveEditorsOutlineService.java
@@ -8,7 +8,6 @@ package io.flutter.editor;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import com.intellij.openapi.Disposable;
-import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.editor.ex.EditorEx;
 import com.intellij.openapi.fileEditor.*;
@@ -61,7 +60,7 @@ public class ActiveEditorsOutlineService implements Disposable {
 
   @NotNull
   public static ActiveEditorsOutlineService getInstance(@NotNull final Project project) {
-    return ServiceManager.getService(project, ActiveEditorsOutlineService.class);
+    return Objects.requireNonNull(project.getService(ActiveEditorsOutlineService.class));
   }
 
   public ActiveEditorsOutlineService(Project project) {

--- a/flutter-idea/src/io/flutter/editor/EditorMouseEventService.java
+++ b/flutter-idea/src/io/flutter/editor/EditorMouseEventService.java
@@ -6,7 +6,6 @@
 package io.flutter.editor;
 
 import com.intellij.openapi.Disposable;
-import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.editor.EditorFactory;
 import com.intellij.openapi.editor.event.EditorEventMulticaster;
 import com.intellij.openapi.editor.event.EditorMouseEvent;
@@ -16,6 +15,7 @@ import com.intellij.openapi.project.Project;
 import org.jetbrains.annotations.NotNull;
 
 import java.awt.event.MouseEvent;
+import java.util.Objects;
 
 /**
  * Service that tracks interactions with editors making it easy to add
@@ -81,7 +81,7 @@ public class EditorMouseEventService extends EditorEventServiceBase<EditorMouseE
 
   @NotNull
   public static EditorMouseEventService getInstance(@NotNull final Project project) {
-    return ServiceManager.getService(project, EditorMouseEventService.class);
+    return Objects.requireNonNull(project.getService(EditorMouseEventService.class));
   }
 
   @Override

--- a/flutter-idea/src/io/flutter/editor/EditorPositionService.java
+++ b/flutter-idea/src/io/flutter/editor/EditorPositionService.java
@@ -12,7 +12,6 @@ package io.flutter.editor;
  */
 
 import com.intellij.openapi.Disposable;
-import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.editor.Caret;
 import com.intellij.openapi.editor.EditorFactory;
 import com.intellij.openapi.editor.event.*;
@@ -21,6 +20,7 @@ import com.intellij.openapi.project.Project;
 import org.jetbrains.annotations.NotNull;
 
 import java.awt.*;
+import java.util.Objects;
 
 /**
  * Service that tracks the visible area and Carat selection of an editor.
@@ -64,7 +64,7 @@ public class EditorPositionService extends EditorEventServiceBase<EditorPosition
 
   @NotNull
   public static EditorPositionService getInstance(@NotNull final Project project) {
-    return ServiceManager.getService(project, EditorPositionService.class);
+    return Objects.requireNonNull(project.getService(EditorPositionService.class));
   }
 
   public void addListener(@NotNull EditorEx editor, @NotNull Listener listener, Disposable disposable) {

--- a/flutter-idea/src/io/flutter/editor/FlutterSaveActionsManager.java
+++ b/flutter-idea/src/io/flutter/editor/FlutterSaveActionsManager.java
@@ -9,7 +9,6 @@ import com.intellij.AppTopics;
 import com.intellij.application.options.CodeStyle;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.command.WriteCommandAction;
-import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
@@ -21,7 +20,6 @@ import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiDocumentManager;
 import com.intellij.psi.PsiFile;
-import com.intellij.psi.codeStyle.CodeStyleSettingsManager;
 import com.intellij.util.PsiErrorElementUtil;
 import com.intellij.util.messages.MessageBus;
 import com.intellij.util.messages.MessageBusConnection;
@@ -34,6 +32,7 @@ import io.flutter.settings.FlutterSettings;
 import org.dartlang.analysis.server.protocol.SourceEdit;
 import org.dartlang.analysis.server.protocol.SourceFileEdit;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Collections;
 import java.util.List;
@@ -52,8 +51,9 @@ public class FlutterSaveActionsManager {
     getInstance(project);
   }
 
+  @Nullable
   public static FlutterSaveActionsManager getInstance(@NotNull Project project) {
-    return ServiceManager.getService(project, FlutterSaveActionsManager.class);
+    return project.getService(FlutterSaveActionsManager.class);
   }
 
   private final @NotNull Project myProject;

--- a/flutter-idea/src/io/flutter/editor/WidgetIndentsHighlightingPassFactory.java
+++ b/flutter-idea/src/io/flutter/editor/WidgetIndentsHighlightingPassFactory.java
@@ -12,7 +12,6 @@ import com.intellij.codeHighlighting.TextEditorHighlightingPassFactory;
 import com.intellij.codeHighlighting.TextEditorHighlightingPassRegistrar;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.editor.EditorFactory;
 import com.intellij.openapi.editor.event.CaretEvent;
@@ -40,7 +39,7 @@ import java.util.Objects;
 
 /**
  * Factory that drives all rendering of widget indents.
- *
+ * <p>
  * Warning: it is unsafe to register the WidgetIndentsHighlightingPassFactory
  * without using WidgetIndentsHighlightingPassFactoryRegistrar as recent
  * versions of IntelliJ will unpredictably clear out all existing highlighting
@@ -68,8 +67,9 @@ public class WidgetIndentsHighlightingPassFactory implements TextEditorHighlight
   // Current configuration setting used to display regular indent guides cached from EditorSettingsExternalizable.
   private boolean isIndentGuidesShown;
 
+  @Nullable
   public static WidgetIndentsHighlightingPassFactory getInstance(Project project) {
-    return ServiceManager.getService(project, WidgetIndentsHighlightingPassFactory.class);
+    return project.getService(WidgetIndentsHighlightingPassFactory.class);
   }
 
   public WidgetIndentsHighlightingPassFactory(@NotNull Project project) {
@@ -191,7 +191,8 @@ public class WidgetIndentsHighlightingPassFactory implements TextEditorHighlight
     // widget indent guides in distracting ways.
     if (EdtInvocationManager.getInstance().isEventDispatchThread()) {
       e.getSettings().setIndentGuidesShown(false);
-    } else {
+    }
+    else {
       ApplicationManager.getApplication().invokeLater(() -> {
         e.getSettings().setIndentGuidesShown(false);
       });

--- a/flutter-idea/src/io/flutter/inspector/InspectorGroupManagerService.java
+++ b/flutter-idea/src/io/flutter/inspector/InspectorGroupManagerService.java
@@ -7,7 +7,6 @@ package io.flutter.inspector;
 
 import com.google.common.collect.Lists;
 import com.intellij.openapi.Disposable;
-import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Disposer;
 import io.flutter.run.FlutterAppManager;
@@ -20,6 +19,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
@@ -148,7 +148,7 @@ public class InspectorGroupManagerService implements Disposable {
 
   @NotNull
   public static InspectorGroupManagerService getInstance(@NotNull final Project project) {
-    return ServiceManager.getService(project, InspectorGroupManagerService.class);
+    return Objects.requireNonNull(project.getService(InspectorGroupManagerService.class));
   }
 
   public InspectorService getInspectorService() {

--- a/flutter-idea/src/io/flutter/jxbrowser/EmbeddedBrowser.java
+++ b/flutter-idea/src/io/flutter/jxbrowser/EmbeddedBrowser.java
@@ -7,7 +7,6 @@ package io.flutter.jxbrowser;
 
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.PathManager;
-import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
@@ -33,8 +32,9 @@ import io.flutter.settings.FlutterSettings;
 import io.flutter.utils.AsyncUtils;
 import org.jetbrains.annotations.NotNull;
 
-import java.awt.Dimension;
+import java.awt.*;
 import java.io.File;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
@@ -43,8 +43,8 @@ public class EmbeddedBrowser {
   private static final Logger LOG = Logger.getInstance(JxBrowserManager.class);
 
   @NotNull
-  public static EmbeddedBrowser getInstance(Project project) {
-    return ServiceManager.getService(project, EmbeddedBrowser.class);
+  public static EmbeddedBrowser getInstance(@NotNull Project project) {
+    return Objects.requireNonNull(project.getService(EmbeddedBrowser.class));
   }
 
   private Browser browser;
@@ -70,9 +70,11 @@ public class EmbeddedBrowser {
         final ConsoleMessage consoleMessage = event.consoleMessage();
         LOG.info("Browser message(" + consoleMessage.level().name() + "): " + consoleMessage.message());
       });
-    } catch (UnsupportedRenderingModeException ex) {
+    }
+    catch (UnsupportedRenderingModeException ex) {
       // Skip using a transparent background if an exception is thrown.
-    } catch (Exception | Error ex) {
+    }
+    catch (Exception | Error ex) {
       LOG.info(ex);
       FlutterInitializer.getAnalytics().sendExpectedException("jxbrowser-setup", ex);
     }
@@ -112,7 +114,8 @@ public class EmbeddedBrowser {
 
     try {
       browser.navigation().loadUrl(devToolsUrl.getUrlString());
-    } catch (Exception ex) {
+    }
+    catch (Exception ex) {
       devToolsUrlFuture.completeExceptionally(ex);
       onBrowserUnavailable.run();
       LOG.info(ex);

--- a/flutter-idea/src/io/flutter/perf/EditorPerfDecorations.java
+++ b/flutter-idea/src/io/flutter/perf/EditorPerfDecorations.java
@@ -9,7 +9,6 @@ import com.intellij.codeInsight.hint.HintManager;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.editor.event.EditorMouseEvent;
 import com.intellij.openapi.editor.event.EditorMouseEventArea;
@@ -361,7 +360,7 @@ class PerfGutterIconRenderer extends GutterIconRenderer {
   }
 
   private void showPerfViewMessage() {
-    final FlutterPerformanceView flutterPerfView = ServiceManager.getService(getApp().getProject(), FlutterPerformanceView.class);
+    final FlutterPerformanceView flutterPerfView = getApp().getProject().getService(FlutterPerformanceView.class);
     flutterPerfView.showForAppRebuildCounts(getApp());
     final String message = "<html><body>" +
                            getTooltipHtmlFragment() +

--- a/flutter-idea/src/io/flutter/perf/FlutterWidgetPerfManager.java
+++ b/flutter-idea/src/io/flutter/perf/FlutterWidgetPerfManager.java
@@ -6,7 +6,6 @@
 package io.flutter.perf;
 
 import com.intellij.openapi.Disposable;
-import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.fileEditor.*;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Computable;
@@ -128,8 +127,9 @@ public class FlutterWidgetPerfManager implements Disposable, FlutterApp.FlutterA
     getInstance(project);
   }
 
+  @Nullable
   public static FlutterWidgetPerfManager getInstance(@NotNull Project project) {
-    return ServiceManager.getService(project, FlutterWidgetPerfManager.class);
+    return project.getService(FlutterWidgetPerfManager.class);
   }
 
   public boolean isTrackRebuildWidgets() {

--- a/flutter-idea/src/io/flutter/performance/FlutterPerformanceViewFactory.java
+++ b/flutter-idea/src/io/flutter/performance/FlutterPerformanceViewFactory.java
@@ -7,7 +7,6 @@ package io.flutter.performance;
 
 import com.intellij.ide.util.PropertiesComponent;
 import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.DumbService;
 import com.intellij.openapi.project.Project;
@@ -37,7 +36,7 @@ public class FlutterPerformanceViewFactory implements ToolWindowFactory, DumbAwa
 
   private static void initPerfView(@NotNull Project project, FlutterViewMessages.FlutterDebugEvent event) {
     ApplicationManager.getApplication().invokeLater(() -> {
-      final FlutterPerformanceView flutterPerfView = ServiceManager.getService(project, FlutterPerformanceView.class);
+      final FlutterPerformanceView flutterPerfView = project.getService(FlutterPerformanceView.class);
       ToolWindowManager.getInstance(project).getToolWindow(FlutterPerformanceView.TOOL_WINDOW_ID).setAvailable(true);
       flutterPerfView.debugActive(event);
     });
@@ -47,7 +46,7 @@ public class FlutterPerformanceViewFactory implements ToolWindowFactory, DumbAwa
   public void createToolWindowContent(@NotNull Project project, @NotNull ToolWindow toolWindow) {
     //noinspection CodeBlock2Expr
     DumbService.getInstance(project).runWhenSmart(() -> {
-      (ServiceManager.getService(project, FlutterPerformanceView.class)).initToolWindow(toolWindow);
+      (project.getService(FlutterPerformanceView.class)).initToolWindow(toolWindow);
     });
   }
 

--- a/flutter-idea/src/io/flutter/preview/PreviewViewFactory.java
+++ b/flutter-idea/src/io/flutter/preview/PreviewViewFactory.java
@@ -6,15 +6,12 @@
 package io.flutter.preview;
 
 import com.intellij.ide.util.PropertiesComponent;
-import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.DumbService;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowFactory;
 import com.intellij.openapi.wm.ToolWindowManager;
-import com.intellij.openapi.wm.ex.ToolWindowManagerListener;
-import io.flutter.performance.FlutterPerformanceView;
 import io.flutter.utils.ViewListener;
 import org.jetbrains.annotations.NotNull;
 
@@ -36,7 +33,7 @@ public class PreviewViewFactory implements ToolWindowFactory, DumbAware {
   public void createToolWindowContent(@NotNull Project project, @NotNull ToolWindow toolWindow) {
     //noinspection CodeBlock2Expr
     DumbService.getInstance(project).runWhenSmart(() -> {
-      (ServiceManager.getService(project, PreviewView.class)).initToolWindow(toolWindow);
+      (project.getService(PreviewView.class)).initToolWindow(toolWindow);
     });
   }
 

--- a/flutter-idea/src/io/flutter/pub/PubRootCache.java
+++ b/flutter-idea/src/io/flutter/pub/PubRootCache.java
@@ -5,7 +5,6 @@
  */
 package io.flutter.pub;
 
-import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleManager;
 import com.intellij.openapi.project.Project;
@@ -15,10 +14,7 @@ import com.intellij.psi.PsiFile;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * Cache the information computed from pubspecs in the project.
@@ -26,7 +22,7 @@ import java.util.Map;
 public class PubRootCache {
   @NotNull
   public static PubRootCache getInstance(@NotNull final Project project) {
-    return ServiceManager.getService(project, PubRootCache.class);
+    return Objects.requireNonNull(project.getService(PubRootCache.class));
   }
 
   @NotNull final Project project;

--- a/flutter-idea/src/io/flutter/run/FlutterAppManager.java
+++ b/flutter-idea/src/io/flutter/run/FlutterAppManager.java
@@ -27,8 +27,9 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 public class FlutterAppManager implements Disposable {
+  @Nullable
   public static FlutterAppManager getInstance(@NotNull Project project) {
-    return ServiceManager.getService(project, FlutterAppManager.class);
+    return project.getService(FlutterAppManager.class);
   }
 
   @NotNull

--- a/flutter-idea/src/io/flutter/run/FlutterReloadManager.java
+++ b/flutter-idea/src/io/flutter/run/FlutterReloadManager.java
@@ -25,7 +25,6 @@ import com.intellij.openapi.actionSystem.ex.AnActionListener;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.application.PathManager;
-import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
@@ -37,7 +36,6 @@ import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.popup.Balloon;
 import com.intellij.openapi.util.Computable;
-import com.intellij.openapi.util.NlsSafe;
 import com.intellij.openapi.util.SystemInfo;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -71,9 +69,7 @@ import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 import javax.swing.event.HyperlinkEvent;
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -109,8 +105,9 @@ public class FlutterReloadManager {
     getInstance(project);
   }
 
+  @Nullable
   public static FlutterReloadManager getInstance(@NotNull Project project) {
-    return ServiceManager.getService(project, FlutterReloadManager.class);
+    return project.getService(FlutterReloadManager.class);
   }
 
   private FlutterReloadManager(@NotNull Project project) {

--- a/flutter-idea/src/io/flutter/run/coverage/FlutterCoverageAnnotator.java
+++ b/flutter-idea/src/io/flutter/run/coverage/FlutterCoverageAnnotator.java
@@ -8,24 +8,24 @@ package io.flutter.run.coverage;
 import com.intellij.coverage.CoverageDataManager;
 import com.intellij.coverage.CoverageSuitesBundle;
 import com.intellij.coverage.SimpleCoverageAnnotator;
-import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ModuleRootManager;
 import com.intellij.openapi.vfs.VirtualFile;
 import io.flutter.utils.FlutterModuleUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.jetbrains.annotations.NotNull;
-
 public class FlutterCoverageAnnotator extends SimpleCoverageAnnotator {
 
+  @Nullable
   public static FlutterCoverageAnnotator getInstance(Project project) {
-    return ServiceManager.getService(project, FlutterCoverageAnnotator.class);
+    return project.getService(FlutterCoverageAnnotator.class);
   }
 
   public FlutterCoverageAnnotator(Project project) {

--- a/flutter-idea/src/io/flutter/run/daemon/DevToolsService.java
+++ b/flutter-idea/src/io/flutter/run/daemon/DevToolsService.java
@@ -13,7 +13,6 @@ import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configurations.GeneralCommandLine;
 import com.intellij.execution.process.*;
 import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
@@ -35,6 +34,7 @@ import io.flutter.utils.MostlySilentColoredProcessHandler;
 import org.jetbrains.annotations.NotNull;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -53,7 +53,7 @@ public class DevToolsService {
 
   @NotNull
   public static DevToolsService getInstance(@NotNull final Project project) {
-    return ServiceManager.getService(project, DevToolsService.class);
+    return Objects.requireNonNull(project.getService(DevToolsService.class));
   }
 
   private DevToolsService(@NotNull final Project project) {

--- a/flutter-idea/src/io/flutter/run/daemon/DeviceService.java
+++ b/flutter-idea/src/io/flutter/run/daemon/DeviceService.java
@@ -12,7 +12,6 @@ import com.intellij.execution.ExecutionException;
 import com.intellij.ide.ActivityTracker;
 import com.intellij.openapi.application.ApplicationInfo;
 import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.DumbService;
 import com.intellij.openapi.project.Project;
@@ -32,6 +31,7 @@ import javax.swing.*;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
@@ -57,7 +57,7 @@ public class DeviceService {
 
   @NotNull
   public static DeviceService getInstance(@NotNull final Project project) {
-    return ServiceManager.getService(project, DeviceService.class);
+    return Objects.requireNonNull(project.getService(DeviceService.class));
   }
 
   private DeviceService(@NotNull final Project project) {
@@ -107,6 +107,7 @@ public class DeviceService {
       return ImmutableSet.copyOf(changed);
     });
   }
+
   public boolean isRefreshInProgress() {
     return refreshInProgress;
   }

--- a/flutter-idea/src/io/flutter/sdk/AndroidEmulatorManager.java
+++ b/flutter-idea/src/io/flutter/sdk/AndroidEmulatorManager.java
@@ -6,7 +6,6 @@
 package io.flutter.sdk;
 
 import com.google.common.collect.ImmutableSet;
-import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.util.concurrency.AppExecutorUtil;
@@ -18,6 +17,7 @@ import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -30,7 +30,7 @@ public class AndroidEmulatorManager {
 
   @NotNull
   public static AndroidEmulatorManager getInstance(@NotNull Project project) {
-    return ServiceManager.getService(project, AndroidEmulatorManager.class);
+    return Objects.requireNonNull(project.getService(AndroidEmulatorManager.class));
   }
 
   private final @NotNull Project project;

--- a/flutter-idea/src/io/flutter/sdk/FlutterSdkManager.java
+++ b/flutter-idea/src/io/flutter/sdk/FlutterSdkManager.java
@@ -6,7 +6,6 @@
 package io.flutter.sdk;
 
 import com.intellij.concurrency.JobScheduler;
-import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
 import com.intellij.openapi.project.ProjectManagerListener;
@@ -18,6 +17,7 @@ import com.intellij.util.EventDispatcher;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.EventListener;
+import java.util.Objects;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -31,7 +31,7 @@ public class FlutterSdkManager {
 
   @NotNull
   public static FlutterSdkManager getInstance(@NotNull Project project) {
-    return ServiceManager.getService(project, FlutterSdkManager.class);
+    return Objects.requireNonNull(project.getService(FlutterSdkManager.class));
   }
 
   private FlutterSdkManager(@NotNull Project project) {

--- a/flutter-idea/src/io/flutter/view/FlutterViewFactory.java
+++ b/flutter-idea/src/io/flutter/view/FlutterViewFactory.java
@@ -7,7 +7,6 @@ package io.flutter.view;
 
 import com.intellij.ide.util.PropertiesComponent;
 import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.DumbService;
 import com.intellij.openapi.project.Project;
@@ -42,7 +41,7 @@ public class FlutterViewFactory implements ToolWindowFactory, DumbAware {
 
   private static void initFlutterView(@NotNull Project project, FlutterViewMessages.FlutterDebugEvent event) {
     ApplicationManager.getApplication().invokeLater(() -> {
-      final FlutterView flutterView = ServiceManager.getService(project, FlutterView.class);
+      final FlutterView flutterView = project.getService(FlutterView.class);
       flutterView.debugActive(event);
     });
   }
@@ -51,7 +50,7 @@ public class FlutterViewFactory implements ToolWindowFactory, DumbAware {
   public void createToolWindowContent(@NotNull Project project, @NotNull ToolWindow toolWindow) {
     //noinspection CodeBlock2Expr
     DumbService.getInstance(project).runWhenSmart(() -> {
-      (ServiceManager.getService(project, FlutterView.class)).initToolWindow(toolWindow);
+      project.getService(FlutterView.class).initToolWindow(toolWindow);
     });
   }
 


### PR DESCRIPTION
Replace `ServiceManager.getService(project, aClass)` with `project.getService(aClass)`. Where it makes sense, the existing nullability rules are annotated. Other minor changes are due to reformatting.