### PR TITLE
add Open in Xcode for macOS

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -23,3 +23,4 @@ Pedro Massango <pedromassango.developer@gmail.com>
 Wagner Silvestre <wagner1343@outlook.com>
 Eli Albert <crasowas@gmail.com>
 Mohamed El Sayed <devblooming@tutanota.com>
+Edwin Ludik <edwin.ludik@gmail.com>

--- a/flutter-idea/src/io/flutter/editor/NativeEditorNotificationProvider.java
+++ b/flutter-idea/src/io/flutter/editor/NativeEditorNotificationProvider.java
@@ -75,6 +75,9 @@ public class NativeEditorNotificationProvider extends EditorNotifications.Provid
     else if (root.getName().equals("ios")) {
       return "flutter.xcode.open";
     }
+    else if (root.getName().equals("macos")) {
+      return "flutter.xcode.open";
+    }
     else {
       return null;
     }

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -109,7 +109,7 @@
               text="Open Android module in Android Studio"
               description="Launch Android Studio to edit the Android module as a top-level project"/>
       <action id="flutter.xcode.open" class="io.flutter.actions.OpenInXcodeAction"
-              text="Open iOS module in Xcode"
+              text="Open iOS/macOS module in Xcode"
               description="Launch Xcode to edit the iOS module as a top-level project"/>
       <action id="flutter.appcode.open" class="io.flutter.actions.OpenInAppCodeAction"
               text="Open iOS module in AppCode"

--- a/resources/META-INF/plugin_template.xml
+++ b/resources/META-INF/plugin_template.xml
@@ -107,7 +107,7 @@
               text="Open Android module in Android Studio"
               description="Launch Android Studio to edit the Android module as a top-level project"/>
       <action id="flutter.xcode.open" class="io.flutter.actions.OpenInXcodeAction"
-              text="Open iOS module in Xcode"
+              text="Open iOS/macOS module in Xcode"
               description="Launch Xcode to edit the iOS module as a top-level project"/>
       <action id="flutter.appcode.open" class="io.flutter.actions.OpenInAppCodeAction"
               text="Open iOS module in AppCode"


### PR DESCRIPTION
I (hopefully) added an option "Open in Xcode". Does anyone else maybe have a test environment ready? I will test locally, opening PR to get feedback on the design question.

**Design Question:** I did not add a second action, using "flutter.xcode.open" for iOS and macOS, should it rather be refactored to use two different actions? Something like ["flutter.xcode.openiOS" and "flutter.xcode.openMacOS"] or ["flutter.xcode.open.iOS" and "flutter.xcode.open.macOS"] or something else?

[Missing open MacOS module in xcode #6209](https://github.com/flutter/flutter-intellij/issues/6209)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities. 
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
