### PR TITLE
Update Dart version for latest EAP build

### DIFF
--- a/product-matrix.json
+++ b/product-matrix.json
@@ -57,9 +57,9 @@
       "version": "2023.1",
       "isUnitTestTarget": "true",
       "ideaProduct": "ideaIC",
-      "ideaVersion": "231.7665.28",
-      "baseVersion": "231.7665.28",
-      "dartPluginVersion": "231.8109.2",
+      "ideaVersion": "231.8770.17",
+      "baseVersion": "231.8770.17",
+      "dartPluginVersion": "231.8770.15",
       "sinceBuild": "231.7665.28",
       "untilBuild": "231.*"
     }


### PR DESCRIPTION
Also note that in `edit.dart` we change the version of IntelliJ to the latest EAP build. All this is really doing is updating the Dart plugin version to work with EAP.

This also fixes the build failure in #6716 and #6717, which I merged before this was approved.