### PR TITLE
Specify failure reason for JX Browser errors

### DIFF
--- a/flutter-idea/src/io/flutter/jxbrowser/EmbeddedJxBrowser.java
+++ b/flutter-idea/src/io/flutter/jxbrowser/EmbeddedJxBrowser.java
@@ -28,7 +28,6 @@ import io.flutter.utils.JxBrowserUtils;
 import io.flutter.view.EmbeddedBrowser;
 import io.flutter.view.EmbeddedTab;
 import io.flutter.utils.LabelInput;
-import org.gradle.wrapper.Install;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 


### PR DESCRIPTION
## Before:

<img width="335" alt="Screenshot 2025-02-04 at 1 11 19 PM" src="https://github.com/user-attachments/assets/2d51e6cf-c496-40be-8123-18a66ee8bce3" />

## After:

<img width="345" alt="Screenshot 2025-02-04 at 1 16 41 PM" src="https://github.com/user-attachments/assets/e2a5bd62-d395-4f58-b429-8a6a39de0f33" />
