### PR TITLE
Remove unused await code

### DIFF
--- a/tool/plugin/lib/plugin.dart
+++ b/tool/plugin/lib/plugin.dart
@@ -147,13 +147,13 @@ bool isTravisFileValid() {
   return isNewer(travisFile, matrixFile);
 }
 
-Future<int> jar(String directory, String outFile) async {
+Future<int> jar(String directory, String outFile) {
   var args = ['cf', p.absolute(outFile)];
   args.addAll(Directory(directory)
       .listSync(followLinks: false)
       .map((f) => p.basename(f.path)));
   args.remove('.DS_Store');
-  return await exec('jar', args, cwd: directory);
+  return exec('jar', args, cwd: directory);
 }
 
 Future<bool> performReleaseChecks(ProductCommand cmd) async {
@@ -347,11 +347,11 @@ class GradleBuildCommand extends BuildCommand {
     return 0;
   }
 
-  Future<int> _stopDaemon() async {
+  Future<int> _stopDaemon() {
     if (Platform.isWindows) {
-      return await exec('.\\third_party\\gradlew.bat', ['--stop']);
+      return exec('.\\third_party\\gradlew.bat', ['--stop']);
     } else {
-      return await exec('./third_party/gradlew', ['--stop']);
+      return exec('./third_party/gradlew', ['--stop']);
     }
   }
 }
@@ -437,8 +437,8 @@ abstract class BuildCommand extends ProductCommand {
 
       log('spec.version: ${spec.version}');
 
-      result = await applyEdits(spec, () async {
-        return await externalBuildCommand(spec);
+      result = await applyEdits(spec, () {
+        return externalBuildCommand(spec);
       });
       if (result != 0) {
         log('applyEdits() returned ${result.toString()}');
@@ -903,18 +903,18 @@ class TestCommand extends ProductCommand {
     final spec = specs.firstWhere((s) => s.isUnitTestTarget);
     if (!argResults!['skip']) {
       if (argResults!['integration']) {
-        return await _runIntegrationTests();
+        return _runIntegrationTests();
       } else {
-        return await _runUnitTests(spec);
+        return _runUnitTests(spec);
       }
     }
     return 0;
   }
 
-  Future<int> _runUnitTests(BuildSpec spec) async {
+  Future<int> _runUnitTests(BuildSpec spec) {
     // run './gradlew test'
-    return await applyEdits(spec, () async {
-      return await runner.runGradleCommand(['test'], spec, '1', 'true');
+    return applyEdits(spec, () {
+      return runner.runGradleCommand(['test'], spec, '1', 'true');
     });
   }
 

--- a/tool/plugin/lib/runner.dart
+++ b/tool/plugin/lib/runner.dart
@@ -41,9 +41,9 @@ jxbrowser.license.key=$jxBrowserKey
     }
   }
 
-  Future<int> buildPlugin(BuildSpec spec, String version) async {
+  Future<int> buildPlugin(BuildSpec spec, String version) {
     writeJxBrowserKeyToFile();
-    return await runGradleCommand(['buildPlugin', '--stacktrace'], spec, version, 'false');
+    return runGradleCommand(['buildPlugin', '--stacktrace'], spec, version, 'false');
   }
 
   Future<int> runGradleCommand(

--- a/tool/plugin/lib/util.dart
+++ b/tool/plugin/lib/util.dart
@@ -22,7 +22,7 @@ Future<int> exec(String cmd, List<String> args, {String? cwd}) async {
   _toLineStream(process.stderr).listen(log);
   _toLineStream(process.stdout).listen(log);
 
-  return await process.exitCode;
+  return process.exitCode;
 }
 
 Future<String> makeDevLog(BuildSpec spec) async {
@@ -99,13 +99,13 @@ void createDir(String name) {
   }
 }
 
-Future<int> curl(String url, {required String to}) async {
-  return await exec('curl', ['-o', to, url]);
+Future<int> curl(String url, {required String to}) {
+  return exec('curl', ['-o', to, url]);
 }
 
 /// Remove the directory without exceptions if it does not exists.
-Future<void> removeAll(String dir) async {
-  await Directory(dir).delete(recursive: true).then((_) {}, onError: (_) {});
+Future<void> removeAll(String dir) {
+  return Directory(dir).delete(recursive: true).then((_) {}, onError: (_) {});
 }
 
 bool isNewer(FileSystemEntity newer, FileSystemEntity older) {


### PR DESCRIPTION
Remove some unused `await` code

before:
```
  Future<int> _stopDaemon() async {
    if (Platform.isWindows) {
      return await exec('.\\third_party\\gradlew.bat', ['--stop']);
    } else {
      return await exec('./third_party/gradlew', ['--stop']);
    }
  }
```
after: 
```
  Future<int> _stopDaemon() {
    if (Platform.isWindows) {
      return exec('.\\third_party\\gradlew.bat', ['--stop']);
    } else {
      return exec('./third_party/gradlew', ['--stop']);
    }
  }
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
