### PR TITLE
[CQ] remove removed `InspectorGroupManagerService`

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -444,9 +444,6 @@
     <projectService serviceInterface="io.flutter.editor.ActiveEditorsOutlineService"
                     serviceImplementation="io.flutter.editor.ActiveEditorsOutlineService"
                     overrides="false"/>
-    <projectService serviceInterface="io.flutter.inspector.InspectorGroupManagerService"
-                    serviceImplementation="io.flutter.inspector.InspectorGroupManagerService"
-                    overrides="false"/>
 
     <iconProvider implementation="io.flutter.project.FlutterIconProvider" order="first"/>
 

--- a/resources/META-INF/plugin_template.xml
+++ b/resources/META-INF/plugin_template.xml
@@ -352,9 +352,6 @@
     <projectService serviceInterface="io.flutter.editor.ActiveEditorsOutlineService"
                     serviceImplementation="io.flutter.editor.ActiveEditorsOutlineService"
                     overrides="false"/>
-    <projectService serviceInterface="io.flutter.inspector.InspectorGroupManagerService"
-                    serviceImplementation="io.flutter.inspector.InspectorGroupManagerService"
-                    overrides="false"/>
 
     <iconProvider implementation="io.flutter.project.FlutterIconProvider" order="first"/>
 


### PR DESCRIPTION
The `InspectorGroupManagerService` was removed a bit ago and this straggling `projectService` registration is dead.

---

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
