### PR TITLE
Revert to using OFF_SCREEN render mode for Linux

### DIFF
--- a/flutter-idea/src/io/flutter/jxbrowser/EmbeddedBrowserEngine.java
+++ b/flutter-idea/src/io/flutter/jxbrowser/EmbeddedBrowserEngine.java
@@ -33,9 +33,8 @@ public class EmbeddedBrowserEngine {
     final String dataPath = JxBrowserManager.DOWNLOAD_PATH + File.separatorChar + "user-data";
     LOG.info("JxBrowser user data path: " + dataPath);
 
-    // TODO(helin24): HiDPI environments is not currently supported for Linux, but once it is we can change to HARDWARE_ACCELERATED there.
     final EngineOptions.Builder optionsBuilder =
-      EngineOptions.newBuilder(SystemInfo.isWindows ? OFF_SCREEN : HARDWARE_ACCELERATED)
+      EngineOptions.newBuilder(SystemInfo.isMac ? HARDWARE_ACCELERATED : OFF_SCREEN)
         .userDataDir(Paths.get(dataPath))
         .passwordStore(PasswordStore.BASIC)
         .addSwitch("--disable-features=NativeNotifications");


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter-intellij/issues/6317 and https://github.com/flutter/flutter-intellij/issues/6318