### PR TITLE
[CQ] migrate off deprecated `ModalityState.NON_MODAL`

### DIFF
--- a/flutter-idea/src/io/flutter/actions/AttachDebuggerAction.java
+++ b/flutter-idea/src/io/flutter/actions/AttachDebuggerAction.java
@@ -200,7 +200,7 @@ public class AttachDebuggerAction extends FlutterSdkAction {
   }
 
   private static void showSelectConfigDialog() {
-    ApplicationManager.getApplication().invokeLater(() -> new SelectConfigDialog().show(), ModalityState.NON_MODAL);
+    ApplicationManager.getApplication().invokeLater(() -> new SelectConfigDialog().show(), ModalityState.nonModal());
   }
 
   private static class SelectConfigDialog extends DialogWrapper {

--- a/flutter-idea/src/io/flutter/run/daemon/DeviceDaemon.java
+++ b/flutter-idea/src/io/flutter/run/daemon/DeviceDaemon.java
@@ -246,7 +246,7 @@ class DeviceDaemon {
                 FlutterMessages.showError("Flutter device daemon", failureMessage, null);
               }
               else if (attempts == DeviceDaemon.RESTART_ATTEMPTS_BEFORE_WARNING + 4) {
-                ApplicationManager.getApplication().invokeLater(() -> new DaemonCrashReporter().show(), ModalityState.NON_MODAL);
+                ApplicationManager.getApplication().invokeLater(() -> new DaemonCrashReporter().show(), ModalityState.nonModal());
                 return null;
               }
             }

--- a/flutter-studio/src/io/flutter/android/AndroidModuleLibraryManager.java
+++ b/flutter-studio/src/io/flutter/android/AndroidModuleLibraryManager.java
@@ -99,7 +99,7 @@ public class AndroidModuleLibraryManager extends AbstractLibraryManager<AndroidM
   private Void scheduleAddAndroidLibraryDeps(@NotNull Project androidProject) {
     ApplicationManager.getApplication().invokeLater(
       () -> addAndroidLibraryDependencies(androidProject),
-      ModalityState.NON_MODAL);
+      ModalityState.nonModal());
     return null;
   }
 


### PR DESCRIPTION
The preferred access to this constant is now `ModalityState.nonModal()`.

![image](https://github.com/user-attachments/assets/959c641d-bbbf-4b20-a194-b99e6ca0e069)

---

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
