### PR TITLE
Fix build issues

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -9,7 +9,7 @@
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="web" url="file://$PROJECT_DIR$" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="IntelliJ IDEA Community Edition" project-jdk-type="IDEA JDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="IntelliJ IDEA Community Edition" project-jdk-type="IDEA JDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/flutter-idea/src/io/flutter/actions/DeviceSelectorAction.java_stub
+++ b/flutter-idea/src/io/flutter/actions/DeviceSelectorAction.java_stub
@@ -65,61 +65,65 @@ public class DeviceSelectorAction extends ComboBoxAction implements DumbAware {
 
     // Only show device menu when the device daemon process is running.
     final Project project = e.getProject();
-    if (!isSelectorVisible(project)) {
-      e.getPresentation().setVisible(false);
-      return;
-    }
+    final Presentation presentation = e.getPresentation();
+    final Application application = ApplicationManager.getApplication();
+    if (application == null) return;
 
     super.update(e);
 
-    final Presentation presentation = e.getPresentation();
-    if (!knownProjects.contains(project)) {
-      knownProjects.add(project);
-      final Application application = ApplicationManager.getApplication();
-      application.getMessageBus().connect().subscribe(ProjectManager.TOPIC, new ProjectManagerListener() {
-        @Override
-        public void projectClosed(@NotNull Project closedProject) {
-          knownProjects.remove(closedProject);
-        }
-      });
-      Runnable deviceListener = () -> queueUpdate(project, e.getPresentation());
-      DeviceService.getInstance(project).addListener(deviceListener);
-
-      // Listen for android device changes, and rebuild the menu if necessary.
-      Runnable emulatorListener = () -> queueUpdate(project, e.getPresentation());
-      AndroidEmulatorManager.getInstance(project).addListener(emulatorListener);
-      ProjectManager.getInstance().addProjectManagerListener(project, new ProjectManagerListener() {
-        public void projectClosing(@NotNull Project project) {
-          DeviceService.getInstance(project).removeListener(deviceListener);
-          AndroidEmulatorManager.getInstance(project).removeListener(emulatorListener);
-        }
-      });
-      update(project, presentation);
-    }
-
-    final DeviceService deviceService = DeviceService.getInstance(project);
-
-    final FlutterDevice selectedDevice = deviceService.getSelectedDevice();
-    final Collection<FlutterDevice> devices = deviceService.getConnectedDevices();
-
-    if (devices.isEmpty()) {
-      final boolean isLoading = deviceService.getStatus() == DeviceService.State.LOADING;
-      if (isLoading) {
-        presentation.setText(FlutterBundle.message("devicelist.loading"));
+    application.invokeLater(() -> {
+      if (!isSelectorVisible(project)) {
+        presentation.setVisible(false);
+        return;
       }
-      else {
-        presentation.setText("<no devices>");
+
+      if (!knownProjects.contains(project)) {
+        knownProjects.add(project);
+        application.getMessageBus().connect().subscribe(ProjectManager.TOPIC, new ProjectManagerListener() {
+          @Override
+          public void projectClosed(@NotNull Project closedProject) {
+            knownProjects.remove(closedProject);
+          }
+        });
+        Runnable deviceListener = () -> queueUpdate(project, presentation);
+        DeviceService.getInstance(project).addListener(deviceListener);
+
+        // Listen for android device changes, and rebuild the menu if necessary.
+        Runnable emulatorListener = () -> queueUpdate(project, presentation);
+        AndroidEmulatorManager.getInstance(project).addListener(emulatorListener);
+        ProjectManager.getInstance().addProjectManagerListener(project, new ProjectManagerListener() {
+          public void projectClosing(@NotNull Project project) {
+            DeviceService.getInstance(project).removeListener(deviceListener);
+            AndroidEmulatorManager.getInstance(project).removeListener(emulatorListener);
+          }
+        });
+        update(project, presentation);
       }
-    }
-    else if (selectedDevice == null) {
-      presentation.setText("<no device selected>");
-    }
-    else if (selectedDeviceAction != null) {
-      final Presentation template = selectedDeviceAction.getTemplatePresentation();
-      presentation.setIcon(template.getIcon());
-      presentation.setText(selectedDevice.presentationName());
-      presentation.setEnabled(true);
-    }
+
+      final DeviceService deviceService = DeviceService.getInstance(project);
+
+      final FlutterDevice selectedDevice = deviceService.getSelectedDevice();
+      final Collection<FlutterDevice> devices = deviceService.getConnectedDevices();
+
+      if (devices.isEmpty()) {
+        final boolean isLoading = deviceService.getStatus() == DeviceService.State.LOADING;
+        if (isLoading) {
+          presentation.setText(FlutterBundle.message("devicelist.loading"));
+        }
+        else {
+          presentation.setText("<no devices>");
+        }
+      }
+      else if (selectedDevice == null) {
+        presentation.setText("<no device selected>");
+      }
+      else if (selectedDeviceAction != null) {
+        final Presentation template = selectedDeviceAction.getTemplatePresentation();
+        presentation.setIcon(template.getIcon());
+        presentation.setText(selectedDevice.presentationName());
+        presentation.setEnabled(true);
+      }
+    });
   }
 
   private void queueUpdate(@NotNull Project project, @NotNull Presentation presentation) {

--- a/product-matrix.json
+++ b/product-matrix.json
@@ -83,7 +83,8 @@
       "baseVersion": "223.7571,182",
       "dartPluginVersion": "223.7571.203",
       "sinceBuild": "223.4884.69",
-      "untilBuild": "223.*"
+      "untilBuild": "223.*",
+      "filesToSkip": ["flutter-idea/src/io/flutter/actions/DeviceSelectorAction.java"]
     }
   ]
 }

--- a/tool/plugin/lib/edit.dart
+++ b/tool/plugin/lib/edit.dart
@@ -44,6 +44,18 @@ List<EditCommand> editCommands = [
     version: '2022.4',
   ),
   Subst(
+    path: 'resources/META-INF/plugin.xml',
+    initial: '<add-to-group group-id="MainToolbarRight" />',
+    replacement: '',
+    versions: ['AS.211', 'AS.212', 'AS.213', '2022.1', '2022.2'],
+  ),
+  Subst(
+    path: '',
+    initial: '<add-to-group group-id="MainToolbarRight" />',
+    replacement: '',
+    versions: ['AS.211', 'AS.212', 'AS.213', '2022.1', '2022.2'],
+  ),
+  Subst(
     path: 'flutter-idea/src/io/flutter/pub/PubRoot.java',
     initial: 'String @NotNull [] TEST_DIRS',
     replacement: 'String [] TEST_DIRS',

--- a/tool/plugin/lib/edit.dart
+++ b/tool/plugin/lib/edit.dart
@@ -44,16 +44,10 @@ List<EditCommand> editCommands = [
     version: '2022.4',
   ),
   Subst(
-    path: 'resources/META-INF/plugin.xml',
+    path: 'resources/META-INF/plugin_template.xml',
     initial: '<add-to-group group-id="MainToolbarRight" />',
     replacement: '',
-    versions: ['AS.211', 'AS.212', 'AS.213', '2022.1', '2022.2'],
-  ),
-  Subst(
-    path: '',
-    initial: '<add-to-group group-id="MainToolbarRight" />',
-    replacement: '',
-    versions: ['AS.211', 'AS.212', 'AS.213', '2022.1', '2022.2'],
+    versions: ['2022.2'],
   ),
   Subst(
     path: 'flutter-idea/src/io/flutter/pub/PubRoot.java',


### PR DESCRIPTION
There are two problems with the build, in all but 2022.3.

First, the change to `DeviceSelectorAction` causes an old, very puzzling bug to re-appear. The fix is to use the old version of the code for all older builds.

Second, the change to show the device selector in the new UI breaks 2022.2. The fix is to remove that line for it.