### PR TITLE
Update icon previews to handle new format

### DIFF
--- a/flutter-idea/src/io/flutter/dart/DartPsiUtil.java
+++ b/flutter-idea/src/io/flutter/dart/DartPsiUtil.java
@@ -55,8 +55,12 @@ public class DartPsiUtil {
   @Nullable
   public static String getValueOfNamedArgument(@NotNull DartArguments arguments, @NotNull String name) {
     final PsiElement family = getNamedArgumentExpression(arguments, "fontFamily");
-    if (family != null && family.getNode().getElementType() == DartTokenTypes.STRING_LITERAL_EXPRESSION) {
-      return DartPsiImplUtil.getUnquotedDartStringAndItsRange(family.getText()).first;
+    if (family != null) {
+      if (family.getNode().getElementType() == DartTokenTypes.STRING_LITERAL_EXPRESSION) {
+        return DartPsiImplUtil.getUnquotedDartStringAndItsRange(family.getText()).first;
+      } else {
+        return ""; // Empty string indicates arg was found but value could not be determined easily.
+      }
     }
     return null;
   }

--- a/flutter-idea/src/io/flutter/editor/FlutterIconLineMarkerProvider.java
+++ b/flutter-idea/src/io/flutter/editor/FlutterIconLineMarkerProvider.java
@@ -296,6 +296,7 @@ public class FlutterIconLineMarkerProvider extends LineMarkerProviderDescriptor 
     if (family.equals("MaterialIcons")) {
       return sdk.getHomePath();
     }
+    // TODO Generalize this to work with other icon packages from pub.
     return FlutterSdkUtil.getPathToCupertinoIconsPackage(project);
   }
 

--- a/flutter-idea/src/io/flutter/editor/FlutterIconLineMarkerProvider.java
+++ b/flutter-idea/src/io/flutter/editor/FlutterIconLineMarkerProvider.java
@@ -262,16 +262,26 @@ public class FlutterIconLineMarkerProvider extends LineMarkerProviderDescriptor 
       String iconName = node.getFirstChildNode().getLastChildNode().getFirstChildNode().getText();
       final FlutterIconLineMarkerProvider.IconInfo iconDef = findDefinition("", iconName, project, parent.getContainingFile().getVirtualFile().getPath());
       if (iconDef == null) return null;
-      return findIconFromDef("", iconDef, knownPath);
+      family = iconDef.familyName;
+      if (family == null) return null;
     }
     if (aPackage == null) {
       // Looking for IconData with no package -- package specification not currently supported.
       final String relativeAssetPath = family.equals("MaterialIcons") ? MaterialRelativeAssetPath : CupertinoRelativeAssetPath;
-      // TODO Base path is wrong for cupertino -- is there a test for this branch (IconData with cupertino family)?
-      final IconPreviewGenerator generator = new IconPreviewGenerator(sdk.getHomePath() + relativeAssetPath);
+      String base = getBasePathForFamily(family, sdk, parent);
+      final IconPreviewGenerator generator = new IconPreviewGenerator(base + relativeAssetPath);
       return generator.convert(code);
     }
     return null;
+  }
+
+  private String getBasePathForFamily(@NotNull String family, @NotNull FlutterSdk sdk, @NotNull PsiElement element) {
+    if (family.equals("MaterialIcons")) {
+      return sdk.getHomePath();
+    }
+    @NotNull List<VirtualFile> library = DartResolveUtil.findLibraryByName(element, "cupertino_icons");
+    library.get(0);
+    return "";
   }
 
   @Nullable

--- a/flutter-idea/src/io/flutter/editor/FlutterIconLineMarkerProvider.java
+++ b/flutter-idea/src/io/flutter/editor/FlutterIconLineMarkerProvider.java
@@ -464,9 +464,6 @@ public class FlutterIconLineMarkerProvider extends LineMarkerProviderDescriptor 
                 final DartExpression dartExpression = list.get(0);
                 assert dartExpression != null;
                 final String codepoint = dartExpression.getText();
-                if (iconName.equals(codepoint)) {
-                  o.getComponentName();
-                }
                 final PsiElement family = getNamedArgumentExpression(arguments, "fontFamily");
                 final String familyName = findFamilyName(family, type);
                 assert className != null;


### PR DESCRIPTION
The Cupertino icons use a static variable to specify the icon family. Material just has string literals, so they worked.

Fixes #6170