### PR TITLE
Updates for developing with a local DevTools version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -379,7 +379,9 @@ Obviously, unit tests can only be run from the command line.
    then adjust it to point to `flutter-intellij/third_party/lib/dart-plugin/xxx.yyyy/Dart.jar`.
    Delete the Dart module from the Project Structure modules list.
 
-## Working with Embedded DevTools (JxBrowser)
+## Flutter DevTools Integration
+
+### Working with Embedded DevTools (JxBrowser)
 
 We use [JxBrowser](https://www.teamdev.com/jxbrowser),
 a commercial product, to embed DevTools within IntelliJ.
@@ -398,3 +400,17 @@ To set up the license key:
 1. Copy the template at resources/jxbrowser/jxbrowser.properties.template
    and save it as resources/jxbrowser/jxbrowser.properties.
 2. Replace `<KEY>` with the actual key.
+
+### Developing with local DevTools
+
+By default, the DevTools version in IntelliJ will match the DevTools version shipped with Flutter. To instead use a local DevTools version (which will be launched with `dt serve`), the following steps are required:
+
+1. Make sure you have `dt` installed
+    - Follow instructions in the [DevTools set-up guide](https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md#set-up-your-devtools-environment)
+2. Set the registry key to your DevTools directory
+    - Go to Help > Find action > Registry > Find "flutter.local.devtools.dir" and set to your DevTools directory. (e.g. Users/user/dev/devtools)
+    - Optional: If you want to pass additional arguments to `dt serve`, put these in the option "flutter.local.devtools.args"
+3. Restart IntelliJ
+4. Open Help > Show log in finder > Open idea.log
+    - Verify you see output like see output `"DevTools startup: <various messages that come from running dt serve>"`
+5. To stop using local DevTools, go back to the registry key set in step 2 and remove it

--- a/flutter-idea/src/io/flutter/run/daemon/DevToolsService.java
+++ b/flutter-idea/src/io/flutter/run/daemon/DevToolsService.java
@@ -140,11 +140,8 @@ public class DevToolsService {
           final String localDevToolsDir = Registry.stringValue(LOCAL_DEVTOOLS_DIR);
           if (!localDevToolsDir.isEmpty()) {
             // This is only for development to check integration with a locally run DevTools server.
-            // The plugin will run `devtools_tool serve` and assumes that setup from
-            // https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md has been done.
-            // To use this option, go to Help > Find action > Registry > Set "flutter.local.devtools.dir" to your local DevTools directory,
-            // e.g. "/Users/username/Documents/devtools".
-            // To go back to using DevTools from the SDK (the standard way), clear out the registry setting.
+            // To enable, follow the instructions in:
+            // https://github.com/flutter/flutter-intellij/blob/master/CONTRIBUTING.md#developing-with-local-devtools
             final DtdUtils dtdUtils = new DtdUtils();
             try {
               final DartToolingDaemonService dtdService = dtdUtils.readyDtdService(project).get();
@@ -159,8 +156,7 @@ public class DevToolsService {
                 args.addAll(Arrays.stream(localDevToolsArgs.split(" ")).toList());
               }
 
-              setUpInDevMode(createCommand(localDevToolsDir, "devtools_tool",
-                                           args));
+              setUpInDevMode(createCommand(localDevToolsDir, "dt", args));
             }
             catch (InterruptedException | java.util.concurrent.ExecutionException e) {
               throw new RuntimeException(e);


### PR DESCRIPTION
This PR:
- Updates the CONTRIBUTING docs to include instructions for how to run IntelliJ with a local DevTools
- Changes the `devtools_tool` command to `dt` now that is has been renamed