### PR TITLE
Use super-initializer parameter in live templates

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -21,3 +21,6 @@ Sander Kersten <spkersten@gmail.com>
 Pradumna Saraf <pradumnasaraf@gmail.com>
 Pedro Massango <pedromassango.developer@gmail.com>
 Wagner Silvestre <wagner1343@outlook.com>
+
+Dizconto Ltd.
+Roman Sirokov <sirokov@dizconto.com>

--- a/resources/liveTemplates/flutter_miscellaneous.xml
+++ b/resources/liveTemplates/flutter_miscellaneous.xml
@@ -1,25 +1,25 @@
 <templateSet group="Flutter">
-  <template name="stless" value="class $NAME$ extends StatelessWidget {&#10;  const $NAME$({Key? key}) : super(key: key);&#10;&#10;  @override&#10;  Widget build(BuildContext context) {&#10;    return Placeholder($END$);&#10;  }&#10;}&#10;" description="New Stateless widget" toReformat="false" toShortenFQNames="true">
+  <template name="stless" value="class $NAME$ extends StatelessWidget {&#10;  const $NAME$({super.key});&#10;&#10;  @override&#10;  Widget build(BuildContext context) {&#10;    return Placeholder($END$);&#10;  }&#10;}&#10;" description="New Stateless widget" toReformat="false" toShortenFQNames="true">
     <variable name="NAME" expression="" defaultValue="" alwaysStopAt="true" />
     <context>
       <option name="DART_TOPLEVEL" value="true" />
     </context>
   </template>
-  <template name="stful" value="class $NAME$ extends StatefulWidget {&#10;  const $NAME$({Key? key}) : super(key: key);&#10;&#10;  @override&#10;  State&lt;$NAME$&gt; createState() =&gt; $SNAME$();&#10;}&#10;&#10;class $SNAME$ extends State&lt;$NAME$&gt; {&#10;  @override&#10;  Widget build(BuildContext context) {&#10;    return Placeholder($END$);&#10;  }&#10;}&#10;" description="New Stateful widget" toReformat="false" toShortenFQNames="true">
+  <template name="stful" value="class $NAME$ extends StatefulWidget {&#10;  const $NAME$({super.key});&#10;&#10;  @override&#10;  State&lt;$NAME$&gt; createState() =&gt; $SNAME$();&#10;}&#10;&#10;class $SNAME$ extends State&lt;$NAME$&gt; {&#10;  @override&#10;  Widget build(BuildContext context) {&#10;    return Placeholder($END$);&#10;  }&#10;}&#10;" description="New Stateful widget" toReformat="false" toShortenFQNames="true">
     <variable name="NAME" expression="" defaultValue="" alwaysStopAt="true" />
     <variable name="SNAME" expression="regularExpression(concat(&quot;_&quot;, NAME, &quot;State&quot;), &quot;^__&quot;, &quot;_&quot;)" defaultValue="" alwaysStopAt="false" />
     <context>
       <option name="DART_TOPLEVEL" value="true" />
     </context>
   </template>
-  <template name="inh" value="class $NAME$ extends InheritedWidget {&#10;  const $NAME$({&#10;    Key? key,&#10;    required Widget child,&#10;  }) : super(key: key, child: child);&#10;&#10;  static $NAME$ of(BuildContext context) {&#10;    final $NAME$? result = context.dependOnInheritedWidgetOfExactType&lt;$NAME$&gt;();&#10;    assert(result != null, 'No $NAME$ found in context');&#10;    return result!;&#10;  }&#10;&#10;  @override&#10;  bool updateShouldNotify($NAME$ old) {&#10;    return $SHOULD_NOTIFY$;&#10;  }&#10;}&#10;" description="New Inherited widget" toReformat="true" toShortenFQNames="true">
+  <template name="inh" value="class $NAME$ extends InheritedWidget {&#10;  const $NAME$({&#10;    super.key,&#10;    required super.child,&#10;  });&#10;&#10;  static $NAME$ of(BuildContext context) {&#10;    final $NAME$? result = context.dependOnInheritedWidgetOfExactType&lt;$NAME$&gt;();&#10;    assert(result != null, 'No $NAME$ found in context');&#10;    return result!;&#10;  }&#10;&#10;  @override&#10;  bool updateShouldNotify($NAME$ old) {&#10;    return $SHOULD_NOTIFY$;&#10;  }&#10;}&#10;" description="New Inherited widget" toReformat="true" toShortenFQNames="true">
     <variable name="NAME" expression="" defaultValue="" alwaysStopAt="true" />
     <variable name="SHOULD_NOTIFY" expression="" defaultValue="" alwaysStopAt="true" />
     <context>
       <option name="DART_TOPLEVEL" value="true" />
     </context>
   </template>
-  <template name="stanim" value="class $NAME$ extends StatefulWidget {&#10;  const $NAME$({Key? key}) : super(key: key);&#10;&#10;  @override&#10;  State&lt;$NAME$&gt; createState() =&gt; _$NAME$State();&#10;}&#10;&#10;class _$NAME$State extends State&lt;$NAME$&gt; with SingleTickerProviderStateMixin {&#10;  late AnimationController _controller;&#10;&#10;  @override&#10;  void initState() {&#10;    super.initState();&#10;    _controller = AnimationController(vsync: this);&#10;  }&#10;&#10;  @override&#10;  void dispose() {&#10;    _controller.dispose();&#10;    super.dispose();&#10;  }&#10;&#10;  @override&#10;  Widget build(BuildContext context) {&#10;    return Placeholder($END$);&#10;  }&#10;}&#10;" description="New Stateful widget with AnimationController" toReformat="false" toShortenFQNames="true">
+  <template name="stanim" value="class $NAME$ extends StatefulWidget {&#10;  const $NAME$({super.key});&#10;&#10;  @override&#10;  State&lt;$NAME$&gt; createState() =&gt; _$NAME$State();&#10;}&#10;&#10;class _$NAME$State extends State&lt;$NAME$&gt; with SingleTickerProviderStateMixin {&#10;  late AnimationController _controller;&#10;&#10;  @override&#10;  void initState() {&#10;    super.initState();&#10;    _controller = AnimationController(vsync: this);&#10;  }&#10;&#10;  @override&#10;  void dispose() {&#10;    _controller.dispose();&#10;    super.dispose();&#10;  }&#10;&#10;  @override&#10;  Widget build(BuildContext context) {&#10;    return Placeholder($END$);&#10;  }&#10;}&#10;" description="New Stateful widget with AnimationController" toReformat="false" toShortenFQNames="true">
     <variable name="NAME" expression="" defaultValue="" alwaysStopAt="true" />
     <context>
       <option name="DART_TOPLEVEL" value="true" />


### PR DESCRIPTION
To avoid having to manually pass each parameter into the super invocation of a constructor, you can use super-initializer parameters to forward parameters to the specified or default superclass constructor. This produces cleaner classes. 

This PR thus updates live templates to use them instead.

[Language Tour | Dart -- Constructors](https://dart.dev/guides/language/language-tour#constructors)
[Language Tour | Dart -- Design](https://dart.dev/guides/language/effective-dart/design#dont-type-annotate-initializing-formals)

Addresses: #6071

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
