### PR TITLE
Gracefully handle perf tool window not being created

### DIFF
--- a/flutter-idea/src/io/flutter/performance/FlutterPerformanceViewFactory.java
+++ b/flutter-idea/src/io/flutter/performance/FlutterPerformanceViewFactory.java
@@ -40,8 +40,11 @@ public class FlutterPerformanceViewFactory implements ToolWindowFactory, DumbAwa
   private static void initPerfView(@NotNull Project project, FlutterViewMessages.FlutterDebugEvent event) {
     ApplicationManager.getApplication().invokeLater(() -> {
       final FlutterPerformanceView flutterPerfView = project.getService(FlutterPerformanceView.class);
-      ToolWindowManager.getInstance(project).getToolWindow(FlutterPerformanceView.TOOL_WINDOW_ID).setAvailable(true);
-      flutterPerfView.debugActive(event);
+      final ToolWindow window = ToolWindowManager.getInstance(project).getToolWindow(FlutterPerformanceView.TOOL_WINDOW_ID);
+      if (flutterPerfView != null && window != null) {
+        window.setAvailable(true);
+        flutterPerfView.debugActive(event);
+      }
     });
   }
 


### PR DESCRIPTION
A workaround for #7691, not accessing the tool window if it wasn't created due to `isApplicableAsync` being false for the SDK version. Does it in this listener so if the SDK version changes, the event still can be handled properly.