### PR TITLE
[CQ] API: migrate off unstable `getInstanceOrNull`

### DIFF
--- a/flutter-idea/src/io/flutter/view/FlutterView.java
+++ b/flutter-idea/src/io/flutter/view/FlutterView.java
@@ -198,10 +198,8 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
             });
           }));
       };
-      final ProgressManager progressManager = ProgressManager.getInstanceOrNull();
-      if (progressManager != null) {
-        progressManager.runProcess(task, new EmptyProgressIndicator());
-      }
+      final ProgressManager progressManager = ProgressManager.getInstance();
+      progressManager.runProcess(task, new EmptyProgressIndicator());
 
       toolWindow.setTitleActions(List.of(new RefreshToolWindowAction(TOOL_WINDOW_ID)));
     }


### PR DESCRIPTION
This method is marked as unstable and slated for possible removal.

![image](https://github.com/user-attachments/assets/feb9c87a-0cc4-44b1-8b40-509b21c48143)

That said, this replacement doesn't totally preserve the current semantics.

@helin24: is there any reason we don't want to prompt a call to the application manager here?

Specifically, we'll now cause this to happen (if `ourInstance` is `null`):

```java
(ProgressManager)ApplicationManager.getApplication().getService(ProgressManager.class);
```

See: #https://github.com/flutter/flutter-intellij/issues/7718


---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
