### PR TITLE
Add gradle to ignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ flutter-idea/build/
 flutter-idea/.gradle/
 tool/plugin/.idea
 lib/kotlin*
+gradle
+gradlew
+gradlew.bat


### PR DESCRIPTION
IntelliJ expects Gradle at the top level. We have it in third_party. You can symlink to it I think, but I just let IntelliJ install it for me. In any case, we don't want to check it in.