### PR TITLE
Change the verifier CLI version back to 1.379

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -139,54 +139,6 @@ intellijPlatform {
       untilBuild = untilBuildInput
     }
   }
-
-  // Verifier documentation
-  // https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-extension.html#intellijPlatform-pluginVerification
-  // https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-extension.html#intellijPlatform-pluginVerification-ides
-  pluginVerification {
-    // https://github.com/JetBrains/intellij-plugin-verifier/?tab=readme-ov-file#specific-options
-    // https://github.com/JetBrains/intellij-plugin-verifier
-    cliPath = file("../third_party/lib/verifier-cli-1.381-all.jar")
-    failureLevel = listOf(
-      // TODO(team) Ideally all of the following FailureLevels should be enabled:
-      // TODO(team) Create a tracking issue for each of the following validations
-//      VerifyPluginTask.FailureLevel.COMPATIBILITY_WARNINGS,
-//      VerifyPluginTask.FailureLevel.COMPATIBILITY_PROBLEMS,
-//      VerifyPluginTask.FailureLevel.DEPRECATED_API_USAGES,
-//      VerifyPluginTask.FailureLevel.SCHEDULED_FOR_REMOVAL_API_USAGES,
-      VerifyPluginTask.FailureLevel.EXPERIMENTAL_API_USAGES,
-//      VerifyPluginTask.FailureLevel.INTERNAL_API_USAGES,
-//      VerifyPluginTask.FailureLevel.OVERRIDE_ONLY_API_USAGES,
-      VerifyPluginTask.FailureLevel.NON_EXTENDABLE_API_USAGES,
-      VerifyPluginTask.FailureLevel.PLUGIN_STRUCTURE_WARNINGS,
-//      VerifyPluginTask.FailureLevel.MISSING_DEPENDENCIES,
-      VerifyPluginTask.FailureLevel.INVALID_PLUGIN,
-//      VerifyPluginTask.FailureLevel.NOT_DYNAMIC,
-    )
-    verificationReportsFormats = VerifyPluginTask.VerificationReportsFormats.ALL
-    subsystemsToCheck = VerifyPluginTask.Subsystems.ALL
-    // Mute and freeArgs documentation
-    // https://github.com/JetBrains/intellij-plugin-verifier/?tab=readme-ov-file#specific-options
-    // https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-faq.html#mutePluginVerifierProblems
-    freeArgs = listOf(
-      "-mute",
-      "TemplateWordInPluginId,ForbiddenPluginIdPrefix,TemplateWordInPluginName"
-    )
-    ides {
-      if (ideaProduct == "android-studio") {
-        ide(IntelliJPlatformType.AndroidStudio, ideaVersion)
-      } else {
-        ide(IntelliJPlatformType.IntellijIdeaCommunity, ideaVersion)
-      }
-//      recommended()
-//      select {
-//        types = listOf(IntelliJPlatformType.AndroidStudio)
-//        channels = listOf(ProductRelease.Channel.RELEASE)
-//        sinceBuild = sinceBuildInput
-//        untilBuild = untilBuildInput
-//      }
-    }
-  }
 }
 
 // Documentation for printProductsReleases:

--- a/flutter-idea/build.gradle.kts
+++ b/flutter-idea/build.gradle.kts
@@ -126,7 +126,7 @@ intellijPlatform {
   pluginVerification {
     // https://github.com/JetBrains/intellij-plugin-verifier/?tab=readme-ov-file#specific-options
     // https://github.com/JetBrains/intellij-plugin-verifier
-    cliPath = file("../third_party/lib/verifier-cli-1.381-all.jar")
+    cliPath = file("../third_party/lib/verifier-cli-1.379-all.jar")
     failureLevel = listOf(
       // TODO(team) Ideally all of the following FailureLevels should be enabled:
       // TODO(team) Create a tracking issue for each of the following validations


### PR DESCRIPTION
I thought this was working in January, however clearly the jar was not included in the original PR: https://github.com/flutter/flutter-intellij/pull/7871

Changing back for now until we update the verifier jar again.

This is the start of the work involved with https://github.com/flutter/flutter-intellij/issues/8034