### PR TITLE
Update Flutter commands on Build and Tools menu to run for all Flutter modules

### DIFF
--- a/flutter-idea/src/io/flutter/actions/FlutterSdkAction.java
+++ b/flutter-idea/src/io/flutter/actions/FlutterSdkAction.java
@@ -17,10 +17,13 @@ import io.flutter.FlutterMessages;
 import io.flutter.FlutterUtils;
 import io.flutter.bazel.Workspace;
 import io.flutter.pub.PubRoot;
+import io.flutter.pub.PubRoots;
 import io.flutter.sdk.FlutterSdk;
 import io.flutter.utils.FlutterModuleUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
 
 /**
  * Base class for Flutter commands.
@@ -52,7 +55,17 @@ public abstract class FlutterSdkAction extends DumbAwareAction {
 
     FlutterInitializer.sendAnalyticsAction(this);
     FileDocumentManager.getInstance().saveAllDocuments();
-    startCommand(project, sdk, PubRoot.forEventWithRefresh(event), event.getDataContext());
+    PubRoot root = PubRoot.forEventWithRefresh(event);
+    @NotNull DataContext context = event.getDataContext();
+    if (root != null) {
+      startCommand(project, sdk, root, context);
+    }
+    else {
+      List<PubRoot> roots = PubRoots.forProject(project);
+      for (PubRoot sub : roots) {
+        startCommand(project, sdk, sub, context);
+      }
+    }
   }
 
   public abstract void startCommand(@NotNull Project project,

--- a/flutter-idea/src/io/flutter/pub/PubRoot.java
+++ b/flutter-idea/src/io/flutter/pub/PubRoot.java
@@ -82,13 +82,13 @@ public class PubRoot {
       }
     }
 
-    final Project project = event.getData(CommonDataKeys.PROJECT);
-    if (project != null) {
-      final List<PubRoot> roots = PubRoots.forProject(project);
-      if (!roots.isEmpty()) {
-        return roots.get(0);
-      }
-    }
+    //final Project project = event.getData(CommonDataKeys.PROJECT);
+    //if (project != null) {
+    //  final List<PubRoot> roots = PubRoots.forProject(project);
+    //  if (!roots.isEmpty()) {
+    //    return roots.get(0);
+    //  }
+    //}
 
     return null;
   }

--- a/flutter-idea/src/io/flutter/pub/PubRoot.java
+++ b/flutter-idea/src/io/flutter/pub/PubRoot.java
@@ -82,14 +82,6 @@ public class PubRoot {
       }
     }
 
-    //final Project project = event.getData(CommonDataKeys.PROJECT);
-    //if (project != null) {
-    //  final List<PubRoot> roots = PubRoots.forProject(project);
-    //  if (!roots.isEmpty()) {
-    //    return roots.get(0);
-    //  }
-    //}
-
     return null;
   }
 

--- a/flutter-idea/src/io/flutter/utils/FlutterModuleUtils.java
+++ b/flutter-idea/src/io/flutter/utils/FlutterModuleUtils.java
@@ -164,7 +164,7 @@ public class FlutterModuleUtils {
   }
 
   @Nullable
-  public static VirtualFile findXcodeProjectFile(@NotNull Project project) {
+  private static VirtualFile findXcodeProjectFile(@NotNull Project project) {
     if (project.isDisposed()) return null;
 
     // Look for Xcode metadata file in `ios/`.

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -216,6 +216,8 @@
         <!--suppress PluginXmlCapitalization -->
         <action id="flutter.build.ios" text="Build iOS" description="Building a Flutter app for Apple App Store distribution"
                 class="io.flutter.actions.FlutterBuildActionGroup$Ios"/>
+        <action id="flutter.build.web" text="Build Web" description="Building a Flutter app for web"
+                class="io.flutter.actions.FlutterBuildActionGroup$Web"/>
       </group>
       <add-to-group group-id="BuildMenu" anchor="first"/>
     </group>

--- a/resources/META-INF/plugin_template.xml
+++ b/resources/META-INF/plugin_template.xml
@@ -160,6 +160,8 @@
         <!--suppress PluginXmlCapitalization -->
         <action id="flutter.build.ios" text="Build iOS" description="Building a Flutter app for Apple App Store distribution"
                 class="io.flutter.actions.FlutterBuildActionGroup$Ios"/>
+        <action id="flutter.build.web" text="Build Web" description="Building a Flutter app for web"
+                class="io.flutter.actions.FlutterBuildActionGroup$Web"/>
       </group>
       <add-to-group group-id="BuildMenu" anchor="first"/>
     </group>


### PR DESCRIPTION
Update Flutter commands on Build and Tools menu to run for all Flutter modules when no files are open and nothing is selected in the Project view. This may not be a great UI, but I hope to get something out to experiment with.

Also adds a Build option for the Web platform.

Fixes #5808
Helps with #5291