### PR TITLE
Ensure disconnect even if import cancelled

### DIFF
--- a/flutter-idea/src/io/flutter/module/FlutterModuleBuilder.java
+++ b/flutter-idea/src/io/flutter/module/FlutterModuleBuilder.java
@@ -213,11 +213,16 @@ public class FlutterModuleBuilder extends ModuleBuilder {
         toCommit = null;
       }
 
-      model.loadModule(androidFile.getPath());
+      Module newModule = model.loadModule(androidFile.getPath());
 
       if (toCommit != null) {
         ApplicationManager.getApplication().invokeLater(() -> {
-          WriteAction.run(toCommit::commit);
+          // This check isn't normally needed but can prevent scary problems during testing.
+          // Even if .idea is removed modules may still be created from something in the cache files
+          // if the project had been opened previously.
+          if (ModuleManager.getInstance(project).findModuleByName(newModule.getName()) == null) {
+            WriteAction.run(toCommit::commit);
+          }
         });
       }
     }

--- a/flutter-idea/src/io/flutter/project/FlutterProjectStructureDetector.java
+++ b/flutter-idea/src/io/flutter/project/FlutterProjectStructureDetector.java
@@ -12,10 +12,13 @@ import com.intellij.ide.util.projectWizard.importSources.ProjectFromSourcesBuild
 import com.intellij.ide.util.projectWizard.importSources.ProjectStructureDetector;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleManager;
 import com.intellij.openapi.project.DumbService;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
 import com.intellij.openapi.project.ProjectManagerListener;
+import com.intellij.openapi.roots.ModuleRootManager;
 import com.intellij.openapi.startup.StartupManager;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VfsUtil;
@@ -80,13 +83,20 @@ public class FlutterProjectStructureDetector extends ProjectStructureDetector {
 
   private void scheduleAndroidModuleAddition(@NotNull String projectName, @NotNull List<ModuleDescriptor> modules, int tries) {
     //noinspection ConstantConditions
-    @NotNull MessageBusConnection connection = ApplicationManager.getApplication().getMessageBus().connect();
-    connection.subscribe(ProjectManager.TOPIC, new ProjectManagerListener() {
+    final MessageBusConnection[] connection = {ApplicationManager.getApplication().getMessageBus().connect()};
+    scheduleDisconnectIfCancelled(connection);
+    //noinspection ConstantConditions
+    connection[0].subscribe(ProjectManager.TOPIC, new ProjectManagerListener() {
       @Override
       public void projectOpened(@NotNull Project project) {
-        connection.disconnect();
+        if (connection[0] != null) {
+          connection[0].disconnect();
+          connection[0] = null;
+        }
         if (!projectName.equals(project.getName())) {
-          LOG.info("Project name is " + project.getName() + " but was expecting " + projectName);
+          // This can happen if you have selected project roots in the import wizard then cancel the import,
+          // and then import a project with a different name, before the scheduled disconnect runs.
+          return;
         }
         //noinspection ConstantConditions
         StartupManager.getInstance(project).runAfterOpened(() -> {
@@ -98,6 +108,8 @@ public class FlutterProjectStructureDetector extends ProjectStructureDetector {
               String moduleName = module.getName();
               if (roots == null || roots.size() != 1 || moduleName == null) continue;
               File root = roots.iterator().next();
+              assert root != null;
+              if (!projectHasContentRoot(project, root)) continue;
               String imlName = moduleName + "_android.iml";
               File moduleDir = null;
               if (new File(root, imlName).exists()) {
@@ -142,6 +154,38 @@ public class FlutterProjectStructureDetector extends ProjectStructureDetector {
         });
       }
     });
+  }
+
+  @SuppressWarnings("ConstantConditions")
+  private static void scheduleDisconnectIfCancelled(MessageBusConnection[] connection) {
+    // If the import was cancelled the subscription will never be removed.
+    ApplicationManager.getApplication().executeOnPooledThread(() -> {
+      Project project = ProjectManager.getInstance().getDefaultProject();
+      try {
+        Thread.sleep(300000L); // Allow five minutes to complete the project import wizard.
+      }
+      catch (InterruptedException ignored) {
+      }
+      if (connection[0] != null) {
+        connection[0].disconnect();
+        connection[0] = null;
+      }
+    });
+  }
+
+  @SuppressWarnings("ConstantConditions")
+  private static boolean projectHasContentRoot(@NotNull Project project, @NotNull File root) {
+    // Verify that the project has the given content root. If the import was cancelled and restarted
+    // for the same project, but a content root was not selected the second time, then it might be absent.
+    VirtualFile virtualFile = LocalFileSystem.getInstance().findFileByIoFile(root);
+    for (Module module : ModuleManager.getInstance(project).getModules()) {
+      for (VirtualFile file : ModuleRootManager.getInstance(module).getContentRoots()) {
+        if (file != null && file.equals(virtualFile)) {
+          return true;
+        }
+      }
+    }
+    return false;
   }
 
   private static class FlutterProjectRoot extends DetectedProjectRoot {


### PR DESCRIPTION
Much of this is concerned with what happens when the import wizard is cancelled and restarted, or simply has the `Previous` button clicked and a different set of content roots are selected. In these cases there will be multiple subscriptions running with potentially different sets of content roots. We need to be careful that we only do what the user requested the final time, and to ignore duplicates.

It might be possible to handle the `Previous` case with a listener, but I could find no way to detect that `Cancel` had been clicked.