### PR TITLE
✨ Support multiple running instance for inspectors

### DIFF
--- a/flutter-idea/src/io/flutter/run/FlutterDevice.java
+++ b/flutter-idea/src/io/flutter/run/FlutterDevice.java
@@ -111,6 +111,7 @@ public class FlutterDevice {
   /**
    * Given a collection of devices, return a unique name for this device.
    */
+  @NotNull
   public String getUniqueName(Collection<FlutterDevice> devices) {
     for (final FlutterDevice other : devices) {
       if (other == this) {
@@ -141,6 +142,7 @@ public class FlutterDevice {
     return new FlutterDevice("flutter-tester", "Flutter test device", null, false);
   }
 
+  @NotNull
   public String presentationName() {
     if (category() != null) {
       return deviceName() + " (" + category() + ")";

--- a/flutter-idea/src/io/flutter/view/FlutterView.java
+++ b/flutter-idea/src/io/flutter/view/FlutterView.java
@@ -705,7 +705,6 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
       if (contentManager.isDisposed()) {
         return;
       }
-      contentManager.removeAllContents(true);
 
       final JPanel panel = new JPanel(new BorderLayout());
       panel.add(label, BorderLayout.CENTER);


### PR DESCRIPTION
Resolves #6189.

https://github.com/flutter/flutter-intellij/assets/15884415/b5a3438b-4fbd-4fa8-9027-fd3fe0f11963

## Implementation details

- `Browser` is a singleton in the previous implementation. The PR updates it to be stored as a mapping between the tab name (the unique device name) and the browser instance.
- `Content`s are also cached to ensure they can be added after removing the empty content.

## Additional context

`FlutterPerformanceView` should be able to apply the same update but I didn't investigate it yet.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
