### PR TITLE
[perf] optimize EDT `SdkRunConfig.getState`

### DIFF
--- a/flutter-idea/src/io/flutter/run/MainFile.java
+++ b/flutter-idea/src/io/flutter/run/MainFile.java
@@ -6,8 +6,8 @@
 package io.flutter.run;
 
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.project.BaseProjectDirectories;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.roots.ProjectRootManager;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.LocalFileSystem;
@@ -79,9 +79,13 @@ public class MainFile {
    * If there is an error, {@link Result#canLaunch} will return false and the error is available via {@link Result#getError}
    */
   @NotNull
-  public static MainFile.Result verify(@Nullable String path, Project project) {
+  public static MainFile.Result verify(@Nullable String path, @Nullable Project project) {
     if (!ApplicationManager.getApplication().isReadAccessAllowed()) {
       throw new IllegalStateException("need read access");
+    }
+
+    if (project == null) {
+      return error("Project is not set.");
     }
 
     if (StringUtil.isEmptyOrSpaces(path)) {
@@ -123,7 +127,7 @@ public class MainFile {
   private static VirtualFile findAppDir(@Nullable VirtualFile file, @NotNull Project project) {
     if (WorkspaceCache.getInstance(project).isBazel()) {
       final Workspace workspace = WorkspaceCache.getInstance(project).get();
-      assert(workspace != null);
+      assert (workspace != null);
       return workspace.getRoot();
     }
 
@@ -134,7 +138,7 @@ public class MainFile {
   }
 
   private static boolean isAppDir(@NotNull VirtualFile dir, @NotNull Project project) {
-    assert(!WorkspaceCache.getInstance(project).isBazel());
+    assert (!WorkspaceCache.getInstance(project).isBazel());
     return dir.isDirectory() && (
       dir.findChild(PubRoot.PUBSPEC_YAML) != null ||
       dir.findChild(PubRoot.DOT_DART_TOOL) != null ||
@@ -143,7 +147,10 @@ public class MainFile {
   }
 
   private static boolean inProject(@Nullable VirtualFile file, @NotNull Project project) {
-    return file != null && ProjectRootManager.getInstance(project).getFileIndex().isInContent(file);
+    // Do a speedy check for containment over accessing the file index (which we did historically)
+    // but is very slow and unacceptably blocks the UI thread.
+    // See: https://github.com/flutter/flutter-intellij/issues/8089
+    return file != null && BaseProjectDirectories.getInstance(project).contains(file);
   }
 
   /**

--- a/flutter-idea/src/io/flutter/run/SdkRunConfig.java
+++ b/flutter-idea/src/io/flutter/run/SdkRunConfig.java
@@ -136,9 +136,10 @@ public class SdkRunConfig extends LocatableConfigurationBase<LaunchState>
     final MainFile mainFile = MainFile.verify(launchFields.getFilePath(), env.getProject()).get();
     final Project project = env.getProject();
     final RunMode mode = RunMode.fromEnv(env);
-    final Module module = ModuleUtilCore.findModuleForFile(mainFile.getFile(), env.getProject());
+
     final LaunchState.CreateAppCallback createAppCallback = (@Nullable FlutterDevice device) -> {
       if (device == null) return null;
+      if (mainFile == null) return null;
 
       final GeneralCommandLine command = getCommand(env, device);
 
@@ -190,20 +191,23 @@ public class SdkRunConfig extends LocatableConfigurationBase<LaunchState>
         }
       }
 
+      var module = ModuleUtilCore.findModuleForFile(mainFile.getFile(), env.getProject());
+      if (module == null) return null;
+
       return getFlutterApp(env, device, project, module, mode, command);
     };
 
     final LaunchState launcher = new LaunchState(env, mainFile.getAppDir(), mainFile.getFile(), this, createAppCallback);
-    addConsoleFilters(launcher, env, mainFile, module);
+    addConsoleFilters(launcher, env, mainFile, null /* look up the module in an async read context */);
     return launcher;
   }
 
   static @NotNull FlutterApp getFlutterApp(@NotNull ExecutionEnvironment env,
-                                            @NotNull FlutterDevice device,
-                                            Project project,
-                                            Module module,
-                                            RunMode mode,
-                                            GeneralCommandLine command) throws ExecutionException {
+                                           @NotNull FlutterDevice device,
+                                           Project project,
+                                           Module module,
+                                           RunMode mode,
+                                           GeneralCommandLine command) throws ExecutionException {
     final FlutterApp app = FlutterApp.start(env, project, module, mode, device, command,
                                             StringUtil.capitalize(mode.mode()) + "App",
                                             "StopApp");
@@ -224,10 +228,18 @@ public class SdkRunConfig extends LocatableConfigurationBase<LaunchState>
   protected void addConsoleFilters(@NotNull LaunchState launcher,
                                    @NotNull ExecutionEnvironment env,
                                    @NotNull MainFile mainFile,
+                                   // If unspecified, we'll try and find it in a non-blocking read context.
                                    @Nullable Module module) {
     // Creating console filters is expensive so we want to make sure we are not blocking.
     // See: https://github.com/flutter/flutter-intellij/issues/8089
     ReadAction.nonBlocking(() -> {
+        // Make a copy of the module reference, since we may update it in this lambda.
+        var moduleReference = module;
+        // If no module was passed in, try and find one.
+        if (moduleReference == null) {
+          moduleReference = ModuleUtilCore.findModuleForFile(mainFile.getFile(), env.getProject());
+        }
+
         // Set up additional console filters.
         final TextConsoleBuilder builder = launcher.getConsoleBuilder();
         if (builder == null) return null;
@@ -235,9 +247,9 @@ public class SdkRunConfig extends LocatableConfigurationBase<LaunchState>
         builder.addFilter(new DartConsoleFilter(env.getProject(), mainFile.getFile()));
         //// links often found when running tests
         //builder.addFilter(new DartRelativePathsConsoleFilter(env.getProject(), mainFile.getAppDir().getPath()));
-        if (module != null) {
+        if (moduleReference != null) {
           // various flutter run links
-          builder.addFilter(new FlutterConsoleFilter(module));
+          builder.addFilter(new FlutterConsoleFilter(moduleReference));
         }
         // general urls
         builder.addFilter(new UrlFilter());


### PR DESCRIPTION
Speeds up `SdkRunConfig.getState` which necessarily runs on the Event Dispatch Thread.

The fix has two parts:

1. Move the expensive call to `ModuleUtilCore.findModuleForFile(..)` into an async read action (because we can) and
2. Speed up `inProject` because we can't background it and there's a speedy alternative to the old more expensive approach

Addresses stack traces like this:

```
java.lang.Throwable: Slow operations are prohibited on EDT. See SlowOperations.assertSlowOperationsAreAllowed javadoc.
	at com.intellij.openapi.diagnostic.Logger.error(Logger.java:376)
	at com.intellij.util.SlowOperations.assertSlowOperationsAreAllowed(SlowOperations.java:114)
	at com.intellij.workspaceModel.core.fileIndex.impl.WorkspaceFileIndexDataImpl.ensureIsUpToDate(WorkspaceFileIndexDataImpl.kt:153)
	at com.intellij.workspaceModel.core.fileIndex.impl.WorkspaceFileIndexDataImpl.getFileInfo(WorkspaceFileIndexDataImpl.kt:98)
	at com.intellij.workspaceModel.core.fileIndex.impl.WorkspaceFileIndexImpl.getFileInfo(WorkspaceFileIndexImpl.kt:267)
	at com.intellij.workspaceModel.core.fileIndex.impl.WorkspaceFileIndexImpl.findFileSetWithCustomData(WorkspaceFileIndexImpl.kt:250)
	at com.intellij.openapi.roots.impl.ProjectFileIndexImpl.getModuleForFile(ProjectFileIndexImpl.java:102)
	at com.intellij.openapi.roots.impl.ProjectFileIndexImpl.getModuleForFile(ProjectFileIndexImpl.java:95)
	at com.intellij.openapi.module.ModuleUtilCore.lambda$findModuleForFile$0(ModuleUtilCore.java:84)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runReadAction(AnyThreadWriteThreadingSupport.kt:272)
	at com.intellij.openapi.application.impl.AnyThreadWriteThreadingSupport.runReadAction(AnyThreadWriteThreadingSupport.kt:262)
	at com.intellij.openapi.application.impl.ApplicationImpl.runReadAction(ApplicationImpl.java:863)
	at com.intellij.openapi.application.ReadAction.compute(ReadAction.java:66)
	at com.intellij.openapi.module.ModuleUtilCore.findModuleForFile(ModuleUtilCore.java:84)
	at io.flutter.run.SdkRunConfig.getState(SdkRunConfig.java:139)
	at io.flutter.run.SdkRunConfig.getState(SdkRunConfig.java:59)
```

See: https://github.com/flutter/flutter-intellij/issues/8089

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
