### PR TITLE
Remove the old logic (2017) to migrate Flutter projects from one module type to another

### DIFF
--- a/flutter-idea/src/io/flutter/FlutterBundle.properties
+++ b/flutter-idea/src/io/flutter/FlutterBundle.properties
@@ -82,8 +82,6 @@ flutter.analytics.notification.content=The Flutter plugin reports feature usage 
   <a href="url">www.google.com/policies/privacy</a>.<br><br>Send usage statistics?
 flutter.analytics.privacyUrl=https://www.google.com/policies/privacy/
 
-flutter.initializer.module.converted.title=Flutter module type updated
-
 flutter.reload.firstRun.title=Flutter supports hot reload!
 flutter.reload.firstRun.content=Apply changes to your app in place, instantly.
 flutter.reload.firstRun.url=https://flutter.dev/docs/development/tools/hot-reload

--- a/flutter-idea/src/io/flutter/FlutterInitializer.java
+++ b/flutter-idea/src/io/flutter/FlutterInitializer.java
@@ -81,16 +81,6 @@ public class FlutterInitializer implements StartupActivity {
 
   @Override
   public void runActivity(@NotNull Project project) {
-    // Convert all modules of deprecated type FlutterModuleType.
-    if (FlutterModuleUtils.convertFromDeprecatedModuleType(project)) {
-      // If any modules were converted over, create a notification
-      FlutterMessages.showInfo(
-        FlutterBundle.message("flutter.initializer.module.converted.title"),
-        "Converted from '" + FlutterModuleUtils.DEPRECATED_FLUTTER_MODULE_TYPE_ID +
-        "' to '" + FlutterModuleUtils.getModuleTypeIDForFlutter() + "'.",
-        project);
-    }
-
     // Disable the 'Migrate Project to Gradle' notification.
     FlutterUtils.disableGradleProjectMigrationNotification(project);
 

--- a/flutter-idea/src/io/flutter/utils/FlutterModuleUtils.java
+++ b/flutter-idea/src/io/flutter/utils/FlutterModuleUtils.java
@@ -349,22 +349,6 @@ public class FlutterModuleUtils {
     return CollectionUtils.filter(getModules(project), module -> isFlutterModule(module) || declaresFlutter(module));
   }
 
-  public static boolean convertFromDeprecatedModuleType(@NotNull Project project) {
-    boolean modulesConverted = false;
-
-    // Only automatically convert from older module types to JAVA_MODULE types if we're running in Android Studio.
-    if (FlutterUtils.isAndroidStudio()) {
-      for (Module module : getModules(project)) {
-        if (isDeprecatedFlutterModuleType(module)) {
-          setFlutterModuleType(module);
-          modulesConverted = true;
-        }
-      }
-    }
-
-    return modulesConverted;
-  }
-
   // Return true if there is a module with the same name as the project plus the Android suffix.
   public static boolean hasAndroidModule(@NotNull Project project) {
     for (PubRoot root : PubRoots.forProject(project)) {
@@ -378,15 +362,6 @@ public class FlutterModuleUtils {
       }
     }
     return false;
-  }
-
-  public static boolean isDeprecatedFlutterModuleType(@NotNull Module module) {
-    if (!DEPRECATED_FLUTTER_MODULE_TYPE_ID.equals(module.getOptionValue("type"))) {
-      return false;
-    }
-
-    // Validate that the pubspec references flutter.
-    return declaresFlutter(module);
   }
 
   public static boolean isInFlutterAndroidModule(@NotNull Project project, @NotNull VirtualFile file) {

--- a/flutter-idea/testSrc/unit/io/flutter/utils/FlutterModuleUtilsTest.java
+++ b/flutter-idea/testSrc/unit/io/flutter/utils/FlutterModuleUtilsTest.java
@@ -22,11 +22,6 @@ public class FlutterModuleUtilsTest {
   public final ProjectFixture<IdeaProjectTestFixture> fixture = Testing.makeEmptyModule();
 
   @Test
-  public void isDeprecatedFlutterModuleType_false_empty_module() {
-    assertFalse(FlutterModuleUtils.isDeprecatedFlutterModuleType(fixture.getModule()));
-  }
-
-  @Test
   public void isFlutterModule_null() {
     assertFalse(FlutterModuleUtils.isFlutterModule(null));
   }


### PR DESCRIPTION
Original work: https://github.com/flutter/flutter-intellij/commit/da5eea7792c7da6a09740e65ed9bfc590137dcee