### PR TITLE
Change the git clone to sync to the stable branch and only to download the single (stable) branch

### DIFF
--- a/tool/github.sh
+++ b/tool/github.sh
@@ -12,6 +12,7 @@ export JAVA_HOME=$JAVA_HOME_17_X64
 git clone --depth 1 https://github.com/flutter/flutter.git ../flutter
 export PATH="$PATH":`pwd`/../flutter/bin:`pwd`/../flutter/bin/cache/dart-sdk/bin
 flutter config --no-analytics
+flutter channel beta
 flutter doctor
 export FLUTTER_SDK=`pwd`/../flutter
 

--- a/tool/github.sh
+++ b/tool/github.sh
@@ -9,10 +9,10 @@ set -e
 
 export JAVA_HOME=$JAVA_HOME_17_X64
 
-git clone --depth 1 https://github.com/flutter/flutter.git ../flutter
+# Clone and configure Flutter to the latest stable release
+git clone --depth 1 -b stable --single-branch https://github.com/flutter/flutter.git ../flutter
 export PATH="$PATH":`pwd`/../flutter/bin:`pwd`/../flutter/bin/cache/dart-sdk/bin
 flutter config --no-analytics
-flutter channel beta
 flutter doctor
 export FLUTTER_SDK=`pwd`/../flutter
 

--- a/tool/kokoro/setup.sh
+++ b/tool/kokoro/setup.sh
@@ -23,6 +23,7 @@ setup() {
   git clone --depth 1 https://github.com/flutter/flutter.git ../flutter
   export PATH="$PATH":`pwd`/../flutter/bin:`pwd`/../flutter/bin/cache/dart-sdk/bin
   flutter config --no-analytics
+  flutter channel beta
   flutter doctor
   export FLUTTER_SDK=`pwd`/../flutter
 

--- a/tool/kokoro/setup.sh
+++ b/tool/kokoro/setup.sh
@@ -19,14 +19,13 @@ setup() {
   echo "JAVA_HOME=$JAVA_HOME"
   java -version
 
-  # If we move to branch-based builds we might not be able to use such a shallow clone.
-  git clone --depth 1 https://github.com/flutter/flutter.git ../flutter
+  # Clone and configure Flutter to the latest stable release
+  git clone --depth 1 -b stable --single-branch https://github.com/flutter/flutter.git ../flutter
   export PATH="$PATH":`pwd`/../flutter/bin:`pwd`/../flutter/bin/cache/dart-sdk/bin
   flutter config --no-analytics
-  flutter channel beta
   flutter doctor
-  export FLUTTER_SDK=`pwd`/../flutter
 
+  export FLUTTER_SDK=`pwd`/../flutter
   export FLUTTER_KEYSTORE_ID=74840
   export FLUTTER_KEYSTORE_NAME=flutter-intellij-plugin-auth-token
   export FLUTTER_KEYSTORE_JXBROWSER_KEY_NAME=flutter-intellij-plugin-jxbrowser-license-key


### PR DESCRIPTION
This will prevent Flutter IJ work if the master branch gets into a state that the master branch can't build the cli tool.