### PR TITLE
[CQ] remove redundant method declarations

### DIFF
--- a/flutter-idea/src/io/flutter/sdk/FlutterSettingsConfigurable.java
+++ b/flutter-idea/src/io/flutter/sdk/FlutterSettingsConfigurable.java
@@ -176,12 +176,6 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
 
   @Nullable
   @Override
-  public Runnable enableSearch(String s) {
-    return null;
-  }
-
-  @Nullable
-  @Override
   public JComponent createComponent() {
     return mainPanel;
   }
@@ -446,11 +440,6 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     else {
       myVersionLabel.setText(value);
     }
-  }
-
-  @Override
-  public void disposeUIResources() {
-
   }
 
   @Override

--- a/flutter-idea/src/io/flutter/utils/FileWatch.java
+++ b/flutter-idea/src/io/flutter/utils/FileWatch.java
@@ -253,10 +253,6 @@ public class FileWatch {
     }
 
     @Override
-    public void before(@NotNull List<? extends VFileEvent> events) {
-    }
-
-    @Override
     public void after(@NotNull List<? extends VFileEvent> events) {
       final Set<FileWatch> todo = new LinkedHashSet<>();
       synchronized (subscriptions) {


### PR DESCRIPTION
Removes method declarations that are identical to an overridden super.


![image](https://github.com/user-attachments/assets/cf4d95c9-c257-4acb-8387-7daeaa680cc2)


---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
