### PR TITLE
[CQ] API: migrate `FlutterSdkManager` off deprecated `afterLibraryRenamed`

### DIFF
--- a/flutter-idea/src/io/flutter/sdk/FlutterSdkManager.java
+++ b/flutter-idea/src/io/flutter/sdk/FlutterSdkManager.java
@@ -15,6 +15,7 @@ import com.intellij.openapi.roots.libraries.LibraryTablesRegistrar;
 import com.intellij.openapi.util.Disposer;
 import com.intellij.util.EventDispatcher;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.EventListener;
 import java.util.Objects;
@@ -124,7 +125,7 @@ public class FlutterSdkManager {
     }
 
     @Override
-    public void afterLibraryRenamed(@NotNull Library library) {
+    public void afterLibraryRenamed(@NotNull Library library, @Nullable String newName) {
       // Since we key off name, test to be safe.
       checkForFlutterSdkChange();
     }


### PR DESCRIPTION
Move to the stable `afterLibraryRenamed` API variant.

![image](https://github.com/user-attachments/assets/46f4971f-0955-49eb-9338-78faba823aec)

See: https://github.com/flutter/flutter-intellij/issues/7718

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
