### PR TITLE
Support multi-platform builds

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -20,3 +20,4 @@ Hrishikesh Kadam <hrkadam.92@gmail.com>
 Sander Kersten <spkersten@gmail.com>
 Pradumna Saraf <pradumnasaraf@gmail.com>
 Pedro Massango <pedromassango.developer@gmail.com>
+Stryder Crown <stryder.c@gmail.com>

--- a/bin/plugin.bat
+++ b/bin/plugin.bat
@@ -1,0 +1,1 @@
+dart tool/plugin/bin/main.dart %1

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,13 +8,13 @@ buildscript {
   repositories {
     mavenCentral()
     maven {
-      url=uri("https://www.jetbrains.com/intellij-repository/snapshots/")
+      url = uri("https://www.jetbrains.com/intellij-repository/snapshots/")
     }
     maven {
-      url=uri("https://oss.sonatype.org/content/repositories/snapshots/")
+      url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
     }
     maven {
-      url=uri("https://www.jetbrains.com/intellij-repository/releases")
+      url = uri("https://www.jetbrains.com/intellij-repository/releases")
     }
   }
 }
@@ -28,13 +28,13 @@ repositories {
   mavenLocal()
   mavenCentral()
   maven {
-    url=uri("https://www.jetbrains.com/intellij-repository/snapshots/")
+    url = uri("https://www.jetbrains.com/intellij-repository/snapshots/")
   }
   maven {
-    url=uri("https://oss.sonatype.org/content/repositories/snapshots/")
+    url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
   }
   maven {
-    url=uri("https://www.jetbrains.com/intellij-repository/releases")
+    url = uri("https://www.jetbrains.com/intellij-repository/releases")
   }
 }
 
@@ -49,11 +49,12 @@ allprojects {
 }
 
 val ide: String by project
+val ideaPluginName: String by project
 val flutterPluginVersion: String by project
+val ideaVersion: String by project
 val javaVersion: String by project
 val dartVersion: String by project
 val baseVersion: String by project
-val name: String by project
 val buildSpec: String by project
 
 group = "io.flutter"
@@ -65,19 +66,20 @@ java {
 }
 
 intellij {
-  pluginName.set(name)
+  pluginName.set(ideaPluginName)
   // This adds nullability assertions, but also compiles forms.
   instrumentCode.set(true)
   updateSinceUntilBuild.set(false)
-  localPath.set("${project.rootDir.absolutePath}/artifacts/$ide")
+  localPath.set("${project.rootDir.absolutePath}/artifacts/$ide-$ideaVersion")
   downloadSources.set(false)
   val pluginList = mutableListOf(
     project(":flutter-idea"), "java", "properties",
     "junit", "Git4Idea", "Kotlin", "gradle", "org.jetbrains.android",
-    "Groovy", "smali", "IntelliLang", "Dart:$dartVersion")
+    "Groovy", "smali", "IntelliLang", "Dart:$dartVersion"
+  )
   if (ide == "android-studio") {
     pluginList += listOf(project(":flutter-studio"))
-  } else if ("$buildSpec" == "2020.3") {
+  } else if (buildSpec == "2020.3") {
     pluginList += listOf("gradle-dsl-impl")
   }
   plugins.set(pluginList)
@@ -98,9 +100,9 @@ dependencies {
 
 tasks {
   instrumentCode {
-    compilerVersion.set("$baseVersion")
+    compilerVersion.set(baseVersion)
   }
   instrumentTestCode {
-    compilerVersion.set("$baseVersion")
+    compilerVersion.set(baseVersion)
   }
 }

--- a/flutter-idea/build.gradle.kts
+++ b/flutter-idea/build.gradle.kts
@@ -8,15 +8,15 @@ import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 repositories {
   mavenLocal()
   maven {
-    url=uri("https://www.jetbrains.com/intellij-repository/snapshots/")
+    url = uri("https://www.jetbrains.com/intellij-repository/snapshots/")
   }
 
   mavenCentral()
   maven {
-    url=uri("https://oss.sonatype.org/content/repositories/snapshots/")
+    url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
   }
   maven {
-    url=uri("https://www.jetbrains.com/intellij-repository/releases")
+    url = uri("https://www.jetbrains.com/intellij-repository/releases")
   }
 }
 
@@ -28,6 +28,7 @@ plugins {
 
 val ide: String by project
 val flutterPluginVersion: String by project
+val ideaVersion: String by project
 val javaVersion: String by project
 val dartVersion: String by project
 val baseVersion: String by project
@@ -51,9 +52,11 @@ intellij {
   instrumentCode.set(true)
   updateSinceUntilBuild.set(false)
   downloadSources.set(false)
-  localPath.set("${project.rootDir.absolutePath}/artifacts/$ide")
-  val pluginList = mutableListOf("java", "properties", "junit", "Kotlin", "Git4Idea",
-             "gradle", "Groovy", "smali", "IntelliLang", "org.jetbrains.android", "yaml", "Dart:$dartVersion")
+  localPath.set("${project.rootDir.absolutePath}/artifacts/$ide-$ideaVersion")
+  val pluginList = mutableListOf(
+    "java", "properties", "junit", "Kotlin", "Git4Idea",
+    "gradle", "Groovy", "smali", "IntelliLang", "org.jetbrains.android", "yaml", "Dart:$dartVersion"
+  )
   plugins.set(pluginList)
 }
 
@@ -61,57 +64,98 @@ dependencies {
   testImplementation("org.powermock:powermock-api-mockito2:2.0.0")
   testImplementation("org.powermock:powermock-module-junit4:2.0.0")
   if (ide == "android-studio") {
+    // Android Studio specific depdendencies.
     testImplementation(project(":flutter-studio"))
-    testRuntimeOnly(fileTree(mapOf("dir" to "${project.rootDir}/artifacts/android-studio/plugins",
-                         "include" to listOf("**/*.jar"),
-                         "exclude" to listOf("**/android-ndk.jar", "**/kotlin-compiler.jar", "**/kotlin-plugin.jar", "**/kotlin-stdlib-jdk8.jar"))))
-    testRuntimeOnly(fileTree(mapOf("dir" to "${project.rootDir}/artifacts/android-studio/lib",
-                         "include" to listOf("*.jar"))))
-    compileOnly(fileTree(mapOf("dir" to "${project.rootDir}/artifacts/android-studio/plugins/git4idea/lib",
-                         "include" to listOf("*.jar"))))
-    testImplementation(fileTree(mapOf("dir" to "${project.rootDir}/artifacts/android-studio/plugins/git4idea/lib",
-                         "include" to listOf("*.jar"))))
-  } else {
-    compileOnly(fileTree(mapOf("dir" to "${project.rootDir}/artifacts/ideaIC/plugins/git4idea/lib",
-                         "include" to listOf("*.jar"))))
-    testImplementation(fileTree(mapOf("dir" to "${project.rootDir}/artifacts/ideaIC/plugins/git4idea/lib",
-                         "include" to listOf("*.jar"))))
+    testRuntimeOnly(
+      fileTree(
+        mapOf(
+          "dir" to "${project.rootDir}/artifacts/android-studio-$ideaVersion/plugins",
+          "include" to listOf("**/*.jar"),
+          "exclude" to listOf("**/android-ndk.jar", "**/kotlin-compiler.jar", "**/kotlin-plugin.jar", "**/kotlin-stdlib-jdk8.jar")
+        )
+      )
+    )
+    testRuntimeOnly(
+      fileTree(
+        mapOf(
+          "dir" to "${project.rootDir}/artifacts/android-studio/lib",
+          "include" to listOf("*.jar")
+        )
+      )
+    )
   }
+  // Used by both Android Studio and Intellij
+  compileOnly(
+    fileTree(
+      mapOf(
+        "dir" to "${project.rootDir}/artifacts/$ide-$ideaVersion/plugins/git4idea/lib",
+        "include" to listOf("*.jar")
+      )
+    )
+  )
+  testImplementation(
+    fileTree(
+      mapOf(
+        "dir" to "${project.rootDir}/artifacts/$ide-$ideaVersion/plugins/git4idea/lib",
+        "include" to listOf("*.jar")
+      )
+    )
+  )
   compileOnly("com.google.guava:guava:31.0.1-jre")
   compileOnly("com.google.code.gson:gson:2.9.0")
   testImplementation("com.google.guava:guava:31.0.1-jre")
   testImplementation("com.google.code.gson:gson:2.9.0")
-  compileOnly(fileTree(mapOf("dir" to "${project.rootDir}/third_party/lib/jxbrowser",
-                       "include" to listOf("*.jar"))))
-  testImplementation(fileTree(mapOf("dir" to "${project.rootDir}/third_party/lib/jxbrowser",
-                       "include" to listOf("*.jar"))))
+  compileOnly(
+    fileTree(
+      mapOf(
+        "dir" to "${project.rootDir}/third_party/lib/jxbrowser",
+        "include" to listOf("*.jar")
+      )
+    )
+  )
+  testImplementation(
+    fileTree(
+      mapOf(
+        "dir" to "${project.rootDir}/third_party/lib/jxbrowser",
+        "include" to listOf("*.jar")
+      )
+    )
+  )
   testImplementation("junit:junit:4.13.2")
   testImplementation(mapOf("group" to "org.mockito", "name" to "mockito-core", "version" to "2.2.2")) // 3.11.2 is latest
 }
 
 sourceSets {
   main {
-    java.srcDirs(listOf(
-      "src",
-      "third_party/vmServiceDrivers"
-    ))
+    java.srcDirs(
+      listOf(
+        "src",
+        "third_party/vmServiceDrivers"
+      )
+    )
     // Add kotlin.srcDirs if we start using Kotlin in the main plugin.
-    resources.srcDirs(listOf(
-      "src",
-      "${project.rootDir}/resources"
-    ))
+    resources.srcDirs(
+      listOf(
+        "src",
+        "${project.rootDir}/resources"
+      )
+    )
   }
   test {
-    java.srcDirs(listOf(
-      "src",
-      "testSrc/unit",
-      "third_party/vmServiceDrivers"
-    ))
-    resources.srcDirs(listOf(
-      "${project.rootDir}/resources",
-      "testData",
-      "testSrc/unit"
-    ))
+    java.srcDirs(
+      listOf(
+        "src",
+        "testSrc/unit",
+        "third_party/vmServiceDrivers"
+      )
+    )
+    resources.srcDirs(
+      listOf(
+        "${project.rootDir}/resources",
+        "testData",
+        "testSrc/unit"
+      )
+    )
   }
 }
 
@@ -122,11 +166,11 @@ tasks {
   }
 
   instrumentCode {
-    compilerVersion.set("$baseVersion")
+    compilerVersion.set(baseVersion)
   }
 
   instrumentTestCode {
-    compilerVersion.set("$baseVersion")
+    compilerVersion.set(baseVersion)
   }
 
   test {

--- a/flutter-idea/build.gradle.kts
+++ b/flutter-idea/build.gradle.kts
@@ -98,7 +98,7 @@ sourceSets {
     // Add kotlin.srcDirs if we start using Kotlin in the main plugin.
     resources.srcDirs(listOf(
       "src",
-      "resources"
+      "${project.rootDir}/resources"
     ))
   }
   test {
@@ -108,7 +108,7 @@ sourceSets {
       "third_party/vmServiceDrivers"
     ))
     resources.srcDirs(listOf(
-      "resources",
+      "${project.rootDir}/resources",
       "testData",
       "testSrc/unit"
     ))

--- a/flutter-studio/build.gradle.kts
+++ b/flutter-studio/build.gradle.kts
@@ -7,7 +7,7 @@
 repositories {
   mavenCentral()
   maven {
-    url=uri("https://oss.sonatype.org/content/repositories/snapshots/")
+    url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
   }
 }
 
@@ -19,6 +19,7 @@ plugins {
 
 val ide: String by project
 val flutterPluginVersion: String by project
+val ideaVersion: String by project
 val javaVersion: String by project
 val dartVersion: String by project
 val baseVersion: String by project
@@ -42,39 +43,67 @@ intellij {
   instrumentCode.set(true)
   updateSinceUntilBuild.set(false)
   downloadSources.set(false)
-  localPath.set("${project.rootDir.absolutePath}/artifacts/$ide")
-  val pluginList = mutableListOf("java", "Dart:$dartVersion", "properties", "junit",
-             "gradle", "Groovy", "smali", "IntelliLang", "org.jetbrains.android")
+  localPath.set("${project.rootDir.absolutePath}/artifacts/$ide-$ideaVersion")
+  val pluginList = mutableListOf(
+    "java", "Dart:$dartVersion", "properties", "junit",
+    "gradle", "Groovy", "smali", "IntelliLang", "org.jetbrains.android"
+  )
   plugins.set(pluginList)
 }
 
 dependencies {
   compileOnly(project(":flutter-idea"))
   testImplementation(project(":flutter-idea"))
-  compileOnly(fileTree(mapOf("dir" to "${project.rootDir}/artifacts/android-studio/lib",
-                         "include" to listOf("*.jar"))))
-  testImplementation(fileTree(mapOf("dir" to "${project.rootDir}/artifacts/android-studio/lib",
-                         "include" to listOf("*.jar"))))
-  compileOnly(fileTree(mapOf("dir" to "${project.rootDir}/artifacts/android-studio/plugins",
-                         "include" to listOf("**/*.jar"),
-                         "exclude" to listOf("**/kotlin-compiler.jar", "**/kotlin-plugin.jar"))))
-  testImplementation(fileTree(mapOf("dir" to "${project.rootDir}/artifacts/android-studio/plugins",
-                         "include" to listOf("**/*.jar"),
-                         "exclude" to listOf("**/kotlin-compiler.jar", "**/kotlin-plugin.jar"))))
+  compileOnly(
+    fileTree(
+      mapOf(
+        "dir" to "${project.rootDir}/artifacts/android-studio-$ideaVersion/lib",
+        "include" to listOf("*.jar")
+      )
+    )
+  )
+  testImplementation(
+    fileTree(
+      mapOf(
+        "dir" to "${project.rootDir}/artifacts/android-studio-$ideaVersion/lib",
+        "include" to listOf("*.jar")
+      )
+    )
+  )
+  compileOnly(
+    fileTree(
+      mapOf(
+        "dir" to "${project.rootDir}/artifacts/android-studio-$ideaVersion/plugins",
+        "include" to listOf("**/*.jar"),
+        "exclude" to listOf("**/kotlin-compiler.jar", "**/kotlin-plugin.jar")
+      )
+    )
+  )
+  testImplementation(
+    fileTree(
+      mapOf(
+        "dir" to "${project.rootDir}/artifacts/android-studio-$ideaVersion/plugins",
+        "include" to listOf("**/*.jar"),
+        "exclude" to listOf("**/kotlin-compiler.jar", "**/kotlin-plugin.jar")
+      )
+    )
+  )
 }
 
 sourceSets {
   main {
-    java.srcDirs(listOf(
-      "src",
-      "third_party/vmServiceDrivers"
-      //"resources"
-    ))
+    java.srcDirs(
+      listOf(
+        "src",
+        "third_party/vmServiceDrivers"
+        //"resources"
+      )
+    )
     // Add kotlin.srcDirs if we start using Kotlin in the main plugin.
     //resources.srcDirs(listOf(
-      //"src",
-      //project(":flutter-idea").sourceSets.main.get().resources
-      //"resources",
+    //"src",
+    //project(":flutter-idea").sourceSets.main.get().resources
+    //"resources",
     //))
   }
 }
@@ -86,10 +115,10 @@ tasks {
   }
 
   instrumentCode {
-    compilerVersion.set("$baseVersion")
+    compilerVersion.set(baseVersion)
   }
 
   instrumentTestCode {
-    compilerVersion.set("$baseVersion")
+    compilerVersion.set(baseVersion)
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-name = "flutter-intellij"
+ideaPluginName = "flutter-intellij"
 org.gradle.parallel=true
 org.gradle.jvmargs=-Xms128m -Xmx1024m -XX:+CMSClassUnloadingEnabled
 javaVersion=11

--- a/product-matrix.json
+++ b/product-matrix.json
@@ -67,7 +67,7 @@
       "name": "2022.2",
       "version": "2022.2",
       "ideaProduct": "ideaIC",
-      "ideaVersion": "222.3244.4",
+      "ideaVersion": "2022.2.2",
       "baseVersion": "222.3244.4",
       "dartPluginVersion": "222.4167.21",
       "sinceBuild": "222.3244.4",

--- a/product-matrix.json
+++ b/product-matrix.json
@@ -69,7 +69,7 @@
       "ideaProduct": "ideaIC",
       "ideaVersion": "222.3244.4",
       "baseVersion": "222.3244.4",
-      "dartPluginVersion": "222.3244.4",
+      "dartPluginVersion": "222.4167.21",
       "sinceBuild": "222.3244.4",
       "untilBuild": "222.*"
     }

--- a/tool/plugin/README.md
+++ b/tool/plugin/README.md
@@ -16,6 +16,7 @@ will be implemented as compound commands in the CLI tool (similar to `flutter do
 *   `deploy`
 *   `generate`
 *   `lint`
+*   `artifacts`
 
 Each command has its own set of optional arguments. If the CLI tool is invoked without a command then it will print its help message.
 
@@ -88,6 +89,11 @@ during building because it will have a version range that allows use in all targ
 ### Lint
 
 Run the lint tool. It checks for bad imports and prints a report of the Dart plugin API usage.
+
+### Artifacts
+
+Identifies artifacts that are needed, whether they exist, and provides urls that may have the required package
+if not found.
 
 
 ## Examples

--- a/tool/plugin/README.md
+++ b/tool/plugin/README.md
@@ -1,12 +1,15 @@
 
 # Flutter Plugin Maintenance Tool
 
-The previous builder for the Flutter plugin was written in Ant. An expert in Ant would probably have no trouble maintaining it, but we have no such expert available. In order to increase stability and productivity we transformed the builder into a Dart command line tool, inspired by the Flutter tool. The tool is named `plugin`, since it helps with plugin development.
+The previous builder for the Flutter plugin was written in Ant. An expert in Ant would probably have no trouble maintaining it, but
+we have no such expert available. In order to increase stability and productivity we transformed the builder into a Dart command line 
+tool, inspired by the Flutter tool. The tool is named `plugin`, since it helps with plugin development.
 
 
 ## Functions
 
-The tool needs to perform several functions. Building is the basic one, but others are important too. Implementation note: these will be implemented as compound commands in the CLI tool (similar to `flutter doctor` or `flutter run` in the Flutter CLI tool).
+The tool needs to perform several functions. Building is the basic one, but others are important too. Implementation note: these
+will be implemented as compound commands in the CLI tool (similar to `flutter doctor` or `flutter run` in the Flutter CLI tool).
 
 *   `make`
 *   `test`
@@ -21,9 +24,13 @@ There are two global options. On the command line these are given prior to the c
 
 
 *   `-r, --release=XX`
-Use "release mode." The `XX` value specifies the release identifier, like 18 or 19.1. It will be shown in the "version" field of the plugin manager's listing for the Flutter plugin. In this mode additional constraints must be satisfied. The current git branch must have no unsaved changes and must be named "release_XX". The `.github/workflows/presubmit.yaml` file must be newer than the `product-matrix.json` file (see the `generate` command).
+Use "release mode." The `XX` value specifies the release identifier, like 18 or 19.1. It will be shown in the "version" field of the 
+plugin manager's listing for the Flutter plugin. In this mode additional constraints must be satisfied. The current git branch must have 
+no unsaved changes and must be named "release_XX". The `.github/workflows/presubmit.yaml` file must be newer than the `product-matrix.json` 
+file (see the `generate` command).
 *   `-d, --cwd=<working-directory>`
-Set the root directory to the `working-directory` value. This should not be used when running the tool from the command line. It is only intended to be used when running tests from IntelliJ run configurations that have no way to specify the working directory.
+Set the root directory to the `working-directory` value. This should not be used when running the tool from the command line. It is only 
+intended to be used when running tests from IntelliJ run configurations that have no way to specify the working directory.
 
 
 ### Make
@@ -42,7 +49,10 @@ Only build the specified IntelliJ version. `ID` is one of the "version" strings 
 Normally the archive files are not unpacked if the corresponding directory exists. This flag forces the archive files to be unpacked.
 
 
-The make function must generate the correct `plugin.xml` for each platform and generate the correct artifacts for each. In release mode the archive files are always unpacked (--unpack is implied). The plugin files are saved in the `artifacts` directory. In release mode a subdirectory of `artifacts` is created which has the name of the release and they are put there. During a local dev/test run the subdirectory is not created and the created files are children of `artifacts`.
+The make function must generate the correct `plugin.xml` for each platform and generate the correct artifacts for each. In release mode 
+the archive files are always unpacked (--unpack is implied). The plugin files are saved in the `artifacts` directory.
+In release mode a subdirectory of `artifacts` is created which has the name of the release and they are put there. 
+During a local dev/test run the subdirectory is not created and the created files are children of `artifacts`.
 
 Returns a success or failure code to play nice with shell commands.
 
@@ -58,17 +68,21 @@ Both unit and integration tests need to run, and tests should work whether runni
 *   `-i, --[no-]integration`
 Run GUI-based integration tests (or not).
 
-TBD: We may need some mechanism to automatically upload testing artifacts, since we can no longer attach zip files to email. This could also potentially be addressed by creating a 'dev' channel for the plugin on the JetBrains store, and publishing to it when we have release candidates.
+TBD: We may need some mechanism to automatically upload testing artifacts, since we can no longer attach zip files to email. 
+This could also potentially be addressed by creating a 'dev' channel for the plugin on the JetBrains store, and publishing to it
+when we have release candidates.
 
 
 ### Deploy
 
-Automatically upload all required artifacts to the JetBrains site. This function will print instructions to retrieve the password from valentine then prompt for the password to log into the JetBrains site. It has no options. Returns a success or failure code to play nice with shell commands.
-(Used primarily by the dev channel Kokoro job. Not sure if it works for uploading to the stable channel.)
+Automatically upload all required artifacts to the JetBrains site. This function will print instructions to retrieve the password from 
+valentine then prompt for the password to log into the JetBrains site. It has no options. Returns a success or failure code to play nice 
+with shell commands. (Used primarily by the dev channel Kokoro job. Not sure if it works for uploading to the stable channel.)
 
 ### Generate
 
-Generate a `plugin.xml` from `plugin.xml.template` to be used for launching a runtime workbench. This is different from the ones generated during building because it will have a version range that allows use in all targeted platforms.
+Generate a `plugin.xml` from `plugin.xml.template` to be used for launching a runtime workbench. This is different from the ones generated 
+during building because it will have a version range that allows use in all targeted platforms.
 
 
 ### Lint
@@ -90,7 +104,8 @@ Run integration tests without doing a build, assuming an edit-build-test cycle d
 
 	`plugin test --no-unit`
 
-Build everything then run all tests. The big question here is: Can we get integration tests to run using the newly-built plugin rather than sources?
+Build everything then run all tests. The big question here is: Can we get integration tests to run using the newly-built plugin 
+rather than sources?
 
 	`plugin make && plugin test`
 

--- a/tool/plugin/lib/artifact.dart
+++ b/tool/plugin/lib/artifact.dart
@@ -60,7 +60,7 @@ class ArtifactManager {
       await artifact.exists().then((exists) async {
         //  If the artifact doesn't exist...
         if (exists) {
-          log('Artifact exists at ${artifact.fileName}');
+          log('Artifact ${artifact.fileName} found at ${artifact.filePath}');
         } else {
           // ...we need to download it
           await downloadArtifact(artifact);
@@ -137,12 +137,12 @@ class ArtifactManager {
         directory
             .statSync()
             .modified
-            .isAfter(File(artifact.fileName).lastModifiedSync());
+            .isAfter(File(artifact.filePath).lastModifiedSync());
   }
 
   void doReport(Artifact artifact) {
     if (artifact.existsSync()) {
-      log('Artifact exists at ${artifact.fileName}');
+       log('${artifact.fileName} found at ${artifact.filePath}');
     } else {
       log('Artifact ${artifact.fileName} not found.', asError: true);
       log(

--- a/tool/plugin/lib/build_spec.dart
+++ b/tool/plugin/lib/build_spec.dart
@@ -41,7 +41,7 @@ class BuildSpec {
   Artifact dartPlugin;
 
   BuildSpec.fromJson(Map json, this.release, {this.platform = Platforms.linux})
-      : name = json['name'],
+      : name = json['ideaPluginName'],
         channel = json['channel'],
         version = json['version'],
         ijVersion = json['ijVersion'],
@@ -64,7 +64,9 @@ class BuildSpec {
       double version = double.parse(ideaVersion.split('.').take(2).join('.'));
       // ...just
       if (ideaProduct == 'android-studio') {
-        String prefix = version < 2020 ? '$ideaProduct-ide' : ideaProduct;
+        // Oldest supported version is currently 2021.1
+        //   versions < 2020 had a prefix of '$ideaProduct-ide
+        String prefix = ideaProduct;
         String suffix = platform == Platforms.linux && version > 183.5452
             ? 'tar.gz'
             : 'zip'; // Versions prior to 183.5452 used zip

--- a/tool/plugin/lib/edit.dart
+++ b/tool/plugin/lib/edit.dart
@@ -75,8 +75,11 @@ class Unused extends EditCommand {
 Future<int> applyEdits(BuildSpec spec, Function compileFn) async {
   // Handle skipped files.
   for (String file in spec.filesToSkip) {
-    var entity =
-        FileSystemEntity.isFileSync(file) ? File(file) : Directory(file);
+    if(!FileSystemEntity.isFileSync(file)){
+      continue; //we don't apply edits to directories.
+    }
+    var entity = File(file);
+
     if (entity.existsSync()) {
       await entity.rename('$file~');
       log('renamed $file');
@@ -99,7 +102,6 @@ Future<int> applyEdits(BuildSpec spec, Function compileFn) async {
         appliedEditCommands.add(edit);
       }
     }
-
     return await compileFn.call();
   } finally {
     // Restore sources.
@@ -111,8 +113,7 @@ Future<int> applyEdits(BuildSpec spec, Function compileFn) async {
     // Restore skipped files.
     for (var file in spec.filesToSkip) {
       var name = '$file~';
-      var entity =
-          FileSystemEntity.isFileSync(name) ? File(name) : Directory(name);
+      var entity = File(name);
       if (entity.existsSync()) {
         await entity.rename(file);
       }

--- a/tool/plugin/lib/edit.dart
+++ b/tool/plugin/lib/edit.dart
@@ -34,14 +34,14 @@ List<EditCommand> editCommands = [
   Subst(
     path: 'build.gradle.kts',
     initial:
-        'localPath.set("\${project.rootDir.absolutePath}/artifacts/\$ide")',
+        'localPath.set("\${project.rootDir.absolutePath}/artifacts/\$ide-\$ideaVersion")',
     replacement: 'type.set("IC")\n  version.set("LATEST-EAP-SNAPSHOT")',
     version: '2022.3',
   ),
   Subst(
     path: 'flutter-idea/build.gradle.kts',
     initial:
-        'localPath.set("\${project.rootDir.absolutePath}/artifacts/\$ide")',
+        'localPath.set("\${project.rootDir.absolutePath}/artifacts/\$ide-\$ideaVersion")',
     replacement: 'type.set("IC")\n  version.set("LATEST-EAP-SNAPSHOT")',
     version: '2022.3',
   ),

--- a/tool/plugin/lib/edit.dart
+++ b/tool/plugin/lib/edit.dart
@@ -52,7 +52,8 @@ List<EditCommand> editCommands = [
     versions: ['AS.211', 'AS.212'],
   ),
   Subst(
-    path: 'flutter-idea/src/io/flutter/analytics/FlutterAnalysisServerListener.java',
+    path:
+        'flutter-idea/src/io/flutter/analytics/FlutterAnalysisServerListener.java',
     initial: '<@NotNull Analytics>',
     replacement: '<Analytics>',
     versions: ['AS.211', 'AS.212', 'AS.213'],

--- a/tool/plugin/lib/plugin.dart
+++ b/tool/plugin/lib/plugin.dart
@@ -97,13 +97,10 @@ List<String> findJavaFiles(String path) {
 }
 
 Future<bool> genPluginFiles(BuildSpec spec, String destDir) async {
-  var result = await genPluginXml(spec, destDir, 'META-INF/plugin.xml');
-  if (result == null) return false;
-
-  result = await genPluginXml(spec, destDir, 'META-INF/studio-contribs.xml');
-  if (result == null) return false;
-
-  return true;
+  return (await Future.wait([
+    genPluginXml(spec, destDir, 'META-INF/plugin.xml'),
+    genPluginXml(spec, destDir, 'META-INF/studio-contribs.xml'),
+  ])).every((result) => result != null);
 }
 
 Future<File> genPluginXml(BuildSpec spec, String destDir, String path) async {
@@ -333,6 +330,7 @@ class AntBuildCommand extends BuildCommand {
 }
 
 class ArtifactReportCommand extends ProductCommand {
+  @override
   final BuildCommandRunner runner;
 
   ArtifactReportCommand(this.runner) : super('artifacts');
@@ -511,7 +509,8 @@ abstract class BuildCommand extends ProductCommand {
         separator('Built artifact');
         log(releasesFilePath(spec));
       }
-      if (argResults['only-version'] == null) {
+
+      if (onlyVersion == null) {
         checkAndClearAppliedEditCommands();
       }
 
@@ -991,7 +990,7 @@ class TestCommand extends ProductCommand {
   Future<int> _runUnitTests(BuildSpec spec) async {
     // run './gradlew test'
     return await applyEdits(spec, () async {
-      return await runner.runGradleCommand(['test'], spec, '1', 'true');
+      return await runner.runGradleCommand(['test'], spec, '1', true);
     });
   }
 

--- a/tool/plugin/lib/plugin.dart
+++ b/tool/plugin/lib/plugin.dart
@@ -360,11 +360,7 @@ class GradleBuildCommand extends BuildCommand {
   }
 
   Future<int> _stopDaemon() async {
-    if (Platform.isWindows) {
-      return await exec('.\\third_party\\gradlew.bat', ['--stop']);
-    } else {
-      return await exec('./third_party/gradlew', ['--stop']);
-    }
+    return execLocalGradleCommand(['--stop']);
   }
 }
 
@@ -448,7 +444,7 @@ abstract class BuildCommand extends ProductCommand {
 
         result = await spec.artifacts.provision(
           rebuildCache:
-          isReleaseMode || argResults['unpack'] || buildSpecs.length > 1,
+              isReleaseMode || argResults['unpack'] || buildSpecs.length > 1,
         );
         if (result != 0) {
           return result;
@@ -892,7 +888,8 @@ class SetupCommand extends Command {
   }
 
   @override
-  String get description => 'Unpack the artifacts required to debug the plugin in IntelliJ';
+  String get description =>
+      'Unpack the artifacts required to debug the plugin in IntelliJ';
 
   @override
   String get name => 'setup';
@@ -922,8 +919,7 @@ class TestCommand extends ProductCommand {
     try {
       final javaHome = Platform.environment['JAVA_HOME'];
       if (javaHome == null) {
-        log(
-            'JAVA_HOME environment variable not set - this is needed by gradle.');
+        log('JAVA_HOME environment variable not set - this is needed by gradle.');
         return 1;
       }
 

--- a/tool/plugin/lib/runner.dart
+++ b/tool/plugin/lib/runner.dart
@@ -34,8 +34,8 @@ class BuildCommandRunner extends CommandRunner {
   void writeJxBrowserKeyToFile() {
     final jxBrowserKey =
         readTokenFromKeystore('FLUTTER_KEYSTORE_JXBROWSER_KEY_NAME');
-    final propertiesFile =
-        File(p.join(rootPath, "resources", "jxbrowser", "jxbrowser.properties"));
+    final propertiesFile = File(
+        p.join(rootPath, "resources", "jxbrowser", "jxbrowser.properties"));
     if (jxBrowserKey.isNotEmpty) {
       final contents = '''
 jxbrowser.license.key=$jxBrowserKey
@@ -44,16 +44,16 @@ jxbrowser.license.key=$jxBrowserKey
     }
   }
 
-  Future<int> buildPlugin(BuildSpec spec, String version) async {
+  Future<int> buildPlugin(BuildSpec spec, String flutterPluginVersion) async {
     writeJxBrowserKeyToFile();
-    return await runGradleCommand(['buildPlugin'], spec, version, 'false');
+    return await runGradleCommand(['buildPlugin'], spec, flutterPluginVersion, false);
   }
 
   Future<int> runGradleCommand(
     List<String> command,
     BuildSpec spec,
-    String version,
-    String testing,
+    String flutterPluginVersion,
+    bool testing,
   ) async {
     var javaVersion = ['4.1'].contains(spec.version) ? '1.8' : '11';
     final contents = '''
@@ -62,7 +62,7 @@ org.gradle.parallel=true
 org.gradle.jvmargs=-Xms128m -Xmx1024m -XX:+CMSClassUnloadingEnabled
 javaVersion=$javaVersion
 dartVersion=${spec.dartPluginVersion}
-flutterPluginVersion=$version
+flutterPluginVersion=$flutterPluginVersion
 ideaVersion=${spec.ideaVersion}
 ide=${spec.ideaProduct}
 testing=$testing

--- a/tool/plugin/lib/runner.dart
+++ b/tool/plugin/lib/runner.dart
@@ -57,12 +57,13 @@ jxbrowser.license.key=$jxBrowserKey
   ) async {
     var javaVersion = ['4.1'].contains(spec.version) ? '1.8' : '11';
     final contents = '''
-name = "flutter-intellij"
+ideaPluginName = flutter-intellij
 org.gradle.parallel=true
 org.gradle.jvmargs=-Xms128m -Xmx1024m -XX:+CMSClassUnloadingEnabled
 javaVersion=$javaVersion
 dartVersion=${spec.dartPluginVersion}
 flutterPluginVersion=$version
+ideaVersion=${spec.ideaVersion}
 ide=${spec.ideaProduct}
 testing=$testing
 buildSpec=${spec.version}

--- a/tool/plugin/lib/util.dart
+++ b/tool/plugin/lib/util.dart
@@ -110,17 +110,19 @@ Future<int> curl(String url, {String to}) async {
   return await exec('curl', ['-L', '-o', to, url]);
 }
 
+/// Recursively removes the target [dir] and all its content
 Future<int> removeAll(String dir) async {
   var targetDirectory = Directory(dir);
   return targetDirectory.exists().then((exists) async {
     if (exists) {
+      log("Removing directory $targetDirectory");
       await targetDirectory.delete(recursive: true);
-      return 0;
-    } else {
-      return -1;
     }
+    // If it doesn't exist, that's as good as success, right?
+    return 0;
   }).onError((error, stackTrace) {
     log("An error occurred while deleting $targetDirectory");
+    log("$error", asError: true);
     return -1;
   });
 }

--- a/tool/plugin/pubspec.yaml
+++ b/tool/plugin/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   git: ^2.0.0
   markdown: ^4.0.0
   path: ^1.7.0
+  archive: 3.2.2
 
 dev_dependencies:
   lints: ^1.0.0

--- a/tool/plugin/test/artifact_test.dart
+++ b/tool/plugin/test/artifact_test.dart
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+/*
+ * Copyright 2022 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+// @dart = 2.10
+import 'package:path/path.dart' as p;
+import 'package:plugin_tool/util.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Validate `stripComponents` function', () {
+    test('Correct components are removed', () {
+      var testPath = p.join('a', 'b', 'c', 'd');
+      expect(stripComponents(testPath, 1), p.join('b', 'c', 'd'));
+      expect(stripComponents(testPath, 2), p.join('c', 'd'));
+      expect(stripComponents(testPath, 3), p.join('d'));
+    });
+
+    test('Last element is always returned', () {
+      var testPath = p.join('a', 'b', 'c', 'd');
+
+      expect(stripComponents(testPath, 4), p.join('d'));
+      expect(stripComponents(testPath, 5), p.join('d'));
+    });
+  });
+
+}


### PR DESCRIPTION
This is a refactor of the `flutter-intellij` build tool to support multiple platforms including Mac and Windows. Several other bugs and changes were included to streamline and speed up the build process as well.  Additionally, a new  target, 'artifacts' has been added to aid in identifying needed downloads. 

Summary of changes
- 'unpack' cli arg is moved up used in Setup and Build commands to determine if artifacts should be unpacked again.
- Artifacts are now unpacked to version tagged directories. This cuts down on disk I/O on repeated or bulk builds and should speed up the process.
- Artifacts are unpacked using `dart:archive` package instead of relying on local `tar` and `zip` commands.
- `gradle.properties` updated to provide IDEA version to builds and also fix a bug with the `name` property used for determining the plugin name.
- Housekeeping: more comments, renamed variables, Green text for separators and red text for errors in log output.
- `plugin.bat` file created for invocation on Windows platforms.
- More specific changes/info can be found in commit message history.
- 
Addresses: https://github.com/flutter/flutter-intellij/issues/6052

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
