### PR TITLE
[CQ] ensure null-safe read actions

### DIFF
--- a/flutter-idea/src/io/flutter/bazel/PluginConfig.java
+++ b/flutter-idea/src/io/flutter/bazel/PluginConfig.java
@@ -10,11 +10,11 @@ import com.google.common.base.Objects;
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.annotations.SerializedName;
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.util.Computable;
 import com.intellij.openapi.vfs.VirtualFile;
 import io.flutter.FlutterUtils;
+import io.flutter.utils.OpenApiUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -43,6 +43,7 @@ public class PluginConfig {
   String getDevToolsScript() {
     return fields.devToolsScript;
   }
+
   @Nullable
   String getDoctorScript() {
     return fields.doctorScript;
@@ -137,7 +138,7 @@ public class PluginConfig {
       }
     };
 
-    return ApplicationManager.getApplication().runReadAction(readAction);
+    return OpenApiUtils.safeRunReadAction(readAction);
   }
 
   @VisibleForTesting

--- a/flutter-idea/src/io/flutter/bazel/Workspace.java
+++ b/flutter-idea/src/io/flutter/bazel/Workspace.java
@@ -9,7 +9,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableSet;
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
@@ -18,6 +17,7 @@ import com.intellij.openapi.roots.ProjectRootManager;
 import com.intellij.openapi.util.Computable;
 import com.intellij.openapi.vfs.InvalidVirtualFileAccessException;
 import com.intellij.openapi.vfs.VirtualFile;
+import io.flutter.utils.OpenApiUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -379,7 +379,7 @@ public class Workspace {
       // not found
       return null;
     };
-    return ApplicationManager.getApplication().runReadAction(readAction);
+    return OpenApiUtils.safeRunReadAction(readAction);
   }
 
   /**

--- a/flutter-idea/src/io/flutter/run/FlutterPositionMapper.java
+++ b/flutter-idea/src/io/flutter/run/FlutterPositionMapper.java
@@ -6,10 +6,8 @@
 package io.flutter.run;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.util.Computable;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -24,6 +22,7 @@ import com.jetbrains.lang.dart.util.DartResolveUtil;
 import com.jetbrains.lang.dart.util.DartUrlResolver;
 import io.flutter.FlutterUtils;
 import io.flutter.dart.DartPlugin;
+import io.flutter.utils.OpenApiUtils;
 import io.flutter.vmService.DartVmServiceDebugProcess;
 import org.dartlang.vm.service.element.LibraryRef;
 import org.dartlang.vm.service.element.Script;
@@ -150,7 +149,7 @@ public class FlutterPositionMapper implements DartVmServiceDebugProcess.Position
     if (project == null || project.isDisposed()) return null;
 
     // Find files with the same filename (matching the suffix after the last slash).
-    final PsiFile[] localFilesWithSameName = ApplicationManager.getApplication().runReadAction((Computable<PsiFile[]>)() -> {
+    final PsiFile[] localFilesWithSameName = OpenApiUtils.safeRunReadAction(() -> {
       final String remoteFileName = PathUtil.getFileName(remotePath);
       final GlobalSearchScope scope = GlobalSearchScopesCore.directoryScope(project, sourceRoot, true);
       return FilenameIndex.getFilesByName(project, remoteFileName, scope);
@@ -304,7 +303,7 @@ public class FlutterPositionMapper implements DartVmServiceDebugProcess.Position
    */
   @Nullable
   protected VirtualFile findLocalFile(@NotNull String uri, CompletableFuture<String> fileFuture) {
-    return ApplicationManager.getApplication().runReadAction((Computable<VirtualFile>)() -> {
+    return OpenApiUtils.safeRunReadAction(() -> {
       // This can be a remote file or URI.
       if (remoteSourceRoot != null && uri.startsWith(remoteSourceRoot)) {
         final String rootUri = StringUtil.trimEnd(resolver.getDartUrlForFile(sourceRoot), '/');

--- a/flutter-idea/src/io/flutter/run/FlutterReloadManager.java
+++ b/flutter-idea/src/io/flutter/run/FlutterReloadManager.java
@@ -14,8 +14,14 @@ import com.intellij.concurrency.JobScheduler;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configurations.GeneralCommandLine;
 import com.intellij.ide.actions.SaveAllAction;
-import com.intellij.notification.*;
-import com.intellij.openapi.actionSystem.*;
+import com.intellij.notification.Notification;
+import com.intellij.notification.NotificationGroup;
+import com.intellij.notification.NotificationGroupManager;
+import com.intellij.notification.NotificationType;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.CommonDataKeys;
+import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.actionSystem.ex.AnActionListener;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ModalityState;
@@ -30,7 +36,6 @@ import com.intellij.openapi.fileEditor.FileEditor;
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.popup.Balloon;
-import com.intellij.openapi.util.Computable;
 import com.intellij.openapi.util.SystemInfo;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -59,6 +64,7 @@ import io.flutter.run.daemon.FlutterApp;
 import io.flutter.settings.FlutterSettings;
 import io.flutter.utils.FlutterModuleUtils;
 import io.flutter.utils.MostlySilentColoredProcessHandler;
+import io.flutter.utils.OpenApiUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -194,7 +200,7 @@ public class FlutterReloadManager {
 
         ApplicationManager.getApplication().invokeLater(() -> {
           // Find a Dart editor to trigger the reload.
-          final Editor anEditor = ApplicationManager.getApplication().runReadAction((Computable<Editor>)() -> {
+          final Editor anEditor = OpenApiUtils.safeRunReadAction(() -> {
             Editor someEditor = null;
             final EditorFactory editorFactory = EditorFactory.getInstance();
             if(editorFactory != null) {
@@ -479,7 +485,7 @@ public class FlutterReloadManager {
     // are analysis issues in other files; the compilation errors from the flutter tool
     // will indicate to the user where the problems are.
 
-    final PsiErrorElement firstError = ApplicationManager.getApplication().runReadAction((Computable<PsiErrorElement>)() -> {
+    final PsiErrorElement firstError = OpenApiUtils.safeRunReadAction(() -> {
       final PsiFile psiFile = PsiDocumentManager.getInstance(myProject).getPsiFile(document);
       if (psiFile instanceof DartFile) {
         return PsiTreeUtil.findChildOfType(psiFile, PsiErrorElement.class, false);

--- a/flutter-idea/src/io/flutter/run/bazelTest/BazelTestRunner.java
+++ b/flutter-idea/src/io/flutter/run/bazelTest/BazelTestRunner.java
@@ -19,17 +19,15 @@ import com.intellij.execution.process.*;
 import com.intellij.execution.runners.ExecutionEnvironment;
 import com.intellij.execution.runners.GenericProgramRunner;
 import com.intellij.execution.ui.RunContentDescriptor;
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ContentEntry;
 import com.intellij.openapi.roots.ModuleRootManager;
-import com.intellij.openapi.util.Computable;
 import com.intellij.openapi.util.Key;
+import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
-import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.xdebugger.XDebugProcess;
 import com.intellij.xdebugger.XDebugProcessStarter;
 import com.intellij.xdebugger.XDebugSession;
@@ -46,6 +44,7 @@ import io.flutter.run.common.CommonTestConfigUtils;
 import io.flutter.run.test.FlutterTestRunner;
 import io.flutter.settings.FlutterSettings;
 import io.flutter.utils.JsonUtils;
+import io.flutter.utils.OpenApiUtils;
 import io.flutter.utils.StdoutJsonParser;
 import io.flutter.utils.UrlUtils;
 import org.jetbrains.annotations.NotNull;
@@ -284,7 +283,7 @@ public class BazelTestRunner extends GenericProgramRunner {
       final String pathFromWorkspace = uri.substring(workspaceDirName.length() + 1);
 
       // For each root in each module, look for a bazel workspace path, if found attempt to compute the VirtualFile, return when found.
-      return ApplicationManager.getApplication().runReadAction((Computable<VirtualFile>)() -> {
+      return OpenApiUtils.safeRunReadAction(() -> {
         for (Module module : DartSdkLibUtil.getModulesWithDartSdkEnabled(getProject())) {
           for (ContentEntry contentEntry : ModuleRootManager.getInstance(module).getContentEntries()) {
             final VirtualFile includedRoot = contentEntry.getFile();

--- a/flutter-idea/src/io/flutter/utils/EnableDartSupportForModule.java
+++ b/flutter-idea/src/io/flutter/utils/EnableDartSupportForModule.java
@@ -42,7 +42,7 @@ class EnableDartSupportForModule implements Runnable {
           }
         });
         ApplicationManager.getApplication().executeOnPooledThread(() -> {
-          ApplicationManager.getApplication().runReadAction(() -> {
+          OpenApiUtils.safeRunReadAction(() -> {
             DartAnalysisServerService.getInstance(project).serverReadyForRequest();
           });
         });

--- a/flutter-idea/src/io/flutter/utils/OpenApiUtils.java
+++ b/flutter-idea/src/io/flutter/utils/OpenApiUtils.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2025 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.utils;
+
+import com.intellij.openapi.application.Application;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.util.Computable;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class OpenApiUtils {
+
+  public static void safeRunReadAction(@NotNull Runnable runnable) {
+    Application application = ApplicationManager.getApplication();
+    if (application == null) return;
+    application.runReadAction(runnable);
+  }
+
+  public static <T> @Nullable T safeRunReadAction(@NotNull Computable<T> computable) {
+    Application application = ApplicationManager.getApplication();
+    if (application == null) return null;
+    return application.runReadAction(computable);
+  }
+}

--- a/flutter-idea/src/io/flutter/vmService/VmServiceWrapper.java
+++ b/flutter-idea/src/io/flutter/vmService/VmServiceWrapper.java
@@ -27,14 +27,15 @@ import io.flutter.bazel.WorkspaceCache;
 import io.flutter.run.daemon.FlutterApp;
 import io.flutter.sdk.FlutterSdk;
 import io.flutter.sdk.FlutterSdkVersion;
+import io.flutter.utils.OpenApiUtils;
 import io.flutter.vmService.frame.DartAsyncMarkerFrame;
 import io.flutter.vmService.frame.DartVmServiceEvaluator;
 import io.flutter.vmService.frame.DartVmServiceStackFrame;
 import io.flutter.vmService.frame.DartVmServiceValue;
 import org.dartlang.vm.service.VmService;
 import org.dartlang.vm.service.consumer.*;
-import org.dartlang.vm.service.element.Stack;
 import org.dartlang.vm.service.element.*;
+import org.dartlang.vm.service.element.Stack;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -295,7 +296,7 @@ public class VmServiceWrapper implements Disposable {
     // Just to make sure that the main isolate is not handled twice, both from handleDebuggerConnected() and DartVmServiceListener.received(PauseStart)
     if (newIsolate) {
       XDebugSessionImpl session = (XDebugSessionImpl)myDebugProcess.getSession();
-      ApplicationManager.getApplication().runReadAction(() -> {
+      OpenApiUtils.safeRunReadAction(() -> {
         session.reset();
         session.initBreakpoints();
       });

--- a/flutter-idea/src/io/flutter/vmService/frame/DartVmServiceValue.java
+++ b/flutter-idea/src/io/flutter/vmService/frame/DartVmServiceValue.java
@@ -11,6 +11,7 @@ import com.intellij.xdebugger.frame.*;
 import com.intellij.xdebugger.frame.presentation.XKeywordValuePresentation;
 import com.intellij.xdebugger.frame.presentation.XNumericValuePresentation;
 import com.intellij.xdebugger.frame.presentation.XStringValuePresentation;
+import io.flutter.utils.OpenApiUtils;
 import io.flutter.utils.TypedDataList;
 import io.flutter.vmService.DartVmServiceDebugProcess;
 import io.flutter.vmService.VmServiceConsumers;
@@ -145,7 +146,7 @@ public class DartVmServiceValue extends XNamedValue {
 
     ApplicationManager.getApplication().executeOnPooledThread(() -> {
       final XSourcePosition sourcePosition = debugProcess.getSourcePosition(isolateId, script, tokenPos);
-      ApplicationManager.getApplication().runReadAction(() -> navigatable.setSourcePosition(sourcePosition));
+      OpenApiUtils.safeRunReadAction(() -> navigatable.setSourcePosition(sourcePosition));
     });
   }
 

--- a/flutter-idea/testSrc/unit/io/flutter/run/FlutterPositionMapperTest.java
+++ b/flutter-idea/testSrc/unit/io/flutter/run/FlutterPositionMapperTest.java
@@ -8,7 +8,6 @@ package io.flutter.run;
 import com.google.common.collect.ImmutableList;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.roots.ModuleRootModificationUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.xdebugger.XSourcePosition;

--- a/flutter-idea/testSrc/unit/io/flutter/run/FlutterPositionMapperTest.java
+++ b/flutter-idea/testSrc/unit/io/flutter/run/FlutterPositionMapperTest.java
@@ -17,6 +17,7 @@ import com.jetbrains.lang.dart.util.DartUrlResolverImpl;
 import io.flutter.testing.ProjectFixture;
 import io.flutter.testing.TestDir;
 import io.flutter.testing.Testing;
+import io.flutter.utils.OpenApiUtils;
 import io.flutter.vmService.DartVmServiceDebugProcess;
 import org.dartlang.vm.service.element.LibraryRef;
 import org.dartlang.vm.service.element.Script;
@@ -96,7 +97,7 @@ public class FlutterPositionMapperTest {
   @NotNull
   private FlutterPositionMapper setUpMapper(VirtualFile contextFile, String remoteBaseUri) {
     final FlutterPositionMapper[] mapper = new FlutterPositionMapper[1];
-    ApplicationManager.getApplication().runReadAction(() -> {
+    OpenApiUtils.safeRunReadAction(() -> {
       final DartUrlResolver resolver = new DartUrlResolverImpl(fixture.getProject(), contextFile);
       mapper[0] = new FlutterPositionMapper(fixture.getProject(), sourceRoot, resolver, null);
       mapper[0].onConnect(scripts, remoteBaseUri);


### PR DESCRIPTION
Add a null-safe `safeRunReadAction` and migrate unsafe callers to use it.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
