### PR TITLE
Adds Flutter 3.3 support for flutter plugins library manager

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -20,3 +20,4 @@ Hrishikesh Kadam <hrkadam.92@gmail.com>
 Sander Kersten <spkersten@gmail.com>
 Pradumna Saraf <pradumnasaraf@gmail.com>
 Pedro Massango <pedromassango.developer@gmail.com>
+Wagner Silvestre <wagner1343@outlook.com>

--- a/flutter-idea/src/io/flutter/pub/PubRoot.java
+++ b/flutter-idea/src/io/flutter/pub/PubRoot.java
@@ -17,11 +17,13 @@ import com.intellij.openapi.roots.ProjectFileIndex;
 import com.intellij.openapi.roots.ProjectRootManager;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
+import com.jetbrains.lang.dart.util.DotPackagesFileUtil;
 import io.flutter.FlutterUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * A snapshot of the root directory of a pub package.
@@ -274,6 +276,20 @@ public class PubRoot {
     final VirtualFile packages = root.findChild(".packages");
     if (packages != null && !packages.isDirectory()) {
       return packages;
+    }
+
+    return null;
+  }
+
+  public @Nullable Map<String, String> getPackagesMap() {
+    final var packageConfigFile = getPackageConfigFile();
+    if(packageConfigFile != null) {
+      return DotPackagesFileUtil.getPackagesMapFromPackageConfigJsonFile(packageConfigFile);
+    }
+
+    final var packagesFile = getPackagesFile();
+    if(packagesFile != null) {
+      return DotPackagesFileUtil.getPackagesMap(packagesFile);
     }
 
     return null;

--- a/flutter-idea/src/io/flutter/pub/PubRoot.java
+++ b/flutter-idea/src/io/flutter/pub/PubRoot.java
@@ -283,12 +283,12 @@ public class PubRoot {
 
   public @Nullable Map<String, String> getPackagesMap() {
     final var packageConfigFile = getPackageConfigFile();
-    if(packageConfigFile != null) {
+    if (packageConfigFile != null) {
       return DotPackagesFileUtil.getPackagesMapFromPackageConfigJsonFile(packageConfigFile);
     }
 
     final var packagesFile = getPackagesFile();
-    if(packagesFile != null) {
+    if (packagesFile != null) {
       return DotPackagesFileUtil.getPackagesMap(packagesFile);
     }
 

--- a/flutter-idea/src/io/flutter/sdk/FlutterPluginsLibraryManager.java
+++ b/flutter-idea/src/io/flutter/sdk/FlutterPluginsLibraryManager.java
@@ -85,16 +85,23 @@ public class FlutterPluginsLibraryManager extends AbstractLibraryManager<Flutter
     return FlutterPluginLibraryType.LIBRARY_KIND;
   }
 
+  private boolean isPackagesFile(@NotNull final VirtualFile file) {
+    final VirtualFile parent = file.getParent();
+    return file.getName().equals(DotPackagesFileUtil.DOT_PACKAGES) && parent != null && parent.findChild(PUBSPEC_YAML) != null;
+  }
+
+  private boolean isPackageConfigFile(@NotNull final VirtualFile file) {
+    final VirtualFile parent = file.getParent();
+    return file.getName().equals(DotPackagesFileUtil.PACKAGE_CONFIG_JSON)
+           && parent != null
+           && parent.getName().equals(DotPackagesFileUtil.DART_TOOL_DIR);
+  }
+
   private void fileChanged(@NotNull final Project project, @NotNull final VirtualFile file) {
-    if (!DotPackagesFileUtil.DOT_PACKAGES.equals(file.getName())) return;
+    if(!isPackageConfigFile(file) && !isPackagesFile(file)) return;
     if (LocalFileSystem.getInstance() != file.getFileSystem() && !ApplicationManager.getApplication().isUnitTestMode()) return;
 
-    final VirtualFile parent = file.getParent();
-    final VirtualFile pubspec = parent == null ? null : parent.findChild(PUBSPEC_YAML);
-
-    if (pubspec != null) {
-      scheduleUpdate();
-    }
+    scheduleUpdate();
   }
 
   private void scheduleUpdate() {
@@ -132,24 +139,12 @@ public class FlutterPluginsLibraryManager extends AbstractLibraryManager<Flutter
     final Set<String> paths = new HashSet<>();
 
     for (PubRoot pubRoot : roots) {
+      final var packagesMap = pubRoot.getPackagesMap();
+      if(packagesMap == null) {
+        continue;
+      }
 
-      final Map<String, String> map;
-      if (pubRoot.getPackagesFile() == null) {
-        @Nullable VirtualFile configFile = pubRoot.getPackageConfigFile();
-        if (configFile == null) {
-          continue;
-        }
-        // TODO(messick) Use the code in the Dart plugin when available.
-        // This is just a backup in case we need it. It does not have a proper cache, but the Dart plugin does.
-        map = loadPackagesMap(configFile);
-      }
-      else {
-        map = DotPackagesFileUtil.getPackagesMap(pubRoot.getPackagesFile());
-        if (map == null) {
-          continue;
-        }
-      }
-      for (String packagePath : map.values()) {
+      for (String packagePath : packagesMap.values()) {
         final VirtualFile libFolder = LocalFileSystem.getInstance().findFileByPath(packagePath);
         if (libFolder == null) {
           continue;
@@ -166,54 +161,5 @@ public class FlutterPluginsLibraryManager extends AbstractLibraryManager<Flutter
     }
 
     return paths;
-  }
-
-  private static Map<String, String> loadPackagesMap(@NotNull VirtualFile root) {
-    Map<String, String> result = new HashMap<>();
-    try {
-      JsonElement element = JsonUtils.parseString(new String(root.contentsToByteArray(), StandardCharsets.UTF_8));
-      if (element != null) {
-        JsonElement packages = element.getAsJsonObject().get("packages");
-        if (packages != null) {
-          JsonArray array = packages.getAsJsonArray();
-          for (int i = 0; i < array.size(); i++) {
-            JsonObject pkg = array.get(i).getAsJsonObject();
-            String name = pkg.get("name").getAsString();
-            String rootUri = pkg.get("rootUri").getAsString();
-            if (name != null && rootUri != null) {
-              // need to protect '+' chars because URLDecoder.decode replaces '+' with space
-              final String encodedUriWithoutPluses = StringUtil.replace(rootUri, "+", "%2B");
-              final String uri = URLUtil.decode(encodedUriWithoutPluses);
-              final String packageUri = getAbsolutePackageRootPath(root.getParent().getParent(), uri);
-              result.put(name, packageUri);
-            }
-          }
-        }
-      }
-    }
-    catch (IOException | JsonSyntaxException ignored) {
-    }
-    return result;
-  }
-
-  @Nullable
-  private static String getAbsolutePackageRootPath(@NotNull final VirtualFile baseDir, @NotNull final String uri) {
-    // Copied from the Dart plugin.
-    if (uri.startsWith("file:/")) {
-      final String pathAfterSlashes = StringUtil.trimEnd(StringUtil.trimLeading(StringUtil.trimStart(uri, "file:/"), '/'), "/");
-      if (SystemInfo.isWindows && !ApplicationManager.getApplication().isUnitTestMode()) {
-        if (pathAfterSlashes.length() > 2 && Character.isLetter(pathAfterSlashes.charAt(0)) && ':' == pathAfterSlashes.charAt(1)) {
-          return pathAfterSlashes;
-        }
-      }
-      else {
-        return "/" + pathAfterSlashes;
-      }
-    }
-    else {
-      return FileUtil.toCanonicalPath(baseDir.getPath() + "/" + uri);
-    }
-
-    return null;
   }
 }

--- a/flutter-idea/src/io/flutter/sdk/FlutterPluginsLibraryManager.java
+++ b/flutter-idea/src/io/flutter/sdk/FlutterPluginsLibraryManager.java
@@ -98,7 +98,7 @@ public class FlutterPluginsLibraryManager extends AbstractLibraryManager<Flutter
   }
 
   private void fileChanged(@NotNull final Project project, @NotNull final VirtualFile file) {
-    if(!isPackageConfigFile(file) && !isPackagesFile(file)) return;
+    if (!isPackageConfigFile(file) && !isPackagesFile(file)) return;
     if (LocalFileSystem.getInstance() != file.getFileSystem() && !ApplicationManager.getApplication().isUnitTestMode()) return;
 
     scheduleUpdate();
@@ -140,7 +140,7 @@ public class FlutterPluginsLibraryManager extends AbstractLibraryManager<Flutter
 
     for (PubRoot pubRoot : roots) {
       final var packagesMap = pubRoot.getPackagesMap();
-      if(packagesMap == null) {
+      if (packagesMap == null) {
         continue;
       }
 


### PR DESCRIPTION
Since Flutter 3.3 flutter plugins library manager doesn't updates flutter plugins library correctly (see #6330).

This pull request fixes that by watching both .packages and .dart_tool/package_config.json files. It also uses dart plugin method to extract path map from package_config.json.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
