### PR TITLE
Disable fast throttling for multiple events

### DIFF
--- a/flutter-idea/src/io/flutter/analytics/Analytics.java
+++ b/flutter-idea/src/io/flutter/analytics/Analytics.java
@@ -50,8 +50,10 @@ public class Analytics {
   @NotNull
   private final String platformVersion;
 
+  @NotNull
   private Transport transport = new HttpTransport();
-  private final ThrottlingBucket bucket = new ThrottlingBucket(20);
+  @NotNull
+  private ThrottlingBucket bucket = new ThrottlingBucket(20);
   private boolean myCanSend = false;
 
   public Analytics(@NotNull String clientId, @NotNull String pluginVersion, @NotNull String platformName, @NotNull String platformVersion) {
@@ -59,6 +61,16 @@ public class Analytics {
     this.pluginVersion = pluginVersion;
     this.platformName = platformName;
     this.platformVersion = platformVersion;
+  }
+
+  public void disableThrottling(@NotNull Runnable func) {
+    ThrottlingBucket original = bucket;
+    try {
+      bucket = new ThrottlingBucket.NonTrhottlingBucket(0);
+      func.run();
+    } finally {
+      bucket = original;
+    }
   }
 
   @NotNull

--- a/flutter-idea/src/io/flutter/analytics/FlutterAnalysisServerListener.java
+++ b/flutter-idea/src/io/flutter/analytics/FlutterAnalysisServerListener.java
@@ -4,7 +4,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 import com.google.dart.server.AnalysisServerListener;
-import com.google.dart.server.AnalysisServerListenerAdapter;
 import com.google.dart.server.RequestListener;
 import com.google.dart.server.ResponseListener;
 import com.google.gson.Gson;
@@ -232,7 +231,7 @@ public final class FlutterAnalysisServerListener implements Disposable, Analysis
       if ("completion.getSuggestions".equals(details.method())) {
         return id;
       }
-    };
+    }
     return null;
   }
 
@@ -460,18 +459,20 @@ public final class FlutterAnalysisServerListener implements Disposable, Analysis
       errorsTimestamp = currentTimestamp;
       Analytics analytics = FlutterInitializer.getAnalytics();
       LOG.debug(DAS_STATUS_EVENT_TYPE + " " + errorCount + " " + warningCount + " " + hintCount + " " + lintCount);
-      if (errorCount > 0) {
-        analytics.sendEventMetric(DAS_STATUS_EVENT_TYPE, ERRORS, errorCount); // test: serverStatus()
-      }
-      if (warningCount > 0) {
-        analytics.sendEventMetric(DAS_STATUS_EVENT_TYPE, WARNINGS, warningCount); // test: serverStatus()
-      }
-      if (hintCount > 0) {
-        analytics.sendEventMetric(DAS_STATUS_EVENT_TYPE, HINTS, hintCount); // test: serverStatus()
-      }
-      if (lintCount > 0) {
-        analytics.sendEventMetric(DAS_STATUS_EVENT_TYPE, LINTS, lintCount); // test: serverStatus()
-      }
+      analytics.disableThrottling(() -> {
+        if (errorCount > 0) {
+          analytics.sendEventMetric(DAS_STATUS_EVENT_TYPE, ERRORS, errorCount); // test: serverStatus()
+        }
+        if (warningCount > 0) {
+          analytics.sendEventMetric(DAS_STATUS_EVENT_TYPE, WARNINGS, warningCount); // test: serverStatus()
+        }
+        if (hintCount > 0) {
+          analytics.sendEventMetric(DAS_STATUS_EVENT_TYPE, HINTS, hintCount); // test: serverStatus()
+        }
+        if (lintCount > 0) {
+          analytics.sendEventMetric(DAS_STATUS_EVENT_TYPE, LINTS, lintCount); // test: serverStatus()
+        }
+      });
       errorCount = warningCount = hintCount = lintCount = 0;
     }
   }
@@ -631,10 +632,10 @@ public final class FlutterAnalysisServerListener implements Disposable, Analysis
             LOG.debug(ANALYSIS_SERVER_LOG + " " + logEntry);
             // Log the "sdkVersion" only if it was provided in the event
             if (StringUtil.isEmpty(sdkVersionValue)) {
-              FlutterInitializer.getAnalytics().sendEvent(ANALYSIS_SERVER_LOG, logEntry); // test: dasListenerLogging()
+              analytics.sendEvent(ANALYSIS_SERVER_LOG, logEntry); // test: dasListenerLogging()
             }
             else { // test: dasListenerLoggingWithSdk()
-              FlutterInitializer.getAnalytics().sendEventWithSdk(ANALYSIS_SERVER_LOG, logEntry, sdkVersionValue);
+              analytics.sendEventWithSdk(ANALYSIS_SERVER_LOG, logEntry, sdkVersionValue);
             }
           });
         }

--- a/flutter-idea/src/io/flutter/analytics/ThrottlingBucket.java
+++ b/flutter-idea/src/io/flutter/analytics/ThrottlingBucket.java
@@ -49,4 +49,15 @@ public class ThrottlingBucket {
       lastReplenish += (1000L * inc);
     }
   }
+
+  static class NonTrhottlingBucket extends ThrottlingBucket {
+
+    public NonTrhottlingBucket(int startingCount) {
+      super(startingCount);
+    }
+
+    public boolean removeDrop() {
+      return true;
+    }
+  }
 }


### PR DESCRIPTION
The analytics implementation limits events to occur no more than once per second. We have one measurement that sends four events, so we disable the one-second throttling in that case. This could send up to 2KB (including HTTP headers) but it only runs once every two hours.