### PR TITLE
Use ToolEvent for inspect elements

### DIFF
--- a/flutter-idea/src/io/flutter/vmService/VmServiceWrapper.java
+++ b/flutter-idea/src/io/flutter/vmService/VmServiceWrapper.java
@@ -174,6 +174,20 @@ public class VmServiceWrapper implements Disposable {
         });
       }
     });
+
+    streamListen("ToolEvent", new SuccessConsumer() {
+      @Override
+      public void received(Success response) {
+        System.out.println("success");
+        System.out.println(response);
+      }
+
+      @Override
+      public void onError(RPCError error) {
+        System.out.println("error");
+        System.out.println(error);
+      }
+    });
   }
 
   private void streamListen(@NotNull String streamId, @NotNull SuccessConsumer consumer) {

--- a/flutter-idea/src/io/flutter/vmService/VmServiceWrapper.java
+++ b/flutter-idea/src/io/flutter/vmService/VmServiceWrapper.java
@@ -178,14 +178,11 @@ public class VmServiceWrapper implements Disposable {
     streamListen("ToolEvent", new SuccessConsumer() {
       @Override
       public void received(Success response) {
-        System.out.println("success");
-        System.out.println(response);
       }
 
       @Override
       public void onError(RPCError error) {
-        System.out.println("error");
-        System.out.println(error);
+        LOG.error("Error listening to ToolEvent stream: " + error);
       }
     });
   }


### PR DESCRIPTION
Fixes #6875

Some things I'm not sure about:
- I'm currently using the custom VM service stream 'ToolEvent' directly. VS Code is using the DAP forwarding of events from this stream; is this a point where it would make sense to use DAP from DDS?
- This skips large portions of previous architecture to listen for changes in selections, e.g. classes like `InspectorObjectGroupManager` - is that okay?