### PR TITLE
[CQ] remove redundant throws

### DIFF
--- a/flutter-idea/src/io/flutter/view/EmbeddedBrowser.java
+++ b/flutter-idea/src/io/flutter/view/EmbeddedBrowser.java
@@ -227,7 +227,7 @@ public abstract class EmbeddedBrowser {
     return tab;
   }
 
-  public abstract EmbeddedTab openEmbeddedTab(ContentManager contentManager) throws Exception;
+  public abstract EmbeddedTab openEmbeddedTab(ContentManager contentManager);
 
   public void updatePanelToWidget(String widgetId) {
     updateUrlAndReload(devToolsUrl -> {

--- a/flutter-idea/src/io/flutter/view/EmbeddedJcefBrowser.java
+++ b/flutter-idea/src/io/flutter/view/EmbeddedJcefBrowser.java
@@ -40,7 +40,8 @@ class EmbeddedJcefBrowserTab implements EmbeddedTab {
 
   @Override
   public JComponent getTabComponent(ContentManager contentManager) {
-    browser.getComponent().setPreferredSize(new Dimension(contentManager.getComponent().getWidth(), contentManager.getComponent().getHeight()));
+    browser.getComponent()
+      .setPreferredSize(new Dimension(contentManager.getComponent().getWidth(), contentManager.getComponent().getHeight()));
     return browser.getComponent();
   }
 }
@@ -62,7 +63,7 @@ public class EmbeddedJcefBrowser extends EmbeddedBrowser {
   }
 
   @Override
-  public EmbeddedTab openEmbeddedTab(ContentManager contentManager) throws Exception {
+  public EmbeddedTab openEmbeddedTab(ContentManager contentManager) {
     return new EmbeddedJcefBrowserTab();
   }
 }


### PR DESCRIPTION
From the inspection description:

> Reports exceptions that are declared in a method's signature but never thrown by the method itself or its implementations and overriding methods.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
