### PR TITLE
Remove listener for file path on project dispose

### DIFF
--- a/flutter-idea/src/io/flutter/run/common/CommonTestConfigUtils.java
+++ b/flutter-idea/src/io/flutter/run/common/CommonTestConfigUtils.java
@@ -13,6 +13,7 @@ import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Disposer;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
@@ -174,6 +175,9 @@ public abstract class CommonTestConfigUtils {
     final ActiveEditorsOutlineService service = getActiveEditorsOutlineService(file.getProject());
     if (!listenerCache.containsKey(path) && service != null) {
       listenerCache.put(path, new LineMarkerUpdatingListener(this, file.getProject(), service));
+      Disposer.register(file.getProject(), () -> {
+        listenerCache.remove(path);
+      });
     }
     return listenerCache.get(path);
   }


### PR DESCRIPTION
This class was pointed out as a source of memory leaks, and it seems this is because file paths aren't removed from `listenerCache` on project close. I wanted to check with @alexander-doroshko following the conversation on https://github.com/flutter/flutter-intellij/pull/7065 that this is a reasonable fix.