### PR TITLE
Dispose SDK config correctly on app ending

### DIFF
--- a/flutter-idea/src/io/flutter/run/SdkAttachConfig.java
+++ b/flutter-idea/src/io/flutter/run/SdkAttachConfig.java
@@ -94,7 +94,7 @@ public class SdkAttachConfig extends SdkRunConfig {
         }
       };
       FlutterSdkManager.getInstance(project).addListener(sdkListener);
-      Disposer.register(project, () -> FlutterSdkManager.getInstance(project).removeListener(sdkListener));
+      Disposer.register(app, () -> FlutterSdkManager.getInstance(project).removeListener(sdkListener));
 
       return app;
     };

--- a/flutter-idea/src/io/flutter/run/SdkRunConfig.java
+++ b/flutter-idea/src/io/flutter/run/SdkRunConfig.java
@@ -200,7 +200,7 @@ public class SdkRunConfig extends LocatableConfigurationBase<LaunchState>
         }
       };
       FlutterSdkManager.getInstance(project).addListener(sdkListener);
-      Disposer.register(project, () -> FlutterSdkManager.getInstance(project).removeListener(sdkListener));
+      Disposer.register(app, () -> FlutterSdkManager.getInstance(project).removeListener(sdkListener));
 
       return app;
     };


### PR DESCRIPTION
The listener added to shut down a running app should stop listening when an app ends, not when a project is closed.

I believe this should fix https://github.com/flutter/flutter-intellij/issues/6930