### PR TITLE
Fix for #6933: remove deprecated org.apache.commons.lang.* references

### DIFF
--- a/flutter-idea/src/io/flutter/editor/FlutterCompletionContributor.java
+++ b/flutter-idea/src/io/flutter/editor/FlutterCompletionContributor.java
@@ -11,7 +11,7 @@ import com.intellij.util.ui.ColorIcon;
 import com.intellij.util.ui.EmptyIcon;
 import com.jetbrains.lang.dart.ide.completion.DartCompletionExtension;
 import com.jetbrains.lang.dart.ide.completion.DartServerCompletionContributor;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.dartlang.analysis.server.protocol.CompletionSuggestion;
 import org.dartlang.analysis.server.protocol.Element;
 import org.jetbrains.annotations.NotNull;

--- a/flutter-idea/src/io/flutter/inspector/DiagnosticsNode.java
+++ b/flutter-idea/src/io/flutter/inspector/DiagnosticsNode.java
@@ -19,7 +19,7 @@ import io.flutter.run.daemon.FlutterApp;
 import io.flutter.utils.CustomIconMaker;
 import io.flutter.utils.JsonUtils;
 import io.flutter.vmService.frame.DartVmServiceValue;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.dartlang.analysis.server.protocol.HoverInformation;
 import org.dartlang.vm.service.element.InstanceRef;
 import org.jetbrains.annotations.NotNull;

--- a/flutter-idea/src/io/flutter/module/FlutterGeneratorPeer.java
+++ b/flutter-idea/src/io/flutter/module/FlutterGeneratorPeer.java
@@ -31,7 +31,7 @@ import javax.swing.JScrollPane;
 import javax.swing.JTextPane;
 import javax.swing.event.DocumentEvent;
 import javax.swing.text.JTextComponent;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 

--- a/flutter-idea/src/io/flutter/module/FlutterModuleBuilder.java
+++ b/flutter-idea/src/io/flutter/module/FlutterModuleBuilder.java
@@ -58,7 +58,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import javax.swing.ComboBoxEditor;
 import javax.swing.Icon;
 import javax.swing.JComponent;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 

--- a/flutter-idea/src/io/flutter/run/bazelTest/BazelTestRunner.java
+++ b/flutter-idea/src/io/flutter/run/bazelTest/BazelTestRunner.java
@@ -47,7 +47,7 @@ import io.flutter.settings.FlutterSettings;
 import io.flutter.utils.JsonUtils;
 import io.flutter.utils.StdoutJsonParser;
 import io.flutter.utils.UrlUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 

--- a/flutter-idea/src/io/flutter/run/common/CommonTestConfigUtils.java
+++ b/flutter-idea/src/io/flutter/run/common/CommonTestConfigUtils.java
@@ -22,7 +22,7 @@ import io.flutter.dart.DartSyntax;
 import io.flutter.editor.ActiveEditorsOutlineService;
 import java.util.HashMap;
 import java.util.Map;
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.lang3.StringEscapeUtils;
 import org.dartlang.analysis.server.protocol.ElementKind;
 import org.dartlang.analysis.server.protocol.FlutterOutline;
 import org.jetbrains.annotations.NotNull;

--- a/flutter-idea/src/io/flutter/run/common/TestType.java
+++ b/flutter-idea/src/io/flutter/run/common/TestType.java
@@ -7,7 +7,7 @@ package io.flutter.run.common;
 
 import com.intellij.icons.AllIcons;
 import com.intellij.psi.PsiElement;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;

--- a/flutter-idea/src/io/flutter/utils/JsonUtils.java
+++ b/flutter-idea/src/io/flutter/utils/JsonUtils.java
@@ -9,7 +9,7 @@ import com.google.gson.*;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 

--- a/flutter-idea/src/io/flutter/view/DiagnosticsTreeCellRenderer.java
+++ b/flutter-idea/src/io/flutter/view/DiagnosticsTreeCellRenderer.java
@@ -16,7 +16,7 @@ import io.flutter.editor.FlutterMaterialIcons;
 import io.flutter.inspector.DiagnosticLevel;
 import io.flutter.inspector.DiagnosticsNode;
 import io.flutter.utils.ColorIconMaker;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;

--- a/flutter-idea/src/org/dartlang/analysis/server/protocol/FlutterOutline.java
+++ b/flutter-idea/src/org/dartlang/analysis/server/protocol/FlutterOutline.java
@@ -13,7 +13,7 @@ import com.google.dart.server.utilities.general.ObjectUtilities;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import org.apache.commons.lang.StringUtils;
+import static org.apache.commons.lang3.StringUtils.join;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import java.util.ArrayList;
@@ -351,7 +351,7 @@ public class FlutterOutline {
     builder.append(dartElement + ", ");
     if (attributes != null) {
       builder.append("attributes=");
-      builder.append(StringUtils.join(attributes, ", ") + ", ");
+      builder.append(join(attributes, ", ") + ", ");
     }
     builder.append("className=");
     builder.append(className + ", ");
@@ -361,7 +361,7 @@ public class FlutterOutline {
     builder.append(variableName + ", ");
     if (children != null) {
       builder.append("children=");
-      builder.append(StringUtils.join(children, ", "));
+      builder.append(join(children, ", "));
     }
 
     builder.append("]");

--- a/flutter-idea/src/org/dartlang/analysis/server/protocol/FlutterWidgetProperty.java
+++ b/flutter-idea/src/org/dartlang/analysis/server/protocol/FlutterWidgetProperty.java
@@ -13,7 +13,7 @@ import com.google.dart.server.utilities.general.ObjectUtilities;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import org.apache.commons.lang.StringUtils;
+import static org.apache.commons.lang3.StringUtils.join;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import java.util.ArrayList;
@@ -285,7 +285,7 @@ public class FlutterWidgetProperty {
     builder.append("name=");
     builder.append(name + ", ");
     builder.append("children=");
-    builder.append(StringUtils.join(children, ", ") + ", ");
+    builder.append(join(children, ", ") + ", ");
     builder.append("editor=");
     builder.append(editor + ", ");
     builder.append("value=");

--- a/flutter-idea/src/org/dartlang/analysis/server/protocol/FlutterWidgetPropertyEditor.java
+++ b/flutter-idea/src/org/dartlang/analysis/server/protocol/FlutterWidgetPropertyEditor.java
@@ -13,7 +13,7 @@ import com.google.dart.server.utilities.general.ObjectUtilities;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import org.apache.commons.lang.StringUtils;
+import static org.apache.commons.lang3.StringUtils.join;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import java.util.ArrayList;
@@ -112,7 +112,7 @@ public class FlutterWidgetPropertyEditor {
     builder.append("kind=");
     builder.append(kind + ", ");
     builder.append("enumItems=");
-    builder.append(StringUtils.join(enumItems, ", "));
+    builder.append(join(enumItems, ", "));
     builder.append("]");
     return builder.toString();
   }

--- a/tool/plugin/lib/lint.dart
+++ b/tool/plugin/lib/lint.dart
@@ -87,9 +87,12 @@ class LintCommand extends Command {
       'com.android.annotations.NonNull',
       'io.netty.',
       'javax.annotation.Nullable',
-      // Not technically a bad import, but we are using
-      // org.apache.commons.lang.StringUtils already in the codebase.
-      'org.apache.commons.lang3.StringUtils',
+      // org.apache.commons.lang.StringUtils and
+      // org.apache.commons.lang.StringEscapeUtils are being deprecated,
+      // use org.apache.commons.lang3.* instead.
+      // See https://github.com/flutter/flutter-intellij/issues/6933
+      'org.apache.commons.lang.StringUtils',
+      'org.apache.commons.lang.StringEscapeUtils',
 
       // Not technically a bad import, but not all IntelliJ platforms provide
       // this library.


### PR DESCRIPTION
Fix for https://github.com/flutter/flutter-intellij/issues/6933, removal of the soon to be deprecated `org.apache.commons.lang.*` references.
