### PR TITLE
Specify BGT updates for device-related actions

### DIFF
--- a/flutter-idea/src/io/flutter/actions/DeviceSelectorAction.java
+++ b/flutter-idea/src/io/flutter/actions/DeviceSelectorAction.java
@@ -234,5 +234,10 @@ public class DeviceSelectorAction extends ComboBoxAction implements DumbAware {
         service.setSelectedDevice(device);
       }
     }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+      return ActionUpdateThread.BGT;
+    }
   }
 }

--- a/flutter-idea/src/io/flutter/actions/OpenEmulatorAction.java
+++ b/flutter-idea/src/io/flutter/actions/OpenEmulatorAction.java
@@ -5,6 +5,7 @@
  */
 package io.flutter.actions;
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.project.Project;
@@ -46,5 +47,10 @@ public class OpenEmulatorAction extends AnAction {
   @Override
   public void actionPerformed(@NotNull AnActionEvent event) {
     emulator.startEmulator();
+  }
+
+  @Override
+  public @NotNull ActionUpdateThread getActionUpdateThread() {
+    return ActionUpdateThread.BGT;
   }
 }

--- a/flutter-idea/src/io/flutter/actions/OpenSimulatorAction.java
+++ b/flutter-idea/src/io/flutter/actions/OpenSimulatorAction.java
@@ -5,6 +5,7 @@
  */
 package io.flutter.actions;
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.project.Project;
@@ -24,6 +25,11 @@ public class OpenSimulatorAction extends AnAction {
   @Override
   public void update(@NotNull AnActionEvent e) {
     e.getPresentation().setEnabled(enabled);
+  }
+
+  @Override
+  public @NotNull ActionUpdateThread getActionUpdateThread() {
+    return ActionUpdateThread.BGT;
   }
 
   @Override

--- a/flutter-idea/src/io/flutter/actions/RestartFlutterDaemonAction.java
+++ b/flutter-idea/src/io/flutter/actions/RestartFlutterDaemonAction.java
@@ -5,11 +5,13 @@
  */
 package io.flutter.actions;
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.project.Project;
 import io.flutter.FlutterInitializer;
 import io.flutter.run.daemon.DeviceService;
+import org.jetbrains.annotations.NotNull;
 
 public class RestartFlutterDaemonAction extends AnAction {
   public RestartFlutterDaemonAction() {
@@ -26,5 +28,10 @@ public class RestartFlutterDaemonAction extends AnAction {
     }
 
     DeviceService.getInstance(project).restart();
+  }
+
+  @Override
+  public @NotNull ActionUpdateThread getActionUpdateThread() {
+    return ActionUpdateThread.BGT;
   }
 }


### PR DESCRIPTION
Partially addresses #7330 

I'm not sure if these are needed since I wasn't seeing the deprecation notice while using the device menu, but I looked through update activities in these classes and it seems safe to make all of these BGT. 

I think there is potentially a bug with emulator options: https://github.com/flutter/flutter-intellij/issues/7409