### PR TITLE
Add symlink handling when setup the project on Windows

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -175,6 +175,23 @@ version of some code duplicated from the Dart plugin.
     - `cd tool/plugin`
     - `flutter pub get`
 
+### Handle symlinks on Windows
+
+If exceptions like these occurred:
+```
+A problem occurred configuring project ':flutter-idea'.
+> Source directory 'X:\path\to\your\flutter-intellij\flutter-idea\resources' is not a directory.
+```
+
+Check out if the directory is a symlink by open the link in IDEA, and it'll displayed as:
+```symlink
+../resources
+```
+
+Delete the file, then create a Windows-style symlink manually using:
+- Powershell: `New-Item -ItemType Junction -Path "flutter-idea/resources" -Target "resources"`
+- CMD: `mklink /j flutter-idea\resources resources`
+
 ## Running plugin tests
 
 ### Using test run configurations in IntelliJ


### PR DESCRIPTION
Cloning the repo on Windows will cause the symlinks invalid, which requires a manual setup process.

I wonder if it's fine to add a script file in the `/tool` directory to address the extra step.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
