### PR TITLE
[CQ] API: migrate from to-be-removed `AnActionListener` APIs

### DIFF
--- a/flutter-idea/src/io/flutter/run/FlutterReloadManager.java
+++ b/flutter-idea/src/io/flutter/run/FlutterReloadManager.java
@@ -18,10 +18,7 @@ import com.intellij.notification.Notification;
 import com.intellij.notification.NotificationGroup;
 import com.intellij.notification.NotificationGroupManager;
 import com.intellij.notification.NotificationType;
-import com.intellij.openapi.actionSystem.AnAction;
-import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.actionSystem.CommonDataKeys;
-import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.actionSystem.*;
 import com.intellij.openapi.actionSystem.ex.AnActionListener;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ModalityState;
@@ -133,11 +130,8 @@ public class FlutterReloadManager {
       private @Nullable Project eventProject;
       private @Nullable Editor eventEditor;
 
-      /**
-       * WARNING on the deprecation of this API: the modification of this file was made at one point to resolve this error, but Flutter
-       * Hot Reload was broken, see https://github.com/flutter/flutter-intellij/issues/6996, the change had to be rolled back.
-       */
-      public void beforeActionPerformed(@NotNull AnAction action, @NotNull DataContext dataContext, @NotNull AnActionEvent event) {
+      public void beforeActionPerformed(@NotNull AnAction action, @NotNull AnActionEvent event) {
+        // In case of hot-reload breakages, see: https://github.com/flutter/flutter-intellij/issues/6996
         if (!(action instanceof SaveAllAction)) {
           return;
         }
@@ -154,10 +148,8 @@ public class FlutterReloadManager {
         }
       }
 
-      /**
-       * See note above on {{@link #beforeActionPerformed(AnAction, DataContext, AnActionEvent)}}.
-       */
-      public void afterActionPerformed(@NotNull AnAction action, @NotNull DataContext dataContext, @NotNull AnActionEvent event) {
+      public void afterActionPerformed(@NotNull AnAction action, @NotNull AnActionEvent event,  @NotNull AnActionResult result) {
+        // In case of hot-reload breakages, see: https://github.com/flutter/flutter-intellij/issues/6996
         if (!(action instanceof SaveAllAction)) {
           return;
         }


### PR DESCRIPTION
Migrate to safe `AnActionListener` APIs.

This migration has been attempted before but was reverted as possibly causing a hot reload regression (https://github.com/flutter/flutter-intellij/issues/6996).

I've confirmed that hot reload works (Mac OS Meerkat) but have preserved the note in case anything odd happens.

See: https://github.com/flutter/flutter-intellij/issues/7718

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
