### PR TITLE
[PERF] migrate Project parentDisposables to Services

### DIFF
--- a/flutter-idea/src/io/flutter/bazel/WorkspaceCache.java
+++ b/flutter-idea/src/io/flutter/bazel/WorkspaceCache.java
@@ -61,7 +61,7 @@ public class WorkspaceCache {
       FileWatch nextWatch = null;
       if (next != null) {
         nextWatch = FileWatch.subscribe(next.getRoot(), next.getDependencies(), this::scheduleRefresh);
-        nextWatch.setDisposeParent(project);
+        nextWatch.setDisposeParent(FlutterDartAnalysisServer.getInstance(project));
       }
 
       final FileWatch prevWatch = fileWatch.getAndSet(nextWatch);

--- a/flutter-idea/src/io/flutter/dart/FlutterDartAnalysisServer.java
+++ b/flutter-idea/src/io/flutter/dart/FlutterDartAnalysisServer.java
@@ -16,7 +16,6 @@ import com.intellij.openapi.Disposable;
 import com.intellij.openapi.application.Application;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.util.Disposer;
 import com.intellij.util.Consumer;
 import com.jetbrains.lang.dart.analyzer.DartAnalysisServerService;
 import io.flutter.utils.JsonUtils;
@@ -100,7 +99,6 @@ public class FlutterDartAnalysisServer implements Disposable {
         super.computedErrors(file, errors);
       }
     });
-    Disposer.register(project, this);
   }
 
   public void addOutlineListener(@NotNull final String filePath, @NotNull final FlutterOutlineListener listener) {

--- a/flutter-idea/src/io/flutter/run/FlutterReloadManager.java
+++ b/flutter-idea/src/io/flutter/run/FlutterReloadManager.java
@@ -58,6 +58,7 @@ import io.flutter.actions.ProjectActions;
 import io.flutter.actions.ReloadFlutterApp;
 import io.flutter.bazel.Workspace;
 import io.flutter.bazel.WorkspaceCache;
+import io.flutter.dart.FlutterDartAnalysisServer;
 import io.flutter.run.common.RunMode;
 import io.flutter.run.daemon.FlutterApp;
 import io.flutter.settings.FlutterSettings;
@@ -127,7 +128,8 @@ public class FlutterReloadManager {
   private FlutterReloadManager(@NotNull Project project) {
     this.myProject = project;
 
-    final MessageBusConnection connection = ApplicationManager.getApplication().getMessageBus().connect(project);
+    final MessageBusConnection connection =
+      ApplicationManager.getApplication().getMessageBus().connect(FlutterDartAnalysisServer.getInstance(project));
     connection.subscribe(AnActionListener.TOPIC, new AnActionListener() {
       private @Nullable Project eventProject;
       private @Nullable Editor eventEditor;

--- a/flutter-idea/src/io/flutter/run/common/CommonTestConfigUtils.java
+++ b/flutter-idea/src/io/flutter/run/common/CommonTestConfigUtils.java
@@ -16,6 +16,7 @@ import com.intellij.psi.PsiFile;
 import com.jetbrains.lang.dart.psi.DartCallExpression;
 import com.jetbrains.lang.dart.psi.DartStringLiteralExpression;
 import io.flutter.dart.DartSyntax;
+import io.flutter.dart.FlutterDartAnalysisServer;
 import io.flutter.editor.ActiveEditorsOutlineService;
 import io.flutter.utils.OpenApiUtils;
 import org.dartlang.analysis.server.protocol.ElementKind;
@@ -173,7 +174,8 @@ public abstract class CommonTestConfigUtils {
     final ActiveEditorsOutlineService service = getActiveEditorsOutlineService(file.getProject());
     if (!listenerCache.containsKey(path) && service != null) {
       listenerCache.put(path, new LineMarkerUpdatingListener(this, file.getProject(), service));
-      Disposer.register(file.getProject(), () -> {
+      var disposableParent = FlutterDartAnalysisServer.getInstance(file.getProject());
+      Disposer.register(disposableParent, () -> {
         listenerCache.remove(path);
       });
     }

--- a/flutter-idea/src/io/flutter/run/daemon/DeviceService.java
+++ b/flutter-idea/src/io/flutter/run/daemon/DeviceService.java
@@ -20,6 +20,7 @@ import com.intellij.openapi.util.Disposer;
 import io.flutter.FlutterMessages;
 import io.flutter.FlutterUtils;
 import io.flutter.bazel.WorkspaceCache;
+import io.flutter.dart.FlutterDartAnalysisServer;
 import io.flutter.run.FlutterDevice;
 import io.flutter.sdk.AndroidEmulatorManager;
 import io.flutter.sdk.FlutterSdkManager;
@@ -63,7 +64,7 @@ public class DeviceService {
   private DeviceService(@NotNull final Project project) {
     this.project = project;
 
-    deviceDaemon.setDisposeParent(project);
+    deviceDaemon.setDisposeParent(FlutterDartAnalysisServer.getInstance(project));
     deviceDaemon.subscribe(this::refreshDeviceSelection);
     refreshDeviceDaemon();
 
@@ -80,7 +81,8 @@ public class DeviceService {
       }
     };
     FlutterSdkManager.getInstance(project).addListener(sdkListener);
-    Disposer.register(project, () -> FlutterSdkManager.getInstance(project).removeListener(sdkListener));
+    Disposer.register(FlutterDartAnalysisServer.getInstance(project),
+                      () -> FlutterSdkManager.getInstance(project).removeListener(sdkListener));
 
     // Watch for Bazel workspace changes.
     WorkspaceCache.getInstance(project).subscribe(this::refreshDeviceDaemon);

--- a/flutter-idea/src/io/flutter/run/daemon/FlutterApp.java
+++ b/flutter-idea/src/io/flutter/run/daemon/FlutterApp.java
@@ -33,6 +33,7 @@ import io.flutter.FlutterUtils;
 import io.flutter.ObservatoryConnector;
 import io.flutter.bazel.Workspace;
 import io.flutter.bazel.WorkspaceCache;
+import io.flutter.dart.FlutterDartAnalysisServer;
 import io.flutter.logging.FlutterConsoleLogManager;
 import io.flutter.pub.PubRoot;
 import io.flutter.pub.PubRoots;
@@ -260,7 +261,7 @@ public class FlutterApp implements Disposable {
     }
 
     final ProcessHandler process = new MostlySilentColoredProcessHandler(command, onTextAvailable);
-    Disposer.register(project, process::destroyProcess);
+    Disposer.register(FlutterDartAnalysisServer.getInstance(project), process::destroyProcess);
 
     final DaemonApi api = new DaemonApi(process);
     final FlutterApp app = new FlutterApp(project, module, mode, device, process, env, api, command);

--- a/flutter-idea/src/io/flutter/sdk/FlutterPluginsLibraryManager.java
+++ b/flutter-idea/src/io/flutter/sdk/FlutterPluginsLibraryManager.java
@@ -21,7 +21,9 @@ import io.flutter.pub.PubRoot;
 import io.flutter.pub.PubRoots;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.*;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.jetbrains.lang.dart.util.PubspecYamlUtil.PUBSPEC_YAML;
@@ -42,6 +44,7 @@ public class FlutterPluginsLibraryManager extends AbstractLibraryManager<Flutter
   }
 
   public void startWatching() {
+    var project = getProject();
     VirtualFileManager.getInstance().addVirtualFileListener(new VirtualFileContentsChangedAdapter() {
       @Override
       protected void onFileChange(@NotNull VirtualFile file) {
@@ -51,9 +54,9 @@ public class FlutterPluginsLibraryManager extends AbstractLibraryManager<Flutter
       @Override
       protected void onBeforeFileChange(@NotNull VirtualFile file) {
       }
-    }, getProject());
+    }, FlutterDartAnalysisServer.getInstance(project));
 
-    getProject().getMessageBus().connect().subscribe(ModuleRootListener.TOPIC, new ModuleRootListener() {
+    project.getMessageBus().connect().subscribe(ModuleRootListener.TOPIC, new ModuleRootListener() {
       @Override
       public void rootsChanged(@NotNull ModuleRootEvent event) {
         scheduleUpdate();

--- a/flutter-idea/src/io/flutter/sdk/FlutterSdkManager.java
+++ b/flutter-idea/src/io/flutter/sdk/FlutterSdkManager.java
@@ -13,6 +13,7 @@ import com.intellij.openapi.roots.libraries.Library;
 import com.intellij.openapi.roots.libraries.LibraryTable;
 import com.intellij.openapi.util.Disposer;
 import com.intellij.util.EventDispatcher;
+import io.flutter.dart.FlutterDartAnalysisServer;
 import io.flutter.utils.OpenApiUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -48,7 +49,7 @@ public class FlutterSdkManager {
     final ScheduledFuture timer = JobScheduler.getScheduler().scheduleWithFixedDelay(
       this::checkForFlutterSdkChange, 1, 1, TimeUnit.SECONDS);
 
-    Disposer.register(project, () -> {
+    Disposer.register(FlutterDartAnalysisServer.getInstance(project), () -> {
       libraryTable.removeListener(libraryTableListener);
       timer.cancel(false);
     });

--- a/flutter-studio/src/io/flutter/utils/AddToAppUtils.java
+++ b/flutter-studio/src/io/flutter/utils/AddToAppUtils.java
@@ -7,10 +7,6 @@ package io.flutter.utils;
 
 //import static com.android.tools.idea.gradle.project.importing.GradleProjectImporter.ANDROID_PROJECT_TYPE;
 
-import static com.intellij.util.ReflectionUtil.findAssignableField;
-import static io.flutter.actions.AttachDebuggerAction.ATTACH_IS_ACTIVE;
-import static io.flutter.actions.AttachDebuggerAction.findRunConfig;
-
 import com.android.tools.idea.gradle.project.sync.GradleSyncListener;
 import com.android.tools.idea.gradle.project.sync.GradleSyncState;
 import com.intellij.debugger.engine.DebugProcess;
@@ -22,25 +18,32 @@ import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.application.Application;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.module.Module;
-import com.intellij.openapi.project.*;
+import com.intellij.openapi.project.ModuleListener;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectType;
+import com.intellij.openapi.project.ProjectTypeService;
 import com.intellij.util.ThreeState;
 import com.intellij.util.concurrency.AppExecutorUtil;
 import com.intellij.util.messages.MessageBusConnection;
 import com.intellij.util.messages.Topic;
 import io.flutter.FlutterUtils;
 import io.flutter.actions.AttachDebuggerAction;
+import io.flutter.dart.FlutterDartAnalysisServer;
 import io.flutter.pub.PubRoot;
 import io.flutter.run.SdkAttachConfig;
 import io.flutter.sdk.FlutterSdk;
+import org.jetbrains.annotations.NonNls;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.Collection;
 import java.util.List;
 
-import org.jetbrains.annotations.NonNls;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import static com.intellij.util.ReflectionUtil.findAssignableField;
+import static io.flutter.actions.AttachDebuggerAction.ATTACH_IS_ACTIVE;
+import static io.flutter.actions.AttachDebuggerAction.findRunConfig;
 
 public class AddToAppUtils {
   //private static final Logger LOG = Logger.getInstance(AddToAppUtils.class);
@@ -49,7 +52,7 @@ public class AddToAppUtils {
   }
 
   public static boolean initializeAndDetectFlutter(@NotNull Project project) {
-    MessageBusConnection connection = project.getMessageBus().connect(project);
+    MessageBusConnection connection = project.getMessageBus().connect(FlutterDartAnalysisServer.getInstance(project));
     // GRADLE_SYNC_TOPIC is not public in Android Studio 3.5. It is in 3.6. It isn't defined in 3.4.
     //noinspection unchecked
     Topic<GradleSyncListener> topic = getStaticFieldValue(GradleSyncState.class, Topic.class, "GRADLE_SYNC_TOPIC");
@@ -71,7 +74,6 @@ public class AddToAppUtils {
               });
             }
           }
-
         }
       });
       return false;


### PR DESCRIPTION
Using a `Project` as a parent disposable  can lead to plugins not being unloaded correctly leading to memory leaks. This follows the advice given in the Jetbrains [disposer docs](https://plugins.jetbrains.com/docs/intellij/disposers.html?from=IncorrectParentDisposable#choosing-a-disposable-parent) and is (I think) consistent with the Dart plugin (@alexander-doroshko?).

This gets us *most* of the way to fixing https://github.com/flutter/flutter-intellij/issues/8107 with an open question about `AndroidModuleLibraryManager`. (Question posed there 👍 .)

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
