### PR TITLE
⚡️ Use `Directory.delete` instead of `rm`

### DIFF
--- a/tool/plugin/lib/util.dart
+++ b/tool/plugin/lib/util.dart
@@ -108,9 +108,8 @@ Future<int> curl(String url, {required String to}) async {
   return await exec('curl', ['-o', to, url]);
 }
 
-Future<int> removeAll(String dir) async {
-  var args = ['-rf', dir];
-  return await exec('rm', args);
+Future<void> removeAll(String dir) async {
+  await Directory(dir).delete(recursive: true);
 }
 
 bool isCacheDirectoryValid(Artifact artifact) {

--- a/tool/plugin/lib/util.dart
+++ b/tool/plugin/lib/util.dart
@@ -108,8 +108,9 @@ Future<int> curl(String url, {required String to}) async {
   return await exec('curl', ['-o', to, url]);
 }
 
+/// Remove the directory without exceptions if it does not exists.
 Future<void> removeAll(String dir) async {
-  await Directory(dir).delete(recursive: true);
+  await Directory(dir).delete(recursive: true).then((_) {}, onError: (_) {});
 }
 
 bool isCacheDirectoryValid(Artifact artifact) {


### PR DESCRIPTION
The `removeAll` command is never been awaited for the result and it will throw exceptions if the corresponding directory does not exist on Windows.

The PR converts it to a Dart `Directory` delete and ignore exceptions to match previous behavior on all platforms.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
