### PR TITLE
Update the settings in build.gradle.kts for the validate task

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -130,9 +130,20 @@ intellijPlatform {
     // https://github.com/JetBrains/intellij-plugin-verifier
     cliPath = file("../third_party/lib/verifier-cli-1.379-all.jar")
     failureLevel = listOf(
+      // TODO(team) Ideally all of the following FailureLevels should be enabled:
+      // TODO(team) Create a tracking issue for each of the following validations
+//      VerifyPluginTask.FailureLevel.COMPATIBILITY_WARNINGS,
+//      VerifyPluginTask.FailureLevel.COMPATIBILITY_PROBLEMS,
+//      VerifyPluginTask.FailureLevel.DEPRECATED_API_USAGES,
+//      VerifyPluginTask.FailureLevel.SCHEDULED_FOR_REMOVAL_API_USAGES,
       VerifyPluginTask.FailureLevel.EXPERIMENTAL_API_USAGES,
-//      VerifyPluginTask.FailureLevel.PLUGIN_STRUCTURE_WARNINGS,
+//      VerifyPluginTask.FailureLevel.INTERNAL_API_USAGES,
+//      VerifyPluginTask.FailureLevel.OVERRIDE_ONLY_API_USAGES,
+      VerifyPluginTask.FailureLevel.NON_EXTENDABLE_API_USAGES,
+      VerifyPluginTask.FailureLevel.PLUGIN_STRUCTURE_WARNINGS,
+//      VerifyPluginTask.FailureLevel.MISSING_DEPENDENCIES,
       VerifyPluginTask.FailureLevel.INVALID_PLUGIN,
+//      VerifyPluginTask.FailureLevel.NOT_DYNAMIC,
     )
     verificationReportsFormats = VerifyPluginTask.VerificationReportsFormats.ALL
     subsystemsToCheck = VerifyPluginTask.Subsystems.ALL

--- a/flutter-idea/build.gradle.kts
+++ b/flutter-idea/build.gradle.kts
@@ -111,10 +111,21 @@ intellijPlatform {
     // https://github.com/JetBrains/intellij-plugin-verifier
     cliPath = file("../third_party/lib/verifier-cli-1.379-all.jar")
     failureLevel = listOf(
+      // TODO(team) Ideally all of the following FailureLevels should be enabled:
+      // TODO(team) Create a tracking issue for each of the following validations
+//      VerifyPluginTask.FailureLevel.COMPATIBILITY_WARNINGS,
+//      VerifyPluginTask.FailureLevel.COMPATIBILITY_PROBLEMS,
+//      VerifyPluginTask.FailureLevel.DEPRECATED_API_USAGES,
+//      VerifyPluginTask.FailureLevel.SCHEDULED_FOR_REMOVAL_API_USAGES,
       VerifyPluginTask.FailureLevel.EXPERIMENTAL_API_USAGES,
-//      VerifyPluginTask.FailureLevel.PLUGIN_STRUCTURE_WARNINGS,
+//      VerifyPluginTask.FailureLevel.INTERNAL_API_USAGES,
+//      VerifyPluginTask.FailureLevel.OVERRIDE_ONLY_API_USAGES,
+      VerifyPluginTask.FailureLevel.NON_EXTENDABLE_API_USAGES,
+      VerifyPluginTask.FailureLevel.PLUGIN_STRUCTURE_WARNINGS,
+//      VerifyPluginTask.FailureLevel.MISSING_DEPENDENCIES,
       VerifyPluginTask.FailureLevel.INVALID_PLUGIN,
-      )
+//      VerifyPluginTask.FailureLevel.NOT_DYNAMIC,
+    )
     verificationReportsFormats = VerifyPluginTask.VerificationReportsFormats.ALL
     subsystemsToCheck = VerifyPluginTask.Subsystems.ALL
     // Mute and freeArgs documentation

--- a/tool/kokoro/build.sh
+++ b/tool/kokoro/build.sh
@@ -5,8 +5,6 @@ setup
 
 echo "kokoro build start"
 
-./bin/plugin verify
-
 ./bin/plugin make --channel=dev
 
 echo "kokoro build finished"


### PR DESCRIPTION
Local runs are producing different output than the Kokoro bot, hence the continued volatility

Verify has been disabled for the time being as the CI bots currently throw an exception (see below)
