### PR TITLE
Update settings to emphasize global options

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [AS.211, AS.212, AS.213, 2022.1, 2022.2, 2022.3]
+        version: [AS.213, 2022.1, 2022.2, 2022.3]
     steps:
       - name: checkout
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8

--- a/flutter-idea/src/io/flutter/sdk/FlutterSettingsConfigurable.form
+++ b/flutter-idea/src/io/flutter/sdk/FlutterSettingsConfigurable.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="io.flutter.sdk.FlutterSettingsConfigurable">
-  <grid id="27dc6" binding="mainPanel" layout-manager="GridLayoutManager" row-count="8" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="mainPanel" layout-manager="GridLayoutManager" row-count="9" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="972" height="825"/>
@@ -16,7 +16,7 @@
           <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
-        <border type="etched" title="SDK"/>
+        <border type="etched" title="SDK (current project only)"/>
         <children>
           <component id="a59e7" class="javax.swing.JLabel">
             <constraints>
@@ -62,7 +62,7 @@
       <grid id="e885c" layout-manager="GridLayoutManager" row-count="3" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="etched" title="General"/>
@@ -110,7 +110,7 @@
       <grid id="919ec" layout-manager="GridLayoutManager" row-count="5" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="etched" title="App Execution"/>
@@ -159,35 +159,26 @@
           </component>
         </children>
       </grid>
-      <grid id="32490" layout-manager="GridLayoutManager" row-count="4" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="32490" layout-manager="GridLayoutManager" row-count="4" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="etched" title-resource-bundle="io/flutter/FlutterBundle" title-key="settings.editor"/>
         <children>
           <component id="70775" class="javax.swing.JCheckBox" binding="myShowBuildMethodGuides">
             <constraints>
-              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="0" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text resource-bundle="io/flutter/FlutterBundle" key="settings.show.build.guides"/>
               <toolTipText resource-bundle="io/flutter/FlutterBundle" key="settings.show.build.guides.tooltip"/>
             </properties>
           </component>
-          <component id="a0dd8" class="javax.swing.JCheckBox" binding="myFormatCodeOnSaveCheckBox" default-binding="true">
-            <constraints>
-              <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <text resource-bundle="io/flutter/FlutterBundle" key="settings.format.code.on.save"/>
-              <toolTipText resource-bundle="io/flutter/FlutterBundle" key="settings.format.code.tooltip"/>
-            </properties>
-          </component>
           <component id="8bd46" class="javax.swing.JCheckBox" binding="myOrganizeImportsOnSaveCheckBox" default-binding="true">
             <constraints>
-              <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="2" use-parent-layout="false"/>
+              <grid row="3" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="2" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text resource-bundle="io/flutter/FlutterBundle" key="settings.organize.imports.on.save"/>
@@ -196,18 +187,59 @@
           </component>
           <component id="92f7c" class="javax.swing.JCheckBox" binding="myShowClosingLabels" default-binding="true">
             <constraints>
-              <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="1" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties>
               <text resource-bundle="io/flutter/FlutterBundle" key="settings.show.closing.labels"/>
             </properties>
           </component>
+          <grid id="596d1" layout-manager="GridLayoutManager" row-count="1" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+            <margin top="0" left="0" bottom="0" right="0"/>
+            <constraints>
+              <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="2" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties/>
+            <border type="none"/>
+            <children>
+              <component id="a0dd8" class="javax.swing.JCheckBox" binding="myFormatCodeOnSaveCheckBox" default-binding="true">
+                <constraints>
+                  <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text resource-bundle="io/flutter/FlutterBundle" key="settings.format.code.on.save"/>
+                  <toolTipText resource-bundle="io/flutter/FlutterBundle" key="settings.format.code.tooltip"/>
+                </properties>
+              </component>
+              <component id="2bbb1" class="javax.swing.JLabel">
+                <constraints>
+                  <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text value="(For project-specific formatting, use"/>
+                </properties>
+              </component>
+              <component id="4b0d8" class="com.intellij.ui.components.ActionLink" binding="settingsLink" custom-create="true">
+                <constraints>
+                  <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties/>
+              </component>
+              <component id="d9b3b" class="javax.swing.JLabel">
+                <constraints>
+                  <grid row="0" column="3" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text value="instead)"/>
+                </properties>
+              </component>
+            </children>
+          </grid>
         </children>
       </grid>
       <grid id="23e52" layout-manager="GridLayoutManager" row-count="5" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="etched" title-resource-bundle="io/flutter/FlutterBundle" title-key="settings.experiments"/>
@@ -261,7 +293,7 @@
       <grid id="3bf2f" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="7" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="etched" title-resource-bundle="io/flutter/FlutterBundle" title-key="settings.font.packages"/>
@@ -289,12 +321,21 @@
       <grid id="3e8a7" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>
         <children/>
       </grid>
+      <component id="8fe47" class="javax.swing.JLabel">
+        <constraints>
+          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <font swing-font="CheckBoxMenuItem.acceleratorFont"/>
+          <text value="Settings below apply to all projects"/>
+        </properties>
+      </component>
     </children>
   </grid>
 </form>

--- a/flutter-idea/src/io/flutter/sdk/FlutterSettingsConfigurable.java
+++ b/flutter-idea/src/io/flutter/sdk/FlutterSettingsConfigurable.java
@@ -7,6 +7,7 @@ package io.flutter.sdk;
 
 import com.intellij.execution.process.ProcessOutput;
 import com.intellij.ide.actions.ShowSettingsUtilImpl;
+import com.intellij.ide.actionsOnSave.ActionsOnSaveConfigurable;
 import com.intellij.ide.browsers.BrowserLauncher;
 import com.intellij.notification.Notification;
 import com.intellij.notification.NotificationType;
@@ -27,8 +28,11 @@ import com.intellij.openapi.util.io.FileUtilRt;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.ui.ComboboxWithBrowseButton;
 import com.intellij.ui.DocumentAdapter;
+import com.intellij.ui.components.ActionLink;
 import com.intellij.ui.components.JBLabel;
 import com.intellij.ui.components.labels.LinkLabel;
+import com.intellij.uiDesigner.core.GridConstraints;
+import com.intellij.uiDesigner.core.GridLayoutManager;
 import com.intellij.util.PlatformIcons;
 import icons.FlutterIcons;
 import io.flutter.*;
@@ -45,6 +49,7 @@ import org.jetbrains.annotations.Nullable;
 import javax.swing.*;
 import javax.swing.event.DocumentEvent;
 import javax.swing.text.JTextComponent;
+import java.awt.*;
 import java.awt.datatransfer.StringSelection;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -82,6 +87,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
   private FixedSizeButton myCopyButton;
   private JTextArea myFontPackagesTextArea; // This should be changed to a structured list some day.
   private JCheckBox myAllowTestsInSourcesRoot;
+  private ActionLink settingsLink;
 
   private final @NotNull Project myProject;
   private final WorkspaceCache workspaceCache;
@@ -101,7 +107,6 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     this.myProject = project;
     workspaceCache = WorkspaceCache.getInstance(project);
     init();
-
     myVersionLabel.setText(" ");
   }
 
@@ -163,6 +168,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
 
   private void createUIComponents() {
     mySdkCombo = new ComboboxWithBrowseButton(new ComboBox<>());
+    settingsLink = ActionsOnSaveConfigurable.createGoToActionsOnSavePageLink();
   }
 
   @Override

--- a/product-matrix.json
+++ b/product-matrix.json
@@ -2,32 +2,6 @@
   "list": [
     {
       "channel": "stable",
-      "comments": "IntelliJ 2021.1, Android Studio 2021.1.1",
-      "name": "Bumblebee",
-      "version": "AS.211",
-      "ideaProduct": "android-studio",
-      "ideaVersion": "2021.1.1.8",
-      "baseVersion": "211.7628.21",
-      "dartPluginVersion": "211.7811",
-      "sinceBuild": "211.6432.7",
-      "untilBuild": "211.7727",
-      "filesToSkip": ["flutter-idea/src/org/jetbrains/android/facet/AndroidFrameworkDetector.java"]
-    },
-    {
-      "channel": "stable",
-      "comments": "IntelliJ 2021.2, Android Studio 2021.2",
-      "name": "Chipmunk",
-      "version": "AS.212",
-      "ideaProduct": "android-studio",
-      "ideaVersion": "2021.2.1.8",
-      "baseVersion": "212.5457.46",
-      "dartPluginVersion": "212.5742",
-      "sinceBuild": "212.5457.46",
-      "untilBuild": "212.5712.43",
-      "filesToSkip": ["flutter-idea/src/org/jetbrains/android/facet/AndroidFrameworkDetector.java"]
-    },
-    {
-      "channel": "stable",
       "comments": "IntelliJ 2021.3, Android Studio 2021.3 Beta",
       "name": "2021.3",
       "version": "AS.213",

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -21,7 +21,7 @@
 
   <category>Custom Languages</category>
   <version>SNAPSHOT</version>
-  <idea-version since-build="211.6432.7" until-build="222.*"/>
+  <idea-version since-build="213.6461.79" until-build="222.*"/>
 
   <depends>com.intellij.modules.platform</depends>
   <depends>com.intellij.modules.lang</depends>

--- a/tool/plugin/test/plugin_test.dart
+++ b/tool/plugin/test/plugin_test.dart
@@ -44,8 +44,6 @@ void main() {
             specs.map((spec) => spec.ideaProduct).toList(),
             orderedEquals([
               'android-studio',
-              'android-studio',
-              'android-studio',
               'ideaIC',
               'android-studio',
               'android-studio',
@@ -63,8 +61,6 @@ void main() {
             specs.map((spec) => spec.ideaProduct).toList(),
             orderedEquals([
               'android-studio',
-              'android-studio',
-              'android-studio',
               'ideaIC',
               'android-studio',
               'android-studio',
@@ -81,8 +77,6 @@ void main() {
         expect(
             specs.map((spec) => spec.ideaProduct).toList(),
             orderedEquals([
-              'android-studio',
-              'android-studio',
               'android-studio',
               'ideaIC',
               'android-studio',


### PR DESCRIPTION
Makes some cosmetic changes to the settings page.
- Add comment to SDK section saying it applies to current project.
- Add comment that all other options apply to all projects
- Add comment about formatting with link to IDE settings for per-project option
<img width="710" alt="Screenshot 2023-01-30 at 8 50 22 AM" src="https://user-images.githubusercontent.com/8518285/215569983-c8d75d3a-0058-4044-9dec-d00b81f7cc81.png">
