### PR TITLE
Migrate off of FileChooserUtil.setLastOpenedFile(..)

### DIFF
--- a/flutter-studio/src/io/flutter/actions/OpenAndroidModule.java
+++ b/flutter-studio/src/io/flutter/actions/OpenAndroidModule.java
@@ -21,9 +21,10 @@ import org.jetbrains.annotations.Nullable;
 import org.jetbrains.plugins.gradle.util.GradleConstants;
 
 import java.awt.event.InputEvent;
+import java.nio.file.Path;
 
 import static com.android.tools.idea.gradle.project.ProjectImportUtil.findGradleTarget;
-import static com.intellij.ide.impl.ProjectUtil.*;
+import static com.intellij.ide.impl.ProjectUtil.openOrImport;
 import static com.intellij.openapi.fileChooser.impl.FileChooserUtil.setLastOpenedFile;
 
 /**
@@ -74,7 +75,7 @@ public class OpenAndroidModule extends OpenInAndroidStudioAction implements Dumb
     }
     Project newProject = openOrImport(projectFile.getPath(), project, false);
     if (newProject != null) {
-      setLastOpenedFile(newProject, projectFile);
+      setLastOpenedFile(newProject, Path.of(projectFile.getPath()));
       if (sourceFile != null && !sourceFile.isDirectory()) {
         OpenFileAction.openFile(sourceFile, newProject);
       }


### PR DESCRIPTION
https://github.com/JetBrains/intellij-community/blob/768c7392257e8fbedcc1aa4c738fa523b89fa0e6/platform/platform-impl/src/com/intellij/openapi/fileChooser/impl/FileChooserUtil.java#L45

This is progress on https://github.com/flutter/flutter-intellij/issues/7718
