### PR TITLE
[CQ] migrate off deprecated `Messages.OK_BUTTON`

### DIFF
--- a/flutter-idea/src/io/flutter/run/LaunchState.java
+++ b/flutter-idea/src/io/flutter/run/LaunchState.java
@@ -208,7 +208,7 @@ public class LaunchState extends CommandLineState {
       project,
       "No connected devices found; please connect a device, or see flutter.dev/setup for getting started instructions.",
       "No Connected Devices Found",
-      new String[]{Messages.OK_BUTTON}, 0, AllIcons.General.InformationDialog);
+      new String[]{Messages.getOkButton()}, 0, AllIcons.General.InformationDialog);
   }
 
   @NotNull


### PR DESCRIPTION
Move off deprecated `Messages` constant.

See: https://github.com/JetBrains/intellij-community/blob/master/platform/platform-api/src/com/intellij/openapi/ui/Messages.java

`Messages.getOkButton()` is the future.


---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
