### PR TITLE
Catch browser close exceptions

### DIFF
--- a/flutter-idea/src/io/flutter/jxbrowser/EmbeddedBrowser.java
+++ b/flutter-idea/src/io/flutter/jxbrowser/EmbeddedBrowser.java
@@ -85,7 +85,11 @@ public class EmbeddedBrowser {
       @Override
       public void projectClosing(@NotNull Project project) {
         if (browser != null) {
-          browser.close();
+          try {
+            browser.close();
+          } catch (Exception ex) {
+            LOG.info(ex);
+          }
           browser = null;
         }
       }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter-intellij/issues/6351

I'm not able to reproduce that issue myself, but it seems appropriate to catch any exceptions from the JxBrowser browser.