### PR TITLE
Add a lang attribute to the FlutterDependency html tag

### DIFF
--- a/resources/inspectionDescriptions/FlutterDependency.html
+++ b/resources/inspectionDescriptions/FlutterDependency.html
@@ -4,7 +4,7 @@
   ~ found in the LICENSE file.
   -->
 
-<html>
+<html lang="en">
 <body>
 Flutter package dependency check.
 <!-- tooltip end -->


### PR DESCRIPTION
Fixes a warning found by "Inspect Code."


<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
