### PR TITLE
Fix `DaemonCrashReporter` dialog modality type

### DIFF
--- a/flutter-idea/src/io/flutter/run/daemon/DeviceDaemon.java
+++ b/flutter-idea/src/io/flutter/run/daemon/DeviceDaemon.java
@@ -434,7 +434,7 @@ class DeviceDaemon {
     private JTextPane myTextPane;
 
     DaemonCrashReporter() {
-      super(null, false, false);
+      super(null, false, DialogWrapper.IdeModalityType.IDE);
       setTitle("Flutter Device Daemon Crash");
       myPanel = new JPanel();
       myTextPane = new JTextPane();


### PR DESCRIPTION
The constructor we were invoking was defaulting to `IdeModalityType.PROJECT` which is not fully supported. Migrating to use `IdeModalityType.IDE` addresses this. 

(Verified on Meerkat.)

Fixes: https://github.com/flutter/flutter-intellij/issues/7986

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
