### PR TITLE
Change the deprecated JX browser link

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -13,7 +13,7 @@
     JxBrowser complies with LGPL and offers an option to replace Chromium with another component.
     To do this:</p>
     <li>Find the JxBrowser files stored in the <a href="https://www.jetbrains.com/help/idea/tuning-the-ide.html?_ga=2.242942337.2083770720.1598541288-1470153005.1588544220#plugins-directory">plugins directory</a>, under /flutter-intellij/jxbrowser.</li>
-    <li>Use the instructions and build script <a href="https://cloud.teamdev.com/downloads/jxbrowser/7.10/jxbrowser-7.10-relink.zip">from JxBrowser</a> to relink it with modified components.</li>
+    <li>The LGPL requirements are at <a href="https://teamdev.com/jxbrowser/lgpl-compliance/#source-code">from JxBrowser</a>, here you can also download the build script to relink with modified components.</li>
     ]]>
   </description>
   <!--suppress PluginXmlValidity -->

--- a/resources/META-INF/plugin_template.xml
+++ b/resources/META-INF/plugin_template.xml
@@ -11,7 +11,7 @@
     JxBrowser complies with LGPL and offers an option to replace Chromium with another component.
     To do this:</p>
     <li>Find the JxBrowser files stored in the <a href="https://www.jetbrains.com/help/idea/tuning-the-ide.html?_ga=2.242942337.2083770720.1598541288-1470153005.1588544220#plugins-directory">plugins directory</a>, under /flutter-intellij/jxbrowser.</li>
-    <li>Use the instructions and build script <a href="https://cloud.teamdev.com/downloads/jxbrowser/7.10/jxbrowser-7.10-relink.zip">from JxBrowser</a> to relink it with modified components.</li>
+    <li>The LGPL requirements are at <a href="https://teamdev.com/jxbrowser/lgpl-compliance/#source-code">from JxBrowser</a>, here you can also download the build script to relink with modified components.</li>
     ]]>
   </description>
   <!--suppress PluginXmlValidity -->


### PR DESCRIPTION
I copied over changes from https://github.com/flutter/flutter-intellij/pull/7274 so that we would have signed commits.