### PR TITLE
Use emulator ID for Android emulator

### DIFF
--- a/flutter-idea/src/io/flutter/run/daemon/DeviceDaemon.java
+++ b/flutter-idea/src/io/flutter/run/daemon/DeviceDaemon.java
@@ -383,7 +383,9 @@ class DeviceDaemon {
       }
 
       final FlutterDevice newDevice = new FlutterDevice(event.id,
-                                                        event.emulatorId == null ? event.id : event.emulatorId,
+                                                        event.emulatorId == null
+                                                        ? (event.name == null ? event.id : event.name)
+                                                        : (event.platformType.equals("android") ? event.emulatorId : event.name),
                                                         event.platform,
                                                         event.emulator,
                                                         event.category,
@@ -440,11 +442,11 @@ class DeviceDaemon {
       final String link = "https://www.google.com/search?q=increase maximum file handles " + os;
       Messages.installHyperlinkSupport(myTextPane);
       final String message =
-      "<html><body><p>The Flutter device daemon cannot be started. " +
-      "<br>Please check your configuration and restart the IDE. " +
-      "<br><br>You may need to <a href=\"" + link +
-      "\">increase the maximum number of file handles</a>" +
-      "<br>available globally.</body></html>";
+        "<html><body><p>The Flutter device daemon cannot be started. " +
+        "<br>Please check your configuration and restart the IDE. " +
+        "<br><br>You may need to <a href=\"" + link +
+        "\">increase the maximum number of file handles</a>" +
+        "<br>available globally.</body></html>";
 
       myTextPane.setText(message);
       myPanel.add(myTextPane);


### PR DESCRIPTION
Apparently, I forgot to use my phone during release testing. The device list was unusable. We really should have more people testing.

<img width="184" alt="Screen Shot 2022-06-02 at 9 54 41 AM" src="https://user-images.githubusercontent.com/8518285/171683858-d0ae981c-4653-4973-bad7-de5ab1259a64.png">

