### PR TITLE
[CQ] migrate off to-be-removed `Notification` APIs

### DIFF
--- a/flutter-idea/src/io/flutter/FlutterMessages.java
+++ b/flutter-idea/src/io/flutter/FlutterMessages.java
@@ -37,7 +37,7 @@ public class FlutterMessages {
         FLUTTER_NOTIFICATION_GROUP_ID,
         title,
         message,
-        NotificationType.WARNING, NotificationListener.URL_OPENING_LISTENER), project);
+        NotificationType.WARNING).setListener(NotificationListener.URL_OPENING_LISTENER), project);
   }
 
   public static void showInfo(String title, String message, @Nullable Project project) {

--- a/flutter-idea/src/io/flutter/ProjectOpenActivity.java
+++ b/flutter-idea/src/io/flutter/ProjectOpenActivity.java
@@ -122,11 +122,10 @@ public class ProjectOpenActivity implements StartupActivity, DumbAware {
     @NotNull private final PubRoot myRoot;
 
     public PackagesOutOfDateNotification(@NotNull Project project, @NotNull PubRoot root) {
-      super("Flutter Packages", FlutterIcons.Flutter, "Flutter pub get.",
-            null, "The pubspec.yaml file has been modified since " +
-                  "the last time 'flutter pub get' was run.",
-            NotificationType.INFORMATION, null);
-
+      super("Flutter Packages", "The pubspec.yaml file has been modified since " +
+                                "the last time 'flutter pub get' was run.", NotificationType.INFORMATION);
+      setIcon(FlutterIcons.Flutter);
+      
       myProject = project;
       myRoot = root;
 

--- a/flutter-idea/src/io/flutter/survey/FlutterSurveyNotifications.java
+++ b/flutter-idea/src/io/flutter/survey/FlutterSurveyNotifications.java
@@ -88,14 +88,8 @@ public class FlutterSurveyNotifications {
     if (properties.getBoolean(survey.uniqueId)) return;
 
     final Notification notification = new Notification(
-      FlutterMessages.FLUTTER_NOTIFICATION_GROUP_ID,
-      FlutterIcons.Flutter,
-      survey.title,
-      null,
-      null,
-      NotificationType.INFORMATION,
-      null
-    );
+      FlutterMessages.FLUTTER_NOTIFICATION_GROUP_ID, survey.title, "", NotificationType.INFORMATION
+    ).setIcon(FlutterIcons.Flutter);
 
     notification.addAction(new AnAction(SURVEY_ACTION_TEXT) {
       @Override


### PR DESCRIPTION
Migrates from unsafe slated-for-removal `Notification` constructors.

See: https://github.com/flutter/flutter-intellij/issues/7718

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
