### PR TITLE
[perf] stop static initialization in line marker extension

### DIFF
--- a/flutter-idea/src/io/flutter/editor/FlutterIconLineMarkerProvider.java
+++ b/flutter-idea/src/io/flutter/editor/FlutterIconLineMarkerProvider.java
@@ -55,8 +55,16 @@ public class FlutterIconLineMarkerProvider extends LineMarkerProviderDescriptor 
   private static final String CupertinoRelativeAssetPath = "/assets/CupertinoIcons.ttf";
   private static final String CupertinoRelativeIconsPath = "/packages/flutter/lib/src/cupertino/icons.dart";
 
-  static {
-    initialize();
+  private static boolean instantiated = false;
+
+  FlutterIconLineMarkerProvider() {
+    // Extension point implementations can't use static initializers so we keep track of the
+    // first instantiation to make sure #initialize is called to set up initial state. (Note that this state
+    // may get reset with a subsequent explicit call to #initialize.)
+    if (!instantiated) {
+      initialize();
+    }
+    instantiated = true;
   }
 
   public static void initialize() {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/bffce434-6527-4501-95d7-129541d8b4b7)

From the inspection description:

> Static initialization is performed once the class is loaded, which may cause excessive classloading or early initialization of heavy resources. Since extension point implementations are supposed to be cheap to create, they must not have static initializers.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
