### PR TITLE
[CQ] remove redundant warning suppressions

### DIFF
--- a/flutter-idea/src/io/flutter/FlutterErrorReportSubmitter.java
+++ b/flutter-idea/src/io/flutter/FlutterErrorReportSubmitter.java
@@ -226,7 +226,6 @@ public class FlutterErrorReportSubmitter extends ErrorReportSubmitter {
   }
 
   private static byte[] readFully(InputStream in) throws IOException {
-    //noinspection resource
     final ByteArrayOutputStream out = new ByteArrayOutputStream();
     final byte[] temp = new byte[4096];
     int count = in.read(temp);

--- a/flutter-idea/src/io/flutter/actions/ReloadAllFlutterApps.java
+++ b/flutter-idea/src/io/flutter/actions/ReloadAllFlutterApps.java
@@ -21,7 +21,6 @@ import java.util.Objects;
 /**
  * Action that reloads all running Flutter apps.
  */
-@SuppressWarnings("ComponentNotRegistered")
 public class ReloadAllFlutterApps extends FlutterAppAction {
   public static final String ID = "Flutter.ReloadAllFlutterApps"; //NON-NLS
   public static final String TEXT = FlutterBundle.message("app.reload.all.action.text");

--- a/flutter-idea/src/io/flutter/actions/RestartAllFlutterApps.java
+++ b/flutter-idea/src/io/flutter/actions/RestartAllFlutterApps.java
@@ -19,7 +19,6 @@ import org.jetbrains.annotations.NotNull;
 /**
  * Action that restarts all running Flutter apps.
  */
-@SuppressWarnings("ComponentNotRegistered")
 public class RestartAllFlutterApps extends FlutterAppAction {
   public static final String ID = "Flutter.RestartAllFlutterApps"; //NON-NLS
   public static final String TEXT = FlutterBundle.message("app.restart.all.action.text");

--- a/flutter-idea/src/io/flutter/editor/FlutterIconLineMarkerProvider.java
+++ b/flutter-idea/src/io/flutter/editor/FlutterIconLineMarkerProvider.java
@@ -295,7 +295,6 @@ public class FlutterIconLineMarkerProvider extends LineMarkerProviderDescriptor 
   private LineMarkerInfo<PsiElement> createLineMarker(@Nullable PsiElement element, @NotNull Icon icon) {
     if (element == null) return null;
     assert element.getTextRange() != null;
-    //noinspection MissingRecentApi
     return new LineMarkerInfo<>(element, element.getTextRange(), icon, null, null,
                                 GutterIconRenderer.Alignment.LEFT, () -> "");
   }

--- a/flutter-idea/src/io/flutter/jxbrowser/JxBrowserManager.java
+++ b/flutter-idea/src/io/flutter/jxbrowser/JxBrowserManager.java
@@ -157,7 +157,6 @@ public class JxBrowserManager {
       final FlutterSettings settings = FlutterSettings.getInstance();
 
       // Set up JxBrowser files if the embedded inspector option has been turned on and the files aren't already loaded.
-      //noinspection ConstantConditions
       if (getStatus().equals(JxBrowserStatus.NOT_INSTALLED)) {
         setUp(projectName);
       }

--- a/flutter-idea/src/io/flutter/project/FlutterProjectStructureDetector.java
+++ b/flutter-idea/src/io/flutter/project/FlutterProjectStructureDetector.java
@@ -111,7 +111,6 @@ public class FlutterProjectStructureDetector extends ProjectStructureDetector {
         }
         //noinspection ConstantConditions
         StartupManager.getInstance(project).runAfterOpened(() -> {
-          //noinspection ConstantConditions
           DumbService.getInstance(project).smartInvokeLater(() -> {
             for (ModuleDescriptor module : modules) {
               assert module != null;

--- a/flutter-idea/src/io/flutter/run/test/DartTestLocationProviderZ.java
+++ b/flutter-idea/src/io/flutter/run/test/DartTestLocationProviderZ.java
@@ -34,7 +34,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-@SuppressWarnings("Duplicates")
 public class DartTestLocationProviderZ implements SMTestLocator, DumbAware {
   @SuppressWarnings("rawtypes")
   private static final List<Location> NONE = Collections.emptyList();

--- a/flutter-idea/src/io/flutter/survey/FlutterSurveyNotifications.java
+++ b/flutter-idea/src/io/flutter/survey/FlutterSurveyNotifications.java
@@ -97,7 +97,6 @@ public class FlutterSurveyNotifications {
       null
     );
 
-    //noinspection DialogTitleCapitalization
     notification.addAction(new AnAction(SURVEY_ACTION_TEXT) {
       @Override
       public void actionPerformed(@NotNull AnActionEvent event) {
@@ -109,7 +108,6 @@ public class FlutterSurveyNotifications {
       }
     });
 
-    //noinspection DialogTitleCapitalization
     notification.addAction(new AnAction(SURVEY_DISMISSAL_TEXT) {
       @Override
       public void actionPerformed(@NotNull AnActionEvent event) {

--- a/flutter-idea/src/io/flutter/test/DartTestEventsConverterZ.java
+++ b/flutter-idea/src/io/flutter/test/DartTestEventsConverterZ.java
@@ -32,7 +32,7 @@ import java.util.regex.Pattern;
  * event followed some time later by an 'error' event for that same test. That should
  * convert a successful test into a failure. That case is not being handled.
  */
-@SuppressWarnings({"Duplicates", "FieldMayBeFinal", "LocalCanBeFinal", "SameReturnValue"})
+@SuppressWarnings({"FieldMayBeFinal", "LocalCanBeFinal", "SameReturnValue"})
 public class DartTestEventsConverterZ extends OutputToGeneralTestEventsConverter {
   private static final Logger LOG = Logger.getInstance(DartTestEventsConverterZ.class);
 
@@ -156,7 +156,6 @@ public class DartTestEventsConverterZ extends OutputToGeneralTestEventsConverter
     return super.processServiceMessages(text, myCurrentOutputType, myCurrentVisitor);
   }
 
-  @SuppressWarnings("SimplifiableIfStatement")
   private boolean process(JsonObject obj) throws JsonSyntaxException, ParseException {
     String type = obj.get(JSON_TYPE).getAsString();
     if (TYPE_TEST_START.equals(type)) {

--- a/flutter-idea/src/io/flutter/vmService/DartVmServiceListener.java
+++ b/flutter-idea/src/io/flutter/vmService/DartVmServiceListener.java
@@ -40,7 +40,6 @@ public class DartVmServiceListener implements VmServiceListener {
 
   }
 
-  @SuppressWarnings("DuplicateBranchesInSwitch")
   @Override
   public void received(@NotNull final String streamId, @NotNull final Event event) {
     switch (event.getKind()) {

--- a/flutter-idea/testSrc/unit/io/flutter/ide/DartTestUtils.java
+++ b/flutter-idea/testSrc/unit/io/flutter/ide/DartTestUtils.java
@@ -57,7 +57,6 @@ public class DartTestUtils {
     //final String dartSdkHome = sdkHome + "bin/cache/dart-sdk";
     //VfsRootAccess.allowRootAccess(disposable, dartSdkHome);
 
-    //noinspection ConstantConditions
     //ApplicationManager.getApplication().runWriteAction(() -> {
     //  Disposer.register(disposable, DartSdkLibUtil.configureDartSdkAndReturnUndoingDisposable(module.getProject(), dartSdkHome));
     //  Disposer.register(disposable, DartSdkLibUtil.enableDartSdkAndReturnUndoingDisposable(module));

--- a/flutter-studio/src/io/flutter/android/AndroidModuleLibraryManager.java
+++ b/flutter-studio/src/io/flutter/android/AndroidModuleLibraryManager.java
@@ -218,13 +218,11 @@ public class AndroidModuleLibraryManager extends AbstractLibraryManager<AndroidM
     Disposer.register(flutterProject, androidProject);
 
     GradleSyncListener listener = new GradleSyncListener() {
-      @SuppressWarnings("override")
       public void syncTaskCreated(@NotNull Project project, @NotNull GradleSyncInvoker.Request request) {}
 
       // TODO(messick) Remove when 3.6 is stable.
       public void syncStarted(@NotNull Project project, boolean skipped, boolean sourceGenerationRequested) {}
 
-      @SuppressWarnings("override")
       public void setupStarted(@NotNull Project project) {}
 
       @Override

--- a/flutter-studio/src/io/flutter/utils/AddToAppUtils.java
+++ b/flutter-studio/src/io/flutter/utils/AddToAppUtils.java
@@ -119,7 +119,6 @@ public class AddToAppUtils {
         GradleUtils.checkDartSupport(project);
       }
 
-      @SuppressWarnings("override")
       public void sourceGenerationFinished(@NotNull Project project) {
       }
     };

--- a/flutter-studio/src/io/flutter/utils/GradleUtils.java
+++ b/flutter-studio/src/io/flutter/utils/GradleUtils.java
@@ -276,7 +276,6 @@ public class GradleUtils {
 
   // Copied from org.jetbrains.plugins.gradle.execution.GradleRunAnythingProvider.
   @NotNull
-  @SuppressWarnings("DuplicatedCode")
   private static Map<ProjectData, MultiMap<String, String>> getTasksMap(Project project) {
     Map<ProjectData, MultiMap<String, String>> tasks = new LinkedHashMap<>();
     for (GradleProjectSettings setting : GradleSettings.getInstance(project).getLinkedProjectsSettings()) {
@@ -458,7 +457,6 @@ public class GradleUtils {
       try {
         requireNonNull(pathToModule);
         requireNonNull(settingsFile);
-        @SuppressWarnings({"IOResourceOpenedButNotSafelyClosed", "resource"})
         BufferedInputStream str = new BufferedInputStream(settingsFile.getInputStream());
         return FileUtil.loadTextAndClose(new InputStreamReader(str, CharsetToolkit.UTF8_CHARSET));
       }


### PR DESCRIPTION
Clean up a bunch of unneeded (redundant) warning suppressions.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
