### PR TITLE
Permit attach in bazel context

### DIFF
--- a/flutter-idea/src/io/flutter/actions/AttachDebuggerAction.java
+++ b/flutter-idea/src/io/flutter/actions/AttachDebuggerAction.java
@@ -93,7 +93,6 @@ public class AttachDebuggerAction extends FlutterSdkAction {
   }
 
   public void startCommandInBazelContext(@NotNull Project project, @NotNull Workspace workspace, AnActionEvent event) {
-    // NOTE: When making changes here, consider making similar changes to RunFlutterAction.
     FlutterInitializer.sendAnalyticsAction(this);
 
     RunConfiguration configuration = findRunConfig(project);

--- a/flutter-idea/src/io/flutter/actions/AttachDebuggerAction.java
+++ b/flutter-idea/src/io/flutter/actions/AttachDebuggerAction.java
@@ -105,10 +105,6 @@ public class AttachDebuggerAction extends FlutterSdkAction {
       }
       configuration = settings.getConfiguration();
       if (!(configuration instanceof BazelRunConfig)) {
-        if (project.isDefault() || !FlutterSdkUtil.hasFlutterModules(project)) {
-          return;
-        }
-        showSelectConfigDialog();
         return;
       }
     }

--- a/flutter-idea/src/io/flutter/actions/AttachDebuggerAction.java
+++ b/flutter-idea/src/io/flutter/actions/AttachDebuggerAction.java
@@ -120,10 +120,6 @@ public class AttachDebuggerAction extends FlutterSdkAction {
     final ExecutionEnvironment env = builder.activeTarget().dataContext(event.getDataContext()).build();
     FlutterLaunchMode.addToEnvironment(env, FlutterLaunchMode.DEBUG);
 
-    if (project.getUserData(ATTACH_IS_ACTIVE) == null) {
-      project.putUserData(ATTACH_IS_ACTIVE, ThreeState.fromBoolean(true));
-      onAttachTermination(project, (p) -> p.putUserData(ATTACH_IS_ACTIVE, null));
-    }
     ProgramRunnerUtil.executeConfiguration(env, false, true);
   }
 

--- a/flutter-idea/src/io/flutter/actions/AttachDebuggerAction.java
+++ b/flutter-idea/src/io/flutter/actions/AttachDebuggerAction.java
@@ -92,7 +92,7 @@ public class AttachDebuggerAction extends FlutterSdkAction {
     ProgramRunnerUtil.executeConfiguration(env, false, true);
   }
 
-  public void startCommandInBazelContext(@NotNull Project project, @NotNull Workspace workspace, AnActionEvent event) {
+  public void startCommandInBazelContext(@NotNull Project project, @NotNull Workspace workspace, @NotNull AnActionEvent event) {
     FlutterInitializer.sendAnalyticsAction(this);
 
     RunConfiguration configuration = findRunConfig(project);

--- a/flutter-idea/src/io/flutter/actions/FlutterDoctorAction.java
+++ b/flutter-idea/src/io/flutter/actions/FlutterDoctorAction.java
@@ -8,6 +8,7 @@ package io.flutter.actions;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configurations.GeneralCommandLine;
 import com.intellij.execution.process.ColoredProcessHandler;
+import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
@@ -36,7 +37,7 @@ public class FlutterDoctorAction extends FlutterSdkAction {
   }
 
   @Override
-  public void startCommandInBazelContext(@NotNull Project project, @NotNull Workspace workspace) {
+  public void startCommandInBazelContext(@NotNull Project project, @NotNull Workspace workspace, @NotNull AnActionEvent event) {
     final String doctorScript = workspace.getDoctorScript();
     if (doctorScript != null) {
       runWorkspaceFlutterDoctorScript(project, workspace.getRoot().getPath(), doctorScript);

--- a/flutter-idea/src/io/flutter/actions/FlutterSdkAction.java
+++ b/flutter-idea/src/io/flutter/actions/FlutterSdkAction.java
@@ -42,7 +42,7 @@ public abstract class FlutterSdkAction extends DumbAwareAction {
       if (workspace != null) {
         FlutterInitializer.sendAnalyticsAction(this);
         FileDocumentManager.getInstance().saveAllDocuments();
-        startCommandInBazelContext(project, workspace);
+        startCommandInBazelContext(project, workspace, event);
         return;
       }
     }
@@ -77,7 +77,7 @@ public abstract class FlutterSdkAction extends DumbAwareAction {
    * Implemented by actions which are used in the Bazel context ({@link #enableActionInBazelContext()} returns true), by default this method
    * throws an {@link Error}.
    */
-  public void startCommandInBazelContext(@NotNull Project project, @NotNull Workspace workspace) {
+  public void startCommandInBazelContext(@NotNull Project project, @NotNull Workspace workspace, @NotNull AnActionEvent event) {
     throw new Error("This method should not be called directly, but should be overridden.");
   }
 

--- a/flutter-idea/src/io/flutter/bazel/PluginConfig.java
+++ b/flutter-idea/src/io/flutter/bazel/PluginConfig.java
@@ -64,6 +64,11 @@ public class PluginConfig {
   }
 
   @Nullable
+  String getToolsScript() {
+    return fields.toolsScript;
+  }
+
+  @Nullable
   String getSdkHome() {
     return fields.sdkHome;
   }
@@ -144,6 +149,7 @@ public class PluginConfig {
     @Nullable String testScript,
     @Nullable String runScript,
     @Nullable String syncScript,
+    @Nullable String toolsScript,
     @Nullable String sdkHome,
     @Nullable String requiredIJPluginID,
     @Nullable String requiredIJPluginMessage,
@@ -157,6 +163,7 @@ public class PluginConfig {
       testScript,
       runScript,
       syncScript,
+      toolsScript,
       sdkHome,
       requiredIJPluginID,
       requiredIJPluginMessage,
@@ -203,6 +210,9 @@ public class PluginConfig {
     @SerializedName("syncScript")
     private String syncScript;
 
+    @SerializedName("toolsScript")
+    private String toolsScript;
+
     /**
      * The directory containing the SDK tools.
      */
@@ -245,6 +255,7 @@ public class PluginConfig {
            String testScript,
            String runScript,
            String syncScript,
+           String toolsScript,
            String sdkHome,
            String requiredIJPluginID,
            String requiredIJPluginMessage,
@@ -256,6 +267,7 @@ public class PluginConfig {
       this.testScript = testScript;
       this.runScript = runScript;
       this.syncScript = syncScript;
+      this.toolsScript = toolsScript;
       this.sdkHome = sdkHome;
       this.requiredIJPluginID = requiredIJPluginID;
       this.requiredIJPluginMessage = requiredIJPluginMessage;

--- a/flutter-idea/src/io/flutter/bazel/Workspace.java
+++ b/flutter-idea/src/io/flutter/bazel/Workspace.java
@@ -45,6 +45,7 @@ public class Workspace {
   @Nullable private final String testScript;
   @Nullable private final String runScript;
   @Nullable private final String syncScript;
+  @Nullable private final String toolsScript;
   @Nullable private final String sdkHome;
   @Nullable private final String requiredIJPluginID;
   @Nullable private final String requiredIJPluginMessage;
@@ -59,6 +60,7 @@ public class Workspace {
                     @Nullable String testScript,
                     @Nullable String runScript,
                     @Nullable String syncScript,
+                    @Nullable String toolsScript,
                     @Nullable String sdkHome,
                     @Nullable String requiredIJPluginID,
                     @Nullable String requiredIJPluginMessage,
@@ -72,6 +74,7 @@ public class Workspace {
     this.testScript = testScript;
     this.runScript = runScript;
     this.syncScript = syncScript;
+    this.toolsScript = toolsScript;
     this.sdkHome = sdkHome;
     this.requiredIJPluginID = requiredIJPluginID;
     this.requiredIJPluginMessage = requiredIJPluginMessage;
@@ -174,6 +177,11 @@ public class Workspace {
   @Nullable
   public String getSyncScript() {
     return syncScript;
+  }
+
+  @Nullable
+  public String getToolsScript() {
+    return toolsScript;
   }
 
   /**
@@ -288,6 +296,8 @@ public class Workspace {
 
     final String syncScript = config == null ? null : getScriptFromPath(root, readonlyPath, config.getSyncScript());
 
+    final String toolsScript = config == null ? null : getScriptFromPath(root, readonlyPath, config.getToolsScript());
+
     final String sdkHome = config == null ? null : getScriptFromPath(root, readonlyPath, config.getSdkHome());
 
     final String requiredIJPluginID = config == null ? null : config.getRequiredIJPluginID();
@@ -298,7 +308,7 @@ public class Workspace {
 
     final String updatedIosRunMessage = config == null ? null : config.getUpdatedIosRunMessage();
 
-    return new Workspace(root, config, daemonScript, devToolsScript, doctorScript, testScript, runScript, syncScript, sdkHome, requiredIJPluginID, requiredIJPluginMessage, configWarningPrefix, updatedIosRunMessage);
+    return new Workspace(root, config, daemonScript, devToolsScript, doctorScript, testScript, runScript, syncScript, toolsScript, sdkHome, requiredIJPluginID, requiredIJPluginMessage, configWarningPrefix, updatedIosRunMessage);
   }
 
   @VisibleForTesting
@@ -312,6 +322,7 @@ public class Workspace {
       pluginConfig.getTestScript(),
       pluginConfig.getRunScript(),
       pluginConfig.getSyncScript(),
+      pluginConfig.getToolsScript(),
       pluginConfig.getSdkHome(),
       pluginConfig.getRequiredIJPluginID(),
       pluginConfig.getRequiredIJPluginMessage(),

--- a/flutter-idea/src/io/flutter/bazel/Workspace.java
+++ b/flutter-idea/src/io/flutter/bazel/Workspace.java
@@ -179,6 +179,9 @@ public class Workspace {
     return syncScript;
   }
 
+  /**
+   * Returns the generic script for running flutter actions, or null if not configured.
+   */
   @Nullable
   public String getToolsScript() {
     return toolsScript;

--- a/flutter-idea/src/io/flutter/run/bazel/BazelAttachConfig.java
+++ b/flutter-idea/src/io/flutter/run/bazel/BazelAttachConfig.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.run.bazel;
+
+import com.intellij.execution.ExecutionException;
+import com.intellij.execution.configurations.ConfigurationFactory;
+import com.intellij.execution.configurations.GeneralCommandLine;
+import com.intellij.execution.runners.ExecutionEnvironment;
+import com.intellij.openapi.project.Project;
+import io.flutter.run.FlutterDevice;
+import io.flutter.run.common.RunMode;
+import org.jetbrains.annotations.NotNull;
+
+public class BazelAttachConfig extends BazelRunConfig {
+  public BazelAttachConfig(@NotNull Project project,
+                           @NotNull ConfigurationFactory factory,
+                           @NotNull String name) {
+    super(project, factory, name);
+  }
+
+  public BazelAttachConfig(BazelRunConfig configuration) {
+    super(configuration.getProject(), configuration.getFactory(), configuration.getName());
+    setFields(configuration.fields);
+  }
+
+  @NotNull
+  @Override
+  public GeneralCommandLine getCommand(ExecutionEnvironment env, @NotNull FlutterDevice device) throws ExecutionException {
+    final BazelFields launchFields = fields.copy();
+    final RunMode mode = RunMode.fromEnv(env);
+    return launchFields.getLaunchCommand(env.getProject(), device, mode);
+  }
+
+}

--- a/flutter-idea/src/io/flutter/run/bazel/BazelAttachConfig.java
+++ b/flutter-idea/src/io/flutter/run/bazel/BazelAttachConfig.java
@@ -31,7 +31,7 @@ public class BazelAttachConfig extends BazelRunConfig {
   public GeneralCommandLine getCommand(ExecutionEnvironment env, @NotNull FlutterDevice device) throws ExecutionException {
     final BazelFields launchFields = fields.copy();
     final RunMode mode = RunMode.fromEnv(env);
-    return launchFields.getLaunchCommand(env.getProject(), device, mode);
+    return launchFields.getLaunchCommand(env.getProject(), device, mode, true);
   }
 
 }

--- a/flutter-idea/src/io/flutter/run/bazel/BazelFields.java
+++ b/flutter-idea/src/io/flutter/run/bazel/BazelFields.java
@@ -37,6 +37,7 @@ import org.jdom.Element;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -160,7 +161,7 @@ public class BazelFields {
     final Workspace workspace = getWorkspace(project);
     String toolsScript = workspace == null ? null : workspace.getToolsScript();
     if (toolsScript != null) {
-      toolsScript = workspace.getRoot().getPath() + "/" + toolsScript;
+      toolsScript = workspace.getRoot().getPath() + File.separatorChar + toolsScript;
     }
     return toolsScript;
   }

--- a/flutter-idea/src/io/flutter/run/bazel/BazelFields.java
+++ b/flutter-idea/src/io/flutter/run/bazel/BazelFields.java
@@ -156,6 +156,15 @@ public class BazelFields {
     return runScript;
   }
 
+  private String getToolsScriptFromWorkspace(@NotNull final Project project) {
+    final Workspace workspace = getWorkspace(project);
+    String runScript = workspace == null ? null : workspace.getToolsScript();
+    if (runScript != null) {
+      runScript = workspace.getRoot().getPath() + "/" + runScript;
+    }
+    return runScript;
+  }
+
   // TODO(djshuckerow): this is dependency injection; switch this to a framework as we need more DI.
   @Nullable
   protected Workspace getWorkspace(@NotNull Project project) {
@@ -217,7 +226,7 @@ public class BazelFields {
 
     final Workspace workspace = getWorkspace(project);
 
-    final String launchingScript = getRunScriptFromWorkspace(project);
+    final String launchingScript = getToolsScriptFromWorkspace(project);
     assert launchingScript != null; // already checked
     assert workspace != null; // if the workspace is null, then so is the launching script, therefore this was already checked.
 
@@ -230,6 +239,7 @@ public class BazelFields {
       .withWorkDirectory(workspace.getRoot().getPath());
     commandLine.setCharset(StandardCharsets.UTF_8);
     commandLine.setExePath(FileUtil.toSystemDependentName(launchingScript));
+    commandLine.addParameter("attach");
 
     final String inputBazelArgs = StringUtil.notNullize(bazelArgs);
     if (!inputBazelArgs.isEmpty()) {

--- a/flutter-idea/src/io/flutter/run/bazel/BazelFields.java
+++ b/flutter-idea/src/io/flutter/run/bazel/BazelFields.java
@@ -210,12 +210,18 @@ public class BazelFields {
     }
   }
 
+  GeneralCommandLine getLaunchCommand(@NotNull Project project,
+                                      @Nullable FlutterDevice device,
+                                      @NotNull RunMode mode) throws ExecutionException {
+    return getLaunchCommand(project, device, mode, false);
+  }
+
   /**
    * Returns the command to use to launch the Flutter app. (Via running the Bazel target.)
    */
   GeneralCommandLine getLaunchCommand(@NotNull Project project,
                                       @Nullable FlutterDevice device,
-                                      @NotNull RunMode mode)
+                                      @NotNull RunMode mode, boolean isAttach)
     throws ExecutionException {
     try {
       checkRunnable(project);
@@ -226,7 +232,7 @@ public class BazelFields {
 
     final Workspace workspace = getWorkspace(project);
 
-    final String launchingScript = getToolsScriptFromWorkspace(project);
+    final String launchingScript = isAttach ? getToolsScriptFromWorkspace(project) : getRunScriptFromWorkspace(project);
     assert launchingScript != null; // already checked
     assert workspace != null; // if the workspace is null, then so is the launching script, therefore this was already checked.
 
@@ -239,7 +245,10 @@ public class BazelFields {
       .withWorkDirectory(workspace.getRoot().getPath());
     commandLine.setCharset(StandardCharsets.UTF_8);
     commandLine.setExePath(FileUtil.toSystemDependentName(launchingScript));
-    commandLine.addParameter("attach");
+
+    if (isAttach) {
+      commandLine.addParameter("attach");
+    }
 
     final String inputBazelArgs = StringUtil.notNullize(bazelArgs);
     if (!inputBazelArgs.isEmpty()) {

--- a/flutter-idea/src/io/flutter/run/bazel/BazelFields.java
+++ b/flutter-idea/src/io/flutter/run/bazel/BazelFields.java
@@ -158,11 +158,11 @@ public class BazelFields {
 
   private String getToolsScriptFromWorkspace(@NotNull final Project project) {
     final Workspace workspace = getWorkspace(project);
-    String runScript = workspace == null ? null : workspace.getToolsScript();
-    if (runScript != null) {
-      runScript = workspace.getRoot().getPath() + "/" + runScript;
+    String toolsScript = workspace == null ? null : workspace.getToolsScript();
+    if (toolsScript != null) {
+      toolsScript = workspace.getRoot().getPath() + "/" + toolsScript;
     }
-    return runScript;
+    return toolsScript;
   }
 
   // TODO(djshuckerow): this is dependency injection; switch this to a framework as we need more DI.

--- a/flutter-idea/src/io/flutter/run/bazel/BazelRunConfig.java
+++ b/flutter-idea/src/io/flutter/run/bazel/BazelRunConfig.java
@@ -29,7 +29,7 @@ import org.jetbrains.annotations.Nullable;
 
 public class BazelRunConfig extends RunConfigurationBase<LaunchState>
   implements RunConfigurationWithSuppressedDefaultRunAction, LaunchState.RunConfig {
-  @NotNull private BazelFields fields;
+  @NotNull protected BazelFields fields;
 
   BazelRunConfig(final @NotNull Project project, final @NotNull ConfigurationFactory factory, @NotNull final String name) {
     super(project, factory, name);

--- a/flutter-idea/testSrc/unit/io/flutter/bazel/FakeWorkspaceFactory.java
+++ b/flutter-idea/testSrc/unit/io/flutter/bazel/FakeWorkspaceFactory.java
@@ -23,6 +23,7 @@ public class FakeWorkspaceFactory {
     @Nullable String testScript,
     @Nullable String runScript,
     @Nullable String syncScript,
+    @Nullable String toolsScript,
     @Nullable String sdkHome,
     @Nullable String versionFile,
     @Nullable String requiredIJPluginID,
@@ -50,6 +51,9 @@ public class FakeWorkspaceFactory {
     if (syncScript != null) {
       fs.file("/workspace/" + syncScript, "");
     }
+    if (toolsScript != null) {
+      fs.file("/workspace/" + toolsScript, "");
+    }
     if (sdkHome != null) {
       fs.file("/workspace/" + sdkHome, "");
     }
@@ -73,6 +77,7 @@ public class FakeWorkspaceFactory {
           testScript,
           runScript,
           syncScript,
+          toolsScript,
           sdkHome,
           requiredIJPluginID,
           requiredIJPluginMessage,
@@ -97,6 +102,7 @@ public class FakeWorkspaceFactory {
       "scripts/flutter-test.sh",
       "scripts/flutter-run.sh",
       "scripts/flutter-sync.sh",
+      "scripts/flutter-tools.sh",
       "scripts/",
       "flutter-version",
       "some.ij.plugin.id",

--- a/flutter-idea/testSrc/unit/io/flutter/run/bazel/LaunchCommandsTest.java
+++ b/flutter-idea/testSrc/unit/io/flutter/run/bazel/LaunchCommandsTest.java
@@ -379,6 +379,7 @@ public class LaunchCommandsTest {
                     @Nullable String testScript,
                     @Nullable String runScript,
                     @Nullable String syncScript,
+                    @Nullable String toolsScript,
                     @Nullable String sdkHome,
                     @Nullable String versionFile,
                     @Nullable String requiredIJPluginID,
@@ -387,7 +388,7 @@ public class LaunchCommandsTest {
                     @Nullable String updatedIosRunMessage) {
       super(template);
       final Pair.NonNull<MockVirtualFileSystem, Workspace> pair = FakeWorkspaceFactory
-        .createWorkspaceAndFilesystem(daemonScript, devToolsScript, doctorScript, testScript, runScript, syncScript, sdkHome, versionFile,
+        .createWorkspaceAndFilesystem(daemonScript, devToolsScript, doctorScript, testScript, runScript, syncScript, toolsScript, sdkHome, versionFile,
                                       requiredIJPluginID, requiredIJPluginMessage, configWarningMessage, updatedIosRunMessage);
       fs = pair.first;
       fakeWorkspace = pair.second;

--- a/flutter-idea/testSrc/unit/io/flutter/run/bazelTest/BazelTestConfigProducerTest.java
+++ b/flutter-idea/testSrc/unit/io/flutter/run/bazelTest/BazelTestConfigProducerTest.java
@@ -166,7 +166,7 @@ public class BazelTestConfigProducerTest extends AbstractDartElementTest {
       fs.file("/workspace/WORKSPACE", "");
       fakeWorkspace = Workspace.forTest(
         fs.findFileByPath("/workspace/"),
-        PluginConfig.forTest("", "", "", "", "", "", "", "", "", "", "")
+        PluginConfig.forTest("", "", "", "", "", "", "", "", "", "", "", "")
       );
       this.hasWorkspace = hasWorkspace;
       this.hasValidTestFile = hasValidTestFile;

--- a/flutter-idea/testSrc/unit/io/flutter/run/bazelTest/LaunchCommandsTest.java
+++ b/flutter-idea/testSrc/unit/io/flutter/run/bazelTest/LaunchCommandsTest.java
@@ -186,6 +186,7 @@ public class LaunchCommandsTest {
       null,
       null,
       null,
+      null,
       null
     );
     boolean didThrow = false;
@@ -213,6 +214,7 @@ public class LaunchCommandsTest {
       null,
       null,
       null,
+      null,
       null
     );
     boolean didThrow = false;
@@ -232,6 +234,7 @@ public class LaunchCommandsTest {
       "scripts/daemon.sh",
       "scripts/devtools.sh",
       "scripts/doctor.sh",
+      null,
       null,
       null,
       null,
@@ -302,6 +305,7 @@ public class LaunchCommandsTest {
                         @Nullable String testScript,
                         @Nullable String runScript,
                         @Nullable String syncScript,
+                        @Nullable String toolsScript,
                         @Nullable String sdkHome,
                         @Nullable String versionFile,
                         @Nullable String requiredIJPluginID,
@@ -310,7 +314,7 @@ public class LaunchCommandsTest {
                         @Nullable String updatedIosRunMessage) {
       super(template);
       final Pair.NonNull<MockVirtualFileSystem, Workspace> pair = FakeWorkspaceFactory
-        .createWorkspaceAndFilesystem(daemonScript, devToolsScript, doctorScript, testScript, runScript, syncScript, sdkHome, versionFile,
+        .createWorkspaceAndFilesystem(daemonScript, devToolsScript, doctorScript, testScript, runScript, syncScript, toolsScript, sdkHome, versionFile,
                                       requiredIJPluginID, requiredIJPluginMessage, configWarningMessage, updatedIosRunMessage);
       fs = pair.first;
       fakeWorkspace = pair.second;


### PR DESCRIPTION
This enables the attach button for bazel projects and calls the correct command for attach. We wanted to add attach to the IDEs since the internal scripts for attach have been updated to make this easier.

CC @chingjun 