### PR TITLE
Prevent the NativeEditorNotificationProvider from passing `flutter.androidstudio.open` as a valid action id.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Next
+- Resolve "Exception: Cannot invoke "org..AnAction.getTemplatePresentation()" exception (#7488)
 - Resolve Released EditorImpl held by lambda in FlutterReloadManager (#7507)
 - Configure the Project view for Flutter in AS, when creating a new Flutter project (#4470)
 - Migrate to Kotlin UI DSL Version 2 (#7310)

--- a/flutter-idea/src/io/flutter/editor/NativeEditorNotificationProvider.java
+++ b/flutter-idea/src/io/flutter/editor/NativeEditorNotificationProvider.java
@@ -49,14 +49,16 @@ public class NativeEditorNotificationProvider extends EditorNotifications.Provid
     return createPanelForFile(file, findRootDir(file, project.getBaseDir()));
   }
 
-  private EditorNotificationPanel createPanelForFile(VirtualFile file, VirtualFile root) {
+  @Nullable
+  private EditorNotificationPanel createPanelForFile(@NotNull VirtualFile file, @Nullable VirtualFile root) {
     if (root == null) {
       return null;
     }
     return createPanelForAction(file, root, getActionName(root));
   }
 
-  private EditorNotificationPanel createPanelForAction(VirtualFile file, VirtualFile root, String actionName) {
+  @Nullable
+  private EditorNotificationPanel createPanelForAction(@NotNull VirtualFile file, @NotNull VirtualFile root, @Nullable String actionName) {
     if (actionName == null) {
       return null;
     }
@@ -64,15 +66,18 @@ public class NativeEditorNotificationProvider extends EditorNotifications.Provid
     return panel.isValidForFile() ? panel : null;
   }
 
-  private static String getActionName(VirtualFile root) {
+  @Nullable
+  private static String getActionName(@Nullable VirtualFile root) {
     if (root == null) {
       return null;
     }
 
-    if (root.getName().equals("android")) {
-      return "flutter.androidstudio.open";
-    }
-    else if (root.getName().equals("ios")) {
+    // See https://github.com/flutter/flutter-intellij/issues/7103
+    //if (root.getName().equals("android")) {
+    //  return "flutter.androidstudio.open";
+    //}
+    //else
+    if (root.getName().equals("ios")) {
       return "flutter.xcode.open";
     }
     else if (root.getName().equals("macos")) {

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -47,6 +47,7 @@
     <![CDATA[
 <h1>Next</h1>
 <ul>
+  <li>Resolve &quot;Exception: Cannot invoke &quot;org..AnAction.getTemplatePresentation()&quot; exception (#7488)</li>
   <li>Resolve Released EditorImpl held by lambda in FlutterReloadManager (#7507)</li>
   <li>Configure the Project view for Flutter in AS, when creating a new Flutter project (#4470)</li>
   <li>Migrate to Kotlin UI DSL Version 2 (#7310)</li>


### PR DESCRIPTION
Additionally, nullability annotations were added to method signatures.

This is follow up on https://github.com/flutter/flutter-intellij/pull/7412

This resolves https://github.com/flutter/flutter-intellij/issues/7488
