### PR TITLE
Fix SDK browsing NPE in `FlutterSettingsConfigurable`

### DIFF
--- a/flutter-idea/src/io/flutter/sdk/FlutterSettingsConfigurable.java
+++ b/flutter-idea/src/io/flutter/sdk/FlutterSettingsConfigurable.java
@@ -141,6 +141,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
   }
 
   private void createUIComponents() {
+    //noinspection DialogTitleCapitalization
     ExtendableTextComponent.Extension browseExtension =
       ExtendableTextComponent.Extension.create(
         AllIcons.General.OpenDisk,
@@ -149,7 +150,10 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
         () -> {
           FileChooserDescriptor descriptor = FileChooserDescriptorFactory.createSingleFolderDescriptor();
           VirtualFile file = FileChooser.chooseFile(descriptor, mySdkCombo, null, null);
-          mySdkCombo.setItem(file.getPath());
+          if (file != null) {
+            //noinspection DataFlowIssue (sure to be set before the extension is invoked)
+            mySdkCombo.setItem(file.getPath());
+          }
         });
     mySdkCombo = new ComboBox<>();
     mySdkCombo.setEditor(new BasicComboBoxEditor() {


### PR DESCRIPTION
If no file is selected, the file chooser will return `null`. This guards against that.

Fixes: https://github.com/flutter/flutter-intellij/issues/8069


---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
