### PR TITLE
[CQ] migrate off deprecated `AppTopics`

### DIFF
--- a/flutter-idea/src/io/flutter/editor/FlutterSaveActionsManager.java
+++ b/flutter-idea/src/io/flutter/editor/FlutterSaveActionsManager.java
@@ -5,7 +5,6 @@
  */
 package io.flutter.editor;
 
-import com.intellij.AppTopics;
 import com.intellij.application.options.CodeStyle;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.command.WriteCommandAction;
@@ -63,7 +62,7 @@ public class FlutterSaveActionsManager {
 
     final MessageBus bus = project.getMessageBus();
     final MessageBusConnection connection = bus.connect();
-    connection.subscribe(AppTopics.FILE_DOCUMENT_SYNC, new FileDocumentManagerListener() {
+    connection.subscribe(FileDocumentManagerListener.TOPIC, new FileDocumentManagerListener() {
       @Override
       public void beforeDocumentSaving(@NotNull Document document) {
         // Don't try and format read only docs.

--- a/flutter-idea/src/io/flutter/run/FlutterReloadManager.java
+++ b/flutter-idea/src/io/flutter/run/FlutterReloadManager.java
@@ -6,7 +6,6 @@
 package io.flutter.run;
 
 import com.google.common.collect.ImmutableMap;
-import com.intellij.AppTopics;
 import com.intellij.codeInsight.hint.HintManager;
 import com.intellij.codeInsight.hint.HintManagerImpl;
 import com.intellij.codeInsight.hint.HintUtil;
@@ -171,7 +170,7 @@ public class FlutterReloadManager {
         }
       }
     });
-    connection.subscribe(AppTopics.FILE_DOCUMENT_SYNC, new FileDocumentManagerListener() {
+    connection.subscribe(FileDocumentManagerListener.TOPIC, new FileDocumentManagerListener() {
       @Override
       public void beforeAllDocumentsSaving() {
         if (!FlutterSettings.getInstance().isReloadOnSave()) return;


### PR DESCRIPTION
`FileDocumentManagerListener.TOPIC` is preferred and the deprecated reference is just a redirect so this is sure to be behavior-preserving:


![image](https://github.com/user-attachments/assets/ee69151a-e210-4890-b1de-ff1279f50272)


---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
