### PR TITLE
Log and show link to open DevTools in separate browser if JCEF fails

### DIFF
--- a/flutter-idea/src/io/flutter/view/EmbeddedJcefBrowser.java
+++ b/flutter-idea/src/io/flutter/view/EmbeddedJcefBrowser.java
@@ -19,7 +19,7 @@ import java.awt.Dimension;
 class EmbeddedJcefBrowserTab implements EmbeddedTab {
   private JBCefBrowser browser;
 
-  public EmbeddedJcefBrowserTab() {
+  public EmbeddedJcefBrowserTab() throws Exception {
     this.browser = new JBCefBrowser();
   }
 
@@ -57,7 +57,7 @@ public class EmbeddedJcefBrowser extends EmbeddedBrowser {
   }
 
   @Override
-  public EmbeddedTab openEmbeddedTab() {
+  public EmbeddedTab openEmbeddedTab() throws Exception {
     return new EmbeddedJcefBrowserTab();
   }
 }

--- a/flutter-idea/src/io/flutter/view/FlutterView.java
+++ b/flutter-idea/src/io/flutter/view/FlutterView.java
@@ -291,10 +291,10 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
 
       //noinspection CodeBlock2Expr
       ApplicationManager.getApplication().invokeLater(() -> {
-        embeddedBrowserOptional().ifPresent(embeddedBrowser -> embeddedBrowser.openPanel(contentManager, tabName, devToolsUrl, () -> {
+        embeddedBrowserOptional().ifPresent(embeddedBrowser -> embeddedBrowser.openPanel(contentManager, tabName, devToolsUrl, (String error) -> {
           // If the embedded browser doesn't work, offer a link to open in the regular browser.
           final List<LabelInput> inputs = Arrays.asList(
-            new LabelInput("The embedded browser failed to load."),
+            new LabelInput("The embedded browser failed to load. Error: " + error),
             openDevToolsLabel(app, inspectorService, toolWindow)
           );
           presentClickableLabel(toolWindow, inputs);
@@ -709,6 +709,7 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
       final JPanel panel = new JPanel(new BorderLayout());
       panel.add(label, BorderLayout.CENTER);
       final Content content = contentManager.getFactory().createContent(panel, null, false);
+      contentManager.removeAllContents(true);
       contentManager.addContent(content);
     });
   }


### PR DESCRIPTION
Message wasn't displayed previously, and we want this before making JCEF default. I figure logging should help us understand what platforms are failing. 

<img width="468" alt="Screenshot 2023-11-02 at 8 47 22 AM" src="https://github.com/flutter/flutter-intellij/assets/6379305/dea3e1c1-7bb1-4432-bd21-ec9bfdeeb4d2">
