### PR TITLE
Remove automatic refresh of inspector window on theme change and check during manual refresh

### DIFF
--- a/flutter-idea/src/io/flutter/devtools/DevToolsUrl.java
+++ b/flutter-idea/src/io/flutter/devtools/DevToolsUrl.java
@@ -5,6 +5,8 @@
  */
 package io.flutter.devtools;
 
+import com.intellij.util.ui.JBFont;
+import com.intellij.util.ui.UIUtil;
 import io.flutter.bazel.WorkspaceCache;
 import io.flutter.sdk.FlutterSdkUtil;
 import io.flutter.sdk.FlutterSdkVersion;
@@ -224,5 +226,12 @@ public class DevToolsUrl {
 
     colorHexCode = newColor;
     isBright = devToolsUtils.getIsBackgroundBright();
+  }
+
+  public void maybeUpdateFontSize() {
+    final Float newFontSize = UIUtil.getFontSize(UIUtil.FontSize.NORMAL);
+    if (!newFontSize.equals(fontSize)) {
+      fontSize = newFontSize;
+    }
   }
 }

--- a/flutter-idea/src/io/flutter/devtools/DevToolsUrl.java
+++ b/flutter-idea/src/io/flutter/devtools/DevToolsUrl.java
@@ -5,6 +5,8 @@
  */
 package io.flutter.devtools;
 
+import com.intellij.openapi.editor.colors.EditorColorsManager;
+import com.intellij.openapi.editor.colors.EditorColorsScheme;
 import com.intellij.util.ui.JBFont;
 import com.intellij.util.ui.UIUtil;
 import io.flutter.bazel.WorkspaceCache;
@@ -229,8 +231,9 @@ public class DevToolsUrl {
   }
 
   public void maybeUpdateFontSize() {
-    final Float newFontSize = UIUtil.getFontSize(UIUtil.FontSize.NORMAL);
-    if (!newFontSize.equals(fontSize)) {
+    EditorColorsScheme scheme = EditorColorsManager.getInstance().getGlobalScheme();
+    final Float newFontSize = (float) scheme.getEditorFontSize();
+    if (fontSize == null || !fontSize.equals(newFontSize)) {
       fontSize = newFontSize;
     }
   }

--- a/flutter-idea/src/io/flutter/view/EmbeddedBrowser.java
+++ b/flutter-idea/src/io/flutter/view/EmbeddedBrowser.java
@@ -243,23 +243,6 @@ public abstract class EmbeddedBrowser {
     });
   }
 
-  public void updateColor(String newColor) {
-    updateUrlAndReload(devToolsUrl -> {
-      devToolsUrl.maybeUpdateColor();
-      return devToolsUrl;
-    });
-  }
-
-  public void updateFontSize(float newFontSize) {
-    updateUrlAndReload(devToolsUrl -> {
-      if (devToolsUrl.fontSize.equals(newFontSize)) {
-        return null;
-      }
-      devToolsUrl.fontSize = newFontSize;
-      return devToolsUrl;
-    });
-  }
-
   public void updateVmServiceUri(@NotNull String newVmServiceUri) {
     updateUrlAndReload(devToolsUrl -> {
       if (newVmServiceUri.equals(devToolsUrl.vmServiceUri)) {
@@ -284,6 +267,8 @@ public abstract class EmbeddedBrowser {
       if (tab == null || tab.devToolsUrlFuture == null) return;
       tab.devToolsUrlFuture.thenAccept(devToolsUrl -> {
         if (devToolsUrl == null) return;
+        devToolsUrl.maybeUpdateColor();
+        devToolsUrl.maybeUpdateFontSize();
         tab.embeddedTab.loadUrl(devToolsUrl.getUrlString());
       });
     });

--- a/flutter-idea/testSrc/unit/io/flutter/view/FlutterViewTest.java
+++ b/flutter-idea/testSrc/unit/io/flutter/view/FlutterViewTest.java
@@ -38,7 +38,6 @@ public class FlutterViewTest {
   JxBrowserUtils mockUtils = mock(JxBrowserUtils.class);
   JxBrowserManager mockJxBrowserManager = mock(JxBrowserManager.class);
   InspectorGroupManagerService mockInspectorGroupManagerService = mock(InspectorGroupManagerService.class);
-  MessageBusConnection mockBusConnection = mock(MessageBusConnection.class);
 
   @Test
   public void testHandleJxBrowserInstalled() {
@@ -59,7 +58,7 @@ public class FlutterViewTest {
     when(mockJxBrowserManager.getLatestFailureReason()).thenReturn(new InstallationFailedReason(FailureType.FILE_DOWNLOAD_FAILED));
 
     // If JxBrowser failed to install, we should show a failure message that allows the user to manually retry.
-    final FlutterView flutterView = new FlutterView(mockProject, mockJxBrowserManager, mockJxBrowserUtils, mockInspectorGroupManagerService, mockBusConnection);
+    final FlutterView flutterView = new FlutterView(mockProject, mockJxBrowserManager, mockJxBrowserUtils, mockInspectorGroupManagerService);
     final FlutterView spy = spy(flutterView);
     doNothing().when(spy).presentClickableLabel(
       eq(mockToolWindow),
@@ -79,7 +78,7 @@ public class FlutterViewTest {
 
     // If the JxBrowser installation is initially in progress, we should show a message about the installation.
     // If the installation quickly finishes (on the first re-check), then we should call the function to handle successful installation.
-    final FlutterView flutterView = new FlutterView(mockProject, mockJxBrowserManager, mockUtils, mockInspectorGroupManagerService, mockBusConnection);
+    final FlutterView flutterView = new FlutterView(mockProject, mockJxBrowserManager, mockUtils, mockInspectorGroupManagerService);
     final FlutterView spy = spy(flutterView);
 
     doNothing().when(spy).presentOpenDevToolsOptionWithMessage(any(), any(), any(), any());
@@ -97,7 +96,7 @@ public class FlutterViewTest {
 
     // If the JxBrowser installation is in progress and is not finished on the first re-check, we should start a thread to wait for the
     // installation to finish.
-    final FlutterView flutterView = new FlutterView(mockProject, mockJxBrowserManager, mockUtils, mockInspectorGroupManagerService, mockBusConnection);
+    final FlutterView flutterView = new FlutterView(mockProject, mockJxBrowserManager, mockUtils, mockInspectorGroupManagerService);
     final FlutterView spy = spy(flutterView);
 
     doNothing().when(spy).presentOpenDevToolsOptionWithMessage(any(), any(), any(), any());
@@ -115,7 +114,7 @@ public class FlutterViewTest {
     when(mockJxBrowserManager.waitForInstallation(INSTALLATION_WAIT_LIMIT_SECONDS)).thenReturn(JxBrowserStatus.INSTALLATION_FAILED);
 
     // If waiting for JxBrowser installation completes without timing out, then we should return to event thread.
-    final FlutterView flutterView = new FlutterView(mockProject, mockJxBrowserManager, mockUtils, mockInspectorGroupManagerService, mockBusConnection);
+    final FlutterView flutterView = new FlutterView(mockProject, mockJxBrowserManager, mockUtils, mockInspectorGroupManagerService);
     final FlutterView spy = spy(flutterView);
 
     doNothing().when(spy).handleUpdatedJxBrowserStatusOnEventThread(any(), any(), any(), any());
@@ -132,7 +131,7 @@ public class FlutterViewTest {
     when(mockJxBrowserManager.waitForInstallation(INSTALLATION_WAIT_LIMIT_SECONDS)).thenThrow(new TimeoutException());
 
     // If the JxBrowser installation doesn't complete on time, we should show a timed out message.
-    final FlutterView flutterView = new FlutterView(mockProject, mockJxBrowserManager, mockUtils, mockInspectorGroupManagerService, mockBusConnection);
+    final FlutterView flutterView = new FlutterView(mockProject, mockJxBrowserManager, mockUtils, mockInspectorGroupManagerService);
     final FlutterView spy = spy(flutterView);
 
     doNothing().when(spy).presentOpenDevToolsOptionWithMessage(any(), any(), any(), any());


### PR DESCRIPTION
This change:
- Removes an automatic refresh of the inspector tool window when theming changes
- Adds check for theming during manual refresh of all of the DevTools windows