### PR TITLE
Revert "Make JX Browser the fallback and remove settings option (#7232)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 # 78.2, 78.3
 - Fix debugger variable information (#7228)
-- Make JX Browser the fallback and remove settings option (#7232)
 
 # 78, 78.1
 - Fix DevTools Inspector for all Android Studio users (#7147)

--- a/flutter-idea/src/io/flutter/FlutterUtils.java
+++ b/flutter-idea/src/io/flutter/FlutterUtils.java
@@ -633,10 +633,11 @@ public class FlutterUtils {
       return null;
     }
 
-    return EmbeddedJcefBrowser.isUsable() ? EmbeddedJcefBrowser.getInstance(project) : EmbeddedJxBrowser.getInstance(project);
+    return FlutterSettings.getInstance().isEnableJcefBrowser() ? EmbeddedJcefBrowser.getInstance(project) : EmbeddedJxBrowser.getInstance(project);
   }
 
   public static boolean embeddedBrowserAvailable(JxBrowserStatus status) {
-    return status.equals(JxBrowserStatus.INSTALLED) || status.equals(JxBrowserStatus.INSTALLATION_SKIPPED) && EmbeddedJcefBrowser.isUsable();
+    return status.equals(JxBrowserStatus.INSTALLED) || status.equals(JxBrowserStatus.INSTALLATION_SKIPPED) && FlutterSettings.getInstance()
+      .isEnableJcefBrowser();
   }
 }

--- a/flutter-idea/src/io/flutter/sdk/FlutterSettingsConfigurable.form
+++ b/flutter-idea/src/io/flutter/sdk/FlutterSettingsConfigurable.form
@@ -244,7 +244,7 @@
           </grid>
         </children>
       </grid>
-      <grid id="23e52" layout-manager="GridLayoutManager" row-count="4" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="23e52" layout-manager="GridLayoutManager" row-count="5" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -285,6 +285,15 @@
             <properties>
               <text resource-bundle="io/flutter/FlutterBundle" key="settings.show.all.configs"/>
               <toolTipText resource-bundle="io/flutter/FlutterBundle" key="settings.show.all.configs.tooltip"/>
+            </properties>
+          </component>
+          <component id="909bb" class="javax.swing.JCheckBox" binding="myEnableJcefBrowserCheckBox">
+            <constraints>
+              <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text resource-bundle="io/flutter/FlutterBundle" key="settings.jcef.browser"/>
+              <toolTipText resource-bundle="io/flutter/FlutterBundle" key="settings.jcef.browser.tooltip"/>
             </properties>
           </component>
         </children>

--- a/flutter-idea/src/io/flutter/sdk/FlutterSettingsConfigurable.java
+++ b/flutter-idea/src/io/flutter/sdk/FlutterSettingsConfigurable.java
@@ -78,6 +78,8 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
 
   private JCheckBox myShowAllRunConfigurationsInContextCheckBox;
 
+  private JCheckBox myEnableJcefBrowserCheckBox;
+
   private JCheckBox myShowBuildMethodGuides;
   private JCheckBox myShowClosingLabels;
   private FixedSizeButton myCopyButton;
@@ -265,6 +267,10 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
       return true;
     }
 
+    if (settings.isEnableJcefBrowser() != myEnableJcefBrowserCheckBox.isSelected()) {
+      return true;
+    }
+
     return false;
   }
 
@@ -323,6 +329,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     settings.setAllowTestsInSourcesRoot(myAllowTestsInSourcesRoot.isSelected());
     settings.setShowAllRunConfigurationsInContext(myShowAllRunConfigurationsInContextCheckBox.isSelected());
     settings.setFontPackages(myFontPackagesTextArea.getText());
+    settings.setEnableJcefBrowser(myEnableJcefBrowserCheckBox.isSelected());
 
     reset(); // because we rely on remembering initial state
     checkFontPackages(settings.getFontPackages(), oldFontPackages);
@@ -394,6 +401,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     myIncludeAllStackTraces.setEnabled(myShowStructuredErrors.isSelected());
 
     myShowAllRunConfigurationsInContextCheckBox.setSelected(settings.showAllRunConfigurationsInContext());
+    myEnableJcefBrowserCheckBox.setSelected(settings.isEnableJcefBrowser());
     myFontPackagesTextArea.setText(settings.getFontPackages());
   }
 

--- a/flutter-idea/src/io/flutter/settings/FlutterSettings.java
+++ b/flutter-idea/src/io/flutter/settings/FlutterSettings.java
@@ -30,6 +30,7 @@ public class FlutterSettings {
   private static final String enableHotUiKey = "io.flutter.editor.enableHotUi";
   private static final String enableBazelHotRestartKey = "io.flutter.editor.enableBazelHotRestart";
   private static final String showBazelHotRestartWarningKey = "io.flutter.showBazelHotRestartWarning";
+  private static final String enableJcefBrowserKey = "io.flutter.enableJcefBrowser";
   private static final String fontPackagesKey = "io.flutter.fontPackages";
   private static final String allowTestsInSourcesRootKey = "io.flutter.allowTestsInSources";
   private static final String showBazelIosRunNotificationKey = "io.flutter.hideBazelIosRunNotification";
@@ -260,6 +261,16 @@ public class FlutterSettings {
 
   public void setShowAllRunConfigurationsInContext(boolean value) {
     Registry.get(suggestAllRunConfigurationsFromContextKey).setValue(value);
+
+    fireEvent();
+  }
+
+  public boolean isEnableJcefBrowser() {
+    return getPropertiesComponent().getBoolean(enableJcefBrowserKey, false);
+  }
+
+  public void setEnableJcefBrowser(boolean value) {
+    getPropertiesComponent().setValue(enableJcefBrowserKey, value, false);
 
     fireEvent();
   }

--- a/flutter-idea/src/io/flutter/utils/JxBrowserUtils.java
+++ b/flutter-idea/src/io/flutter/utils/JxBrowserUtils.java
@@ -7,7 +7,6 @@ package io.flutter.utils;
 
 import com.intellij.openapi.util.SystemInfo;
 import io.flutter.settings.FlutterSettings;
-import io.flutter.view.EmbeddedJcefBrowser;
 import org.jetbrains.annotations.NotNull;
 // import com.intellij.util.system.CpuArch;
 
@@ -89,6 +88,6 @@ public class JxBrowserUtils {
 
 
   public boolean skipInstallation() {
-    return EmbeddedJcefBrowser.isUsable();
+    return FlutterSettings.getInstance().isEnableJcefBrowser();
   }
 }

--- a/flutter-idea/src/io/flutter/view/EmbeddedJcefBrowser.java
+++ b/flutter-idea/src/io/flutter/view/EmbeddedJcefBrowser.java
@@ -42,7 +42,6 @@ class EmbeddedJcefBrowserTab implements EmbeddedTab {
 
 public class EmbeddedJcefBrowser extends EmbeddedBrowser {
   private static final Logger LOG = Logger.getInstance(JxBrowserManager.class);
-  private static Boolean jcefIsUsable = null;
 
   public EmbeddedJcefBrowser(Project project) {
     super(project);
@@ -51,20 +50,6 @@ public class EmbeddedJcefBrowser extends EmbeddedBrowser {
   @NotNull
   public static EmbeddedJcefBrowser getInstance(Project project) {
     return ServiceManager.getService(project, EmbeddedJcefBrowser.class);
-  }
-
-  public static boolean isUsable() {
-    if (jcefIsUsable != null) return jcefIsUsable;
-
-    try {
-      new JBCefBrowser();
-    }
-    catch (IllegalStateException e) {
-      jcefIsUsable = false;
-      return false;
-    }
-    jcefIsUsable = true;
-    return true;
   }
 
   public Logger logger() {

--- a/flutter-idea/src/io/flutter/view/FlutterView.java
+++ b/flutter-idea/src/io/flutter/view/FlutterView.java
@@ -768,7 +768,7 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
   }
 
   private void displayEmbeddedBrowser(FlutterApp app, InspectorService inspectorService, ToolWindow toolWindow, DevToolsIdeFeature ideFeature) {
-    if (EmbeddedJcefBrowser.isUsable()) {
+    if (FlutterSettings.getInstance().isEnableJcefBrowser()) {
       presentDevTools(app, inspectorService, toolWindow, true, ideFeature);
     } else {
       displayEmbeddedBrowserIfJxBrowser(app, inspectorService, toolWindow, ideFeature);

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -49,7 +49,6 @@
 <h1>78.2, 78.3</h1>
 <ul>
   <li>Fix debugger variable information (#7228)</li>
-  <li>Make JX Browser the fallback and remove settings option (#7232)</li>
 </ul>
 <h1>78, 78.1</h1>
 <ul>


### PR DESCRIPTION
This reverts commit d5a941c302eed420c22c590350bdaa0ddde79978.

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
