### PR TITLE
Revert "Default to JCEF browser (#6834)"

### DIFF
--- a/flutter-idea/src/io/flutter/settings/FlutterSettings.java
+++ b/flutter-idea/src/io/flutter/settings/FlutterSettings.java
@@ -266,11 +266,11 @@ public class FlutterSettings {
   }
 
   public boolean isEnableJcefBrowser() {
-    return getPropertiesComponent().getBoolean(enableJcefBrowserKey, true);
+    return getPropertiesComponent().getBoolean(enableJcefBrowserKey, false);
   }
 
   public void setEnableJcefBrowser(boolean value) {
-    getPropertiesComponent().setValue(enableJcefBrowserKey, value, true);
+    getPropertiesComponent().setValue(enableJcefBrowserKey, value, false);
 
     fireEvent();
   }


### PR DESCRIPTION
Reverts flutter/flutter-intellij#6834

We aren't able to run this on Linux, potentially related to https://youtrack.jetbrains.com/issue/JBR-4484/JCEF-is-not-supported-in-this-env-or-failed-to-initialize-for-CentOS-7-machine