### PR TITLE
[CQ] migrate off slated-for-removal `DataContext` functional interface

### DIFF
--- a/flutter-idea/src/io/flutter/editor/NativeEditorNotificationProvider.java
+++ b/flutter-idea/src/io/flutter/editor/NativeEditorNotificationProvider.java
@@ -6,6 +6,7 @@
 package io.flutter.editor;
 
 import com.intellij.openapi.actionSystem.*;
+import com.intellij.openapi.actionSystem.impl.SimpleDataContext;
 import com.intellij.openapi.fileEditor.FileEditor;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.SystemInfo;
@@ -143,15 +144,7 @@ public class NativeEditorNotificationProvider implements EditorNotificationProvi
     }
 
     private DataContext makeContext() {
-      return dataId -> {
-        if (CommonDataKeys.VIRTUAL_FILE.is(dataId)) {
-          return myFile;
-        }
-        if (CommonDataKeys.PROJECT.is(dataId)) {
-          return project;
-        }
-        return null;
-      };
+      return SimpleDataContext.builder().add(CommonDataKeys.VIRTUAL_FILE, myFile).add(CommonDataKeys.PROJECT, project).build();
     }
   }
 }


### PR DESCRIPTION
The (neat) `DataContext` functional interface is slated to be removed.

![image](https://github.com/user-attachments/assets/dceb05c7-aa6a-4b20-bbd6-def43062e66e)

This migrates us to a `SimpleDataContext` builder which is the [new path forward](https://github.com/JetBrains/intellij-community/blob/7b62c265ab76de3c80882525fdc4047895f3f4b1/platform/core-ui/src/openapi/actionSystem/DataContext.java#L18).

See: https://github.com/flutter/flutter-intellij/issues/7718


---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
