### PR TITLE
Avoid internal AS collections

### DIFF
--- a/flutter-idea/src/io/flutter/perf/FlutterWidgetPerf.java
+++ b/flutter-idea/src/io/flutter/perf/FlutterWidgetPerf.java
@@ -5,7 +5,6 @@
  */
 package io.flutter.perf;
 
-import com.android.tools.idea.io.netty.util.collection.IntObjectHashMap;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.LinkedListMultimap;
@@ -25,6 +24,8 @@ import com.intellij.openapi.util.TextRange;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.util.ui.EdtInvocationManager;
 import io.flutter.utils.AsyncUtils;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.Timer;
@@ -52,7 +53,7 @@ public class FlutterWidgetPerf implements Disposable, WidgetPerfListener {
   public static final long IDLE_DELAY_MILISECONDS = 400;
 
   static class StatsForReportKind {
-    final IntObjectHashMap<SlidingWindowStats> data = new IntObjectHashMap<>();
+    final Int2ObjectMap<SlidingWindowStats> data = new Int2ObjectOpenHashMap<>();
     private int lastStartTime = -1;
     private int lastNonEmptyReportTime = -1;
   }
@@ -73,7 +74,7 @@ public class FlutterWidgetPerf implements Disposable, WidgetPerfListener {
    * Note: any access of editorDecorations contents must happen on the UI thread.
    */
   private final Map<TextEditor, EditorPerfModel> editorDecorations = new HashMap<>();
-  private final IntObjectHashMap<Location> knownLocationIds = new IntObjectHashMap<>();
+  private final Int2ObjectMap<Location> knownLocationIds = new Int2ObjectOpenHashMap<>();
   private final SetMultimap<String, Location> locationsPerFile = HashMultimap.create();
   private final Map<PerfReportKind, StatsForReportKind> stats = new HashMap<>();
 
@@ -419,7 +420,7 @@ public class FlutterWidgetPerf implements Disposable, WidgetPerfListener {
       if (forKind == null) {
         continue;
       }
-      final IntObjectHashMap<SlidingWindowStats> data = forKind.data;
+      final Int2ObjectMap<SlidingWindowStats> data = forKind.data;
       for (Location location : locationsPerFile.get(path)) {
         final SlidingWindowStats entry = data.get(location.id);
         if (entry == null) {

--- a/flutter-idea/src/io/flutter/run/ObservatoryFile.java
+++ b/flutter-idea/src/io/flutter/run/ObservatoryFile.java
@@ -5,7 +5,6 @@
  */
 package io.flutter.run;
 
-import com.android.tools.idea.io.netty.util.collection.IntObjectHashMap;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.testFramework.LightVirtualFile;
 import com.intellij.util.PathUtil;
@@ -13,6 +12,8 @@ import com.intellij.xdebugger.XDebuggerUtil;
 import com.intellij.xdebugger.XSourcePosition;
 import com.jetbrains.lang.dart.DartFileType;
 import io.flutter.vmService.DartVmServiceDebugProcess;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import org.dartlang.vm.service.element.Script;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -36,7 +37,7 @@ class ObservatoryFile {
    * Maps an observatory token id to its line and column.
    */
   @Nullable
-  private final IntObjectHashMap<Position> positionMap;
+  private final Int2ObjectMap<Position> positionMap;
 
   /**
    * User-visible source code downloaded from Observatory.
@@ -92,8 +93,8 @@ class ObservatoryFile {
    * <p>See <a href="https://github.com/dart-lang/vm_service_drivers/blob/master/dart/tool/service.md#scrip">docs</a>.
    */
   @NotNull
-  private static IntObjectHashMap<Position> createPositionMap(@NotNull final List<List<Integer>> table) {
-    final IntObjectHashMap<Position> result = new IntObjectHashMap<>();
+  private static Int2ObjectMap<Position> createPositionMap(@NotNull final List<List<Integer>> table) {
+    final Int2ObjectMap<Position> result = new Int2ObjectOpenHashMap<>();
 
     for (List<Integer> line : table) {
       // Each line consists of a line number followed by (tokenId, columnNumber) pairs.

--- a/tool/plugin/lib/lint.dart
+++ b/tool/plugin/lib/lint.dart
@@ -49,9 +49,7 @@ class LintCommand extends Command<int> {
     final usages = <String, List<String>>{};
 
     imports.split('\n').forEach((String line) {
-      if (line
-          .trim()
-          .isEmpty) {
+      if (line.trim().isEmpty) {
         return;
       }
 
@@ -106,6 +104,9 @@ class LintCommand extends Command<int> {
 
       // gnu.trove. classes seem to all be deprecated, avoid into the future
       'gnu.trove.',
+
+      // Prefer to use built-in Java collections or fastutil.
+      'com.android.tools.idea.io.netty.util.collection.',
     ];
 
     for (var import in proscribedImports) {


### PR DESCRIPTION
The `Int2ObjectOpenHashMap` implementation is the most common implementation I found across the IntelliJ platform, so went with that for its general usage characteristics.