### PR TITLE
[CQ] migrate from deprecated `LayeredIcon` constructor

### DIFF
--- a/flutter-idea/src/io/flutter/utils/CustomIconMaker.java
+++ b/flutter-idea/src/io/flutter/utils/CustomIconMaker.java
@@ -46,8 +46,8 @@ public class CustomIconMaker {
 
     if (!iconCache.containsKey(mapKey)) {
       final Icon baseIcon = isAbstract ? kind.abstractIcon : kind.icon;
-
-      final Icon icon = new LayeredIcon(baseIcon, new Icon() {
+      
+      final Icon icon = LayeredIcon.layeredIcon(() -> new Icon[]{baseIcon, new Icon() {
         public void paintIcon(Component c, Graphics g, int x, int y) {
           final Graphics2D g2 = (Graphics2D)g.create();
 
@@ -78,7 +78,7 @@ public class CustomIconMaker {
         public int getIconHeight() {
           return baseIcon != null ? baseIcon.getIconHeight() : 13;
         }
-      });
+      }});
 
       iconCache.put(mapKey, icon);
     }


### PR DESCRIPTION
Migrate from deprecated `LayeredIcon(...)` to the `layeredIcon` object companion function (now preferred).

See: 

https://github.com/JetBrains/intellij-community/blob/1d1263727bd49f317fdf385e50dded26e98cc76f/platform/core-ui/src/ui/LayeredIcon.kt#L101

---

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
