### PR TITLE
[CQ] (redundancy) remove unused `FlutterSdkChannel` property

### DIFF
--- a/flutter-idea/src/io/flutter/module/settings/PlatformsForm.kt
+++ b/flutter-idea/src/io/flutter/module/settings/PlatformsForm.kt
@@ -6,14 +6,15 @@
 package io.flutter.module.settings
 
 import com.intellij.openapi.ui.DialogPanel
-import com.intellij.ui.dsl.builder.*
+import com.intellij.ui.dsl.builder.Row
+import com.intellij.ui.dsl.builder.actionListener
+import com.intellij.ui.dsl.builder.panel
+import com.intellij.ui.dsl.builder.selected
 import com.intellij.ui.layout.ComponentPredicate
 import io.flutter.FlutterBundle
 import io.flutter.sdk.FlutterCreateAdditionalSettings
-import io.flutter.sdk.FlutterSdkChannel
 
 class PlatformsForm {
-  var channel: FlutterSdkChannel? = null
   private var configAndroid: Boolean = true
   private var configIos: Boolean = true
   private var configLinux: Boolean = true


### PR DESCRIPTION
Micro-change. Removes unused channel symbol.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
