### PR TITLE
Release the Project and Editor references from the FlutterReloadManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Next
+- Resolve Released EditorImpl held by lambda in FlutterReloadManager (#7507)
+
 # 80
 - Resolve debugger issue with the new Dart macro file uri format (#7449)
 - Hide deep links window when insufficient SDK version (#7478)

--- a/flutter-idea/src/io/flutter/run/FlutterReloadManager.java
+++ b/flutter-idea/src/io/flutter/run/FlutterReloadManager.java
@@ -166,6 +166,10 @@ public class FlutterReloadManager {
         }
         catch (Throwable t) {
           FlutterUtils.warn(LOG, "Exception from hot reload on save", t);
+        } finally {
+          // Context: "Released EditorImpl held by lambda in FlutterReloadManager" (https://github.com/flutter/flutter-intellij/issues/7507)
+          eventProject = null;
+          eventEditor = null;
         }
       }
     });

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -45,6 +45,10 @@
 
   <change-notes>
     <![CDATA[
+<h1>Next</h1>
+<ul>
+  <li>Resolve Released EditorImpl held by lambda in FlutterReloadManager (#7507)</li>
+</ul>
 <h1>80</h1>
 <ul>
   <li>Resolve debugger issue with the new Dart macro file uri format (#7449)</li>


### PR DESCRIPTION
This fixes https://github.com/flutter/flutter-intellij/issues/7507
