### PR TITLE
Disable kokoro until other problems are solved

### DIFF
--- a/tool/kokoro/build.sh
+++ b/tool/kokoro/build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+exit
+
 source ./tool/kokoro/setup.sh
 setup
 

--- a/tool/kokoro/deploy.sh
+++ b/tool/kokoro/deploy.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+exit
+
 source ./tool/kokoro/setup.sh
 setup
 

--- a/tool/kokoro/setup.sh
+++ b/tool/kokoro/setup.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+exit
+
 # Initialize everything required by the plugin tool.
 setup() {
   # Fail on any error.

--- a/tool/kokoro/test.sh
+++ b/tool/kokoro/test.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+exit
+
 source ./tool/kokoro/setup.sh
 setup
 


### PR DESCRIPTION
The kokoro job fails due to loss of permissions. It isn't doing anything critical, and I don't have time to fix it now, so I'm disabling it.