### PR TITLE
Revert deletion of deploy command to fix dev build

### DIFF
--- a/tool/plugin/lib/runner.dart
+++ b/tool/plugin/lib/runner.dart
@@ -12,10 +12,10 @@ import 'util.dart';
 
 class BuildCommandRunner extends CommandRunner<int> {
   BuildCommandRunner()
-      : super(
-          'plugin',
-          'A script to build and test the Flutter IntelliJ plugin.',
-        ) {
+    : super(
+        'plugin',
+        'A script to build, test, and deploy the Flutter IntelliJ plugin.',
+      ) {
     argParser.addOption(
       'release',
       abbr: 'r',

--- a/tool/plugin/lib/runner.dart
+++ b/tool/plugin/lib/runner.dart
@@ -12,10 +12,10 @@ import 'util.dart';
 
 class BuildCommandRunner extends CommandRunner<int> {
   BuildCommandRunner()
-    : super(
-        'plugin',
-        'A script to build, test, and deploy the Flutter IntelliJ plugin.',
-      ) {
+      : super(
+          'plugin',
+          'A script to build, test, and deploy the Flutter IntelliJ plugin.',
+        ) {
     argParser.addOption(
       'release',
       abbr: 'r',
@@ -79,9 +79,8 @@ org.gradle.parallel=true
 org.gradle.jvmargs=-Xms1024m -Xmx4048m
 ''';
     final propertiesFile = File("$rootPath/gradle.properties");
-    final source = propertiesFile.existsSync()
-        ? propertiesFile.readAsStringSync()
-        : null;
+    final source =
+        propertiesFile.existsSync() ? propertiesFile.readAsStringSync() : null;
     propertiesFile.writeAsStringSync(contents);
     int result;
     // Using the Gradle daemon causes a strange problem.


### PR DESCRIPTION
I think this should fix the dev build, which stopped uploading back in February. It uses the command `./bin/plugin deploy --channel=dev` (see `tool/kokoro/deploy.sh`). The deletion happened in https://github.com/flutter/flutter-intellij/pull/7929.

I can't test it from an internal command until these changes are in the main branch though.

It could be we no longer need the dev build, but this seems like an easy enough change.