### PR TITLE
Fix simplest cases of ActionUpdateThread

### DIFF
--- a/flutter-idea/src/io/flutter/actions/FlutterBuildActionGroup.java
+++ b/flutter-idea/src/io/flutter/actions/FlutterBuildActionGroup.java
@@ -138,6 +138,11 @@ public class FlutterBuildActionGroup extends DefaultActionGroup {
         }
       }
     }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+      return ActionUpdateThread.BGT;
+    }
   }
 
   public static class AAR extends FlutterBuildAction {

--- a/flutter-idea/src/io/flutter/actions/OpenInAppCodeAction.java
+++ b/flutter-idea/src/io/flutter/actions/OpenInAppCodeAction.java
@@ -11,6 +11,7 @@ import com.intellij.execution.process.ColoredProcessHandler;
 import com.intellij.execution.process.ProcessAdapter;
 import com.intellij.execution.process.ProcessEvent;
 import com.intellij.execution.process.ProcessOutputTypes;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.Presentation;
@@ -73,6 +74,10 @@ public class OpenInAppCodeAction extends AnAction {
     }
   }
 
+  @Override
+  public @NotNull ActionUpdateThread getActionUpdateThread() {
+    return ActionUpdateThread.BGT;
+  }
   @Override
   public void actionPerformed(@NotNull AnActionEvent event) {
     final VirtualFile projectFile = findProjectFile(event);

--- a/flutter-idea/src/io/flutter/actions/OpenInXcodeAction.java
+++ b/flutter-idea/src/io/flutter/actions/OpenInXcodeAction.java
@@ -10,10 +10,7 @@ import com.intellij.execution.configurations.GeneralCommandLine;
 import com.intellij.execution.process.ColoredProcessHandler;
 import com.intellij.execution.process.ProcessAdapter;
 import com.intellij.execution.process.ProcessEvent;
-import com.intellij.openapi.actionSystem.AnAction;
-import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.actionSystem.CommonDataKeys;
-import com.intellij.openapi.actionSystem.Presentation;
+import com.intellij.openapi.actionSystem.*;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectUtil;
 import com.intellij.openapi.util.SystemInfo;
@@ -157,6 +154,11 @@ public class OpenInXcodeAction extends AnAction {
       final boolean enabled = findProjectFile(event) != null;
       presentation.setEnabledAndVisible(enabled);
     }
+  }
+
+  @Override
+  public @NotNull ActionUpdateThread getActionUpdateThread() {
+    return ActionUpdateThread.BGT;
   }
 
   @Override

--- a/flutter-idea/src/io/flutter/actions/RunFlutterAction.java
+++ b/flutter-idea/src/io/flutter/actions/RunFlutterAction.java
@@ -13,6 +13,7 @@ import com.intellij.execution.RunnerAndConfigurationSettings;
 import com.intellij.execution.configurations.RunConfiguration;
 import com.intellij.execution.runners.ExecutionEnvironment;
 import com.intellij.execution.runners.ExecutionEnvironmentBuilder;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.project.Project;
@@ -124,6 +125,11 @@ public abstract class RunFlutterAction extends AnAction {
     final RunConfiguration config = settings == null ? null : settings.getConfiguration();
     // TODO(pq): add support for Bazel.
     return config instanceof SdkRunConfig && LaunchState.getRunningAppProcess((SdkRunConfig)config) == null;
+  }
+
+  @Override
+  public @NotNull ActionUpdateThread getActionUpdateThread() {
+    return ActionUpdateThread.BGT;
   }
 
   @Nullable


### PR DESCRIPTION
Partially addresses https://github.com/flutter/flutter-intellij/issues/7330

These are classes where there's clearly no UI manipulations happening in `update` in either the direct classes or inheriting children.