### PR TITLE
⚡️ Use `FLUTTER_STORAGE_BASE_URL` for `ArtifactManager`

### DIFF
--- a/tool/plugin/lib/artifact.dart
+++ b/tool/plugin/lib/artifact.dart
@@ -39,7 +39,7 @@ class Artifact {
 }
 
 class ArtifactManager {
-  late final String base = () {
+  final String base = () {
     final baseFromEnv = Platform.environment['FLUTTER_STORAGE_BASE_URL'] ?? '';
     final String base;
     if (baseFromEnv.isEmpty) {

--- a/tool/plugin/lib/artifact.dart
+++ b/tool/plugin/lib/artifact.dart
@@ -39,8 +39,16 @@ class Artifact {
 }
 
 class ArtifactManager {
-  final String base =
-      'https://storage.googleapis.com/flutter_infra_release/flutter/intellij';
+  late final String base = () {
+    final baseFromEnv = Platform.environment['FLUTTER_STORAGE_BASE_URL'] ?? '';
+    final String base;
+    if (baseFromEnv.isEmpty) {
+      base = 'https://storage.googleapis.com';
+    } else {
+      base = baseFromEnv;
+    }
+    return '$base/flutter_infra_release/flutter/intellij';
+  }();
 
   final List<Artifact> artifacts = [];
 


### PR DESCRIPTION
Makes the artifact manager no longer uses the fixed base if `FLUTTER_STORAGE_BASE_URL` is configured on the host platform.

The change happens with the tool, I don't think any tests are related at present.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
