### PR TITLE
Catch exception if default project was disposed

### DIFF
--- a/flutter-idea/src/io/flutter/analytics/DartCompletionTimerListener.java
+++ b/flutter-idea/src/io/flutter/analytics/DartCompletionTimerListener.java
@@ -3,6 +3,7 @@ package io.flutter.analytics;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
 
+import com.intellij.util.IncorrectOperationException;
 import com.jetbrains.lang.dart.ide.completion.DartCompletionTimerExtension;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -20,8 +21,12 @@ public class DartCompletionTimerListener extends DartCompletionTimerExtension {
   @Override
   public void dartCompletionStart() {
     if (dasListener == null) {
-      Project project = ProjectManager.getInstance().getDefaultProject();
-      dasListener = FlutterAnalysisServerListener.getInstance(project);
+      try {
+        Project project = ProjectManager.getInstance().getDefaultProject();
+        dasListener = FlutterAnalysisServerListener.getInstance(project);
+      } catch (IncorrectOperationException ex) {
+        return;
+      }
     }
     startTimeMS = Instant.now().toEpochMilli();
   }


### PR DESCRIPTION
I think this will eliminate the symptom observed in #6400, but I don't know how the default project got disposed.

Fixes #6400