### PR TITLE
[CQ] plugin.xml: specify missing group and context ids

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -22,6 +22,7 @@
 
   <category>Custom Languages</category>
   <version>SNAPSHOT</version>
+  <!--suppress PluginXmlValidity -->
   <idea-version since-build="243" until-build="243.*"/>
 
   <depends>com.intellij.modules.platform</depends>
@@ -222,7 +223,7 @@
     <group id="FlutterPackagesExplorerActionGroup" class="io.flutter.actions.FlutterPackagesExplorerActionGroup">
       <separator/>
       <!--suppress PluginXmlCapitalization -->
-      <group text="Flutter" description="Flutter Tools" icon="FlutterIcons.Flutter" popup="true">
+      <group id="FlutterToolsGroup" text="Flutter" description="Flutter Tools" icon="FlutterIcons.Flutter" popup="true">
         <separator/>
         <reference ref="flutter.pub.get"/>
         <reference ref="flutter.pub.upgrade"/>
@@ -250,7 +251,7 @@
 <!--    </group>-->
     <group id="FlutterBuildActionGroup" class="io.flutter.actions.FlutterBuildActionGroup">
       <separator/>
-      <group text="Flutter" popup="true">
+      <group id="FlutterBuildGroup" text="Flutter" popup="true">
         <action id="flutter.build.aar" text="Build AAR" description="Building a Flutter module for Android add-to-app"
                 class="io.flutter.actions.FlutterBuildActionGroup$AAR"/>
         <action id="flutter.build.apk" text="Build APK" description="Building a Flutter app for general distribution"
@@ -268,7 +269,7 @@
     </group>
 
     <!-- main toolbar run actions -->
-    <group>
+    <group id="MainToolBarRunActionsGroup">
       <action id="AttachDebuggerAction"
               class="io.flutter.actions.AttachDebuggerAction"
               text="Flutter Attach"
@@ -393,7 +394,7 @@
     <runLineMarkerContributor language="Dart" implementationClass="io.flutter.run.bazelTest.FlutterBazelTestLineMarkerContributor"/>
 
     <defaultLiveTemplatesProvider implementation="io.flutter.template.FlutterLiveTemplatesProvider"/>
-    <liveTemplateContext implementation="io.flutter.template.DartToplevelTemplateContextType"/>
+    <liveTemplateContext contextId="DART_TOPLEVEL" implementation="io.flutter.template.DartToplevelTemplateContextType"/>
 
     <!-- IDEA only -->
     <moduleBuilder builderClass="io.flutter.module.FlutterModuleBuilder"/>

--- a/resources/META-INF/plugin_template.xml
+++ b/resources/META-INF/plugin_template.xml
@@ -20,6 +20,7 @@
 
   <category>Custom Languages</category>
   @VERSION@
+  <!--suppress PluginXmlValidity -->
   <idea-version since-build="@SINCE@" until-build="@UNTIL@"/>
 
   <depends>com.intellij.modules.platform</depends>
@@ -130,7 +131,7 @@
     <group id="FlutterPackagesExplorerActionGroup" class="io.flutter.actions.FlutterPackagesExplorerActionGroup">
       <separator/>
       <!--suppress PluginXmlCapitalization -->
-      <group text="Flutter" description="Flutter Tools" icon="FlutterIcons.Flutter" popup="true">
+      <group id="FlutterToolsGroup" text="Flutter" description="Flutter Tools" icon="FlutterIcons.Flutter" popup="true">
         <separator/>
         <reference ref="flutter.pub.get"/>
         <reference ref="flutter.pub.upgrade"/>
@@ -158,7 +159,7 @@
 <!--    </group>-->
     <group id="FlutterBuildActionGroup" class="io.flutter.actions.FlutterBuildActionGroup">
       <separator/>
-      <group text="Flutter" popup="true">
+      <group id="FlutterBuildGroup" text="Flutter" popup="true">
         <action id="flutter.build.aar" text="Build AAR" description="Building a Flutter module for Android add-to-app"
                 class="io.flutter.actions.FlutterBuildActionGroup$AAR"/>
         <action id="flutter.build.apk" text="Build APK" description="Building a Flutter app for general distribution"
@@ -176,7 +177,7 @@
     </group>
 
     <!-- main toolbar run actions -->
-    <group>
+    <group id="MainToolBarRunActionsGroup">
       <action id="AttachDebuggerAction"
               class="io.flutter.actions.AttachDebuggerAction"
               text="Flutter Attach"
@@ -301,7 +302,7 @@
     <runLineMarkerContributor language="Dart" implementationClass="io.flutter.run.bazelTest.FlutterBazelTestLineMarkerContributor"/>
 
     <defaultLiveTemplatesProvider implementation="io.flutter.template.FlutterLiveTemplatesProvider"/>
-    <liveTemplateContext implementation="io.flutter.template.DartToplevelTemplateContextType"/>
+    <liveTemplateContext contextId="DART_TOPLEVEL" implementation="io.flutter.template.DartToplevelTemplateContextType"/>
 
     <!-- IDEA only -->
     <moduleBuilder builderClass="io.flutter.module.FlutterModuleBuilder"/>


### PR DESCRIPTION
Further embracing the yak shave, tidies up some more plugin.xml inspections.

✅ Adds missing (required) group `id` attributes

![image](https://github.com/user-attachments/assets/ae8492e3-0cf7-480e-b63a-fc62dc69a45d)

✅ Defines a `contextId` for our contributed ``liveTemplateContext`

![image](https://github.com/user-attachments/assets/739c7b2a-681b-43d3-b0f8-48f96822edaa)

✅ Suppresses `PluginXmlValidity` for build variables

With this, we are left with 17 remaining problems.

<img width="996" alt="image" src="https://github.com/user-attachments/assets/c8e97b70-8fed-4202-a420-94da382d787e" />



---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>

