### PR TITLE
Move JX Browser engine initialization to a separate thread

### DIFF
--- a/flutter-idea/src/io/flutter/FlutterUtils.java
+++ b/flutter-idea/src/io/flutter/FlutterUtils.java
@@ -639,6 +639,7 @@ public class FlutterUtils {
     return null;
   }
 
+  // TODO(helin24): Make other usages of embedded browser initialization safe for UI?
   @Nullable
   public static EmbeddedBrowser embeddedBrowser(Project project) {
     if (project == null || project.isDisposed()) {

--- a/flutter-idea/src/io/flutter/jxbrowser/EmbeddedBrowserEngine.java
+++ b/flutter-idea/src/io/flutter/jxbrowser/EmbeddedBrowserEngine.java
@@ -29,9 +29,7 @@ public class EmbeddedBrowserEngine {
     return ServiceManager.getService(EmbeddedBrowserEngine.class);
   }
 
-  // This can take a long time
   public EmbeddedBrowserEngine() {
-    System.out.println("Within EmbeddedBrowserEngine::init");
     final String dataPath = JxBrowserManager.DOWNLOAD_PATH + File.separatorChar + "user-data";
     LOG.info("JxBrowser user data path: " + dataPath);
 

--- a/flutter-idea/src/io/flutter/jxbrowser/EmbeddedBrowserEngine.java
+++ b/flutter-idea/src/io/flutter/jxbrowser/EmbeddedBrowserEngine.java
@@ -29,7 +29,9 @@ public class EmbeddedBrowserEngine {
     return ServiceManager.getService(EmbeddedBrowserEngine.class);
   }
 
+  // This can take a long time
   public EmbeddedBrowserEngine() {
+    System.out.println("Within EmbeddedBrowserEngine::init");
     final String dataPath = JxBrowserManager.DOWNLOAD_PATH + File.separatorChar + "user-data";
     LOG.info("JxBrowser user data path: " + dataPath);
 

--- a/flutter-idea/src/io/flutter/view/FlutterView.java
+++ b/flutter-idea/src/io/flutter/view/FlutterView.java
@@ -211,15 +211,10 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
         .build();
 
       //noinspection CodeBlock2Expr
-      // Can this use a thread instead?
-      final long start = System.currentTimeMillis();
 
       Thread thread = new Thread(() -> {
-        System.out.println("Within thread and about to call optional, time elapsed: " + (System.currentTimeMillis() - start));
         embeddedBrowserOptional().ifPresent(
           embeddedBrowser -> ApplicationManager.getApplication().invokeLater(() -> {
-            System.out.println("Embedded browser is present and in invokeLater, time elapsed: " + (System.currentTimeMillis() - start));
-
             embeddedBrowser.openPanel(toolWindow, tabName, devToolsUrl, (String error) -> {
               // If the embedded browser doesn't work, offer a link to open in the regular browser.
               final List<LabelInput> inputs = Arrays.asList(
@@ -228,28 +223,10 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
               );
               presentClickableLabel(toolWindow, inputs);
             });
-            System.out.println("After opening panel, time elapsed: " + (System.currentTimeMillis() - start));
           }));
       });
       thread.start();
-      System.out.println("Started thread, time elapsed: " + (System.currentTimeMillis() - start));
 
-      //ApplicationManager.getApplication().invokeLater(() -> {
-      //  final long start = System.currentTimeMillis();
-      //
-      //  embeddedBrowserOptional().ifPresent(embeddedBrowser -> embeddedBrowser.openPanel(toolWindow, tabName, devToolsUrl, (String error) -> {
-      //    // If the embedded browser doesn't work, offer a link to open in the regular browser.
-      //    final List<LabelInput> inputs = Arrays.asList(
-      //      new LabelInput("The embedded browser failed to load. Error: " + error),
-      //      openDevToolsLabel(app, toolWindow, ideFeature)
-      //    );
-      //    presentClickableLabel(toolWindow, inputs);
-      //  }));
-      //
-      //  System.out.println("elapsed time: " + (System.currentTimeMillis() - start));
-      //});
-
-      // would this also need to be in thread?
       if (!busSubscribed) {
         busConnection.subscribe(EditorColorsManager.TOPIC, (EditorColorsListener)scheme ->
           embeddedBrowserOptional()

--- a/flutter-idea/src/io/flutter/view/FlutterView.java
+++ b/flutter-idea/src/io/flutter/view/FlutterView.java
@@ -211,17 +211,45 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
         .build();
 
       //noinspection CodeBlock2Expr
-      ApplicationManager.getApplication().invokeLater(() -> {
-        embeddedBrowserOptional().ifPresent(embeddedBrowser -> embeddedBrowser.openPanel(toolWindow, tabName, devToolsUrl, (String error) -> {
-          // If the embedded browser doesn't work, offer a link to open in the regular browser.
-          final List<LabelInput> inputs = Arrays.asList(
-            new LabelInput("The embedded browser failed to load. Error: " + error),
-            openDevToolsLabel(app, toolWindow, ideFeature)
-          );
-          presentClickableLabel(toolWindow, inputs);
-        }));
-      });
+      // Can this use a thread instead?
+      final long start = System.currentTimeMillis();
 
+      Thread thread = new Thread(() -> {
+        System.out.println("Within thread and about to call optional, time elapsed: " + (System.currentTimeMillis() - start));
+        embeddedBrowserOptional().ifPresent(
+          embeddedBrowser -> ApplicationManager.getApplication().invokeLater(() -> {
+            System.out.println("Embedded browser is present and in invokeLater, time elapsed: " + (System.currentTimeMillis() - start));
+
+            embeddedBrowser.openPanel(toolWindow, tabName, devToolsUrl, (String error) -> {
+              // If the embedded browser doesn't work, offer a link to open in the regular browser.
+              final List<LabelInput> inputs = Arrays.asList(
+                new LabelInput("The embedded browser failed to load. Error: " + error),
+                openDevToolsLabel(app, toolWindow, ideFeature)
+              );
+              presentClickableLabel(toolWindow, inputs);
+            });
+            System.out.println("After opening panel, time elapsed: " + (System.currentTimeMillis() - start));
+          }));
+      });
+      thread.start();
+      System.out.println("Started thread, time elapsed: " + (System.currentTimeMillis() - start));
+
+      //ApplicationManager.getApplication().invokeLater(() -> {
+      //  final long start = System.currentTimeMillis();
+      //
+      //  embeddedBrowserOptional().ifPresent(embeddedBrowser -> embeddedBrowser.openPanel(toolWindow, tabName, devToolsUrl, (String error) -> {
+      //    // If the embedded browser doesn't work, offer a link to open in the regular browser.
+      //    final List<LabelInput> inputs = Arrays.asList(
+      //      new LabelInput("The embedded browser failed to load. Error: " + error),
+      //      openDevToolsLabel(app, toolWindow, ideFeature)
+      //    );
+      //    presentClickableLabel(toolWindow, inputs);
+      //  }));
+      //
+      //  System.out.println("elapsed time: " + (System.currentTimeMillis() - start));
+      //});
+
+      // would this also need to be in thread?
       if (!busSubscribed) {
         busConnection.subscribe(EditorColorsManager.TOPIC, (EditorColorsListener)scheme ->
           embeddedBrowserOptional()


### PR DESCRIPTION
Sometimes starting the JX Browser engine is causing the UI freezes. This is trying to move some work out of the UI thread according to info from https://plugins.jetbrains.com/docs/intellij/general-threading-rules.html