### PR TITLE
Check for project disposal before JxBrowser download

### DIFF
--- a/flutter-idea/src/io/flutter/jxbrowser/JxBrowserManager.java
+++ b/flutter-idea/src/io/flutter/jxbrowser/JxBrowserManager.java
@@ -293,6 +293,9 @@ public class JxBrowserManager {
     final Task.Backgroundable task = new Task.Backgroundable(project, "Downloading jxbrowser") {
       @Override
       public void run(@NotNull ProgressIndicator indicator) {
+        if (project.isDisposed()) {
+          return;
+        }
         String currentFileName = null;
         final long startTime = System.currentTimeMillis();
         try {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter-intellij/issues/6144 (hopefully)