### PR TITLE
[CQ] introduce null-safe `OpenApi` wrappers

### DIFF
--- a/flutter-idea/src/io/flutter/FlutterInitializer.java
+++ b/flutter-idea/src/io/flutter/FlutterInitializer.java
@@ -9,17 +9,19 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 import com.intellij.ide.plugins.PluginManagerCore;
 import com.intellij.ide.ui.UISettingsListener;
-import com.intellij.notification.*;
+import com.intellij.notification.Notification;
+import com.intellij.notification.NotificationType;
+import com.intellij.notification.Notifications;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.colors.EditorColorsListener;
 import com.intellij.openapi.editor.colors.EditorColorsManager;
 import com.intellij.openapi.extensions.PluginId;
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.module.Module;
-import com.intellij.openapi.module.ModuleManager;
 import com.intellij.openapi.project.ModuleListener;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ProjectRootManager;
@@ -49,6 +51,7 @@ import io.flutter.sdk.FlutterSdkVersion;
 import io.flutter.settings.FlutterSettings;
 import io.flutter.survey.FlutterSurveyNotifications;
 import io.flutter.utils.FlutterModuleUtils;
+import io.flutter.utils.OpenApiUtils;
 import io.flutter.view.FlutterViewFactory;
 import org.jetbrains.annotations.NotNull;
 
@@ -88,7 +91,7 @@ public class FlutterInitializer implements StartupActivity {
     // If the project declares a Flutter dependency, do some extra initialization.
     boolean hasFlutterModule = false;
 
-    for (Module module : ModuleManager.getInstance(project).getModules()) {
+    for (Module module : OpenApiUtils.getModules(project)) {
       final boolean declaresFlutter = FlutterModuleUtils.declaresFlutter(module);
 
       hasFlutterModule = hasFlutterModule || declaresFlutter;
@@ -285,7 +288,7 @@ public class FlutterInitializer implements StartupActivity {
       final FlutterSettings settings = FlutterSettings.getInstance();
       if (settings == null || settings.isSdkVersionOutdatedWarningAcknowledged(version.getVersionText())) return;
 
-      ApplicationManager.getApplication().invokeLater(() -> {
+      OpenApiUtils.safeInvokeLater(() -> {
         final Notification notification = new Notification(FlutterMessages.FLUTTER_NOTIFICATION_GROUP_ID,
                                                            "Flutter SDK requires update",
                                                            "Support for v" +
@@ -313,7 +316,7 @@ public class FlutterInitializer implements StartupActivity {
           }
         });
         Notifications.Bus.notify(notification, project);
-      });
+      }, ModalityState.defaultModalityState(), project.getDisposed());
     }
   }
 
@@ -338,6 +341,6 @@ public class FlutterInitializer implements StartupActivity {
       return; // ANDROID_HOME not set or Android SDK not created in IDEA; not clear what to do.
     }
 
-    ApplicationManager.getApplication().runWriteAction(() -> wanted.setCurrent(project));
+    OpenApiUtils.safeRunWriteAction(() -> wanted.setCurrent(project));
   }
 }

--- a/flutter-idea/src/io/flutter/FlutterInitializer.java
+++ b/flutter-idea/src/io/flutter/FlutterInitializer.java
@@ -15,7 +15,6 @@ import com.intellij.notification.Notifications;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.colors.EditorColorsListener;
 import com.intellij.openapi.editor.colors.EditorColorsManager;
@@ -316,7 +315,7 @@ public class FlutterInitializer implements StartupActivity {
           }
         });
         Notifications.Bus.notify(notification, project);
-      }, ModalityState.defaultModalityState(), project.getDisposed());
+      });
     }
   }
 

--- a/flutter-idea/src/io/flutter/FlutterUtils.java
+++ b/flutter-idea/src/io/flutter/FlutterUtils.java
@@ -12,7 +12,6 @@ import com.intellij.ide.util.PropertiesComponent;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.extensions.PluginId;
 import com.intellij.openapi.module.Module;
-import com.intellij.openapi.module.ModuleManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
 import com.intellij.openapi.roots.*;
@@ -34,6 +33,7 @@ import io.flutter.pub.PubRootCache;
 import io.flutter.settings.FlutterSettings;
 import io.flutter.utils.AndroidUtils;
 import io.flutter.utils.FlutterModuleUtils;
+import io.flutter.utils.OpenApiUtils;
 import io.flutter.view.EmbeddedBrowser;
 import io.flutter.view.EmbeddedJcefBrowser;
 import org.jetbrains.annotations.NotNull;
@@ -479,8 +479,7 @@ public class FlutterUtils {
 
   @Nullable
   public static Module findModuleNamed(@NotNull Project project, @NotNull String name) {
-    final Module[] modules = ModuleManager.getInstance(project).getModules();
-    assert modules != null;
+    final Module[] modules = OpenApiUtils.getModules(project);
     for (Module module : modules) {
       assert module != null;
       if (module.getName().equals(name)) {

--- a/flutter-idea/src/io/flutter/actions/AttachDebuggerAction.java
+++ b/flutter-idea/src/io/flutter/actions/AttachDebuggerAction.java
@@ -10,8 +10,9 @@ import com.intellij.execution.configurations.RunConfiguration;
 import com.intellij.execution.process.ProcessHandler;
 import com.intellij.execution.runners.ExecutionEnvironment;
 import com.intellij.execution.runners.ExecutionEnvironmentBuilder;
-import com.intellij.openapi.actionSystem.*;
-import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.DialogWrapper;
@@ -30,6 +31,7 @@ import io.flutter.run.bazel.BazelAttachConfig;
 import io.flutter.run.bazel.BazelRunConfig;
 import io.flutter.sdk.FlutterSdk;
 import io.flutter.sdk.FlutterSdkUtil;
+import io.flutter.utils.OpenApiUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -200,7 +202,7 @@ public class AttachDebuggerAction extends FlutterSdkAction {
   }
 
   private static void showSelectConfigDialog() {
-    ApplicationManager.getApplication().invokeLater(() -> new SelectConfigDialog().show(), ModalityState.nonModal());
+    OpenApiUtils.safeInvokeLater(() -> new SelectConfigDialog().show(), ModalityState.nonModal());
   }
 
   private static class SelectConfigDialog extends DialogWrapper {

--- a/flutter-idea/src/io/flutter/actions/DeviceSelectorRefresherAction.java
+++ b/flutter-idea/src/io/flutter/actions/DeviceSelectorRefresherAction.java
@@ -31,8 +31,9 @@ public class DeviceSelectorRefresherAction extends AnAction {
 
   @Override
   public void update(@NotNull AnActionEvent e) {
-    if (e.getProject() != null) {
-      e.getPresentation().setVisible(FlutterModuleUtils.hasInternalDartSdkPath(e.getProject()));
+    var project = e.getProject();
+    if (project != null) {
+      e.getPresentation().setVisible(FlutterModuleUtils.hasInternalDartSdkPath(project));
     }
   }
 }

--- a/flutter-idea/src/io/flutter/actions/FlutterBuildActionGroup.java
+++ b/flutter-idea/src/io/flutter/actions/FlutterBuildActionGroup.java
@@ -12,7 +12,6 @@ import com.intellij.openapi.actionSystem.*;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleUtilCore;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.roots.ModuleRootManager;
 import com.intellij.openapi.util.SystemInfo;
 import com.intellij.openapi.vfs.VirtualFile;
 import io.flutter.FlutterMessages;
@@ -20,6 +19,7 @@ import io.flutter.pub.PubRoot;
 import io.flutter.pub.PubRoots;
 import io.flutter.sdk.FlutterSdk;
 import io.flutter.utils.FlutterModuleUtils;
+import io.flutter.utils.OpenApiUtils;
 import io.flutter.utils.ProgressHelper;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -105,7 +105,7 @@ public class FlutterBuildActionGroup extends DefaultActionGroup {
       return module;
     }
     // We may get here if the file is in the Android module of a Flutter module project.
-    final VirtualFile parent = ModuleRootManager.getInstance(module).getContentRoots()[0].getParent();
+    final VirtualFile parent = OpenApiUtils.getContentRoots(module)[0].getParent();
     module = ModuleUtilCore.findModuleForFile(parent, project);
     if (module == null) {
       return null;

--- a/flutter-idea/src/io/flutter/analytics/UnifiedAnalytics.java
+++ b/flutter-idea/src/io/flutter/analytics/UnifiedAnalytics.java
@@ -12,13 +12,14 @@ import com.intellij.notification.NotificationType;
 import com.intellij.notification.Notifications;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.jetbrains.lang.dart.ide.toolingDaemon.DartToolingDaemonService;
 import de.roderick.weberknecht.WebSocketException;
 import io.flutter.dart.DtdUtils;
 import io.flutter.sdk.FlutterSdkUtil;
+import io.flutter.utils.OpenApiUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -118,7 +119,9 @@ public class UnifiedAnalytics {
     });
   }
 
-  private @Nullable CompletableFuture<Boolean> setTelemetry(@NotNull DartToolingDaemonService service, @NotNull JsonObject params, Boolean canSendAnalytics) {
+  private @Nullable CompletableFuture<Boolean> setTelemetry(@NotNull DartToolingDaemonService service,
+                                                            @NotNull JsonObject params,
+                                                            Boolean canSendAnalytics) {
     params.addProperty("enable", canSendAnalytics);
     return makeUnifiedAnalyticsRequest("setTelemetry", service, params).thenCompose(result -> {
       assert result != null;
@@ -135,7 +138,7 @@ public class UnifiedAnalytics {
 
   private CompletableFuture<Boolean> showMessage(@NotNull String message) {
     CompletableFuture<Boolean> finalResult = new CompletableFuture<>();
-    ApplicationManager.getApplication().invokeLater(() -> {
+    OpenApiUtils.safeInvokeLater(() -> {
       final Notification notification = new Notification(
         "Flutter Usage Statistics", // Analytics.GROUP_DISPLAY_ID,
         "Welcome to Flutter!",
@@ -159,7 +162,7 @@ public class UnifiedAnalytics {
       });
       Notifications.Bus.notify(notification, project);
       System.out.println("Ran notification");
-    });
+    }, ModalityState.defaultModalityState(), project.getDisposed());
     return finalResult;
   }
 

--- a/flutter-idea/src/io/flutter/analytics/UnifiedAnalytics.java
+++ b/flutter-idea/src/io/flutter/analytics/UnifiedAnalytics.java
@@ -12,7 +12,6 @@ import com.intellij.notification.NotificationType;
 import com.intellij.notification.Notifications;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.jetbrains.lang.dart.ide.toolingDaemon.DartToolingDaemonService;
@@ -162,7 +161,7 @@ public class UnifiedAnalytics {
       });
       Notifications.Bus.notify(notification, project);
       System.out.println("Ran notification");
-    }, ModalityState.defaultModalityState(), project.getDisposed());
+    });
     return finalResult;
   }
 

--- a/flutter-idea/src/io/flutter/android/AndroidEmulator.java
+++ b/flutter-idea/src/io/flutter/android/AndroidEmulator.java
@@ -21,6 +21,7 @@ import com.intellij.openapi.wm.ToolWindowManager;
 import com.intellij.util.ReflectionUtil;
 import io.flutter.FlutterMessages;
 import io.flutter.utils.MostlySilentColoredProcessHandler;
+import io.flutter.utils.OpenApiUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.lang.reflect.InvocationTargetException;
@@ -119,7 +120,7 @@ public class AndroidEmulator {
     }
 
     assert ApplicationManager.getApplication() != null;
-    ApplicationManager.getApplication().invokeLater(() -> {
+    OpenApiUtils.safeInvokeLater(() -> {
       tw.setAutoHide(false);
       tw.show();
     }, ModalityState.stateForComponent(tw.getComponent()));

--- a/flutter-idea/src/io/flutter/bazel/Workspace.java
+++ b/flutter-idea/src/io/flutter/bazel/Workspace.java
@@ -12,7 +12,6 @@ import com.google.common.collect.ImmutableSet;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.roots.ModuleRootManager;
 import com.intellij.openapi.roots.ProjectRootManager;
 import com.intellij.openapi.util.Computable;
 import com.intellij.openapi.vfs.InvalidVirtualFileAccessException;
@@ -90,7 +89,7 @@ public class Workspace {
   @NotNull
   public ImmutableSet<String> getContentPaths(@NotNull final Module module) {
     // Find all the content roots within this workspace.
-    final VirtualFile[] contentRoots = ModuleRootManager.getInstance(module).getContentRoots();
+    final VirtualFile[] contentRoots = OpenApiUtils.getContentRoots(module);
     final ImmutableSet.Builder<String> result = ImmutableSet.builder();
     for (VirtualFile root : contentRoots) {
       final String path = getRelativePath(root);

--- a/flutter-idea/src/io/flutter/console/FlutterConsoleFilter.java
+++ b/flutter-idea/src/io/flutter/console/FlutterConsoleFilter.java
@@ -18,7 +18,6 @@ import com.intellij.openapi.editor.markup.EffectType;
 import com.intellij.openapi.editor.markup.TextAttributes;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.roots.ModuleRootManager;
 import com.intellij.openapi.ui.Messages;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -26,6 +25,7 @@ import com.intellij.util.ui.UIUtil;
 import io.flutter.FlutterMessages;
 import io.flutter.FlutterUtils;
 import io.flutter.sdk.FlutterSdk;
+import io.flutter.utils.OpenApiUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -91,7 +91,7 @@ public class FlutterConsoleFilter implements Filter {
       return null;
     }
 
-    final VirtualFile[] roots = ModuleRootManager.getInstance(module).getContentRoots();
+    final VirtualFile[] roots = OpenApiUtils.getContentRoots(module);
     for (VirtualFile root : roots) {
       if (!pathPart.isEmpty()) {
         final String baseDirPath = root.getPath();
@@ -237,7 +237,7 @@ public class FlutterConsoleFilter implements Filter {
   }
 
   private String findRelativePath(String threeSlashFileName) {
-    final VirtualFile[] roots = ModuleRootManager.getInstance(module).getContentRoots();
+    final VirtualFile[] roots = OpenApiUtils.getContentRoots(module);
     for (VirtualFile root : roots) {
       final String path = root.getPath();
       int index = threeSlashFileName.indexOf(path);

--- a/flutter-idea/src/io/flutter/console/FlutterConsoles.java
+++ b/flutter-idea/src/io/flutter/console/FlutterConsoles.java
@@ -7,12 +7,13 @@ package io.flutter.console;
 
 import com.intellij.execution.process.ColoredProcessHandler;
 import com.intellij.execution.ui.ConsoleViewContentType;
-import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Key;
 import com.intellij.ui.content.Content;
 import com.intellij.ui.content.MessageView;
+import io.flutter.utils.OpenApiUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -37,7 +38,7 @@ public class FlutterConsoles {
                                          @NotNull Runnable onReady) {
 
     // Getting a MessageView has to happen on the UI thread.
-    ApplicationManager.getApplication().invokeLater(() -> {
+    OpenApiUtils.safeInvokeLater(() -> {
       final MessageView messageView = MessageView.getInstance(project);
       messageView.runWhenInitialized(() -> {
         final FlutterConsole console = findOrCreate(project, module);
@@ -45,7 +46,7 @@ public class FlutterConsoles {
         console.bringToFront();
         onReady.run();
       });
-    });
+    }, ModalityState.defaultModalityState(), project.getDisposed());
   }
 
   public static void displayMessage(@NotNull Project project, @Nullable Module module, @NotNull String message) {
@@ -54,7 +55,7 @@ public class FlutterConsoles {
 
   public static void displayMessage(@NotNull Project project, @Nullable Module module, @NotNull String message, boolean clearContent) {
     // Getting a MessageView has to happen on the UI thread.
-    ApplicationManager.getApplication().invokeLater(() -> {
+    OpenApiUtils.safeInvokeLater(() -> {
       final MessageView messageView = MessageView.getInstance(project);
       messageView.runWhenInitialized(() -> {
         final FlutterConsole console = findOrCreate(project, module);
@@ -64,7 +65,7 @@ public class FlutterConsoles {
         console.view.print(message, ConsoleViewContentType.NORMAL_OUTPUT);
         console.bringToFront();
       });
-    });
+    }, ModalityState.defaultModalityState(), project.getDisposed());
   }
 
   @NotNull

--- a/flutter-idea/src/io/flutter/console/FlutterConsoles.java
+++ b/flutter-idea/src/io/flutter/console/FlutterConsoles.java
@@ -7,7 +7,6 @@ package io.flutter.console;
 
 import com.intellij.execution.process.ColoredProcessHandler;
 import com.intellij.execution.ui.ConsoleViewContentType;
-import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Key;
@@ -46,7 +45,7 @@ public class FlutterConsoles {
         console.bringToFront();
         onReady.run();
       });
-    }, ModalityState.defaultModalityState(), project.getDisposed());
+    });
   }
 
   public static void displayMessage(@NotNull Project project, @Nullable Module module, @NotNull String message) {
@@ -65,7 +64,7 @@ public class FlutterConsoles {
         console.view.print(message, ConsoleViewContentType.NORMAL_OUTPUT);
         console.bringToFront();
       });
-    }, ModalityState.defaultModalityState(), project.getDisposed());
+    });
   }
 
   @NotNull

--- a/flutter-idea/src/io/flutter/deeplinks/DeepLinksViewFactory.java
+++ b/flutter-idea/src/io/flutter/deeplinks/DeepLinksViewFactory.java
@@ -5,7 +5,7 @@
  */
 package io.flutter.deeplinks;
 
-import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowFactory;
@@ -18,6 +18,7 @@ import io.flutter.run.daemon.DevToolsService;
 import io.flutter.sdk.FlutterSdk;
 import io.flutter.sdk.FlutterSdkVersion;
 import io.flutter.utils.AsyncUtils;
+import io.flutter.utils.OpenApiUtils;
 import kotlin.coroutines.Continuation;
 import org.jetbrains.annotations.NotNull;
 
@@ -65,11 +66,11 @@ public class DeepLinksViewFactory implements ToolWindowFactory {
           .setIdeFeature(DevToolsIdeFeature.TOOL_WINDOW)
           .build();
 
-        ApplicationManager.getApplication().invokeLater(() -> {
+        OpenApiUtils.safeInvokeLater(() -> {
           Optional.ofNullable(
               FlutterUtils.embeddedBrowser(project))
             .ifPresent(embeddedBrowser -> embeddedBrowser.openPanel(toolWindow, "Deep Links", devToolsUrl, System.out::println));
-        });
+        }, ModalityState.defaultModalityState(), project.getDisposed());
       }
     );
 

--- a/flutter-idea/src/io/flutter/deeplinks/DeepLinksViewFactory.java
+++ b/flutter-idea/src/io/flutter/deeplinks/DeepLinksViewFactory.java
@@ -5,7 +5,6 @@
  */
 package io.flutter.deeplinks;
 
-import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowFactory;
@@ -70,7 +69,7 @@ public class DeepLinksViewFactory implements ToolWindowFactory {
           Optional.ofNullable(
               FlutterUtils.embeddedBrowser(project))
             .ifPresent(embeddedBrowser -> embeddedBrowser.openPanel(toolWindow, "Deep Links", devToolsUrl, System.out::println));
-        }, ModalityState.defaultModalityState(), project.getDisposed());
+        });
       }
     );
 

--- a/flutter-idea/src/io/flutter/devtools/DevToolsExtensionsViewFactory.java
+++ b/flutter-idea/src/io/flutter/devtools/DevToolsExtensionsViewFactory.java
@@ -5,7 +5,6 @@
  */
 package io.flutter.devtools;
 
-import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowFactory;
@@ -81,7 +80,7 @@ public class DevToolsExtensionsViewFactory implements ToolWindowFactory {
               embeddedBrowser.openPanel(window, "Flutter DevTools", devToolsUrl, System.out::println);
               service.setEmbeddedBrowser(embeddedBrowser);
             });
-        }, ModalityState.defaultModalityState(), project.getDisposed());
+        });
       }
     );
 

--- a/flutter-idea/src/io/flutter/devtools/DevToolsExtensionsViewFactory.java
+++ b/flutter-idea/src/io/flutter/devtools/DevToolsExtensionsViewFactory.java
@@ -5,7 +5,7 @@
  */
 package io.flutter.devtools;
 
-import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowFactory;
@@ -17,6 +17,7 @@ import io.flutter.run.daemon.DevToolsService;
 import io.flutter.sdk.FlutterSdk;
 import io.flutter.sdk.FlutterSdkVersion;
 import io.flutter.utils.AsyncUtils;
+import io.flutter.utils.OpenApiUtils;
 import io.flutter.view.FlutterViewMessages;
 import kotlin.coroutines.Continuation;
 import org.jetbrains.annotations.NotNull;
@@ -73,14 +74,14 @@ public class DevToolsExtensionsViewFactory implements ToolWindowFactory {
           .setIdeFeature(DevToolsIdeFeature.TOOL_WINDOW)
           .build();
 
-        ApplicationManager.getApplication().invokeLater(() -> {
+        OpenApiUtils.safeInvokeLater(() -> {
           Optional.ofNullable(
               FlutterUtils.embeddedBrowser(project))
             .ifPresent(embeddedBrowser -> {
               embeddedBrowser.openPanel(window, "Flutter DevTools", devToolsUrl, System.out::println);
               service.setEmbeddedBrowser(embeddedBrowser);
             });
-        });
+        }, ModalityState.defaultModalityState(), project.getDisposed());
       }
     );
 

--- a/flutter-idea/src/io/flutter/devtools/RemainingDevToolsViewFactory.java
+++ b/flutter-idea/src/io/flutter/devtools/RemainingDevToolsViewFactory.java
@@ -5,7 +5,7 @@
  */
 package io.flutter.devtools;
 
-import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowFactory;
@@ -17,6 +17,7 @@ import io.flutter.run.daemon.DevToolsService;
 import io.flutter.sdk.FlutterSdk;
 import io.flutter.sdk.FlutterSdkVersion;
 import io.flutter.utils.AsyncUtils;
+import io.flutter.utils.OpenApiUtils;
 import io.flutter.view.FlutterViewMessages;
 import kotlin.coroutines.Continuation;
 import org.jetbrains.annotations.NotNull;
@@ -27,6 +28,7 @@ import java.util.Optional;
 
 public class RemainingDevToolsViewFactory implements ToolWindowFactory {
   @NotNull private static String TOOL_WINDOW_ID = "Flutter DevTools";
+
   public static void init(Project project) {
     project.getMessageBus().connect().subscribe(
       FlutterViewMessages.FLUTTER_DEBUG_TOPIC, (FlutterViewMessages.FlutterDebugNotifier)event -> initView(project, event)
@@ -73,14 +75,14 @@ public class RemainingDevToolsViewFactory implements ToolWindowFactory {
           .setIdeFeature(DevToolsIdeFeature.TOOL_WINDOW)
           .build();
 
-        ApplicationManager.getApplication().invokeLater(() -> {
+        OpenApiUtils.safeInvokeLater(() -> {
           Optional.ofNullable(
               FlutterUtils.embeddedBrowser(project))
             .ifPresent(embeddedBrowser -> {
               embeddedBrowser.openPanel(window, "Flutter DevTools", devToolsUrl, System.out::println);
               service.setEmbeddedBrowser(embeddedBrowser);
             });
-        });
+        }, ModalityState.defaultModalityState(), project.getDisposed());
       }
     );
 

--- a/flutter-idea/src/io/flutter/devtools/RemainingDevToolsViewFactory.java
+++ b/flutter-idea/src/io/flutter/devtools/RemainingDevToolsViewFactory.java
@@ -5,7 +5,6 @@
  */
 package io.flutter.devtools;
 
-import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowFactory;
@@ -82,7 +81,7 @@ public class RemainingDevToolsViewFactory implements ToolWindowFactory {
               embeddedBrowser.openPanel(window, "Flutter DevTools", devToolsUrl, System.out::println);
               service.setEmbeddedBrowser(embeddedBrowser);
             });
-        }, ModalityState.defaultModalityState(), project.getDisposed());
+        });
       }
     );
 

--- a/flutter-idea/src/io/flutter/editor/FlutterSaveActionsManager.java
+++ b/flutter-idea/src/io/flutter/editor/FlutterSaveActionsManager.java
@@ -6,7 +6,7 @@
 package io.flutter.editor;
 
 import com.intellij.application.options.CodeStyle;
-import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.command.WriteCommandAction;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Document;
@@ -28,6 +28,7 @@ import com.jetbrains.lang.dart.assists.AssistUtils;
 import io.flutter.FlutterUtils;
 import io.flutter.dart.DartPlugin;
 import io.flutter.settings.FlutterSettings;
+import io.flutter.utils.OpenApiUtils;
 import org.dartlang.analysis.server.protocol.SourceEdit;
 import org.dartlang.analysis.server.protocol.SourceFileEdit;
 import org.jetbrains.annotations.NotNull;
@@ -128,7 +129,7 @@ public class FlutterSaveActionsManager {
     final SourceFileEdit fileEdit = DartAnalysisServerService.getInstance(myProject).edit_organizeDirectives(filePath);
 
     if (fileEdit != null) {
-      ApplicationManager.getApplication().invokeLater(() -> {
+      OpenApiUtils.safeInvokeLater(() -> {
         if (myProject.isDisposed()) {
           return;
         }
@@ -147,12 +148,12 @@ public class FlutterSaveActionsManager {
 
             // Run this in an invoke later so that we don't exeucte the initial part of performFormat in a write action.
             //noinspection CodeBlock2Expr
-            ApplicationManager.getApplication().invokeLater(() -> {
+            OpenApiUtils.safeInvokeLater(() -> {
               performFormat(document, file, true, psiFile);
-            });
+            }, ModalityState.defaultModalityState(), project.getDisposed());
           }
         }.execute();
-      });
+      }, ModalityState.defaultModalityState(), project.getDisposed());
     }
   }
 
@@ -171,7 +172,7 @@ public class FlutterSaveActionsManager {
       return;
     }
 
-    ApplicationManager.getApplication().invokeLater(() -> {
+    OpenApiUtils.safeInvokeLater(() -> {
       if (myProject.isDisposed()) {
         return;
       }
@@ -197,13 +198,13 @@ public class FlutterSaveActionsManager {
           // Don't perform the save in a write action - it could invoke EDT work.
           if (reSave || didFormat) {
             //noinspection CodeBlock2Expr
-            ApplicationManager.getApplication().invokeLater(() -> {
+            OpenApiUtils.safeInvokeLater(() -> {
               FileDocumentManager.getInstance().saveDocument(document);
-            });
+            }, ModalityState.defaultModalityState(), project.getDisposed());
           }
         }
       }.execute();
-    });
+    }, ModalityState.defaultModalityState(), project.getDisposed());
   }
 
   private static int getRightMargin(@NotNull PsiFile psiFile) {

--- a/flutter-idea/src/io/flutter/editor/FlutterSaveActionsManager.java
+++ b/flutter-idea/src/io/flutter/editor/FlutterSaveActionsManager.java
@@ -6,7 +6,6 @@
 package io.flutter.editor;
 
 import com.intellij.application.options.CodeStyle;
-import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.command.WriteCommandAction;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Document;
@@ -150,10 +149,10 @@ public class FlutterSaveActionsManager {
             //noinspection CodeBlock2Expr
             OpenApiUtils.safeInvokeLater(() -> {
               performFormat(document, file, true, psiFile);
-            }, ModalityState.defaultModalityState(), project.getDisposed());
+            });
           }
         }.execute();
-      }, ModalityState.defaultModalityState(), project.getDisposed());
+      });
     }
   }
 
@@ -200,11 +199,11 @@ public class FlutterSaveActionsManager {
             //noinspection CodeBlock2Expr
             OpenApiUtils.safeInvokeLater(() -> {
               FileDocumentManager.getInstance().saveDocument(document);
-            }, ModalityState.defaultModalityState(), project.getDisposed());
+            });
           }
         }
       }.execute();
-    }, ModalityState.defaultModalityState(), project.getDisposed());
+    });
   }
 
   private static int getRightMargin(@NotNull PsiFile psiFile) {

--- a/flutter-idea/src/io/flutter/font/FontPreviewProcessor.java
+++ b/flutter-idea/src/io/flutter/font/FontPreviewProcessor.java
@@ -33,6 +33,7 @@ import com.jetbrains.lang.dart.util.DartResolveUtil;
 import io.flutter.FlutterBundle;
 import io.flutter.editor.FlutterIconLineMarkerProvider;
 import io.flutter.settings.FlutterSettings;
+import io.flutter.utils.OpenApiUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -352,7 +353,7 @@ public class FontPreviewProcessor {
   private void deleteNextFile(Project project, WorkItem item) {
     final VirtualFile filteredFile = item.getFileToDelete();
     if (filteredFile != null) {
-      ApplicationManager.getApplication().runWriteAction(() -> {
+      OpenApiUtils.safeRunWriteAction(() -> {
         try {
           log("Deleting file ", filteredFile.getName());
           filteredFile.delete(this); // need write access

--- a/flutter-idea/src/io/flutter/module/FlutterModuleBuilder.java
+++ b/flutter-idea/src/io/flutter/module/FlutterModuleBuilder.java
@@ -14,7 +14,6 @@ import com.intellij.ide.util.projectWizard.ModuleWizardStep;
 import com.intellij.ide.util.projectWizard.SettingsStep;
 import com.intellij.ide.util.projectWizard.WizardContext;
 import com.intellij.openapi.Disposable;
-import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.application.WriteAction;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.module.*;
@@ -151,9 +150,9 @@ public class FlutterModuleBuilder extends ModuleBuilder {
           ProjectView view = ProjectView.getInstance(project);
           if (view == null) return;
           view.changeView(ProjectViewPane.ID);
-        }, ModalityState.defaultModalityState(), project.getDisposed());
+        });
       });
-    }, ModalityState.defaultModalityState(), project.getDisposed());
+    });
   }
 
   private String validateSettings(FlutterCreateAdditionalSettings settings) {
@@ -220,7 +219,7 @@ public class FlutterModuleBuilder extends ModuleBuilder {
           if (ModuleManager.getInstance(project).findModuleByName(newModule.getName()) == null) {
             WriteAction.run(toCommit::commit);
           }
-        }, ModalityState.defaultModalityState(), project.getDisposed());
+        });
       }
     }
     catch (ModuleWithNameAlreadyExists | IOException e) {

--- a/flutter-idea/src/io/flutter/module/FlutterModuleBuilder.java
+++ b/flutter-idea/src/io/flutter/module/FlutterModuleBuilder.java
@@ -5,8 +5,6 @@
  */
 package io.flutter.module;
 
-import static java.util.Arrays.asList;
-
 import com.intellij.execution.OutputListener;
 import com.intellij.execution.process.ProcessListener;
 import com.intellij.ide.projectView.ProjectView;
@@ -16,14 +14,11 @@ import com.intellij.ide.util.projectWizard.ModuleWizardStep;
 import com.intellij.ide.util.projectWizard.SettingsStep;
 import com.intellij.ide.util.projectWizard.WizardContext;
 import com.intellij.openapi.Disposable;
-import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.application.WriteAction;
 import com.intellij.openapi.diagnostic.Logger;
-import com.intellij.openapi.module.ModifiableModuleModel;
+import com.intellij.openapi.module.*;
 import com.intellij.openapi.module.Module;
-import com.intellij.openapi.module.ModuleManager;
-import com.intellij.openapi.module.ModuleType;
-import com.intellij.openapi.module.ModuleWithNameAlreadyExists;
 import com.intellij.openapi.options.ConfigurationException;
 import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.project.DumbService;
@@ -48,16 +43,17 @@ import io.flutter.sdk.FlutterSdk;
 import io.flutter.sdk.FlutterSdkUtil;
 import io.flutter.utils.AndroidUtils;
 import io.flutter.utils.FlutterModuleUtils;
+import io.flutter.utils.OpenApiUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.atomic.AtomicReference;
-import javax.swing.ComboBoxEditor;
-import javax.swing.Icon;
-import javax.swing.JComponent;
 
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import static java.util.Arrays.asList;
 
 public class FlutterModuleBuilder extends ModuleBuilder {
   private static final Logger LOG = Logger.getInstance(FlutterModuleBuilder.class);
@@ -149,15 +145,15 @@ public class FlutterModuleBuilder extends ModuleBuilder {
   }
 
   private void showProjectInProjectWindow(@NotNull Project project) {
-    ApplicationManager.getApplication().invokeLater(() -> {
+    OpenApiUtils.safeInvokeLater(() -> {
       DumbService.getInstance(project).runWhenSmart(() -> {
-        ApplicationManager.getApplication().invokeLater(() -> {
+        OpenApiUtils.safeInvokeLater(() -> {
           ProjectView view = ProjectView.getInstance(project);
           if (view == null) return;
           view.changeView(ProjectViewPane.ID);
-        });
+        }, ModalityState.defaultModalityState(), project.getDisposed());
       });
-    });
+    }, ModalityState.defaultModalityState(), project.getDisposed());
   }
 
   private String validateSettings(FlutterCreateAdditionalSettings settings) {
@@ -180,10 +176,10 @@ public class FlutterModuleBuilder extends ModuleBuilder {
   }
 
   public static void addAndroidModule(@NotNull Project project,
-                                       @Nullable ModifiableModuleModel model,
-                                       @NotNull String baseDirPath,
-                                       @NotNull String flutterModuleName,
-                                       boolean isTopLevel) {
+                                      @Nullable ModifiableModuleModel model,
+                                      @NotNull String baseDirPath,
+                                      @NotNull String flutterModuleName,
+                                      boolean isTopLevel) {
     final VirtualFile baseDir = LocalFileSystem.getInstance().refreshAndFindFileByPath(baseDirPath);
     if (baseDir == null) {
       return;
@@ -213,7 +209,7 @@ public class FlutterModuleBuilder extends ModuleBuilder {
       Module newModule = model.loadModule(androidFile.getPath());
 
       if (toCommit != null) {
-        ApplicationManager.getApplication().invokeLater(() -> {
+        OpenApiUtils.safeInvokeLater(() -> {
           // This check was due to https://github.com/flutter/flutter-intellij/issues/7306:
           if (project.isDisposed()) {
             return;
@@ -224,7 +220,7 @@ public class FlutterModuleBuilder extends ModuleBuilder {
           if (ModuleManager.getInstance(project).findModuleByName(newModule.getName()) == null) {
             WriteAction.run(toCommit::commit);
           }
-        });
+        }, ModalityState.defaultModalityState(), project.getDisposed());
       }
     }
     catch (ModuleWithNameAlreadyExists | IOException e) {

--- a/flutter-idea/src/io/flutter/project/FlutterProjectStructureDetector.java
+++ b/flutter-idea/src/io/flutter/project/FlutterProjectStructureDetector.java
@@ -13,12 +13,10 @@ import com.intellij.ide.util.projectWizard.importSources.ProjectStructureDetecto
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.module.Module;
-import com.intellij.openapi.module.ModuleManager;
 import com.intellij.openapi.project.DumbService;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
 import com.intellij.openapi.project.ProjectManagerListener;
-import com.intellij.openapi.roots.ModuleRootManager;
 import com.intellij.openapi.startup.StartupManager;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VfsUtil;
@@ -27,6 +25,7 @@ import com.intellij.util.messages.MessageBusConnection;
 import io.flutter.module.FlutterModuleBuilder;
 import io.flutter.pub.PubRoot;
 import io.flutter.utils.FlutterModuleUtils;
+import io.flutter.utils.OpenApiUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
@@ -188,8 +187,8 @@ public class FlutterProjectStructureDetector extends ProjectStructureDetector {
     // Verify that the project has the given content root. If the import was cancelled and restarted
     // for the same project, but a content root was not selected the second time, then it might be absent.
     VirtualFile virtualFile = LocalFileSystem.getInstance().findFileByIoFile(root);
-    for (Module module : ModuleManager.getInstance(project).getModules()) {
-      for (VirtualFile file : ModuleRootManager.getInstance(module).getContentRoots()) {
+    for (Module module : OpenApiUtils.getModules(project)) {
+      for (VirtualFile file : OpenApiUtils.getContentRoots(module)) {
         if (file != null && file.equals(virtualFile)) {
           return true;
         }

--- a/flutter-idea/src/io/flutter/propertyeditor/PropertyEditorViewFactory.java
+++ b/flutter-idea/src/io/flutter/propertyeditor/PropertyEditorViewFactory.java
@@ -5,7 +5,7 @@
  */
 package io.flutter.propertyeditor;
 
-import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowFactory;
@@ -20,6 +20,7 @@ import io.flutter.run.daemon.DevToolsService;
 import io.flutter.sdk.FlutterSdk;
 import io.flutter.sdk.FlutterSdkVersion;
 import io.flutter.utils.AsyncUtils;
+import io.flutter.utils.OpenApiUtils;
 import io.flutter.view.ViewUtils;
 import kotlin.coroutines.Continuation;
 import org.jetbrains.annotations.NotNull;
@@ -77,11 +78,11 @@ public class PropertyEditorViewFactory implements ToolWindowFactory {
           .setIdeFeature(DevToolsIdeFeature.TOOL_WINDOW)
           .build();
 
-        ApplicationManager.getApplication().invokeLater(() -> {
+        OpenApiUtils.safeInvokeLater(() -> {
           Optional.ofNullable(
               FlutterUtils.embeddedBrowser(project))
             .ifPresent(embeddedBrowser -> embeddedBrowser.openPanel(toolWindow, "Property Editor", devToolsUrl, System.out::println));
-        });
+        }, ModalityState.defaultModalityState(), project.getDisposed());
       }
     );
 

--- a/flutter-idea/src/io/flutter/propertyeditor/PropertyEditorViewFactory.java
+++ b/flutter-idea/src/io/flutter/propertyeditor/PropertyEditorViewFactory.java
@@ -5,7 +5,6 @@
  */
 package io.flutter.propertyeditor;
 
-import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowFactory;
@@ -82,7 +81,7 @@ public class PropertyEditorViewFactory implements ToolWindowFactory {
           Optional.ofNullable(
               FlutterUtils.embeddedBrowser(project))
             .ifPresent(embeddedBrowser -> embeddedBrowser.openPanel(toolWindow, "Property Editor", devToolsUrl, System.out::println));
-        }, ModalityState.defaultModalityState(), project.getDisposed());
+        });
       }
     );
 

--- a/flutter-idea/src/io/flutter/pub/PubRoot.java
+++ b/flutter-idea/src/io/flutter/pub/PubRoot.java
@@ -9,9 +9,7 @@ import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
 import com.intellij.openapi.actionSystem.LangDataKeys;
 import com.intellij.openapi.module.Module;
-import com.intellij.openapi.module.ModuleManager;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.roots.ModuleRootManager;
 import com.intellij.openapi.roots.ProjectFileIndex;
 import com.intellij.openapi.roots.ProjectRootManager;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -423,14 +421,14 @@ public class PubRoot {
   /**
    * Returns true if the project has a module for the "android" directory.
    */
-  public boolean hasAndroidModule(Project project) {
+  public boolean hasAndroidModule(@NotNull Project project) {
     final VirtualFile androidDir = getAndroidDir();
     if (androidDir == null) {
       return false;
     }
 
-    for (Module module : ModuleManager.getInstance(project).getModules()) {
-      for (VirtualFile contentRoot : ModuleRootManager.getInstance(module).getContentRoots()) {
+    for (Module module : OpenApiUtils.getModules(project)) {
+      for (VirtualFile contentRoot : OpenApiUtils.getContentRoots(module)) {
         if (Objects.equals(contentRoot, androidDir)) {
           return true;
         }

--- a/flutter-idea/src/io/flutter/pub/PubRootCache.java
+++ b/flutter-idea/src/io/flutter/pub/PubRootCache.java
@@ -6,11 +6,11 @@
 package io.flutter.pub;
 
 import com.intellij.openapi.module.Module;
-import com.intellij.openapi.module.ModuleManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ModuleRootManager;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
+import io.flutter.utils.OpenApiUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -61,10 +61,10 @@ public class PubRootCache {
   }
 
   @NotNull
-  public List<PubRoot> getRoots(Module module) {
+  public List<@NotNull PubRoot> getRoots(@NotNull Module module) {
     final List<PubRoot> result = new ArrayList<>();
 
-    for (VirtualFile dir : ModuleRootManager.getInstance(module).getContentRoots()) {
+    for (VirtualFile dir : OpenApiUtils.getContentRoots(module)) {
       PubRoot root = cache.get(dir);
 
       if (root == null) {
@@ -83,7 +83,7 @@ public class PubRootCache {
   @NotNull
   public List<PubRoot> getRoots(@NotNull Project project) {
     final List<PubRoot> result = new ArrayList<>();
-    for (Module module : ModuleManager.getInstance(project).getModules()) {
+    for (Module module : OpenApiUtils.getModules(project)) {
       result.addAll(getRoots(module));
     }
     return result;

--- a/flutter-idea/src/io/flutter/pub/PubRoots.java
+++ b/flutter-idea/src/io/flutter/pub/PubRoots.java
@@ -6,10 +6,9 @@
 package io.flutter.pub;
 
 import com.intellij.openapi.module.Module;
-import com.intellij.openapi.module.ModuleManager;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.roots.ModuleRootManager;
 import com.intellij.openapi.vfs.VirtualFile;
+import io.flutter.utils.OpenApiUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -29,11 +28,11 @@ public class PubRoots {
    * (Based on the filesystem cache; doesn't refresh anything.)
    */
   @NotNull
-  public static List<PubRoot> forModule(@NotNull Module module) {
+  public static List<@NotNull PubRoot> forModule(@NotNull Module module) {
     final List<PubRoot> result = new ArrayList<>();
     if (module.isDisposed()) return result;
 
-    for (VirtualFile dir : ModuleRootManager.getInstance(module).getContentRoots()) {
+    for (VirtualFile dir : OpenApiUtils.getContentRoots(module)) {
       final PubRoot root = PubRoot.forDirectory(dir);
       if (root != null) {
         result.add(root);
@@ -52,7 +51,7 @@ public class PubRoots {
     final List<PubRoot> result = new ArrayList<>();
     if (project.isDisposed()) return result;
 
-    for (Module module : ModuleManager.getInstance(project).getModules()) {
+    for (Module module : OpenApiUtils.getModules(project)) {
       result.addAll(forModule(module));
     }
     return result;

--- a/flutter-idea/src/io/flutter/run/common/CommonTestConfigUtils.java
+++ b/flutter-idea/src/io/flutter/run/common/CommonTestConfigUtils.java
@@ -5,12 +5,8 @@
  */
 package io.flutter.run.common;
 
-import static org.dartlang.analysis.server.protocol.ElementKind.UNIT_TEST_GROUP;
-import static org.dartlang.analysis.server.protocol.ElementKind.UNIT_TEST_TEST;
-
 import com.google.common.annotations.VisibleForTesting;
 import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer;
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Disposer;
@@ -21,12 +17,17 @@ import com.jetbrains.lang.dart.psi.DartCallExpression;
 import com.jetbrains.lang.dart.psi.DartStringLiteralExpression;
 import io.flutter.dart.DartSyntax;
 import io.flutter.editor.ActiveEditorsOutlineService;
-import java.util.HashMap;
-import java.util.Map;
+import io.flutter.utils.OpenApiUtils;
 import org.dartlang.analysis.server.protocol.ElementKind;
 import org.dartlang.analysis.server.protocol.FlutterOutline;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.dartlang.analysis.server.protocol.ElementKind.UNIT_TEST_GROUP;
+import static org.dartlang.analysis.server.protocol.ElementKind.UNIT_TEST_TEST;
 
 /**
  * Common utilities for processing Flutter tests.
@@ -266,7 +267,7 @@ public abstract class CommonTestConfigUtils {
       // but it will cache RemoteAnalysisServerImpl$ServerResponseReaderThread in FileStatusMap.threads and as a result,
       // DartAnalysisServerService.myProject will be leaked in tests
 
-      ApplicationManager.getApplication().invokeLater(
+      OpenApiUtils.safeInvokeLater(
         () -> DaemonCodeAnalyzer.getInstance(project).restart(),
         ModalityState.defaultModalityState(),
         project.getDisposed()

--- a/flutter-idea/src/io/flutter/run/coverage/FlutterCoverageProgramRunner.java
+++ b/flutter-idea/src/io/flutter/run/coverage/FlutterCoverageProgramRunner.java
@@ -20,12 +20,12 @@ import com.intellij.execution.runners.DefaultProgramRunnerKt;
 import com.intellij.execution.runners.ExecutionEnvironment;
 import com.intellij.execution.runners.GenericProgramRunner;
 import com.intellij.execution.ui.RunContentDescriptor;
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VfsUtil;
 import io.flutter.FlutterBundle;
 import io.flutter.run.test.TestConfig;
+import io.flutter.utils.OpenApiUtils;
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -71,7 +71,7 @@ public class FlutterCoverageProgramRunner extends GenericProgramRunner<RunnerSet
       listener = new ProcessAdapter() {
         @Override
         public void processTerminated(@NotNull ProcessEvent event) {
-          ApplicationManager.getApplication().invokeLater(() -> processCoverage(env));
+          OpenApiUtils.safeInvokeLater(() -> processCoverage(env));
         }
       };
       handler.addProcessListener(listener);

--- a/flutter-idea/src/io/flutter/run/daemon/DeviceDaemon.java
+++ b/flutter-idea/src/io/flutter/run/daemon/DeviceDaemon.java
@@ -11,7 +11,6 @@ import com.google.common.collect.ImmutableList;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configurations.GeneralCommandLine;
 import com.intellij.execution.process.ProcessHandler;
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
@@ -29,6 +28,7 @@ import io.flutter.sdk.FlutterSdk;
 import io.flutter.sdk.FlutterSdkUtil;
 import io.flutter.utils.FlutterModuleUtils;
 import io.flutter.utils.MostlySilentColoredProcessHandler;
+import io.flutter.utils.OpenApiUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -246,7 +246,7 @@ class DeviceDaemon {
                 FlutterMessages.showError("Flutter device daemon", failureMessage, null);
               }
               else if (attempts == DeviceDaemon.RESTART_ATTEMPTS_BEFORE_WARNING + 4) {
-                ApplicationManager.getApplication().invokeLater(() -> new DaemonCrashReporter().show(), ModalityState.nonModal());
+                OpenApiUtils.safeInvokeLater(() -> new DaemonCrashReporter().show(), ModalityState.nonModal());
                 return null;
               }
             }

--- a/flutter-idea/src/io/flutter/sdk/FlutterSdkManager.java
+++ b/flutter-idea/src/io/flutter/sdk/FlutterSdkManager.java
@@ -11,9 +11,9 @@ import com.intellij.openapi.project.ProjectManager;
 import com.intellij.openapi.project.ProjectManagerListener;
 import com.intellij.openapi.roots.libraries.Library;
 import com.intellij.openapi.roots.libraries.LibraryTable;
-import com.intellij.openapi.roots.libraries.LibraryTablesRegistrar;
 import com.intellij.openapi.util.Disposer;
 import com.intellij.util.EventDispatcher;
+import io.flutter.utils.OpenApiUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -38,8 +38,10 @@ public class FlutterSdkManager {
   private FlutterSdkManager(@NotNull Project project) {
     myProject = project;
 
+    final LibraryTable libraryTable = OpenApiUtils.getLibraryTable(project);
+    if (libraryTable == null) return;
+
     final LibraryTableListener libraryTableListener = new LibraryTableListener();
-    final LibraryTable libraryTable = LibraryTablesRegistrar.getInstance().getLibraryTable(project);
     libraryTable.addListener(libraryTableListener);
 
     // TODO(devoncarew): We should replace this polling solution with listeners to project structure changes.
@@ -47,7 +49,7 @@ public class FlutterSdkManager {
       this::checkForFlutterSdkChange, 1, 1, TimeUnit.SECONDS);
 
     Disposer.register(project, () -> {
-      LibraryTablesRegistrar.getInstance().getLibraryTable(project).removeListener(libraryTableListener);
+      libraryTable.removeListener(libraryTableListener);
       timer.cancel(false);
     });
 

--- a/flutter-idea/src/io/flutter/sdk/FlutterSdkUtil.java
+++ b/flutter-idea/src/io/flutter/sdk/FlutterSdkUtil.java
@@ -16,7 +16,6 @@ import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ApplicationNamesInfo;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.module.Module;
-import com.intellij.openapi.module.ModuleManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
 import com.intellij.openapi.util.SystemInfo;
@@ -33,6 +32,7 @@ import io.flutter.pub.PubRoot;
 import io.flutter.pub.PubRoots;
 import io.flutter.utils.FlutterModuleUtils;
 import io.flutter.utils.JsonUtils;
+import io.flutter.utils.OpenApiUtils;
 import io.flutter.utils.SystemUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -229,7 +229,7 @@ public class FlutterSdkUtil {
   public static void setFlutterSdkPath(@NotNull final Project project, @NotNull final String flutterSdkPath) {
     // In reality this method sets Dart SDK (that is inside the Flutter SDK).
     final String dartSdk = flutterSdkPath + "/bin/cache/dart-sdk";
-    ApplicationManager.getApplication().runWriteAction(() -> DartPlugin.ensureDartSdkConfigured(project, dartSdk));
+    OpenApiUtils.safeRunWriteAction(() -> DartPlugin.ensureDartSdkConfigured(project, dartSdk));
 
     // Checking for updates doesn't make sense since the channels don't correspond to Flutter...
     DartSdkUpdateOption.setDartSdkUpdateOption(DartSdkUpdateOption.DoNotCheck);
@@ -248,8 +248,8 @@ public class FlutterSdkUtil {
    */
   public static void enableDartSdk(@NotNull final Project project) {
     //noinspection ConstantConditions
-    for (Module module : ModuleManager.getInstance(project).getModules()) {
-      if (module != null && !PubRoots.forModule(module).isEmpty()) {
+    for (Module module : OpenApiUtils.getModules(project)) {
+      if (!PubRoots.forModule(module).isEmpty()) {
         DartPlugin.enableDartSdk(module);
       }
     }

--- a/flutter-idea/src/io/flutter/sdk/FlutterSettingsConfigurable.java
+++ b/flutter-idea/src/io/flutter/sdk/FlutterSettingsConfigurable.java
@@ -44,6 +44,7 @@ import io.flutter.font.FontPreviewProcessor;
 import io.flutter.pub.PubRoot;
 import io.flutter.pub.PubRoots;
 import io.flutter.settings.FlutterSettings;
+import io.flutter.utils.OpenApiUtils;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -260,7 +261,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
       final String sdkHomePath = getSdkPathText();
       if (FlutterSdkUtil.isFlutterSdkHome(sdkHomePath)) {
 
-        ApplicationManager.getApplication().runWriteAction(() -> {
+        OpenApiUtils.safeRunWriteAction(() -> {
           FlutterSdkUtil.setFlutterSdkPath(myProject, sdkHomePath);
           FlutterSdkUtil.enableDartSdk(myProject);
 
@@ -406,14 +407,14 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
         Thread.sleep(100L);
         lock.acquire();
 
-        ApplicationManager.getApplication().invokeLater(() -> {
+        OpenApiUtils.safeInvokeLater(() -> {
           // "flutter --version" can take a long time on a slow network.
           updater = sdk.flutterVersion().start((ProcessOutput output) -> {
             fullVersionString = output.getStdout();
             final String[] lines = StringUtil.splitByLines(fullVersionString);
             final String singleLineVersion = lines.length > 0 ? lines[0] : "";
 
-            ApplicationManager.getApplication().invokeLater(() -> {
+            OpenApiUtils.safeInvokeLater(() -> {
               updater = null;
               lock.release();
               updateVersionTextIfCurrent(sdk, singleLineVersion);

--- a/flutter-idea/src/io/flutter/utils/EnableDartSupportForModule.java
+++ b/flutter-idea/src/io/flutter/utils/EnableDartSupportForModule.java
@@ -28,8 +28,8 @@ class EnableDartSupportForModule implements Runnable {
     final Project project = myModule.getProject();
 
     EdtInvocationManager.getInstance().invokeLater(() -> {
-      ApplicationManager.getApplication().invokeLater(() -> {
-        ApplicationManager.getApplication().runWriteAction(() -> {
+      OpenApiUtils.safeInvokeLater(() -> {
+        OpenApiUtils.safeRunWriteAction(() -> {
           if (DartSdk.getDartSdk(project) == null || !DartSdkLibUtil.isDartSdkEnabled(myModule)) {
             final String sdkPath = DartSdkUtil.getFirstKnownDartSdkPath();
             if (DartSdkUtil.isDartSdkHome(sdkPath)) {

--- a/flutter-idea/src/io/flutter/utils/FlutterModuleUtils.java
+++ b/flutter-idea/src/io/flutter/utils/FlutterModuleUtils.java
@@ -13,7 +13,9 @@ import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.fileEditor.FileEditor;
 import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.module.Module;
-import com.intellij.openapi.module.*;
+import com.intellij.openapi.module.ModuleType;
+import com.intellij.openapi.module.ModuleTypeManager;
+import com.intellij.openapi.module.ModuleUtilCore;
 import com.intellij.openapi.project.DumbService;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
@@ -98,7 +100,7 @@ public class FlutterModuleUtils {
             path.endsWith(FlutterSdk.MAC_DART_SUFFIX));
   }
 
-  public static boolean hasInternalDartSdkPath(Project project) {
+  public static boolean hasInternalDartSdkPath(@NotNull Project project) {
     final DartSdk dartSdk = DartPlugin.getDartSdk(project);
     final String dartSdkPath = dartSdk != null ? dartSdk.getHomePath() : "";
     return dartSdkPath.endsWith(FlutterSdk.LINUX_DART_SUFFIX) || dartSdkPath.endsWith(FlutterSdk.MAC_DART_SUFFIX);
@@ -213,12 +215,12 @@ public class FlutterModuleUtils {
     return null;
   }
 
-  @NotNull
-  public static Module[] getModules(@NotNull Project project) {
+
+  public static @NotNull Module @NotNull[] getModules(@NotNull Project project) {
     // A disposed project has no modules.
     if (project.isDisposed()) return Module.EMPTY_ARRAY;
 
-    return ModuleManager.getInstance(project).getModules();
+    return OpenApiUtils.getModules(project);
   }
 
   /**
@@ -428,7 +430,7 @@ public class FlutterModuleUtils {
       if (dartSdkPath == null) {
         return; // Not cached. TODO call flutterSdk.sync() here?
       }
-      ApplicationManager.getApplication().runWriteAction(() -> {
+      OpenApiUtils.safeRunWriteAction(() -> {
         DartPlugin.ensureDartSdkConfigured(module.getProject(), dartSdkPath);
         DartPlugin.enableDartSdk(module);
       });

--- a/flutter-idea/src/io/flutter/utils/OpenApiUtils.java
+++ b/flutter-idea/src/io/flutter/utils/OpenApiUtils.java
@@ -7,11 +7,36 @@ package io.flutter.utils;
 
 import com.intellij.openapi.application.Application;
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ModalityState;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleManager;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.ModuleRootManager;
+import com.intellij.openapi.roots.libraries.LibraryTable;
+import com.intellij.openapi.roots.libraries.LibraryTablesRegistrar;
 import com.intellij.openapi.util.Computable;
+import com.intellij.openapi.util.Condition;
+import com.intellij.openapi.util.ThrowableComputable;
+import com.intellij.openapi.vfs.VirtualFile;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class OpenApiUtils {
+
+  public static @NotNull VirtualFile @NotNull [] getContentRoots(@NotNull Module module) {
+    var moduleRootManager = ModuleRootManager.getInstance(module);
+    return moduleRootManager == null ? VirtualFile.EMPTY_ARRAY : moduleRootManager.getContentRoots();
+  }
+
+  public static @Nullable LibraryTable getLibraryTable(@NotNull Project project) {
+    var registrar = LibraryTablesRegistrar.getInstance();
+    return registrar == null ? null : registrar.getLibraryTable(project);
+  }
+
+  public static @NotNull Module @NotNull [] getModules(@NotNull Project project) {
+    var modules = ModuleManager.getInstance(project).getModules();
+    return modules == null ? Module.EMPTY_ARRAY : modules;
+  }
 
   public static void safeRunReadAction(@NotNull Runnable runnable) {
     Application application = ApplicationManager.getApplication();
@@ -23,5 +48,43 @@ public class OpenApiUtils {
     Application application = ApplicationManager.getApplication();
     if (application == null) return null;
     return application.runReadAction(computable);
+  }
+
+
+  public static void safeInvokeLater(@NotNull Runnable runnable) {
+    Application application = ApplicationManager.getApplication();
+    if (application == null) return;
+    application.invokeLater(runnable);
+  }
+
+  public static void safeInvokeLater(@NotNull Runnable runnable, @NotNull ModalityState state) {
+    Application application = ApplicationManager.getApplication();
+    if (application == null) return;
+    application.invokeLater(runnable, state);
+  }
+
+  public static void safeInvokeLater(@NotNull Runnable runnable, @NotNull ModalityState state, @NotNull Condition<?> disposed) {
+    Application application = ApplicationManager.getApplication();
+    if (application == null) return;
+    application.invokeLater(runnable, state, disposed);
+  }
+
+
+  public static void safeInvokeAndWait(@NotNull Runnable runnable) {
+    Application application = ApplicationManager.getApplication();
+    if (application == null) return;
+    application.invokeAndWait(runnable);
+  }
+
+  public static <T, E extends Throwable> @Nullable T safeRunWriteAction(@NotNull ThrowableComputable<T, E> computation) throws E {
+    Application application = ApplicationManager.getApplication();
+    if (application == null) return null;
+    return application.runWriteAction(computation);
+  }
+
+  public static void safeRunWriteAction(@NotNull Runnable runnable) {
+    Application application = ApplicationManager.getApplication();
+    if (application == null) return;
+    application.runWriteAction(runnable);
   }
 }

--- a/flutter-idea/src/io/flutter/utils/ProgressHelper.java
+++ b/flutter-idea/src/io/flutter/utils/ProgressHelper.java
@@ -5,7 +5,6 @@
  */
 package io.flutter.utils;
 
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.progress.Task;
@@ -58,7 +57,7 @@ public class ProgressHelper {
           }
         };
 
-        ApplicationManager.getApplication().invokeLater(() -> {
+        OpenApiUtils.safeInvokeLater(() -> {
           synchronized (myTasks) {
             if (myTask != null && !myProject.isDisposed()) {
               ProgressManager.getInstance().run(myTask);

--- a/flutter-idea/src/io/flutter/view/EmbeddedBrowser.java
+++ b/flutter-idea/src/io/flutter/view/EmbeddedBrowser.java
@@ -6,7 +6,6 @@
 package io.flutter.view;
 
 import com.intellij.ide.browsers.BrowserLauncher;
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
@@ -21,6 +20,7 @@ import icons.FlutterIcons;
 import io.flutter.devtools.DevToolsUrl;
 import io.flutter.utils.AsyncUtils;
 import io.flutter.utils.LabelInput;
+import io.flutter.utils.OpenApiUtils;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
@@ -116,7 +116,7 @@ public abstract class EmbeddedBrowser {
 
     JComponent component = tab.embeddedTab.getTabComponent(tab.contentManager);
 
-    ApplicationManager.getApplication().invokeLater(() -> {
+    OpenApiUtils.safeInvokeLater(() -> {
       if (tab.contentManager.isDisposed()) {
         return;
       }
@@ -206,7 +206,7 @@ public abstract class EmbeddedBrowser {
   }
 
   private void replacePanelLabel(JComponent label, ContentManager contentManager) {
-    ApplicationManager.getApplication().invokeLater(() -> {
+    OpenApiUtils.safeInvokeLater(() -> {
       if (contentManager.isDisposed()) {
         return;
       }

--- a/flutter-idea/src/io/flutter/view/FlutterView.java
+++ b/flutter-idea/src/io/flutter/view/FlutterView.java
@@ -43,10 +43,7 @@ import io.flutter.sdk.FlutterSdk;
 import io.flutter.sdk.FlutterSdkVersion;
 import io.flutter.settings.FlutterSettings;
 import io.flutter.toolwindow.FlutterViewToolWindowManagerListener;
-import io.flutter.utils.AsyncUtils;
-import io.flutter.utils.EventStream;
-import io.flutter.utils.JxBrowserUtils;
-import io.flutter.utils.LabelInput;
+import io.flutter.utils.*;
 import org.dartlang.vm.service.VmService;
 import org.jetbrains.annotations.NotNull;
 
@@ -103,7 +100,10 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
 
   @VisibleForTesting
   @NonInjectable
-  protected FlutterView(@NotNull Project project, @NotNull JxBrowserManager jxBrowserManager, JxBrowserUtils jxBrowserUtils, ViewUtils viewUtils) {
+  protected FlutterView(@NotNull Project project,
+                        @NotNull JxBrowserManager jxBrowserManager,
+                        JxBrowserUtils jxBrowserUtils,
+                        ViewUtils viewUtils) {
     myProject = project;
     this.jxBrowserUtils = jxBrowserUtils;
     this.jxBrowserManager = jxBrowserManager;
@@ -189,7 +189,7 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
 
       Runnable task = () -> {
         embeddedBrowserOptional().ifPresent(
-          embeddedBrowser -> ApplicationManager.getApplication().invokeLater(() -> {
+          embeddedBrowser -> OpenApiUtils.safeInvokeLater(() -> {
             embeddedBrowser.openPanel(toolWindow, tabName, devToolsUrl, (String error) -> {
               // If the embedded browser doesn't work, offer a link to open in the regular browser.
               final List<LabelInput> inputs = Arrays.asList(
@@ -238,7 +238,7 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
     if (app.getFlutterDebugProcess() == null) {
       return;
     }
-    ApplicationManager.getApplication().invokeLater(() -> debugActiveHelper(app));
+    OpenApiUtils.safeInvokeLater(() -> debugActiveHelper(app));
   }
 
   protected void handleJxBrowserInstalled(FlutterApp app, ToolWindow toolWindow, DevToolsIdeFeature ideFeature) {
@@ -406,6 +406,7 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
 
     viewUtils.presentClickableLabel(toolWindow, inputs);
   }
+
   protected void presentOpenDevToolsOptionWithMessage(FlutterApp app,
                                                       ToolWindow toolWindow,
                                                       String message,
@@ -417,7 +418,7 @@ public class FlutterView implements PersistentStateComponent<FlutterViewState>, 
   }
 
   private void replacePanelLabel(ToolWindow toolWindow, JComponent label) {
-    ApplicationManager.getApplication().invokeLater(() -> {
+    OpenApiUtils.safeInvokeLater(() -> {
       final ContentManager contentManager = toolWindow.getContentManager();
       if (contentManager.isDisposed()) {
         return;

--- a/flutter-idea/src/io/flutter/view/FlutterViewFactory.java
+++ b/flutter-idea/src/io/flutter/view/FlutterViewFactory.java
@@ -6,13 +6,13 @@
 package io.flutter.view;
 
 import com.intellij.ide.util.PropertiesComponent;
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.DumbService;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowFactory;
 import com.intellij.openapi.wm.ToolWindowManager;
+import io.flutter.utils.OpenApiUtils;
 import io.flutter.utils.ViewListener;
 import org.jetbrains.annotations.NotNull;
 
@@ -40,7 +40,7 @@ public class FlutterViewFactory implements ToolWindowFactory, DumbAware {
   }
 
   private static void initFlutterView(@NotNull Project project, FlutterViewMessages.FlutterDebugEvent event) {
-    ApplicationManager.getApplication().invokeLater(() -> {
+    OpenApiUtils.safeInvokeLater(() -> {
       final FlutterView flutterView = project.getService(FlutterView.class);
       flutterView.debugActive(event);
     });

--- a/flutter-idea/src/io/flutter/view/ViewUtils.java
+++ b/flutter-idea/src/io/flutter/view/ViewUtils.java
@@ -5,7 +5,6 @@
  */
 package io.flutter.view;
 
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.ui.VerticalFlowLayout;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.ui.components.JBLabel;
@@ -15,6 +14,7 @@ import com.intellij.ui.content.ContentManager;
 import com.intellij.util.ui.JBUI;
 import com.intellij.util.ui.UIUtil;
 import io.flutter.utils.LabelInput;
+import io.flutter.utils.OpenApiUtils;
 
 import javax.swing.*;
 import java.awt.*;
@@ -52,7 +52,7 @@ public class ViewUtils {
   }
 
   private void replacePanelLabel(ToolWindow toolWindow, JComponent label) {
-    ApplicationManager.getApplication().invokeLater(() -> {
+    OpenApiUtils.safeInvokeLater(() -> {
       final ContentManager contentManager = toolWindow.getContentManager();
       if (contentManager.isDisposed()) {
         return;

--- a/flutter-idea/src/io/flutter/vmService/DartVmServiceDebugProcess.java
+++ b/flutter-idea/src/io/flutter/vmService/DartVmServiceDebugProcess.java
@@ -36,14 +36,15 @@ import io.flutter.FlutterBundle;
 import io.flutter.FlutterUtils;
 import io.flutter.ObservatoryConnector;
 import io.flutter.run.FlutterLaunchMode;
+import io.flutter.utils.OpenApiUtils;
 import io.flutter.vmService.frame.DartVmServiceEvaluator;
 import io.flutter.vmService.frame.DartVmServiceStackFrame;
 import io.flutter.vmService.frame.DartVmServiceSuspendContext;
 import org.dartlang.vm.service.VmService;
 import org.dartlang.vm.service.consumer.GetObjectConsumer;
 import org.dartlang.vm.service.consumer.VMConsumer;
-import org.dartlang.vm.service.element.Event;
 import org.dartlang.vm.service.element.*;
+import org.dartlang.vm.service.element.Event;
 import org.dartlang.vm.service.logging.Logging;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -502,14 +503,14 @@ public abstract class DartVmServiceDebugProcess extends XDebugProcess {
                 final Event event = isolate.getPauseEvent();
                 final EventKind eventKind = event.getKind();
                 if (eventKind == EventKind.PauseStart) {
-                  ApplicationManager.getApplication().invokeLater(() -> {
+                  OpenApiUtils.safeInvokeLater(() -> {
                     // We are assuming it is safe to call handleIsolate multiple times.
                     myVmServiceWrapper.handleIsolate(isolateRef, true);
                   });
                 }
                 else if (eventKind == EventKind.Resume) {
                   // Currently true if we got here via 'flutter attach'
-                  ApplicationManager.getApplication().invokeLater(() -> {
+                  OpenApiUtils.safeInvokeLater(() -> {
                     myVmServiceWrapper.attachIsolate(isolateRef, isolate);
                   });
                 }
@@ -552,7 +553,7 @@ public abstract class DartVmServiceDebugProcess extends XDebugProcess {
               final Project project = getSession().getProject();
               final OpenFileHyperlinkInfo
                 info = new OpenFileHyperlinkInfo(project, source.getFile(), source.getLine());
-              ApplicationManager.getApplication().invokeLater(() -> ApplicationManager.getApplication().runWriteAction(() -> {
+              OpenApiUtils.safeInvokeLater(() -> OpenApiUtils.safeRunWriteAction(() -> {
                 info.navigate(project);
 
                 ProjectUtil.focusProjectWindow(project, true);
@@ -635,7 +636,7 @@ public abstract class DartVmServiceDebugProcess extends XDebugProcess {
 
         @Override
         public void windowActivated(WindowEvent e) {
-          if(projectFrame.isDisplayable()) {
+          if (projectFrame.isDisplayable()) {
             projectFrame.setVisible(true);
           }
           anchor.dispose();

--- a/flutter-idea/src/io/flutter/vmService/DisplayRefreshRateManager.java
+++ b/flutter-idea/src/io/flutter/vmService/DisplayRefreshRateManager.java
@@ -6,10 +6,10 @@
 package io.flutter.vmService;
 
 import com.google.gson.JsonObject;
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import io.flutter.FlutterMessages;
 import io.flutter.utils.EventStream;
+import io.flutter.utils.OpenApiUtils;
 import io.flutter.utils.StreamSubscription;
 import org.dartlang.vm.service.VmService;
 import org.dartlang.vm.service.consumer.ServiceExtensionConsumer;
@@ -37,7 +37,7 @@ public class DisplayRefreshRateManager {
   public void queryRefreshRate() {
     // This needs to happen on the UI thread.
     //noinspection CodeBlock2Expr
-    ApplicationManager.getApplication().invokeLater(() -> {
+    OpenApiUtils.safeInvokeLater(() -> {
       getDisplayRefreshRate().thenAcceptAsync(displayRefreshRateStream::setValue);
     });
   }

--- a/flutter-idea/testSrc/unit/io/flutter/ide/DartTestUtils.java
+++ b/flutter-idea/testSrc/unit/io/flutter/ide/DartTestUtils.java
@@ -6,7 +6,6 @@
 package io.flutter.ide;
 
 import com.intellij.openapi.Disposable;
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.*;
@@ -17,6 +16,7 @@ import com.intellij.psi.PsiFileFactory;
 import com.intellij.util.SmartList;
 import com.jetbrains.lang.dart.DartLanguage;
 import io.flutter.sdk.FlutterSdkUtil;
+import io.flutter.utils.OpenApiUtils;
 import junit.framework.TestCase;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -68,7 +68,7 @@ public class DartTestUtils {
    */
   public static void resetModuleRoots(@NotNull final Module module) {
     //noinspection ConstantConditions
-    ApplicationManager.getApplication().runWriteAction(() -> {
+    OpenApiUtils.safeRunWriteAction(() -> {
       final ModifiableRootModel modifiableModel = Objects.requireNonNull(ModuleRootManager.getInstance(module)).getModifiableModel();
 
       try {

--- a/flutter-idea/testSrc/unit/io/flutter/testing/Testing.java
+++ b/flutter-idea/testSrc/unit/io/flutter/testing/Testing.java
@@ -12,6 +12,7 @@ import com.intellij.testFramework.builders.EmptyModuleFixtureBuilder;
 import com.intellij.testFramework.fixtures.IdeaProjectTestFixture;
 import com.intellij.testFramework.fixtures.IdeaTestFixtureFactory;
 import com.intellij.testFramework.fixtures.TestFixtureBuilder;
+import io.flutter.utils.OpenApiUtils;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
@@ -71,7 +72,7 @@ public class Testing {
       callback.run();
       return null;
     };
-    runOnDispatchThread(() -> ApplicationManager.getApplication().runWriteAction(action));
+    runOnDispatchThread(() -> OpenApiUtils.safeRunWriteAction(action));
   }
 
   public static <T> T computeOnDispatchThread(ThrowableComputable<T, Exception> callback) throws Exception {
@@ -85,7 +86,7 @@ public class Testing {
       final AtomicReference<Exception> ex = new AtomicReference<>();
       assert (!SwingUtilities.isEventDispatchThread());
 
-      ApplicationManager.getApplication().invokeAndWait(() -> {
+      OpenApiUtils.safeInvokeAndWait(() -> {
         try {
           callback.run();
         }

--- a/flutter-studio/src/io/flutter/android/AndroidModuleLibraryManager.java
+++ b/flutter-studio/src/io/flutter/android/AndroidModuleLibraryManager.java
@@ -5,11 +5,6 @@
  */
 package io.flutter.android;
 
-import static com.android.tools.idea.gradle.util.GradleProjectSystemUtil.GRADLE_SYSTEM_ID;
-import static com.google.wireless.android.sdk.stats.GradleSyncStats.Trigger.TRIGGER_PROJECT_MODIFIED;
-import static io.flutter.android.AndroidModuleLibraryType.LIBRARY_KIND;
-import static io.flutter.android.AndroidModuleLibraryType.LIBRARY_NAME;
-
 import com.android.tools.idea.gradle.project.sync.GradleSyncInvoker;
 import com.android.tools.idea.gradle.project.sync.GradleSyncListener;
 import com.intellij.facet.FacetManager;
@@ -22,31 +17,20 @@ import com.intellij.openapi.application.TransactionGuard;
 import com.intellij.openapi.application.WriteAction;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.module.Module;
-import com.intellij.openapi.module.ModuleManager;
 import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.project.DumbService;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.impl.ProjectImpl;
 import com.intellij.openapi.project.impl.ProjectManagerImpl;
 import com.intellij.openapi.projectRoots.Sdk;
-import com.intellij.openapi.roots.DependencyScope;
-import com.intellij.openapi.roots.JavaProjectModelModifier;
-import com.intellij.openapi.roots.ModuleRootEvent;
-import com.intellij.openapi.roots.ModuleRootListener;
-import com.intellij.openapi.roots.ModuleRootManager;
-import com.intellij.openapi.roots.OrderRootType;
+import com.intellij.openapi.roots.*;
 import com.intellij.openapi.roots.impl.IdeaProjectModelModifier;
 import com.intellij.openapi.roots.libraries.Library;
 import com.intellij.openapi.roots.libraries.LibraryTable;
-import com.intellij.openapi.roots.libraries.LibraryTablesRegistrar;
 import com.intellij.openapi.roots.libraries.PersistentLibraryKind;
 import com.intellij.openapi.util.Disposer;
 import com.intellij.openapi.util.io.FileUtilRt;
-import com.intellij.openapi.vfs.LocalFileSystem;
-import com.intellij.openapi.vfs.VfsUtilCore;
-import com.intellij.openapi.vfs.VirtualFile;
-import com.intellij.openapi.vfs.VirtualFileContentsChangedAdapter;
-import com.intellij.openapi.vfs.VirtualFileManager;
+import com.intellij.openapi.vfs.*;
 import com.intellij.serviceContainer.ComponentManagerImpl;
 import com.intellij.util.ReflectionUtil;
 import com.intellij.util.modules.CircularModuleDependenciesDetector;
@@ -54,6 +38,10 @@ import io.flutter.sdk.AbstractLibraryManager;
 import io.flutter.sdk.FlutterSdkUtil;
 import io.flutter.settings.FlutterSettings;
 import io.flutter.utils.FlutterModuleUtils;
+import io.flutter.utils.OpenApiUtils;
+import org.jetbrains.android.facet.AndroidFacet;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -64,9 +52,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import org.jetbrains.android.facet.AndroidFacet;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import static com.android.tools.idea.gradle.util.GradleProjectSystemUtil.GRADLE_SYSTEM_ID;
+import static com.google.wireless.android.sdk.stats.GradleSyncStats.Trigger.TRIGGER_PROJECT_MODIFIED;
+import static io.flutter.android.AndroidModuleLibraryType.LIBRARY_KIND;
+import static io.flutter.android.AndroidModuleLibraryType.LIBRARY_NAME;
 
 /**
  * Manages the Android libraries. Add the libraries used by Android modules referenced in a project
@@ -97,7 +86,7 @@ public class AndroidModuleLibraryManager extends AbstractLibraryManager<AndroidM
   }
 
   private Void scheduleAddAndroidLibraryDeps(@NotNull Project androidProject) {
-    ApplicationManager.getApplication().invokeLater(
+    OpenApiUtils.safeInvokeLater(
       () -> addAndroidLibraryDependencies(androidProject),
       ModalityState.nonModal());
     return null;
@@ -106,7 +95,7 @@ public class AndroidModuleLibraryManager extends AbstractLibraryManager<AndroidM
   private void addAndroidLibraryDependencies(@NotNull Project androidProject) {
     for (Module flutterModule : FlutterModuleUtils.getModules(getProject())) {
       if (FlutterModuleUtils.isFlutterModule(flutterModule)) {
-        for (Module module : ModuleManager.getInstance(androidProject).getModules()) {
+        for (Module module : OpenApiUtils.getModules(androidProject)) {
           addAndroidLibraryDependencies(androidProject, module, flutterModule);
         }
       }
@@ -122,9 +111,11 @@ public class AndroidModuleLibraryManager extends AbstractLibraryManager<AndroidM
     if (currentSdk != null) {
       // TODO(messick) Add sdk dependency on currentSdk if not already set
     }
-    LibraryTable androidProjectLibraryTable = LibraryTablesRegistrar.getInstance().getLibraryTable(androidProject);
+    LibraryTable androidProjectLibraryTable = OpenApiUtils.getLibraryTable(androidProject);
+    if (androidProjectLibraryTable == null) return;
     Library[] androidProjectLibraries = androidProjectLibraryTable.getLibraries();
-    LibraryTable flutterProjectLibraryTable = LibraryTablesRegistrar.getInstance().getLibraryTable(getProject());
+    LibraryTable flutterProjectLibraryTable = OpenApiUtils.getLibraryTable(getProject());
+    if (flutterProjectLibraryTable == null) return;
     Library[] flutterProjectLibraries = flutterProjectLibraryTable.getLibraries();
     Set<String> knownLibraryNames = new HashSet<>(flutterProjectLibraries.length);
     for (Library lib : flutterProjectLibraries) {
@@ -149,7 +140,7 @@ public class AndroidModuleLibraryManager extends AbstractLibraryManager<AndroidM
 
   @Override
   protected void updateModuleLibraryDependencies(@NotNull Library library) {
-    for (final Module module : ModuleManager.getInstance(getProject()).getModules()) {
+    for (final Module module : OpenApiUtils.getModules(getProject())) {
       // The logic is inverted wrt superclass.
       if (!FlutterModuleUtils.declaresFlutter(module)) {
         addFlutterLibraryDependency(module, library);
@@ -161,7 +152,7 @@ public class AndroidModuleLibraryManager extends AbstractLibraryManager<AndroidM
   }
 
   private void updateAndroidModuleLibraryDependencies(Module flutterModule) {
-    for (final Module module : ModuleManager.getInstance(getProject()).getModules()) {
+    for (final Module module : OpenApiUtils.getModules(getProject())) {
       if (module != flutterModule) {
         if (null != FacetManager.getInstance(module).findFacet(AndroidFacet.ID, "Android")) {
           Object circularModules = CircularModuleDependenciesDetector.addingDependencyFormsCircularity(module, flutterModule);

--- a/flutter-studio/src/io/flutter/utils/GradleUtils.java
+++ b/flutter-studio/src/io/flutter/utils/GradleUtils.java
@@ -14,7 +14,6 @@ import com.android.tools.idea.gradle.dsl.parser.elements.GradleDslLiteral;
 import com.android.tools.idea.gradle.dsl.parser.files.GradleSettingsFile;
 import com.android.tools.idea.gradle.project.sync.GradleSyncState;
 import com.android.tools.idea.gradle.util.GradleProjectSystemUtil;
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.externalSystem.model.DataNode;
 import com.intellij.openapi.externalSystem.model.ExternalProjectInfo;
 import com.intellij.openapi.externalSystem.model.ProjectKeys;
@@ -126,7 +125,7 @@ public class GradleUtils {
       }
       if (!col.isEmpty()) {
         if (col.parallelStream().anyMatch((x) -> x.startsWith(FLUTTER_TASK_PREFIX))) {
-          ApplicationManager.getApplication().invokeLater(() -> enableCoEditing(project));
+          OpenApiUtils.safeInvokeLater(() -> enableCoEditing(project));
         }
       }
     }
@@ -418,7 +417,7 @@ public class GradleUtils {
     }
 
     private void createBuildFile() {
-      ApplicationManager.getApplication().runWriteAction(() -> {
+      OpenApiUtils.safeRunWriteAction(() -> {
         try {
           buildFile = flutterModuleDir.findOrCreateChildData(this, SdkConstants.FN_BUILD_GRADLE);
         }
@@ -429,7 +428,7 @@ public class GradleUtils {
     }
 
     private void writeBuildFile() {
-      ApplicationManager.getApplication().runWriteAction(() -> {
+      OpenApiUtils.safeRunWriteAction(() -> {
         try (OutputStream out = new BufferedOutputStream(buildFile.getOutputStream(this))) {
           out.write("buildscript {}".getBytes(StandardCharsets.UTF_8));
         }
@@ -484,7 +483,7 @@ public class GradleUtils {
     }
 
     private void writeSettingsFile(String newContent, String originalContent) {
-      ApplicationManager.getApplication().runWriteAction(() -> {
+      OpenApiUtils.safeRunWriteAction(() -> {
         try (OutputStream out = new BufferedOutputStream(settingsFile.getOutputStream(this))) {
           out.write(newContent.getBytes(StandardCharsets.UTF_8));
         }


### PR DESCRIPTION
Currently there are a number of common platform accesses that are not safe, prone to runtime exceptions and spam the inspection log with nullability warnings. This change introduces a host of wrappers around common IntelliJ Open API calls that introduce null-safety, reducing NPE risk, quieting 86 "Nullability and data flow problems" inspections.

Specifically, this change introduces and migrates calls to new `OpenApiUtils` utility methods:

* `safeRunWriteAction`
* `safeInvokeAndWait`
* `safeInvokeLater`
* `getModules`
* `getLibraryTable`
* `getContentRoots`
 

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
