### PR TITLE
[CQ] `AddToAppUtils`: fix deprecated API use and unchecked calls

### DIFF
--- a/flutter-studio/src/io/flutter/utils/AddToAppUtils.java
+++ b/flutter-studio/src/io/flutter/utils/AddToAppUtils.java
@@ -36,6 +36,7 @@ import io.flutter.sdk.FlutterSdk;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.Collection;
+import java.util.List;
 
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
@@ -59,24 +60,30 @@ public class AddToAppUtils {
     if (!FlutterModuleUtils.hasFlutterModule(project)) {
       connection.subscribe(ModuleListener.TOPIC, new ModuleListener() {
         @Override
-        public void moduleAdded(@NotNull Project proj, @NotNull Module mod) {
-          if (AndroidUtils.FLUTTER_MODULE_NAME.equals(mod.getName()) ||
-              (FlutterUtils.flutterGradleModuleName(project)).equals(mod.getName())) {
-            //connection.disconnect(); TODO(messick) Test this deletion!
-            AppExecutorUtil.getAppExecutorService().execute(() -> {
-              GradleUtils.enableCoeditIfAddToAppDetected(project);
-            });
+        public void modulesAdded(@NotNull Project proj, @NotNull List<? extends Module> modules) {
+          for (Module module : modules) {
+            if (module == null) continue;
+            if (AndroidUtils.FLUTTER_MODULE_NAME.equals(module.getName()) ||
+                (FlutterUtils.flutterGradleModuleName(project)).equals(module.getName())) {
+              //connection.disconnect(); TODO(messick) Test this deletion!
+              AppExecutorUtil.getAppExecutorService().execute(() -> {
+                GradleUtils.enableCoeditIfAddToAppDetected(project);
+              });
+            }
           }
+
         }
       });
       return false;
     }
     else {
       Collection<ProjectType> projectTypes = ProjectTypeService.getProjectTypes(project);
-      for(ProjectType projectType : projectTypes) {
-        if (projectType != null && "Android".equals(projectType.getId())) {
-          // This is an add-to-app project.
-          connection.subscribe(DebuggerManagerListener.TOPIC, makeAddToAppAttachListener(project));
+      if (projectTypes != null) {
+        for (ProjectType projectType : projectTypes) {
+          if (projectType != null && "Android".equals(projectType.getId())) {
+            // This is an add-to-app project.
+            connection.subscribe(DebuggerManagerListener.TOPIC, makeAddToAppAttachListener(project));
+          }
         }
       }
     }


### PR DESCRIPTION
Migrate to future-safe `modulesAdded` API and fix unchecked calls.

(Removing another bit of noise from the run console.)

![image](https://github.com/user-attachments/assets/820a76c6-a99a-4251-9bab-f684fff60754)

See: https://github.com/flutter/flutter-intellij/issues/7718.


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
