### PR TITLE
[PE] migrate `printStackTrace` to proper logging

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -49,6 +49,9 @@
     </inspection_tool>
     <inspection_tool class="StringTemplateMigration" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="StringTemplateReverseMigration" enabled="false" level="INFORMATION" enabled_by_default="false" />
+    <inspection_tool class="ThrowablePrintStackTrace" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="Tests" level="WARNING" enabled="false" />
+    </inspection_tool>
     <inspection_tool class="XmlUnboundNsPrefix" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="unused" enabled="false" level="WARNING" enabled_by_default="false" checkParameterExcludingHierarchy="false">
       <option name="LOCAL_VARIABLE" value="true" />

--- a/flutter-idea/src/io/flutter/logging/FlutterConsoleLogManager.java
+++ b/flutter-idea/src/io/flutter/logging/FlutterConsoleLogManager.java
@@ -166,7 +166,7 @@ public class FlutterConsoleLogManager {
         }
       }
       catch (InterruptedException e) {
-        e.printStackTrace();
+        LOG.error(e);
       }
     }
   }


### PR DESCRIPTION
Inspection description:

> Reports calls to Throwable.printStackTrace() without arguments.
Such statements are often used for temporary debugging and should be either removed from the production code or replaced with a more robust logging facility.

Note that this PR disables the inspection in TEST scopes since `printStackTrace()` is handy there and "robust" logging in a test context is often more of a hinderance than help.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
