### PR TITLE
[CQ] `InspectorView` de-duping and null-awareness

### DIFF
--- a/flutter-idea/src/io/flutter/devtools/DevToolsUrl.java
+++ b/flutter-idea/src/io/flutter/devtools/DevToolsUrl.java
@@ -9,6 +9,7 @@ import io.flutter.bazel.WorkspaceCache;
 import io.flutter.sdk.FlutterSdkUtil;
 import io.flutter.sdk.FlutterSdkVersion;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -37,16 +38,16 @@ public class DevToolsUrl {
   @NotNull private final DevToolsUtils devToolsUtils;
 
   public static class Builder {
-    private String devToolsHost;
+    private @Nullable String devToolsHost;
 
     private int devToolsPort;
-    private String vmServiceUri;
+    private @Nullable String vmServiceUri;
     private String page;
     private Boolean embed;
     private String widgetId;
     private String hide;
 
-    private FlutterSdkVersion flutterSdkVersion;
+    private @Nullable FlutterSdkVersion flutterSdkVersion;
     private WorkspaceCache workspaceCache;
     private DevToolsIdeFeature ideFeature;
 
@@ -54,10 +55,11 @@ public class DevToolsUrl {
 
     private FlutterSdkUtil flutterSdkUtil;
 
-    public Builder() {}
+    public Builder() {
+    }
 
     @NotNull
-    public Builder setDevToolsHost(String devToolsHost) {
+    public Builder setDevToolsHost(@Nullable String devToolsHost) {
       this.devToolsHost = devToolsHost;
       return this;
     }
@@ -69,7 +71,7 @@ public class DevToolsUrl {
     }
 
     @NotNull
-    public Builder setVmServiceUri(String vmServiceUri) {
+    public Builder setVmServiceUri(@Nullable String vmServiceUri) {
       this.vmServiceUri = vmServiceUri;
       return this;
     }
@@ -105,7 +107,7 @@ public class DevToolsUrl {
     }
 
     @NotNull
-    public Builder setFlutterSdkVersion(FlutterSdkVersion sdkVersion) {
+    public Builder setFlutterSdkVersion(@Nullable FlutterSdkVersion sdkVersion) {
       this.flutterSdkVersion = sdkVersion;
       return this;
     }
@@ -163,10 +165,12 @@ public class DevToolsUrl {
     if (builder.workspaceCache != null && builder.workspaceCache.isBazel()) {
       this.canUseDevToolsPathUrl = true;
       this.canUseMultiEmbed = true;
-    } else if (flutterSdkVersion != null) {
+    }
+    else if (flutterSdkVersion != null) {
       this.canUseDevToolsPathUrl = flutterSdkVersion.canUseDevToolsPathUrls();
       this.canUseMultiEmbed = flutterSdkVersion.canUseDevToolsMultiEmbed();
-    } else {
+    }
+    else {
       this.canUseDevToolsPathUrl = false;
       this.canUseMultiEmbed = false;
     }
@@ -192,12 +196,14 @@ public class DevToolsUrl {
       if (!this.canUseMultiEmbed) {
         // This is for older versions of DevTools that do not support embed= one vs. many.
         params.add("embed=true");
-      } else {
+      }
+      else {
         if (hide != null) {
           // If we are using the hide param, we can assume that we are trying to embed multiple tabs.
           params.add("embedMode=many");
           params.add("hide=" + hide);
-        } else {
+        }
+        else {
           params.add("embedMode=one");
         }
       }

--- a/flutter-idea/src/io/flutter/jxbrowser/InstallationFailedReason.java
+++ b/flutter-idea/src/io/flutter/jxbrowser/InstallationFailedReason.java
@@ -1,15 +1,18 @@
 package io.flutter.jxbrowser;
 
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
 public class InstallationFailedReason {
-    public FailureType failureType;
-    public String detail;
+  public final @NotNull FailureType failureType;
+  public final @Nullable String detail;
 
-    public InstallationFailedReason(FailureType failureType) {
-        this(failureType, null);
-    }
+  public InstallationFailedReason(@NotNull FailureType failureType) {
+    this(failureType, null);
+  }
 
-    InstallationFailedReason(FailureType failureType, String detail) {
-        this.failureType = failureType;
-        this.detail = detail;
-    }
+  InstallationFailedReason(@NotNull FailureType failureType, @Nullable String detail) {
+    this.failureType = failureType;
+    this.detail = detail;
+  }
 }

--- a/flutter-idea/src/io/flutter/settings/FlutterSettings.java
+++ b/flutter-idea/src/io/flutter/settings/FlutterSettings.java
@@ -11,6 +11,7 @@ import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.util.registry.Registry;
 import com.intellij.util.EventDispatcher;
 import com.jetbrains.lang.dart.analyzer.DartClosingLabelManager;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.EventListener;
 import java.util.Objects;
@@ -59,12 +60,12 @@ public class FlutterSettings {
     testInstance = instance;
   }
 
-  public static FlutterSettings getInstance() {
+  public static @NotNull FlutterSettings getInstance() {
     if (testInstance != null) {
       return testInstance;
     }
 
-    return Objects.requireNonNull(ApplicationManager.getApplication()).getService(FlutterSettings.class);
+    return Objects.requireNonNull(Objects.requireNonNull(ApplicationManager.getApplication()).getService(FlutterSettings.class));
   }
 
   protected static PropertiesComponent getPropertiesComponent() {

--- a/flutter-idea/src/io/flutter/utils/OpenApiUtils.java
+++ b/flutter-idea/src/io/flutter/utils/OpenApiUtils.java
@@ -38,6 +38,12 @@ public class OpenApiUtils {
     return modules == null ? Module.EMPTY_ARRAY : modules;
   }
 
+  public static void safeExecuteOnPooledThread(@NotNull Runnable action) {
+    var application = ApplicationManager.getApplication();
+    if (application == null) return;
+    application.executeOnPooledThread(action);
+  }
+
   public static void safeRunReadAction(@NotNull Runnable runnable) {
     Application application = ApplicationManager.getApplication();
     if (application == null) return;

--- a/flutter-idea/src/io/flutter/view/ViewUtils.java
+++ b/flutter-idea/src/io/flutter/view/ViewUtils.java
@@ -54,7 +54,6 @@ public class ViewUtils {
   }
 
 
-
   public void presentClickableLabel(ToolWindow toolWindow, List<LabelInput> labels) {
     final JPanel panel = new JPanel(new GridLayout(0, 1));
 
@@ -79,7 +78,7 @@ public class ViewUtils {
     replacePanelLabel(toolWindow, center);
   }
 
-  private void replacePanelLabel(ToolWindow toolWindow, JComponent label) {
+  public void replacePanelLabel(ToolWindow toolWindow, JComponent label) {
     OpenApiUtils.safeInvokeLater(() -> {
       final ContentManager contentManager = toolWindow.getContentManager();
       if (contentManager.isDisposed()) {


### PR DESCRIPTION
Some opportunistic `InspectorView` clean-up.

* a bit of de-duplication and
* some added null-awareness

---

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
