### PR TITLE
[perf] create action presentations lazily

### DIFF
--- a/flutter-idea/src/io/flutter/actions/DeviceSelectorRefresherAction.java
+++ b/flutter-idea/src/io/flutter/actions/DeviceSelectorRefresherAction.java
@@ -5,18 +5,15 @@
  */
 package io.flutter.actions;
 
-import com.intellij.openapi.actionSystem.*;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.project.Project;
-import icons.FlutterIcons;
 import io.flutter.run.daemon.DeviceService;
 import io.flutter.utils.FlutterModuleUtils;
 import org.jetbrains.annotations.NotNull;
 
 public class DeviceSelectorRefresherAction extends AnAction {
-  public DeviceSelectorRefresherAction() {
-    super(FlutterIcons.RefreshItems);
-  }
-
   @Override
   public void actionPerformed(@NotNull AnActionEvent e) {
     final Project project = e.getProject();

--- a/flutter-idea/src/io/flutter/actions/RestartFlutterDaemonAction.java
+++ b/flutter-idea/src/io/flutter/actions/RestartFlutterDaemonAction.java
@@ -13,10 +13,6 @@ import io.flutter.run.daemon.DeviceService;
 import org.jetbrains.annotations.NotNull;
 
 public class RestartFlutterDaemonAction extends AnAction {
-  public RestartFlutterDaemonAction() {
-    super("Refresh");
-  }
-
   @Override
   public void actionPerformed(AnActionEvent event) {
     final Project project = event.getProject();

--- a/flutter-idea/src/io/flutter/actions/RunFlutterAction.java
+++ b/flutter-idea/src/io/flutter/actions/RunFlutterAction.java
@@ -25,7 +25,6 @@ import io.flutter.run.SdkRunConfig;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import javax.swing.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -35,14 +34,10 @@ public abstract class RunFlutterAction extends AnAction {
   private final @NotNull FlutterLaunchMode myLaunchMode;
   private final @NotNull String myExecutorId;
 
-  public RunFlutterAction(@NotNull String text,
-                          @NotNull String detailedTextKey,
-                          @NotNull String description,
-                          @NotNull Icon icon,
-                          @NotNull FlutterLaunchMode launchMode,
-                          @NotNull String executorId) {
-    super(text, description, icon);
-
+  public RunFlutterAction(
+    @NotNull String detailedTextKey,
+    @NotNull FlutterLaunchMode launchMode,
+    @NotNull String executorId) {
     myDetailedTextKey = detailedTextKey;
     myLaunchMode = launchMode;
     myExecutorId = executorId;

--- a/flutter-idea/src/io/flutter/actions/RunProfileFlutterApp.java
+++ b/flutter-idea/src/io/flutter/actions/RunProfileFlutterApp.java
@@ -5,17 +5,13 @@
  */
 package io.flutter.actions;
 
-import com.intellij.icons.AllIcons;
 import com.intellij.openapi.wm.ToolWindowId;
-import io.flutter.FlutterBundle;
 import io.flutter.run.FlutterLaunchMode;
 
 public class RunProfileFlutterApp extends RunFlutterAction {
-  public static final String TEXT = FlutterBundle.message("app.profile.action.text");
-  public static final String DESCRIPTION = FlutterBundle.message("app.profile.action.description");
   private static final String TEXT_DETAIL_MSG_KEY = "app.profile.config.action.text";
 
   public RunProfileFlutterApp() {
-    super(TEXT, TEXT_DETAIL_MSG_KEY, DESCRIPTION, AllIcons.Actions.Execute, FlutterLaunchMode.PROFILE, ToolWindowId.RUN);
+    super(TEXT_DETAIL_MSG_KEY, FlutterLaunchMode.PROFILE, ToolWindowId.RUN);
   }
 }

--- a/flutter-idea/src/io/flutter/actions/RunReleaseFlutterApp.java
+++ b/flutter-idea/src/io/flutter/actions/RunReleaseFlutterApp.java
@@ -5,17 +5,13 @@
  */
 package io.flutter.actions;
 
-import com.intellij.icons.AllIcons;
 import com.intellij.openapi.wm.ToolWindowId;
-import io.flutter.FlutterBundle;
 import io.flutter.run.FlutterLaunchMode;
 
 public class RunReleaseFlutterApp extends RunFlutterAction {
-  public static final String TEXT = FlutterBundle.message("app.release.action.text");
-  public static final String DESCRIPTION = FlutterBundle.message("app.release.action.description");
   private static final String TEXT_DETAIL_MSG_KEY = "app.release.config.action.text";
 
   public RunReleaseFlutterApp() {
-    super(TEXT, TEXT_DETAIL_MSG_KEY, DESCRIPTION, AllIcons.Actions.Execute, FlutterLaunchMode.RELEASE, ToolWindowId.RUN);
+    super(TEXT_DETAIL_MSG_KEY, FlutterLaunchMode.RELEASE, ToolWindowId.RUN);
   }
 }

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -160,7 +160,8 @@
               icon="FlutterIcons.Phone"/>
       <action id="Flutter.DeviceSelectorRefresher" class="io.flutter.actions.DeviceSelectorRefresherAction"
               text="Refresh Device List"
-              description="Refresh device list" />
+              description="Refresh device list"
+              icon="FlutterIcons.RefreshItems"/>
       <add-to-group anchor="before" group-id="RunToolbarMainActionGroup" relative-to-action="RedesignedRunConfigurationSelector"/>
     </group>
 
@@ -316,12 +317,14 @@
       <separator/>
       <!--suppress PluginXmlCapitalization -->
       <action id="Flutter.Menu.RunProfileAction" class="io.flutter.actions.RunProfileFlutterApp"
-              description="Flutter Run Profile Mode"
+              description="Run Flutter app in profile mode"
+              text="Run in Flutter Profile Mode"
               icon="AllIcons.Actions.Execute">
       </action>
       <!--suppress PluginXmlCapitalization -->
       <action id="Flutter.Menu.RunReleaseAction" class="io.flutter.actions.RunReleaseFlutterApp"
-              description="Flutter Run Release Mode"
+              description="Run Flutter app in release mode"
+              text="Run in Flutter release mode"
               icon="AllIcons.Actions.Execute">
       </action>
       <reference ref="AttachDebuggerAction"/>

--- a/resources/META-INF/plugin_template.xml
+++ b/resources/META-INF/plugin_template.xml
@@ -62,7 +62,8 @@
               icon="FlutterIcons.Phone"/>
       <action id="Flutter.DeviceSelectorRefresher" class="io.flutter.actions.DeviceSelectorRefresherAction"
               text="Refresh Device List"
-              description="Refresh device list" />
+              description="Refresh device list"
+              icon="FlutterIcons.RefreshItems"/>
       <add-to-group anchor="before" group-id="RunToolbarMainActionGroup" relative-to-action="RedesignedRunConfigurationSelector"/>
     </group>
 
@@ -218,12 +219,14 @@
       <separator/>
       <!--suppress PluginXmlCapitalization -->
       <action id="Flutter.Menu.RunProfileAction" class="io.flutter.actions.RunProfileFlutterApp"
-              description="Flutter Run Profile Mode"
+              description="Run Flutter app in profile mode"
+              text="Run in Flutter Profile Mode"
               icon="AllIcons.Actions.Execute">
       </action>
       <!--suppress PluginXmlCapitalization -->
       <action id="Flutter.Menu.RunReleaseAction" class="io.flutter.actions.RunReleaseFlutterApp"
-              description="Flutter Run Release Mode"
+              description="Run Flutter app in release mode"
+              text="Run in Flutter release mode"
               icon="AllIcons.Actions.Execute">
       </action>
       <reference ref="AttachDebuggerAction"/>


### PR DESCRIPTION
Stops eagerly creating action presentations (allocating resources prematurely and possibly unnecessarily) in favor of the preferred registration in plugin metadata that will only get loaded as-needed.

From the inspection:

> Reports any actions that are registered in the plugin.xml file and instantiate the com.intellij.openapi.actionSystem.Presentation object in their constructors.

> Any of the constructors of AnAction with parameters instantiate the Presentation object. However, instantiating the  Presentation object in constructor results in allocating resources, which may not be necessary. Instead of creating an instance of Presentation that stores text, description, or icon, it is more efficient to utilize no-argument constructors of 
AnAction and other base classes and follow the convention for setting the text, description, and icon in plugin.xml. The IDE will load text, description, and icon only when the action is actually displayed in the UI.

> The convention for setting the text, description, and icon is as follows:
Set the id attribute for the action in the plugin.xml file.
Optionally, set the icon attribute if an icon is needed.

Our actions:

![image](https://github.com/user-attachments/assets/7eb77ea8-006b-44aa-afcf-e8c3784f52b3)

The only risk is in ensuring that the templated menu text is still getting properly filled in, and I confirmed that:

![image](https://github.com/user-attachments/assets/00697fdf-9a32-4204-ac49-a73c32cdf0c2)





---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
