### PR TITLE
[CQ] remove slated-for-removal `Welcome.CreateNewProject` reference

### DIFF
--- a/flutter-studio/src/io/flutter/actions/FlutterNewProjectAction.java
+++ b/flutter-studio/src/io/flutter/actions/FlutterNewProjectAction.java
@@ -5,7 +5,6 @@
  */
 package io.flutter.actions;
 
-import com.intellij.icons.AllIcons;
 import com.intellij.ide.impl.NewProjectUtil;
 import com.intellij.ide.projectWizard.NewProjectWizard;
 import com.intellij.openapi.actionSystem.ActionUpdateThread;
@@ -14,12 +13,7 @@ import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.roots.ui.configuration.ModulesProvider;
 import com.intellij.openapi.wm.impl.welcomeScreen.NewWelcomeScreen;
-import com.intellij.ui.LayeredIcon;
-import com.intellij.ui.OffsetIcon;
-import icons.FlutterIcons;
 import io.flutter.FlutterBundle;
-import javax.swing.Icon;
-
 import io.flutter.FlutterUtils;
 import org.jetbrains.annotations.NotNull;
 
@@ -32,7 +26,6 @@ public class FlutterNewProjectAction extends AnAction implements DumbAware {
   @Override
   public void update(@NotNull AnActionEvent e) {
     if (NewWelcomeScreen.isNewWelcomeScreen(e)) {
-      //e.getPresentation().setIcon(getFlutterDecoratedIcon());
       e.getPresentation().setText(FlutterBundle.message("welcome.new.project.compact"));
     }
   }
@@ -50,16 +43,5 @@ public class FlutterNewProjectAction extends AnAction implements DumbAware {
   @NotNull
   public ActionUpdateThread getActionUpdateThread() {
     return ActionUpdateThread.BGT;
-  }
-
-  @NotNull
-  Icon getFlutterDecoratedIcon() {
-    Icon icon = AllIcons.Welcome.CreateNewProject;
-    Icon badgeIcon = new OffsetIcon(0, FlutterIcons.Flutter_badge).scale(0.666f);
-
-    LayeredIcon decorated = new LayeredIcon(2);
-    decorated.setIcon(badgeIcon, 0, 7, 7);
-    decorated.setIcon(icon, 1, 0, 0);
-    return decorated;
   }
 }


### PR DESCRIPTION
Removes `Welcome.CreateNewProject` which is slated for removal.

![image](https://github.com/user-attachments/assets/0f220bac-8e30-493c-8afc-7537b0810bf5)


Interestingly this code has been dead since https://github.com/flutter/flutter-intellij/commit/6350cf8d1da5fc8d4739a2519ca22dfdc037bfcb#diff-677d60b823c040a662bc3a70f9be4541281838b806d79c129da0e1227bada185.

See: https://github.com/flutter/flutter-intellij/issues/7718

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
