### PR TITLE
[CQ] suppress ignored results

### DIFF
--- a/flutter-idea/src/io/flutter/logging/DiagnosticsNode.java
+++ b/flutter-idea/src/io/flutter/logging/DiagnosticsNode.java
@@ -19,7 +19,10 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -488,7 +491,7 @@ public class DiagnosticsNode {
     return value.getAsBoolean();
   }
 
-  private DiagnosticLevel getLevelMember(String memberName, DiagnosticLevel defaultValue) {
+  private DiagnosticLevel getLevelMember(String memberName, @NotNull DiagnosticLevel defaultValue) {
     if (!json.has(memberName)) {
       return defaultValue;
     }

--- a/flutter-idea/src/io/flutter/logging/FlutterConsoleLogManager.java
+++ b/flutter-idea/src/io/flutter/logging/FlutterConsoleLogManager.java
@@ -45,7 +45,10 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.concurrent.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -516,8 +519,8 @@ public class FlutterConsoleLogManager {
     return ref.getValueAsString() + "...";
   }
 
-  private String getFullStringValue(@NotNull VmService service, String isolateId, @Nullable InstanceRef ref) {
-    if (ref == null) return null;
+  private @Nullable String getFullStringValue(@NotNull VmService service, @Nullable String isolateId, @Nullable InstanceRef ref) {
+    if (ref == null || isolateId == null) return null;
 
     if (!ref.getValueAsStringIsTruncated()) {
       return ref.getValueAsString();
@@ -553,10 +556,12 @@ public class FlutterConsoleLogManager {
     });
 
     try {
+      // The return can be safely ignored. An unset result will just return 0.
+      //noinspection ResultOfMethodCallIgnored
       latch.await(1, TimeUnit.SECONDS);
     }
     catch (InterruptedException e) {
-      return null;
+      // Fall through to returning an empty result.
     }
 
     return result[0];

--- a/flutter-idea/testSrc/unit/io/flutter/view/FlutterViewTest.java
+++ b/flutter-idea/testSrc/unit/io/flutter/view/FlutterViewTest.java
@@ -10,6 +10,7 @@ import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.ui.content.ContentFactory;
+import com.intellij.ui.content.ContentManager;
 import io.flutter.ObservatoryConnector;
 import io.flutter.devtools.DevToolsIdeFeature;
 import io.flutter.jxbrowser.FailureType;
@@ -22,8 +23,10 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.mockito.*;
-import com.intellij.ui.content.ContentManager;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
 
 import java.util.concurrent.TimeoutException;
 
@@ -53,6 +56,7 @@ public class FlutterViewTest {
 
       // Static mocking for ApplicationManager.
       mockedStaticApplicationManager = Mockito.mockStatic(ApplicationManager.class);
+      //noinspection ResultOfMethodCallIgnored
       mockedStaticApplicationManager.when(ApplicationManager::getApplication).thenReturn(mockApplication);
       doAnswer(invocation -> {
         Runnable runnable = invocation.getArgument(0);
@@ -167,7 +171,8 @@ public class FlutterViewTest {
 
     spy.waitForJxBrowserInstallation(mockApp, mockToolWindow, DevToolsIdeFeature.TOOL_WINDOW);
     verify(spy, times(1))
-      .handleUpdatedJxBrowserStatusOnEventThread(mockApp, mockToolWindow, JxBrowserStatus.INSTALLATION_FAILED, DevToolsIdeFeature.TOOL_WINDOW);
+      .handleUpdatedJxBrowserStatusOnEventThread(mockApp, mockToolWindow, JxBrowserStatus.INSTALLATION_FAILED,
+                                                 DevToolsIdeFeature.TOOL_WINDOW);
   }
 
   @Ignore
@@ -193,7 +198,8 @@ public class FlutterViewTest {
     final FlutterView partialMockFlutterView = mock(FlutterView.class);
     doCallRealMethod().when(partialMockFlutterView)
       .handleUpdatedJxBrowserStatus(mockApp, mockToolWindow, JxBrowserStatus.INSTALLATION_FAILED, DevToolsIdeFeature.TOOL_WINDOW);
-    partialMockFlutterView.handleUpdatedJxBrowserStatus(mockApp, mockToolWindow, JxBrowserStatus.INSTALLATION_FAILED, DevToolsIdeFeature.TOOL_WINDOW);
+    partialMockFlutterView.handleUpdatedJxBrowserStatus(mockApp, mockToolWindow, JxBrowserStatus.INSTALLATION_FAILED,
+                                                        DevToolsIdeFeature.TOOL_WINDOW);
     verify(partialMockFlutterView, times(1)).handleJxBrowserInstallationFailed(mockApp, mockToolWindow, DevToolsIdeFeature.TOOL_WINDOW);
   }
 
@@ -213,7 +219,8 @@ public class FlutterViewTest {
     final FlutterView partialMockFlutterView = mock(FlutterView.class);
     doCallRealMethod().when(partialMockFlutterView)
       .handleUpdatedJxBrowserStatus(mockApp, mockToolWindow, JxBrowserStatus.NOT_INSTALLED, DevToolsIdeFeature.TOOL_WINDOW);
-    partialMockFlutterView.handleUpdatedJxBrowserStatus(mockApp, mockToolWindow, JxBrowserStatus.NOT_INSTALLED, DevToolsIdeFeature.TOOL_WINDOW);
+    partialMockFlutterView.handleUpdatedJxBrowserStatus(mockApp, mockToolWindow, JxBrowserStatus.NOT_INSTALLED,
+                                                        DevToolsIdeFeature.TOOL_WINDOW);
     verify(partialMockFlutterView, times(1))
       .presentOpenDevToolsOptionWithMessage(mockApp, mockToolWindow, INSTALLATION_WAIT_FAILED, DevToolsIdeFeature.TOOL_WINDOW);
   }


### PR DESCRIPTION
These unused results can be safely ignored. (The latch case took some thinking through so I added a comment.)

![image](https://github.com/user-attachments/assets/e4c9d047-59a6-44c9-a47a-b9991e19113a)

---

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
