### PR TITLE
[CQ] remove (dead) empty methods

### DIFF
--- a/flutter-idea/src/io/flutter/editor/OutlineLocation.java
+++ b/flutter-idea/src/io/flutter/editor/OutlineLocation.java
@@ -139,9 +139,6 @@ public class OutlineLocation implements Comparable<OutlineLocation> {
     this.indent = indent;
   }
 
-  public void dispose() {
-  }
-
   /**
    * This method must be called if the location is set to update to reflect
    * edits to the document.

--- a/flutter-idea/src/io/flutter/sdk/FlutterCreateAdditionalSettings.java
+++ b/flutter-idea/src/io/flutter/sdk/FlutterCreateAdditionalSettings.java
@@ -127,7 +127,7 @@ public class FlutterCreateAdditionalSettings {
       args.add(org);
     }
 
-    if (kotlin == null || Boolean.FALSE.equals(kotlin)) {
+    if (kotlin == null || !kotlin) {
       args.add("--android-language");
       args.add("java");
     }

--- a/flutter-idea/src/io/flutter/sdk/FlutterPluginsLibraryManager.java
+++ b/flutter-idea/src/io/flutter/sdk/FlutterPluginsLibraryManager.java
@@ -142,7 +142,7 @@ public class FlutterPluginsLibraryManager extends AbstractLibraryManager<Flutter
       }
 
       for (String packagePath : packagesMap.values()) {
-        if (packagePath == null) continue;;
+        if (packagePath == null) continue;
         final VirtualFile libFolder = LocalFileSystem.getInstance().findFileByPath(packagePath);
         if (libFolder == null) {
           continue;

--- a/flutter-studio/src/io/flutter/utils/AddToAppUtils.java
+++ b/flutter-studio/src/io/flutter/utils/AddToAppUtils.java
@@ -126,9 +126,6 @@ public class AddToAppUtils {
       public void syncSkipped(@NotNull Project project) {
         GradleUtils.checkDartSupport(project);
       }
-
-      public void sourceGenerationFinished(@NotNull Project project) {
-      }
     };
   }
 


### PR DESCRIPTION
More opportunistic tidying.

🧹 Remove unused empty method bodies. (Also a rogue `;`.) 
🧹 Simplify a boolean expression.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
