### PR TITLE
Make JX Browser the fallback and remove settings option

### DIFF
--- a/flutter-idea/src/io/flutter/FlutterUtils.java
+++ b/flutter-idea/src/io/flutter/FlutterUtils.java
@@ -633,11 +633,10 @@ public class FlutterUtils {
       return null;
     }
 
-    return FlutterSettings.getInstance().isEnableJcefBrowser() ? EmbeddedJcefBrowser.getInstance(project) : EmbeddedJxBrowser.getInstance(project);
+    return EmbeddedJcefBrowser.isUsable() ? EmbeddedJcefBrowser.getInstance(project) : EmbeddedJxBrowser.getInstance(project);
   }
 
   public static boolean embeddedBrowserAvailable(JxBrowserStatus status) {
-    return status.equals(JxBrowserStatus.INSTALLED) || status.equals(JxBrowserStatus.INSTALLATION_SKIPPED) && FlutterSettings.getInstance()
-      .isEnableJcefBrowser();
+    return status.equals(JxBrowserStatus.INSTALLED) || status.equals(JxBrowserStatus.INSTALLATION_SKIPPED) && EmbeddedJcefBrowser.isUsable();
   }
 }

--- a/flutter-idea/src/io/flutter/sdk/FlutterSettingsConfigurable.form
+++ b/flutter-idea/src/io/flutter/sdk/FlutterSettingsConfigurable.form
@@ -244,7 +244,7 @@
           </grid>
         </children>
       </grid>
-      <grid id="23e52" layout-manager="GridLayoutManager" row-count="5" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="23e52" layout-manager="GridLayoutManager" row-count="4" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -285,15 +285,6 @@
             <properties>
               <text resource-bundle="io/flutter/FlutterBundle" key="settings.show.all.configs"/>
               <toolTipText resource-bundle="io/flutter/FlutterBundle" key="settings.show.all.configs.tooltip"/>
-            </properties>
-          </component>
-          <component id="909bb" class="javax.swing.JCheckBox" binding="myEnableJcefBrowserCheckBox">
-            <constraints>
-              <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <text resource-bundle="io/flutter/FlutterBundle" key="settings.jcef.browser"/>
-              <toolTipText resource-bundle="io/flutter/FlutterBundle" key="settings.jcef.browser.tooltip"/>
             </properties>
           </component>
         </children>

--- a/flutter-idea/src/io/flutter/sdk/FlutterSettingsConfigurable.java
+++ b/flutter-idea/src/io/flutter/sdk/FlutterSettingsConfigurable.java
@@ -78,8 +78,6 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
 
   private JCheckBox myShowAllRunConfigurationsInContextCheckBox;
 
-  private JCheckBox myEnableJcefBrowserCheckBox;
-
   private JCheckBox myShowBuildMethodGuides;
   private JCheckBox myShowClosingLabels;
   private FixedSizeButton myCopyButton;
@@ -267,10 +265,6 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
       return true;
     }
 
-    if (settings.isEnableJcefBrowser() != myEnableJcefBrowserCheckBox.isSelected()) {
-      return true;
-    }
-
     return false;
   }
 
@@ -329,7 +323,6 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     settings.setAllowTestsInSourcesRoot(myAllowTestsInSourcesRoot.isSelected());
     settings.setShowAllRunConfigurationsInContext(myShowAllRunConfigurationsInContextCheckBox.isSelected());
     settings.setFontPackages(myFontPackagesTextArea.getText());
-    settings.setEnableJcefBrowser(myEnableJcefBrowserCheckBox.isSelected());
 
     reset(); // because we rely on remembering initial state
     checkFontPackages(settings.getFontPackages(), oldFontPackages);
@@ -401,7 +394,6 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     myIncludeAllStackTraces.setEnabled(myShowStructuredErrors.isSelected());
 
     myShowAllRunConfigurationsInContextCheckBox.setSelected(settings.showAllRunConfigurationsInContext());
-    myEnableJcefBrowserCheckBox.setSelected(settings.isEnableJcefBrowser());
     myFontPackagesTextArea.setText(settings.getFontPackages());
   }
 

--- a/flutter-idea/src/io/flutter/settings/FlutterSettings.java
+++ b/flutter-idea/src/io/flutter/settings/FlutterSettings.java
@@ -30,7 +30,6 @@ public class FlutterSettings {
   private static final String enableHotUiKey = "io.flutter.editor.enableHotUi";
   private static final String enableBazelHotRestartKey = "io.flutter.editor.enableBazelHotRestart";
   private static final String showBazelHotRestartWarningKey = "io.flutter.showBazelHotRestartWarning";
-  private static final String enableJcefBrowserKey = "io.flutter.enableJcefBrowser";
   private static final String fontPackagesKey = "io.flutter.fontPackages";
   private static final String allowTestsInSourcesRootKey = "io.flutter.allowTestsInSources";
   private static final String showBazelIosRunNotificationKey = "io.flutter.hideBazelIosRunNotification";
@@ -261,16 +260,6 @@ public class FlutterSettings {
 
   public void setShowAllRunConfigurationsInContext(boolean value) {
     Registry.get(suggestAllRunConfigurationsFromContextKey).setValue(value);
-
-    fireEvent();
-  }
-
-  public boolean isEnableJcefBrowser() {
-    return getPropertiesComponent().getBoolean(enableJcefBrowserKey, false);
-  }
-
-  public void setEnableJcefBrowser(boolean value) {
-    getPropertiesComponent().setValue(enableJcefBrowserKey, value, false);
 
     fireEvent();
   }

--- a/flutter-idea/src/io/flutter/utils/JxBrowserUtils.java
+++ b/flutter-idea/src/io/flutter/utils/JxBrowserUtils.java
@@ -7,6 +7,7 @@ package io.flutter.utils;
 
 import com.intellij.openapi.util.SystemInfo;
 import io.flutter.settings.FlutterSettings;
+import io.flutter.view.EmbeddedJcefBrowser;
 import org.jetbrains.annotations.NotNull;
 // import com.intellij.util.system.CpuArch;
 
@@ -88,6 +89,6 @@ public class JxBrowserUtils {
 
 
   public boolean skipInstallation() {
-    return FlutterSettings.getInstance().isEnableJcefBrowser();
+    return EmbeddedJcefBrowser.isUsable();
   }
 }

--- a/flutter-idea/src/io/flutter/view/EmbeddedJcefBrowser.java
+++ b/flutter-idea/src/io/flutter/view/EmbeddedJcefBrowser.java
@@ -42,6 +42,7 @@ class EmbeddedJcefBrowserTab implements EmbeddedTab {
 
 public class EmbeddedJcefBrowser extends EmbeddedBrowser {
   private static final Logger LOG = Logger.getInstance(JxBrowserManager.class);
+  private static Boolean jcefIsUsable = null;
 
   public EmbeddedJcefBrowser(Project project) {
     super(project);
@@ -53,13 +54,16 @@ public class EmbeddedJcefBrowser extends EmbeddedBrowser {
   }
 
   public static boolean isUsable() {
+    if (jcefIsUsable != null) return jcefIsUsable;
+
     try {
-      // TODO(helin24): This may need to be a different check. I'm unsure whether this is robust.
-      Class<?> clazz = Class.forName("com.intellij.ui.jcef.JBCefBrowser");
+      new JBCefBrowser();
     }
-    catch (ClassNotFoundException e) {
+    catch (IllegalStateException e) {
+      jcefIsUsable = false;
       return false;
     }
+    jcefIsUsable = true;
     return true;
   }
 

--- a/flutter-idea/src/io/flutter/view/EmbeddedJcefBrowser.java
+++ b/flutter-idea/src/io/flutter/view/EmbeddedJcefBrowser.java
@@ -52,6 +52,17 @@ public class EmbeddedJcefBrowser extends EmbeddedBrowser {
     return ServiceManager.getService(project, EmbeddedJcefBrowser.class);
   }
 
+  public static boolean isUsable() {
+    try {
+      // TODO(helin24): This may need to be a different check. I'm unsure whether this is robust.
+      Class<?> clazz = Class.forName("com.intellij.ui.jcef.JBCefBrowser");
+    }
+    catch (ClassNotFoundException e) {
+      return false;
+    }
+    return true;
+  }
+
   public Logger logger() {
     return LOG;
   }

--- a/flutter-idea/src/io/flutter/view/FlutterView.java
+++ b/flutter-idea/src/io/flutter/view/FlutterView.java
@@ -768,7 +768,7 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
   }
 
   private void displayEmbeddedBrowser(FlutterApp app, InspectorService inspectorService, ToolWindow toolWindow, DevToolsIdeFeature ideFeature) {
-    if (FlutterSettings.getInstance().isEnableJcefBrowser()) {
+    if (EmbeddedJcefBrowser.isUsable()) {
       presentDevTools(app, inspectorService, toolWindow, true, ideFeature);
     } else {
       displayEmbeddedBrowserIfJxBrowser(app, inspectorService, toolWindow, ideFeature);


### PR DESCRIPTION
This removes the option to select JCEF or JX Browser in settings for simplicity. We will instead check if JCEF is available first, and if not, download and use JX Browser. Embedded browser failures in IJ (where JCEF is included by default) were very low, so I think it's unlikely users will benefit from having a choice here.

I still need to build this to check whether this is detecting the presence of JCEF accurately.