### PR TITLE
[PE] make color picker “dark theme” aware

### DIFF
--- a/flutter-studio/src/io/flutter/editor/AndroidStudioColorPickerProvider.java
+++ b/flutter-studio/src/io/flutter/editor/AndroidStudioColorPickerProvider.java
@@ -5,6 +5,7 @@
  */
 package io.flutter.editor;
 
+import com.intellij.ui.Gray;
 import com.intellij.ui.colorpicker.ColorPickerBuilder;
 import com.intellij.openapi.ui.popup.Balloon;
 import com.intellij.openapi.ui.popup.BalloonBuilder;
@@ -38,7 +39,7 @@ public class AndroidStudioColorPickerProvider implements ColorPickerProvider {
     popup = null;
 
     final LightCalloutPopup colorPanel = new ColorPickerBuilder()
-      .setOriginalColor(initialColor != null ? initialColor : new Color(255, 255, 255))
+      .setOriginalColor(initialColor != null ? initialColor : Gray._255)
       .addSaturationBrightnessComponent()
       .addColorAdjustPanel()
       .addColorValuePanel().withFocus()


### PR DESCRIPTION
`java.awt` colors are not dark-theme friendly but `JBColor`s are. As a bonus we can use the `Gray` constant.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
