### PR TITLE
[CQ] Language migration: use pattern variables

### DIFF
--- a/flutter-idea/src/io/flutter/run/LaunchState.java
+++ b/flutter-idea/src/io/flutter/run/LaunchState.java
@@ -137,12 +137,11 @@ public class LaunchState extends CommandLineState {
     device.bringToFront();
 
     // Check for and display any analysis errors when we launch an app.
-    if (env.getRunProfile() instanceof SdkRunConfig) {
+    if (env.getRunProfile() instanceof SdkRunConfig config) {
       final Class dartExecutionHelper = classForName("com.jetbrains.lang.dart.ide.runner.DartExecutionHelper");
       if (dartExecutionHelper != null) {
         final String message = ("<a href='open.dart.analysis'>Analysis issues</a> may affect " +
                                 "the execution of '" + env.getRunProfile().getName() + "'.");
-        final SdkRunConfig config = (SdkRunConfig)env.getRunProfile();
         final SdkFields sdkFields = config.getFields();
         final MainFile mainFile = MainFile.verify(sdkFields.getFilePath(), env.getProject()).get();
 

--- a/flutter-idea/src/io/flutter/run/test/FlutterTestRunner.java
+++ b/flutter-idea/src/io/flutter/run/test/FlutterTestRunner.java
@@ -70,7 +70,7 @@ public class FlutterTestRunner extends GenericProgramRunner {
       return false;
     }
 
-    final FlutterSdk sdk = FlutterSdk.getFlutterSdk(((TestConfig)profile).getProject());
+    final FlutterSdk sdk = FlutterSdk.getFlutterSdk(config.getProject());
     if (sdk == null) {
       return false;
     }


### PR DESCRIPTION
Java 16 introduces [pattern matching](https://dev.java/learn/pattern-matching/) which allows us to cleanup some unnecessary casts.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
