### PR TITLE
Migrate off of `ServiceManager.getServiceIfCreated` API usage

### DIFF
--- a/flutter-idea/src/io/flutter/run/FlutterAppManager.java
+++ b/flutter-idea/src/io/flutter/run/FlutterAppManager.java
@@ -13,7 +13,6 @@ import com.intellij.execution.process.ProcessHandler;
 import com.intellij.execution.ui.RunContentDescriptor;
 import com.intellij.execution.ui.RunContentManager;
 import com.intellij.openapi.Disposable;
-import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Disposer;
 import io.flutter.run.daemon.FlutterApp;
@@ -125,9 +124,9 @@ public class FlutterAppManager implements Disposable {
     }
     // Creating a RunContentManager causes a blank window to appear, so don't create it here.
     // See https://github.com/flutter/flutter-intellij/issues/4217
-    if (ServiceManager.getServiceIfCreated(project, RunContentManager.class) == null) {
+    if (project.getServiceIfCreated(RunContentManager.class) == null) {
       return null;
     }
-    return ExecutionManager.getInstance(project).getContentManager();
+    return RunContentManager.getInstance(project);
   }
 }


### PR DESCRIPTION
https://github.com/JetBrains/intellij-community/blob/337bcc327a5d34720e134e312768de414c5572b0/platform/core-api/src/com/intellij/openapi/components/ServiceManager.java#L35

https://github.com/JetBrains/intellij-community/blob/d587049edb9cc85f67d4e070584ad79f68befc2e/platform/execution/src/com/intellij/execution/ExecutionManager.kt#L40

This is progress towards resolving https://github.com/flutter/flutter-intellij/issues/7718