### PR TITLE
Use URI keys in ActiveEditorsOutlineService, this fixes the run icons for flutter tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Next
+- Restore Flutter test icons in the editor gutter (#7505)
+- Fix widget tree highlighting in the editor (#7522)
 - Resolve "Exception: Cannot invoke "org..AnAction.getTemplatePresentation()" exception (#7488)
 - Resolve "Pubspec has been edited" editor notification is stuck (#7538)
 - Resolve Released EditorImpl held by lambda in FlutterReloadManager (#7507)

--- a/flutter-idea/src/io/flutter/editor/ActiveEditorsOutlineService.java
+++ b/flutter-idea/src/io/flutter/editor/ActiveEditorsOutlineService.java
@@ -133,19 +133,19 @@ public class ActiveEditorsOutlineService implements Disposable {
       }
 
       for (final String path : obsoletePaths) {
-        final FlutterOutlineListener listener = outlineListeners.remove(path);
+        final String filePathOrUri = getAnalysisServer().getAnalysisService().getLocalFileUri(path);
+        final FlutterOutlineListener listener = outlineListeners.remove(filePathOrUri);
         if (listener != null) {
-          getAnalysisServer().removeOutlineListener(path, listener);
+          getAnalysisServer().removeOutlineListener(FileUtil.toSystemDependentName(path), listener);
         }
       }
 
       // Register new outline listeners.
       for (final String path : newPaths) {
-        if (outlineListeners.containsKey(path)) {
+        final String filePathOrUri = getAnalysisServer().getAnalysisService().getLocalFileUri(path);
+        if (outlineListeners.containsKey(filePathOrUri)) {
           continue;
         }
-
-        final String filePathOrUri = getAnalysisServer().getAnalysisService().getLocalFileUri(path);
         final FlutterOutlineListener listener = new OutlineListener(filePathOrUri);
         outlineListeners.put(filePathOrUri, listener);
         getAnalysisServer().addOutlineListener(FileUtil.toSystemDependentName(path), listener);
@@ -189,7 +189,11 @@ public class ActiveEditorsOutlineService implements Disposable {
    */
   @Nullable
   public FlutterOutline getOutline(@Nullable String path) {
-    return pathToOutline.get(path);
+    if(path != null) {
+      final String filePathOrUri = path.contains("://") ? path : getAnalysisServer().getAnalysisService().getLocalFileUri(path);
+      return pathToOutline.get(filePathOrUri);
+    }
+    return null;
   }
 
   /**

--- a/flutter-idea/src/io/flutter/run/common/CommonTestConfigUtils.java
+++ b/flutter-idea/src/io/flutter/run/common/CommonTestConfigUtils.java
@@ -269,7 +269,7 @@ public abstract class CommonTestConfigUtils {
 
       ApplicationManager.getApplication().invokeLater(
         () -> DaemonCodeAnalyzer.getInstance(project).restart(),
-        ModalityState.NON_MODAL,
+        ModalityState.defaultModalityState(),
         project.getDisposed()
       );
     }

--- a/flutter-idea/src/io/flutter/run/test/FlutterTestLineMarkerContributor.java
+++ b/flutter-idea/src/io/flutter/run/test/FlutterTestLineMarkerContributor.java
@@ -8,7 +8,7 @@ package io.flutter.run.test;
 import io.flutter.run.common.TestLineMarkerContributor;
 
 /**
- * Annotates conventional Flutter tests with line markers.
+ * Annotates conventional Flutter tests with line markers for running tests.
  */
 public class FlutterTestLineMarkerContributor extends TestLineMarkerContributor {
   public FlutterTestLineMarkerContributor() {

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -47,6 +47,8 @@
     <![CDATA[
 <h1>Next</h1>
 <ul>
+  <li>Restore Flutter test icons in the editor gutter (#7505)</li>
+  <li>Fix widget tree highlighting in the editor (#7522)</li>
   <li>Resolve &quot;Exception: Cannot invoke &quot;org..AnAction.getTemplatePresentation()&quot; exception (#7488)</li>
   <li>Resolve &quot;Pubspec has been edited&quot; editor notification is stuck (#7538)</li>
   <li>Resolve Released EditorImpl held by lambda in FlutterReloadManager (#7507)</li>


### PR DESCRIPTION
This resolves https://github.com/flutter/flutter-intellij/issues/7505 and https://github.com/flutter/flutter-intellij/issues/7522
