### PR TITLE
[CQ] remove `FlutterCreateAdditionalSettingsField` deadcode

### DIFF
--- a/flutter-idea/src/io/flutter/module/settings/FlutterCreateAdditionalSettingsFields.java
+++ b/flutter-idea/src/io/flutter/module/settings/FlutterCreateAdditionalSettingsFields.java
@@ -142,10 +142,6 @@ public class FlutterCreateAdditionalSettingsFields {
     });
   }
 
-  public void updateProjectType(FlutterProjectType projectType) {
-    // TODO(messick) Remove this method and its caller, which is in the flutter-studio module.
-  }
-
   public FlutterCreateAdditionalSettings getAdditionalSettings() {
     return new FlutterCreateAdditionalSettings.Builder()
       .setDescription(!descriptionField.getText().trim().isEmpty() ? descriptionField.getText().trim() : null)

--- a/flutter-studio/src/io/flutter/project/FlutterModuleGroup.java
+++ b/flutter-studio/src/io/flutter/project/FlutterModuleGroup.java
@@ -26,9 +26,8 @@ public abstract class FlutterModuleGroup extends FlutterModuleBuilder {
   public ModuleWizardStep getCustomOptionsStep(final WizardContext context, final Disposable parentDisposable) {
     // This runs each time the project type selection changes.
     FlutterModuleWizardStep step = (FlutterModuleWizardStep)super.getCustomOptionsStep(context, parentDisposable);
-    assert step!= null;
+    assert step != null;
     getSettingsField().linkHelpForm(step.getHelpForm());
-    setProjectTypeInSettings();
     return step;
   }
 
@@ -36,7 +35,6 @@ public abstract class FlutterModuleGroup extends FlutterModuleBuilder {
   public ModuleWizardStep modifySettingsStep(@NotNull SettingsStep settingsStep) {
     // This runs when the Next button takes the wizard to the second page.
     ModuleWizardStep wizard = super.modifySettingsStep(settingsStep);
-    setProjectTypeInSettings(); // TODO (messick) Remove this if possible (needs testing).
     return wizard;
   }
 
@@ -44,10 +42,6 @@ public abstract class FlutterModuleGroup extends FlutterModuleBuilder {
   @Override
   public String getParentGroup() {
     return "Flutter";
-  }
-
-  protected void setProjectTypeInSettings() {
-    getSettingsField().updateProjectType(getFlutterProjectType());
   }
 
   public static class App extends FlutterModuleGroup {


### PR DESCRIPTION
Following up on a TODO from Steve to remove an unused method and callers.

Interestingly, `FlutterModuleGroup` seems entirely unused. It's meant to:

```
// Define a group of Flutter project types for use in Android Studio 4.2 and later.
```

Steve warns:

```
// TODO (messick) DO NOT delete this during post-4.2 clean-up.
```

but maybe we can? Especially if noone has plans to re-integrate.

@jwren : do you have any context on this?


---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
