### PR TITLE
Fix missing `FlutterBundle` property parameters

### DIFF
--- a/flutter-idea/src/io/flutter/module/FlutterModuleBuilder.java
+++ b/flutter-idea/src/io/flutter/module/FlutterModuleBuilder.java
@@ -163,14 +163,14 @@ public class FlutterModuleBuilder extends ModuleBuilder {
   private String validateSettings(FlutterCreateAdditionalSettings settings) {
     final String description = settings.getDescription();
     if (description != null && description.contains(": ")) {
-      return FlutterBundle.message("npw_invalid_desc_error");
+      return FlutterBundle.message("npw_invalid_desc_error", description);
     }
     final String org = settings.getOrg();
     if (org == null) {
       return null;
     }
     if (StringUtil.endsWith(org, ".")) {
-      return FlutterBundle.message("npw_invalid_org_error");
+      return FlutterBundle.message("npw_invalid_org_error", org);
     }
     if (mySettingsFields.shouldIncludePlatforms() && !settings.isSomePlatformSelected()) {
       return FlutterBundle.message("npw_none_selected_error");


### PR DESCRIPTION
These validation messages were not getting passed their required parameters.

<img width="820" alt="image" src="https://github.com/user-attachments/assets/c336a213-3822-402a-8ccb-f5a5a86690c3" />

And so weren't being properly created.

![image](https://github.com/user-attachments/assets/000075f6-726d-4dc9-bffe-db8711d8f198)

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
