### PR TITLE
Refactor product handling logic in build script

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,6 @@
  * found in the LICENSE file.
  */
 
-import org.jetbrains.intellij.platform.gradle.IntelliJPlatform
 import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
 import org.jetbrains.intellij.platform.gradle.models.ProductRelease
@@ -94,8 +93,12 @@ dependencies {
     // https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-dependencies-extension.html#default-target-platforms
     if (ideaProduct == "android-studio") {
       androidStudio(ideaVersion)
-    } else { // if (ideaProduct == "IC") {
-      intellijIdeaCommunity(ideaVersion)
+    } else {
+      when (ideaProduct) {
+        "IU" -> intellijIdeaUltimate(ideaVersion)
+        "IC" -> intellijIdeaCommunity(ideaVersion)
+        else -> throw IllegalArgumentException("ideaProduct must be defined in the product matrix as either \"IU\" or \"IC\", but is not for $ideaVersion")
+      }
     }
     testFramework(TestFrameworkType.Platform)
 
@@ -109,12 +112,11 @@ dependencies {
       "org.jetbrains.kotlin",
       "org.jetbrains.plugins.gradle",
       "org.intellij.intelliLang")
+    val pluginList = mutableListOf("Dart:$dartPluginVersion")
     if (ideaProduct == "android-studio") {
       bundledPluginList.add("org.jetbrains.android")
       bundledPluginList.add("com.android.tools.idea.smali")
-    }
-    val pluginList = mutableListOf("Dart:$dartPluginVersion")
-    if (ideaProduct == "IC") {
+    } else {
       pluginList.add("org.jetbrains.android:$androidPluginVersion")
     }
 

--- a/flutter-idea/build.gradle.kts
+++ b/flutter-idea/build.gradle.kts
@@ -74,7 +74,11 @@ dependencies {
     if (ideaProduct == "android-studio") {
       androidStudio(ideaVersion)
     } else { // if (ideaProduct == "IC") {
-      intellijIdeaCommunity(ideaVersion)
+      when (ideaProduct) {
+        "IU" -> intellijIdeaUltimate(ideaVersion)
+        "IC" -> intellijIdeaCommunity(ideaVersion)
+        else -> throw IllegalArgumentException("ideaProduct must be defined in the product matrix as either \"IU\" or \"IC\", but is not for $ideaVersion")
+      }
     }
     testFramework(TestFrameworkType.Platform)
 
@@ -89,12 +93,11 @@ dependencies {
       "org.jetbrains.plugins.gradle",
       "org.intellij.intelliLang",
     )
+    val pluginList = mutableListOf("Dart:$dartPluginVersion")
     if (ideaProduct == "android-studio") {
       bundledPluginList.add("org.jetbrains.android")
       bundledPluginList.add("com.android.tools.idea.smali")
-    }
-    val pluginList = mutableListOf("Dart:$dartPluginVersion")
-    if (ideaProduct == "IC") {
+    } else {
       pluginList.add("org.jetbrains.android:$androidPluginVersion")
     }
 


### PR DESCRIPTION
Adds handling for the "IU" (Idea Ultimate) product variant, currently skipped over and failing builds due to android plugin dependency logic being tied to "IC". This conflicts with the [contributing.md](https://github.com/flutter/flutter-intellij/blob/944aa028132052a6d14a99e073ebe4c7e5525ce3/CONTRIBUTING.md#L111):

> ...
> 1. Make sure you're using the latest stable release of IntelliJ,
>    or download and install the latest version of IntelliJ (2023.1 or later). 
>     - [IntelliJ Downloads](https://www.jetbrains.com/idea/download/)
>     - **Either the community edition (free) or Ultimate will work.** <-- no it won't
> 
> 2. Create a `gradle.properties` file.
> ...

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.