### PR TITLE
[fix] stop swallowing `ProcessCanceledException`

### DIFF
--- a/flutter-idea/src/io/flutter/run/FlutterDebugProcess.java
+++ b/flutter-idea/src/io/flutter/run/FlutterDebugProcess.java
@@ -138,12 +138,16 @@ public class FlutterDebugProcess extends DartVmServiceDebugProcess {
 
     final String name = XDebuggerBundle.message("debugger.session.tab.console.content.name");
     for (Content c : ui.getContents()) {
-      if (!Objects.equals(c.getTabName(), name)) {
+      if (c != null && !Objects.equals(c.getTabName(), name)) {
         try {
-          ApplicationManager.getApplication().invokeAndWait(() -> ui.removeContent(c, false /* dispose? */));
+          var application = ApplicationManager.getApplication();
+          if (application != null) {
+            application.invokeAndWait(() -> ui.removeContent(c, false /* dispose? */));
+          }
         }
         catch (ProcessCanceledException e) {
           FlutterUtils.warn(LOG, e);
+          throw e;
         }
       }
     }


### PR DESCRIPTION
`ProcessCanceledException`s need to be rethrown so that the IDEA infrastructure can handle them properly.

![image](https://github.com/user-attachments/assets/722f1b68-e540-48e1-886f-c12e5406c7a7)




---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
