### PR TITLE
⚡️ Always use `Utf8Codec` for plugin logs

### DIFF
--- a/tool/plugin/lib/util.dart
+++ b/tool/plugin/lib/util.dart
@@ -22,10 +22,9 @@ Future<int> exec(String cmd, List<String> args, {String? cwd}) async {
     log(_shorten('$cmd ${args.join(' ')}'));
   }
 
-  var codec = Platform.isWindows ? latin1 : utf8;
   final process = await Process.start(cmd, args, workingDirectory: cwd);
-  _toLineStream(process.stderr, codec).listen(log);
-  _toLineStream(process.stdout, codec).listen(log);
+  _toLineStream(process.stderr).listen(log);
+  _toLineStream(process.stdout).listen(log);
 
   return await process.exitCode;
 }
@@ -144,8 +143,8 @@ String _shorten(String str) {
       : '${str.substring(0, 170)} ... ${str.substring(str.length - 30)}';
 }
 
-Stream<String> _toLineStream(Stream<List<int>> s, Encoding encoding) =>
-    s.transform(encoding.decoder).transform(const LineSplitter());
+Stream<String> _toLineStream(Stream<List<int>> s) =>
+    s.transform(utf8.decoder).transform(const LineSplitter());
 
 String readTokenFromKeystore(String keyName) {
   var env = Platform.environment;


### PR DESCRIPTION
Windows can change the encoding setting in its system region setting, and Gradle output options can be defined in system environments. There is no need to use `latin1` and it will break if the system or Gradle has manually set the encoding to UTF-8.

![image](https://user-images.githubusercontent.com/15884415/221816091-414687d4-1236-45c1-b43d-c57a1d8a6375.png)

![image](https://user-images.githubusercontent.com/15884415/221816242-ba26abe3-3b8b-401f-b389-996c250e7a17.png)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
