### PR TITLE
[CQ] Write-only: remove unused stopwatch

### DIFF
--- a/flutter-idea/src/io/flutter/run/daemon/FlutterApp.java
+++ b/flutter-idea/src/io/flutter/run/daemon/FlutterApp.java
@@ -780,8 +780,6 @@ class FlutterAppDaemonEventListener implements DaemonEvent.Listener {
   private final @NotNull FlutterApp app;
   private final @NotNull ProgressHelper progress;
 
-  private final AtomicReference<Stopwatch> stopwatch = new AtomicReference<>();
-
   FlutterAppDaemonEventListener(@NotNull FlutterApp app, @NotNull Project project) {
     this.app = app;
     this.progress = new ProgressHelper(project);
@@ -887,8 +885,6 @@ class FlutterAppDaemonEventListener implements DaemonEvent.Listener {
           app.getConsole().clear();
         }
       }
-
-      stopwatch.set(Stopwatch.createStarted());
     }
 
     if (app.getConsole() != null) {


### PR DESCRIPTION
This `stopwatch` field is unused so can be safely removed.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
