### PR TITLE
[CQ] migrate off deprecated descriptor, EDT, clientProperty accesses

### DIFF
--- a/flutter-idea/src/io/flutter/actions/DeviceSelectorAction.java
+++ b/flutter-idea/src/io/flutter/actions/DeviceSelectorAction.java
@@ -16,6 +16,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
 import com.intellij.openapi.project.ProjectManagerListener;
 import com.intellij.openapi.util.Condition;
+import com.intellij.openapi.util.Key;
 import com.intellij.openapi.util.SystemInfo;
 import com.intellij.util.ModalityUiUtil;
 import icons.FlutterIcons;
@@ -132,10 +133,10 @@ public class DeviceSelectorAction extends ComboBoxAction implements DumbAware {
     updateVisibility(project, presentation);
   }
 
-  private static void updateVisibility(final Project project, final Presentation presentation) {
+  private static void updateVisibility(final Project project, final @NotNull Presentation presentation) {
     final boolean visible = isSelectorVisible(project);
 
-    final JComponent component = (JComponent)presentation.getClientProperty("customComponent");
+    final JComponent component = presentation.getClientProperty(new Key<>("customComponent"));
     if (component != null) {
       component.setVisible(visible);
       if (component.getParent() != null) {

--- a/flutter-idea/src/io/flutter/run/LaunchState.java
+++ b/flutter-idea/src/io/flutter/run/LaunchState.java
@@ -5,7 +5,10 @@
  */
 package io.flutter.run;
 
-import com.intellij.execution.*;
+import com.intellij.execution.DefaultExecutionResult;
+import com.intellij.execution.ExecutionException;
+import com.intellij.execution.ExecutionResult;
+import com.intellij.execution.Executor;
 import com.intellij.execution.configurations.CommandLineState;
 import com.intellij.execution.configurations.GeneralCommandLine;
 import com.intellij.execution.configurations.RunProfile;
@@ -21,6 +24,7 @@ import com.intellij.execution.runners.RunContentBuilder;
 import com.intellij.execution.ui.ConsoleView;
 import com.intellij.execution.ui.ConsoleViewContentType;
 import com.intellij.execution.ui.RunContentDescriptor;
+import com.intellij.execution.ui.RunContentManager;
 import com.intellij.icons.AllIcons;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.Separator;
@@ -389,7 +393,7 @@ public class LaunchState extends CommandLineState {
 
       // See if we should issue a hot-reload.
       final List<RunContentDescriptor> runningProcesses =
-        ExecutionManager.getInstance(env.getProject()).getContentManager().getAllDescriptors();
+        RunContentManager.getInstance(env.getProject()).getAllDescriptors();
 
       final ProcessHandler process = getRunningAppProcess(launchState.runConfig);
       if (process != null) {
@@ -446,15 +450,18 @@ public class LaunchState extends CommandLineState {
    * Returns the currently running app for the given RunConfig, if any.
    */
   @Nullable
-  public static ProcessHandler getRunningAppProcess(RunConfig config) {
+  public static ProcessHandler getRunningAppProcess(@NotNull RunConfig config) {
     final Project project = config.getProject();
-    final List<RunContentDescriptor> runningProcesses =
-      ExecutionManager.getInstance(project).getContentManager().getAllDescriptors();
+    if (project != null) {
+      final List<RunContentDescriptor> runningProcesses =
+        RunContentManager.getInstance(project).getAllDescriptors();
 
-    for (RunContentDescriptor descriptor : runningProcesses) {
-      final ProcessHandler process = descriptor.getProcessHandler();
-      if (process != null && !process.isProcessTerminated() && process.getUserData(FLUTTER_RUN_CONFIG_KEY) == config) {
-        return process;
+      for (RunContentDescriptor descriptor : runningProcesses) {
+        if (descriptor == null) continue;
+        final ProcessHandler process = descriptor.getProcessHandler();
+        if (process != null && !process.isProcessTerminated() && process.getUserData(FLUTTER_RUN_CONFIG_KEY) == config) {
+          return process;
+        }
       }
     }
 

--- a/flutter-idea/src/io/flutter/run/daemon/FlutterApp.java
+++ b/flutter-idea/src/io/flutter/run/daemon/FlutterApp.java
@@ -8,7 +8,6 @@ package io.flutter.run.daemon;
 import com.google.common.base.Stopwatch;
 import com.google.gson.JsonObject;
 import com.intellij.execution.ExecutionException;
-import com.intellij.execution.ExecutionManager;
 import com.intellij.execution.configurations.GeneralCommandLine;
 import com.intellij.execution.process.ProcessAdapter;
 import com.intellij.execution.process.ProcessEvent;
@@ -17,6 +16,7 @@ import com.intellij.execution.runners.ExecutionEnvironment;
 import com.intellij.execution.ui.ConsoleView;
 import com.intellij.execution.ui.ConsoleViewContentType;
 import com.intellij.execution.ui.RunContentDescriptor;
+import com.intellij.execution.ui.RunContentManager;
 import com.intellij.history.LocalHistory;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.diagnostic.Logger;
@@ -187,7 +187,7 @@ public class FlutterApp implements Disposable {
   public static List<FlutterApp> allFromProjectProcess(@NotNull Project project) {
     final List<FlutterApp> allRunningApps = new ArrayList<>();
     final List<RunContentDescriptor> runningProcesses =
-      ExecutionManager.getInstance(project).getContentManager().getAllDescriptors();
+      RunContentManager.getInstance(project).getAllDescriptors();
     for (RunContentDescriptor descriptor : runningProcesses) {
       final ProcessHandler process = descriptor.getProcessHandler();
       if (process != null) {
@@ -469,7 +469,7 @@ public class FlutterApp implements Disposable {
     }
     return getVMServiceManager().hasServiceExtension(name, onData);
   }
-  
+
   public void setConsole(@Nullable ConsoleView console) {
     myConsole = console;
   }

--- a/flutter-idea/src/io/flutter/sdk/FlutterSdk.java
+++ b/flutter-idea/src/io/flutter/sdk/FlutterSdk.java
@@ -26,7 +26,7 @@ import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.vfs.VirtualFileManager;
-import com.intellij.util.ui.EdtInvocationManager;
+import com.intellij.util.ui.EDT;
 import com.jetbrains.lang.dart.sdk.DartSdk;
 import git4idea.config.GitExecutableManager;
 import io.flutter.FlutterBundle;
@@ -159,7 +159,7 @@ public class FlutterSdk {
   @Nullable
   private static Library getDartSdkLibrary(@NotNull Project project) {
     LibraryTablesRegistrar registrar = LibraryTablesRegistrar.getInstance();
-    if (registrar == null) return  null;
+    if (registrar == null) return null;
     final LibraryTable libraryTable = registrar.getLibraryTable(project);
     for (Library lib : libraryTable.getLibraries()) {
       if (lib != null && "Dart SDK".equals(lib.getName())) {
@@ -458,7 +458,7 @@ public class FlutterSdk {
       return null;
     }
 
-    if (EdtInvocationManager.getInstance().isEventDispatchThread()) {
+    if (EDT.isCurrentThreadEdt()) {
       VfsUtil.markDirtyAndRefresh(false, true, true, baseDir); // Need this for AS.
     }
     else {
@@ -670,7 +670,7 @@ public class FlutterSdk {
         }
 
         final JsonObject obj = elem.getAsJsonObject();
-        if (obj == null) return  null;
+        if (obj == null) return null;
 
         for (String jsonKey : JsonUtils.getKeySet(obj)) {
           final JsonElement element = obj.get(jsonKey);


### PR DESCRIPTION
Migrate off deprecated APIs:

* `getClientProperty`
* `ExecutionManager.getInstance(project).getContentManager()` (for run content descriptors)
* `EdtInvocationManager.getInstance()` (for `EDT` querying)

See: https://github.com/flutter/flutter-intellij/issues/7718

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
