### PR TITLE
Revert "Revert to previous version of scorecards."

### DIFF
--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -28,7 +28,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@865b4092859256271290c77adbd10a43f4779972
+        uses: ossf/scorecard-action@e363bfca00e752f91de7b7d2a77340e2e523cb18
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
Reverts flutter/flutter-intellij#6329

Reverting to use the latest version the problem was actually the workflow using a repo level token rather than the repository one.