### PR TITLE
[CQ] prefer “magic” flow layout constants

### DIFF
--- a/flutter-idea/src/io/flutter/view/EmbeddedBrowser.java
+++ b/flutter-idea/src/io/flutter/view/EmbeddedBrowser.java
@@ -200,7 +200,7 @@ public abstract class EmbeddedBrowser {
       }
     }
 
-    final JPanel center = new JPanel(new VerticalFlowLayout(VerticalFlowLayout.CENTER));
+    final JPanel center = new JPanel(new VerticalFlowLayout(VerticalFlowLayout.MIDDLE));
     center.add(panel);
     replacePanelLabel(center, contentManager);
   }

--- a/flutter-idea/src/io/flutter/view/ViewUtils.java
+++ b/flutter-idea/src/io/flutter/view/ViewUtils.java
@@ -47,7 +47,7 @@ public class ViewUtils {
     }
 
     // Use VerticalFlowLayout to center the block of labels vertically
-    final JPanel centerPanel = new JPanel(new VerticalFlowLayout(VerticalFlowLayout.CENTER));
+    final JPanel centerPanel = new JPanel(new VerticalFlowLayout(VerticalFlowLayout.MIDDLE));
     centerPanel.add(labelsPanel);
 
     replacePanelLabel(toolWindow, centerPanel);
@@ -73,7 +73,7 @@ public class ViewUtils {
       }
     }
 
-    final JPanel center = new JPanel(new VerticalFlowLayout(VerticalFlowLayout.CENTER));
+    final JPanel center = new JPanel(new VerticalFlowLayout(VerticalFlowLayout.MIDDLE));
     center.add(panel);
     replacePanelLabel(toolWindow, center);
   }


### PR DESCRIPTION
`VerticalFlowAlignment` identifies some "magic" constants:

![image](https://github.com/user-attachments/assets/d49fa227-d381-4cf3-867d-17db1c5fe1c5)

that are prefered:

![image](https://github.com/user-attachments/assets/8c852821-d863-4d27-8723-b91fe260731b)

(Note that both `CENTER` and `MIDDLE` are initialized to `1` so this is semantics preserving.)



---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
