### PR TITLE
Add separate browser windows and save content manager

### DIFF
--- a/flutter-idea/src/io/flutter/deeplinks/DeepLinksViewFactory.java
+++ b/flutter-idea/src/io/flutter/deeplinks/DeepLinksViewFactory.java
@@ -19,7 +19,6 @@ import io.flutter.devtools.DevToolsUrl;
 import io.flutter.run.daemon.DevToolsService;
 import io.flutter.sdk.FlutterSdk;
 import io.flutter.sdk.FlutterSdkVersion;
-import io.flutter.settings.FlutterSettings;
 import io.flutter.utils.AsyncUtils;
 import org.jetbrains.annotations.NotNull;
 
@@ -64,7 +63,7 @@ public class DeepLinksViewFactory implements ToolWindowFactory {
 
           ApplicationManager.getApplication().invokeLater(() -> {
             Optional.ofNullable(
-              FlutterUtils.embeddedBrowser(project)).ifPresent(embeddedBrowser -> embeddedBrowser.openPanel(contentManager, "Deep Links", devToolsUrl, (String err) -> {
+              FlutterUtils.embeddedBrowser(project)).ifPresent(embeddedBrowser -> embeddedBrowser.openPanel(toolWindow, "Deep Links", devToolsUrl, (String err) -> {
               System.out.println(err);
             }));
           });

--- a/flutter-idea/src/io/flutter/view/EmbeddedJcefBrowser.java
+++ b/flutter-idea/src/io/flutter/view/EmbeddedJcefBrowser.java
@@ -57,7 +57,7 @@ public class EmbeddedJcefBrowser extends EmbeddedBrowser {
   }
 
   @Override
-  public EmbeddedTab openEmbeddedTab() throws Exception {
+  public EmbeddedTab openEmbeddedTab(ContentManager contentManager) throws Exception {
     return new EmbeddedJcefBrowserTab();
   }
 }

--- a/flutter-idea/src/io/flutter/view/FlutterView.java
+++ b/flutter-idea/src/io/flutter/view/FlutterView.java
@@ -294,7 +294,7 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
 
       //noinspection CodeBlock2Expr
       ApplicationManager.getApplication().invokeLater(() -> {
-        embeddedBrowserOptional().ifPresent(embeddedBrowser -> embeddedBrowser.openPanel(contentManager, tabName, devToolsUrl, (String error) -> {
+        embeddedBrowserOptional().ifPresent(embeddedBrowser -> embeddedBrowser.openPanel(toolWindow, tabName, devToolsUrl, (String error) -> {
           // If the embedded browser doesn't work, offer a link to open in the regular browser.
           final List<LabelInput> inputs = Arrays.asList(
             new LabelInput("The embedded browser failed to load. Error: " + error),


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter-intellij/issues/7323

There's some code in embedded browser to manage showing multiple tabs in one window for the situation where a user is running multiple apps and wants to see the inspector for each of those apps, but it was also pushing the deep links tab into the inspector window because I hadn't differentiated windows.

I also added specification of content manager for each tab. I don't know if this is truly necessary given that the content manager is only used when first displaying the content, but this seems more correct.


Uploading deep_links_and_inspector.mp4…

