### PR TITLE
[CQ] API: migrate `TestForm` from removed `addBrowseFolderListener` API

### DIFF
--- a/flutter-idea/src/io/flutter/run/test/TestForm.java
+++ b/flutter-idea/src/io/flutter/run/test/TestForm.java
@@ -9,6 +9,7 @@ import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory;
 import com.intellij.openapi.options.ConfigurationException;
 import com.intellij.openapi.options.SettingsEditor;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.TextComponentAccessor;
 import com.intellij.openapi.ui.TextFieldWithBrowseButton;
 import com.intellij.ui.ListCellRendererWrapper;
 import io.flutter.run.test.TestFields.Scope;
@@ -64,8 +65,8 @@ public class TestForm extends SettingsEditor<TestConfig> {
     });
 
     initDartFileTextWithBrowse(project, testFile);
-    testDir.addBrowseFolderListener("Test Directory", null, project,
-                                    FileChooserDescriptorFactory.createSingleFolderDescriptor());
+    testDir.addBrowseFolderListener(project, FileChooserDescriptorFactory.createSingleFolderDescriptor()
+      .withTitle("Test Directory"));
   }
 
   @NotNull


### PR DESCRIPTION
Another unsafe `addBrowseFolderListener` migration, as in https://github.com/flutter/flutter-intellij/pull/8070.

See: https://github.com/flutter/flutter-intellij/issues/7718

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
