### PR TITLE
[fix] stale `testing.md` link

### DIFF
--- a/docs/Release-testing.md
+++ b/docs/Release-testing.md
@@ -1,2 +1,2 @@
 The following use cases should be tested on all new releases:
-https://github.com/flutter/flutter-intellij/blob/master/testing.md
+[https://github.com/flutter/flutter-intellij/blob/master/testing.md](https://github.com/flutter/flutter-intellij/blob/master/docs/testing.md)


### PR DESCRIPTION
The link didn't seem to make the wiki migration:

![image](https://github.com/user-attachments/assets/24306222-276d-4903-aba4-5638aea0023c)


---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
