### PR TITLE
Remove the SDK minimum validation notification in the Flutter Plugin

### DIFF
--- a/flutter-idea/src/io/flutter/FlutterBundle.properties
+++ b/flutter-idea/src/io/flutter/FlutterBundle.properties
@@ -37,7 +37,6 @@ flutter.command.exception.message=Exception: {0}
 flutter.incompatible.dart.plugin.warning=Flutter requires a Dart plugin with a minimum version of {0} (currently installed: {1}).
 flutter.module.name=Flutter
 flutter.no.sdk.warning=No Flutter SDK Configured.
-flutter.old.sdk.warning=The current configured Flutter SDK is not known to be fully supported. Please update your SDK and restart IntelliJ.
 flutter.project.description=Build high-performance, high-fidelity, apps using the Flutter framework.
 flutter.sdk.browse.path.label=Select Flutter SDK Path
 flutter.sdk.is.not.configured=The Flutter SDK is not configured

--- a/flutter-idea/src/io/flutter/inspections/SdkConfigurationNotificationProvider.java
+++ b/flutter-idea/src/io/flutter/inspections/SdkConfigurationNotificationProvider.java
@@ -74,25 +74,7 @@ public class SdkConfigurationNotificationProvider extends EditorNotifications.Pr
     if (flutterSdk == null) {
       return createNoFlutterSdkPanel(project);
     }
-    else if (!flutterSdk.getVersion().isMinRecommendedSupported()) {
-      return createOutOfDateFlutterSdkPanel(flutterSdk);
-    }
 
     return null;
-  }
-
-  private EditorNotificationPanel createOutOfDateFlutterSdkPanel(@NotNull FlutterSdk sdk) {
-    final FlutterUIConfig settings = FlutterUIConfig.getInstance();
-    if (settings.shouldIgnoreOutOfDateFlutterSdks()) return null;
-
-    final EditorNotificationPanel panel = new EditorNotificationPanel();
-    panel.icon(FlutterIcons.Flutter);
-    panel.setText(FlutterBundle.message("flutter.old.sdk.warning"));
-    panel.createActionLabel("Dismiss", () -> {
-      settings.setIgnoreOutOfDateFlutterSdks();
-      panel.setVisible(false);
-    });
-
-    return panel;
   }
 }


### PR DESCRIPTION
Race conditions where the sdk hasn't been cached resulting in the notification provides more of a distraction than value. (The Flutter SDK being tested here is pre-`0.0.12`.)

This work should be replaced with something such as https://github.com/flutter/flutter-intellij/issues/2932
