### PR TITLE
Create only a single service at a time

### DIFF
--- a/flutter-idea/src/io/flutter/editor/ActiveEditorsOutlineService.java
+++ b/flutter-idea/src/io/flutter/editor/ActiveEditorsOutlineService.java
@@ -5,7 +5,6 @@
  */
 package io.flutter.editor;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.editor.Editor;
@@ -41,22 +40,21 @@ import java.util.*;
  * </ul>
  */
 public class ActiveEditorsOutlineService implements Disposable {
-  private final Project project;
-  private final FlutterDartAnalysisServer analysisServer;
+  @NotNull private final Project project;
 
   /**
    * Outlines for the currently visible files.
    */
-  private final Map<String, FlutterOutline> pathToOutline = new HashMap<>();
+  @NotNull private final Map<String, FlutterOutline> pathToOutline = new HashMap<>();
   /**
    * Outline listeners for the currently visible files.
    */
-  private final Map<String, FlutterOutlineListener> outlineListeners = new HashMap<>();
+  @NotNull private final Map<String, FlutterOutlineListener> outlineListeners = new HashMap<>();
 
   /**
    * List of listeners.
    */
-  private final Set<Listener> listeners = new HashSet<>();
+  @NotNull private final Set<Listener> listeners = new HashSet<>();
 
   @NotNull
   public static ActiveEditorsOutlineService getInstance(@NotNull final Project project) {
@@ -64,19 +62,18 @@ public class ActiveEditorsOutlineService implements Disposable {
   }
 
   public ActiveEditorsOutlineService(Project project) {
-    this(project, FlutterDartAnalysisServer.getInstance(project));
-  }
-
-  @VisibleForTesting
-  ActiveEditorsOutlineService(Project project, FlutterDartAnalysisServer analysisServer) {
     this.project = project;
-    this.analysisServer = analysisServer;
     updateActiveEditors();
     project.getMessageBus().connect(project).subscribe(FileEditorManagerListener.FILE_EDITOR_MANAGER, new FileEditorManagerListener() {
       public void selectionChanged(@NotNull FileEditorManagerEvent event) {
         updateActiveEditors();
       }
     });
+  }
+
+  @NotNull
+  FlutterDartAnalysisServer getAnalysisServer() {
+    return FlutterDartAnalysisServer.getInstance(project);
   }
 
   /**
@@ -127,6 +124,7 @@ public class ActiveEditorsOutlineService implements Disposable {
 
     // Remove obsolete outline listeners.
     final List<String> obsoletePaths = new ArrayList<>();
+    FlutterDartAnalysisServer analysisServer = getAnalysisServer();
 
     synchronized (outlineListeners) {
       for (final String path : outlineListeners.keySet()) {
@@ -225,6 +223,7 @@ public class ActiveEditorsOutlineService implements Disposable {
 
   @Override
   public void dispose() {
+    FlutterDartAnalysisServer analysisServer = getAnalysisServer();
     synchronized (outlineListeners) {
       final Iterator<Map.Entry<String, FlutterOutlineListener>> iterator = outlineListeners.entrySet().iterator();
 

--- a/flutter-idea/testSrc/unit/io/flutter/editor/ActiveEditorsOutlineServiceTest.java
+++ b/flutter-idea/testSrc/unit/io/flutter/editor/ActiveEditorsOutlineServiceTest.java
@@ -59,7 +59,7 @@ public class ActiveEditorsOutlineServiceTest {
     innerFixture = projectFixture.getInner();
     project = projectFixture.getProject();
     flutterDas = new TestFlutterDartAnalysisServer(project);
-    service = new ActiveEditorsOutlineService(project, flutterDas);
+    service = new ActiveEditorsOutlineService(project);
     listener = new Listener();
     service.addListener(listener);
     mainFile = innerFixture.addFileToProject("lib/main.dart", fileContents);


### PR DESCRIPTION
This is for #6613, which I don't want to close yet. It has a custom plugin build attached to it that includes this patch.

When a service is created, it should not cause another service to be created. I'm not sure when that rule was created, but it is causing errors in the latest EAP. This PR fixes that error. There may be other places that cause cascaded service creation, but they don't run at start-up, and we'll have to track them down.