### PR TITLE
[CQ] suppress insecure URL warnings for devtools URLs

### DIFF
--- a/flutter-idea/src/io/flutter/devtools/DevToolsUrl.java
+++ b/flutter-idea/src/io/flutter/devtools/DevToolsUrl.java
@@ -159,6 +159,7 @@ public class DevToolsUrl {
     }
   }
 
+  @SuppressWarnings("HttpUrlsUsage")
   @NotNull
   public String getUrlString() {
     final List<String> params = new ArrayList<>();

--- a/flutter-idea/src/io/flutter/run/SdkFields.java
+++ b/flutter-idea/src/io/flutter/run/SdkFields.java
@@ -227,6 +227,7 @@ public class SdkFields {
         }
       }, "Starting DevTools", false, project);
       final DevToolsInstance instance = devToolsFuture.get();
+      //noinspection HttpUrlsUsage
       args = ArrayUtil.append(args, "--devtools-server-address=http://" + instance.host() + ":" + instance.port());
     }
     catch (Exception e) {

--- a/flutter-idea/src/io/flutter/run/bazel/BazelFields.java
+++ b/flutter-idea/src/io/flutter/run/bazel/BazelFields.java
@@ -333,6 +333,7 @@ public class BazelFields {
         }
       }, "Starting DevTools", false, project);
       final DevToolsInstance instance = devToolsFuture.get();
+      //noinspection HttpUrlsUsage
       commandLine.addParameter("--devtools-server-address=http://" + instance.host() + ":" + instance.port());
     }
     catch (Exception e) {

--- a/flutter-idea/testSrc/unit/io/flutter/utils/UrlUtilsTest.java
+++ b/flutter-idea/testSrc/unit/io/flutter/utils/UrlUtilsTest.java
@@ -4,6 +4,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
+@SuppressWarnings("HttpUrlsUsage")
 public class UrlUtilsTest {
   @Test
   public void testGenerateHtmlFragmentWithHrefTags() {


### PR DESCRIPTION
We can't make URLs secure, so the warnings are just noise.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
