### PR TITLE
Log bazel mapping differences from analyzer

### DIFF
--- a/flutter-idea/src/io/flutter/run/FlutterPositionMapper.java
+++ b/flutter-idea/src/io/flutter/run/FlutterPositionMapper.java
@@ -5,6 +5,7 @@
  */
 package io.flutter.run;
 
+import com.android.internal.inputmethod.CancellationGroup;
 import com.google.common.annotations.VisibleForTesting;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
@@ -25,6 +26,7 @@ import com.jetbrains.lang.dart.util.DartUrlResolver;
 import gnu.trove.THashMap;
 import io.flutter.FlutterInitializer;
 import io.flutter.FlutterUtils;
+import io.flutter.analytics.Analytics;
 import io.flutter.bazel.WorkspaceCache;
 import io.flutter.dart.DartPlugin;
 import io.flutter.vmService.DartVmServiceDebugProcess;
@@ -39,6 +41,10 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * Converts positions between Dart files in Observatory and local Dart files.
@@ -233,8 +239,8 @@ public class FlutterPositionMapper implements DartVmServiceDebugProcess.Position
    * Returns the local position (to display to the user) corresponding to a token position in Observatory.
    */
   @Nullable
-  public XSourcePosition getSourcePosition(@NotNull final String isolateId, @NotNull final ScriptRef scriptRef, int tokenPos) {
-    return getSourcePosition(isolateId, scriptRef.getId(), scriptRef.getUri(), tokenPos);
+  public XSourcePosition getSourcePosition(@NotNull final String isolateId, @NotNull final ScriptRef scriptRef, int tokenPos, CompletableFuture<String> fileFuture) {
+    return getSourcePosition(isolateId, scriptRef.getId(), scriptRef.getUri(), tokenPos, fileFuture);
   }
 
   /**
@@ -245,18 +251,22 @@ public class FlutterPositionMapper implements DartVmServiceDebugProcess.Position
     return getSourcePosition(isolateId, script.getId(), script.getUri(), tokenPos);
   }
 
+  private XSourcePosition getSourcePosition(@NotNull final String isolateId, @NotNull final String scriptId,
+                                            @NotNull final String scriptUri, int tokenPos) {
+    return getSourcePosition(isolateId, scriptId, scriptUri, tokenPos, null);
+  }
   /**
    * Returns the local position (to display to the user) corresponding to a token position in Observatory.
    */
   @Nullable
   private XSourcePosition getSourcePosition(@NotNull final String isolateId, @NotNull final String scriptId,
-                                            @NotNull final String scriptUri, int tokenPos) {
+                                            @NotNull final String scriptUri, int tokenPos, CompletableFuture<String> fileFuture) {
     if (scriptProvider == null) {
       FlutterUtils.warn(LOG, "attempted to get source position before connected to observatory");
       return null;
     }
 
-    final VirtualFile local = findLocalFile(scriptUri);
+    final VirtualFile local = findLocalFile(scriptUri, fileFuture);
 
     final ObservatoryFile.Cache cache =
       fileCache.computeIfAbsent(isolateId, (id) -> new ObservatoryFile.Cache(id, scriptProvider));
@@ -289,11 +299,15 @@ public class FlutterPositionMapper implements DartVmServiceDebugProcess.Position
     return findLocalFile(script.getUri());
   }
 
+  @Nullable
+  protected VirtualFile findLocalFile(@NotNull String uri) {
+    return findLocalFile(uri, null);
+  }
   /**
    * Attempt to find a local Dart file corresponding to a script in Observatory.
    */
   @Nullable
-  protected VirtualFile findLocalFile(@NotNull String uri) {
+  protected VirtualFile findLocalFile(@NotNull String uri, CompletableFuture<String> fileFuture) {
     return ApplicationManager.getApplication().runReadAction((Computable<VirtualFile>)() -> {
       // This can be a remote file or URI.
       if (remoteSourceRoot != null && uri.startsWith(remoteSourceRoot)) {
@@ -321,6 +335,20 @@ public class FlutterPositionMapper implements DartVmServiceDebugProcess.Position
       if (analyzer != null && !isDartPatchUri(remoteUri)) {
         final String path = analyzer.getAbsolutePath(remoteUri);
         if (path != null) {
+          if (fileFuture != null && path.contains("google3")) {
+            // Check if this path matches file future
+            final Analytics analytics = FlutterInitializer.getAnalytics();
+            try {
+              final String vmServiceFilePath = fileFuture.get(1000, TimeUnit.MILLISECONDS);
+              if (!path.equals(vmServiceFilePath)) {
+                analytics.sendEvent("file-mapping", String.format("mismatch|%s|%s", path, vmServiceFilePath));
+              }
+            }
+            catch (Exception e) {
+              analytics.sendEvent("file-mapping", String.format("exception|%s|%s", path, e.getMessage()));
+            }
+          }
+
           return LocalFileSystem.getInstance().findFileByPath(path);
         }
       }

--- a/flutter-idea/src/io/flutter/run/FlutterPositionMapper.java
+++ b/flutter-idea/src/io/flutter/run/FlutterPositionMapper.java
@@ -5,7 +5,6 @@
  */
 package io.flutter.run;
 
-import com.android.internal.inputmethod.CancellationGroup;
 import com.google.common.annotations.VisibleForTesting;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;

--- a/flutter-idea/src/io/flutter/run/FlutterPositionMapper.java
+++ b/flutter-idea/src/io/flutter/run/FlutterPositionMapper.java
@@ -334,7 +334,7 @@ public class FlutterPositionMapper implements DartVmServiceDebugProcess.Position
       if (analyzer != null && !isDartPatchUri(remoteUri)) {
         final String path = analyzer.getAbsolutePath(remoteUri);
         if (path != null) {
-          if (fileFuture != null && path.contains("google3")) {
+          if (fileFuture != null && WorkspaceCache.getInstance(project).isBazel() && path.contains("google3")) {
             // Check if this path matches file future
             final Analytics analytics = FlutterInitializer.getAnalytics();
             try {

--- a/flutter-idea/src/io/flutter/vmService/DartVmServiceDebugProcess.java
+++ b/flutter-idea/src/io/flutter/vmService/DartVmServiceDebugProcess.java
@@ -433,7 +433,8 @@ public abstract class DartVmServiceDebugProcess extends XDebugProcess {
 
   @Nullable
   public XSourcePosition getSourcePosition(@NotNull final String isolateId, @NotNull final ScriptRef scriptRef, int tokenPos) {
-    return mapper.getSourcePosition(isolateId, scriptRef, tokenPos);
+    CompletableFuture<String> fileFuture = myVmServiceWrapper.findResolvedFile(isolateId, scriptRef.getUri());
+    return mapper.getSourcePosition(isolateId, scriptRef, tokenPos, fileFuture);
   }
 
   @Nullable
@@ -694,7 +695,7 @@ public abstract class DartVmServiceDebugProcess extends XDebugProcess {
     /**
      * Returns the local position (to display to the user) corresponding to a token position in Observatory.
      */
-    XSourcePosition getSourcePosition(String isolateId, ScriptRef scriptRef, int tokenPos);
+    XSourcePosition getSourcePosition(String isolateId, ScriptRef scriptRef, int tokenPos, CompletableFuture<String> fileFuture);
 
     /**
      * Returns the local position (to display to the user) corresponding to a token position in Observatory.

--- a/flutter-idea/testSrc/unit/io/flutter/run/FlutterPositionMapperTest.java
+++ b/flutter-idea/testSrc/unit/io/flutter/run/FlutterPositionMapperTest.java
@@ -69,7 +69,7 @@ public class FlutterPositionMapperTest {
 
     scripts.addScript("1", "2", "some/stuff/to/ignore/lib/hello.dart", ImmutableList.of(new Line(10, 123, 1)));
 
-    final XSourcePosition pos = mapper.getSourcePosition("1", makeScriptRef("2", "some/stuff/to/ignore/lib/hello.dart"), 123);
+    final XSourcePosition pos = mapper.getSourcePosition("1", makeScriptRef("2", "some/stuff/to/ignore/lib/hello.dart"), 123, null);
     assertNotNull(pos);
     assertEquals(pos.getFile(), hello);
     assertEquals(pos.getLine(), 9); // zero-based
@@ -86,7 +86,7 @@ public class FlutterPositionMapperTest {
 
     scripts.addScript("1", "2", "remote:root/lib/hello.dart", ImmutableList.of(new Line(10, 123, 1)));
 
-    final XSourcePosition pos = mapper.getSourcePosition("1", makeScriptRef("2", "remote:root/lib/hello.dart"), 123);
+    final XSourcePosition pos = mapper.getSourcePosition("1", makeScriptRef("2", "remote:root/lib/hello.dart"), 123, null);
     assertNotNull(pos);
     assertEquals(pos.getFile(), hello);
     assertEquals(pos.getLine(), 9); // zero-based

--- a/flutter-idea/third_party/vmServiceDrivers/org/dartlang/vm/service/VmService.java
+++ b/flutter-idea/third_party/vmServiceDrivers/org/dartlang/vm/service/VmService.java
@@ -83,7 +83,7 @@ public class VmService extends VmServiceBase {
   /**
    * The minor version number of the protocol supported by this client.
    */
-  public static final int versionMinor = 56;
+  public static final int versionMinor = 58;
 
   /**
    * The [addBreakpoint] RPC is used to add a breakpoint at a specific line of some script.
@@ -449,8 +449,9 @@ public class VmService extends VmServiceBase {
    * @param endTokenPos This parameter is optional and may be null.
    * @param forceCompile This parameter is optional and may be null.
    * @param reportLines This parameter is optional and may be null.
+   * @param libraryFilters This parameter is optional and may be null.
    */
-  public void getSourceReport(String isolateId, List<SourceReportKind> reports, String scriptId, Integer tokenPos, Integer endTokenPos, Boolean forceCompile, Boolean reportLines, GetSourceReportConsumer consumer) {
+  public void getSourceReport(String isolateId, List<SourceReportKind> reports, String scriptId, Integer tokenPos, Integer endTokenPos, Boolean forceCompile, Boolean reportLines, List<String> libraryFilters, GetSourceReportConsumer consumer) {
     final JsonObject params = new JsonObject();
     params.addProperty("isolateId", isolateId);
     params.add("reports", convertIterableToJsonArray(reports));
@@ -459,6 +460,7 @@ public class VmService extends VmServiceBase {
     if (endTokenPos != null) params.addProperty("endTokenPos", endTokenPos);
     if (forceCompile != null) params.addProperty("forceCompile", forceCompile);
     if (reportLines != null) params.addProperty("reportLines", reportLines);
+    if (libraryFilters != null) params.add("libraryFilters", convertIterableToJsonArray(libraryFilters));
     request("getSourceReport", params, consumer);
   }
 
@@ -598,6 +600,19 @@ public class VmService extends VmServiceBase {
     params.addProperty("isolateId", isolateId);
     params.add("uris", convertIterableToJsonArray(uris));
     request("lookupPackageUris", params, consumer);
+  }
+
+  /**
+   * The [lookupResolvedPackageUris] RPC is used to convert a list of URIs to their resolved (or
+   * absolute) paths. For example, URIs passed to this RPC are mapped in the following ways:
+   * @param local This parameter is optional and may be null.
+   */
+  public void lookupResolvedPackageUris(String isolateId, List<String> uris, Boolean local, UriListConsumer consumer) {
+    final JsonObject params = new JsonObject();
+    params.addProperty("isolateId", isolateId);
+    params.add("uris", convertIterableToJsonArray(uris));
+    if (local != null) params.addProperty("local", local);
+    request("lookupResolvedPackageUris", params, consumer);
   }
 
   /**

--- a/flutter-idea/third_party/vmServiceDrivers/org/dartlang/vm/service/element/CpuSamples.java
+++ b/flutter-idea/third_party/vmServiceDrivers/org/dartlang/vm/service/element/CpuSamples.java
@@ -30,7 +30,7 @@ public class CpuSamples extends Response {
 
   /**
    * A list of functions seen in the relevant samples. These references can be looked up using the
-   * indicies provided in a `CpuSample` `stack` to determine which function was on the stack.
+   * indices provided in a `CpuSample` `stack` to determine which function was on the stack.
    */
   public ElementList<ProfileFunction> getFunctions() {
     return new ElementList<ProfileFunction>(json.get("functions").getAsJsonArray()) {

--- a/flutter-idea/third_party/vmServiceDrivers/org/dartlang/vm/service/element/CpuSamplesEvent.java
+++ b/flutter-idea/third_party/vmServiceDrivers/org/dartlang/vm/service/element/CpuSamplesEvent.java
@@ -27,7 +27,7 @@ public class CpuSamplesEvent extends Element {
 
   /**
    * A list of references to functions seen in the relevant samples. These references can be looked
-   * up using the indicies provided in a `CpuSample` `stack` to determine which function was on the
+   * up using the indices provided in a `CpuSample` `stack` to determine which function was on the
    * stack.
    *
    * @return one of <code>ElementList<ObjRef></code> or <code>ElementList<NativeFunction></code>

--- a/flutter-idea/third_party/vmServiceDrivers/org/dartlang/vm/service/element/Field.java
+++ b/flutter-idea/third_party/vmServiceDrivers/org/dartlang/vm/service/element/Field.java
@@ -40,6 +40,9 @@ public class Field extends Obj {
   /**
    * The location of this field in the source code.
    *
+   * Note: this may not agree with the location of `owner` if this is a field from a mixin
+   * application, patched class, etc.
+   *
    * Can return <code>null</code>.
    */
   public SourceLocation getLocation() {
@@ -62,6 +65,9 @@ public class Field extends Obj {
 
   /**
    * The owner of this field, which can be either a Library or a Class.
+   *
+   * Note: the location of `owner` may not agree with `location` if this is a field from a mixin
+   * application, patched class, etc.
    */
   public ObjRef getOwner() {
     return new ObjRef((JsonObject) json.get("owner"));

--- a/flutter-idea/third_party/vmServiceDrivers/org/dartlang/vm/service/element/FieldRef.java
+++ b/flutter-idea/third_party/vmServiceDrivers/org/dartlang/vm/service/element/FieldRef.java
@@ -39,6 +39,9 @@ public class FieldRef extends ObjRef {
   /**
    * The location of this field in the source code.
    *
+   * Note: this may not agree with the location of `owner` if this is a field from a mixin
+   * application, patched class, etc.
+   *
    * Can return <code>null</code>.
    */
   public SourceLocation getLocation() {
@@ -61,6 +64,9 @@ public class FieldRef extends ObjRef {
 
   /**
    * The owner of this field, which can be either a Library or a Class.
+   *
+   * Note: the location of `owner` may not agree with `location` if this is a field from a mixin
+   * application, patched class, etc.
    */
   public ObjRef getOwner() {
     return new ObjRef((JsonObject) json.get("owner"));

--- a/flutter-idea/third_party/vmServiceDrivers/org/dartlang/vm/service/element/Func.java
+++ b/flutter-idea/third_party/vmServiceDrivers/org/dartlang/vm/service/element/Func.java
@@ -53,6 +53,9 @@ public class Func extends Obj {
   /**
    * The location of this function in the source code.
    *
+   * Note: this may not agree with the location of `owner` if this is a function from a mixin
+   * application, expression evaluation, patched class, etc.
+   *
    * Can return <code>null</code>.
    */
   public SourceLocation getLocation() {
@@ -75,6 +78,9 @@ public class Func extends Obj {
 
   /**
    * The owner of this function, which can be a Library, Class, or a Function.
+   *
+   * Note: the location of `owner` may not agree with `location` if this is a function from a mixin
+   * application, expression evaluation, patched class, etc.
    *
    * @return one of <code>LibraryRef</code>, <code>ClassRef</code> or <code>FuncRef</code>
    */

--- a/flutter-idea/third_party/vmServiceDrivers/org/dartlang/vm/service/element/FuncRef.java
+++ b/flutter-idea/third_party/vmServiceDrivers/org/dartlang/vm/service/element/FuncRef.java
@@ -37,6 +37,9 @@ public class FuncRef extends ObjRef {
   /**
    * The location of this function in the source code.
    *
+   * Note: this may not agree with the location of `owner` if this is a function from a mixin
+   * application, expression evaluation, patched class, etc.
+   *
    * Can return <code>null</code>.
    */
   public SourceLocation getLocation() {
@@ -59,6 +62,9 @@ public class FuncRef extends ObjRef {
 
   /**
    * The owner of this function, which can be a Library, Class, or a Function.
+   *
+   * Note: the location of `owner` may not agree with `location` if this is a function from a mixin
+   * application, expression evaluation, patched class, etc.
    *
    * @return one of <code>LibraryRef</code>, <code>ClassRef</code> or <code>FuncRef</code>
    */


### PR DESCRIPTION
This should not change behavior, as the old analyzer path mapping is the one that will be used for file mapping. I'm only using the new bazel mapping package to see whether the path generated is the same, logging if not.