### PR TITLE
🐛 Resolves the referenced element before parsing colors

### DIFF
--- a/flutter-idea/src/io/flutter/editor/FlutterColorProvider.java
+++ b/flutter-idea/src/io/flutter/editor/FlutterColorProvider.java
@@ -58,24 +58,26 @@ public class FlutterColorProvider implements ElementColorProvider {
       return parseColorElements(parent, refExpr);
     }
     else {
-      final PsiElement reference = resolveReferencedElement(refExpr);
-      if (reference != null && reference.getLastChild() != null) {
-        Color tryParseColor = null;
-        if (reference instanceof DartCallExpression) {
-          final DartExpression expression = ((DartCallExpression)reference).getExpression();
-          if (expression != null && expression.getLastChild() instanceof DartReferenceExpression) {
-            tryParseColor = parseColorElements(reference, expression);
-            if (tryParseColor != null) return tryParseColor;
+      if (parent.getNode().getElementType() == DartTokenTypes.VAR_INIT) {
+        final PsiElement reference = resolveReferencedElement(refExpr);
+        if (reference != null && reference.getLastChild() != null) {
+          Color tryParseColor = null;
+          if (reference instanceof DartCallExpression) {
+            final DartExpression expression = ((DartCallExpression)reference).getExpression();
+            if (expression != null && expression.getLastChild() instanceof DartReferenceExpression) {
+              tryParseColor = parseColorElements(reference, expression);
+              if (tryParseColor != null) return tryParseColor;
+            }
           }
+          final PsiElement lastChild = reference.getLastChild();
+          if (lastChild instanceof DartArguments && reference.getParent() != null) {
+            tryParseColor = parseColorElements(reference, reference.getParent());
+          }
+          else {
+            tryParseColor = parseColorElements(reference, reference.getLastChild());
+          }
+          if (tryParseColor != null) return tryParseColor;
         }
-        final PsiElement lastChild = reference.getLastChild();
-        if (lastChild instanceof DartArguments && reference.getParent() != null) {
-          tryParseColor = parseColorElements(reference, reference.getParent());
-        }
-        else {
-          tryParseColor = parseColorElements(reference, reference.getLastChild());
-        }
-        if (tryParseColor != null) return tryParseColor;
       }
       // name.equals(refExpr.getFirstChild().getText()) -> Colors.blue
       final PsiElement idNode = refExpr.getFirstChild();

--- a/flutter-idea/src/io/flutter/editor/FlutterColorProvider.java
+++ b/flutter-idea/src/io/flutter/editor/FlutterColorProvider.java
@@ -101,6 +101,9 @@ public class FlutterColorProvider implements ElementColorProvider {
 
   @Nullable
   private PsiElement resolveReferencedElement(@NotNull PsiElement element) {
+    if (element instanceof DartCallExpression && element.getFirstChild().getText().equals("Color")) {
+      return element;
+    }
     final PsiElement symbol = element.getLastChild();
     final PsiElement result;
     if (symbol instanceof DartReference) {
@@ -112,14 +115,16 @@ public class FlutterColorProvider implements ElementColorProvider {
     else {
       return null;
     }
-    // Recursively determine reference if the result is still a `DartReference`.
-    if (result instanceof DartReference) return resolveReferencedElement(result);
     if (!(result instanceof DartComponentName) || result.getParent() == null) return null;
     final PsiElement declaration = result.getParent().getParent();
     if (!(declaration instanceof DartVarDeclarationList)) return null;
     final PsiElement lastChild = declaration.getLastChild();
     if (!(lastChild instanceof DartVarInit)) return null;
-    return lastChild.getLastChild();
+
+    final PsiElement effectiveElement = lastChild.getLastChild();
+    // Recursively determine reference if the initialization is still a `DartReference`.
+    if (effectiveElement instanceof DartReference) return resolveReferencedElement(effectiveElement);
+    return effectiveElement;
   }
 
   @Nullable

--- a/flutter-idea/src/io/flutter/editor/FlutterColorProvider.java
+++ b/flutter-idea/src/io/flutter/editor/FlutterColorProvider.java
@@ -58,7 +58,8 @@ public class FlutterColorProvider implements ElementColorProvider {
       return parseColorElements(parent, refExpr);
     }
     else {
-      if (parent.getNode().getElementType() == DartTokenTypes.VAR_INIT) {
+      if (parent.getNode().getElementType() == DartTokenTypes.VAR_INIT ||
+          parent.getNode().getElementType() == DartTokenTypes.FUNCTION_BODY) {
         final PsiElement reference = resolveReferencedElement(refExpr);
         if (reference != null && reference.getLastChild() != null) {
           Color tryParseColor = null;
@@ -123,7 +124,9 @@ public class FlutterColorProvider implements ElementColorProvider {
 
     final PsiElement effectiveElement = lastChild.getLastChild();
     // Recursively determine reference if the initialization is still a `DartReference`.
-    if (effectiveElement instanceof DartReference) return resolveReferencedElement(effectiveElement);
+    if (effectiveElement instanceof DartReference && !(effectiveElement instanceof DartCallExpression)) {
+      return resolveReferencedElement(effectiveElement);
+    }
     return effectiveElement;
   }
 

--- a/flutter-idea/src/io/flutter/editor/FlutterColorProvider.java
+++ b/flutter-idea/src/io/flutter/editor/FlutterColorProvider.java
@@ -60,7 +60,21 @@ public class FlutterColorProvider implements ElementColorProvider {
     else {
       final PsiElement reference = resolveReferencedElement(refExpr);
       if (reference != null && reference.getLastChild() != null) {
-        final Color tryParseColor = parseColorElements(reference, reference.getLastChild());
+        Color tryParseColor = null;
+        if (reference instanceof DartCallExpression) {
+          final DartExpression expression = ((DartCallExpression)reference).getExpression();
+          if (expression != null && expression.getLastChild() instanceof DartReferenceExpression) {
+            tryParseColor = parseColorElements(reference, expression);
+            if (tryParseColor != null) return tryParseColor;
+          }
+        }
+        final PsiElement lastChild = reference.getLastChild();
+        if (lastChild instanceof DartArguments && reference.getParent() != null) {
+          tryParseColor = parseColorElements(reference, reference.getParent());
+        }
+        else {
+          tryParseColor = parseColorElements(reference, reference.getLastChild());
+        }
         if (tryParseColor != null) return tryParseColor;
       }
       // name.equals(refExpr.getFirstChild().getText()) -> Colors.blue

--- a/flutter-idea/src/io/flutter/editor/FlutterColorProvider.java
+++ b/flutter-idea/src/io/flutter/editor/FlutterColorProvider.java
@@ -14,10 +14,7 @@ import com.intellij.psi.impl.PsiFileFactoryImpl;
 import com.intellij.psi.impl.source.tree.AstBufferUtil;
 import com.jetbrains.lang.dart.DartLanguage;
 import com.jetbrains.lang.dart.DartTokenTypes;
-import com.jetbrains.lang.dart.psi.DartArgumentList;
-import com.jetbrains.lang.dart.psi.DartArguments;
-import com.jetbrains.lang.dart.psi.DartExpression;
-import com.jetbrains.lang.dart.psi.DartLiteralExpression;
+import com.jetbrains.lang.dart.psi.*;
 import io.flutter.FlutterBundle;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -38,7 +35,6 @@ public class FlutterColorProvider implements ElementColorProvider {
     if (element.getNode().getElementType() != DartTokenTypes.IDENTIFIER) return null;
 
     final String name = element.getText();
-    if (!(name.equals("Colors") || name.equals("CupertinoColors") || name.equals("Color"))) return null;
 
     final PsiElement refExpr = topmostReferenceExpression(element);
     if (refExpr == null) return null;
@@ -62,6 +58,11 @@ public class FlutterColorProvider implements ElementColorProvider {
       return parseColorElements(parent, refExpr);
     }
     else {
+      final PsiElement reference = resolveReferencedElement(refExpr);
+      if (reference != null && reference.getLastChild() != null) {
+        final Color tryParseColor = parseColorElements(reference, reference.getLastChild());
+        if (tryParseColor != null) return tryParseColor;
+      }
       // name.equals(refExpr.getFirstChild().getText()) -> Colors.blue
       final PsiElement idNode = refExpr.getFirstChild();
       if (idNode == null) return null;
@@ -80,6 +81,29 @@ public class FlutterColorProvider implements ElementColorProvider {
       }
     }
     return null;
+  }
+
+  @Nullable
+  private PsiElement resolveReferencedElement(@NotNull PsiElement element) {
+    final PsiElement symbol = element.getLastChild();
+    final PsiElement result;
+    if (symbol instanceof DartReference) {
+      result = ((DartReference)symbol).resolve();
+    }
+    else if (element instanceof DartReference) {
+      result = ((DartReference)element).resolve();
+    }
+    else {
+      return null;
+    }
+    // Recursively determine reference if the result is still a `DartReference`.
+    if (result instanceof DartReference) return resolveReferencedElement(result);
+    if (!(result instanceof DartComponentName) || result.getParent() == null) return null;
+    final PsiElement declaration = result.getParent().getParent();
+    if (!(declaration instanceof DartVarDeclarationList)) return null;
+    final PsiElement lastChild = declaration.getLastChild();
+    if (!(lastChild instanceof DartVarInit)) return null;
+    return lastChild.getLastChild();
   }
 
   @Nullable


### PR DESCRIPTION
Fixes #5436.

| Before | After |
|------|------|
| ![image](https://github.com/flutter/flutter-intellij/assets/15884415/632e3d1c-9bf4-4ff9-9b87-dd79930a5830) | ![image](https://github.com/flutter/flutter-intellij/assets/15884415/c9188e22-4e93-4bc8-a0ab-756b5aec6f43) |

## Implementation details

- `Colors` and `CupertinoColors` are hard-coded to determine *colored element*. The condition has been removed, which means all elements will be predicated.
- Referenced will be resolved before the element gets parsed by text directly.
- All the additional checks will be called only if the element type is `VAR_INIT` (for declarations) or `FUNCTION_BODY` (for getters) to avoid too much performance regression.

Test case:
```dart
import 'package:flutter/material.dart' hide Colors;

const Color _c1 = Color(0xff000000);
final _c2 = _c1;
Color get _c3 => _c2;

void test() {
  const Color c1 = _c1;
  const Color c2 = Color(0xffffffff);
  const Color c3 = Color.fromARGB(255, 123, 231, 31);
  const Color c4 = Color(0xff923998);
  const Color c5 = c2;
  const Color c6 = TC.c1;
  const Color c7 = TC.c2;
  const Color c8 = TC.c3;
  const Color c9 = Colors.black;
}

class TC {
  static const Color c1 = Color(0xff449978);
  static const Color c2 = Color(0xffdb2f7f);
  static const Color c3 = Color.fromARGB(150, 66, 231, 31);
}

class Colors {
  static const Color white = Color(0xffaa9933);
  static const Color tests = Colors.white;
  static const Color black = Colors.tests;
  static const Color tcC1 = TC.c1;
  final Color tcC2 = TC.c2;
  Color get tcC3 => TC.c3;
}
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
