### PR TITLE
[CQ] debugability: fix mis-ordered asserts

### DIFF
--- a/flutter-idea/testSrc/unit/io/flutter/run/FlutterPositionMapperTest.java
+++ b/flutter-idea/testSrc/unit/io/flutter/run/FlutterPositionMapperTest.java
@@ -73,7 +73,7 @@ public class FlutterPositionMapperTest {
     final XSourcePosition pos = mapper.getSourcePosition("1", makeScriptRef("2", "some/stuff/to/ignore/lib/hello.dart"), 123, null);
     assertNotNull(pos);
     assertEquals(pos.getFile(), hello);
-    assertEquals(pos.getLine(), 9); // zero-based
+    assertEquals(9, pos.getLine()); // zero-based
   }
 
   @Test
@@ -90,7 +90,7 @@ public class FlutterPositionMapperTest {
     final XSourcePosition pos = mapper.getSourcePosition("1", makeScriptRef("2", "remote:root/lib/hello.dart"), 123, null);
     assertNotNull(pos);
     assertEquals(pos.getFile(), hello);
-    assertEquals(pos.getLine(), 9); // zero-based
+    assertEquals(9, pos.getLine()); // zero-based
   }
 
   @NotNull

--- a/flutter-idea/testSrc/unit/io/flutter/sdk/FlutterSdkVersionTest.java
+++ b/flutter-idea/testSrc/unit/io/flutter/sdk/FlutterSdkVersionTest.java
@@ -36,76 +36,76 @@ public class FlutterSdkVersionTest {
   @Test
   public void comparesBetaVersions() {
     assertEquals(
-      new FlutterSdkVersion("1.0.0").compareTo(new FlutterSdkVersion("1.0.1")),
-      -1
+      -1,
+      new FlutterSdkVersion("1.0.0").compareTo(new FlutterSdkVersion("1.0.1"))
     );
     assertEquals(
-      new FlutterSdkVersion("1.0.0").compareTo(new FlutterSdkVersion("1.0.0")),
-      0
+      0,
+      new FlutterSdkVersion("1.0.0").compareTo(new FlutterSdkVersion("1.0.0"))
     );
     assertEquals(
-      new FlutterSdkVersion("1.0.1").compareTo(new FlutterSdkVersion("1.0.0")),
-      1
+      1,
+      new FlutterSdkVersion("1.0.1").compareTo(new FlutterSdkVersion("1.0.0"))
     );
     // Stable version is ahead of all beta versions with the same major/minor/patch numbers.
     assertEquals(
-      new FlutterSdkVersion("1.0.0").compareTo(new FlutterSdkVersion("1.0.0-1.0.pre")),
-      1
+      1,
+      new FlutterSdkVersion("1.0.0").compareTo(new FlutterSdkVersion("1.0.0-1.0.pre"))
     );
     assertEquals(
-      new FlutterSdkVersion("1.0.0-1.1.pre").compareTo(new FlutterSdkVersion("1.0.0")),
-      -1
+      -1,
+      new FlutterSdkVersion("1.0.0-1.1.pre").compareTo(new FlutterSdkVersion("1.0.0"))
     );
     assertEquals(
-      new FlutterSdkVersion("1.0.0-1.1.pre").compareTo(new FlutterSdkVersion("1.0.0-1.0.pre")),
-      1
+      1,
+      new FlutterSdkVersion("1.0.0-1.1.pre").compareTo(new FlutterSdkVersion("1.0.0-1.0.pre"))
     );
     assertEquals(
-      new FlutterSdkVersion("1.0.0-2.0.pre").compareTo(new FlutterSdkVersion("1.0.0-1.0.pre")),
-      1
+      1,
+      new FlutterSdkVersion("1.0.0-2.0.pre").compareTo(new FlutterSdkVersion("1.0.0-1.0.pre"))
     );
     assertEquals(
-      new FlutterSdkVersion("1.0.0-1.1.pre").compareTo(new FlutterSdkVersion("1.0.0-1.2.pre")),
-      -1
+      -1,
+      new FlutterSdkVersion("1.0.0-1.1.pre").compareTo(new FlutterSdkVersion("1.0.0-1.2.pre"))
     );
     assertEquals(
-      new FlutterSdkVersion("1.0.0-1.1.pre").compareTo(new FlutterSdkVersion("1.0.0-2.1.pre")),
-      -1
+      -1,
+      new FlutterSdkVersion("1.0.0-1.1.pre").compareTo(new FlutterSdkVersion("1.0.0-2.1.pre"))
     );
     assertEquals(
-      new FlutterSdkVersion("1.0.0-1.1.pre").compareTo(new FlutterSdkVersion("1.0.0-1.1.pre")),
-      0
+      0,
+      new FlutterSdkVersion("1.0.0-1.1.pre").compareTo(new FlutterSdkVersion("1.0.0-1.1.pre"))
     );
     assertEquals(
-      new FlutterSdkVersion("1.0.0-1.1.pre.123").compareTo(new FlutterSdkVersion("1.0.0-1.1.pre.123")),
-      0
+      0,
+      new FlutterSdkVersion("1.0.0-1.1.pre.123").compareTo(new FlutterSdkVersion("1.0.0-1.1.pre.123"))
     );
     assertEquals(
-      new FlutterSdkVersion("1.0.0-1.1.pre.123").compareTo(new FlutterSdkVersion("1.0.0-1.1.pre.124")),
-      -1
+      -1,
+      new FlutterSdkVersion("1.0.0-1.1.pre.123").compareTo(new FlutterSdkVersion("1.0.0-1.1.pre.124"))
     );
     assertEquals(
-      new FlutterSdkVersion("1.0.0-1.1.pre.124").compareTo(new FlutterSdkVersion("1.0.0-1.1.pre.123")),
-      1
+      1,
+      new FlutterSdkVersion("1.0.0-1.1.pre.124").compareTo(new FlutterSdkVersion("1.0.0-1.1.pre.123"))
     );
     // Master versions will be aware of the latest preceding dev version and have a version number higher than the preceding dev version.
     // e.g. the next commit to master after cutting dev version 2.0.0-2.0.pre would be 2.0.0-3.0.pre.1, with the number 1 signifying 1
     // commit after the previous version.
     assertEquals(
-      new FlutterSdkVersion("1.0.0-1.1.pre.123").compareTo(new FlutterSdkVersion("1.0.0-1.1.pre")),
-      -1
+      -1,
+      new FlutterSdkVersion("1.0.0-1.1.pre.123").compareTo(new FlutterSdkVersion("1.0.0-1.1.pre"))
     );
     assertEquals(
-      new FlutterSdkVersion("1.0.0-1.1.pre").compareTo(new FlutterSdkVersion("1.0.0-1.1.pre.123")),
-      1
+      1,
+      new FlutterSdkVersion("1.0.0-1.1.pre").compareTo(new FlutterSdkVersion("1.0.0-1.1.pre.123"))
     );
     assertEquals(
-      new FlutterSdkVersion("1.0.0-2.0.pre.123").compareTo(new FlutterSdkVersion("1.0.0-1.0.pre")),
-      1
+      1,
+      new FlutterSdkVersion("1.0.0-2.0.pre.123").compareTo(new FlutterSdkVersion("1.0.0-1.0.pre"))
     );
     assertEquals(
-      new FlutterSdkVersion("1.0.0-2.0.pre").compareTo(new FlutterSdkVersion("1.0.0-1.0.pre.123")),
-      1
+      1,
+      new FlutterSdkVersion("1.0.0-2.0.pre").compareTo(new FlutterSdkVersion("1.0.0-1.0.pre.123"))
     );
   }
 }

--- a/flutter-idea/testSrc/unit/io/flutter/utils/UrlUtilsTest.java
+++ b/flutter-idea/testSrc/unit/io/flutter/utils/UrlUtilsTest.java
@@ -5,16 +5,16 @@ import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 
 public class UrlUtilsTest {
-    @Test
-    public void testGenerateHtmlFragmentWithHrefTags() {
-        assertEquals(
-                UrlUtils.generateHtmlFragmentWithHrefTags("Open http://link.com"),
-                "Open <a href=\"http://link.com\">http://link.com</a>"
-        );
-        assertEquals(UrlUtils.generateHtmlFragmentWithHrefTags("Unchanged text without URLs"), "Unchanged text without URLs");
-        assertEquals(
-                UrlUtils.generateHtmlFragmentWithHrefTags("Multiple http://link1.com links http://link2.com test"),
-                "Multiple <a href=\"http://link1.com\">http://link1.com</a> links <a href=\"http://link2.com\">http://link2.com</a> test"
-        );
-    }
+  @Test
+  public void testGenerateHtmlFragmentWithHrefTags() {
+    assertEquals(
+      "Open <a href=\"http://link.com\">http://link.com</a>",
+      UrlUtils.generateHtmlFragmentWithHrefTags("Open http://link.com")
+    );
+    assertEquals("Unchanged text without URLs", UrlUtils.generateHtmlFragmentWithHrefTags("Unchanged text without URLs"));
+    assertEquals(
+      "Multiple <a href=\"http://link1.com\">http://link1.com</a> links <a href=\"http://link2.com\">http://link2.com</a> test",
+      UrlUtils.generateHtmlFragmentWithHrefTags("Multiple http://link1.com links http://link2.com test")
+    );
+  }
 }


### PR DESCRIPTION
Similar to #8015. Fix order of `actual` and `expected` assert args to keep debugging sane. 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
