### PR TITLE
[CQ] rename `Flutter` -> `InspectorView`

### DIFF
--- a/flutter-idea/src/io/flutter/FlutterInitializer.java
+++ b/flutter-idea/src/io/flutter/FlutterInitializer.java
@@ -52,7 +52,7 @@ import io.flutter.settings.FlutterSettings;
 import io.flutter.survey.FlutterSurveyNotifications;
 import io.flutter.utils.FlutterModuleUtils;
 import io.flutter.utils.OpenApiUtils;
-import io.flutter.view.FlutterViewFactory;
+import io.flutter.view.InspectorViewFactory;
 import org.jetbrains.annotations.NotNull;
 
 import java.time.LocalDate;
@@ -366,7 +366,7 @@ public class FlutterInitializer implements StartupActivity {
 
   private void initializeToolWindows(@NotNull final Project project) {
     // Start watching for Flutter debug active events.
-    FlutterViewFactory.init(project);
+    InspectorViewFactory.init(project);
     RemainingDevToolsViewFactory.init(project);
     DevToolsExtensionsViewFactory.init(project);
     toolWindowsInitialized = true;

--- a/flutter-idea/src/io/flutter/logging/FlutterConsoleLogManager.java
+++ b/flutter-idea/src/io/flutter/logging/FlutterConsoleLogManager.java
@@ -35,7 +35,7 @@ import io.flutter.run.daemon.FlutterApp;
 import io.flutter.settings.FlutterSettings;
 import io.flutter.utils.JsonUtils;
 import io.flutter.view.EmbeddedBrowser;
-import io.flutter.view.FlutterView;
+import io.flutter.view.InspectorView;
 import io.flutter.vmService.VmServiceConsumers;
 import org.dartlang.vm.service.VmService;
 import org.dartlang.vm.service.consumer.GetObjectConsumer;
@@ -372,7 +372,7 @@ public class FlutterConsoleLogManager {
           return;
         }
 
-        final ToolWindow toolWindow = toolWindowManager.getToolWindow(FlutterView.TOOL_WINDOW_ID);
+        final ToolWindow toolWindow = toolWindowManager.getToolWindow(InspectorView.TOOL_WINDOW_ID);
         if (toolWindow != null && !toolWindow.isVisible()) {
           toolWindow.show();
         }

--- a/flutter-idea/src/io/flutter/toolwindow/InspectorViewToolWindowManagerListener.java
+++ b/flutter-idea/src/io/flutter/toolwindow/InspectorViewToolWindowManagerListener.java
@@ -9,15 +9,15 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowManager;
 import com.intellij.openapi.wm.ex.ToolWindowManagerListener;
-import io.flutter.view.FlutterView;
+import io.flutter.view.InspectorView;
 import org.jetbrains.annotations.NotNull;
 
-public class FlutterViewToolWindowManagerListener implements ToolWindowManagerListener {
+public class InspectorViewToolWindowManagerListener implements ToolWindowManagerListener {
   private boolean inspectorIsOpen;
   private Runnable onWindowOpen;
   private Runnable onWindowFirstVisible;
 
-  public FlutterViewToolWindowManagerListener(Project project, ToolWindow toolWindow) {
+  public InspectorViewToolWindowManagerListener(Project project, ToolWindow toolWindow) {
     project.getMessageBus().connect().subscribe(ToolWindowManagerListener.TOPIC, this);
 
     inspectorIsOpen = toolWindow.isShowStripeButton();
@@ -33,7 +33,7 @@ public class FlutterViewToolWindowManagerListener implements ToolWindowManagerLi
 
   @Override
   public void stateChanged(@NotNull ToolWindowManager toolWindowManager) {
-    final ToolWindow inspectorWindow = toolWindowManager.getToolWindow(FlutterView.TOOL_WINDOW_ID);
+    final ToolWindow inspectorWindow = toolWindowManager.getToolWindow(InspectorView.TOOL_WINDOW_ID);
     if (inspectorWindow == null) {
       return;
     }

--- a/flutter-idea/src/io/flutter/view/InspectorViewFactory.java
+++ b/flutter-idea/src/io/flutter/view/InspectorViewFactory.java
@@ -13,18 +13,17 @@ import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowFactory;
 import com.intellij.openapi.wm.ToolWindowManager;
 import io.flutter.utils.OpenApiUtils;
-import io.flutter.utils.ViewListener;
 import org.jetbrains.annotations.NotNull;
 
-public class FlutterViewFactory implements ToolWindowFactory, DumbAware {
+public class InspectorViewFactory implements ToolWindowFactory, DumbAware {
   private static final String TOOL_WINDOW_VISIBLE_PROPERTY = "flutter.view.tool.window.visible";
 
   public static void init(@NotNull Project project) {
     project.getMessageBus().connect().subscribe(
-      FlutterViewMessages.FLUTTER_DEBUG_TOPIC, (FlutterViewMessages.FlutterDebugNotifier)(event) -> initFlutterView(project, event)
+      FlutterViewMessages.FLUTTER_DEBUG_TOPIC, (FlutterViewMessages.FlutterDebugNotifier)(event) -> initInspectorView(project, event)
     );
 
-    final ToolWindow window = ToolWindowManager.getInstance(project).getToolWindow(FlutterView.TOOL_WINDOW_ID);
+    final ToolWindow window = ToolWindowManager.getInstance(project).getToolWindow(InspectorView.TOOL_WINDOW_ID);
     if (window != null) {
       window.setAvailable(true);
 
@@ -39,10 +38,10 @@ public class FlutterViewFactory implements ToolWindowFactory, DumbAware {
     return false;
   }
 
-  private static void initFlutterView(@NotNull Project project, FlutterViewMessages.FlutterDebugEvent event) {
+  private static void initInspectorView(@NotNull Project project, FlutterViewMessages.FlutterDebugEvent event) {
     OpenApiUtils.safeInvokeLater(() -> {
-      final FlutterView flutterView = project.getService(FlutterView.class);
-      flutterView.debugActive(event);
+      final InspectorView inspectorView = project.getService(InspectorView.class);
+      inspectorView.debugActive(event);
     });
   }
 
@@ -50,13 +49,7 @@ public class FlutterViewFactory implements ToolWindowFactory, DumbAware {
   public void createToolWindowContent(@NotNull Project project, @NotNull ToolWindow toolWindow) {
     //noinspection CodeBlock2Expr
     DumbService.getInstance(project).runWhenSmart(() -> {
-      project.getService(FlutterView.class).initToolWindow(toolWindow);
+      project.getService(InspectorView.class).initToolWindow(toolWindow);
     });
-  }
-
-  public static class FlutterViewListener extends ViewListener {
-    public FlutterViewListener(@NotNull Project project) {
-      super(project, FlutterView.TOOL_WINDOW_ID, TOOL_WINDOW_VISIBLE_PROPERTY);
-    }
   }
 }

--- a/flutter-idea/src/io/flutter/view/InspectorViewState.java
+++ b/flutter-idea/src/io/flutter/view/InspectorViewState.java
@@ -7,18 +7,19 @@ package io.flutter.view;
 
 import com.intellij.util.EventDispatcher;
 import com.intellij.util.xmlb.annotations.Attribute;
+import org.jetbrains.annotations.NotNull;
 
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 
 /**
- * State for the Flutter view.
+ * State for the Inspector view.
  */
-public class FlutterViewState {
+public class InspectorViewState {
   public static final boolean AUTO_SCROLL_DEFAULT = false;
   public static final boolean HIGHLIGHT_NODES_SHOWN_IN_BOTH_TREES_DEFAULT = false;
 
-  private final EventDispatcher<ChangeListener> dispatcher = EventDispatcher.create(ChangeListener.class);
+  private final @NotNull EventDispatcher<ChangeListener> dispatcher = EventDispatcher.create(ChangeListener.class);
 
   @Attribute(value = "splitter-proportion")
   public float splitterProportion;
@@ -29,7 +30,7 @@ public class FlutterViewState {
   @Attribute(value = "highlight-nodes-shown-in-both-trees")
   public boolean highlightNodesShownInBothTrees = HIGHLIGHT_NODES_SHOWN_IN_BOTH_TREES_DEFAULT;
 
-  public FlutterViewState() {
+  public InspectorViewState() {
   }
 
   public float getSplitterProportion() {
@@ -58,7 +59,7 @@ public class FlutterViewState {
     dispatcher.removeListener(listener);
   }
 
-  void copyFrom(FlutterViewState other) {
+  void copyFrom(InspectorViewState other) {
     splitterProportion = other.splitterProportion;
   }
 

--- a/flutter-idea/src/io/flutter/vmService/DisplayRefreshRateManager.java
+++ b/flutter-idea/src/io/flutter/vmService/DisplayRefreshRateManager.java
@@ -79,7 +79,7 @@ public class DisplayRefreshRateManager {
 
   private CompletableFuture<Double> getDisplayRefreshRate() {
     final CompletableFuture<Double> displayRefreshRate = new CompletableFuture<>();
-    vmServiceManager.getFlutterViewId().whenComplete((String id, Throwable throwable) -> {
+    vmServiceManager.getInspectorViewId().whenComplete((String id, Throwable throwable) -> {
       if (throwable != null) {
         // We often see "java.lang.RuntimeException: Method not found" from here; perhaps a race condition?
         LOG.warn(throwable.getMessage());
@@ -102,11 +102,11 @@ public class DisplayRefreshRateManager {
     return displayRefreshRate;
   }
 
-  private CompletableFuture<Double> invokeGetDisplayRefreshRate(String flutterViewId) {
+  private CompletableFuture<Double> invokeGetDisplayRefreshRate(String inspectorViewId) {
     final CompletableFuture<Double> ret = new CompletableFuture<>();
 
     final JsonObject params = new JsonObject();
-    params.addProperty("viewId", flutterViewId);
+    params.addProperty("viewId", inspectorViewId);
 
     vmService.callServiceExtension(
       vmServiceManager.getCurrentFlutterIsolateRaw().getId(), ServiceExtensions.displayRefreshRate, params,

--- a/flutter-idea/src/io/flutter/vmService/VMServiceManager.java
+++ b/flutter-idea/src/io/flutter/vmService/VMServiceManager.java
@@ -518,14 +518,14 @@ public class VMServiceManager implements FlutterApp.FlutterAppListener, Disposab
     }
   }
 
-  public CompletableFuture<String> getFlutterViewId() {
+  public CompletableFuture<String> getInspectorViewId() {
     return getFlutterViewsList().exceptionally(exception -> {
       throw new RuntimeException(exception.getMessage());
     }).thenApplyAsync((JsonElement element) -> {
       final JsonArray viewsList = element.getAsJsonObject().get("views").getAsJsonArray();
       for (JsonElement jsonElement : viewsList) {
         final JsonObject view = jsonElement.getAsJsonObject();
-        if (Objects.equals(view.get("type").getAsString(), "FlutterView")) {
+        if (Objects.equals(view.get("type").getAsString(), "InspectorView")) {
           return view.get("id").getAsString();
         }
       }

--- a/flutter-idea/testSrc/unit/io/flutter/view/InspectorViewTest.java
+++ b/flutter-idea/testSrc/unit/io/flutter/view/InspectorViewTest.java
@@ -30,12 +30,12 @@ import org.mockito.MockitoAnnotations;
 
 import java.util.concurrent.TimeoutException;
 
-import static io.flutter.view.FlutterView.*;
+import static io.flutter.view.InspectorView.*;
 import static org.mockito.Mockito.*;
 
 //@PrepareForTest({ThreadUtil.class, FlutterInitializer.class, JxBrowserUtils.class,
 //  InspectorGroupManagerService.class, SwingUtilities.class})
-public class FlutterViewTest {
+public class InspectorViewTest {
   Project mockProject = mock(Project.class);
   @Mock FlutterApp mockApp;
   @Mock ToolWindow mockToolWindow;
@@ -87,8 +87,8 @@ public class FlutterViewTest {
   public void testHandleJxBrowserInstalled() {
     // If JxBrowser has been installed, we should use the DevTools instance to open the embedded browser.
     final JxBrowserUtils mockJxBrowserUtils = mock(JxBrowserUtils.class);
-    final FlutterView flutterView = new FlutterView(mockProject, mockJxBrowserManager, mockJxBrowserUtils, viewUtilsSpy);
-    final FlutterView spy = spy(flutterView);
+    final InspectorView inspectorView = new InspectorView(mockProject, mockJxBrowserManager, mockJxBrowserUtils, viewUtilsSpy);
+    final InspectorView spy = spy(inspectorView);
 
     doNothing().when(spy).verifyEventDispatchThread();
     doNothing().when(spy).openInspectorWithDevTools(any(), any(), anyBoolean(), any());
@@ -108,8 +108,8 @@ public class FlutterViewTest {
     when(mockJxBrowserManager.getLatestFailureReason()).thenReturn(new InstallationFailedReason(FailureType.FILE_DOWNLOAD_FAILED));
 
     // If JxBrowser failed to install, we should show a failure message that allows the user to manually retry.
-    final FlutterView flutterView = new FlutterView(mockProject, mockJxBrowserManager, mockJxBrowserUtils, viewUtilsSpy);
-    final FlutterView spy = spy(flutterView);
+    final InspectorView inspectorView = new InspectorView(mockProject, mockJxBrowserManager, mockJxBrowserUtils, viewUtilsSpy);
+    final InspectorView spy = spy(inspectorView);
     doNothing().when(viewUtilsSpy).presentClickableLabel(
       eq(mockToolWindow),
       anyList()
@@ -128,8 +128,8 @@ public class FlutterViewTest {
 
     // If the JxBrowser installation is initially in progress, we should show a message about the installation.
     // If the installation quickly finishes (on the first re-check), then we should call the function to handle successful installation.
-    final FlutterView flutterView = new FlutterView(mockProject, mockJxBrowserManager, mockUtils, viewUtilsSpy);
-    final FlutterView spy = spy(flutterView);
+    final InspectorView inspectorView = new InspectorView(mockProject, mockJxBrowserManager, mockUtils, viewUtilsSpy);
+    final InspectorView spy = spy(inspectorView);
 
     doNothing().when(spy).presentOpenDevToolsOptionWithMessage(any(), any(), any(), any());
     doNothing().when(spy).handleJxBrowserInstalled(any(), any(), any());
@@ -146,8 +146,8 @@ public class FlutterViewTest {
 
     // If the JxBrowser installation is in progress and is not finished on the first re-check, we should start a thread to wait for the
     // installation to finish.
-    final FlutterView flutterView = new FlutterView(mockProject, mockJxBrowserManager, mockUtils, viewUtilsSpy);
-    final FlutterView spy = spy(flutterView);
+    final InspectorView inspectorView = new InspectorView(mockProject, mockJxBrowserManager, mockUtils, viewUtilsSpy);
+    final InspectorView spy = spy(inspectorView);
 
     doNothing().when(spy).presentOpenDevToolsOptionWithMessage(any(), any(), any(), any());
     doNothing().when(spy).startJxBrowserInstallationWaitingThread(any(), any(), any());
@@ -164,8 +164,8 @@ public class FlutterViewTest {
     when(mockJxBrowserManager.waitForInstallation(INSTALLATION_WAIT_LIMIT_SECONDS)).thenReturn(JxBrowserStatus.INSTALLATION_FAILED);
 
     // If waiting for JxBrowser installation completes without timing out, then we should return to event thread.
-    final FlutterView flutterView = new FlutterView(mockProject, mockJxBrowserManager, mockUtils, viewUtilsSpy);
-    final FlutterView spy = spy(flutterView);
+    final InspectorView inspectorView = new InspectorView(mockProject, mockJxBrowserManager, mockUtils, viewUtilsSpy);
+    final InspectorView spy = spy(inspectorView);
 
     doNothing().when(spy).handleUpdatedJxBrowserStatusOnEventThread(any(), any(), any(), any());
 
@@ -182,8 +182,8 @@ public class FlutterViewTest {
     when(mockJxBrowserManager.waitForInstallation(INSTALLATION_WAIT_LIMIT_SECONDS)).thenThrow(new TimeoutException());
 
     // If the JxBrowser installation doesn't complete on time, we should show a timed out message.
-    final FlutterView flutterView = new FlutterView(mockProject, mockJxBrowserManager, mockUtils, viewUtilsSpy);
-    final FlutterView spy = spy(flutterView);
+    final InspectorView inspectorView = new InspectorView(mockProject, mockJxBrowserManager, mockUtils, viewUtilsSpy);
+    final InspectorView spy = spy(inspectorView);
 
     doNothing().when(spy).presentOpenDevToolsOptionWithMessage(any(), any(), any(), any());
 
@@ -195,33 +195,34 @@ public class FlutterViewTest {
   @Test
   public void testHandleUpdatedJxBrowserStatusWithFailure() {
     // If waiting for JxBrowser installation completes with failure, then we should redirect to the function that handles failure.
-    final FlutterView partialMockFlutterView = mock(FlutterView.class);
-    doCallRealMethod().when(partialMockFlutterView)
+    final InspectorView partialMockInspectorView = mock(InspectorView.class);
+    doCallRealMethod().when(partialMockInspectorView)
       .handleUpdatedJxBrowserStatus(mockApp, mockToolWindow, JxBrowserStatus.INSTALLATION_FAILED, DevToolsIdeFeature.TOOL_WINDOW);
-    partialMockFlutterView.handleUpdatedJxBrowserStatus(mockApp, mockToolWindow, JxBrowserStatus.INSTALLATION_FAILED,
-                                                        DevToolsIdeFeature.TOOL_WINDOW);
-    verify(partialMockFlutterView, times(1)).handleJxBrowserInstallationFailed(mockApp, mockToolWindow, DevToolsIdeFeature.TOOL_WINDOW);
+    partialMockInspectorView.handleUpdatedJxBrowserStatus(mockApp, mockToolWindow, JxBrowserStatus.INSTALLATION_FAILED,
+                                                          DevToolsIdeFeature.TOOL_WINDOW);
+    verify(partialMockInspectorView, times(1)).handleJxBrowserInstallationFailed(mockApp, mockToolWindow, DevToolsIdeFeature.TOOL_WINDOW);
   }
 
   @Test
   public void testHandleUpdatedJxBrowserStatusWithSuccess() {
     // If waiting for JxBrowser installation completes with failure, then we should redirect to the function that handles failure.
-    final FlutterView partialMockFlutterView = mock(FlutterView.class);
-    doCallRealMethod().when(partialMockFlutterView)
+    final InspectorView partialMockInspectorView = mock(InspectorView.class);
+    doCallRealMethod().when(partialMockInspectorView)
       .handleUpdatedJxBrowserStatus(mockApp, mockToolWindow, JxBrowserStatus.INSTALLED, DevToolsIdeFeature.TOOL_WINDOW);
-    partialMockFlutterView.handleUpdatedJxBrowserStatus(mockApp, mockToolWindow, JxBrowserStatus.INSTALLED, DevToolsIdeFeature.TOOL_WINDOW);
-    verify(partialMockFlutterView, times(1)).handleJxBrowserInstalled(mockApp, mockToolWindow, DevToolsIdeFeature.TOOL_WINDOW);
+    partialMockInspectorView.handleUpdatedJxBrowserStatus(mockApp, mockToolWindow, JxBrowserStatus.INSTALLED,
+                                                          DevToolsIdeFeature.TOOL_WINDOW);
+    verify(partialMockInspectorView, times(1)).handleJxBrowserInstalled(mockApp, mockToolWindow, DevToolsIdeFeature.TOOL_WINDOW);
   }
 
   @Test
   public void testHandleUpdatedJxBrowserStatusWithOtherstatus() {
     // If waiting for JxBrowser installation completes with any other status, then we should recommend opening non-embedded DevTools.
-    final FlutterView partialMockFlutterView = mock(FlutterView.class);
-    doCallRealMethod().when(partialMockFlutterView)
+    final InspectorView partialMockInspectorView = mock(InspectorView.class);
+    doCallRealMethod().when(partialMockInspectorView)
       .handleUpdatedJxBrowserStatus(mockApp, mockToolWindow, JxBrowserStatus.NOT_INSTALLED, DevToolsIdeFeature.TOOL_WINDOW);
-    partialMockFlutterView.handleUpdatedJxBrowserStatus(mockApp, mockToolWindow, JxBrowserStatus.NOT_INSTALLED,
-                                                        DevToolsIdeFeature.TOOL_WINDOW);
-    verify(partialMockFlutterView, times(1))
+    partialMockInspectorView.handleUpdatedJxBrowserStatus(mockApp, mockToolWindow, JxBrowserStatus.NOT_INSTALLED,
+                                                          DevToolsIdeFeature.TOOL_WINDOW);
+    verify(partialMockInspectorView, times(1))
       .presentOpenDevToolsOptionWithMessage(mockApp, mockToolWindow, INSTALLATION_WAIT_FAILED, DevToolsIdeFeature.TOOL_WINDOW);
   }
 }

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -422,7 +422,7 @@
     <codeInsight.lineMarkerProvider language="Dart" implementationClass="io.flutter.editor.FlutterIconLineMarkerProvider"/>
     <errorHandler implementation="io.flutter.FlutterErrorReportSubmitter"/>
 
-    <toolWindow id="Flutter Inspector" anchor="right" icon="FlutterIcons.DevToolsInspector" factoryClass="io.flutter.view.FlutterViewFactory"/>
+    <toolWindow id="Flutter Inspector" anchor="right" icon="FlutterIcons.DevToolsInspector" factoryClass="io.flutter.view.InspectorViewFactory"/>
     <toolWindow id="Flutter Deep Links" anchor="right" icon="FlutterIcons.DevToolsDeepLinks" factoryClass="io.flutter.deeplinks.DeepLinksViewFactory" />
     <toolWindow id="Flutter DevTools" anchor="right" icon="FlutterIcons.DevTools" factoryClass="io.flutter.devtools.RemainingDevToolsViewFactory" />
     <toolWindow id="Flutter DevTools Extensions" anchor="right" icon="FlutterIcons.DevToolsExtensions" factoryClass="io.flutter.devtools.DevToolsExtensionsViewFactory" />
@@ -431,7 +431,7 @@
 
     <!-- Having the projectService defined after the toolWindows allows them to all be picked up by the platform -->
     <!-- See https://github.com/flutter/flutter-intellij/issues/8029 -->
-    <projectService serviceImplementation="io.flutter.view.FlutterView" overrides="false"/>
+    <projectService serviceImplementation="io.flutter.view.InspectorView" overrides="false"/>
 
     <projectOpenProcessor id="flutter" implementation="io.flutter.project.FlutterProjectOpenProcessor" order="first"/>
 

--- a/resources/META-INF/plugin_template.xml
+++ b/resources/META-INF/plugin_template.xml
@@ -324,7 +324,7 @@
     <codeInsight.lineMarkerProvider language="Dart" implementationClass="io.flutter.editor.FlutterIconLineMarkerProvider"/>
     <errorHandler implementation="io.flutter.FlutterErrorReportSubmitter"/>
 
-    <toolWindow id="Flutter Inspector" anchor="right" icon="FlutterIcons.DevToolsInspector" factoryClass="io.flutter.view.FlutterViewFactory"/>
+    <toolWindow id="Flutter Inspector" anchor="right" icon="FlutterIcons.DevToolsInspector" factoryClass="io.flutter.view.InspectorViewFactory"/>
     <toolWindow id="Flutter Deep Links" anchor="right" icon="FlutterIcons.DevToolsDeepLinks" factoryClass="io.flutter.deeplinks.DeepLinksViewFactory" />
     <toolWindow id="Flutter DevTools" anchor="right" icon="FlutterIcons.DevTools" factoryClass="io.flutter.devtools.RemainingDevToolsViewFactory" />
     <toolWindow id="Flutter DevTools Extensions" anchor="right" icon="FlutterIcons.DevToolsExtensions" factoryClass="io.flutter.devtools.DevToolsExtensionsViewFactory" />
@@ -333,7 +333,7 @@
 
     <!-- Having the projectService defined after the toolWindows allows them to all be picked up by the platform -->
     <!-- See https://github.com/flutter/flutter-intellij/issues/8029 -->
-    <projectService serviceImplementation="io.flutter.view.FlutterView" overrides="false"/>
+    <projectService serviceImplementation="io.flutter.view.InspectorView" overrides="false"/>
 
     <projectOpenProcessor id="flutter" implementation="io.flutter.project.FlutterProjectOpenProcessor" order="first"/>
 


### PR DESCRIPTION
As discussed, when the inspector was the only view, it made sense to dub it `FlutterView` but now that's a little general (and suggests an abstract class of some kind).

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
