### PR TITLE
[CQ] migrate post-startup `Startup` to `Project` activities

### DIFF
--- a/flutter-idea/src/io/flutter/FlutterInitializer.java
+++ b/flutter-idea/src/io/flutter/FlutterInitializer.java
@@ -25,7 +25,6 @@ import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.ModuleListener;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ProjectRootManager;
-import com.intellij.openapi.startup.StartupActivity;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.util.messages.MessageBusConnection;
 import com.jetbrains.lang.dart.ide.toolingDaemon.DartToolingDaemonService;
@@ -68,7 +67,7 @@ import java.util.concurrent.atomic.AtomicLong;
  * @see io.flutter.project.FlutterProjectOpenProcessor for additional actions that
  * may run when a project is being imported.
  */
-public class FlutterInitializer implements StartupActivity {
+public class FlutterInitializer extends FlutterProjectActivity {
   private static final @NotNull Logger LOG = Logger.getInstance(FlutterInitializer.class);
 
   private boolean toolWindowsInitialized = false;
@@ -78,7 +77,7 @@ public class FlutterInitializer implements StartupActivity {
   private @NotNull AtomicLong lastScheduledThemeChangeTime = new AtomicLong();
 
   @Override
-  public void runActivity(@NotNull Project project) {
+  public void executeProjectStartup(@NotNull Project project) {
     // Disable the 'Migrate Project to Gradle' notification.
     FlutterUtils.disableGradleProjectMigrationNotification(project);
 

--- a/flutter-idea/src/io/flutter/FlutterProjectActivity.kt
+++ b/flutter-idea/src/io/flutter/FlutterProjectActivity.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2025 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+package io.flutter
+
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.startup.ProjectActivity
+
+abstract class FlutterProjectActivity : ProjectActivity {
+
+  protected val log = Logger.getInstance(this::class.java)
+  abstract fun executeProjectStartup(project: Project)
+
+  override suspend fun execute(project: Project) {
+    runCatching {
+      executeProjectStartup(project)
+    }.onFailure {
+      log.error(it)
+    }
+  }
+}

--- a/flutter-idea/src/io/flutter/ProjectOpenActivity.java
+++ b/flutter-idea/src/io/flutter/ProjectOpenActivity.java
@@ -20,7 +20,6 @@ import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectType;
 import com.intellij.openapi.project.ProjectTypeService;
-import com.intellij.openapi.startup.StartupActivity;
 import com.intellij.openapi.ui.Messages;
 import icons.FlutterIcons;
 import io.flutter.bazel.WorkspaceCache;
@@ -40,14 +39,14 @@ import java.util.Collection;
  *
  * @see FlutterInitializer for actions that run later.
  */
-public class ProjectOpenActivity implements StartupActivity, DumbAware {
+public class ProjectOpenActivity extends FlutterProjectActivity implements DumbAware {
   public static final ProjectType FLUTTER_PROJECT_TYPE = new ProjectType("io.flutter");
 
   public ProjectOpenActivity() {
   }
 
   @Override
-  public void runActivity(@NotNull Project project) {
+  public void executeProjectStartup(@NotNull Project project) {
     // TODO(helinx): We don't have a good way to check whether a Bazel project is using Flutter. Look into whether we can
     // build a better Flutter Bazel check into `declaresFlutter` so we don't need the second condition.
     if (!FlutterModuleUtils.declaresFlutter(project) && !WorkspaceCache.getInstance(project).isBazel()) {


### PR DESCRIPTION
`StartupActivity` is marked as obsolete with `ProjectActivity` identified as the path forward.

This introduces a `FlutterProjectActivity` that does some rudimentary error handling as well.

See https://github.com/flutter/flutter-intellij/issues/7718 and https://github.com/flutter/flutter-intellij/issues/8100

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
