### PR TITLE
[CQ] stop storing property service instance

### DIFF
--- a/flutter-idea/src/io/flutter/survey/FlutterSurveyService.java
+++ b/flutter-idea/src/io/flutter/survey/FlutterSurveyService.java
@@ -21,18 +21,20 @@ public class FlutterSurveyService {
   private static final String FLUTTER_LAST_SURVEY_CONTENT_CHECK_KEY = "FLUTTER_LAST_SURVEY_CONTENT_CHECK_KEY";
   private static final long CHECK_INTERVAL_IN_MS = TimeUnit.HOURS.toMillis(40);
   private static final String CONTENT_URL = "https://storage.googleapis.com/flutter-uxr/surveys/flutter-survey-metadata.json";
-  private static final PropertiesComponent properties = PropertiesComponent.getInstance();
   private static final Logger LOG = Logger.getInstance(FlutterSurveyService.class);
-  private static FlutterSurvey cachedSurvey;
+  private static @Nullable FlutterSurvey cachedSurvey;
 
   private static boolean timeToUpdateCachedContent() {
     // Don't check more often than daily.
     final long currentTimeMillis = System.currentTimeMillis();
-    final long lastCheckedMillis = properties.getLong(FLUTTER_LAST_SURVEY_CONTENT_CHECK_KEY, 0);
-    final boolean timeToUpdateCache = currentTimeMillis - lastCheckedMillis >= CHECK_INTERVAL_IN_MS;
-    if (timeToUpdateCache) {
-      properties.setValue(FLUTTER_LAST_SURVEY_CONTENT_CHECK_KEY, String.valueOf(currentTimeMillis));
-      return true;
+    final PropertiesComponent properties = PropertiesComponent.getInstance();
+    if (properties != null) {
+      final long lastCheckedMillis = properties.getLong(FLUTTER_LAST_SURVEY_CONTENT_CHECK_KEY, 0);
+      final boolean timeToUpdateCache = currentTimeMillis - lastCheckedMillis >= CHECK_INTERVAL_IN_MS;
+      if (timeToUpdateCache) {
+        properties.setValue(FLUTTER_LAST_SURVEY_CONTENT_CHECK_KEY, String.valueOf(currentTimeMillis));
+        return true;
+      }
     }
     return false;
   }


### PR DESCRIPTION
A bit pedantic but generally good practice and easy to fix. (There's also no real reason to store the instance.)

![image](https://github.com/user-attachments/assets/529be20b-134e-4c41-8093-7928c676bab7)

Inspection motivation:

> Such services' assignments contribute to global state and make it impossible to tear down an application and set up another one in tests, therefore, repeated tests in the same process may fail. The only exception is an explicit constructor call to store dummy/default instances.
> The recommended way to avoid storing services is to retrieve a service locally. Alternatively, one can wrap it in java.util.function.Supplier (Java, Kotlin) or convert the property to a function (Kotlin).

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
