### PR TITLE
[CQ] API: migrate from unstable `CharsetToolkit`

### DIFF
--- a/flutter-studio/src/io/flutter/utils/GradleUtils.java
+++ b/flutter-studio/src/io/flutter/utils/GradleUtils.java
@@ -26,7 +26,6 @@ import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.util.io.FileUtilRt;
-import com.intellij.openapi.vfs.CharsetToolkit;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiElement;
 import com.intellij.util.ReflectionUtil;
@@ -458,7 +457,7 @@ public class GradleUtils {
         requireNonNull(pathToModule);
         requireNonNull(settingsFile);
         BufferedInputStream str = new BufferedInputStream(settingsFile.getInputStream());
-        return FileUtil.loadTextAndClose(new InputStreamReader(str, CharsetToolkit.UTF8_CHARSET));
+        return FileUtil.loadTextAndClose(new InputStreamReader(str, StandardCharsets.UTF_8));
       }
       catch (NullPointerException | IOException e) {
         cleanupAfterError();


### PR DESCRIPTION
The `com.intellij.openapi.vfs. CharsetToolkit` is marked unstable.

![image](https://github.com/user-attachments/assets/e5b65300-897d-4240-a31f-1c77474f731b)

Luckily there's a standard Java substitute (as of Java 7).

See: https://github.com/flutter/flutter-intellij/issues/7718

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
