### PR TITLE
[PE] remove stale commit signing instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -282,35 +282,3 @@ To set up the license key:
 1. Copy the template at resources/jxbrowser/jxbrowser.properties.template
    and save it as resources/jxbrowser/jxbrowser.properties.
 2. Replace `<KEY>` with the actual key.
-
-## Signing commits
-
-We require that all commits to the repository are signed with GPG or SSH, see [GitHub's documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification).
-
-If you are on macOS, and choose to sign with GPG, here are some additonal notes:
-
-- Download GPG's tarball along with its dependencies from [here](https://www.gnupg.org/download/).
-  GPG is the first item, the dependencies are in the block below (Libgpg-error, Libgcrypt, etc.).
-- To install these tarballs on macOS, follow these instructions:
-    - Download the desired `.tar.gz` or (`.tar.bz2`) file
-    - Open Terminal
-    - Extract the `.tar.gz` or (`.tar.bz2`) file with the following commands (Follow these steps for the dependencies first, then for GPG):
-    ```bash
-    tar xvjf PACKAGENAME.tar.bz2
-    # Navigate to the extracted folder using cd command
-    cd PACKAGENAME
-    # Now run the following command to install the tarball
-    ./configure
-    make
-    sudo make install
-    ```
-- You may need to install pinentry (`brew install pinentry`)
-- If the Pinentry continues to not work, check its path (`which pinentry`) and add it to the file `~/.gnupg/gpg-agent.conf`, i.e.:
-  ```bash
-  pinentry-program /path/to/pinentry
-  ```
-- You may need to set the tty `export GPG_TTY=$(tty)` if you get this error when trying to commit:
-  ```bash
-  error: gpg failed to sign the data
-  fatal: failed to write commit object
-  ```


### PR DESCRIPTION
Since we're not requiring signing anymore, we can remove this bit from the contributing docs.


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
