### PR TITLE
Try to use project service for disposal [draft]

### DIFF
--- a/flutter-idea/src/io/flutter/FlutterProjectDisposable.java
+++ b/flutter-idea/src/io/flutter/FlutterProjectDisposable.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter;
+
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.project.Project;
+import io.flutter.sdk.FlutterSdkManager;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
+
+public class FlutterProjectDisposable implements Disposable {
+  private final Project project;
+  public static FlutterProjectDisposable getInstance(@NotNull Project project) {
+    return Objects.requireNonNull(project.getService(FlutterProjectDisposable.class));
+  }
+
+  private FlutterProjectDisposable(@NotNull Project project) {
+    this.project = project;
+  }
+
+  @Override
+  public void dispose() {
+    System.out.println("in dispose");
+  }
+}

--- a/flutter-idea/src/io/flutter/dart/FlutterDartAnalysisServer.java
+++ b/flutter-idea/src/io/flutter/dart/FlutterDartAnalysisServer.java
@@ -23,6 +23,7 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.util.Consumer;
 import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService;
 import io.flutter.FlutterInitializer;
+import io.flutter.FlutterProjectDisposable;
 import io.flutter.analytics.TimeTracker;
 import io.flutter.utils.JsonUtils;
 import org.dartlang.analysis.server.protocol.*;
@@ -98,7 +99,7 @@ public class FlutterDartAnalysisServer implements Disposable {
         super.computedErrors(file, errors);
       }
     });
-    Disposer.register(project, this);
+    Disposer.register(FlutterProjectDisposable.getInstance(project), this);
   }
 
   public void addOutlineListener(@NotNull final String filePath, @NotNull final FlutterOutlineListener listener) {

--- a/flutter-idea/src/io/flutter/editor/EditorEventServiceBase.java
+++ b/flutter-idea/src/io/flutter/editor/EditorEventServiceBase.java
@@ -12,6 +12,7 @@ import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.editor.ex.EditorEx;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Disposer;
+import io.flutter.FlutterProjectDisposable;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -27,7 +28,7 @@ public class EditorEventServiceBase<L> implements Disposable {
 
   public EditorEventServiceBase(Project project) {
     this.project = project;
-    Disposer.register(project, this);
+    Disposer.register(FlutterProjectDisposable.getInstance(project), this);
   }
 
   protected void invokeAll(InvokeListener<L> invoke, Editor editor) {
@@ -59,7 +60,7 @@ public class EditorEventServiceBase<L> implements Disposable {
   public void addListener(@NotNull EditorEx editor, @NotNull L listener, Disposable parent) {
     synchronized (listeners) {
       listeners.put(editor, listener);
-      Disposer.register(parent, () -> removeListener(editor, listener));
+      Disposer.register(FlutterProjectDisposable.getInstance(project), () -> removeListener(editor, listener));
     }
   }
 

--- a/flutter-idea/src/io/flutter/inspector/InspectorGroupManagerService.java
+++ b/flutter-idea/src/io/flutter/inspector/InspectorGroupManagerService.java
@@ -9,6 +9,7 @@ import com.google.common.collect.Lists;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Disposer;
+import io.flutter.FlutterProjectDisposable;
 import io.flutter.run.FlutterAppManager;
 import io.flutter.run.daemon.FlutterApp;
 import io.flutter.utils.AsyncUtils;
@@ -143,7 +144,7 @@ public class InspectorGroupManagerService implements Disposable {
   public InspectorGroupManagerService(Project project) {
     FlutterAppManager.getInstance(project).getActiveAppAsStream().listen(
       this::updateActiveApp, true);
-    Disposer.register(project, this);
+    Disposer.register(FlutterProjectDisposable.getInstance(project), this);
   }
 
   @NotNull

--- a/flutter-idea/src/io/flutter/perf/FlutterWidgetPerfManager.java
+++ b/flutter-idea/src/io/flutter/perf/FlutterWidgetPerfManager.java
@@ -13,6 +13,7 @@ import com.intellij.openapi.util.Disposer;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.util.messages.MessageBusConnection;
 import io.flutter.FlutterInitializer;
+import io.flutter.FlutterProjectDisposable;
 import io.flutter.FlutterUtils;
 import io.flutter.run.FlutterAppManager;
 import io.flutter.run.daemon.FlutterApp;
@@ -77,7 +78,7 @@ public class FlutterWidgetPerfManager implements Disposable, FlutterApp.FlutterA
   private FlutterWidgetPerfManager(@NotNull Project project) {
     this.project = project;
 
-    Disposer.register(project, this);
+    Disposer.register(FlutterProjectDisposable.getInstance(project), this);
 
     FlutterAppManager.getInstance(project).getActiveAppAsStream().listen(
       this::updateCurrentAppChanged, true);

--- a/flutter-idea/src/io/flutter/run/FlutterAppManager.java
+++ b/flutter-idea/src/io/flutter/run/FlutterAppManager.java
@@ -16,6 +16,7 @@ import com.intellij.openapi.Disposable;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Disposer;
+import io.flutter.FlutterProjectDisposable;
 import io.flutter.run.daemon.FlutterApp;
 import io.flutter.utils.EventStream;
 import org.jetbrains.annotations.NotNull;
@@ -44,7 +45,7 @@ public class FlutterAppManager implements Disposable {
     this.project = project;
 
     // TODO This object shoud have a different disposable parent to enable dynamic plugin loading.
-    Disposer.register(project, this);
+    Disposer.register(FlutterProjectDisposable.getInstance(project), this);
 
     task = JobScheduler.getScheduler().scheduleWithFixedDelay(
       this::updateActiveApp, 1, 1, TimeUnit.SECONDS);

--- a/flutter-idea/src/io/flutter/run/SdkAttachConfig.java
+++ b/flutter-idea/src/io/flutter/run/SdkAttachConfig.java
@@ -32,6 +32,7 @@ import com.intellij.refactoring.listeners.RefactoringElementListener;
 import com.jetbrains.lang.dart.sdk.DartConfigurable;
 import com.jetbrains.lang.dart.sdk.DartSdk;
 import io.flutter.FlutterBundle;
+import io.flutter.FlutterProjectDisposable;
 import io.flutter.dart.DartPlugin;
 import io.flutter.pub.PubRoot;
 import io.flutter.run.common.RunMode;
@@ -94,7 +95,7 @@ public class SdkAttachConfig extends SdkRunConfig {
         }
       };
       FlutterSdkManager.getInstance(project).addListener(sdkListener);
-      Disposer.register(project, () -> FlutterSdkManager.getInstance(project).removeListener(sdkListener));
+      Disposer.register(FlutterSdkManager.getInstance(project), () -> FlutterSdkManager.getInstance(project).removeListener(sdkListener));
 
       return app;
     };

--- a/flutter-idea/src/io/flutter/run/SdkRunConfig.java
+++ b/flutter-idea/src/io/flutter/run/SdkRunConfig.java
@@ -35,6 +35,7 @@ import com.intellij.util.PathUtil;
 import com.intellij.util.xmlb.SkipDefaultValuesSerializationFilters;
 import com.intellij.util.xmlb.XmlSerializer;
 import com.jetbrains.lang.dart.ide.runner.DartConsoleFilter;
+import io.flutter.FlutterProjectDisposable;
 import io.flutter.FlutterUtils;
 import io.flutter.console.FlutterConsoleFilter;
 import io.flutter.run.common.RunMode;
@@ -64,6 +65,11 @@ public class SdkRunConfig extends LocatableConfigurationBase<LaunchState>
 
   public SdkRunConfig(final @NotNull Project project, final @NotNull ConfigurationFactory factory, final @NotNull String name) {
     super(project, factory, name);
+    //while (true) {
+    //  System.out.println("in SdkRunConfig");
+    //  System.out.println(this);
+    //  Thread.sleep(30000);
+    //}
   }
 
   @NotNull
@@ -200,7 +206,8 @@ public class SdkRunConfig extends LocatableConfigurationBase<LaunchState>
         }
       };
       FlutterSdkManager.getInstance(project).addListener(sdkListener);
-      Disposer.register(project, () -> FlutterSdkManager.getInstance(project).removeListener(sdkListener));
+      //Disposer.register(project, () -> FlutterSdkManager.getInstance(project).removeListener(sdkListener));
+      Disposer.register(FlutterSdkManager.getInstance(project), () -> FlutterSdkManager.getInstance(project).removeListener(sdkListener));
 
       return app;
     };

--- a/flutter-idea/src/io/flutter/run/daemon/DeviceService.java
+++ b/flutter-idea/src/io/flutter/run/daemon/DeviceService.java
@@ -18,6 +18,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ex.ProjectRootManagerEx;
 import com.intellij.openapi.util.Disposer;
 import io.flutter.FlutterMessages;
+import io.flutter.FlutterProjectDisposable;
 import io.flutter.FlutterUtils;
 import io.flutter.bazel.WorkspaceCache;
 import io.flutter.run.FlutterDevice;
@@ -79,8 +80,9 @@ public class DeviceService {
         refreshDeviceDaemon();
       }
     };
-    FlutterSdkManager.getInstance(project).addListener(sdkListener);
-    Disposer.register(project, () -> FlutterSdkManager.getInstance(project).removeListener(sdkListener));
+    FlutterSdkManager instance = FlutterSdkManager.getInstance(project);
+    instance.addListener(sdkListener);
+    Disposer.register(instance, () -> instance.removeListener(sdkListener));
 
     // Watch for Bazel workspace changes.
     WorkspaceCache.getInstance(project).subscribe(this::refreshDeviceDaemon);

--- a/flutter-idea/src/io/flutter/run/daemon/FlutterApp.java
+++ b/flutter-idea/src/io/flutter/run/daemon/FlutterApp.java
@@ -28,10 +28,7 @@ import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.util.EventDispatcher;
 import com.intellij.util.concurrency.AppExecutorUtil;
-import io.flutter.FlutterInitializer;
-import io.flutter.FlutterMessages;
-import io.flutter.FlutterUtils;
-import io.flutter.ObservatoryConnector;
+import io.flutter.*;
 import io.flutter.bazel.Workspace;
 import io.flutter.bazel.WorkspaceCache;
 import io.flutter.logging.FlutterConsoleLogManager;
@@ -266,7 +263,7 @@ public class FlutterApp implements Disposable {
     }
 
     final ProcessHandler process = new MostlySilentColoredProcessHandler(command, onTextAvailable);
-    Disposer.register(project, process::destroyProcess);
+    Disposer.register(FlutterProjectDisposable.getInstance(project), process::destroyProcess);
 
     // Send analytics for the start and stop events.
     if (analyticsStart != null) {

--- a/flutter-idea/src/io/flutter/sdk/FlutterSdkManager.java
+++ b/flutter-idea/src/io/flutter/sdk/FlutterSdkManager.java
@@ -6,6 +6,7 @@
 package io.flutter.sdk;
 
 import com.intellij.concurrency.JobScheduler;
+import com.intellij.openapi.Disposable;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
 import com.intellij.openapi.project.ProjectManagerListener;
@@ -14,6 +15,7 @@ import com.intellij.openapi.roots.libraries.LibraryTable;
 import com.intellij.openapi.roots.libraries.LibraryTablesRegistrar;
 import com.intellij.openapi.util.Disposer;
 import com.intellij.util.EventDispatcher;
+import io.flutter.FlutterProjectDisposable;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.EventListener;
@@ -24,7 +26,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * Monitors the application library table to notify clients when Flutter SDK configuration changes.
  */
-public class FlutterSdkManager {
+public class FlutterSdkManager implements Disposable {
   private final EventDispatcher<Listener> myListenerDispatcher = EventDispatcher.create(Listener.class);
   private boolean isFlutterConfigured;
   private final @NotNull Project myProject;
@@ -45,7 +47,7 @@ public class FlutterSdkManager {
     final ScheduledFuture timer = JobScheduler.getScheduler().scheduleWithFixedDelay(
       this::checkForFlutterSdkChange, 1, 1, TimeUnit.SECONDS);
 
-    Disposer.register(project, () -> {
+    Disposer.register(FlutterProjectDisposable.getInstance(project), () -> {
       LibraryTablesRegistrar.getInstance().getLibraryTable(project).removeListener(libraryTableListener);
       timer.cancel(false);
     });
@@ -138,5 +140,10 @@ public class FlutterSdkManager {
     public void afterLibraryRemoved(@NotNull Library library) {
       checkForFlutterSdkChange();
     }
+  }
+
+  @Override
+  public void dispose() {
+    System.out.println("disposing FlutterSdkManager");
   }
 }

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -587,6 +587,9 @@
     <projectService serviceInterface="io.flutter.inspector.InspectorGroupManagerService"
                     serviceImplementation="io.flutter.inspector.InspectorGroupManagerService"
                     overrides="false"/>
+    <projectService serviceInterface="io.flutter.FlutterProjectDisposable"
+                    serviceImplementation="io.flutter.FlutterProjectDisposable"
+                    overrides="false"/>
 
     <iconProvider implementation="io.flutter.project.FlutterIconProvider" order="first"/>
 


### PR DESCRIPTION
I'm trying to follow the instructions from https://plugins.jetbrains.com/docs/intellij/disposers.html#choosing-a-disposable-parent for how to properly dispose of objects, because the plugin is leaking memory and I can see in the debugging memory panel that many of our project services (e.g. `FlutterSdkManager`) open a new instance every time a project is opened and doesn't go away when the project is closed. (Is that how project services should work?)

I was hoping that registering dispose actions to a parent disposable that is a project service (`FlutterProjectDisposable` introduced in this change) would make a difference, but I don't see that working.

This other change is more basic because the registered disposer isn't called on app ending: https://github.com/flutter/flutter-intellij/pull/7064. However, in the cases in this PR, I do see that the registered disposers are called on project close; it's just that the project services themselves tend to stick around.

@alexander-doroshko do you have any tips on how to properly manage these classes for disposal?