### PR TITLE
[CQ] migrate off deprecated `GlobalSearchScopes` scope

### DIFF
--- a/flutter-idea/src/io/flutter/run/daemon/DaemonConsoleView.java
+++ b/flutter-idea/src/io/flutter/run/daemon/DaemonConsoleView.java
@@ -15,8 +15,8 @@ import com.intellij.execution.ui.ConsoleViewContentType;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.search.ExecutionSearchScopes;
 import com.intellij.psi.search.GlobalSearchScope;
-import com.intellij.psi.search.GlobalSearchScopes;
 import com.jetbrains.lang.dart.ide.runner.DartRelativePathsConsoleFilter;
 import io.flutter.settings.FlutterSettings;
 import io.flutter.utils.FlutterModuleUtils;
@@ -36,7 +36,7 @@ public class DaemonConsoleView extends ConsoleViewImpl {
     // Create our own console builder.
     //
     // We need to filter input to this console without affecting other consoles, so we cannot use a consoleFilterInputProvider.
-    final GlobalSearchScope searchScope = GlobalSearchScopes.executionScope(env.getProject(), env.getRunProfile());
+    final GlobalSearchScope searchScope = ExecutionSearchScopes.executionScope(env.getProject(), env.getRunProfile());
     final TextConsoleBuilder builder = new TextConsoleBuilderImpl(env.getProject(), searchScope) {
       @NotNull
       @Override


### PR DESCRIPTION
Move deprecated `GlobalSearchScopes` to preferred `ExecutionSearchScopes`. Source confirms this is behavior-preserving:

![image](https://github.com/user-attachments/assets/f85df58b-767a-46c0-b73a-86545f79bc6b)


---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
