### PR TITLE
Migrate off of Extensions.findExtension(..) usages

### DIFF
--- a/flutter-idea/src/io/flutter/run/FlutterRunConfigurationType.java
+++ b/flutter-idea/src/io/flutter/run/FlutterRunConfigurationType.java
@@ -9,7 +9,6 @@ import com.intellij.execution.configurations.ConfigurationFactory;
 import com.intellij.execution.configurations.ConfigurationTypeBase;
 import com.intellij.execution.configurations.RunConfiguration;
 import com.intellij.execution.configurations.RunConfigurationSingletonPolicy;
-import com.intellij.openapi.extensions.Extensions;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.search.FileTypeIndex;
 import com.intellij.psi.search.GlobalSearchScope;
@@ -44,7 +43,7 @@ public class FlutterRunConfigurationType extends ConfigurationTypeBase {
   }
 
   public static FlutterRunConfigurationType getInstance() {
-    return Extensions.findExtension(CONFIGURATION_TYPE_EP, FlutterRunConfigurationType.class);
+    return CONFIGURATION_TYPE_EP.findExtensionOrFail(FlutterRunConfigurationType.class);
   }
 
   public static class Factory extends ConfigurationFactory {

--- a/flutter-idea/src/io/flutter/run/bazelTest/FlutterBazelTestConfigurationType.java
+++ b/flutter-idea/src/io/flutter/run/bazelTest/FlutterBazelTestConfigurationType.java
@@ -8,7 +8,6 @@ package io.flutter.run.bazelTest;
 import com.intellij.execution.configurations.ConfigurationFactory;
 import com.intellij.execution.configurations.ConfigurationTypeBase;
 import com.intellij.execution.configurations.RunConfiguration;
-import com.intellij.openapi.extensions.Extensions;
 import com.intellij.openapi.project.Project;
 import icons.FlutterIcons;
 import io.flutter.FlutterBundle;
@@ -35,7 +34,7 @@ public class FlutterBazelTestConfigurationType extends ConfigurationTypeBase {
   }
 
   public static FlutterBazelTestConfigurationType getInstance() {
-    return Extensions.findExtension(CONFIGURATION_TYPE_EP, FlutterBazelTestConfigurationType.class);
+    return CONFIGURATION_TYPE_EP.findExtensionOrFail(FlutterBazelTestConfigurationType.class);
   }
 
   /**

--- a/flutter-idea/src/io/flutter/run/test/FlutterTestConfigType.java
+++ b/flutter-idea/src/io/flutter/run/test/FlutterTestConfigType.java
@@ -8,7 +8,6 @@ package io.flutter.run.test;
 import com.intellij.execution.configurations.ConfigurationFactory;
 import com.intellij.execution.configurations.ConfigurationTypeBase;
 import com.intellij.execution.configurations.RunConfiguration;
-import com.intellij.openapi.extensions.Extensions;
 import com.intellij.openapi.project.Project;
 import icons.FlutterIcons;
 import io.flutter.run.FlutterRunConfigurationType;
@@ -26,7 +25,7 @@ public class FlutterTestConfigType extends ConfigurationTypeBase {
   }
 
   public static FlutterTestConfigType getInstance() {
-    return Extensions.findExtension(CONFIGURATION_TYPE_EP, FlutterTestConfigType.class);
+    return CONFIGURATION_TYPE_EP.findExtensionOrFail(FlutterTestConfigType.class);
   }
 
   private static class Factory extends ConfigurationFactory {


### PR DESCRIPTION
This is progress on https://github.com/flutter/flutter-intellij/issues/7718