### PR TITLE
Declare ActionUpdateThread as EDT for RunFlutterAction

### DIFF
--- a/flutter-idea/src/io/flutter/actions/RunFlutterAction.java
+++ b/flutter-idea/src/io/flutter/actions/RunFlutterAction.java
@@ -13,6 +13,7 @@ import com.intellij.execution.RunnerAndConfigurationSettings;
 import com.intellij.execution.configurations.RunConfiguration;
 import com.intellij.execution.runners.ExecutionEnvironment;
 import com.intellij.execution.runners.ExecutionEnvironmentBuilder;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.project.Project;
@@ -124,6 +125,13 @@ public abstract class RunFlutterAction extends AnAction {
     final RunConfiguration config = settings == null ? null : settings.getConfiguration();
     // TODO(pq): add support for Bazel.
     return config instanceof SdkRunConfig && LaunchState.getRunningAppProcess((SdkRunConfig)config) == null;
+  }
+
+  @Override
+  public @NotNull ActionUpdateThread getActionUpdateThread() {
+    // Since we're modifying presentation in update(), we need to run on the EDT, not BGT
+    // See https://plugins.jetbrains.com/docs/intellij/general-threading-rules.html
+    return ActionUpdateThread.EDT;
   }
 
   @Nullable


### PR DESCRIPTION
From Intellij 2024.1, any actions that doesn't override `getActionUpdateThread` triggers a warning. This is because the default behavior `OLD_EDT` will be removed in the future. To suppress the warning, we need to declare this action as EDT, as it's modifying the presentation in `update()`.

Fixes #7331


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
