### PR TITLE
Always open Android module in new window

### DIFF
--- a/flutter-studio/src/io/flutter/actions/OpenAndroidModule.java
+++ b/flutter-studio/src/io/flutter/actions/OpenAndroidModule.java
@@ -60,20 +60,6 @@ public class OpenAndroidModule extends OpenInAndroidStudioAction implements Dumb
     if (canImportAsGradleProject(projectFile)) {
       VirtualFile target = findGradleTarget(projectFile);
       if (target != null) {
-        Project[] openProjects = ProjectManager.getInstance().getOpenProjects();
-        if (openProjects.length > 0) {
-          int exitCode = forceOpenInNewFrame ? GeneralSettings.OPEN_PROJECT_NEW_WINDOW : confirmOpenNewProject(false);
-          if (exitCode == GeneralSettings.OPEN_PROJECT_SAME_WINDOW) {
-            Project toClose = ((project != null) && !project.isDefault()) ? project : openProjects[openProjects.length - 1];
-            if (!closeAndDispose(toClose)) {
-              return;
-            }
-          }
-          else if (exitCode != GeneralSettings.OPEN_PROJECT_NEW_WINDOW) {
-            return;
-          }
-        }
-
         GradleProjectImporter gradleImporter = GradleProjectImporter.getInstance();
         gradleImporter.importAndOpenProjectCore(null, true, projectFile);
         for (Project proj : ProjectManager.getInstance().getOpenProjects()) {


### PR DESCRIPTION
The Android Studio-specific code we relied on to make the choice is no longer available as of 2022.3.

Fixes #6644