### PR TITLE
[CQ] limit internal `XDebugSessionImpl` dependence; remove dead code

### DIFF
--- a/flutter-idea/src/io/flutter/vmService/DartVmServiceDebugProcess.java
+++ b/flutter-idea/src/io/flutter/vmService/DartVmServiceDebugProcess.java
@@ -511,7 +511,7 @@ public abstract class DartVmServiceDebugProcess extends XDebugProcess {
                 else if (eventKind == EventKind.Resume) {
                   // Currently true if we got here via 'flutter attach'
                   OpenApiUtils.safeInvokeLater(() -> {
-                    myVmServiceWrapper.attachIsolate(isolateRef, isolate);
+                    myVmServiceWrapper.attachIsolate(isolateRef);
                   });
                 }
               }


### PR DESCRIPTION
🤫 Limits `XDebugSessionImpl` dependence (silencing two internal API access inspections); adding a note explaining our usage
🧹 Removes `VmServiceWrapper` dead code

---

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
