### PR TITLE
Escape spaces for VM mapping

### DIFF
--- a/flutter-idea/src/io/flutter/vmService/VmServiceWrapper.java
+++ b/flutter-idea/src/io/flutter/vmService/VmServiceWrapper.java
@@ -2,6 +2,7 @@ package io.flutter.vmService;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import com.google.common.net.PercentEscaper;
 import com.google.gson.JsonObject;
 import com.intellij.execution.ui.ConsoleViewContentType;
 import com.intellij.openapi.Disposable;
@@ -569,7 +570,7 @@ public class VmServiceWrapper implements Disposable {
 
       final String resolvedUri = getResolvedUri(position);
       LOG.info("Computed resolvedUri: " + resolvedUri);
-      final List<String> resolvedUriList = List.of(resolvedUri);
+      final List<String> resolvedUriList = List.of(percentEscapeUri(resolvedUri));
 
       final CanonicalBreakpoint canonicalBreakpoint =
         new CanonicalBreakpoint(position.getFile().getName(), position.getFile().getCanonicalPath(), line);
@@ -679,6 +680,11 @@ public class VmServiceWrapper implements Disposable {
     }
 
     return url;
+  }
+
+  private String percentEscapeUri(String uri) {
+    final PercentEscaper escaper = new PercentEscaper("!#$&'()*+,-./:;=?@_~", false);
+    return escaper.escape(uri);
   }
 
   public void addBreakpointForIsolates(@NotNull final XLineBreakpoint<XBreakpointProperties> xBreakpoint,


### PR DESCRIPTION
Partially addresses: https://github.com/flutter/flutter-intellij/issues/6159, namely the issue with directory paths that include spaces.

The string of characters passed to `PercentEncoder` matches the list for Dart's [encodeFull](https://api.dart.dev/stable/2.17.1/dart-core/Uri/encodeFull.html), which is what the VM uses.