### PR TITLE
Remove unused inspector service from jxbrowser functions

### DIFF
--- a/flutter-idea/src/io/flutter/view/FlutterView.java
+++ b/flutter-idea/src/io/flutter/view/FlutterView.java
@@ -253,7 +253,6 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
   }
 
   private void addBrowserInspectorViewContent(FlutterApp app,
-                                              @Nullable InspectorService inspectorService,
                                               ToolWindow toolWindow,
                                               boolean isEmbedded,
                                               DevToolsIdeFeature ideFeature,
@@ -299,7 +298,7 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
           // If the embedded browser doesn't work, offer a link to open in the regular browser.
           final List<LabelInput> inputs = Arrays.asList(
             new LabelInput("The embedded browser failed to load. Error: " + error),
-            openDevToolsLabel(app, inspectorService, toolWindow, ideFeature)
+            openDevToolsLabel(app, toolWindow, ideFeature)
           );
           presentClickableLabel(toolWindow, inputs);
         }));
@@ -501,19 +500,19 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
     }
   }
 
-  protected void handleJxBrowserInstalled(FlutterApp app, InspectorService inspectorService, ToolWindow toolWindow, DevToolsIdeFeature ideFeature) {
-    presentDevTools(app, inspectorService, toolWindow, true, ideFeature);
+  protected void handleJxBrowserInstalled(FlutterApp app, ToolWindow toolWindow, DevToolsIdeFeature ideFeature) {
+    presentDevTools(app, toolWindow, true, ideFeature);
   }
 
-  private void presentDevTools(FlutterApp app, InspectorService inspectorService, ToolWindow toolWindow, boolean isEmbedded, DevToolsIdeFeature ideFeature) {
+  private void presentDevTools(FlutterApp app, ToolWindow toolWindow, boolean isEmbedded, DevToolsIdeFeature ideFeature) {
     verifyEventDispatchThread();
 
     devToolsInstallCount += 1;
     presentLabel(toolWindow, getInstallingDevtoolsLabel());
 
-    openInspectorWithDevTools(app, inspectorService, toolWindow, isEmbedded, ideFeature);
+    openInspectorWithDevTools(app, toolWindow, isEmbedded, ideFeature);
 
-    setUpToolWindowListener(app, inspectorService, toolWindow, isEmbedded, ideFeature);
+    setUpToolWindowListener(app, toolWindow, isEmbedded, ideFeature);
   }
 
   @VisibleForTesting
@@ -522,14 +521,14 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
   }
 
   @VisibleForTesting
-  protected void setUpToolWindowListener(FlutterApp app, InspectorService inspectorService, ToolWindow toolWindow, boolean isEmbedded, DevToolsIdeFeature ideFeature) {
+  protected void setUpToolWindowListener(FlutterApp app, ToolWindow toolWindow, boolean isEmbedded, DevToolsIdeFeature ideFeature) {
     if (this.toolWindowListener == null) {
       this.toolWindowListener = new FlutterViewToolWindowManagerListener(myProject, toolWindow);
     }
     this.toolWindowListener.updateOnWindowOpen(() -> {
       devToolsInstallCount += 1;
       presentLabel(toolWindow, getInstallingDevtoolsLabel());
-      openInspectorWithDevTools(app, inspectorService, toolWindow, isEmbedded, ideFeature, true);
+      openInspectorWithDevTools(app, toolWindow, isEmbedded, ideFeature, true);
     });
   }
 
@@ -539,12 +538,11 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
   }
 
   @VisibleForTesting
-  protected void openInspectorWithDevTools(FlutterApp app, InspectorService inspectorService, ToolWindow toolWindow, boolean isEmbedded, DevToolsIdeFeature ideFeature) {
-    openInspectorWithDevTools(app, inspectorService, toolWindow, isEmbedded, ideFeature, false);
+  protected void openInspectorWithDevTools(FlutterApp app, ToolWindow toolWindow, boolean isEmbedded, DevToolsIdeFeature ideFeature) {
+    openInspectorWithDevTools(app, toolWindow, isEmbedded, ideFeature, false);
   }
 
   private void openInspectorWithDevTools(FlutterApp app,
-                                           InspectorService inspectorService,
                                            ToolWindow toolWindow,
                                            boolean isEmbedded,
                                            DevToolsIdeFeature ideFeature,
@@ -571,45 +569,45 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
           return;
         }
 
-        addBrowserInspectorViewContent(app, inspectorService, toolWindow, isEmbedded, ideFeature, instance);
+        addBrowserInspectorViewContent(app, toolWindow, isEmbedded, ideFeature, instance);
       }
     );
   }
 
-  private LabelInput openDevToolsLabel(FlutterApp app, InspectorService inspectorService, ToolWindow toolWindow, DevToolsIdeFeature ideFeature) {
+  private LabelInput openDevToolsLabel(FlutterApp app, ToolWindow toolWindow, DevToolsIdeFeature ideFeature) {
     return new LabelInput("Open DevTools in the browser?", (linkLabel, data) -> {
-      presentDevTools(app, inspectorService, toolWindow, false, ideFeature);
+      presentDevTools(app, toolWindow, false, ideFeature);
     });
   }
 
-  protected void handleJxBrowserInstallationInProgress(FlutterApp app, InspectorService inspectorService, ToolWindow toolWindow,
+  protected void handleJxBrowserInstallationInProgress(FlutterApp app, ToolWindow toolWindow,
                                                        DevToolsIdeFeature ideFeature) {
-    presentOpenDevToolsOptionWithMessage(app, inspectorService, toolWindow, INSTALLATION_IN_PROGRESS_LABEL, ideFeature);
+    presentOpenDevToolsOptionWithMessage(app, toolWindow, INSTALLATION_IN_PROGRESS_LABEL, ideFeature);
 
     if (jxBrowserManager.getStatus().equals(JxBrowserStatus.INSTALLED)) {
-      handleJxBrowserInstalled(app, inspectorService, toolWindow, ideFeature);
+      handleJxBrowserInstalled(app, toolWindow, ideFeature);
     }
     else {
-      startJxBrowserInstallationWaitingThread(app, inspectorService, toolWindow, ideFeature);
+      startJxBrowserInstallationWaitingThread(app, toolWindow, ideFeature);
     }
   }
 
-  protected void startJxBrowserInstallationWaitingThread(FlutterApp app, InspectorService inspectorService, ToolWindow toolWindow,
+  protected void startJxBrowserInstallationWaitingThread(FlutterApp app, ToolWindow toolWindow,
                                                          DevToolsIdeFeature ideFeature) {
     ApplicationManager.getApplication().executeOnPooledThread(() -> {
-      waitForJxBrowserInstallation(app, inspectorService, toolWindow, ideFeature);
+      waitForJxBrowserInstallation(app, toolWindow, ideFeature);
     });
   }
 
-  protected void waitForJxBrowserInstallation(FlutterApp app, InspectorService inspectorService, ToolWindow toolWindow,
+  protected void waitForJxBrowserInstallation(FlutterApp app, ToolWindow toolWindow,
                                               DevToolsIdeFeature ideFeature) {
     try {
       final JxBrowserStatus newStatus = jxBrowserManager.waitForInstallation(INSTALLATION_WAIT_LIMIT_SECONDS);
 
-      handleUpdatedJxBrowserStatusOnEventThread(app, inspectorService, toolWindow, newStatus, ideFeature);
+      handleUpdatedJxBrowserStatusOnEventThread(app, toolWindow, newStatus, ideFeature);
     }
     catch (TimeoutException e) {
-      presentOpenDevToolsOptionWithMessage(app, inspectorService, toolWindow, INSTALLATION_TIMED_OUT_LABEL, ideFeature);
+      presentOpenDevToolsOptionWithMessage(app, toolWindow, INSTALLATION_TIMED_OUT_LABEL, ideFeature);
 
       FlutterInitializer.getAnalytics().sendEvent(JxBrowserManager.ANALYTICS_CATEGORY, "timedOut");
     }
@@ -617,33 +615,31 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
 
   protected void handleUpdatedJxBrowserStatusOnEventThread(
           FlutterApp app,
-          InspectorService inspectorService,
           ToolWindow toolWindow,
           JxBrowserStatus jxBrowserStatus,
           DevToolsIdeFeature ideFeature) {
-    AsyncUtils.invokeLater(() -> handleUpdatedJxBrowserStatus(app, inspectorService, toolWindow, jxBrowserStatus, ideFeature));
+    AsyncUtils.invokeLater(() -> handleUpdatedJxBrowserStatus(app, toolWindow, jxBrowserStatus, ideFeature));
   }
 
   protected void handleUpdatedJxBrowserStatus(
           FlutterApp app,
-          InspectorService inspectorService,
           ToolWindow toolWindow,
           JxBrowserStatus jxBrowserStatus,
           DevToolsIdeFeature ideFeature) {
     if (jxBrowserStatus.equals(JxBrowserStatus.INSTALLED)) {
-      handleJxBrowserInstalled(app, inspectorService, toolWindow, ideFeature);
+      handleJxBrowserInstalled(app, toolWindow, ideFeature);
     } else if (jxBrowserStatus.equals(JxBrowserStatus.INSTALLATION_FAILED)) {
-      handleJxBrowserInstallationFailed(app, inspectorService, toolWindow, ideFeature);
+      handleJxBrowserInstallationFailed(app, toolWindow, ideFeature);
     } else {
       // newStatus can be null if installation is interrupted or stopped for another reason.
-      presentOpenDevToolsOptionWithMessage(app, inspectorService, toolWindow, INSTALLATION_WAIT_FAILED, ideFeature);
+      presentOpenDevToolsOptionWithMessage(app, toolWindow, INSTALLATION_WAIT_FAILED, ideFeature);
     }
   }
 
-  protected void handleJxBrowserInstallationFailed(FlutterApp app, InspectorService inspectorService, ToolWindow toolWindow,
+  protected void handleJxBrowserInstallationFailed(FlutterApp app, ToolWindow toolWindow,
                                                    DevToolsIdeFeature ideFeature) {
     final List<LabelInput> inputs = new ArrayList<>();
-    final LabelInput openDevToolsLabel = openDevToolsLabel(app, inspectorService, toolWindow, ideFeature);
+    final LabelInput openDevToolsLabel = openDevToolsLabel(app, toolWindow, ideFeature);
 
     final InstallationFailedReason latestFailureReason = jxBrowserManager.getLatestFailureReason();
 
@@ -661,7 +657,7 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
       inputs.add(new LabelInput("JxBrowser installation failed."));
       inputs.add(new LabelInput("Retry installation?", (linkLabel, data) -> {
         jxBrowserManager.retryFromFailed(app.getProject());
-        handleJxBrowserInstallationInProgress(app, inspectorService, toolWindow, ideFeature);
+        handleJxBrowserInstallationInProgress(app, toolWindow, ideFeature);
       }));
       inputs.add(openDevToolsLabel);
     }
@@ -699,13 +695,12 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
   }
 
   protected void presentOpenDevToolsOptionWithMessage(FlutterApp app,
-                                                      InspectorService inspectorService,
                                                       ToolWindow toolWindow,
                                                       String message,
                                                       DevToolsIdeFeature ideFeature) {
     final List<LabelInput> inputs = new ArrayList<>();
     inputs.add(new LabelInput(message));
-    inputs.add(openDevToolsLabel(app, inspectorService, toolWindow, ideFeature));
+    inputs.add(openDevToolsLabel(app, toolWindow, ideFeature));
     presentClickableLabel(toolWindow, inputs);
   }
 
@@ -754,7 +749,7 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
     toolWindow.setIcon(ExecutionUtil.getLiveIndicator(FlutterIcons.Flutter_13));
 
     if (toolWindow.isVisible()) {
-      displayEmbeddedBrowser(app, inspectorService, toolWindow, ideFeature.get());
+      displayEmbeddedBrowser(app, toolWindow, ideFeature.get());
     }
     else {
       if (toolWindowListener == null) {
@@ -762,35 +757,35 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
       }
       // If the window isn't visible yet, only executed embedded browser steps when it becomes visible.
       toolWindowListener.updateOnWindowFirstVisible(() -> {
-        displayEmbeddedBrowser(app, inspectorService, toolWindow, DevToolsIdeFeature.TOOL_WINDOW);
+        displayEmbeddedBrowser(app, toolWindow, DevToolsIdeFeature.TOOL_WINDOW);
       });
     }
   }
 
-  private void displayEmbeddedBrowser(FlutterApp app, InspectorService inspectorService, ToolWindow toolWindow, DevToolsIdeFeature ideFeature) {
+  private void displayEmbeddedBrowser(FlutterApp app, ToolWindow toolWindow, DevToolsIdeFeature ideFeature) {
     if (FlutterSettings.getInstance().isEnableJcefBrowser()) {
-      presentDevTools(app, inspectorService, toolWindow, true, ideFeature);
+      presentDevTools(app, toolWindow, true, ideFeature);
     } else {
-      displayEmbeddedBrowserIfJxBrowser(app, inspectorService, toolWindow, ideFeature);
+      displayEmbeddedBrowserIfJxBrowser(app, toolWindow, ideFeature);
     }
   }
 
-  private void displayEmbeddedBrowserIfJxBrowser(FlutterApp app, InspectorService inspectorService, ToolWindow toolWindow,
+  private void displayEmbeddedBrowserIfJxBrowser(FlutterApp app, ToolWindow toolWindow,
                                                  DevToolsIdeFeature ideFeature) {
     final JxBrowserManager manager = jxBrowserManager;
     final JxBrowserStatus jxBrowserStatus = manager.getStatus();
 
     if (jxBrowserStatus.equals(JxBrowserStatus.INSTALLED)) {
-      handleJxBrowserInstalled(app, inspectorService, toolWindow, ideFeature);
+      handleJxBrowserInstalled(app, toolWindow, ideFeature);
     }
     else if (jxBrowserStatus.equals(JxBrowserStatus.INSTALLATION_IN_PROGRESS)) {
-      handleJxBrowserInstallationInProgress(app, inspectorService, toolWindow, ideFeature);
+      handleJxBrowserInstallationInProgress(app, toolWindow, ideFeature);
     }
     else if (jxBrowserStatus.equals(JxBrowserStatus.INSTALLATION_FAILED)) {
-      handleJxBrowserInstallationFailed(app, inspectorService, toolWindow,  ideFeature);
+      handleJxBrowserInstallationFailed(app, toolWindow,  ideFeature);
     } else if (jxBrowserStatus.equals(JxBrowserStatus.NOT_INSTALLED) || jxBrowserStatus.equals(JxBrowserStatus.INSTALLATION_SKIPPED)) {
       manager.setUp(myProject);
-      handleJxBrowserInstallationInProgress(app, inspectorService, toolWindow, ideFeature);
+      handleJxBrowserInstallationInProgress(app, toolWindow, ideFeature);
     }
   }
 

--- a/flutter-idea/testSrc/unit/io/flutter/view/FlutterViewTest.java
+++ b/flutter-idea/testSrc/unit/io/flutter/view/FlutterViewTest.java
@@ -44,11 +44,11 @@ public class FlutterViewTest {
   public void testHandleJxBrowserInstalled() {
     // If JxBrowser has been installed, we should use the DevTools instance to open the embedded browser.
     final FlutterView partialMockFlutterView = mock(FlutterView.class);
-    doCallRealMethod().when(partialMockFlutterView).handleJxBrowserInstalled(mockApp, mockInspectorService, mockToolWindow, DevToolsIdeFeature.TOOL_WINDOW);
+    doCallRealMethod().when(partialMockFlutterView).handleJxBrowserInstalled(mockApp, mockToolWindow, DevToolsIdeFeature.TOOL_WINDOW);
 
-    partialMockFlutterView.handleJxBrowserInstalled(mockApp, mockInspectorService, mockToolWindow, DevToolsIdeFeature.TOOL_WINDOW);
-    verify(partialMockFlutterView, times(1)).openInspectorWithDevTools(mockApp, mockInspectorService, mockToolWindow, true, DevToolsIdeFeature.TOOL_WINDOW);
-    verify(partialMockFlutterView, times(1)).setUpToolWindowListener(mockApp, mockInspectorService, mockToolWindow, true, DevToolsIdeFeature.TOOL_WINDOW);
+    partialMockFlutterView.handleJxBrowserInstalled(mockApp, mockToolWindow, DevToolsIdeFeature.TOOL_WINDOW);
+    verify(partialMockFlutterView, times(1)).openInspectorWithDevTools(mockApp, mockToolWindow, true, DevToolsIdeFeature.TOOL_WINDOW);
+    verify(partialMockFlutterView, times(1)).setUpToolWindowListener(mockApp, mockToolWindow, true, DevToolsIdeFeature.TOOL_WINDOW);
   }
 
   @Test
@@ -66,7 +66,7 @@ public class FlutterViewTest {
       anyList()
     );
 
-    spy.handleJxBrowserInstallationFailed(mockApp, mockInspectorService, mockToolWindow, DevToolsIdeFeature.TOOL_WINDOW);
+    spy.handleJxBrowserInstallationFailed(mockApp, mockToolWindow, DevToolsIdeFeature.TOOL_WINDOW);
     verify(spy, times(1)).presentClickableLabel(
       eq(mockToolWindow),
       anyList()
@@ -82,13 +82,13 @@ public class FlutterViewTest {
     final FlutterView flutterView = new FlutterView(mockProject, mockJxBrowserManager, mockUtils, mockInspectorGroupManagerService, mockBusConnection);
     final FlutterView spy = spy(flutterView);
 
-    doNothing().when(spy).presentOpenDevToolsOptionWithMessage(any(), any(), any(), any(), any());
-    doNothing().when(spy).handleJxBrowserInstalled(any(), any(), any(), any());
+    doNothing().when(spy).presentOpenDevToolsOptionWithMessage(any(), any(), any(), any());
+    doNothing().when(spy).handleJxBrowserInstalled(any(), any(), any());
 
-    spy.handleJxBrowserInstallationInProgress(mockApp, mockInspectorService, mockToolWindow, DevToolsIdeFeature.TOOL_WINDOW);
+    spy.handleJxBrowserInstallationInProgress(mockApp, mockToolWindow, DevToolsIdeFeature.TOOL_WINDOW);
     verify(spy, times(1))
-      .presentOpenDevToolsOptionWithMessage(mockApp, mockInspectorService, mockToolWindow, INSTALLATION_IN_PROGRESS_LABEL, DevToolsIdeFeature.TOOL_WINDOW);
-    verify(spy, times(1)).handleJxBrowserInstalled(mockApp, mockInspectorService, mockToolWindow, DevToolsIdeFeature.TOOL_WINDOW);
+      .presentOpenDevToolsOptionWithMessage(mockApp, mockToolWindow, INSTALLATION_IN_PROGRESS_LABEL, DevToolsIdeFeature.TOOL_WINDOW);
+    verify(spy, times(1)).handleJxBrowserInstalled(mockApp, mockToolWindow, DevToolsIdeFeature.TOOL_WINDOW);
   }
 
   @Test
@@ -100,13 +100,13 @@ public class FlutterViewTest {
     final FlutterView flutterView = new FlutterView(mockProject, mockJxBrowserManager, mockUtils, mockInspectorGroupManagerService, mockBusConnection);
     final FlutterView spy = spy(flutterView);
 
-    doNothing().when(spy).presentOpenDevToolsOptionWithMessage(any(), any(), any(), any(), any());
-    doNothing().when(spy).startJxBrowserInstallationWaitingThread(any(), any(), any(), any());
+    doNothing().when(spy).presentOpenDevToolsOptionWithMessage(any(), any(), any(), any());
+    doNothing().when(spy).startJxBrowserInstallationWaitingThread(any(), any(), any());
 
-    spy.handleJxBrowserInstallationInProgress(mockApp, mockInspectorService, mockToolWindow, DevToolsIdeFeature.TOOL_WINDOW);
+    spy.handleJxBrowserInstallationInProgress(mockApp, mockToolWindow, DevToolsIdeFeature.TOOL_WINDOW);
     verify(spy, times(1))
-      .presentOpenDevToolsOptionWithMessage(mockApp, mockInspectorService, mockToolWindow, INSTALLATION_IN_PROGRESS_LABEL, DevToolsIdeFeature.TOOL_WINDOW);
-    verify(spy, times(1)).startJxBrowserInstallationWaitingThread(mockApp, mockInspectorService, mockToolWindow, DevToolsIdeFeature.TOOL_WINDOW);
+      .presentOpenDevToolsOptionWithMessage(mockApp, mockToolWindow, INSTALLATION_IN_PROGRESS_LABEL, DevToolsIdeFeature.TOOL_WINDOW);
+    verify(spy, times(1)).startJxBrowserInstallationWaitingThread(mockApp, mockToolWindow, DevToolsIdeFeature.TOOL_WINDOW);
   }
 
   @Test
@@ -118,11 +118,11 @@ public class FlutterViewTest {
     final FlutterView flutterView = new FlutterView(mockProject, mockJxBrowserManager, mockUtils, mockInspectorGroupManagerService, mockBusConnection);
     final FlutterView spy = spy(flutterView);
 
-    doNothing().when(spy).handleUpdatedJxBrowserStatusOnEventThread(any(), any(), any(), any(), any());
+    doNothing().when(spy).handleUpdatedJxBrowserStatusOnEventThread(any(), any(), any(), any());
 
-    spy.waitForJxBrowserInstallation(mockApp, mockInspectorService, mockToolWindow, DevToolsIdeFeature.TOOL_WINDOW);
+    spy.waitForJxBrowserInstallation(mockApp, mockToolWindow, DevToolsIdeFeature.TOOL_WINDOW);
     verify(spy, times(1))
-      .handleUpdatedJxBrowserStatusOnEventThread(mockApp, mockInspectorService, mockToolWindow, JxBrowserStatus.INSTALLATION_FAILED, DevToolsIdeFeature.TOOL_WINDOW);
+      .handleUpdatedJxBrowserStatusOnEventThread(mockApp, mockToolWindow, JxBrowserStatus.INSTALLATION_FAILED, DevToolsIdeFeature.TOOL_WINDOW);
   }
 
   @Ignore
@@ -135,11 +135,11 @@ public class FlutterViewTest {
     final FlutterView flutterView = new FlutterView(mockProject, mockJxBrowserManager, mockUtils, mockInspectorGroupManagerService, mockBusConnection);
     final FlutterView spy = spy(flutterView);
 
-    doNothing().when(spy).presentOpenDevToolsOptionWithMessage(any(), any(), any(), any(), any());
+    doNothing().when(spy).presentOpenDevToolsOptionWithMessage(any(), any(), any(), any());
 
-    spy.waitForJxBrowserInstallation(mockApp, mockInspectorService, mockToolWindow, DevToolsIdeFeature.TOOL_WINDOW);
+    spy.waitForJxBrowserInstallation(mockApp, mockToolWindow, DevToolsIdeFeature.TOOL_WINDOW);
     verify(spy, times(1))
-      .presentOpenDevToolsOptionWithMessage(mockApp, mockInspectorService, mockToolWindow, INSTALLATION_TIMED_OUT_LABEL, DevToolsIdeFeature.TOOL_WINDOW);
+      .presentOpenDevToolsOptionWithMessage(mockApp, mockToolWindow, INSTALLATION_TIMED_OUT_LABEL, DevToolsIdeFeature.TOOL_WINDOW);
   }
 
   @Test
@@ -147,9 +147,9 @@ public class FlutterViewTest {
     // If waiting for JxBrowser installation completes with failure, then we should redirect to the function that handles failure.
     final FlutterView partialMockFlutterView = mock(FlutterView.class);
     doCallRealMethod().when(partialMockFlutterView)
-      .handleUpdatedJxBrowserStatus(mockApp, mockInspectorService, mockToolWindow, JxBrowserStatus.INSTALLATION_FAILED, DevToolsIdeFeature.TOOL_WINDOW);
-    partialMockFlutterView.handleUpdatedJxBrowserStatus(mockApp, mockInspectorService, mockToolWindow, JxBrowserStatus.INSTALLATION_FAILED, DevToolsIdeFeature.TOOL_WINDOW);
-    verify(partialMockFlutterView, times(1)).handleJxBrowserInstallationFailed(mockApp, mockInspectorService, mockToolWindow, DevToolsIdeFeature.TOOL_WINDOW);
+      .handleUpdatedJxBrowserStatus(mockApp, mockToolWindow, JxBrowserStatus.INSTALLATION_FAILED, DevToolsIdeFeature.TOOL_WINDOW);
+    partialMockFlutterView.handleUpdatedJxBrowserStatus(mockApp, mockToolWindow, JxBrowserStatus.INSTALLATION_FAILED, DevToolsIdeFeature.TOOL_WINDOW);
+    verify(partialMockFlutterView, times(1)).handleJxBrowserInstallationFailed(mockApp, mockToolWindow, DevToolsIdeFeature.TOOL_WINDOW);
   }
 
   @Test
@@ -157,9 +157,9 @@ public class FlutterViewTest {
     // If waiting for JxBrowser installation completes with failure, then we should redirect to the function that handles failure.
     final FlutterView partialMockFlutterView = mock(FlutterView.class);
     doCallRealMethod().when(partialMockFlutterView)
-      .handleUpdatedJxBrowserStatus(mockApp, mockInspectorService, mockToolWindow, JxBrowserStatus.INSTALLED, DevToolsIdeFeature.TOOL_WINDOW);
-    partialMockFlutterView.handleUpdatedJxBrowserStatus(mockApp, mockInspectorService, mockToolWindow, JxBrowserStatus.INSTALLED, DevToolsIdeFeature.TOOL_WINDOW);
-    verify(partialMockFlutterView, times(1)).handleJxBrowserInstalled(mockApp, mockInspectorService, mockToolWindow, DevToolsIdeFeature.TOOL_WINDOW);
+      .handleUpdatedJxBrowserStatus(mockApp, mockToolWindow, JxBrowserStatus.INSTALLED, DevToolsIdeFeature.TOOL_WINDOW);
+    partialMockFlutterView.handleUpdatedJxBrowserStatus(mockApp, mockToolWindow, JxBrowserStatus.INSTALLED, DevToolsIdeFeature.TOOL_WINDOW);
+    verify(partialMockFlutterView, times(1)).handleJxBrowserInstalled(mockApp, mockToolWindow, DevToolsIdeFeature.TOOL_WINDOW);
   }
 
   @Test
@@ -167,9 +167,9 @@ public class FlutterViewTest {
     // If waiting for JxBrowser installation completes with any other status, then we should recommend opening non-embedded DevTools.
     final FlutterView partialMockFlutterView = mock(FlutterView.class);
     doCallRealMethod().when(partialMockFlutterView)
-      .handleUpdatedJxBrowserStatus(mockApp, mockInspectorService, mockToolWindow, JxBrowserStatus.NOT_INSTALLED, DevToolsIdeFeature.TOOL_WINDOW);
-    partialMockFlutterView.handleUpdatedJxBrowserStatus(mockApp, mockInspectorService, mockToolWindow, JxBrowserStatus.NOT_INSTALLED, DevToolsIdeFeature.TOOL_WINDOW);
+      .handleUpdatedJxBrowserStatus(mockApp, mockToolWindow, JxBrowserStatus.NOT_INSTALLED, DevToolsIdeFeature.TOOL_WINDOW);
+    partialMockFlutterView.handleUpdatedJxBrowserStatus(mockApp, mockToolWindow, JxBrowserStatus.NOT_INSTALLED, DevToolsIdeFeature.TOOL_WINDOW);
     verify(partialMockFlutterView, times(1))
-      .presentOpenDevToolsOptionWithMessage(mockApp, mockInspectorService, mockToolWindow, INSTALLATION_WAIT_FAILED, DevToolsIdeFeature.TOOL_WINDOW);
+      .presentOpenDevToolsOptionWithMessage(mockApp, mockToolWindow, INSTALLATION_WAIT_FAILED, DevToolsIdeFeature.TOOL_WINDOW);
   }
 }


### PR DESCRIPTION
This is a refactor while working on adding a deep links panel. It seems that the `FlutterView` class is passing around `inspectorService` in a lot of places, but I don't see it being used.