### PR TITLE
[CQ] mark `LOG`s @NotNull

### DIFF
--- a/flutter-idea/src/io/flutter/FlutterInitializer.java
+++ b/flutter-idea/src/io/flutter/FlutterInitializer.java
@@ -70,7 +70,7 @@ import java.util.concurrent.atomic.AtomicLong;
  * may run when a project is being imported.
  */
 public class FlutterInitializer implements StartupActivity {
-  private static final Logger LOG = Logger.getInstance(FlutterInitializer.class);
+  private static final @NotNull Logger LOG = Logger.getInstance(FlutterInitializer.class);
 
   private boolean toolWindowsInitialized = false;
 

--- a/flutter-idea/src/io/flutter/actions/FlutterDoctorAction.java
+++ b/flutter-idea/src/io/flutter/actions/FlutterDoctorAction.java
@@ -25,7 +25,7 @@ import java.nio.charset.StandardCharsets;
 
 public class FlutterDoctorAction extends FlutterSdkAction {
 
-  private static final Logger LOG = Logger.getInstance(FlutterDoctorAction.class);
+  private static final @NotNull Logger LOG = Logger.getInstance(FlutterDoctorAction.class);
 
   public void startCommand(@NotNull Project project, @NotNull FlutterSdk sdk, @Nullable PubRoot root) {
     sdk.flutterDoctor().startInConsole(project);

--- a/flutter-idea/src/io/flutter/analytics/UnifiedAnalytics.java
+++ b/flutter-idea/src/io/flutter/analytics/UnifiedAnalytics.java
@@ -28,7 +28,7 @@ import java.util.concurrent.CompletableFuture;
  * Facilitates sending information to unified analytics.
  */
 public class UnifiedAnalytics {
-  private static final Logger LOG = Logger.getInstance(UnifiedAnalytics.class);
+  private static final @NotNull Logger LOG = Logger.getInstance(UnifiedAnalytics.class);
 
   @Nullable Boolean enabled = null;
   final Project project;

--- a/flutter-idea/src/io/flutter/android/AndroidSdk.java
+++ b/flutter-idea/src/io/flutter/android/AndroidSdk.java
@@ -29,7 +29,7 @@ import java.util.List;
  * A wrapper around an Android SDK on disk.
  */
 public class AndroidSdk {
-  private static final Logger LOG = Logger.getInstance(AndroidSdk.class);
+  private static final @NotNull Logger LOG = Logger.getInstance(AndroidSdk.class);
 
   @Nullable
   public static AndroidSdk createFromProject(@NotNull Project project) {

--- a/flutter-idea/src/io/flutter/bazel/PluginConfig.java
+++ b/flutter-idea/src/io/flutter/bazel/PluginConfig.java
@@ -299,5 +299,5 @@ public class PluginConfig {
   }
 
   private static final Gson GSON = new Gson();
-  private static final Logger LOG = Logger.getInstance(PluginConfig.class);
+  private static final @NotNull Logger LOG = Logger.getInstance(PluginConfig.class);
 }

--- a/flutter-idea/src/io/flutter/bazel/WorkspaceCache.java
+++ b/flutter-idea/src/io/flutter/bazel/WorkspaceCache.java
@@ -178,5 +178,5 @@ public class WorkspaceCache {
     }
   }
 
-  private static final Logger LOG = Logger.getInstance(WorkspaceCache.class);
+  private static final @NotNull Logger LOG = Logger.getInstance(WorkspaceCache.class);
 }

--- a/flutter-idea/src/io/flutter/editor/FlutterColors.java
+++ b/flutter-idea/src/io/flutter/editor/FlutterColors.java
@@ -17,7 +17,7 @@ import java.util.Map;
 import java.util.Properties;
 
 public class FlutterColors {
-  private static final Logger LOG = Logger.getInstance(FlutterColors.class);
+  private static final @NotNull Logger LOG = Logger.getInstance(FlutterColors.class);
 
   public static class FlutterColor {
     @NotNull

--- a/flutter-idea/src/io/flutter/editor/FlutterCupertinoColors.java
+++ b/flutter-idea/src/io/flutter/editor/FlutterCupertinoColors.java
@@ -17,7 +17,7 @@ import java.util.Map;
 import java.util.Properties;
 
 public class FlutterCupertinoColors {
-  private static final Logger LOG = Logger.getInstance(FlutterCupertinoColors.class);
+  private static final @NotNull Logger LOG = Logger.getInstance(FlutterCupertinoColors.class);
 
   private static final Properties colors;
 

--- a/flutter-idea/src/io/flutter/editor/FlutterCupertinoIcons.java
+++ b/flutter-idea/src/io/flutter/editor/FlutterCupertinoIcons.java
@@ -14,7 +14,7 @@ import java.io.IOException;
 import java.util.Properties;
 
 public class FlutterCupertinoIcons {
-  private static final Logger LOG = Logger.getInstance(FlutterCupertinoIcons.class);
+  private static final @NotNull Logger LOG = Logger.getInstance(FlutterCupertinoIcons.class);
 
   private static final Properties icons;
 

--- a/flutter-idea/src/io/flutter/editor/FlutterCupertinoIcons.java
+++ b/flutter-idea/src/io/flutter/editor/FlutterCupertinoIcons.java
@@ -8,6 +8,7 @@ package io.flutter.editor;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.util.IconLoader;
 import io.flutter.FlutterUtils;
+import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
 import java.io.IOException;

--- a/flutter-idea/src/io/flutter/editor/FlutterIconLineMarkerProvider.java
+++ b/flutter-idea/src/io/flutter/editor/FlutterIconLineMarkerProvider.java
@@ -49,7 +49,7 @@ public class FlutterIconLineMarkerProvider extends LineMarkerProviderDescriptor 
 
   public static final Map<String, Set<String>> KnownPaths = new HashMap<>();
   private static final Map<String, String> BuiltInPaths = new HashMap<>();
-  private static final Logger LOG = Logger.getInstance(FlutterIconLineMarkerProvider.class);
+  private static final @NotNull Logger LOG = Logger.getInstance(FlutterIconLineMarkerProvider.class);
   private static final String MaterialRelativeAssetPath = "/bin/cache/artifacts/material_fonts/MaterialIcons-Regular.otf";
   private static final String MaterialRelativeIconsPath = "/packages/flutter/lib/src/material/icons.dart";
   private static final String CupertinoRelativeAssetPath = "/assets/CupertinoIcons.ttf";

--- a/flutter-idea/src/io/flutter/editor/FlutterMaterialIcons.java
+++ b/flutter-idea/src/io/flutter/editor/FlutterMaterialIcons.java
@@ -14,7 +14,7 @@ import java.io.IOException;
 import java.util.Properties;
 
 public class FlutterMaterialIcons {
-  private static final Logger LOG = Logger.getInstance(FlutterMaterialIcons.class);
+  private static final @NotNull Logger LOG = Logger.getInstance(FlutterMaterialIcons.class);
 
   private static final Properties icons;
 

--- a/flutter-idea/src/io/flutter/editor/FlutterMaterialIcons.java
+++ b/flutter-idea/src/io/flutter/editor/FlutterMaterialIcons.java
@@ -8,6 +8,7 @@ package io.flutter.editor;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.util.IconLoader;
 import io.flutter.FlutterUtils;
+import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
 import java.io.IOException;

--- a/flutter-idea/src/io/flutter/jxbrowser/EmbeddedBrowserEngine.java
+++ b/flutter-idea/src/io/flutter/jxbrowser/EmbeddedBrowserEngine.java
@@ -12,6 +12,7 @@ import com.intellij.openapi.util.SystemInfo;
 import com.teamdev.jxbrowser.engine.Engine;
 import com.teamdev.jxbrowser.engine.EngineOptions;
 import com.teamdev.jxbrowser.engine.PasswordStore;
+import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
 import java.nio.file.Paths;

--- a/flutter-idea/src/io/flutter/jxbrowser/EmbeddedBrowserEngine.java
+++ b/flutter-idea/src/io/flutter/jxbrowser/EmbeddedBrowserEngine.java
@@ -20,7 +20,7 @@ import static com.teamdev.jxbrowser.engine.RenderingMode.HARDWARE_ACCELERATED;
 import static com.teamdev.jxbrowser.engine.RenderingMode.OFF_SCREEN;
 
 public class EmbeddedBrowserEngine {
-  private static final Logger LOG = Logger.getInstance(EmbeddedBrowserEngine.class);
+  private static final @NotNull Logger LOG = Logger.getInstance(EmbeddedBrowserEngine.class);
   private final Engine engine;
 
   public static EmbeddedBrowserEngine getInstance() {
@@ -46,7 +46,8 @@ public class EmbeddedBrowserEngine {
     Engine temp;
     try {
       temp = Engine.newInstance(options);
-    } catch (Exception ex) {
+    }
+    catch (Exception ex) {
       temp = null;
       LOG.info(ex);
     }
@@ -59,7 +60,8 @@ public class EmbeddedBrowserEngine {
           if (engine != null && !engine.isClosed()) {
             engine.close();
           }
-        } catch (Exception ex) {
+        }
+        catch (Exception ex) {
           LOG.info(ex);
         }
         return true;

--- a/flutter-idea/src/io/flutter/jxbrowser/EmbeddedJxBrowser.java
+++ b/flutter-idea/src/io/flutter/jxbrowser/EmbeddedJxBrowser.java
@@ -49,7 +49,7 @@ class EmbeddedJxBrowserTab implements EmbeddedTab {
   private Browser browser;
   private Zoom zoom;
   private final ZoomLevelSelector zoomSelector = new ZoomLevelSelector();
-  private static final Logger LOG = Logger.getInstance(EmbeddedJxBrowserTab.class);
+  private static final @NotNull Logger LOG = Logger.getInstance(EmbeddedJxBrowserTab.class);
 
   public EmbeddedJxBrowserTab(Engine engine) {
     this.engine = engine;
@@ -122,7 +122,7 @@ class EmbeddedJxBrowserTab implements EmbeddedTab {
 }
 
 public class EmbeddedJxBrowser extends EmbeddedBrowser {
-  private static final Logger LOG = Logger.getInstance(JxBrowserManager.class);
+  private static final @NotNull Logger LOG = Logger.getInstance(JxBrowserManager.class);
   private static final String INSTALLATION_IN_PROGRESS_LABEL = "Installing JxBrowser...";
   private static final String INSTALLATION_TIMED_OUT_LABEL =
     "Waiting for JxBrowser installation timed out. Restart your IDE to try again.";
@@ -181,7 +181,8 @@ public class EmbeddedJxBrowser extends EmbeddedBrowser {
     if (engine == null) {
       showMessageWithUrlLink(jxBrowserErrorMessage(), contentManager);
       return null;
-    } else {
+    }
+    else {
       return new EmbeddedJxBrowserTab(engine);
     }
   }
@@ -210,7 +211,7 @@ public class EmbeddedJxBrowser extends EmbeddedBrowser {
   private @Nullable String jxBrowserErrorFromFailedReason(@Nullable InstallationFailedReason failedReason) {
     if (failedReason == null) return null;
     final FailureType failureType = failedReason.failureType;
-    if (failureType == null)  return null;
+    if (failureType == null) return null;
     return switch (failureType) {
       case SYSTEM_INCOMPATIBLE -> "System is incompatible with JX Browser";
       case FILE_DOWNLOAD_FAILED -> "JX Browser file download failed";
@@ -220,7 +221,6 @@ public class EmbeddedJxBrowser extends EmbeddedBrowser {
       case CLASS_LOAD_FAILED -> "JX Browser class load failed";
       case CLASS_NOT_FOUND -> "JX Browser class not found";
     };
-
   }
 
   private void manageJxBrowserDownload(ContentManager contentManager) {
@@ -234,7 +234,8 @@ public class EmbeddedJxBrowser extends EmbeddedBrowser {
     }
     else if (jxBrowserStatus.equals(JxBrowserStatus.INSTALLATION_FAILED)) {
       handleJxBrowserInstallationFailed(contentManager);
-    } else if (jxBrowserStatus.equals(JxBrowserStatus.NOT_INSTALLED) || jxBrowserStatus.equals(JxBrowserStatus.INSTALLATION_SKIPPED)) {
+    }
+    else if (jxBrowserStatus.equals(JxBrowserStatus.NOT_INSTALLED) || jxBrowserStatus.equals(JxBrowserStatus.INSTALLATION_SKIPPED)) {
       jxBrowserManager.setUp(project.getName());
       handleJxBrowserInstallationInProgress(contentManager);
     }
@@ -269,9 +270,11 @@ public class EmbeddedJxBrowser extends EmbeddedBrowser {
   protected void handleUpdatedJxBrowserStatus(JxBrowserStatus jxBrowserStatus, ContentManager contentManager) {
     if (Objects.equals(jxBrowserStatus, JxBrowserStatus.INSTALLED)) {
       return;
-    } else if (jxBrowserStatus.equals(JxBrowserStatus.INSTALLATION_FAILED)) {
+    }
+    else if (jxBrowserStatus.equals(JxBrowserStatus.INSTALLATION_FAILED)) {
       handleJxBrowserInstallationFailed(contentManager);
-    } else {
+    }
+    else {
       // newStatus can be null if installation is interrupted or stopped for another reason.
       showMessageWithUrlLink(INSTALLATION_WAIT_FAILED, contentManager);
     }
@@ -285,7 +288,8 @@ public class EmbeddedJxBrowser extends EmbeddedBrowser {
     if (!jxBrowserUtils.licenseIsSet()) {
       // If the license isn't available, allow the user to open the equivalent page in a non-embedded browser window.
       inputs.add(new LabelInput("The JxBrowser license could not be found."));
-    } else if (latestFailureReason != null && Objects.equals(latestFailureReason.failureType, FailureType.SYSTEM_INCOMPATIBLE)) {
+    }
+    else if (latestFailureReason != null && Objects.equals(latestFailureReason.failureType, FailureType.SYSTEM_INCOMPATIBLE)) {
       // If we know the system is incompatible, skip retry link and offer to open in browser.
       inputs.add(new LabelInput(latestFailureReason.detail));
     }

--- a/flutter-idea/src/io/flutter/jxbrowser/JxBrowserManager.java
+++ b/flutter-idea/src/io/flutter/jxbrowser/JxBrowserManager.java
@@ -81,7 +81,7 @@ public class JxBrowserManager {
   @NotNull
   private static final AtomicBoolean listeningForSetting = new AtomicBoolean(false);
   @NotNull
-  private static final Logger LOG = Logger.getInstance(JxBrowserManager.class);
+  private static final @NotNull Logger LOG = Logger.getInstance(JxBrowserManager.class);
   @NotNull
   public static CompletableFuture<JxBrowserStatus> installation = new CompletableFuture<>();
   @NotNull

--- a/flutter-idea/src/io/flutter/jxbrowser/JxBrowserManager.java
+++ b/flutter-idea/src/io/flutter/jxbrowser/JxBrowserManager.java
@@ -81,7 +81,7 @@ public class JxBrowserManager {
   @NotNull
   private static final AtomicBoolean listeningForSetting = new AtomicBoolean(false);
   @NotNull
-  private static final @NotNull Logger LOG = Logger.getInstance(JxBrowserManager.class);
+  private static final Logger LOG = Logger.getInstance(JxBrowserManager.class);
   @NotNull
   public static CompletableFuture<JxBrowserStatus> installation = new CompletableFuture<>();
   @NotNull

--- a/flutter-idea/src/io/flutter/logging/DiagnosticsNode.java
+++ b/flutter-idea/src/io/flutter/logging/DiagnosticsNode.java
@@ -45,7 +45,7 @@ import java.util.concurrent.CompletableFuture;
  * also available via the getValue() method.
  */
 public class DiagnosticsNode {
-  private static final Logger LOG = Logger.getInstance(DiagnosticsNode.class);
+  private static final @NotNull Logger LOG = Logger.getInstance(DiagnosticsNode.class);
 
   private static final CustomIconMaker iconMaker = new CustomIconMaker();
 

--- a/flutter-idea/src/io/flutter/logging/FlutterConsoleLogManager.java
+++ b/flutter-idea/src/io/flutter/logging/FlutterConsoleLogManager.java
@@ -56,7 +56,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * console.
  */
 public class FlutterConsoleLogManager {
-  private static final Logger LOG = Logger.getInstance(FlutterConsoleLogManager.class);
+  private static final @NotNull Logger LOG = Logger.getInstance(FlutterConsoleLogManager.class);
 
   private static final String consolePreferencesSetKey = "io.flutter.console.preferencesSet";
   private static final String DEEP_LINK_GROUP_ID = "deeplink";

--- a/flutter-idea/src/io/flutter/module/FlutterModuleBuilder.java
+++ b/flutter-idea/src/io/flutter/module/FlutterModuleBuilder.java
@@ -55,7 +55,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import static java.util.Arrays.asList;
 
 public class FlutterModuleBuilder extends ModuleBuilder {
-  private static final Logger LOG = Logger.getInstance(FlutterModuleBuilder.class);
+  private static final @NotNull Logger LOG = Logger.getInstance(FlutterModuleBuilder.class);
 
   protected FlutterModuleWizardStep myStep;
   private FlutterCreateAdditionalSettingsFields mySettingsFields;

--- a/flutter-idea/src/io/flutter/project/ProjectWatch.java
+++ b/flutter-idea/src/io/flutter/project/ProjectWatch.java
@@ -87,5 +87,5 @@ public class ProjectWatch implements Closeable {
     }
   }
 
-  private static final Logger LOG = Logger.getInstance(ProjectWatch.class);
+  private static final @NotNull Logger LOG = Logger.getInstance(ProjectWatch.class);
 }

--- a/flutter-idea/src/io/flutter/run/FlutterDebugProcess.java
+++ b/flutter-idea/src/io/flutter/run/FlutterDebugProcess.java
@@ -42,7 +42,7 @@ import java.util.Objects;
  * when not debugging in order to support hot reload.)
  */
 public class FlutterDebugProcess extends DartVmServiceDebugProcess {
-  private static final Logger LOG = Logger.getInstance(FlutterDebugProcess.class);
+  private static final @NotNull Logger LOG = Logger.getInstance(FlutterDebugProcess.class);
 
   private final @NotNull FlutterApp app;
 
@@ -55,7 +55,7 @@ public class FlutterDebugProcess extends DartVmServiceDebugProcess {
     super(executionEnvironment, session, executionResult, dartUrlResolver, app.getConnector(), mapper);
     this.app = app;
   }
-  
+
   @Override
   protected void onVmConnected(@NotNull VmService vmService) {
     app.setFlutterDebugProcess(this);

--- a/flutter-idea/src/io/flutter/run/FlutterPositionMapper.java
+++ b/flutter-idea/src/io/flutter/run/FlutterPositionMapper.java
@@ -40,7 +40,7 @@ import java.util.concurrent.CompletableFuture;
  * Used when setting breakpoints, stepping through code, and so on while debugging.
  */
 public class FlutterPositionMapper implements DartVmServiceDebugProcess.PositionMapper {
-  private static final Logger LOG = Logger.getInstance(FlutterPositionMapper.class);
+  private static final @NotNull Logger LOG = Logger.getInstance(FlutterPositionMapper.class);
 
   /**
    * This Project can't be non-null as we set it to null {@link #shutdown()} so the Project isn't held onto.

--- a/flutter-idea/src/io/flutter/run/FlutterReloadManager.java
+++ b/flutter-idea/src/io/flutter/run/FlutterReloadManager.java
@@ -80,7 +80,7 @@ import java.util.concurrent.atomic.AtomicReference;
  * Handle the mechanics of performing a hot reload on file save.
  */
 public class FlutterReloadManager {
-  private static final Logger LOG = Logger.getInstance(FlutterReloadManager.class);
+  private static final @NotNull Logger LOG = Logger.getInstance(FlutterReloadManager.class);
 
   private static final Map<String, NotificationGroup> toolWindowNotificationGroups = new HashMap<>();
 

--- a/flutter-idea/src/io/flutter/run/LaunchState.java
+++ b/flutter-idea/src/io/flutter/run/LaunchState.java
@@ -463,5 +463,5 @@ public class LaunchState extends CommandLineState {
 
   private static final Key<RunConfig> FLUTTER_RUN_CONFIG_KEY = new Key<>("FLUTTER_RUN_CONFIG_KEY");
 
-  private static final Logger LOG = Logger.getInstance(LaunchState.class);
+  private static final @NotNull Logger LOG = Logger.getInstance(LaunchState.class);
 }

--- a/flutter-idea/src/io/flutter/run/OpenDevToolsAction.java
+++ b/flutter-idea/src/io/flutter/run/OpenDevToolsAction.java
@@ -27,7 +27,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.Objects;
 
 public class OpenDevToolsAction extends DumbAwareAction {
-  private static final Logger LOG = Logger.getInstance(OpenDevToolsAction.class);
+  private static final @NotNull Logger LOG = Logger.getInstance(OpenDevToolsAction.class);
   private static final String title = "Open Flutter DevTools in Browser";
   private final @Nullable ObservatoryConnector myConnector;
   private final Computable<Boolean> myIsApplicable;
@@ -92,7 +92,7 @@ public class OpenDevToolsAction extends DumbAwareAction {
         .setIdeFeature(DevToolsIdeFeature.RUN_CONSOLE)
         .build()
         .getUrlString();
-      BrowserLauncher.getInstance().browse(devToolsUrl,null);
+      BrowserLauncher.getInstance().browse(devToolsUrl, null);
     });
   }
 }

--- a/flutter-idea/src/io/flutter/run/SdkFields.java
+++ b/flutter-idea/src/io/flutter/run/SdkFields.java
@@ -40,7 +40,7 @@ import java.util.concurrent.TimeUnit;
  * Fields used when launching an app using the Flutter SDK (non-bazel).
  */
 public class SdkFields {
-  private static final Logger LOG = Logger.getInstance(SdkFields.class);
+  private static final @NotNull Logger LOG = Logger.getInstance(SdkFields.class);
   private @Nullable String filePath;
   private @Nullable String buildFlavor;
   private @Nullable String additionalArgs;

--- a/flutter-idea/src/io/flutter/run/SdkRunConfig.java
+++ b/flutter-idea/src/io/flutter/run/SdkRunConfig.java
@@ -59,7 +59,7 @@ import static java.nio.file.FileVisitResult.CONTINUE;
 public class SdkRunConfig extends LocatableConfigurationBase<LaunchState>
   implements LaunchState.RunConfig, RefactoringListenerProvider, RunConfigurationWithSuppressedDefaultRunAction {
 
-  private static final Logger LOG = Logger.getInstance(SdkRunConfig.class);
+  private static final @NotNull Logger LOG = Logger.getInstance(SdkRunConfig.class);
   private boolean firstRun = true;
 
   private @NotNull SdkFields fields = new SdkFields();

--- a/flutter-idea/src/io/flutter/run/bazel/BazelFields.java
+++ b/flutter-idea/src/io/flutter/run/bazel/BazelFields.java
@@ -52,7 +52,7 @@ import static io.flutter.run.common.RunMode.PROFILE;
  * This class is immutable.
  */
 public class BazelFields {
-  private static final Logger LOG = Logger.getInstance(BazelFields.class);
+  private static final @NotNull Logger LOG = Logger.getInstance(BazelFields.class);
 
   /**
    * The Bazel target or Dart file to invoke.

--- a/flutter-idea/src/io/flutter/run/bazelTest/BazelTestRunner.java
+++ b/flutter-idea/src/io/flutter/run/bazelTest/BazelTestRunner.java
@@ -54,7 +54,7 @@ import org.jetbrains.annotations.Nullable;
  * The Bazel version of the {@link FlutterTestRunner}. Runs a Bazel Flutter test configuration in the debugger.
  */
 public class BazelTestRunner extends GenericProgramRunner {
-  private static final Logger LOG = Logger.getInstance(BazelTestRunner.class);
+  private static final @NotNull Logger LOG = Logger.getInstance(BazelTestRunner.class);
 
   @NotNull
   @Override
@@ -121,7 +121,7 @@ public class BazelTestRunner extends GenericProgramRunner {
 
     public Connector(ProcessHandler handler, Project project) {
       Workspace workspace = WorkspaceCache.getInstance(project).get();
-      assert(workspace != null);
+      assert (workspace != null);
       String configWarningPrefix = workspace.getConfigWarningPrefix();
       listener = new ProcessAdapter() {
         @Override
@@ -129,9 +129,9 @@ public class BazelTestRunner extends GenericProgramRunner {
           final String text = event.getText();
           if (configWarningPrefix != null && text.startsWith(configWarningPrefix)) {
             FlutterMessages.showWarning(
-                    "Configuration warning",
-                    UrlUtils.generateHtmlFragmentWithHrefTags(text.substring(configWarningPrefix.length())),
-                    null
+              "Configuration warning",
+              UrlUtils.generateHtmlFragmentWithHrefTags(text.substring(configWarningPrefix.length())),
+              null
             );
           }
 

--- a/flutter-idea/src/io/flutter/run/coverage/FlutterCoverageProgramRunner.java
+++ b/flutter-idea/src/io/flutter/run/coverage/FlutterCoverageProgramRunner.java
@@ -35,7 +35,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 public class FlutterCoverageProgramRunner extends GenericProgramRunner<RunnerSettings> {
-  private static final Logger LOG = Logger.getInstance(FlutterCoverageProgramRunner.class.getName());
+  private static final @NotNull Logger LOG = Logger.getInstance(FlutterCoverageProgramRunner.class.getName());
 
   private static final String ID = "FlutterCoverageProgramRunner";
   private ProcessHandler handler;

--- a/flutter-idea/src/io/flutter/run/coverage/FlutterCoverageRunner.java
+++ b/flutter-idea/src/io/flutter/run/coverage/FlutterCoverageRunner.java
@@ -19,7 +19,7 @@ import java.io.IOException;
 
 public class FlutterCoverageRunner extends CoverageRunner {
   private static final String ID = "FlutterCoverageRunner";
-  private static final Logger LOG = Logger.getInstance(FlutterCoverageRunner.class.getName());
+  private static final @NotNull Logger LOG = Logger.getInstance(FlutterCoverageRunner.class.getName());
 
   @Nullable
   @Override

--- a/flutter-idea/src/io/flutter/run/daemon/DaemonApi.java
+++ b/flutter-idea/src/io/flutter/run/daemon/DaemonApi.java
@@ -41,7 +41,7 @@ public class DaemonApi {
 
   private static final int STDERR_LINES_TO_KEEP = 100;
   private static final Gson GSON = new Gson();
-  private static final Logger LOG = Logger.getInstance(DaemonApi.class);
+  private static final @NotNull Logger LOG = Logger.getInstance(DaemonApi.class);
   @NotNull private final Consumer<String> callback;
   private final AtomicInteger nextId = new AtomicInteger();
   private final Map<Integer, Command> pending = new LinkedHashMap<>();

--- a/flutter-idea/src/io/flutter/run/daemon/DaemonConsoleView.java
+++ b/flutter-idea/src/io/flutter/run/daemon/DaemonConsoleView.java
@@ -27,7 +27,7 @@ import org.jetbrains.annotations.NotNull;
  * A console view that filters out JSON messages sent in --machine mode.
  */
 public class DaemonConsoleView extends ConsoleViewImpl {
-  private static final Logger LOG = Logger.getInstance(DaemonConsoleView.class);
+  private static final @NotNull Logger LOG = Logger.getInstance(DaemonConsoleView.class);
 
   /**
    * Sets up a launcher to use a DaemonConsoleView.

--- a/flutter-idea/src/io/flutter/run/daemon/DaemonEvent.java
+++ b/flutter-idea/src/io/flutter/run/daemon/DaemonEvent.java
@@ -316,5 +316,5 @@ abstract class DaemonEvent {
   }
 
   private static final Gson GSON = new Gson();
-  private static final Logger LOG = Logger.getInstance(DaemonEvent.class);
+  private static final @NotNull Logger LOG = Logger.getInstance(DaemonEvent.class);
 }

--- a/flutter-idea/src/io/flutter/run/daemon/DevToolsService.java
+++ b/flutter-idea/src/io/flutter/run/daemon/DevToolsService.java
@@ -21,7 +21,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class DevToolsService {
-  private static final Logger LOG = Logger.getInstance(DevToolsService.class);
+  private static final @NotNull Logger LOG = Logger.getInstance(DevToolsService.class);
+
   protected static class DevToolsServiceListener implements DaemonEvent.Listener {
   }
 
@@ -96,13 +97,15 @@ public class DevToolsService {
       if (devToolsServerProgressIndicator != null && devToolsServerProgressIndicator.isRunning()) {
         devToolsServerProgressIndicator.cancel();
       }
-    } else {
+    }
+    else {
       // If this is not a force-restart request, do not start a new DevTools server if one is already running, or if we have a
       // DevTools instance.
       if (devToolsServerProgressIndicator != null) {
         if (devToolsServerProgressIndicator.isRunning() || devToolsInstanceExists()) {
           return;
-        } else {
+        }
+        else {
           devToolsServerProgressIndicator.cancel();
         }
       }
@@ -123,6 +126,7 @@ public class DevToolsService {
     }
     return false;
   }
+
   private CompletableFuture<Boolean> pubActivateDevTools(FlutterSdk sdk) {
     final FlutterCommand command = sdk.flutterPub(null, "global", "activate", "devtools");
 

--- a/flutter-idea/src/io/flutter/run/daemon/DeviceDaemon.java
+++ b/flutter-idea/src/io/flutter/run/daemon/DeviceDaemon.java
@@ -423,7 +423,7 @@ class DeviceDaemon {
     }
   }
 
-  private static final Logger LOG = Logger.getInstance(DeviceDaemon.class);
+  private static final @NotNull Logger LOG = Logger.getInstance(DeviceDaemon.class);
 
   // If the daemon cannot be started, display a modal dialog with hopefully helpful
   // instructions on how to fix the problem. This is a big problem; we really do

--- a/flutter-idea/src/io/flutter/run/daemon/DeviceService.java
+++ b/flutter-idea/src/io/flutter/run/daemon/DeviceService.java
@@ -284,5 +284,5 @@ public class DeviceService {
 
   public enum State {INACTIVE, LOADING, READY}
 
-  private static final Logger LOG = Logger.getInstance(DeviceService.class);
+  private static final @NotNull Logger LOG = Logger.getInstance(DeviceService.class);
 }

--- a/flutter-idea/src/io/flutter/run/daemon/FlutterApp.java
+++ b/flutter-idea/src/io/flutter/run/daemon/FlutterApp.java
@@ -61,7 +61,7 @@ import java.util.function.Consumer;
  * A running Flutter app.
  */
 public class FlutterApp implements Disposable {
-  private static final Logger LOG = Logger.getInstance(FlutterApp.class);
+  private static final @NotNull Logger LOG = Logger.getInstance(FlutterApp.class);
   private static final Key<FlutterApp> FLUTTER_APP_KEY = new Key<>("FLUTTER_APP_KEY");
 
   private final @NotNull Project myProject;
@@ -689,7 +689,7 @@ public class FlutterApp implements Disposable {
  * Listens for events while running or debugging an app.
  */
 class FlutterAppDaemonEventListener implements DaemonEvent.Listener {
-  private static final Logger LOG = Logger.getInstance(FlutterAppDaemonEventListener.class);
+  private static final @NotNull Logger LOG = Logger.getInstance(FlutterAppDaemonEventListener.class);
 
   private final @NotNull FlutterApp app;
   private final @NotNull ProgressHelper progress;

--- a/flutter-idea/src/io/flutter/run/test/FlutterTestRunner.java
+++ b/flutter-idea/src/io/flutter/run/test/FlutterTestRunner.java
@@ -66,7 +66,8 @@ public class FlutterTestRunner extends GenericProgramRunner {
 
   @Override
   public boolean canRun(@NotNull String executorId, @NotNull RunProfile profile) {
-    if (!(DefaultDebugExecutor.EXECUTOR_ID.equals(executorId) || ToolWindowId.RUN.equals(executorId)) || !(profile instanceof TestConfig config)) {
+    if (!(DefaultDebugExecutor.EXECUTOR_ID.equals(executorId) || ToolWindowId.RUN.equals(executorId)) ||
+        !(profile instanceof TestConfig config)) {
       return false;
     }
 
@@ -330,5 +331,5 @@ public class FlutterTestRunner extends GenericProgramRunner {
     }
   }
 
-  private static final Logger LOG = Logger.getInstance(FlutterTestRunner.class);
+  private static final @NotNull Logger LOG = Logger.getInstance(FlutterTestRunner.class);
 }

--- a/flutter-idea/src/io/flutter/sdk/AndroidEmulatorManager.java
+++ b/flutter-idea/src/io/flutter/sdk/AndroidEmulatorManager.java
@@ -26,7 +26,7 @@ import java.util.concurrent.atomic.AtomicReference;
  * as notifying interested parties when the list changes.
  */
 public class AndroidEmulatorManager {
-  private static final Logger LOG = Logger.getInstance(AndroidEmulatorManager.class);
+  private static final @NotNull Logger LOG = Logger.getInstance(AndroidEmulatorManager.class);
 
   @NotNull
   public static AndroidEmulatorManager getInstance(@NotNull Project project) {

--- a/flutter-idea/src/io/flutter/sdk/FlutterCommand.java
+++ b/flutter-idea/src/io/flutter/sdk/FlutterCommand.java
@@ -31,7 +31,7 @@ import java.util.function.Consumer;
  * A Flutter command to run, with its arguments.
  */
 public class FlutterCommand {
-  private static final Logger LOG = Logger.getInstance(FlutterCommand.class);
+  private static final @NotNull Logger LOG = Logger.getInstance(FlutterCommand.class);
 
   private static final Set<Type> pubRelatedCommands = new HashSet<>(
     Arrays.asList(Type.PUB_GET, Type.PUB_UPGRADE, Type.PUB_OUTDATED, Type.UPGRADE));

--- a/flutter-idea/src/io/flutter/test/DartTestEventsConverterZ.java
+++ b/flutter-idea/src/io/flutter/test/DartTestEventsConverterZ.java
@@ -31,7 +31,7 @@ import java.util.regex.Pattern;
  */
 @SuppressWarnings({"FieldMayBeFinal", "LocalCanBeFinal", "SameReturnValue"})
 public class DartTestEventsConverterZ extends OutputToGeneralTestEventsConverter {
-  private static final Logger LOG = Logger.getInstance(DartTestEventsConverterZ.class);
+  private static final @NotNull Logger LOG = Logger.getInstance(DartTestEventsConverterZ.class);
 
   private static final String TYPE_START = "start";
   private static final String TYPE_SUITE = "suite";
@@ -378,7 +378,8 @@ public class DartTestEventsConverterZ extends OutputToGeneralTestEventsConverter
     boolean result = true;
 
     if (!test.myTestStartReported) {
-      if (Objects.equals(test.getBaseName(), SET_UP_ALL_VIRTUAL_TEST_NAME) || Objects.equals(test.getBaseName(), TEAR_DOWN_ALL_VIRTUAL_TEST_NAME)) {
+      if (Objects.equals(test.getBaseName(), SET_UP_ALL_VIRTUAL_TEST_NAME) ||
+          Objects.equals(test.getBaseName(), TEAR_DOWN_ALL_VIRTUAL_TEST_NAME)) {
         return true; // output in successfully passing setUpAll/tearDownAll is not important enough to make these nodes visible
       }
 

--- a/flutter-idea/src/io/flutter/utils/FileWatch.java
+++ b/flutter-idea/src/io/flutter/utils/FileWatch.java
@@ -269,5 +269,5 @@ public class FileWatch {
     }
   }
 
-  private static final Logger LOG = Logger.getInstance(FileWatch.class);
+  private static final @NotNull Logger LOG = Logger.getInstance(FileWatch.class);
 }

--- a/flutter-idea/src/io/flutter/utils/IconPreviewGenerator.java
+++ b/flutter-idea/src/io/flutter/utils/IconPreviewGenerator.java
@@ -9,6 +9,7 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.util.TripleFunction;
 import io.flutter.FlutterUtils;
+
 import java.awt.AlphaComposite;
 import java.awt.Color;
 import java.awt.Font;
@@ -29,12 +30,13 @@ import java.util.Properties;
 import javax.imageio.ImageIO;
 import javax.swing.Icon;
 import javax.swing.ImageIcon;
+
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 @SuppressWarnings("UseJBColor")
 public class IconPreviewGenerator {
-  private static final Logger LOG = Logger.getInstance(IconPreviewGenerator.class);
+  private static final @NotNull Logger LOG = Logger.getInstance(IconPreviewGenerator.class);
 
   @NotNull final String fontFilePath;
   int iconSize = 16;

--- a/flutter-idea/src/io/flutter/utils/Refreshable.java
+++ b/flutter-idea/src/io/flutter/utils/Refreshable.java
@@ -257,7 +257,7 @@ public class Refreshable<T> implements Closeable {
     }
   }
 
-  private static final Logger LOG = Logger.getInstance(Refreshable.class);
+  private static final @NotNull Logger LOG = Logger.getInstance(Refreshable.class);
 
   /**
    * A value indicating whether the Refreshable is being updated or not.

--- a/flutter-idea/src/io/flutter/view/EmbeddedJcefBrowser.java
+++ b/flutter-idea/src/io/flutter/view/EmbeddedJcefBrowser.java
@@ -47,7 +47,7 @@ class EmbeddedJcefBrowserTab implements EmbeddedTab {
 }
 
 public class EmbeddedJcefBrowser extends EmbeddedBrowser {
-  private static final Logger LOG = Logger.getInstance(JxBrowserManager.class);
+  private static final @NotNull Logger LOG = Logger.getInstance(JxBrowserManager.class);
 
   public EmbeddedJcefBrowser(Project project) {
     super(project);

--- a/flutter-idea/src/io/flutter/view/InspectorView.java
+++ b/flutter-idea/src/io/flutter/view/InspectorView.java
@@ -61,7 +61,7 @@ import java.util.concurrent.atomic.AtomicReference;
   storages = {@Storage("$WORKSPACE_FILE$")}
 )
 public class InspectorView implements Disposable {
-  private static final Logger LOG = Logger.getInstance(InspectorView.class);
+  private static final @NotNull Logger LOG = Logger.getInstance(InspectorView.class);
 
   public static final @NotNull String TOOL_WINDOW_ID = "Flutter Inspector";
 

--- a/flutter-idea/src/io/flutter/vmService/DartVmServiceDebugProcess.java
+++ b/flutter-idea/src/io/flutter/vmService/DartVmServiceDebugProcess.java
@@ -59,7 +59,7 @@ import java.util.*;
 import java.util.concurrent.CompletableFuture;
 
 public abstract class DartVmServiceDebugProcess extends XDebugProcess {
-  private static final Logger LOG = Logger.getInstance(DartVmServiceDebugProcess.class.getName());
+  private static final @NotNull Logger LOG = Logger.getInstance(DartVmServiceDebugProcess.class.getName());
 
   @NotNull private final ExecutionResult myExecutionResult;
   @NotNull private final DartUrlResolver myDartUrlResolver;

--- a/flutter-idea/src/io/flutter/vmService/DartVmServiceListener.java
+++ b/flutter-idea/src/io/flutter/vmService/DartVmServiceListener.java
@@ -23,7 +23,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class DartVmServiceListener implements VmServiceListener {
-  private static final Logger LOG = Logger.getInstance(DartVmServiceListener.class.getName());
+  private static final @NotNull Logger LOG = Logger.getInstance(DartVmServiceListener.class.getName());
 
   @NotNull private final DartVmServiceDebugProcess myDebugProcess;
   @NotNull private final DartVmServiceBreakpointHandler myBreakpointHandler;

--- a/flutter-idea/src/io/flutter/vmService/DisplayRefreshRateManager.java
+++ b/flutter-idea/src/io/flutter/vmService/DisplayRefreshRateManager.java
@@ -13,6 +13,7 @@ import io.flutter.utils.OpenApiUtils;
 import org.dartlang.vm.service.VmService;
 import org.dartlang.vm.service.consumer.ServiceExtensionConsumer;
 import org.dartlang.vm.service.element.RPCError;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.concurrent.CompletableFuture;
 

--- a/flutter-idea/src/io/flutter/vmService/DisplayRefreshRateManager.java
+++ b/flutter-idea/src/io/flutter/vmService/DisplayRefreshRateManager.java
@@ -17,7 +17,7 @@ import org.dartlang.vm.service.element.RPCError;
 import java.util.concurrent.CompletableFuture;
 
 public class DisplayRefreshRateManager {
-  private static final Logger LOG = Logger.getInstance(DisplayRefreshRateManager.class);
+  private static final @NotNull Logger LOG = Logger.getInstance(DisplayRefreshRateManager.class);
   private static boolean notificationDisplayedAlready = false;
 
   public static final double defaultRefreshRate = 60.0;


### PR DESCRIPTION
`LOG` objects are statically initialized and sure to be not-null. Annotating them all quiets downstream unsafe access warnings. 

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
