### PR TITLE
Hide deep links window when insufficient SDK version

### DIFF
--- a/flutter-idea/src/io/flutter/deeplinks/DeepLinksViewFactory.java
+++ b/flutter-idea/src/io/flutter/deeplinks/DeepLinksViewFactory.java
@@ -9,9 +9,7 @@ import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowFactory;
-import com.intellij.ui.content.Content;
 import com.intellij.ui.content.ContentManager;
-import com.intellij.util.ui.JBUI;
 import io.flutter.FlutterUtils;
 import io.flutter.bazel.WorkspaceCache;
 import io.flutter.devtools.DevToolsIdeFeature;
@@ -20,63 +18,59 @@ import io.flutter.run.daemon.DevToolsService;
 import io.flutter.sdk.FlutterSdk;
 import io.flutter.sdk.FlutterSdkVersion;
 import io.flutter.utils.AsyncUtils;
+import kotlin.coroutines.Continuation;
 import org.jetbrains.annotations.NotNull;
 
-import javax.swing.*;
-import java.awt.*;
 import java.util.Optional;
 
 public class DeepLinksViewFactory implements ToolWindowFactory {
+  @Override
+  public Object isApplicableAsync(@NotNull Project project, @NotNull Continuation<? super Boolean> $completion) {
+    FlutterSdk sdk = FlutterSdk.getFlutterSdk(project);
+    FlutterSdkVersion sdkVersion = sdk == null ? null : sdk.getVersion();
+    return sdkVersion != null && sdkVersion.canUseDeepLinksTool();
+  }
+
   @Override
   public void createToolWindowContent(@NotNull Project project, @NotNull ToolWindow toolWindow) {
     final ContentManager contentManager = toolWindow.getContentManager();
     FlutterSdk sdk = FlutterSdk.getFlutterSdk(project);
     FlutterSdkVersion sdkVersion = sdk == null ? null : sdk.getVersion();
-    if (sdkVersion == null || !sdkVersion.canUseDeepLinksTool()) {
-      JLabel label = new JLabel("<html>Deep links isn't supported<br> for this version of the Flutter SDK.<br>The minimum version required is 3.19.0.</html>");
-      label.setBorder(JBUI.Borders.empty(5));
-      label.setHorizontalAlignment(SwingConstants.CENTER);
-      final JPanel panel = new JPanel(new BorderLayout());
-      panel.add(label, BorderLayout.CENTER);
-      final Content content = contentManager.getFactory().createContent(panel, null, false);
 
-      toolWindow.getContentManager().addContent(content);
-      return;
-    }
+    AsyncUtils.whenCompleteUiThread(
+      DevToolsService.getInstance(project).getDevToolsInstance(),
+      (instance, error) -> {
+        // Skip displaying if the project has been closed.
+        if (!project.isOpen()) {
+          return;
+        }
 
-      AsyncUtils.whenCompleteUiThread(
-        DevToolsService.getInstance(project).getDevToolsInstance(),
-        (instance, error) -> {
-          // Skip displaying if the project has been closed.
-          if (!project.isOpen()) {
-            return;
-          }
+        if (error != null) {
+          return;
+        }
 
-          if (error != null) {
-            return;
-          }
+        if (instance == null) {
+          return;
+        }
 
-          if (instance == null) {
-            return;
-          }
+        final DevToolsUrl devToolsUrl = new DevToolsUrl.Builder()
+          .setDevToolsHost(instance.host)
+          .setDevToolsPort(instance.port)
+          .setPage("deep-links")
+          .setEmbed(true)
+          .setFlutterSdkVersion(sdkVersion)
+          .setWorkspaceCache(WorkspaceCache.getInstance(project))
+          .setIdeFeature(DevToolsIdeFeature.TOOL_WINDOW)
+          .build();
 
-          final DevToolsUrl devToolsUrl = new DevToolsUrl.Builder()
-            .setDevToolsHost(instance.host)
-            .setDevToolsPort(instance.port)
-            .setPage("deep-links")
-            .setEmbed(true)
-            .setFlutterSdkVersion(sdkVersion)
-            .setWorkspaceCache(WorkspaceCache.getInstance(project))
-            .setIdeFeature(DevToolsIdeFeature.TOOL_WINDOW)
-            .build();
-
-          ApplicationManager.getApplication().invokeLater(() -> {
-            Optional.ofNullable(
-              FlutterUtils.embeddedBrowser(project)).ifPresent(embeddedBrowser -> embeddedBrowser.openPanel(toolWindow, "Deep Links", devToolsUrl, (String err) -> {
+        ApplicationManager.getApplication().invokeLater(() -> {
+          Optional.ofNullable(
+              FlutterUtils.embeddedBrowser(project))
+            .ifPresent(embeddedBrowser -> embeddedBrowser.openPanel(toolWindow, "Deep Links", devToolsUrl, (String err) -> {
               System.out.println(err);
             }));
-          });
-        }
-      );
+        });
+      }
+    );
   }
 }


### PR DESCRIPTION
I didn't know we could hide tool windows based on SDK using `isApplicableAsync`. Originally we only added an error message about SDK version because we thought we couldn't hide tool windows. I think it's neater to hide unusable tool windows - this takes off deep links as a window option in the View menu.