### PR TITLE
[CQ] Nullability: add missing annotations to overrides

### DIFF
--- a/flutter-idea/src/io/flutter/FlutterErrorReportSubmitter.java
+++ b/flutter-idea/src/io/flutter/FlutterErrorReportSubmitter.java
@@ -51,7 +51,7 @@ public class FlutterErrorReportSubmitter extends ErrorReportSubmitter {
   }
 
   //@Override
-  public boolean submit(@NotNull IdeaLoggingEvent[] events,
+  public boolean submit(@NotNull IdeaLoggingEvent @NotNull [] events,
                         @Nullable String additionalInfo,
                         @NotNull Component parentComponent,
                         @NotNull Consumer<? super SubmittedReportInfo> consumer) {

--- a/flutter-idea/src/io/flutter/project/FlutterProjectOpenProcessor.java
+++ b/flutter-idea/src/io/flutter/project/FlutterProjectOpenProcessor.java
@@ -26,9 +26,8 @@ import java.util.Objects;
 public class FlutterProjectOpenProcessor extends ProjectOpenProcessor {
   private static final Logger LOG = Logger.getInstance(FlutterProjectOpenProcessor.class);
 
-  @NotNull
   @Override
-  public String getName() {
+  public @NotNull String getName() {
     return FlutterBundle.message("flutter.module.name");
   }
 

--- a/flutter-idea/src/io/flutter/run/FlutterPositionMapper.java
+++ b/flutter-idea/src/io/flutter/run/FlutterPositionMapper.java
@@ -109,7 +109,8 @@ public class FlutterPositionMapper implements DartVmServiceDebugProcess.Position
 
   @NotNull
   public Project getProject() {
-    return project;
+    // Project may be null after shutdown but clients have no business accessing it after that so it's reasonable to fail here.
+    return Objects.requireNonNull(project);
   }
 
   public void onConnect(@NotNull DartVmServiceDebugProcess.ScriptProvider provider, @Nullable String remoteBaseUri) {
@@ -330,9 +331,10 @@ public class FlutterPositionMapper implements DartVmServiceDebugProcess.Position
       if (analyzer != null && !isDartPatchUri(remoteUri)) {
         final String path = analyzer.getAbsolutePath(remoteUri);
         if (path != null) {
-          if(path.startsWith("file://")) {
+          if (path.startsWith("file://")) {
             LocalFileSystem.getInstance().findFileByPath(path.substring(7));
-          } else {
+          }
+          else {
             LocalFileSystem.getInstance().findFileByPath(path);
           }
         }

--- a/flutter-idea/src/io/flutter/run/SdkRunConfig.java
+++ b/flutter-idea/src/io/flutter/run/SdkRunConfig.java
@@ -96,7 +96,7 @@ public class SdkRunConfig extends LocatableConfigurationBase<LaunchState>
     }
 
     @Override
-    public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+    public @NotNull FileVisitResult visitFile(Path file, @NotNull BasicFileAttributes attrs) {
       final Path name = file.getFileName();
       if (name != null && matcher.matches(name)) {
         try {
@@ -111,12 +111,12 @@ public class SdkRunConfig extends LocatableConfigurationBase<LaunchState>
     }
 
     @Override
-    public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
+    public @NotNull FileVisitResult preVisitDirectory(@NotNull Path dir, @NotNull BasicFileAttributes attrs) {
       return CONTINUE;
     }
 
     @Override
-    public FileVisitResult visitFileFailed(Path file, IOException exc) {
+    public @NotNull FileVisitResult visitFileFailed(@NotNull Path file, @NotNull IOException exc) {
       FlutterUtils.warn(LOG, exc);
       return CONTINUE;
     }
@@ -199,11 +199,11 @@ public class SdkRunConfig extends LocatableConfigurationBase<LaunchState>
   }
 
   static @NotNull FlutterApp getFlutterApp(@NotNull ExecutionEnvironment env,
-                                            @NotNull FlutterDevice device,
-                                            Project project,
-                                            Module module,
-                                            RunMode mode,
-                                            GeneralCommandLine command) throws ExecutionException {
+                                           @NotNull FlutterDevice device,
+                                           Project project,
+                                           Module module,
+                                           RunMode mode,
+                                           GeneralCommandLine command) throws ExecutionException {
     final FlutterApp app = FlutterApp.start(env, project, module, mode, device, command,
                                             StringUtil.capitalize(mode.mode()) + "App",
                                             "StopApp");

--- a/flutter-idea/src/io/flutter/run/coverage/FlutterCoverageEngine.java
+++ b/flutter-idea/src/io/flutter/run/coverage/FlutterCoverageEngine.java
@@ -5,21 +5,14 @@
  */
 package io.flutter.run.coverage;
 
-import com.intellij.coverage.CoverageAnnotator;
-import com.intellij.coverage.CoverageEngine;
-import com.intellij.coverage.CoverageFileProvider;
-import com.intellij.coverage.CoverageRunner;
-import com.intellij.coverage.CoverageSuite;
-import com.intellij.coverage.CoverageSuitesBundle;
+import com.intellij.coverage.*;
 import com.intellij.execution.configurations.RunConfigurationBase;
 import com.intellij.execution.configurations.RunProfile;
 import com.intellij.execution.configurations.WrappingRunConfiguration;
 import com.intellij.execution.configurations.coverage.CoverageEnabledConfiguration;
-import com.intellij.execution.testframework.AbstractTestProxy;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
-import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.jetbrains.lang.dart.DartFileType;
 import com.jetbrains.lang.dart.psi.DartFile;
@@ -27,14 +20,12 @@ import io.flutter.FlutterBundle;
 import io.flutter.FlutterUtils;
 import io.flutter.pub.PubRoot;
 import io.flutter.run.test.TestConfig;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
-
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 public class FlutterCoverageEngine extends CoverageEngine {
 
@@ -132,16 +123,6 @@ public class FlutterCoverageEngine extends CoverageEngine {
     final Set<String> qualifiedNames = new HashSet<>();
     qualifiedNames.add(getQName(sourceFile));
     return qualifiedNames;
-  }
-
-  @Override
-  public List<PsiElement> findTestsByNames(@NotNull String[] testNames, @NotNull Project project) {
-    return null;
-  }
-
-  @Override
-  public @Nullable String getTestMethodName(@NotNull PsiElement element, @NotNull AbstractTestProxy testProxy) {
-    return null;
   }
 
   @Override

--- a/flutter-idea/third_party/vmServiceDrivers/org/dartlang/vm/service/element/ElementList.java
+++ b/flutter-idea/third_party/vmServiceDrivers/org/dartlang/vm/service/element/ElementList.java
@@ -2,6 +2,7 @@ package org.dartlang.vm.service.element;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.Iterator;
 
@@ -27,7 +28,7 @@ public abstract class ElementList<T> implements Iterable<T> {
   }
 
   @Override
-  public Iterator<T> iterator() {
+  public @NotNull Iterator<T> iterator() {
     return new Iterator<T>() {
       int index = 0;
 

--- a/flutter-studio/src/io/flutter/actions/OpenAndroidModule.java
+++ b/flutter-studio/src/io/flutter/actions/OpenAndroidModule.java
@@ -33,7 +33,7 @@ import static com.intellij.openapi.fileChooser.impl.FileChooserUtil.setLastOpene
  */
 public class OpenAndroidModule extends OpenInAndroidStudioAction implements DumbAware {
   @Override
-  public void actionPerformed(AnActionEvent e) {
+  public void actionPerformed(@NotNull AnActionEvent e) {
     final VirtualFile projectFile = findProjectFile(e);
     if (projectFile == null) {
       FlutterMessages.showError("Error Opening Android Studio", "Project not found.", e.getProject());

--- a/flutter-studio/src/io/flutter/android/AndroidModuleLibraryManager.java
+++ b/flutter-studio/src/io/flutter/android/AndroidModuleLibraryManager.java
@@ -5,11 +5,6 @@
  */
 package io.flutter.android;
 
-import static com.android.tools.idea.gradle.util.GradleProjectSystemUtil.GRADLE_SYSTEM_ID;
-import static com.google.wireless.android.sdk.stats.GradleSyncStats.Trigger.TRIGGER_PROJECT_MODIFIED;
-import static io.flutter.android.AndroidModuleLibraryType.LIBRARY_KIND;
-import static io.flutter.android.AndroidModuleLibraryType.LIBRARY_NAME;
-
 import com.android.tools.idea.gradle.project.sync.GradleSyncInvoker;
 import com.android.tools.idea.gradle.project.sync.GradleSyncListener;
 import com.intellij.facet.FacetManager;
@@ -29,12 +24,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.impl.ProjectImpl;
 import com.intellij.openapi.project.impl.ProjectManagerImpl;
 import com.intellij.openapi.projectRoots.Sdk;
-import com.intellij.openapi.roots.DependencyScope;
-import com.intellij.openapi.roots.JavaProjectModelModifier;
-import com.intellij.openapi.roots.ModuleRootEvent;
-import com.intellij.openapi.roots.ModuleRootListener;
-import com.intellij.openapi.roots.ModuleRootManager;
-import com.intellij.openapi.roots.OrderRootType;
+import com.intellij.openapi.roots.*;
 import com.intellij.openapi.roots.impl.IdeaProjectModelModifier;
 import com.intellij.openapi.roots.libraries.Library;
 import com.intellij.openapi.roots.libraries.LibraryTable;
@@ -42,11 +32,7 @@ import com.intellij.openapi.roots.libraries.LibraryTablesRegistrar;
 import com.intellij.openapi.roots.libraries.PersistentLibraryKind;
 import com.intellij.openapi.util.Disposer;
 import com.intellij.openapi.util.io.FileUtilRt;
-import com.intellij.openapi.vfs.LocalFileSystem;
-import com.intellij.openapi.vfs.VfsUtilCore;
-import com.intellij.openapi.vfs.VirtualFile;
-import com.intellij.openapi.vfs.VirtualFileContentsChangedAdapter;
-import com.intellij.openapi.vfs.VirtualFileManager;
+import com.intellij.openapi.vfs.*;
 import com.intellij.serviceContainer.ComponentManagerImpl;
 import com.intellij.util.ReflectionUtil;
 import com.intellij.util.modules.CircularModuleDependenciesDetector;
@@ -54,6 +40,9 @@ import io.flutter.sdk.AbstractLibraryManager;
 import io.flutter.sdk.FlutterSdkUtil;
 import io.flutter.settings.FlutterSettings;
 import io.flutter.utils.FlutterModuleUtils;
+import org.jetbrains.android.facet.AndroidFacet;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -64,9 +53,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import org.jetbrains.android.facet.AndroidFacet;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import static com.android.tools.idea.gradle.util.GradleProjectSystemUtil.GRADLE_SYSTEM_ID;
+import static com.google.wireless.android.sdk.stats.GradleSyncStats.Trigger.TRIGGER_PROJECT_MODIFIED;
+import static io.flutter.android.AndroidModuleLibraryType.LIBRARY_KIND;
+import static io.flutter.android.AndroidModuleLibraryType.LIBRARY_NAME;
 
 /**
  * Manages the Android libraries. Add the libraries used by Android modules referenced in a project
@@ -316,7 +306,7 @@ public class AndroidModuleLibraryManager extends AbstractLibraryManager<AndroidM
 
     static final String TEMPLATE_PROJECT_NAME = "_android";
 
-    public String getLocationHash() {
+    public @NotNull String getLocationHash() {
       return "";
     }
 

--- a/flutter-studio/src/io/flutter/editor/FlutterStudioProjectOpenProcessor.java
+++ b/flutter-studio/src/io/flutter/editor/FlutterStudioProjectOpenProcessor.java
@@ -11,7 +11,6 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.projectImport.ProjectOpenProcessor;
 import com.intellij.ui.EditorNotifications;
 import io.flutter.FlutterUtils;
-//import io.flutter.project.FlutterProjectCreator;
 import io.flutter.project.FlutterProjectOpenProcessor;
 import io.flutter.pub.PubRoot;
 import io.flutter.utils.FlutterModuleUtils;
@@ -20,7 +19,7 @@ import org.jetbrains.annotations.Nullable;
 
 public class FlutterStudioProjectOpenProcessor extends FlutterProjectOpenProcessor {
   @Override
-  public String getName() {
+  public @NotNull String getName() {
     return "Flutter Studio";
   }
 


### PR DESCRIPTION
Addresses a number of places where we're overriding methods that provide nullability guarantees that we're not respecting in our implementations. Also removes a few unstable overrides (that were just duplicating super behavior anyway).

![image](https://github.com/user-attachments/assets/a843b919-b709-4762-b611-b4b45a93a59f)




---

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
