### PR TITLE
[CQ] [unchecked cast]: fix generic bounds

### DIFF
--- a/flutter-idea/src/io/flutter/FlutterErrorReportSubmitter.java
+++ b/flutter-idea/src/io/flutter/FlutterErrorReportSubmitter.java
@@ -56,8 +56,7 @@ public class FlutterErrorReportSubmitter extends ErrorReportSubmitter {
                         @NotNull Component parentComponent,
                         @NotNull Consumer<? super SubmittedReportInfo> consumer) {
     if (events.length == 0) {
-      // Don't remove the cast until a later version of Android Studio.
-      fail(((Consumer<SubmittedReportInfo>)consumer));
+      fail(consumer);
       return false;
     }
 
@@ -97,8 +96,7 @@ public class FlutterErrorReportSubmitter extends ErrorReportSubmitter {
     final DataContext dataContext = DataManager.getInstance().getDataContext(parentComponent);
     final Project project = PROJECT.getData(dataContext);
     if (project == null) {
-      // Don't remove the cast until a later version of Android Studio.
-      fail(((Consumer<SubmittedReportInfo>)consumer));
+      fail(consumer);
       return false;
     }
 
@@ -187,8 +185,7 @@ public class FlutterErrorReportSubmitter extends ErrorReportSubmitter {
     final VirtualFile file = scratchRoot.createScratchFile(project, "bug-report.md", PlainTextLanguage.INSTANCE, text);
 
     if (file == null) {
-      // Don't remove the cast until a later version of Android Studio.
-      fail(((Consumer<SubmittedReportInfo>)consumer));
+      fail(consumer);
       return false;
     }
 
@@ -218,7 +215,7 @@ public class FlutterErrorReportSubmitter extends ErrorReportSubmitter {
     }
   }
 
-  private static void fail(@NotNull Consumer<SubmittedReportInfo> consumer) {
+  private static void fail(@NotNull Consumer<? super SubmittedReportInfo> consumer) {
     consumer.consume(new SubmittedReportInfo(
       null,
       null,


### PR DESCRIPTION
Fix up the generic wildcard bounds so we can remove these unsafe casts (that are spamming the logs).

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
