### PR TITLE
Migrate off of ServiceManager.getService(..)

### DIFF
--- a/flutter-idea/src/io/flutter/FlutterUtils.java
+++ b/flutter-idea/src/io/flutter/FlutterUtils.java
@@ -550,7 +550,12 @@ public class FlutterUtils {
       return null;
     }
 
-    return FlutterSettings.getInstance().isEnableJcefBrowser()
+    FlutterSettings settings = FlutterSettings.getInstance();
+    if (settings == null) {
+      return null;
+    }
+
+    return settings.isEnableJcefBrowser()
            ? EmbeddedJcefBrowser.getInstance(project)
            : EmbeddedJxBrowser.getInstance(project);
   }

--- a/flutter-idea/src/io/flutter/jxbrowser/EmbeddedBrowserEngine.java
+++ b/flutter-idea/src/io/flutter/jxbrowser/EmbeddedBrowserEngine.java
@@ -25,7 +25,7 @@ public class EmbeddedBrowserEngine {
   private final Engine engine;
 
   public static EmbeddedBrowserEngine getInstance() {
-    return ServiceManager.getService(EmbeddedBrowserEngine.class);
+    return ApplicationManager.getApplication().getService(EmbeddedBrowserEngine.class);
   }
 
   public EmbeddedBrowserEngine() {

--- a/flutter-idea/src/io/flutter/module/settings/SettingsHelpForm.java
+++ b/flutter-idea/src/io/flutter/module/settings/SettingsHelpForm.java
@@ -6,7 +6,6 @@
 package io.flutter.module.settings;
 
 import com.intellij.ide.browsers.BrowserLauncher;
-import com.intellij.openapi.components.ServiceManager;
 import com.intellij.ui.components.labels.LinkLabel;
 import io.flutter.FlutterBundle;
 import io.flutter.FlutterConstants;
@@ -35,10 +34,6 @@ public class SettingsHelpForm {
 
   @SuppressWarnings("rawtypes")
   private LinkLabel gettingStartedUrl;
-
-  public static SettingsHelpForm getInstance() {
-    return ServiceManager.getService(SettingsHelpForm.class);
-  }
 
   public SettingsHelpForm() {
     projectTypeLabel.setText(FlutterBundle.message("flutter.module.create.settings.help.project_type.label"));

--- a/flutter-idea/src/io/flutter/settings/FlutterSettings.java
+++ b/flutter-idea/src/io/flutter/settings/FlutterSettings.java
@@ -7,12 +7,14 @@ package io.flutter.settings;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.intellij.ide.util.PropertiesComponent;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.util.registry.Registry;
 import com.intellij.util.EventDispatcher;
 import com.jetbrains.lang.dart.analyzer.DartClosingLabelManager;
 
 import java.util.EventListener;
+import java.util.Objects;
 
 public class FlutterSettings {
   private static final String reloadOnSaveKey = "io.flutter.reloadOnSave";
@@ -62,7 +64,7 @@ public class FlutterSettings {
       return testInstance;
     }
 
-    return ServiceManager.getService(FlutterSettings.class);
+    return Objects.requireNonNull(ApplicationManager.getApplication()).getService(FlutterSettings.class);
   }
 
   protected static PropertiesComponent getPropertiesComponent() {

--- a/flutter-idea/src/io/flutter/view/EmbeddedJcefBrowser.java
+++ b/flutter-idea/src/io/flutter/view/EmbeddedJcefBrowser.java
@@ -15,6 +15,7 @@ import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
 import java.awt.Dimension;
+import java.util.Objects;
 
 class EmbeddedJcefBrowserTab implements EmbeddedTab {
   private JBCefBrowser browser;
@@ -48,8 +49,8 @@ public class EmbeddedJcefBrowser extends EmbeddedBrowser {
   }
 
   @NotNull
-  public static EmbeddedJcefBrowser getInstance(Project project) {
-    return ServiceManager.getService(project, EmbeddedJcefBrowser.class);
+  public static EmbeddedJcefBrowser getInstance(@NotNull Project project) {
+    return Objects.requireNonNull(project.getService(EmbeddedJcefBrowser.class));
   }
 
   public Logger logger() {

--- a/flutter-studio/src/io/flutter/android/AndroidModuleLibraryManager.java
+++ b/flutter-studio/src/io/flutter/android/AndroidModuleLibraryManager.java
@@ -61,10 +61,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -263,7 +260,7 @@ public class AndroidModuleLibraryManager extends AbstractLibraryManager<AndroidM
 
   @NotNull
   public static AndroidModuleLibraryManager getInstance(@NotNull final Project project) {
-    return ServiceManager.getService(project, AndroidModuleLibraryManager.class);
+    return Objects.requireNonNull(project.getService(AndroidModuleLibraryManager.class));
   }
 
   public static void startWatching(@NotNull Project project) {


### PR DESCRIPTION
https://github.com/JetBrains/intellij-community/blob/768c7392257e8fbedcc1aa4c738fa523b89fa0e6/platform/core-api/src/com/intellij/openapi/components/ServiceManager.java#L19

This is progress on https://github.com/flutter/flutter-intellij/issues/7718

The removal of the method in flutter-idea/src/io/flutter/module/settings/SettingsHelpForm.java is due to the method being unused