### PR TITLE
Fix `FlutterOutline` service infinite subscriptions

### DIFF
--- a/flutter-idea/src/io/flutter/editor/ActiveEditorsOutlineService.java
+++ b/flutter-idea/src/io/flutter/editor/ActiveEditorsOutlineService.java
@@ -132,8 +132,7 @@ public class ActiveEditorsOutlineService implements Disposable {
       }
 
       for (final String path : obsoletePaths) {
-        final String filePathOrUri = getAnalysisServer().getAnalysisService().getLocalFileUri(path);
-        final FlutterOutlineListener listener = outlineListeners.remove(filePathOrUri);
+        final FlutterOutlineListener listener = outlineListeners.remove(path);
         if (listener != null) {
           getAnalysisServer().removeOutlineListener(FileUtil.toSystemDependentName(path), listener);
         }


### PR DESCRIPTION
Fixes an issue where we never unsubscribe outline listeners.

The rub is that `getLocalFileUri` is being called on a path that is already a URI and is producing a bogus path which has no associated listener registered (because it’s bogus).

In general the issue here is a symptom of URIs being encoded in strings that are never validated.

The quick fix is to not “uri-ify” an already valid UR string. Longer term we should consider a deeper audit of places we’re passing URIs around. It’s possible there are other related issues. If/when we do this, Alex shared some [interesting thoughts from his work on the Dart plugin](https://github.com/flutter/flutter-intellij/issues/7980#issuecomment-2785510617) that’d be worth synthesizing.

Fixes: https://github.com/flutter/flutter-intellij/issues/7980

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
