### PR TITLE
[CQ] migrate off deprecated `moduleAdded` API

### DIFF
--- a/flutter-idea/src/io/flutter/FlutterInitializer.java
+++ b/flutter-idea/src/io/flutter/FlutterInitializer.java
@@ -9,7 +9,9 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 import com.intellij.ide.plugins.PluginManagerCore;
 import com.intellij.ide.ui.UISettingsListener;
-import com.intellij.notification.*;
+import com.intellij.notification.Notification;
+import com.intellij.notification.NotificationType;
+import com.intellij.notification.Notifications;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.application.ApplicationManager;
@@ -123,8 +125,8 @@ public class FlutterInitializer implements StartupActivity {
     else {
       project.getMessageBus().connect().subscribe(ModuleListener.TOPIC, new ModuleListener() {
         @Override
-        public void moduleAdded(@NotNull Project project, @NotNull Module module) {
-          if (!toolWindowsInitialized && FlutterModuleUtils.isFlutterModule(module)) {
+        public void modulesAdded(@NotNull Project project, @NotNull List<? extends Module> modules) {
+          if (!toolWindowsInitialized && modules.stream().anyMatch(FlutterModuleUtils::isFlutterModule)) {
             initializeToolWindows(project);
           }
         }


### PR DESCRIPTION
The `moduleAdded` callback has been deprecated in favor of a more general `modulesAdded`:

![image](https://github.com/user-attachments/assets/2ea14067-bb8c-499a-a14d-3d29674c922c)

with source/recommendation:

<img width="849" alt="image" src="https://github.com/user-attachments/assets/665138b4-9a2e-49a0-aae8-77ed1426c901" />

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
