### PR TITLE
[CQ] fix visibility scope of leaked classes

### DIFF
--- a/flutter-idea/src/io/flutter/run/test/TestLaunchState.java
+++ b/flutter-idea/src/io/flutter/run/test/TestLaunchState.java
@@ -37,7 +37,7 @@ import org.jetbrains.annotations.Nullable;
 /**
  * A launcher that starts a process to run flutter tests, created from a run configuration.
  */
-class TestLaunchState extends CommandLineState {
+public class TestLaunchState extends CommandLineState {
   @NotNull
   private final TestConfig config;
 

--- a/flutter-idea/src/io/flutter/view/EmbeddedBrowser.java
+++ b/flutter-idea/src/io/flutter/view/EmbeddedBrowser.java
@@ -32,18 +32,19 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-class BrowserTab {
-  protected EmbeddedTab embeddedTab;
-  protected Content content;
-  protected CompletableFuture<DevToolsUrl> devToolsUrlFuture;
-  public ContentManager contentManager;
-}
 
 /**
  * There is one instance of embedded browser across the project, but it manages tabs across multiple tool
  * windows. Each tab can display contents of an independent URL.
  */
 public abstract class EmbeddedBrowser {
+  static public class BrowserTab {
+    protected EmbeddedTab embeddedTab;
+    protected Content content;
+    protected CompletableFuture<DevToolsUrl> devToolsUrlFuture;
+    public ContentManager contentManager;
+  }
+
   public static final String ANALYTICS_CATEGORY = "embedded-browser";
 
   protected final Map<@NotNull String, Map<@NotNull String, @NotNull BrowserTab>> windows = new HashMap<>();

--- a/flutter-idea/src/io/flutter/vmService/frame/DartVmServiceValue.java
+++ b/flutter-idea/src/io/flutter/vmService/frame/DartVmServiceValue.java
@@ -532,7 +532,8 @@ public class DartVmServiceValue extends XNamedValue {
             final String n;
             if (name instanceof String) {
               n = (String)name;
-            } else {
+            }
+            else {
               n = "$" + (int)name;
             }
             childrenList.add(new DartVmServiceValue(myDebugProcess, myIsolateId, n, value, null, null, false));
@@ -599,7 +600,7 @@ public class DartVmServiceValue extends XNamedValue {
     return myInstanceRef;
   }
 
-  static class LocalVarSourceLocation {
+  public static class LocalVarSourceLocation {
     @NotNull private final ScriptRef myScriptRef;
     private final int myTokenPos;
 


### PR DESCRIPTION
These classes are exposed but not available outside their visibility scopes. The APIs exposing them seem reasonable but if we revisit them we can always make these classes (more) private again. 

![image](https://github.com/user-attachments/assets/8dcd2cdb-47cb-4d48-96fb-4d12b8800d04)


---

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
