### PR TITLE
Enable notification when SDK will soon be unsupported soon

### DIFF
--- a/flutter-idea/src/io/flutter/FlutterInitializer.java
+++ b/flutter-idea/src/io/flutter/FlutterInitializer.java
@@ -217,6 +217,8 @@ public class FlutterInitializer implements StartupActivity {
     // Initialize notifications for theme changes.
     setUpThemeChangeNotifications(project);
 
+    // TODO(jwren) For releases in early H1 2025, include this message as well as a new one if the user is using a Flutter SDK version that
+    //  is not supported, i.e. match VS Code implementation.
     // Send unsupported SDK notifications if relevant.
     checkSdkVersionNotification(project);
 
@@ -363,28 +365,30 @@ public class FlutterInitializer implements StartupActivity {
     if (sdk == null) return;
     final FlutterSdkVersion version = sdk.getVersion();
 
-    if (!version.sdkIsSupported() && version.getVersionText() != null) {
+    // See FlutterSdkVersion.MIN_SDK_SUPPORTED.
+    if (version.isValid() && !version.sdkIsSupported()) {
       final FlutterSettings settings = FlutterSettings.getInstance();
       if (settings == null || settings.isSdkVersionOutdatedWarningAcknowledged(version.getVersionText())) return;
 
       ApplicationManager.getApplication().invokeLater(() -> {
-        final Notification notification = new Notification("flutter-sdk",
+        final Notification notification = new Notification(FlutterMessages.FLUTTER_NOTIFICATION_GROUP_ID,
                                                            "Flutter SDK requires update",
                                                            "Support for v" +
                                                            version.getVersionText() +
-                                                           " of the Flutter SDK will be removed in an upcoming release of the Flutter plugin. Consider updating to a more recent Flutter SDK",
+                                                           " of the Flutter SDK will be removed in an upcoming release of the Flutter " +
+                                                           "plugin. Consider updating to a more recent Flutter SDK.",
                                                            NotificationType.WARNING);
-        notification.addAction(new AnAction("More Info") {
-          @Override
-          public void actionPerformed(@NotNull AnActionEvent event) {
-            // TODO(helin24): Update with informational URL.
-            BrowserLauncher.getInstance().browse("https://www.google.com", null);
-            settings.setSdkVersionOutdatedWarningAcknowledged(version.getVersionText(), true);
-            notification.expire();
-          }
-        });
+        //notification.addAction(new AnAction("More Info") {
+        //  @Override
+        //  public void actionPerformed(@NotNull AnActionEvent event) {
+        //    // TODO(helin24): Update with informational URL.
+        //    BrowserLauncher.getInstance().browse("https://www.google.com", null);
+        //    settings.setSdkVersionOutdatedWarningAcknowledged(version.getVersionText(), true);
+        //    notification.expire();
+        //  }
+        //});
 
-        notification.addAction(new AnAction("I understand") {
+        notification.addAction(new AnAction("Dismiss") {
           @Override
           public void actionPerformed(@NotNull AnActionEvent event) {
             settings.setSdkVersionOutdatedWarningAcknowledged(version.getVersionText(), true);

--- a/flutter-idea/src/io/flutter/FlutterInitializer.java
+++ b/flutter-idea/src/io/flutter/FlutterInitializer.java
@@ -378,7 +378,9 @@ public class FlutterInitializer implements StartupActivity {
                                                            " of the Flutter SDK will be removed in an upcoming release of the Flutter " +
                                                            "plugin. Consider updating to a more recent Flutter SDK.",
                                                            NotificationType.WARNING);
-        //notification.addAction(new AnAction("More Info") {
+        // TODO(jwren) If we can get a URL on the Flutter website with the appropriate information, we should include it in the
+        //  notification as an action:
+        // notification.addAction(new AnAction("More Info") {
         //  @Override
         //  public void actionPerformed(@NotNull AnActionEvent event) {
         //    // TODO(helin24): Update with informational URL.

--- a/flutter-idea/src/io/flutter/sdk/FlutterSdkVersion.java
+++ b/flutter-idea/src/io/flutter/sdk/FlutterSdkVersion.java
@@ -130,9 +130,19 @@ public final class FlutterSdkVersion implements Comparable<FlutterSdkVersion> {
   @NotNull
   private static final FlutterSdkVersion MIN_SUPPORTS_DTD = new FlutterSdkVersion("3.22.0");
 
+  /**
+   * The minimum version that will trigger a notification that the Flutter SDK needs to be updated, otherwise support may be lost in the
+   * Flutter Plugin.
+   * <p>
+   * Note, this is for the Flutter SDK version, not the Dart SDK version, this mapping can be found:
+   * <a href="https://docs.flutter.dev/release/archive">Flutter SDK Release Archive list</a>.
+   * <p>
+   * The Flutter version `3.7.12` maps to the Dart SDK version in before NNBD (early 2023 stable).
+   * <p>
+   * This version was updated last on November 4th, 2024, and in coordination with the VS Code support.
+   */
   @NotNull
-  // TODO(helin24): Update with the right version.
-  private static final FlutterSdkVersion MIN_SDK_SUPPORTED = new FlutterSdkVersion("0.0.1");
+  private static final FlutterSdkVersion MIN_SDK_SUPPORTED = new FlutterSdkVersion("3.10.0");
 
   @Nullable
   private final Version version;

--- a/flutter-idea/src/io/flutter/settings/FlutterSettings.java
+++ b/flutter-idea/src/io/flutter/settings/FlutterSettings.java
@@ -377,6 +377,9 @@ public class FlutterSettings {
     fireEvent();
   }
 
+  /**
+   * See {FlutterSdkVersion#MIN_SDK_SUPPORTED}.
+   */
   public boolean isSdkVersionOutdatedWarningAcknowledged(String versionText) {
     return getPropertiesComponent().getBoolean(getSdkVersionKey(versionText));
   }


### PR DESCRIPTION
Flutter SDK version `3.10.0`, Dart SDK version `3.0.0`

This work is in prep for a point release soon (1-2 days).

This work is in sync with DartCode, see https://dartcode.org/releases/#v31000-2024-10-31.