### PR TITLE
[CQ] migrate away from slated-for-removal adapter API

### DIFF
--- a/flutter-studio/src/io/flutter/utils/FlutterExternalSystemTaskNotificationListener.java
+++ b/flutter-studio/src/io/flutter/utils/FlutterExternalSystemTaskNotificationListener.java
@@ -11,6 +11,7 @@ import org.jetbrains.plugins.gradle.util.GradleConstants;
 public class FlutterExternalSystemTaskNotificationListener extends ExternalSystemTaskNotificationListenerAdapter {
 
   public FlutterExternalSystemTaskNotificationListener() {
+    super(null);
   }
 
   @Override


### PR DESCRIPTION
The default constructor is slated for removal.

<img width="1194" alt="image" src="https://github.com/user-attachments/assets/27b2554b-4248-4ef2-8069-326df64f0543" />


See: https://github.com/JetBrains/intellij-community/blob/b41a4084da5521effedd334e28896fd9d07410da/platform/external-system-api/src/com/intellij/openapi/externalSystem/model/task/ExternalSystemTaskNotificationListenerAdapter.java#L18

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
