### PR TITLE
Add the .intellijPlatform directories to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,8 @@ resources/jxbrowser/jxbrowser.properties
 .idea/libraries/Gradle_*.xml
 **/.idea/modules.xml
 .kotlin/
+.intellijPlatform/
+**/.intellijPlatform/
 flutter-studio/build/
 flutter-studio/.gradle/
 flutter-idea/build/


### PR DESCRIPTION
This is part of the Gradle IntelliJ migration, https://github.com/flutter/flutter-intellij/issues/7670

Message from the updated plugin:
```
> Task :flutter-idea:verifyPluginProjectConfiguration
[org.jetbrains.intellij.platform] The following plugin configuration issues were found:
- The IntelliJ Platform cache directory should be excluded from the version control system. Add the '.intellijPlatform' entry to the '.gitignore' file.
```