### PR TITLE
Fix DevTools opening for bazel workspaces

### DIFF
--- a/flutter-idea/src/io/flutter/performance/FlutterPerformanceView.java
+++ b/flutter-idea/src/io/flutter/performance/FlutterPerformanceView.java
@@ -29,6 +29,7 @@ import com.intellij.ui.content.ContentManager;
 import com.intellij.util.ui.JBUI;
 import com.intellij.util.ui.UIUtil;
 import icons.FlutterIcons;
+import io.flutter.bazel.WorkspaceCache;
 import io.flutter.devtools.DevToolsUrl;
 import io.flutter.run.FlutterDevice;
 import io.flutter.run.FlutterLaunchMode;
@@ -217,12 +218,8 @@ public class FlutterPerformanceView implements Disposable {
         }
 
         FlutterSdk flutterSdk = FlutterSdk.getFlutterSdk(app.getProject());
-        if (flutterSdk == null) {
-          return;
-        }
-
         BrowserLauncher.getInstance().browse(
-                (new DevToolsUrl(instance.host, instance.port, app.getConnector().getBrowserUrl(), null, false, null, null, flutterSdk.getVersion())).getUrlString(),
+                (new DevToolsUrl(instance.host, instance.port, app.getConnector().getBrowserUrl(), null, false, null, null, flutterSdk == null ? null : flutterSdk.getVersion(), WorkspaceCache.getInstance(app.getProject()))).getUrlString(),
                 null
         );
       });

--- a/flutter-idea/src/io/flutter/run/OpenDevToolsAction.java
+++ b/flutter-idea/src/io/flutter/run/OpenDevToolsAction.java
@@ -14,6 +14,7 @@ import com.intellij.openapi.util.Computable;
 import icons.FlutterIcons;
 import io.flutter.FlutterInitializer;
 import io.flutter.ObservatoryConnector;
+import io.flutter.bazel.WorkspaceCache;
 import io.flutter.devtools.DevToolsUrl;
 import io.flutter.run.daemon.DevToolsService;
 import io.flutter.run.daemon.FlutterApp;
@@ -77,12 +78,8 @@ public class OpenDevToolsAction extends DumbAwareAction {
       final String serviceUrl = myConnector != null && myConnector.getBrowserUrl() != null ? myConnector.getBrowserUrl() : null;
 
       FlutterSdk flutterSdk = FlutterSdk.getFlutterSdk(project);
-      if (flutterSdk == null) {
-        return;
-      }
-
       BrowserLauncher.getInstance().browse(
-        (new DevToolsUrl(instance.host, instance.port, serviceUrl, null, false, null, null, flutterSdk.getVersion()).getUrlString()),
+        (new DevToolsUrl(instance.host, instance.port, serviceUrl, null, false, null, null, flutterSdk == null ? null : flutterSdk.getVersion(), WorkspaceCache.getInstance(project)).getUrlString()),
         null
       );
     });

--- a/flutter-idea/src/io/flutter/view/FlutterView.java
+++ b/flutter-idea/src/io/flutter/view/FlutterView.java
@@ -50,6 +50,7 @@ import icons.FlutterIcons;
 import io.flutter.FlutterBundle;
 import io.flutter.FlutterInitializer;
 import io.flutter.FlutterUtils;
+import io.flutter.bazel.WorkspaceCache;
 import io.flutter.devtools.DevToolsUrl;
 import io.flutter.inspector.DiagnosticsNode;
 import io.flutter.inspector.InspectorGroupManagerService;
@@ -61,6 +62,7 @@ import io.flutter.run.daemon.DevToolsInstance;
 import io.flutter.run.daemon.DevToolsService;
 import io.flutter.run.daemon.FlutterApp;
 import io.flutter.sdk.FlutterSdk;
+import io.flutter.sdk.FlutterSdkVersion;
 import io.flutter.settings.FlutterSettings;
 import io.flutter.toolwindow.FlutterViewToolWindowManagerListener;
 import io.flutter.utils.AsyncUtils;
@@ -274,21 +276,20 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
 
     final String browserUrl = app.getConnector().getBrowserUrl();
     FlutterSdk flutterSdk = FlutterSdk.getFlutterSdk(app.getProject());
-    if (flutterSdk == null) {
-      return;
-    }
+    FlutterSdkVersion flutterSdkVersion = flutterSdk == null ? null : flutterSdk.getVersion();
 
     if (isEmbedded) {
       final String color = ColorUtil.toHex(UIUtil.getEditorPaneBackground());
       final DevToolsUrl devToolsUrl = new DevToolsUrl(
-              devToolsInstance.host,
-              devToolsInstance.port,
-              browserUrl,
-              "inspector",
-              true,
-              color,
-              UIUtil.getFontSize(UIUtil.FontSize.NORMAL),
-              flutterSdk.getVersion()
+        devToolsInstance.host,
+        devToolsInstance.port,
+        browserUrl,
+        "inspector",
+        true,
+        color,
+        UIUtil.getFontSize(UIUtil.FontSize.NORMAL),
+        flutterSdkVersion,
+        WorkspaceCache.getInstance(app.getProject())
       );
 
       //noinspection CodeBlock2Expr
@@ -317,7 +318,7 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
     } else {
       BrowserLauncher.getInstance().browse(
         (new DevToolsUrl(devToolsInstance.host, devToolsInstance.port, browserUrl, "inspector", false, null, null,
-                         flutterSdk.getVersion()).getUrlString()),
+                         flutterSdkVersion, WorkspaceCache.getInstance(app.getProject())).getUrlString()),
         null
       );
       presentLabel(toolWindow, "DevTools inspector has been opened in the browser.");
@@ -977,12 +978,8 @@ class FlutterViewDevToolsAction extends FlutterViewAction {
         }
 
         FlutterSdk flutterSdk = FlutterSdk.getFlutterSdk(app.getProject());
-        if (flutterSdk == null) {
-          return;
-        }
-
         BrowserLauncher.getInstance().browse(
-          (new DevToolsUrl(instance.host, instance.port, urlString, null, false, null, null, flutterSdk.getVersion()).getUrlString()),
+          (new DevToolsUrl(instance.host, instance.port, urlString, null, false, null, null, flutterSdk == null ? null : flutterSdk.getVersion(), WorkspaceCache.getInstance(app.getProject())).getUrlString()),
           null
         );
       });

--- a/flutter-idea/testSrc/unit/io/flutter/devtools/DevToolsUrlTest.java
+++ b/flutter-idea/testSrc/unit/io/flutter/devtools/DevToolsUrlTest.java
@@ -1,5 +1,6 @@
 package io.flutter.devtools;
 
+import io.flutter.bazel.WorkspaceCache;
 import io.flutter.sdk.FlutterSdkUtil;
 import io.flutter.sdk.FlutterSdkVersion;
 import org.junit.Test;
@@ -19,48 +20,64 @@ public class DevToolsUrlTest {
     final FlutterSdkUtil mockSdkUtil = mock(FlutterSdkUtil.class);
     when(mockSdkUtil.getFlutterHostEnvValue()).thenReturn("IntelliJ-IDEA");
 
+    final WorkspaceCache notBazelWorkspaceCache = mock(WorkspaceCache.class);
+    when(notBazelWorkspaceCache.isBazel()).thenReturn(false);
+
+    final WorkspaceCache bazelWorkspaceCache = mock(WorkspaceCache.class);
+    when(bazelWorkspaceCache.isBazel()).thenReturn(true);
+
     FlutterSdkVersion newVersion = new FlutterSdkVersion("3.3.0");
     assertEquals(
       "http://127.0.0.1:9100/timeline?ide=IntelliJ-IDEA&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F",
-      (new DevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false, null, null, newVersion, mockSdkUtil)).getUrlString()
+      (new DevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false, null, null, newVersion, notBazelWorkspaceCache, mockSdkUtil)).getUrlString()
     );
 
     assertEquals(
       "http://127.0.0.1:9100/timeline?ide=IntelliJ-IDEA&embed=true&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F",
-      (new DevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, true, null, null, newVersion, mockSdkUtil)).getUrlString()
+      (new DevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, true, null, null, newVersion, notBazelWorkspaceCache, mockSdkUtil)).getUrlString()
     );
 
     assertEquals(
       "http://127.0.0.1:9100/?ide=IntelliJ-IDEA",
-      (new DevToolsUrl(devtoolsHost, devtoolsPort, null, null, false, null, null, newVersion, mockSdkUtil).getUrlString())
+      (new DevToolsUrl(devtoolsHost, devtoolsPort, null, null, false, null, null, newVersion, notBazelWorkspaceCache, mockSdkUtil).getUrlString())
     );
 
     assertEquals(
       "http://127.0.0.1:9100/timeline?ide=IntelliJ-IDEA&backgroundColor=ffffff&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F",
-      (new DevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false, "ffffff", null, newVersion, mockSdkUtil).getUrlString())
+      (new DevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false, "ffffff", null, newVersion, notBazelWorkspaceCache, mockSdkUtil).getUrlString())
     );
 
     assertEquals(
       "http://127.0.0.1:9100/timeline?ide=IntelliJ-IDEA&backgroundColor=ffffff&fontSize=12.0&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F",
-      (new DevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false, "ffffff", 12.0f, newVersion, mockSdkUtil).getUrlString())
+      (new DevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false, "ffffff", 12.0f, newVersion, notBazelWorkspaceCache, mockSdkUtil).getUrlString())
     );
 
     when(mockSdkUtil.getFlutterHostEnvValue()).thenReturn("Android-Studio");
 
     assertEquals(
       "http://127.0.0.1:9100/timeline?ide=Android-Studio&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F",
-      (new DevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false, null, null, newVersion, mockSdkUtil).getUrlString())
+      (new DevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false, null, null, newVersion, notBazelWorkspaceCache, mockSdkUtil).getUrlString())
     );
 
     assertEquals(
       "http://127.0.0.1:9100/timeline?ide=Android-Studio&backgroundColor=3c3f41&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F",
-      (new DevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false, "3c3f41", null, newVersion, mockSdkUtil).getUrlString())
+      (new DevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false, "3c3f41", null, newVersion, notBazelWorkspaceCache, mockSdkUtil).getUrlString())
     );
 
     FlutterSdkVersion oldVersion = new FlutterSdkVersion("3.0.0");
     assertEquals(
       "http://127.0.0.1:9100/#/?ide=Android-Studio&page=timeline&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F",
-      (new DevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false, null, null, oldVersion, mockSdkUtil)).getUrlString()
+      (new DevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false, null, null, oldVersion, notBazelWorkspaceCache, mockSdkUtil)).getUrlString()
+    );
+
+    assertEquals(
+      "http://127.0.0.1:9100/#/?ide=Android-Studio&page=timeline&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F",
+      (new DevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false, null, null, null, notBazelWorkspaceCache, mockSdkUtil)).getUrlString()
+    );
+
+    assertEquals(
+      "http://127.0.0.1:9100/timeline?ide=Android-Studio&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F",
+      (new DevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false, null, null, null, bazelWorkspaceCache, mockSdkUtil)).getUrlString()
     );
   }
 }


### PR DESCRIPTION
I forgot while making this change: https://github.com/flutter/flutter-intellij/pull/6614 that Bazel cases will not have a Flutter SDK, and this prevented DevTools from opening for bazel workspaces. Instead, we should check both workspace status and Flutter SDK before deciding what type of DevTools URL to use (we can assume bazel is always up to date).