### PR TITLE
Run update() on BGT

### DIFF
--- a/flutter-idea/src/io/flutter/actions/DeviceSelectorAction.java
+++ b/flutter-idea/src/io/flutter/actions/DeviceSelectorAction.java
@@ -20,7 +20,6 @@ import com.intellij.openapi.util.SystemInfo;
 import com.intellij.util.ModalityUiUtil;
 import icons.FlutterIcons;
 import io.flutter.FlutterBundle;
-import io.flutter.FlutterUtils;
 import io.flutter.run.FlutterDevice;
 import io.flutter.run.daemon.DeviceService;
 import io.flutter.sdk.AndroidEmulatorManager;
@@ -129,10 +128,8 @@ public class DeviceSelectorAction extends ComboBoxAction implements DumbAware {
     if (project.isDisposed()) {
       return; // This check is probably unnecessary, but safe.
     }
-    FlutterUtils.invokeAndWait(() -> {
-      updateActions(project, presentation);
-      updateVisibility(project, presentation);
-    });
+    updateActions(project, presentation);
+    updateVisibility(project, presentation);
   }
 
   private static void updateVisibility(final Project project, final Presentation presentation) {

--- a/flutter-idea/src/io/flutter/actions/DeviceSelectorAction.java
+++ b/flutter-idea/src/io/flutter/actions/DeviceSelectorAction.java
@@ -41,6 +41,10 @@ public class DeviceSelectorAction extends ComboBoxAction implements DumbAware {
     setSmallVariant(true);
   }
 
+  public @NotNull ActionUpdateThread getActionUpdateThread() {
+    return ActionUpdateThread.BGT;
+  }
+
   @NotNull
   @Override
   protected DefaultActionGroup createPopupActionGroup(JComponent button) {
@@ -55,14 +59,7 @@ public class DeviceSelectorAction extends ComboBoxAction implements DumbAware {
   }
 
   @Override
-  public void update(final AnActionEvent e) {
-    // Suppress device actions in all but the toolbars.
-    final String place = e.getPlace();
-    if (!Objects.equals(place, ActionPlaces.NAVIGATION_BAR_TOOLBAR) && !Objects.equals(place, ActionPlaces.MAIN_TOOLBAR)) {
-      e.getPresentation().setVisible(false);
-      return;
-    }
-
+  public void update(@NotNull AnActionEvent e) {
     // Only show device menu when the device daemon process is running.
     final Project project = e.getProject();
     if (!isSelectorVisible(project)) {

--- a/flutter-idea/src/io/flutter/actions/DeviceSelectorAction.java_stub
+++ b/flutter-idea/src/io/flutter/actions/DeviceSelectorAction.java_stub
@@ -38,7 +38,6 @@ public class DeviceSelectorAction extends ComboBoxAction implements DumbAware {
   private SelectDeviceAction selectedDeviceAction;
 
   DeviceSelectorAction() {
-    getTemplatePresentation().setText(" ", false);
     setSmallVariant(true);
   }
 

--- a/product-matrix.json
+++ b/product-matrix.json
@@ -88,8 +88,7 @@
       "baseVersion": "222.3739.54",
       "dartPluginVersion": "222.3739.24",
       "sinceBuild": "223.4884.69",
-      "untilBuild": "223.*",
-      "filesToSkip": ["flutter-idea/src/io/flutter/actions/DeviceSelectorAction.java"]
+      "untilBuild": "223.*"
     }
   ]
 }

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -182,7 +182,7 @@
       <action id="Flutter.DeviceSelectorRefresher" class="io.flutter.actions.DeviceSelectorRefresherAction"
               text="Refresh Device List"
               description="Refresh device list" />
-      <add-to-group anchor="before" group-id="RunContextGroup" relative-to-action="RunConfiguration"/>
+      <add-to-group group-id="MainToolbarRight" />
       <add-to-group anchor="before" group-id="ToolbarRunGroup" relative-to-action="RunConfiguration"/>
     </group>
 

--- a/resources/META-INF/plugin_template.xml
+++ b/resources/META-INF/plugin_template.xml
@@ -70,7 +70,7 @@
       <action id="Flutter.DeviceSelectorRefresher" class="io.flutter.actions.DeviceSelectorRefresherAction"
               text="Refresh Device List"
               description="Refresh device list" />
-      <add-to-group anchor="before" group-id="RunContextGroup" relative-to-action="RunConfiguration"/>
+      <add-to-group group-id="MainToolbarRight" />
       <add-to-group anchor="before" group-id="ToolbarRunGroup" relative-to-action="RunConfiguration"/>
     </group>
 

--- a/tool/plugin/lib/edit.dart
+++ b/tool/plugin/lib/edit.dart
@@ -63,6 +63,16 @@ List<EditCommand> editCommands = [
     replacement: '<Analytics>',
     versions: ['AS.211', 'AS.212', 'AS.213'],
   ),
+  Subst(
+    path: 'flutter-idea/src/io/flutter/actions/DeviceSelectorAction.java',
+    initial: '''
+  public @NotNull ActionUpdateThread getActionUpdateThread() {
+    return ActionUpdateThread.BGT;
+  }
+''',
+    replacement: '',
+    version: '2022.1',
+  ),
   MultiSubst(
     path: 'flutter-idea/src/io/flutter/actions/DeviceSelectorAction.java',
     initials: [
@@ -72,6 +82,11 @@ List<EditCommand> editCommands = [
       ModalityState.defaultModalityState(),
       () -> update(project, presentation));
 ''',
+      '''
+  public @NotNull ActionUpdateThread getActionUpdateThread() {
+    return ActionUpdateThread.BGT;
+  }
+''',
     ],
     replacements: [
       'import com.intellij.ui.GuiUtils;',
@@ -80,6 +95,7 @@ List<EditCommand> editCommands = [
       () -> update(project, presentation),
       ModalityState.defaultModalityState());
 ''',
+      '',
     ],
     versions: ['AS.211', 'AS.212', 'AS.213'],
   ),


### PR DESCRIPTION
Fixes: #6549 
Fixes: #6477

Getting this stack trace on start up. Waiting on resolution of the [Gradle plugin bug](https://github.com/JetBrains/gradle-intellij-plugin/issues/1246) to continue. The device selector is visible in the new UI. it is only visible for Flutter projects in new and old UI.
```java
DeviceSelectorAction#update@NavBarToolbar (io.flutter.actions.DeviceSelectorAction), actionId=Flutter.DeviceSelector

java.lang.IllegalStateException: Calling invokeAndWait from read-action leads to possible deadlock.
	at com.intellij.openapi.application.impl.ApplicationImpl.invokeAndWait(ApplicationImpl.java:417)
	at io.flutter.FlutterUtils.invokeAndWait(FlutterUtils.java:99)
	at io.flutter.actions.DeviceSelectorAction.update(DeviceSelectorAction.java:132)
	at io.flutter.actions.DeviceSelectorAction.update(DeviceSelectorAction.java:94)
	at com.intellij.openapi.actionSystem.ex.ActionUtil.lambda$performDumbAwareUpdate$0(ActionUtil.java:153)
	at com.intellij.openapi.actionSystem.ex.ActionUtil.performDumbAwareUpdate(ActionUtil.java:176)
	at com.intellij.openapi.actionSystem.impl.ActionUpdater.doUpdate(ActionUpdater.java:720)
	at com.intellij.openapi.actionSystem.impl.ActionUpdater.lambda$updateActionReal$4(ActionUpdater.java:136)
	at com.intellij.openapi.actionSystem.impl.ActionUpdater.lambda$callAction$5(ActionUpdater.java:186)
	at com.intellij.diagnostic.telemetry.TraceKt.computeWithSpan(trace.kt:123)
	at com.intellij.openapi.actionSystem.impl.ActionUpdater.callAction(ActionUpdater.java:182)
	at com.intellij.openapi.actionSystem.impl.ActionUpdater.callAction(ActionUpdater.java:161)
	at com.intellij.openapi.actionSystem.impl.ActionUpdater.updateActionReal(ActionUpdater.java:137)
	at com.intellij.openapi.actionSystem.impl.ActionUpdater.lambda$new$0(ActionUpdater.java:124)
	at com.intellij.openapi.actionSystem.impl.ActionUpdater.update(ActionUpdater.java:705)
	at com.intellij.openapi.actionSystem.impl.ActionUpdater.expandGroupChild(ActionUpdater.java:556)
	at com.intellij.openapi.actionSystem.impl.ActionUpdater.lambda$doExpandActionGroup$23(ActionUpdater.java:529)
	at com.intellij.util.containers.ContainerUtil.concat(ContainerUtil.java:1406)
	at com.intellij.openapi.actionSystem.impl.ActionUpdater.doExpandActionGroup(ActionUpdater.java:529)
	at com.intellij.openapi.actionSystem.impl.ActionUpdater.expandGroupChild(ActionUpdater.java:606)
	at com.intellij.openapi.actionSystem.impl.ActionUpdater.lambda$doExpandActionGroup$23(ActionUpdater.java:529)
	at com.intellij.util.containers.ContainerUtil.concat(ContainerUtil.java:1406)
	at com.intellij.openapi.actionSystem.impl.ActionUpdater.doExpandActionGroup(ActionUpdater.java:529)
	at com.intellij.openapi.actionSystem.impl.ActionUpdater.expandGroupChild(ActionUpdater.java:606)
	at com.intellij.openapi.actionSystem.impl.ActionUpdater.lambda$doExpandActionGroup$23(ActionUpdater.java:529)
	at com.intellij.util.containers.ContainerUtil.concat(ContainerUtil.java:1406)
	at com.intellij.openapi.actionSystem.impl.ActionUpdater.doExpandActionGroup(ActionUpdater.java:529)
	at com.intellij.openapi.actionSystem.impl.ActionUpdater.expandActionGroup(ActionUpdater.java:309)
	at com.intellij.openapi.actionSystem.impl.ActionUpdater.lambda$doExpandActionGroupAsync$14(ActionUpdater.java:377)
	at com.intellij.openapi.actionSystem.impl.ActionUpdater.lambda$doExpandActionGroupAsync$15(ActionUpdater.java:396)
	at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:1086)
	at com.intellij.openapi.actionSystem.impl.ActionUpdater.lambda$tryRunReadActionAndCancelBeforeWrite$19(ActionUpdater.java:428)
	at com.intellij.openapi.progress.util.ProgressIndicatorUtilService.runActionAndCancelBeforeWrite(ProgressIndicatorUtilService.java:63)
	at com.intellij.openapi.progress.util.ProgressIndicatorUtils.runActionAndCancelBeforeWrite(ProgressIndicatorUtils.java:128)
	at com.intellij.openapi.actionSystem.impl.ActionUpdater.tryRunReadActionAndCancelBeforeWrite(ActionUpdater.java:424)
	at com.intellij.openapi.actionSystem.impl.ActionUpdater.lambda$doExpandActionGroupAsync$16(ActionUpdater.java:396)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$runProcess$2(CoreProgressManager.java:188)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$executeProcessUnderProgress$13(CoreProgressManager.java:589)
	at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:664)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computeUnderProgress(CoreProgressManager.java:620)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:588)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:60)
	at com.intellij.openapi.progress.impl.CoreProgressManager.runProcess(CoreProgressManager.java:175)
	at com.intellij.openapi.progress.util.BackgroundTaskUtil.runUnderDisposeAwareIndicator(BackgroundTaskUtil.java:366)
	at com.intellij.openapi.actionSystem.impl.ActionUpdater.lambda$doExpandActionGroupAsync$17(ActionUpdater.java:395)
	at io.opentelemetry.context.Context.lambda$wrap$1(Context.java:212)
	at com.intellij.util.concurrency.BoundedTaskExecutor.doRun(BoundedTaskExecutor.java:243)
	at com.intellij.util.concurrency.BoundedTaskExecutor.access$200(BoundedTaskExecutor.java:29)
	at com.intellij.util.concurrency.BoundedTaskExecutor$1.executeFirstTaskAndHelpQueue(BoundedTaskExecutor.java:216)
	at com.intellij.util.ConcurrencyUtil.runUnderThreadName(ConcurrencyUtil.java:212)
	at com.intellij.util.concurrency.BoundedTaskExecutor$1.run(BoundedTaskExecutor.java:205)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1$1.run(Executors.java:702)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1$1.run(Executors.java:699)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:399)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1.run(Executors.java:699)
	at java.base/java.lang.Thread.run(Thread.java:833)
```