### PR TITLE
[CQ] cleanup unused .properties

### DIFF
--- a/flutter-idea/src/io/flutter/FlutterBundle.properties
+++ b/flutter-idea/src/io/flutter/FlutterBundle.properties
@@ -31,6 +31,8 @@ flutter.no.sdk.warning=No Flutter SDK configured.
 flutter.project.description=Build high-performance, high-fidelity, apps using the Flutter framework.
 flutter.sdk.browse.path.label=Select Flutter SDK Path
 flutter.sdk.is.not.configured=The Flutter SDK is not configured
+# suppress inspection "UnusedProperty" (used in `FlutterGeneratorPeer.form`)
+flutter.sdk.path.label=Flutter &SDK path:
 flutter.title=Flutter
 flutter.sdk.notAvailable.title=No Flutter SDK Configured
 flutter.sdk.notAvailable.message=This action requires a Flutter SDK to be configured; configure one now?
@@ -103,13 +105,18 @@ flutter.module.create.settings.help.project_type.description.app=Select an "Appl
 flutter.module.create.settings.help.project_type.description.plugin=Select a "Plugin" when exposing an Android or iOS API for developers.
 flutter.module.create.settings.help.project_type.description.package=Select a "Package" when creating a pure Dart component, like a new Widget.
 flutter.module.create.settings.help.project_type.description.module=Select a "Module" when creating a Flutter component to add to an Android or iOS app.
+
 module.wizard.language.name_kotlin=Include Kotlin support for Android code
 module.wizard.language.name_swift=Include Swift support for iOS code
 
 module.wizard.app_title_short=Flutter App
+
 module.wizard.package_title=Flutter Package
+
 module.wizard.plugin_title=Flutter Plugin
+
 module.wizard.module_title=Flutter Module
+
 old.android.studio.title=Wrong Version
 old.android.studio.message=Your path contains Android Studio 2.x,\n\
   which does not support Flutter.\n\n\
@@ -136,6 +143,10 @@ settings.allow.tests.in.sources=<html>Allow files ending with <b>_test.dart</b> 
 settings.allow.tests.tooltip=The directory must be marked as a sources root, such as <b>lib</b>.
 settings.font.packages=Font Packages
 settings.show.all.configs.tooltip=If there is a defined run configuration to watch a specific test and one to just run it, show both.
+# suppress inspection "UnusedProperty" (used in `FlutterSettingsConfigurable.form`)
+settings.jcef.browser=Use JCEF browser to show embedded DevTools
+# suppress inspection "UnusedProperty" (used in `FlutterSettingsConfigurable.form`)
+settings.jcef.browser.tooltip=JCEF is a browser included in IntelliJ that is an alternative to using JxBrowser for showing embedded DevTools.
 settings.enable.androi.gradle.sync.tooltip=Provides advanced editing capabilities for Java and Kotlin code. Uses Gradle to find Android libraries then links them into the Flutter project.
 settings.experiments=Experiments
 settings.editor=Editor
@@ -147,6 +158,9 @@ settings.show.closing.labels=Show closing labels in Dart source code
 settings.sdk.copy.content=Copy to Clipboard
 settings.report.analytics.tooltip=Report anonymized usage information to Google Analytics.
 settings.enable.verbose.logging.tooltip=Enables verbose logging (this can be useful for diagnostic purposes).
+# suppress inspection "UnusedProperty" (used in a `FlutterSettingsConfigurable.form`)
+settings.enable.logs.preserve.during.hot.reload.and.restart=Preserve console logs during Hot Reload and Hot Restart
+
 action.new.project.title=New Flutter Project...
 welcome.new.project.compact=New Flutter Project
 

--- a/flutter-idea/src/io/flutter/FlutterBundle.properties
+++ b/flutter-idea/src/io/flutter/FlutterBundle.properties
@@ -19,13 +19,6 @@ app.release.action.text=Run in Flutter release mode
 app.release.config.action.text=Flutter Run ''{0}'' in Release Mode
 app.release.action.description=Run Flutter app in release mode
 
-app.inspector.no_properties=Selected node has no properties
-app.inspector.all_properties_hidden=All properties of the selected node are hidden
-app.inspector.error_loading_properties=Error loading properties
-app.inspector.error_loading_property_details=Error loading property details
-app.inspector.loading_properties=Loading properties
-app.inspector.nothing_to_show=Nothing to show
-
 dart.sdk.is.not.configured=Dart SDK is not configured
 
 error.folder.specified.as.sdk.not.exists=The folder specified as the Flutter SDK home does not exist.
@@ -38,7 +31,6 @@ flutter.no.sdk.warning=No Flutter SDK configured.
 flutter.project.description=Build high-performance, high-fidelity, apps using the Flutter framework.
 flutter.sdk.browse.path.label=Select Flutter SDK Path
 flutter.sdk.is.not.configured=The Flutter SDK is not configured
-flutter.sdk.path.label=Flutter &SDK path: 
 flutter.title=Flutter
 flutter.sdk.notAvailable.title=No Flutter SDK Configured
 flutter.sdk.notAvailable.message=This action requires a Flutter SDK to be configured; configure one now?
@@ -74,16 +66,6 @@ flutter.run.bazel.startWithSlashSlash=Bazel targets should start with '//'
 flutter.run.bazel.newBazelTestRunnerUnavailable=The new Bazel test runner is not available. Only Bazel targets can be run with the old test runner
 flutter.run.bazel.noBazelOrDartTargetSet=No Bazel target or Dart entrypoint set
 
-flutter.perf.linter.statefulWidget.url=https://api.flutter.dev/flutter/widgets/StatefulWidget-class.html#performance-considerations
-flutter.perf.linter.listViewLoad.url=https://api.flutter.dev/flutter/widgets/ListView-class.html
-flutter.perf.linter.animatedBuilder.url=https://api.flutter.dev/flutter/widgets/AnimatedBuilder-class.html#performance-optimizations
-flutter.perf.linter.opacityAnimations.url=https://api.flutter.dev/flutter/widgets/Opacity-class.html#performance-considerations-for-opacity-animation
-
-flutter.analytics.notification.content=The Flutter plugin reports feature usage statistics and crash reports to Google \
-  in order to help Google contribute improvements to Flutter over time. See Google's privacy policy: \
-  <a href="url">www.google.com/policies/privacy</a>.<br><br>Send usage statistics?
-flutter.analytics.privacyUrl=https://www.google.com/policies/privacy/
-
 flutter.reload.firstRun.title=Flutter supports hot reload!
 flutter.reload.firstRun.content=Apply changes to your app in place, instantly.
 flutter.reload.firstRun.url=https://flutter.dev/to/hot-reload
@@ -104,79 +86,30 @@ flutter.module.create.settings.type.package=Package
 flutter.module.create.settings.type.module=Module
 flutter.module.create.settings.type.import_module=Import Module
 flutter.module.create.settings.type.tip=Select a project type.
-flutter.module.create.settings.sample.tip=Select sample content.
-flutter.module.create.settings.sample.text=Generate sample content:
 flutter.module.create.settings.radios.org.label=&Organization:
 flutter.module.create.settings.org.default_text=com.example
 flutter.module.create.settings.org.tip=Enter a domain.
 flutter.module.create.settings.description.label=&Description:
 flutter.module.create.settings.description.tip=Enter a project description which shows up in the pubsec.yaml.
 flutter.module.create.settings.description.default_text=A new Flutter project.
-flutter.module.create.settings.location.select=Select Project Location
 flutter.module.create.settings.radios.android.label=Android language:
 flutter.module.create.settings.radios.android.java=&Java
 flutter.module.create.settings.radios.android.kotlin=&Kotlin
 flutter.module.create.settings.radios.android.tip=Select an Android language.
 
-flutter.module.create.settings.help.label=Help:
 flutter.module.create.settings.help.getting_started_link_text=Getting started with your first Flutter app.
-flutter.module.create.settings.help.packages_and_plugins_text=Developing packages and plugins.
-flutter.module.create.settings.help.project_name.label=Project name:
-flutter.module.create.settings.help.project_name.description=Enter the project name with all lower case letters.
-flutter.module.create.settings.help.module_name.label=Module name:
-flutter.module.create.settings.help.module_name.description=Enter the module name with all lower case letters.
-flutter.module.create.settings.help.org.label=Organization:
-flutter.module.create.settings.help.org.description=Enter the organization domain name in reverse domain notation.
 flutter.module.create.settings.help.project_type.label=Project type:
 flutter.module.create.settings.help.project_type.description.app=Select an "Application" when building for end users.
 flutter.module.create.settings.help.project_type.description.plugin=Select a "Plugin" when exposing an Android or iOS API for developers.
 flutter.module.create.settings.help.project_type.description.package=Select a "Package" when creating a pure Dart component, like a new Widget.
 flutter.module.create.settings.help.project_type.description.module=Select a "Module" when creating a Flutter component to add to an Android or iOS app.
-flutter.module.create.settings.help.type.application=An "application" is a stand-alone app that can be installed and run on a mobile device.
-flutter.module.create.settings.help.type.package=A "package" is a pure-Dart component, like a new Widget, with no native code.
-flutter.module.create.settings.help.type.plugin=A "plugin" is used to expose an Android or iOS API for developers.
-
 module.wizard.language.name_kotlin=Include Kotlin support for Android code
 module.wizard.language.name_swift=Include Swift support for iOS code
 
-module.wizard.app_title=Flutter Application
 module.wizard.app_title_short=Flutter App
-module.wizard.app_description=Creates a Flutter application
-module.wizard.app_step_title=New Flutter Application
-module.wizard.app_step_body=Configure the new Flutter application
-module.wizard.app_name=flutter_app
-module.wizard.app_text=A new Flutter application.
-
 module.wizard.package_title=Flutter Package
-module.wizard.package_description=Creates a Flutter package
-module.wizard.package_step_title=New Flutter Package
-module.wizard.package_step_body=Configure the new Flutter package
-module.wizard.package_name=flutter_package
-module.wizard.package_text=A new Flutter package.
-
 module.wizard.plugin_title=Flutter Plugin
-module.wizard.plugin_description=Creates a Flutter plugin
-module.wizard.plugin_step_title=New Flutter Plugin
-module.wizard.plugin_step_body=Configure the new Flutter plugin
-module.wizard.plugin_name=flutter_plugin
-module.wizard.plugin_text=A new Flutter plugin.
-
 module.wizard.module_title=Flutter Module
-module.wizard.module_description=Creates a Flutter module to use in an Android app
-module.wizard.module_step_title=New Flutter Module
-module.wizard.module_step_body=Configure the new Flutter module
-module.wizard.module_name=flutter_module
-module.wizard.module_text=A new Flutter module.
-
-module.wizard.import_module_title=Import Flutter Module
-module.wizard.import_module_description=Import a Flutter module into an Android app
-module.wizard.import_module_step_title=Import Flutter Module
-module.wizard.import_module_step_body=Flutter module location:
-module.wizard.import_module_name=flutter_module_location
-module.wizard.import_module_text=Import a Flutter module.
-flutter.module.import.settings.help.description=Import a Flutter module into an Android app (without copying).
-flutter.module.import.settings.location.select=Select Module Location
-
 old.android.studio.title=Wrong Version
 old.android.studio.message=Your path contains Android Studio 2.x,\n\
   which does not support Flutter.\n\n\
@@ -203,8 +136,6 @@ settings.allow.tests.in.sources=<html>Allow files ending with <b>_test.dart</b> 
 settings.allow.tests.tooltip=The directory must be marked as a sources root, such as <b>lib</b>.
 settings.font.packages=Font Packages
 settings.show.all.configs.tooltip=If there is a defined run configuration to watch a specific test and one to just run it, show both.
-settings.jcef.browser=Use JCEF browser to show embedded DevTools
-settings.jcef.browser.tooltip=JCEF is a browser included in IntelliJ that is an alternative to using JxBrowser for showing embedded DevTools.
 settings.enable.androi.gradle.sync.tooltip=Provides advanced editing capabilities for Java and Kotlin code. Uses Gradle to find Android libraries then links them into the Flutter project.
 settings.experiments=Experiments
 settings.editor=Editor
@@ -216,10 +147,7 @@ settings.show.closing.labels=Show closing labels in Dart source code
 settings.sdk.copy.content=Copy to Clipboard
 settings.report.analytics.tooltip=Report anonymized usage information to Google Analytics.
 settings.enable.verbose.logging.tooltip=Enables verbose logging (this can be useful for diagnostic purposes).
-settings.enable.logs.preserve.during.hot.reload.and.restart=Preserve console logs during Hot Reload and Hot Restart
-
 action.new.project.title=New Flutter Project...
-welcome.new.project.title=Create New Flutter Project
 welcome.new.project.compact=New Flutter Project
 
 npw_platform_android=Android
@@ -241,8 +169,6 @@ flutter.devtools.installing=Installing DevTools... <br><br>If this takes more th
 
 flutter.coverage.presentable.text=Flutter Coverage
 coverage.path.not.found=Coverage file not found: {0}
-progress.title.loading.coverage.data=Loading coverage data...
-project.root.not.found=Could not find project root
 coverage.data.not.read=Cannot read coverage data from file: {0}
 icon.preview.disallow.flutter_icons=Package "flutter_icons" is not supported.
 icon.preview.disallow.flutter_vector_icons=Package "flutter_vector_icons" cannot show previews because it does not include a font file.


### PR DESCRIPTION
Remove unused properties. (Interestingly the associated inspection doesn't catch references in `.form`s, so there are some ignores for those (and grepping to double check).

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
