### PR TITLE
changed the depreciated JxBrowser link in flutter JetBrains plugin documentation

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -13,7 +13,7 @@
     JxBrowser complies with LGPL and offers an option to replace Chromium with another component.
     To do this:</p>
     <li>Find the JxBrowser files stored in the <a href="https://www.jetbrains.com/help/idea/tuning-the-ide.html?_ga=2.242942337.2083770720.1598541288-1470153005.1588544220#plugins-directory">plugins directory</a>, under /flutter-intellij/jxbrowser.</li>
-    <li>Use the instructions and build script <a href="https://cloud.teamdev.com/downloads/jxbrowser/7.10/jxbrowser-7.10-relink.zip">from JxBrowser</a> to relink it with modified components.</li>
+    <li>Use the instructions and build script <a href="https://teamdev.com/jxbrowser/lgpl-compliance/#source-code">from JxBrowser</a> to relink it with modified components.</li>
     ]]>
   </description>
   <!--suppress PluginXmlValidity -->

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -13,7 +13,7 @@
     JxBrowser complies with LGPL and offers an option to replace Chromium with another component.
     To do this:</p>
     <li>Find the JxBrowser files stored in the <a href="https://www.jetbrains.com/help/idea/tuning-the-ide.html?_ga=2.242942337.2083770720.1598541288-1470153005.1588544220#plugins-directory">plugins directory</a>, under /flutter-intellij/jxbrowser.</li>
-    <li>Use the instructions and build script <a href="https://teamdev.com/jxbrowser/lgpl-compliance/#source-code">from JxBrowser</a> to relink it with modified components.</li>
+    <li>The LGPL requirements are at <a href="https://teamdev.com/jxbrowser/lgpl-compliance/#source-code">from JxBrowser</a>, here you can also download the build script to relink with modified components.</li>
     ]]>
   </description>
   <!--suppress PluginXmlValidity -->

--- a/resources/META-INF/plugin_template.xml
+++ b/resources/META-INF/plugin_template.xml
@@ -11,7 +11,7 @@
     JxBrowser complies with LGPL and offers an option to replace Chromium with another component.
     To do this:</p>
     <li>Find the JxBrowser files stored in the <a href="https://www.jetbrains.com/help/idea/tuning-the-ide.html?_ga=2.242942337.2083770720.1598541288-1470153005.1588544220#plugins-directory">plugins directory</a>, under /flutter-intellij/jxbrowser.</li>
-    <li>Use the instructions and build script <a href="https://teamdev.com/jxbrowser/lgpl-compliance/#source-code">from JxBrowser</a> to relink it with modified components.</li>
+    <li>The LGPL requirements are at <a href="https://teamdev.com/jxbrowser/lgpl-compliance/#source-code">from JxBrowser</a>, here you can also download the build script to relink with modified components.</li>
     ]]>
   </description>
   <!--suppress PluginXmlValidity -->

--- a/resources/META-INF/plugin_template.xml
+++ b/resources/META-INF/plugin_template.xml
@@ -11,7 +11,7 @@
     JxBrowser complies with LGPL and offers an option to replace Chromium with another component.
     To do this:</p>
     <li>Find the JxBrowser files stored in the <a href="https://www.jetbrains.com/help/idea/tuning-the-ide.html?_ga=2.242942337.2083770720.1598541288-1470153005.1588544220#plugins-directory">plugins directory</a>, under /flutter-intellij/jxbrowser.</li>
-    <li>Use the instructions and build script <a href="https://cloud.teamdev.com/downloads/jxbrowser/7.10/jxbrowser-7.10-relink.zip">from JxBrowser</a> to relink it with modified components.</li>
+    <li>Use the instructions and build script <a href="https://teamdev.com/jxbrowser/lgpl-compliance/#source-code">from JxBrowser</a> to relink it with modified components.</li>
     ]]>
   </description>
   <!--suppress PluginXmlValidity -->


### PR DESCRIPTION
Updated the link in plugin.xml (and plugin_template.xml) to the updated link from issue #7271. This allows users to access the current source code and removes the depreciated link.  

Addresses issue #7271 

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
