### PR TITLE
[fix] remove infinitely recursive `getConfiguration` call

### DIFF
--- a/flutter-idea/src/io/flutter/run/test/FlutterTestConsoleProperties.java
+++ b/flutter-idea/src/io/flutter/run/test/FlutterTestConsoleProperties.java
@@ -7,7 +7,6 @@ package io.flutter.run.test;
 
 import com.intellij.execution.Executor;
 import com.intellij.execution.configurations.RunConfiguration;
-import com.intellij.execution.configurations.RunProfile;
 import com.intellij.execution.testframework.sm.runner.SMTRunnerConsoleProperties;
 import org.jetbrains.annotations.NotNull;
 
@@ -18,10 +17,5 @@ public class FlutterTestConsoleProperties extends SMTRunnerConsoleProperties {
 
   public FlutterTestConsoleProperties(@NotNull RunConfiguration config, @NotNull Executor executor) {
     super(config, "FlutterWidgetTests", executor);
-  }
-
-  @Override
-  public RunProfile getConfiguration() {
-    return getConfiguration();
   }
 }


### PR DESCRIPTION
And out of the noise of inspection spam, comes an interesting one. Any calls to `getConfiguration()` will result in an infinite regress.

![image](https://github.com/user-attachments/assets/235cfde7-cf2e-4cd8-b3e9-7fb381b04f87)

Defaulting to `super` seems like a reasonable thing to do here.

---

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
