### PR TITLE
[CQ] nullability: make equality checks safe w/ `Objects.equals()`

### DIFF
--- a/flutter-idea/src/io/flutter/FlutterUtils.java
+++ b/flutter-idea/src/io/flutter/FlutterUtils.java
@@ -222,7 +222,7 @@ public class FlutterUtils {
   }
 
   public static boolean isIntegrationTestingMode() {
-    return System.getProperty("idea.required.plugins.id", "").equals("io.flutter.tests.gui.flutter-gui-tests");
+    return Objects.equals(System.getProperty("idea.required.plugins.id", ""), "io.flutter.tests.gui.flutter-gui-tests");
   }
 
   @Nullable
@@ -561,7 +561,7 @@ public class FlutterUtils {
   }
 
   public static boolean embeddedBrowserAvailable(JxBrowserStatus status) {
-    return status.equals(JxBrowserStatus.INSTALLED) || status.equals(JxBrowserStatus.INSTALLATION_SKIPPED) && FlutterSettings.getInstance()
+    return Objects.equals(status, JxBrowserStatus.INSTALLED) || status.equals(JxBrowserStatus.INSTALLATION_SKIPPED) && FlutterSettings.getInstance()
       .isEnableJcefBrowser();
   }
 }

--- a/flutter-idea/src/io/flutter/android/IntelliJAndroidSdk.java
+++ b/flutter-idea/src/io/flutter/android/IntelliJAndroidSdk.java
@@ -20,6 +20,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * An Android SDK and its home directory; this references an IntelliJ @{@link Sdk} instance.
@@ -90,7 +91,7 @@ public class IntelliJAndroidSdk {
   @Nullable
   public static IntelliJAndroidSdk fromHome(VirtualFile file) {
     for (IntelliJAndroidSdk candidate : findAll()) {
-      if (file.equals(candidate.getHome())) {
+      if (Objects.equals(file, candidate.getHome())) {
         return candidate;
       }
     }

--- a/flutter-idea/src/io/flutter/console/FlutterConsoleFilter.java
+++ b/flutter-idea/src/io/flutter/console/FlutterConsoleFilter.java
@@ -30,6 +30,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.awt.*;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -170,7 +171,7 @@ public class FlutterConsoleFilter implements Filter {
           highlightLength = pathPart.length();
           break;
         }
-        else if (split.length == 4 && split[0].equals("file")) {
+        else if (split.length == 4 && Objects.equals(split[0], "file")) {
           // part = file:///Users/user/AndroidStudioProjects/flutter_app/test/widget_test.dart:23:18
           try {
             // Reconcile line number indexing.

--- a/flutter-idea/src/io/flutter/dart/FlutterDartAnalysisServer.java
+++ b/flutter-idea/src/io/flutter/dart/FlutterDartAnalysisServer.java
@@ -287,7 +287,7 @@ public class FlutterDartAnalysisServer implements Disposable {
   private void processNotification(JsonObject response, @NotNull JsonElement eventName) {
     // If we add code to handle more event types below, update the filter in processString().
     final String event = eventName.getAsString();
-    if (event.equals(FLUTTER_NOTIFICATION_OUTLINE)) {
+    if (Objects.equals(event, FLUTTER_NOTIFICATION_OUTLINE)) {
       final JsonObject paramsObject = response.get("params").getAsJsonObject();
       final String file = paramsObject.get("file").getAsString();
 

--- a/flutter-idea/src/io/flutter/editor/FlutterColorProvider.java
+++ b/flutter-idea/src/io/flutter/editor/FlutterColorProvider.java
@@ -22,6 +22,7 @@ import org.jetbrains.annotations.Nullable;
 import java.awt.*;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 import static io.flutter.dart.DartPsiUtil.getNewExprFromType;
 import static io.flutter.dart.DartPsiUtil.topmostReferenceExpression;
@@ -136,7 +137,7 @@ public class FlutterColorProvider implements ElementColorProvider {
 
   @Nullable
   private PsiElement resolveReferencedElement(@NotNull PsiElement element) {
-    if (element instanceof DartCallExpression && element.getFirstChild().getText().equals("Color")) {
+    if (element instanceof DartCallExpression && Objects.equals(element.getFirstChild().getText(), "Color")) {
       return element;
     }
     final PsiElement symbol = element.getLastChild();
@@ -216,7 +217,7 @@ public class FlutterColorProvider implements ElementColorProvider {
   public void setColorTo(@NotNull PsiElement element, @NotNull Color color) {
     // Not trying to look up Material or Cupertino colors.
     // Unfortunately, there is no way to prevent the color picker from showing (if clicked) for those expressions.
-    if (!element.getText().equals("Color")) return;
+    if (!Objects.equals(element.getText(), "Color")) return;
     final Document document = PsiDocumentManager.getInstance(element.getProject()).getDocument(element.getContainingFile());
     final Runnable command = () -> {
       final PsiElement refExpr = topmostReferenceExpression(element);

--- a/flutter-idea/src/io/flutter/editor/OutlineLocation.java
+++ b/flutter-idea/src/io/flutter/editor/OutlineLocation.java
@@ -12,6 +12,8 @@ import com.intellij.openapi.vfs.VirtualFile;
 import org.dartlang.analysis.server.protocol.FlutterOutline;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Objects;
+
 class TextRangeTracker {
   private final TextRange rawRange;
   private RangeMarker marker;
@@ -96,7 +98,7 @@ class TextRangeTracker {
       // to update marker locations has hit a bad edge case as sometimes
       // happens when there is a large document edit due to running a
       // code formatter.
-      endingWord.equals(TextRangeTracker.getCurrentWord(marker.getDocument(), marker.getEndOffset() - 1));
+      Objects.equals(endingWord, TextRangeTracker.getCurrentWord(marker.getDocument(), marker.getEndOffset() - 1));
   }
 }
 

--- a/flutter-idea/src/io/flutter/jxbrowser/EmbeddedJxBrowser.java
+++ b/flutter-idea/src/io/flutter/jxbrowser/EmbeddedJxBrowser.java
@@ -160,7 +160,7 @@ public class EmbeddedJxBrowser extends EmbeddedBrowser {
     }
 
     JxBrowserManager.installation.thenAccept((JxBrowserStatus status) -> {
-      if (status.equals(JxBrowserStatus.INSTALLED)) {
+      if (Objects.equals(status, JxBrowserStatus.INSTALLED)) {
         engineRef.compareAndSet(null, EmbeddedBrowserEngine.getInstance().getEngine());
       }
     });
@@ -268,7 +268,7 @@ public class EmbeddedJxBrowser extends EmbeddedBrowser {
   }
 
   protected void handleUpdatedJxBrowserStatus(JxBrowserStatus jxBrowserStatus, ContentManager contentManager) {
-    if (jxBrowserStatus.equals(JxBrowserStatus.INSTALLED)) {
+    if (Objects.equals(jxBrowserStatus, JxBrowserStatus.INSTALLED)) {
       return;
     } else if (jxBrowserStatus.equals(JxBrowserStatus.INSTALLATION_FAILED)) {
       handleJxBrowserInstallationFailed(contentManager);
@@ -286,7 +286,7 @@ public class EmbeddedJxBrowser extends EmbeddedBrowser {
     if (!jxBrowserUtils.licenseIsSet()) {
       // If the license isn't available, allow the user to open the equivalent page in a non-embedded browser window.
       inputs.add(new LabelInput("The JxBrowser license could not be found."));
-    } else if (latestFailureReason != null && latestFailureReason.failureType.equals(FailureType.SYSTEM_INCOMPATIBLE)) {
+    } else if (latestFailureReason != null && Objects.equals(latestFailureReason.failureType, FailureType.SYSTEM_INCOMPATIBLE)) {
       // If we know the system is incompatible, skip retry link and offer to open in browser.
       inputs.add(new LabelInput(latestFailureReason.detail));
     }

--- a/flutter-idea/src/io/flutter/jxbrowser/JxBrowserManager.java
+++ b/flutter-idea/src/io/flutter/jxbrowser/JxBrowserManager.java
@@ -198,7 +198,7 @@ public class JxBrowserManager {
       return;
     }
 
-    if (!jxBrowserUtils.skipInstallation() && status.get().equals(JxBrowserStatus.INSTALLATION_SKIPPED)) {
+    if (!jxBrowserUtils.skipInstallation() && Objects.equals(status.get(), JxBrowserStatus.INSTALLATION_SKIPPED)) {
       // This check returns status to NOT_INSTALLED so that JxBrowser can be downloaded and installed in cases where it is enabled after being disabled.
       status.compareAndSet(JxBrowserStatus.INSTALLATION_SKIPPED, JxBrowserStatus.NOT_INSTALLED);
     }

--- a/flutter-idea/src/io/flutter/logging/DiagnosticsNode.java
+++ b/flutter-idea/src/io/flutter/logging/DiagnosticsNode.java
@@ -26,10 +26,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
 
@@ -81,7 +78,7 @@ public class DiagnosticsNode {
   @Override
   public boolean equals(Object other) {
     if (other instanceof DiagnosticsNode otherNode) {
-      return getDartDiagnosticRef().equals(otherNode.getDartDiagnosticRef());
+      return Objects.equals(getDartDiagnosticRef(), otherNode.getDartDiagnosticRef());
     }
     return false;
   }
@@ -653,10 +650,10 @@ public class DiagnosticsNode {
     }
     for (Map.Entry<String, JsonElement> entry : entries) {
       final String key = entry.getKey();
-      if (key.equals("objectId") || key.equals("valueId")) {
+      if (Objects.equals(key, "objectId") || key.equals("valueId")) {
         continue;
       }
-      if (!entry.getValue().equals(node.json.get(key))) {
+      if (!Objects.equals(entry.getValue(), node.json.get(key))) {
         return false;
       }
     }

--- a/flutter-idea/src/io/flutter/pub/PubRoot.java
+++ b/flutter-idea/src/io/flutter/pub/PubRoot.java
@@ -26,6 +26,7 @@ import org.jetbrains.annotations.Nullable;
 import java.io.File;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * A snapshot of the root directory of a pub package.
@@ -427,7 +428,7 @@ public class PubRoot {
 
     for (Module module : ModuleManager.getInstance(project).getModules()) {
       for (VirtualFile contentRoot : ModuleRootManager.getInstance(module).getContentRoots()) {
-        if (contentRoot.equals(androidDir)) {
+        if (Objects.equals(contentRoot, androidDir)) {
           return true;
         }
       }

--- a/flutter-idea/src/io/flutter/run/bazel/FlutterBazelRunConfigurationType.java
+++ b/flutter-idea/src/io/flutter/run/bazel/FlutterBazelRunConfigurationType.java
@@ -20,6 +20,8 @@ import io.flutter.FlutterBundle;
 import io.flutter.utils.FlutterModuleUtils;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Objects;
+
 public class FlutterBazelRunConfigurationType extends ConfigurationTypeBase {
   @VisibleForTesting final Factory factory = new Factory(this);
 
@@ -75,7 +77,7 @@ public class FlutterBazelRunConfigurationType extends ConfigurationTypeBase {
       // This is a hack based on what the code does in RunConfigurable.createUniqueName().
       // If it fails to match, the new run config still works, just without any defaults set.
       final String baseName = ExecutionBundle.message("run.configuration.unnamed.name.prefix");
-      return name.equals(baseName) || name.startsWith(baseName + " (");
+      return Objects.equals(name, baseName) || name.startsWith(baseName + " (");
     }
 
     @Override

--- a/flutter-idea/src/io/flutter/run/bazelTest/FlutterBazelTestConfigurationEditorForm.java
+++ b/flutter-idea/src/io/flutter/run/bazelTest/FlutterBazelTestConfigurationEditorForm.java
@@ -21,6 +21,7 @@ import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 import java.awt.event.ActionEvent;
+import java.util.Objects;
 
 import static io.flutter.run.bazelTest.BazelTestFields.Scope.*;
 
@@ -163,7 +164,7 @@ public class FlutterBazelTestConfigurationEditorForm extends SettingsEditor<Baze
 
     // Because the scope of the underlying fields is calculated based on which parameters are assigned,
     // we remove fields that aren't part of the selected scope.
-    if (next.equals(Scope.TARGET_PATTERN)) {
+    if (Objects.equals(next, Scope.TARGET_PATTERN)) {
       myTestName.setText("");
       myEntryFile.setText("");
     }

--- a/flutter-idea/src/io/flutter/run/common/RunMode.java
+++ b/flutter-idea/src/io/flutter/run/common/RunMode.java
@@ -13,6 +13,8 @@ import io.flutter.run.LaunchState;
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Objects;
+
 /**
  * The IntelliJ launch mode.
  */
@@ -59,7 +61,7 @@ public enum RunMode {
     else if (DefaultDebugExecutor.EXECUTOR_ID.equals(mode)) {
       return DEBUG;
     }
-    else if (COVERAGE.myModeString.equals(mode)) {
+    else if (Objects.equals(COVERAGE.myModeString, mode)) {
       return COVERAGE;
     }
     else if (LaunchState.ANDROID_PROFILER_EXECUTOR_ID.equals(mode)) {

--- a/flutter-idea/src/io/flutter/run/daemon/DevToolsService.java
+++ b/flutter-idea/src/io/flutter/run/daemon/DevToolsService.java
@@ -245,7 +245,7 @@ public class DevToolsService {
 
         final JsonObject obj = element.getAsJsonObject();
 
-        if (JsonUtils.getStringMember(obj, "event").equals("server.started")) {
+        if (Objects.equals(JsonUtils.getStringMember(obj, "event"), "server.started")) {
           final JsonObject params = obj.getAsJsonObject("params");
           final String host = JsonUtils.getStringMember(params, "host");
           final int port = JsonUtils.getIntMember(params, "port");

--- a/flutter-idea/src/io/flutter/run/daemon/DeviceDaemon.java
+++ b/flutter-idea/src/io/flutter/run/daemon/DeviceDaemon.java
@@ -384,7 +384,8 @@ class DeviceDaemon {
       final FlutterDevice newDevice = new FlutterDevice(event.id,
                                                         event.emulatorId == null
                                                         ? (event.name == null ? event.id : event.name)
-                                                        : (event.platformType.equals("android") ? event.emulatorId : event.name),
+                                                        : (java.util.Objects.equals(event.platformType, "android")
+                                                           ? event.emulatorId : event.name),
                                                         event.platform,
                                                         event.emulator,
                                                         event.category,

--- a/flutter-idea/src/io/flutter/run/test/DartTestLocationProviderZ.java
+++ b/flutter-idea/src/io/flutter/run/test/DartTestLocationProviderZ.java
@@ -33,6 +33,7 @@ import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 @SuppressWarnings("Duplicates")
 public class DartTestLocationProviderZ implements SMTestLocator, DumbAware {
@@ -123,11 +124,11 @@ public class DartTestLocationProviderZ implements SMTestLocator, DumbAware {
         public boolean execute(@NotNull final PsiElement element) {
           if (element instanceof DartCallExpression expression) {
             if (isTest(expression) || TestUtil.isGroup(expression)) {
-              if (nodes.get(nodes.size() - 1).equals(getTestLabel(expression))) {
+              if (Objects.equals(nodes.get(nodes.size() - 1), getTestLabel(expression))) {
                 boolean matches = true;
                 for (int i = nodes.size() - 2; i >= 0 && matches; --i) {
                   expression = getGroup(expression);
-                  if (expression == null || !nodes.get(i).equals(getTestLabel(expression))) {
+                  if (expression == null || !Objects.equals(nodes.get(i), getTestLabel(expression))) {
                     matches = false;
                   }
                 }

--- a/flutter-idea/src/io/flutter/sdk/AndroidEmulatorManager.java
+++ b/flutter-idea/src/io/flutter/sdk/AndroidEmulatorManager.java
@@ -105,7 +105,7 @@ public class AndroidEmulatorManager {
     if (project.isDisposed()) return;
 
     // Don't fire if the list of devices is unchanged.
-    if (cachedEmulators.equals(newEmulators)) {
+    if (Objects.equals(cachedEmulators, newEmulators)) {
       return;
     }
 

--- a/flutter-idea/src/io/flutter/sdk/FlutterSdk.java
+++ b/flutter-idea/src/io/flutter/sdk/FlutterSdk.java
@@ -365,7 +365,7 @@ public class FlutterSdk {
 
     // Starting the app paused so the IDE can catch early errors is ideal. However, we don't have a way to resume for multiple test files
     // yet, so we want to exclude directory scope tests from starting paused. See https://github.com/flutter/flutter-intellij/issues/4737.
-    if (mode == RunMode.DEBUG || (mode == RunMode.RUN && !scope.equals(TestFields.Scope.DIRECTORY))) {
+    if (mode == RunMode.DEBUG || (mode == RunMode.RUN && !Objects.equals(scope, TestFields.Scope.DIRECTORY))) {
       args.add("--start-paused");
     }
     if (FlutterSettings.getInstance().isVerboseLogging()) {

--- a/flutter-idea/src/io/flutter/sdk/FlutterSettingsConfigurable.java
+++ b/flutter-idea/src/io/flutter/sdk/FlutterSettingsConfigurable.java
@@ -47,6 +47,7 @@ import javax.swing.event.DocumentEvent;
 import javax.swing.text.JTextComponent;
 import java.awt.datatransfer.StringSelection;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.Semaphore;
 
 // Note: when updating the settings here, update FlutterSearchableOptionContributor as well.
@@ -221,7 +222,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
       return true;
     }
 
-    if (!settings.getFontPackages().equals(myFontPackagesTextArea.getText())) {
+    if (!Objects.equals(settings.getFontPackages(), myFontPackagesTextArea.getText())) {
       return true;
     }
 

--- a/flutter-idea/src/io/flutter/test/DartTestEventsConverterZ.java
+++ b/flutter-idea/src/io/flutter/test/DartTestEventsConverterZ.java
@@ -18,10 +18,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.lang.reflect.Type;
 import java.text.ParseException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -247,9 +244,9 @@ public class DartTestEventsConverterZ extends OutputToGeneralTestEventsConverter
     final Group group = test.getParent();
     return group == null && (test.getName().startsWith(LOADING_PREFIX) || test.getName().startsWith(COMPILING_PREFIX))
            ||
-           group != null && group.getDoneTestsCount() == 0 && test.getBaseName().equals(SET_UP_ALL_VIRTUAL_TEST_NAME)
+           group != null && group.getDoneTestsCount() == 0 && Objects.equals(test.getBaseName(), SET_UP_ALL_VIRTUAL_TEST_NAME)
            ||
-           group != null && group.getDoneTestsCount() > 0 && test.getBaseName().equals(TEAR_DOWN_ALL_VIRTUAL_TEST_NAME);
+           group != null && group.getDoneTestsCount() > 0 && Objects.equals(test.getBaseName(), TEAR_DOWN_ALL_VIRTUAL_TEST_NAME);
   }
 
   private boolean handleTestDone(JsonObject obj) throws ParseException {
@@ -382,7 +379,7 @@ public class DartTestEventsConverterZ extends OutputToGeneralTestEventsConverter
     boolean result = true;
 
     if (!test.myTestStartReported) {
-      if (test.getBaseName().equals(SET_UP_ALL_VIRTUAL_TEST_NAME) || test.getBaseName().equals(TEAR_DOWN_ALL_VIRTUAL_TEST_NAME)) {
+      if (Objects.equals(test.getBaseName(), SET_UP_ALL_VIRTUAL_TEST_NAME) || Objects.equals(test.getBaseName(), TEAR_DOWN_ALL_VIRTUAL_TEST_NAME)) {
         return true; // output in successfully passing setUpAll/tearDownAll is not important enough to make these nodes visible
       }
 

--- a/flutter-idea/src/io/flutter/view/EmbeddedBrowser.java
+++ b/flutter-idea/src/io/flutter/view/EmbeddedBrowser.java
@@ -25,10 +25,8 @@ import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
 import java.awt.*;
-import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.*;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
@@ -126,7 +124,7 @@ public abstract class EmbeddedBrowser {
       tab.contentManager.removeAllContents(false);
 
       for (final String otherTabName : tabs.keySet()) {
-        if (otherTabName.equals(tabName)) {
+        if (Objects.equals(otherTabName, tabName)) {
           continue;
         }
         final BrowserTab browserTab = tabs.get(otherTabName);

--- a/flutter-idea/src/io/flutter/view/FlutterView.java
+++ b/flutter-idea/src/io/flutter/view/FlutterView.java
@@ -53,10 +53,8 @@ import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
 import java.awt.*;
-import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.*;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -357,7 +355,7 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
     ToolWindow toolWindow,
     JxBrowserStatus jxBrowserStatus,
     DevToolsIdeFeature ideFeature) {
-    if (jxBrowserStatus.equals(JxBrowserStatus.INSTALLED)) {
+    if (Objects.equals(jxBrowserStatus, JxBrowserStatus.INSTALLED)) {
       handleJxBrowserInstalled(app, toolWindow, ideFeature);
     }
     else if (jxBrowserStatus.equals(JxBrowserStatus.INSTALLATION_FAILED)) {
@@ -381,7 +379,7 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
       inputs.add(new LabelInput("The JxBrowser license could not be found."));
       inputs.add(openDevToolsLabel);
     }
-    else if (latestFailureReason != null && latestFailureReason.failureType.equals(FailureType.SYSTEM_INCOMPATIBLE)) {
+    else if (latestFailureReason != null && Objects.equals(latestFailureReason.failureType, FailureType.SYSTEM_INCOMPATIBLE)) {
       // If we know the system is incompatible, skip retry link and offer to open in browser.
       inputs.add(new LabelInput(latestFailureReason.detail));
       inputs.add(openDevToolsLabel);

--- a/flutter-idea/src/io/flutter/vmService/DartVmServiceDebugProcess.java
+++ b/flutter-idea/src/io/flutter/vmService/DartVmServiceDebugProcess.java
@@ -386,7 +386,7 @@ public abstract class DartVmServiceDebugProcess extends XDebugProcess {
     myIsolatesInfo.deleteIsolate(isolateRef);
     mySuspendedIsolateIds.remove(isolateRef.getId());
 
-    if (isolateRef.getId().equals(myLatestCurrentIsolateId)) {
+    if (Objects.equals(isolateRef.getId(), myLatestCurrentIsolateId)) {
       resume(getSession().getSuspendContext()); // otherwise no way no resume them from UI
     }
   }

--- a/flutter-idea/src/io/flutter/vmService/VMServiceManager.java
+++ b/flutter-idea/src/io/flutter/vmService/VMServiceManager.java
@@ -248,7 +248,7 @@ public class VMServiceManager implements FlutterApp.FlutterAppListener, Disposab
           if (extension != null) {
             final Object value = getExtensionValueFromEventJson(name, valueFromJson);
             if (extension instanceof ToggleableServiceExtensionDescription toggleableExtension) {
-              setServiceExtensionState(name, value.equals(toggleableExtension.getEnabledValue()), value);
+              setServiceExtensionState(name, Objects.equals(value, toggleableExtension.getEnabledValue()), value);
             }
             else {
               setServiceExtensionState(name, true, value);
@@ -291,7 +291,7 @@ public class VMServiceManager implements FlutterApp.FlutterAppListener, Disposab
       ServiceExtensions.toggleableExtensionsAllowList.get(name).getValueClass();
 
     if (valueClass == Boolean.class) {
-      return valueFromJson.equals("true");
+      return Objects.equals(valueFromJson, "true");
     }
     else if (valueClass == Double.class) {
       return Double.valueOf(valueFromJson);
@@ -365,7 +365,7 @@ public class VMServiceManager implements FlutterApp.FlutterAppListener, Disposab
       Object value = null;
       if (obj != null) {
         if (valueClass == Boolean.class) {
-          value = obj.get("enabled").getAsString().equals("true");
+          value = Objects.equals(obj.get("enabled").getAsString(), "true");
           maybeRestoreExtension(name, value);
         }
         else if (valueClass == String.class) {
@@ -383,7 +383,7 @@ public class VMServiceManager implements FlutterApp.FlutterAppListener, Disposab
 
   private void maybeRestoreExtension(String name, Object value) {
     if (ServiceExtensions.toggleableExtensionsAllowList.get(name) instanceof ToggleableServiceExtensionDescription extensionDescription) {
-      if (value.equals(extensionDescription.getEnabledValue())) {
+      if (Objects.equals(value, extensionDescription.getEnabledValue())) {
         setServiceExtensionState(name, true, value);
       }
     }
@@ -527,7 +527,7 @@ public class VMServiceManager implements FlutterApp.FlutterAppListener, Disposab
       final JsonArray viewsList = element.getAsJsonObject().get("views").getAsJsonArray();
       for (JsonElement jsonElement : viewsList) {
         final JsonObject view = jsonElement.getAsJsonObject();
-        if (view.get("type").getAsString().equals("FlutterView")) {
+        if (Objects.equals(view.get("type").getAsString(), "FlutterView")) {
           return view.get("id").getAsString();
         }
       }

--- a/flutter-idea/src/io/flutter/vmService/frame/DartVmServiceEvaluator.java
+++ b/flutter-idea/src/io/flutter/vmService/frame/DartVmServiceEvaluator.java
@@ -28,10 +28,7 @@ import org.dartlang.vm.service.element.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -136,7 +133,7 @@ public class DartVmServiceEvaluator extends XDebuggerEvaluator {
           public void received(Obj response) {
             final Library library = (Library)response;
             for (ClassRef classRef : library.getClasses()) {
-              if (classRef.getName().equals(dartClassName)) {
+              if (Objects.equals(classRef.getName(), dartClassName)) {
                 vmService.evaluateInTargetContext(isolateId, classRef.getId(), expression, wrappedCallback);
                 return;
               }
@@ -204,7 +201,7 @@ public class DartVmServiceEvaluator extends XDebuggerEvaluator {
     final List<String> lines = StringUtil.split(StringUtil.convertLineSeparators(rawError), "\n");
 
     if (!lines.isEmpty()) {
-      if ((lines.get(0).equals("Error: Unhandled exception:") || lines.get(0).equals("Unhandled exception:")) && lines.size() > 1) {
+      if ((Objects.equals(lines.get(0), "Error: Unhandled exception:") || Objects.equals(lines.get(0), "Unhandled exception:")) && lines.size() > 1) {
         return lines.get(1);
       }
       final Matcher matcher = ERROR_PATTERN.matcher(lines.get(0));

--- a/flutter-idea/src/io/flutter/vmService/frame/DartVmServiceSuspendContext.java
+++ b/flutter-idea/src/io/flutter/vmService/frame/DartVmServiceSuspendContext.java
@@ -13,6 +13,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 
 public class DartVmServiceSuspendContext extends XSuspendContext {
   @NotNull private final DartVmServiceDebugProcess myDebugProcess;
@@ -47,7 +48,7 @@ public class DartVmServiceSuspendContext extends XSuspendContext {
       final Collection<IsolatesInfo.IsolateInfo> isolateInfos = myDebugProcess.getIsolateInfos();
       myExecutionStacks = new ArrayList<>(isolateInfos.size());
       for (IsolatesInfo.IsolateInfo isolateInfo : isolateInfos) {
-        if (isolateInfo.getIsolateId().equals(myActiveExecutionStack.getIsolateId())) {
+        if (Objects.equals(isolateInfo.getIsolateId(), myActiveExecutionStack.getIsolateId())) {
           myExecutionStacks.add(myActiveExecutionStack);
         }
         else {

--- a/flutter-idea/testSrc/unit/io/flutter/utils/IconPreviewGeneratorTest.java
+++ b/flutter-idea/testSrc/unit/io/flutter/utils/IconPreviewGeneratorTest.java
@@ -12,6 +12,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Objects;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -37,7 +38,7 @@ public class IconPreviewGeneratorTest {
     // The list is not sorted and there's no need to sort it.
     // We just want to verify that a specific file exists.
     for (String each : list) {
-      if (each.equals("add.png")) {
+      if (Objects.equals(each, "add.png")) {
         found = true;
         break;
       }

--- a/flutter-studio/src/io/flutter/utils/GradleUtils.java
+++ b/flutter-studio/src/io/flutter/utils/GradleUtils.java
@@ -340,7 +340,7 @@ public class GradleUtils {
   private static boolean matchesName(PsiElement expr, String name) {
     if (expr == null) return false;
     String text = expr.getText();
-    return name.equals(text.substring(2, text.length() - 1));
+    return Objects.equals(name, text.substring(2, text.length() - 1));
   }
 
   private static class CoEditHelper {
@@ -381,7 +381,7 @@ public class GradleUtils {
         addCoeditTransformedProject(project);
         // We may have multiple Gradle sync listeners. Write the files to disk synchronously so we won't edit them twice.
         projectRoot.refresh(false, true);
-        if (!projectRoot.equals(flutterModuleDir.getParent())) {
+        if (!Objects.equals(projectRoot, flutterModuleDir.getParent())) {
           flutterModuleDir.refresh(false, true);
         }
         AppExecutorUtil.getAppExecutorService().execute(() -> scheduleGradleSyncAfterSyncFinishes(project));
@@ -453,7 +453,7 @@ public class GradleUtils {
     }
 
     private String readSettingsFile() {
-      inSameDir = flutterModuleDir.getParent().equals(projectRoot);
+      inSameDir = Objects.equals(flutterModuleDir.getParent(), projectRoot);
       pathToModule = FileUtilRt.getRelativePath(new File(projectRoot.getPath()), flutterModuleRoot);
       try {
         requireNonNull(pathToModule);


### PR DESCRIPTION
Get null-safe comparisons when comparators might be null using [`Object.equals`](https://docs.oracle.com/javase/8/docs/api/java/util/Objects.html#equals-java.lang.Object-java.lang.Object-).

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
