### PR TITLE
Only init perf view if tool window was created

### DIFF
--- a/flutter-idea/src/io/flutter/performance/FlutterPerformanceViewFactory.java
+++ b/flutter-idea/src/io/flutter/performance/FlutterPerformanceViewFactory.java
@@ -37,11 +37,14 @@ public class FlutterPerformanceViewFactory implements ToolWindowFactory, DumbAwa
     }
   }
 
-  private static void initPerfView(@NotNull Project project, FlutterViewMessages.FlutterDebugEvent event) {
+  private static void initPerfView(@NotNull Project project, @NotNull FlutterViewMessages.FlutterDebugEvent event) {
     ApplicationManager.getApplication().invokeLater(() -> {
       final FlutterPerformanceView flutterPerfView = project.getService(FlutterPerformanceView.class);
-      ToolWindowManager.getInstance(project).getToolWindow(FlutterPerformanceView.TOOL_WINDOW_ID).setAvailable(true);
-      flutterPerfView.debugActive(event);
+      final ToolWindow window = ToolWindowManager.getInstance(project).getToolWindow(FlutterPerformanceView.TOOL_WINDOW_ID);
+      if (flutterPerfView != null && window != null) {
+        window.setAvailable(true);
+        flutterPerfView.debugActive(event);
+      }
     });
   }
 

--- a/flutter-idea/src/io/flutter/view/FlutterViewMessages.java
+++ b/flutter-idea/src/io/flutter/view/FlutterViewMessages.java
@@ -21,7 +21,7 @@ public class FlutterViewMessages {
   public static final Topic<FlutterDebugNotifier> FLUTTER_DEBUG_TOPIC = Topic.create("flutter.debugActive", FlutterDebugNotifier.class);
 
   public interface FlutterDebugNotifier {
-    void debugActive(FlutterDebugEvent event);
+    void debugActive(@NotNull FlutterDebugEvent event);
   }
 
   public static class FlutterDebugEvent {


### PR DESCRIPTION
A naive workaround for https://github.com/flutter/flutter-intellij/issues/7691, but conditionally calling the init logic or not doing so ourselves might be a better long term solution.