### PR TITLE
Fix background color

### DIFF
--- a/flutter-idea/src/io/flutter/deeplinks/DeepLinksViewFactory.java
+++ b/flutter-idea/src/io/flutter/deeplinks/DeepLinksViewFactory.java
@@ -10,6 +10,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowFactory;
 import com.intellij.ui.ColorUtil;
+import com.intellij.ui.JBColor;
 import com.intellij.ui.content.Content;
 import com.intellij.ui.content.ContentManager;
 import com.intellij.util.ui.JBUI;
@@ -62,19 +63,15 @@ public class DeepLinksViewFactory implements ToolWindowFactory {
             return;
           }
 
-          final String color = ColorUtil.toHex(UIUtil.getEditorPaneBackground());
-          final DevToolsUrl devToolsUrl = new DevToolsUrl(
-            instance.host,
-            instance.port,
-            null,
-            "deep-links",
-            true,
-            color,
-            UIUtil.getFontSize(UIUtil.FontSize.NORMAL),
-            sdkVersion,
-            WorkspaceCache.getInstance(project),
-            DevToolsIdeFeature.TOOL_WINDOW
-          );
+          final DevToolsUrl devToolsUrl = new DevToolsUrl.Builder()
+            .setDevToolsHost(instance.host)
+            .setDevToolsPort(instance.port)
+            .setPage("deep-links")
+            .setEmbed(true)
+            .setFlutterSdkVersion(sdkVersion)
+            .setWorkspaceCache(WorkspaceCache.getInstance(project))
+            .setIdeFeature(DevToolsIdeFeature.TOOL_WINDOW)
+            .build();
 
           ApplicationManager.getApplication().invokeLater(() -> {
             Optional.ofNullable(

--- a/flutter-idea/src/io/flutter/devtools/DevToolsUrl.java
+++ b/flutter-idea/src/io/flutter/devtools/DevToolsUrl.java
@@ -17,12 +17,13 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class DevToolsUrl {
-  private String devtoolsHost;
-  private int devtoolsPort;
+  private String devToolsHost;
+  private int devToolsPort;
   private String vmServiceUri;
   private String page;
   private boolean embed;
   public String colorHexCode;
+  public Boolean isBright;
   public String widgetId;
   public Float fontSize;
   private final FlutterSdkVersion flutterSdkVersion;
@@ -32,53 +33,128 @@ public class DevToolsUrl {
 
   public final DevToolsIdeFeature ideFeature;
 
-  public DevToolsUrl(String devtoolsHost,
-                     int devtoolsPort,
-                     String vmServiceUri,
-                     String page,
-                     boolean embed,
-                     String colorHexCode,
-                     Float fontSize,
-                     @Nullable FlutterSdkVersion flutterSdkVersion,
-                     WorkspaceCache workspaceCache,
-                     DevToolsIdeFeature ideFeature) {
-    this(devtoolsHost, devtoolsPort, vmServiceUri, page, embed, colorHexCode, fontSize, flutterSdkVersion, workspaceCache, ideFeature, new FlutterSdkUtil());
+  public static class Builder {
+    private String devToolsHost;
+
+    private int devToolsPort;
+    private String vmServiceUri;
+    private String page;
+    private Boolean embed;
+    private String widgetId;
+    private Float fontSize;
+
+    private FlutterSdkVersion flutterSdkVersion;
+    private WorkspaceCache workspaceCache;
+    private DevToolsIdeFeature ideFeature;
+
+    private DevToolsUtils devToolsUtils;
+
+    private FlutterSdkUtil flutterSdkUtil;
+
+    public Builder() {}
+
+    public Builder setDevToolsHost(String devToolsHost) {
+      this.devToolsHost = devToolsHost;
+      return this;
+    }
+
+    public Builder setDevToolsPort(int devToolsPort) {
+      this.devToolsPort = devToolsPort;
+      return this;
+    }
+
+    public Builder setVmServiceUri(String vmServiceUri) {
+      this.vmServiceUri = vmServiceUri;
+      return this;
+    }
+
+    public Builder setPage(String page) {
+      this.page = page;
+      return this;
+    }
+
+    public Builder setEmbed(Boolean embed) {
+      this.embed = embed;
+      return this;
+    }
+
+    public Builder setWidgetId(String widgetId) {
+      this.widgetId = widgetId;
+      return this;
+    }
+
+    public Builder setFontSize(Float fontSize) {
+      this.fontSize = fontSize;
+      return this;
+    }
+
+    public Builder setDevToolsUtils(DevToolsUtils devToolsUtils) {
+      this.devToolsUtils = devToolsUtils;
+      return this;
+    }
+
+    public Builder setFlutterSdkVersion(FlutterSdkVersion sdkVersion) {
+      this.flutterSdkVersion = sdkVersion;
+      return this;
+    }
+
+    public Builder setWorkspaceCache(WorkspaceCache workspaceCache) {
+      this.workspaceCache = workspaceCache;
+      return this;
+    }
+
+    public Builder setIdeFeature(DevToolsIdeFeature ideFeature) {
+      this.ideFeature = ideFeature;
+      return this;
+    }
+
+    public Builder setFlutterSdkUtil(FlutterSdkUtil flutterSdkUtil) {
+      this.flutterSdkUtil = flutterSdkUtil;
+      return this;
+    }
+
+    public DevToolsUrl build() {
+      if (devToolsUtils == null) {
+        devToolsUtils = new DevToolsUtils();
+      }
+      if (flutterSdkUtil == null) {
+        flutterSdkUtil = new FlutterSdkUtil();
+      }
+      if (embed == null) {
+        embed = false;
+      }
+      return new DevToolsUrl(this);
+    }
   }
 
+  private DevToolsUrl(Builder builder) {
+    this.devToolsHost = builder.devToolsHost;
+    this.devToolsPort = builder.devToolsPort;
+    this.vmServiceUri = builder.vmServiceUri;
+    this.page = builder.page;
+    this.embed = builder.embed;
+    if (builder.embed) {
+      this.colorHexCode = builder.devToolsUtils.getColorHexCode();
+      this.isBright = builder.devToolsUtils.getIsBackgroundBright();
+      this.fontSize = builder.devToolsUtils.getFontSize();
+    }
+    this.widgetId = builder.widgetId;
+    this.flutterSdkVersion = builder.flutterSdkVersion;
+    this.ideFeature = builder.ideFeature;
+    this.sdkUtil = builder.flutterSdkUtil;
 
-  public DevToolsUrl(String devtoolsHost,
-                     int devtoolsPort,
-                     String vmServiceUri,
-                     String page,
-                     boolean embed,
-                     String colorHexCode,
-                     Float fontSize,
-                     FlutterSdkVersion flutterSdkVersion,
-                     WorkspaceCache workspaceCache,
-                     DevToolsIdeFeature ideFeature,
-                     FlutterSdkUtil flutterSdkUtil) {
-    this.devtoolsHost = devtoolsHost;
-    this.devtoolsPort = devtoolsPort;
-    this.vmServiceUri = vmServiceUri;
-    this.page = page;
-    this.embed = embed;
-    this.colorHexCode = colorHexCode;
-    this.fontSize = fontSize;
-    this.flutterSdkVersion = flutterSdkVersion;
-    this.ideFeature = ideFeature;
-    this.sdkUtil = flutterSdkUtil;
-
-    if (workspaceCache != null && workspaceCache.isBazel()) {
+    if (builder.workspaceCache != null && builder.workspaceCache.isBazel()) {
       this.canUseDevToolsPathUrl = true;
-    } else if (flutterSdkVersion != null) {
+    }
+    else if (flutterSdkVersion != null) {
       this.canUseDevToolsPathUrl = flutterSdkVersion.canUseDevToolsPathUrls();
-    } else {
+    }
+    else {
       this.canUseDevToolsPathUrl = false;
     }
   }
 
   @NotNull
-
   public String getUrlString() {
     final List<String> params = new ArrayList<>();
 
@@ -88,6 +164,9 @@ public class DevToolsUrl {
     }
     if (colorHexCode != null) {
       params.add("backgroundColor=" + colorHexCode);
+    }
+    if (isBright != null) {
+      params.add("theme=" + (isBright ? "light" : "dark"));
     }
     if (embed) {
       params.add("embed=true");
@@ -106,9 +185,10 @@ public class DevToolsUrl {
       params.add("inspectorRef=" + widgetId);
     }
     if (this.canUseDevToolsPathUrl) {
-      return "http://" + devtoolsHost + ":" + devtoolsPort + "/" + ( page != null ? page : "" )  + "?" + String.join("&", params);
-    } else {
-      return "http://" + devtoolsHost + ":" + devtoolsPort + "/#/?" + String.join("&", params);
+      return "http://" + devToolsHost + ":" + devToolsPort + "/" + (page != null ? page : "") + "?" + String.join("&", params);
+    }
+    else {
+      return "http://" + devToolsHost + ":" + devToolsPort + "/#/?" + String.join("&", params);
     }
   }
 }

--- a/flutter-idea/src/io/flutter/devtools/DevToolsUrl.java
+++ b/flutter-idea/src/io/flutter/devtools/DevToolsUrl.java
@@ -33,6 +33,8 @@ public class DevToolsUrl {
 
   public final DevToolsIdeFeature ideFeature;
 
+  private final DevToolsUtils devToolsUtils;
+
   public static class Builder {
     private String devToolsHost;
 
@@ -133,6 +135,7 @@ public class DevToolsUrl {
     this.vmServiceUri = builder.vmServiceUri;
     this.page = builder.page;
     this.embed = builder.embed;
+    this.devToolsUtils = builder.devToolsUtils;
     if (builder.embed) {
       this.colorHexCode = builder.devToolsUtils.getColorHexCode();
       this.isBright = builder.devToolsUtils.getIsBackgroundBright();
@@ -190,5 +193,15 @@ public class DevToolsUrl {
     else {
       return "http://" + devToolsHost + ":" + devToolsPort + "/#/?" + String.join("&", params);
     }
+  }
+
+  public void maybeUpdateColor() {
+    final String newColor = devToolsUtils.getColorHexCode();
+    if (colorHexCode == newColor) {
+      return;
+    }
+
+    colorHexCode = newColor;
+    isBright = devToolsUtils.getIsBackgroundBright();
   }
 }

--- a/flutter-idea/src/io/flutter/devtools/DevToolsUtils.java
+++ b/flutter-idea/src/io/flutter/devtools/DevToolsUtils.java
@@ -5,6 +5,10 @@
  */
 package io.flutter.devtools;
 
+import com.intellij.ui.ColorUtil;
+import com.intellij.ui.JBColor;
+import com.intellij.util.ui.UIUtil;
+
 public class DevToolsUtils {
   public static String findWidgetId(String url) {
     final String searchFor = "inspectorRef=";
@@ -16,4 +20,14 @@ public class DevToolsUtils {
     }
     return null;
   }
+
+  public String getColorHexCode() {
+    return ColorUtil.toHex(UIUtil.getEditorPaneBackground());
+  }
+
+  public Boolean getIsBackgroundBright() {
+    return JBColor.isBright();
+  }
+
+  public Float getFontSize() {return UIUtil.getFontSize(UIUtil.FontSize.NORMAL);}
 }

--- a/flutter-idea/src/io/flutter/performance/FlutterPerformanceView.java
+++ b/flutter-idea/src/io/flutter/performance/FlutterPerformanceView.java
@@ -218,7 +218,14 @@ public class FlutterPerformanceView implements Disposable {
 
         FlutterSdk flutterSdk = FlutterSdk.getFlutterSdk(app.getProject());
         BrowserLauncher.getInstance().browse(
-                (new DevToolsUrl(instance.host, instance.port, app.getConnector().getBrowserUrl(), null, false, null, null, flutterSdk == null ? null : flutterSdk.getVersion(), WorkspaceCache.getInstance(app.getProject()), null)).getUrlString(),
+          new DevToolsUrl.Builder()
+            .setDevToolsHost(instance.host)
+            .setDevToolsPort(instance.port)
+            .setVmServiceUri(app.getConnector().getBrowserUrl())
+            .setFlutterSdkVersion(flutterSdk == null ? null : flutterSdk.getVersion())
+            .setWorkspaceCache(WorkspaceCache.getInstance(app.getProject()))
+            .build()
+            .getUrlString(),
                 null
         );
       });

--- a/flutter-idea/src/io/flutter/run/OpenDevToolsAction.java
+++ b/flutter-idea/src/io/flutter/run/OpenDevToolsAction.java
@@ -86,7 +86,15 @@ public class OpenDevToolsAction extends DumbAwareAction {
 
       FlutterSdk flutterSdk = FlutterSdk.getFlutterSdk(project);
       BrowserLauncher.getInstance().browse(
-        (new DevToolsUrl(instance.host, instance.port, serviceUrl, null, false, null, null, flutterSdk == null ? null : flutterSdk.getVersion(), WorkspaceCache.getInstance(project), DevToolsIdeFeature.RUN_CONSOLE).getUrlString()),
+        new DevToolsUrl.Builder()
+          .setDevToolsHost(instance.host)
+          .setDevToolsPort(instance.port)
+          .setVmServiceUri(serviceUrl)
+          .setFlutterSdkVersion(flutterSdk == null ? null : flutterSdk.getVersion())
+          .setWorkspaceCache(WorkspaceCache.getInstance(project))
+          .setIdeFeature(DevToolsIdeFeature.RUN_CONSOLE)
+          .build()
+          .getUrlString(),
         null
       );
     });

--- a/flutter-idea/src/io/flutter/view/EmbeddedBrowser.java
+++ b/flutter-idea/src/io/flutter/view/EmbeddedBrowser.java
@@ -107,7 +107,8 @@ public abstract class EmbeddedBrowser {
     final AtomicBoolean contentLoaded = new AtomicBoolean(false);
 
     try {
-      tab.embeddedTab.loadUrl(devToolsUrl.getUrlString());
+      final String url = devToolsUrl.getUrlString();
+      tab.embeddedTab.loadUrl(url);
     } catch (Exception ex) {
       tab.devToolsUrlFuture.completeExceptionally(ex);
       onBrowserUnavailable.accept(ex.getMessage());

--- a/flutter-idea/src/io/flutter/view/EmbeddedBrowser.java
+++ b/flutter-idea/src/io/flutter/view/EmbeddedBrowser.java
@@ -239,10 +239,7 @@ public abstract class EmbeddedBrowser {
 
   public void updateColor(String newColor) {
     updateUrlAndReload(devToolsUrl -> {
-      if (devToolsUrl.colorHexCode.equals(newColor)) {
-        return null;
-      }
-      devToolsUrl.colorHexCode = newColor;
+      devToolsUrl.maybeUpdateColor();
       return devToolsUrl;
     });
   }

--- a/flutter-idea/src/io/flutter/view/FlutterView.java
+++ b/flutter-idea/src/io/flutter/view/FlutterView.java
@@ -214,19 +214,16 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
     FlutterSdkVersion flutterSdkVersion = flutterSdk == null ? null : flutterSdk.getVersion();
 
     if (isEmbedded) {
-      final String color = ColorUtil.toHex(UIUtil.getEditorPaneBackground());
-      final DevToolsUrl devToolsUrl = new DevToolsUrl(
-        devToolsInstance.host,
-        devToolsInstance.port,
-        browserUrl,
-        "inspector",
-        true,
-        color,
-        UIUtil.getFontSize(UIUtil.FontSize.NORMAL),
-        flutterSdkVersion,
-        WorkspaceCache.getInstance(app.getProject()),
-        ideFeature
-      );
+      final DevToolsUrl devToolsUrl = new DevToolsUrl.Builder()
+        .setDevToolsHost(devToolsInstance.host)
+        .setDevToolsPort(devToolsInstance.port)
+        .setVmServiceUri(browserUrl)
+        .setPage("inspector")
+        .setEmbed(true)
+        .setFlutterSdkVersion(flutterSdkVersion)
+        .setWorkspaceCache(WorkspaceCache.getInstance(app.getProject()))
+        .setIdeFeature(ideFeature)
+        .build();
 
       //noinspection CodeBlock2Expr
       ApplicationManager.getApplication().invokeLater(() -> {
@@ -253,8 +250,16 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
       }
     } else {
       BrowserLauncher.getInstance().browse(
-        (new DevToolsUrl(devToolsInstance.host, devToolsInstance.port, browserUrl, "inspector", false, null, null,
-                         flutterSdkVersion, WorkspaceCache.getInstance(app.getProject()), ideFeature).getUrlString()),
+        new DevToolsUrl.Builder()
+          .setDevToolsHost(devToolsInstance.host)
+          .setDevToolsPort(devToolsInstance.port)
+          .setVmServiceUri(browserUrl)
+          .setPage("inspector")
+          .setFlutterSdkVersion(flutterSdkVersion)
+          .setWorkspaceCache(WorkspaceCache.getInstance(app.getProject()))
+          .setIdeFeature(ideFeature)
+          .build()
+          .getUrlString(),
         null
       );
       presentLabel(toolWindow, "DevTools inspector has been opened in the browser.");

--- a/flutter-idea/testSrc/unit/io/flutter/devtools/DevToolsUrlTest.java
+++ b/flutter-idea/testSrc/unit/io/flutter/devtools/DevToolsUrlTest.java
@@ -3,6 +3,7 @@ package io.flutter.devtools;
 import io.flutter.bazel.WorkspaceCache;
 import io.flutter.sdk.FlutterSdkUtil;
 import io.flutter.sdk.FlutterSdkVersion;
+import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -10,79 +11,198 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class DevToolsUrlTest {
-  @Test
-  public void testGetUrlString() {
-    final String devtoolsHost = "127.0.0.1";
-    final int devtoolsPort = 9100;
-    final String serviceProtocolUri = "http://127.0.0.1:50224/WTFTYus3IPU=/";
-    final String page = "timeline";
+  final String devtoolsHost = "127.0.0.1";
+  final int devtoolsPort = 9100;
+  final String serviceProtocolUri = "http://127.0.0.1:50224/WTFTYus3IPU=/";
+  final String page = "timeline";
+  final FlutterSdkUtil mockSdkUtil = mock(FlutterSdkUtil.class);
+  final WorkspaceCache notBazelWorkspaceCache = mock(WorkspaceCache.class);
+  final WorkspaceCache bazelWorkspaceCache = mock(WorkspaceCache.class);
+  FlutterSdkVersion newVersion = new FlutterSdkVersion("3.3.0");
 
-    final FlutterSdkUtil mockSdkUtil = mock(FlutterSdkUtil.class);
+  @Before
+  public void setUp() {
     when(mockSdkUtil.getFlutterHostEnvValue()).thenReturn("IntelliJ-IDEA");
 
-    final WorkspaceCache notBazelWorkspaceCache = mock(WorkspaceCache.class);
     when(notBazelWorkspaceCache.isBazel()).thenReturn(false);
 
-    final WorkspaceCache bazelWorkspaceCache = mock(WorkspaceCache.class);
     when(bazelWorkspaceCache.isBazel()).thenReturn(true);
+  }
 
-    FlutterSdkVersion newVersion = new FlutterSdkVersion("3.3.0");
+  @Test
+  public void testGetUrlStringWithoutColor() {
+    final DevToolsUtils noColorUtils = mock(DevToolsUtils.class);
+    when(noColorUtils.getColorHexCode()).thenReturn(null);
+    when(noColorUtils.getIsBackgroundBright()).thenReturn(null);
+
     assertEquals(
       "http://127.0.0.1:9100/timeline?ide=IntelliJ-IDEA&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F",
-      (new DevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false, null, null, newVersion, notBazelWorkspaceCache, null, mockSdkUtil)).getUrlString()
+      new DevToolsUrl.Builder()
+        .setDevToolsHost(devtoolsHost)
+        .setDevToolsPort(devtoolsPort)
+        .setVmServiceUri(serviceProtocolUri)
+        .setFlutterSdkVersion(newVersion)
+        .setWorkspaceCache(notBazelWorkspaceCache)
+        .setFlutterSdkUtil(mockSdkUtil)
+        .setDevToolsUtils(noColorUtils)
+        .build()
+        .getUrlString()
     );
 
     assertEquals(
       "http://127.0.0.1:9100/timeline?ide=IntelliJ-IDEA&embed=true&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F",
-      (new DevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, true, null, null, newVersion, notBazelWorkspaceCache, null, mockSdkUtil)).getUrlString()
+      new DevToolsUrl.Builder()
+        .setDevToolsHost(devtoolsHost)
+        .setDevToolsPort(devtoolsPort)
+        .setVmServiceUri(serviceProtocolUri)
+        .setEmbed(true)
+        .setFlutterSdkVersion(newVersion)
+        .setWorkspaceCache(notBazelWorkspaceCache)
+        .setFlutterSdkUtil(mockSdkUtil)
+        .setDevToolsUtils(noColorUtils)
+        .build()
+        .getUrlString()
     );
 
     assertEquals(
       "http://127.0.0.1:9100/?ide=IntelliJ-IDEA",
-      (new DevToolsUrl(devtoolsHost, devtoolsPort, null, null, false, null, null, newVersion, notBazelWorkspaceCache, null, mockSdkUtil).getUrlString())
-    );
-
-    assertEquals(
-      "http://127.0.0.1:9100/timeline?ide=IntelliJ-IDEA&backgroundColor=ffffff&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F",
-      (new DevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false, "ffffff", null, newVersion, notBazelWorkspaceCache, null, mockSdkUtil).getUrlString())
-    );
-
-    assertEquals(
-      "http://127.0.0.1:9100/timeline?ide=IntelliJ-IDEA&backgroundColor=ffffff&fontSize=12.0&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F",
-      (new DevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false, "ffffff", 12.0f, newVersion, notBazelWorkspaceCache, null, mockSdkUtil).getUrlString())
+      new DevToolsUrl.Builder()
+        .setDevToolsHost(devtoolsHost)
+        .setDevToolsPort(devtoolsPort)
+        .setFlutterSdkVersion(newVersion)
+        .setWorkspaceCache(notBazelWorkspaceCache)
+        .setFlutterSdkUtil(mockSdkUtil)
+        .setDevToolsUtils(noColorUtils)
+        .build()
+        .getUrlString()
     );
 
     when(mockSdkUtil.getFlutterHostEnvValue()).thenReturn("Android-Studio");
 
     assertEquals(
       "http://127.0.0.1:9100/timeline?ide=Android-Studio&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F",
-      (new DevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false, null, null, newVersion, notBazelWorkspaceCache, null, mockSdkUtil).getUrlString())
-    );
-
-    assertEquals(
-      "http://127.0.0.1:9100/timeline?ide=Android-Studio&backgroundColor=3c3f41&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F",
-      (new DevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false, "3c3f41", null, newVersion, notBazelWorkspaceCache, null, mockSdkUtil).getUrlString())
+      new DevToolsUrl.Builder()
+        .setDevToolsHost(devtoolsHost)
+        .setDevToolsPort(devtoolsPort)
+        .setVmServiceUri(serviceProtocolUri)
+        .setFlutterSdkVersion(newVersion)
+        .setWorkspaceCache(notBazelWorkspaceCache)
+        .setFlutterSdkUtil(mockSdkUtil)
+        .setDevToolsUtils(noColorUtils)
+        .build()
+        .getUrlString()
     );
 
     FlutterSdkVersion oldVersion = new FlutterSdkVersion("3.0.0");
     assertEquals(
       "http://127.0.0.1:9100/#/?ide=Android-Studio&page=timeline&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F",
-      (new DevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false, null, null, oldVersion, notBazelWorkspaceCache, null, mockSdkUtil)).getUrlString()
+      new DevToolsUrl.Builder()
+        .setDevToolsHost(devtoolsHost)
+        .setDevToolsPort(devtoolsPort)
+        .setVmServiceUri(serviceProtocolUri)
+        .setFlutterSdkVersion(oldVersion)
+        .setWorkspaceCache(notBazelWorkspaceCache)
+        .setFlutterSdkUtil(mockSdkUtil)
+        .setDevToolsUtils(noColorUtils)
+        .build()
+        .getUrlString()
     );
 
     assertEquals(
       "http://127.0.0.1:9100/#/?ide=Android-Studio&page=timeline&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F",
-      (new DevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false, null, null, null, notBazelWorkspaceCache, null, mockSdkUtil)).getUrlString()
+      new DevToolsUrl.Builder()
+        .setDevToolsHost(devtoolsHost)
+        .setDevToolsPort(devtoolsPort)
+        .setVmServiceUri(serviceProtocolUri)
+        .setWorkspaceCache(notBazelWorkspaceCache)
+        .setFlutterSdkUtil(mockSdkUtil)
+        .setDevToolsUtils(noColorUtils)
+        .build()
+        .getUrlString()
     );
 
     assertEquals(
       "http://127.0.0.1:9100/timeline?ide=Android-Studio&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F",
-      (new DevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false, null, null, null, bazelWorkspaceCache, null, mockSdkUtil)).getUrlString()
+      new DevToolsUrl.Builder()
+        .setDevToolsHost(devtoolsHost)
+        .setDevToolsPort(devtoolsPort)
+        .setVmServiceUri(serviceProtocolUri)
+        .setWorkspaceCache(bazelWorkspaceCache)
+        .setFlutterSdkUtil(mockSdkUtil)
+        .setDevToolsUtils(noColorUtils)
+        .build()
+        .getUrlString()
     );
 
     assertEquals(
       "http://127.0.0.1:9100/timeline?ide=Android-Studio&ideFeature=toolWindow&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F",
-      (new DevToolsUrl(devtoolsHost, devtoolsPort, serviceProtocolUri, page, false, null, null, null, bazelWorkspaceCache, DevToolsIdeFeature.TOOL_WINDOW, mockSdkUtil)).getUrlString()
+      new DevToolsUrl.Builder()
+        .setDevToolsHost(devtoolsHost)
+        .setDevToolsPort(devtoolsPort)
+        .setVmServiceUri(serviceProtocolUri)
+        .setIdeFeature(DevToolsIdeFeature.TOOL_WINDOW)
+        .setWorkspaceCache(bazelWorkspaceCache)
+        .setFlutterSdkUtil(mockSdkUtil)
+        .setDevToolsUtils(noColorUtils)
+        .build()
+        .getUrlString()
+    );
+
+  }
+
+  @Test
+  public final void testGetUrlStringWithColor() {
+    final DevToolsUtils lightUtils = mock(DevToolsUtils.class);
+    when(lightUtils.getColorHexCode()).thenReturn("ffffff");
+    when(lightUtils.getIsBackgroundBright()).thenReturn(true);
+
+    assertEquals(
+      "http://127.0.0.1:9100/timeline?ide=IntelliJ-IDEA&backgroundColor=ffffff&theme=light&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F",
+      new DevToolsUrl.Builder()
+        .setDevToolsHost(devtoolsHost)
+        .setDevToolsPort(devtoolsPort)
+        .setVmServiceUri(serviceProtocolUri)
+        .setFlutterSdkVersion(newVersion)
+        .setWorkspaceCache(notBazelWorkspaceCache)
+        .setFlutterSdkUtil(mockSdkUtil)
+        .setDevToolsUtils(lightUtils)
+        .build()
+        .getUrlString()
+    );
+
+    assertEquals(
+      "http://127.0.0.1:9100/timeline?ide=IntelliJ-IDEA&backgroundColor=ffffff&fontSize=12.0&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F",
+      new DevToolsUrl.Builder()
+        .setDevToolsHost(devtoolsHost)
+        .setDevToolsPort(devtoolsPort)
+        .setVmServiceUri(serviceProtocolUri)
+        .setFontSize(12.0f)
+        .setFlutterSdkVersion(newVersion)
+        .setWorkspaceCache(notBazelWorkspaceCache)
+        .setFlutterSdkUtil(mockSdkUtil)
+        .setDevToolsUtils(lightUtils)
+        .build()
+        .getUrlString()
+    );
+
+    when(mockSdkUtil.getFlutterHostEnvValue()).thenReturn("Android-Studio");
+
+    final DevToolsUtils darkUtils = mock(DevToolsUtils.class);
+    when(darkUtils.getColorHexCode()).thenReturn("3c3f41");
+    when(darkUtils.getIsBackgroundBright()).thenReturn(false);
+
+    assertEquals(
+      "http://127.0.0.1:9100/timeline?ide=Android-Studio&backgroundColor=3c3f41&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F",
+      new DevToolsUrl.Builder()
+        .setDevToolsHost(devtoolsHost)
+        .setDevToolsPort(devtoolsPort)
+        .setVmServiceUri(serviceProtocolUri)
+        .setFlutterSdkVersion(newVersion)
+        .setWorkspaceCache(notBazelWorkspaceCache)
+        .setFlutterSdkUtil(mockSdkUtil)
+        .setDevToolsUtils(darkUtils)
+        .build()
+        .getUrlString()
     );
   }
 }

--- a/flutter-idea/testSrc/unit/io/flutter/devtools/DevToolsUrlTest.java
+++ b/flutter-idea/testSrc/unit/io/flutter/devtools/DevToolsUrlTest.java
@@ -34,6 +34,7 @@ public class DevToolsUrlTest {
     final DevToolsUtils noColorUtils = mock(DevToolsUtils.class);
     when(noColorUtils.getColorHexCode()).thenReturn(null);
     when(noColorUtils.getIsBackgroundBright()).thenReturn(null);
+    when(noColorUtils.getFontSize()).thenReturn(null);
 
     assertEquals(
       "http://127.0.0.1:9100/timeline?ide=IntelliJ-IDEA&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F",
@@ -42,6 +43,7 @@ public class DevToolsUrlTest {
         .setDevToolsPort(devtoolsPort)
         .setVmServiceUri(serviceProtocolUri)
         .setFlutterSdkVersion(newVersion)
+        .setPage(page)
         .setWorkspaceCache(notBazelWorkspaceCache)
         .setFlutterSdkUtil(mockSdkUtil)
         .setDevToolsUtils(noColorUtils)
@@ -55,6 +57,7 @@ public class DevToolsUrlTest {
         .setDevToolsHost(devtoolsHost)
         .setDevToolsPort(devtoolsPort)
         .setVmServiceUri(serviceProtocolUri)
+        .setPage(page)
         .setEmbed(true)
         .setFlutterSdkVersion(newVersion)
         .setWorkspaceCache(notBazelWorkspaceCache)
@@ -85,6 +88,7 @@ public class DevToolsUrlTest {
         .setDevToolsHost(devtoolsHost)
         .setDevToolsPort(devtoolsPort)
         .setVmServiceUri(serviceProtocolUri)
+        .setPage(page)
         .setFlutterSdkVersion(newVersion)
         .setWorkspaceCache(notBazelWorkspaceCache)
         .setFlutterSdkUtil(mockSdkUtil)
@@ -100,6 +104,7 @@ public class DevToolsUrlTest {
         .setDevToolsHost(devtoolsHost)
         .setDevToolsPort(devtoolsPort)
         .setVmServiceUri(serviceProtocolUri)
+        .setPage(page)
         .setFlutterSdkVersion(oldVersion)
         .setWorkspaceCache(notBazelWorkspaceCache)
         .setFlutterSdkUtil(mockSdkUtil)
@@ -114,6 +119,7 @@ public class DevToolsUrlTest {
         .setDevToolsHost(devtoolsHost)
         .setDevToolsPort(devtoolsPort)
         .setVmServiceUri(serviceProtocolUri)
+        .setPage(page)
         .setWorkspaceCache(notBazelWorkspaceCache)
         .setFlutterSdkUtil(mockSdkUtil)
         .setDevToolsUtils(noColorUtils)
@@ -126,6 +132,7 @@ public class DevToolsUrlTest {
       new DevToolsUrl.Builder()
         .setDevToolsHost(devtoolsHost)
         .setDevToolsPort(devtoolsPort)
+        .setPage(page)
         .setVmServiceUri(serviceProtocolUri)
         .setWorkspaceCache(bazelWorkspaceCache)
         .setFlutterSdkUtil(mockSdkUtil)
@@ -140,6 +147,7 @@ public class DevToolsUrlTest {
         .setDevToolsHost(devtoolsHost)
         .setDevToolsPort(devtoolsPort)
         .setVmServiceUri(serviceProtocolUri)
+        .setPage(page)
         .setIdeFeature(DevToolsIdeFeature.TOOL_WINDOW)
         .setWorkspaceCache(bazelWorkspaceCache)
         .setFlutterSdkUtil(mockSdkUtil)
@@ -155,13 +163,16 @@ public class DevToolsUrlTest {
     final DevToolsUtils lightUtils = mock(DevToolsUtils.class);
     when(lightUtils.getColorHexCode()).thenReturn("ffffff");
     when(lightUtils.getIsBackgroundBright()).thenReturn(true);
+    when(lightUtils.getFontSize()).thenReturn(null);
 
     assertEquals(
-      "http://127.0.0.1:9100/timeline?ide=IntelliJ-IDEA&backgroundColor=ffffff&theme=light&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F",
+      "http://127.0.0.1:9100/timeline?ide=IntelliJ-IDEA&backgroundColor=ffffff&theme=light&embed=true&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F",
       new DevToolsUrl.Builder()
         .setDevToolsHost(devtoolsHost)
         .setDevToolsPort(devtoolsPort)
         .setVmServiceUri(serviceProtocolUri)
+        .setEmbed(true)
+        .setPage(page)
         .setFlutterSdkVersion(newVersion)
         .setWorkspaceCache(notBazelWorkspaceCache)
         .setFlutterSdkUtil(mockSdkUtil)
@@ -170,13 +181,15 @@ public class DevToolsUrlTest {
         .getUrlString()
     );
 
+    when(lightUtils.getFontSize()).thenReturn(12f);
     assertEquals(
-      "http://127.0.0.1:9100/timeline?ide=IntelliJ-IDEA&backgroundColor=ffffff&fontSize=12.0&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F",
+      "http://127.0.0.1:9100/timeline?ide=IntelliJ-IDEA&backgroundColor=ffffff&theme=light&embed=true&fontSize=12.0&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F",
       new DevToolsUrl.Builder()
         .setDevToolsHost(devtoolsHost)
         .setDevToolsPort(devtoolsPort)
         .setVmServiceUri(serviceProtocolUri)
-        .setFontSize(12.0f)
+        .setEmbed(true)
+        .setPage(page)
         .setFlutterSdkVersion(newVersion)
         .setWorkspaceCache(notBazelWorkspaceCache)
         .setFlutterSdkUtil(mockSdkUtil)
@@ -190,13 +203,16 @@ public class DevToolsUrlTest {
     final DevToolsUtils darkUtils = mock(DevToolsUtils.class);
     when(darkUtils.getColorHexCode()).thenReturn("3c3f41");
     when(darkUtils.getIsBackgroundBright()).thenReturn(false);
+    when(darkUtils.getFontSize()).thenReturn(null);
 
     assertEquals(
-      "http://127.0.0.1:9100/timeline?ide=Android-Studio&backgroundColor=3c3f41&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F",
+      "http://127.0.0.1:9100/timeline?ide=Android-Studio&backgroundColor=3c3f41&theme=dark&embed=true&uri=http%3A%2F%2F127.0.0.1%3A50224%2FWTFTYus3IPU%3D%2F",
       new DevToolsUrl.Builder()
         .setDevToolsHost(devtoolsHost)
         .setDevToolsPort(devtoolsPort)
         .setVmServiceUri(serviceProtocolUri)
+        .setEmbed(true)
+        .setPage(page)
         .setFlutterSdkVersion(newVersion)
         .setWorkspaceCache(notBazelWorkspaceCache)
         .setFlutterSdkUtil(mockSdkUtil)


### PR DESCRIPTION
Fixes #7319 

This became a larger change than I originally intended, but I figured refactoring the `DevToolsUrl` class would be helpful for upcoming work on integrating more DevTools panels.

Summary of changes:
- Add param `&theme=[light/dark]` to fix the original issue
- Use builder for making DevToolsUrl class
- Use utility class for finding the IDE's background color, light/dark mode, and font size
- Only send theming information when browser is embedded