### PR TITLE
Fix the Flutter outline

### DIFF
--- a/flutter-idea/src/io/flutter/dart/FlutterDartAnalysisServer.java
+++ b/flutter-idea/src/io/flutter/dart/FlutterDartAnalysisServer.java
@@ -63,7 +63,7 @@ public class FlutterDartAnalysisServer implements Disposable {
   }
 
   @NotNull
-  private DartAnalysisServerService getAnalysisService() {
+  public DartAnalysisServerService getAnalysisService() {
     return Objects.requireNonNull(DartPlugin.getInstance().getAnalysisService(project));
   }
 
@@ -118,7 +118,7 @@ public class FlutterDartAnalysisServer implements Disposable {
       return;
     }
     synchronized (fileOutlineListeners) {
-      final List<FlutterOutlineListener> listeners = fileOutlineListeners.computeIfAbsent("file://" + filePath, k -> new ArrayList<>());
+      final List<FlutterOutlineListener> listeners = fileOutlineListeners.computeIfAbsent(getAnalysisService().getLocalFileUri(filePath), k -> new ArrayList<>());
       listeners.add(listener);
     }
     addSubscription(FlutterService.OUTLINE, filePath);

--- a/flutter-idea/src/io/flutter/dart/FlutterDartAnalysisServer.java
+++ b/flutter-idea/src/io/flutter/dart/FlutterDartAnalysisServer.java
@@ -118,7 +118,7 @@ public class FlutterDartAnalysisServer implements Disposable {
       return;
     }
     synchronized (fileOutlineListeners) {
-      final List<FlutterOutlineListener> listeners = fileOutlineListeners.computeIfAbsent(filePath, k -> new ArrayList<>());
+      final List<FlutterOutlineListener> listeners = fileOutlineListeners.computeIfAbsent("file://" + filePath, k -> new ArrayList<>());
       listeners.add(listener);
     }
     addSubscription(FlutterService.OUTLINE, filePath);

--- a/flutter-idea/src/io/flutter/editor/ActiveEditorsOutlineService.java
+++ b/flutter-idea/src/io/flutter/editor/ActiveEditorsOutlineService.java
@@ -146,8 +146,8 @@ public class ActiveEditorsOutlineService implements Disposable {
           continue;
         }
 
-        final FlutterOutlineListener listener = new OutlineListener(path);
-        outlineListeners.put(path, listener);
+        final FlutterOutlineListener listener = new OutlineListener("file://" + path);
+        outlineListeners.put("file://" + path, listener);
         getAnalysisServer().addOutlineListener(FileUtil.toSystemDependentName(path), listener);
       }
     }

--- a/flutter-idea/src/io/flutter/editor/ActiveEditorsOutlineService.java
+++ b/flutter-idea/src/io/flutter/editor/ActiveEditorsOutlineService.java
@@ -146,8 +146,9 @@ public class ActiveEditorsOutlineService implements Disposable {
           continue;
         }
 
-        final FlutterOutlineListener listener = new OutlineListener("file://" + path);
-        outlineListeners.put("file://" + path, listener);
+        final String filePathOrUri = getAnalysisServer().getAnalysisService().getLocalFileUri(path);
+        final FlutterOutlineListener listener = new OutlineListener(filePathOrUri);
+        outlineListeners.put(filePathOrUri, listener);
         getAnalysisServer().addOutlineListener(FileUtil.toSystemDependentName(path), listener);
       }
     }

--- a/flutter-idea/src/io/flutter/preview/PreviewView.java
+++ b/flutter-idea/src/io/flutter/preview/PreviewView.java
@@ -108,7 +108,9 @@ public class PreviewView implements PersistentStateComponent<PreviewViewState> {
   private final FlutterOutlineListener outlineListener = new FlutterOutlineListener() {
     @Override
     public void outlineUpdated(@NotNull String filePath, @NotNull FlutterOutline outline, @Nullable String instrumentedCode) {
-      if (Objects.equals("file://" + currentFilePath, filePath)) {
+
+      final String filePathOrUri = flutterAnalysisServer.getAnalysisService().getLocalFileUri(currentFilePath);
+      if (Objects.equals(filePathOrUri, filePath)) {
         ApplicationManager.getApplication().invokeLater(() -> updateOutline(outline));
       }
     }

--- a/flutter-idea/src/io/flutter/preview/PreviewView.java
+++ b/flutter-idea/src/io/flutter/preview/PreviewView.java
@@ -108,7 +108,7 @@ public class PreviewView implements PersistentStateComponent<PreviewViewState> {
   private final FlutterOutlineListener outlineListener = new FlutterOutlineListener() {
     @Override
     public void outlineUpdated(@NotNull String filePath, @NotNull FlutterOutline outline, @Nullable String instrumentedCode) {
-      if (Objects.equals(currentFilePath, filePath)) {
+      if (Objects.equals("file://" + currentFilePath, filePath)) {
         ApplicationManager.getApplication().invokeLater(() -> updateOutline(outline));
       }
     }


### PR DESCRIPTION
This fixes the Flutter outline by using the new file uri keys, dependent on the version of the Dart SDK being used, i.e. support for macro enabled SDKs.

This is follow up on https://github.com/flutter/flutter-intellij/pull/7462

