### PR TITLE
[PE] fix missing ai, yaml plugin dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -117,6 +117,7 @@ dependencies {
     // Plugin dependency documentation:
     // https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-dependencies-extension.html#plugins
     val bundledPluginList = mutableListOf(
+      "com.google.tools.ij.aiplugin",
       "com.intellij.java",
       "com.intellij.properties",
       "JUnit",

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -64,9 +64,11 @@ jvmVersion = when (javaVersion) {
   "17" -> {
     JvmTarget.JVM_17
   }
+
   "21" -> {
     JvmTarget.JVM_21
   }
+
   else -> {
     throw IllegalArgumentException("javaVersion must be defined in the product matrix as either \"17\" or \"21\", but is not for $ideaVersion")
   }
@@ -121,7 +123,9 @@ dependencies {
       "Git4Idea",
       "org.jetbrains.kotlin",
       "org.jetbrains.plugins.gradle",
-      "org.intellij.intelliLang")
+      "org.jetbrains.plugins.yaml",
+      "org.intellij.intelliLang"
+    )
     val pluginList = mutableListOf("Dart:$dartPluginVersion")
     if (ideaProduct == "android-studio") {
       bundledPluginList.add("org.jetbrains.android")

--- a/flutter-idea/build.gradle.kts
+++ b/flutter-idea/build.gradle.kts
@@ -96,6 +96,7 @@ dependencies {
     // Plugin dependency documentation:
     // https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-dependencies-extension.html#plugins
     val bundledPluginList = mutableListOf(
+      "com.google.tools.ij.aiplugin",
       "com.intellij.java",
       "com.intellij.properties",
       "JUnit",

--- a/flutter-idea/build.gradle.kts
+++ b/flutter-idea/build.gradle.kts
@@ -43,9 +43,11 @@ jvmVersion = when (javaVersion) {
   "17" -> {
     JvmTarget.JVM_17
   }
+
   "21" -> {
     JvmTarget.JVM_21
   }
+
   else -> {
     throw IllegalArgumentException("javaVersion must be defined in the product matrix as either \"17\" or \"21\", but is not for $ideaVersion")
   }
@@ -62,9 +64,11 @@ javaCompatibilityVersion = when (javaVersion) {
   "17" -> {
     JavaVersion.VERSION_17
   }
+
   "21" -> {
     JavaVersion.VERSION_21
   }
+
   else -> {
     throw IllegalArgumentException("javaVersion must be defined in the product matrix as either \"17\" or \"21\", but is not for $ideaVersion")
   }
@@ -98,6 +102,7 @@ dependencies {
       "Git4Idea",
       "org.jetbrains.kotlin",
       "org.jetbrains.plugins.gradle",
+      "org.jetbrains.plugins.yaml",
       "org.intellij.intelliLang",
     )
     val pluginList = mutableListOf("Dart:$dartPluginVersion")
@@ -178,62 +183,136 @@ dependencies {
   testImplementation(mapOf("group" to "org.mockito", "name" to "mockito-core", "version" to "5.2.0"))
   if (ideaProduct == "android-studio") {
     testImplementation(project(":flutter-studio"))
-    testRuntimeOnly(fileTree(mapOf("dir" to "${project.rootDir}/artifacts/android-studio/plugins",
-      "include" to listOf("**/*.jar"),
-      "exclude" to listOf("**/kotlin-compiler.jar", "**/kotlin-plugin.jar", "**/kotlin-stdlib-jdk8.jar"))))
-    compileOnly(fileTree(mapOf("dir" to "${project.rootDir}/artifacts/android-studio/lib",
-      "include" to listOf("*.jar"),
-      "exclude" to listOf("**/annotations.jar"))))
-    testRuntimeOnly(fileTree(mapOf("dir" to "${project.rootDir}/artifacts/android-studio/lib",
-      "include" to listOf("*.jar"))))
-    compileOnly(fileTree(mapOf("dir" to "${project.rootDir}/artifacts/android-studio/plugins/git4idea/lib",
-      "include" to listOf("*.jar"))))
-    testImplementation(fileTree(mapOf("dir" to "${project.rootDir}/artifacts/android-studio/plugins/git4idea/lib",
-      "include" to listOf("*.jar"))))
+    testRuntimeOnly(
+      fileTree(
+        mapOf(
+          "dir" to "${project.rootDir}/artifacts/android-studio/plugins",
+          "include" to listOf("**/*.jar"),
+          "exclude" to listOf("**/kotlin-compiler.jar", "**/kotlin-plugin.jar", "**/kotlin-stdlib-jdk8.jar")
+        )
+      )
+    )
+    compileOnly(
+      fileTree(
+        mapOf(
+          "dir" to "${project.rootDir}/artifacts/android-studio/lib",
+          "include" to listOf("*.jar"),
+          "exclude" to listOf("**/annotations.jar")
+        )
+      )
+    )
+    testRuntimeOnly(
+      fileTree(
+        mapOf(
+          "dir" to "${project.rootDir}/artifacts/android-studio/lib",
+          "include" to listOf("*.jar")
+        )
+      )
+    )
+    compileOnly(
+      fileTree(
+        mapOf(
+          "dir" to "${project.rootDir}/artifacts/android-studio/plugins/git4idea/lib",
+          "include" to listOf("*.jar")
+        )
+      )
+    )
+    testImplementation(
+      fileTree(
+        mapOf(
+          "dir" to "${project.rootDir}/artifacts/android-studio/plugins/git4idea/lib",
+          "include" to listOf("*.jar")
+        )
+      )
+    )
   } else {
-    compileOnly(fileTree(mapOf("dir" to "${project.rootDir}/artifacts/ideaIC/plugins/git4idea/lib",
-      "include" to listOf("*.jar"))))
-    compileOnly(fileTree(mapOf("dir" to "${project.rootDir}/artifacts/ideaIC/plugins/java/lib",
-      "include" to listOf("*.jar"))))
-    testImplementation(fileTree(mapOf("dir" to "${project.rootDir}/artifacts/ideaIC/plugins/git4idea/lib",
-      "include" to listOf("*.jar"))))
+    compileOnly(
+      fileTree(
+        mapOf(
+          "dir" to "${project.rootDir}/artifacts/ideaIC/plugins/git4idea/lib",
+          "include" to listOf("*.jar")
+        )
+      )
+    )
+    compileOnly(
+      fileTree(
+        mapOf(
+          "dir" to "${project.rootDir}/artifacts/ideaIC/plugins/java/lib",
+          "include" to listOf("*.jar")
+        )
+      )
+    )
+    testImplementation(
+      fileTree(
+        mapOf(
+          "dir" to "${project.rootDir}/artifacts/ideaIC/plugins/git4idea/lib",
+          "include" to listOf("*.jar")
+        )
+      )
+    )
   }
   compileOnly("com.google.guava:guava:32.0.1-android")
   compileOnly("com.google.code.gson:gson:2.10.1")
   testImplementation("com.google.guava:guava:32.0.1-jre")
   testImplementation("com.google.code.gson:gson:2.10.1")
   testImplementation("junit:junit:4.13.2")
-  runtimeOnly(fileTree(mapOf("dir" to "${project.rootDir}/third_party/lib/jxbrowser",
-    "include" to listOf("*.jar"))))
-  compileOnly(fileTree(mapOf("dir" to "${project.rootDir}/third_party/lib/jxbrowser",
-    "include" to listOf("*.jar"))))
-  testImplementation(fileTree(mapOf("dir" to "${project.rootDir}/third_party/lib/jxbrowser",
-    "include" to listOf("*.jar"))))
+  runtimeOnly(
+    fileTree(
+      mapOf(
+        "dir" to "${project.rootDir}/third_party/lib/jxbrowser",
+        "include" to listOf("*.jar")
+      )
+    )
+  )
+  compileOnly(
+    fileTree(
+      mapOf(
+        "dir" to "${project.rootDir}/third_party/lib/jxbrowser",
+        "include" to listOf("*.jar")
+      )
+    )
+  )
+  testImplementation(
+    fileTree(
+      mapOf(
+        "dir" to "${project.rootDir}/third_party/lib/jxbrowser",
+        "include" to listOf("*.jar")
+      )
+    )
+  )
 }
 
 sourceSets {
   main {
-    java.srcDirs(listOf(
-      "src",
-      "third_party/vmServiceDrivers"
-    ))
+    java.srcDirs(
+      listOf(
+        "src",
+        "third_party/vmServiceDrivers"
+      )
+    )
     // Add kotlin.srcDirs if we start using Kotlin in the main plugin.
-    resources.srcDirs(listOf(
-      "src",
-      "resources"
-    ))
+    resources.srcDirs(
+      listOf(
+        "src",
+        "resources"
+      )
+    )
   }
   test {
-    java.srcDirs(listOf(
-      "src",
-      "testSrc/unit",
-      "third_party/vmServiceDrivers"
-    ))
-    resources.srcDirs(listOf(
-      "resources",
-      "testData",
-      "testSrc/unit"
-    ))
+    java.srcDirs(
+      listOf(
+        "src",
+        "testSrc/unit",
+        "third_party/vmServiceDrivers"
+      )
+    )
+    resources.srcDirs(
+      listOf(
+        "resources",
+        "testData",
+        "testSrc/unit"
+      )
+    )
   }
 }
 

--- a/flutter-studio/build.gradle.kts
+++ b/flutter-studio/build.gradle.kts
@@ -92,6 +92,7 @@ dependencies {
     // Plugin dependency documentation:
     // https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-dependencies-extension.html#plugins
     val bundledPluginList = mutableListOf(
+      "com.google.tools.ij.aiplugin",
       "com.intellij.java",
       "com.intellij.properties",
       "JUnit",

--- a/flutter-studio/build.gradle.kts
+++ b/flutter-studio/build.gradle.kts
@@ -43,9 +43,11 @@ jvmVersion = when (javaVersion) {
   "17" -> {
     JvmTarget.JVM_17
   }
+
   "21" -> {
     JvmTarget.JVM_21
   }
+
   else -> {
     throw IllegalArgumentException("javaVersion must be defined in the product matrix as either \"17\" or \"21\", but is not for $ideaVersion")
   }
@@ -62,9 +64,11 @@ javaCompatibilityVersion = when (javaVersion) {
   "17" -> {
     JavaVersion.VERSION_17
   }
+
   "21" -> {
     JavaVersion.VERSION_21
   }
+
   else -> {
     throw IllegalArgumentException("javaVersion must be defined in the product matrix as either \"17\" or \"21\", but is not for $ideaVersion")
   }
@@ -94,8 +98,9 @@ dependencies {
       "Git4Idea",
       "org.jetbrains.kotlin",
       "org.jetbrains.plugins.gradle",
-      "org.intellij.intelliLang",
-      "org.intellij.intelliLang")
+      "org.jetbrains.plugins.yaml",
+      "org.intellij.intelliLang"
+    )
     if (ideaProduct == "android-studio") {
       bundledPluginList.add("org.jetbrains.android")
       bundledPluginList.add("com.android.tools.idea.smali")
@@ -130,23 +135,49 @@ intellijPlatform {
 dependencies {
   compileOnly(project(":flutter-idea"))
   testImplementation(project(":flutter-idea"))
-  compileOnly(fileTree(mapOf("dir" to "${project.rootDir}/artifacts/android-studio/lib",
-    "include" to listOf("*.jar"))))
-  testImplementation(fileTree(mapOf("dir" to "${project.rootDir}/artifacts/android-studio/lib",
-    "include" to listOf("*.jar"))))
-  compileOnly(fileTree(mapOf("dir" to "${project.rootDir}/artifacts/android-studio/plugins",
-    "include" to listOf("**/*.jar"),
-    "exclude" to listOf("**/kotlin-compiler.jar", "**/kotlin-plugin.jar"))))
-  testImplementation(fileTree(mapOf("dir" to "${project.rootDir}/artifacts/android-studio/plugins",
-    "include" to listOf("**/*.jar"),
-    "exclude" to listOf("**/kotlin-compiler.jar", "**/kotlin-plugin.jar"))))
+  compileOnly(
+    fileTree(
+      mapOf(
+        "dir" to "${project.rootDir}/artifacts/android-studio/lib",
+        "include" to listOf("*.jar")
+      )
+    )
+  )
+  testImplementation(
+    fileTree(
+      mapOf(
+        "dir" to "${project.rootDir}/artifacts/android-studio/lib",
+        "include" to listOf("*.jar")
+      )
+    )
+  )
+  compileOnly(
+    fileTree(
+      mapOf(
+        "dir" to "${project.rootDir}/artifacts/android-studio/plugins",
+        "include" to listOf("**/*.jar"),
+        "exclude" to listOf("**/kotlin-compiler.jar", "**/kotlin-plugin.jar")
+      )
+    )
+  )
+  testImplementation(
+    fileTree(
+      mapOf(
+        "dir" to "${project.rootDir}/artifacts/android-studio/plugins",
+        "include" to listOf("**/*.jar"),
+        "exclude" to listOf("**/kotlin-compiler.jar", "**/kotlin-plugin.jar")
+      )
+    )
+  )
 }
 
 sourceSets {
   main {
-    java.srcDirs(listOf(
-      "src",
-      "third_party/vmServiceDrivers"
-    ))
+    java.srcDirs(
+      listOf(
+        "src",
+        "third_party/vmServiceDrivers"
+      )
+    )
   }
 }


### PR DESCRIPTION
Fixes broken `com.google.tools.ij.aiplugin` and `org.jetbrains.plugins.yaml` plugin references by adding missing gradle dependencies.

See inspection details here:

https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html?from=DevkitPluginXmlInspection

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
