### PR TITLE
Add the run configuration to make the plugin

### DIFF
--- a/.idea/runConfigurations/flutter_idea__make_.xml
+++ b/.idea/runConfigurations/flutter_idea__make_.xml
@@ -1,0 +1,8 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="flutter-idea [make]" type="DartCommandLineRunConfigurationType" factoryName="Dart Command Line Application">
+    <option name="arguments" value="make" />
+    <option name="filePath" value="$PROJECT_DIR$/tool/plugin/bin/main.dart" />
+    <option name="workingDirectory" value="$PROJECT_DIR$" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/flutter_intellij__make_.xml
+++ b/.idea/runConfigurations/flutter_intellij__make_.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="flutter-idea [make]" type="DartCommandLineRunConfigurationType" factoryName="Dart Command Line Application">
+  <configuration default="false" name="flutter-intellij [make]" type="DartCommandLineRunConfigurationType" factoryName="Dart Command Line Application">
     <option name="arguments" value="make" />
     <option name="filePath" value="$PROJECT_DIR$/tool/plugin/bin/main.dart" />
     <option name="workingDirectory" value="$PROJECT_DIR$" />


### PR DESCRIPTION
This could be a handy step when first setting up the environment at met the exception guided in [CONTRIBUTING.md](https://github.com/flutter/flutter-intellij/blob/master/CONTRIBUTING.md#flutter-plugin-development-on-macos-and-linux).

> Specified localPath '/.../flutter-intellij/artifacts/ideaIC' doesn't exist or is not a directory

![image](https://user-images.githubusercontent.com/15884415/221330612-aa7d2b29-880c-4fd5-be1c-8ce22b226437.png)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
