### PR TITLE
Add a way for developers of DevTools to use Flutter plugin with locally served DevTools

### DIFF
--- a/flutter-idea/src/io/flutter/run/daemon/DevToolsService.java
+++ b/flutter-idea/src/io/flutter/run/daemon/DevToolsService.java
@@ -5,7 +5,7 @@
  */
 package io.flutter.run.daemon;
 
-import  com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableList;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonSyntaxException;

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -21,7 +21,7 @@
 
   <category>Custom Languages</category>
   <version>SNAPSHOT</version>
-  <idea-version since-build="242.20224.300" until-build="242.*"/>
+  <idea-version since-build="241.14494.158" until-build="242.*"/>
 
   <depends>com.intellij.modules.platform</depends>
   <depends>com.intellij.modules.lang</depends>
@@ -718,6 +718,8 @@
     <notificationGroup displayType="TOOL_WINDOW" id="flutter-run" toolWindowId="Run" />
     <notificationGroup displayType="TOOL_WINDOW" id="flutter-debug" toolWindowId="Debug" />
     <notificationGroup displayType="TOOL_WINDOW" id="flutter-analysis" toolWindowId="Dart Analysis" />
+
+    <registryKey defaultValue="" description="Launch local server for DevTools" key="flutter.local.devtools.dir"/>
   </extensions>
 
   <!-- Dart Plugin extensions -->

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -720,6 +720,7 @@
     <notificationGroup displayType="TOOL_WINDOW" id="flutter-analysis" toolWindowId="Dart Analysis" />
 
     <registryKey defaultValue="" description="Launch local server for DevTools" key="flutter.local.devtools.dir"/>
+    <registryKey defaultValue="" description="Local DevTools server arguments" key="flutter.local.devtools.args"/>
   </extensions>
 
   <!-- Dart Plugin extensions -->

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -21,7 +21,7 @@
 
   <category>Custom Languages</category>
   <version>SNAPSHOT</version>
-  <idea-version since-build="241.14494.158" until-build="242.*"/>
+  <idea-version since-build="242.20224.300" until-build="242.*"/>
 
   <depends>com.intellij.modules.platform</depends>
   <depends>com.intellij.modules.lang</depends>

--- a/resources/META-INF/plugin_template.xml
+++ b/resources/META-INF/plugin_template.xml
@@ -419,6 +419,7 @@
     <notificationGroup displayType="TOOL_WINDOW" id="flutter-analysis" toolWindowId="Dart Analysis" />
 
     <registryKey defaultValue="" description="Launch local server for DevTools" key="flutter.local.devtools.dir"/>
+    <registryKey defaultValue="" description="Local DevTools server arguments" key="flutter.local.devtools.args"/>
   </extensions>
 
   <!-- Dart Plugin extensions -->

--- a/resources/META-INF/plugin_template.xml
+++ b/resources/META-INF/plugin_template.xml
@@ -417,6 +417,8 @@
     <notificationGroup displayType="TOOL_WINDOW" id="flutter-run" toolWindowId="Run" />
     <notificationGroup displayType="TOOL_WINDOW" id="flutter-debug" toolWindowId="Debug" />
     <notificationGroup displayType="TOOL_WINDOW" id="flutter-analysis" toolWindowId="Dart Analysis" />
+
+    <registryKey defaultValue="" description="Launch local server for DevTools" key="flutter.local.devtools.dir"/>
   </extensions>
 
   <!-- Dart Plugin extensions -->


### PR DESCRIPTION
This offers a way to use a development version of DevTools (whatever `devtools_tool serve` runs) while using a standard Flutter plugin. This should be helpful when testing DevTools-IJ interactions.

Typically, the Dart plugin starts DTD and then also starts DevTools, passing in the DTD URL. The Flutter plugin will then use this instance of DevTools to access embedded tool windows. When using this locally served DevTools, the Dart plugin behaves the same way, but the Flutter plugin starts its own instance of local DevTools using the same DTD URL. (Note that there could be some side effects from having two DevTools instances started, connected to the same DTD instance.)

Instructions for using this:
1. Set the registry key to your DevTools directory: Go to Help > Find action > Registry > Find "flutter.local.devtools.dir" and set to your DevTools directory. (e.g. `Users/helinx/Documents/devtools`). If you want to add additional args, put these in the option "flutter.local.devtools.args".
2. Restart IntelliJ
3. You should be able to open Help > Show log in finder > Open idea.log; in here with the registry key set as above, then you should see output like "DevTools startup: <various messages that come from running `devtools_tool serve`>"
4. To turn off using local DevTools, go back to the registry key and clear out the setting.

CC @kenzieschmoll @elliette 