### PR TITLE
Rename the Open Flutter DevTools action

### DIFF
--- a/flutter-idea/src/io/flutter/run/OpenDevToolsAction.java
+++ b/flutter-idea/src/io/flutter/run/OpenDevToolsAction.java
@@ -26,7 +26,7 @@ import org.jetbrains.annotations.Nullable;
 
 public class OpenDevToolsAction extends DumbAwareAction {
   private static final Logger LOG = Logger.getInstance(OpenDevToolsAction.class);
-  private static final String title = "Open Flutter DevTools";
+  private static final String title = "Open Flutter DevTools in Browser";
   private final @Nullable ObservatoryConnector myConnector;
   private final Computable<Boolean> myIsApplicable;
 

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -159,8 +159,8 @@
               description="Run 'flutter clean'"/>
       <separator/>
       <action id="flutter.devtools.open" class="io.flutter.run.OpenDevToolsAction"
-              text="Open Flutter DevTools"
-              description="Open Flutter DevTools"/>
+              text="Open Flutter DevTools in Browser"
+              description="Open Flutter DevTools in Browser"/>
       <separator/>
 <!--      <action id="flutter.androidstudio.open" class="io.flutter.actions.OpenInAndroidStudioAction"-->
 <!--              text="Open Android module in Android Studio"-->
@@ -292,7 +292,7 @@
     </action>
 
     <action id="io.flutter.OpenDevToolsAction" class="io.flutter.run.OpenDevToolsAction"
-            text="Open Flutter DevTools" description="Open Flutter DevTools" icon="FlutterIcons.Dart_16">
+            text="Open Flutter DevTools in Browser" description="Open Flutter DevTools in Browser" icon="FlutterIcons.Dart_16">
     </action>
 
     <action id="io.flutter.RefreshToolWindow" class="io.flutter.actions.RefreshToolWindowAction" text="Refresh Tool Window"

--- a/resources/META-INF/plugin_template.xml
+++ b/resources/META-INF/plugin_template.xml
@@ -96,8 +96,8 @@
               description="Run 'flutter clean'"/>
       <separator/>
       <action id="flutter.devtools.open" class="io.flutter.run.OpenDevToolsAction"
-              text="Open Flutter DevTools"
-              description="Open Flutter DevTools"/>
+              text="Open Flutter DevTools in Browser"
+              description="Open Flutter DevTools in Browser"/>
       <separator/>
 <!--      <action id="flutter.androidstudio.open" class="io.flutter.actions.OpenInAndroidStudioAction"-->
 <!--              text="Open Android module in Android Studio"-->
@@ -229,7 +229,7 @@
     </action>
 
     <action id="io.flutter.OpenDevToolsAction" class="io.flutter.run.OpenDevToolsAction"
-            text="Open Flutter DevTools" description="Open Flutter DevTools" icon="FlutterIcons.Dart_16">
+            text="Open Flutter DevTools in Browser" description="Open Flutter DevTools in Browser" icon="FlutterIcons.Dart_16">
     </action>
 
     <action id="io.flutter.RefreshToolWindow" class="io.flutter.actions.RefreshToolWindowAction" text="Refresh Tool Window"


### PR DESCRIPTION
Append "Open Flutter DevTools" action with to "in Browser", this makes the action consistent with other actions in IDEA which trigger the browser to open.

Cleanup related to https://github.com/flutter/flutter-intellij/issues/7839
