### PR TITLE
[perf] `FlutterExternalIdeActionGroup`: make action update thread explicit

### DIFF
--- a/flutter-idea/src/io/flutter/actions/FlutterExternalIdeActionGroup.java
+++ b/flutter-idea/src/io/flutter/actions/FlutterExternalIdeActionGroup.java
@@ -5,10 +5,7 @@
  */
 package io.flutter.actions;
 
-import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.actionSystem.CommonDataKeys;
-import com.intellij.openapi.actionSystem.DefaultActionGroup;
-import com.intellij.openapi.actionSystem.Presentation;
+import com.intellij.openapi.actionSystem.*;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import io.flutter.FlutterUtils;
@@ -34,6 +31,11 @@ public class FlutterExternalIdeActionGroup extends DefaultActionGroup {
       isProjectDirectory(file, project) ||
       isWithinIOsDirectory(file, project) ||
       FlutterUtils.isXcodeProjectFileName(file.getName()) || OpenInAndroidStudioAction.isProjectFileName(file.getName());
+  }
+
+  @Override
+  public @NotNull ActionUpdateThread getActionUpdateThread() {
+    return ActionUpdateThread.EDT;
   }
 
   public static boolean isAndroidDirectory(@NotNull VirtualFile file) {


### PR DESCRIPTION
Making the action update thread explicit saves the platform from the work of figuring it out for itself (required caching of potentially unneeded data).  From a related inspection:

> Reports actions, action groups and other ActionUpdateThreadAware classes that do not explicitly state their mode.
> When an action or an action group defines its own update() method, IntelliJ Platform tries to mimic the old synchronous way of calling update() and getChildren() methods in the UI thread and supply it with all the data in AnActionEvent.dataContext(). To do that, it caches all the possible data on a background thread beforehand, even if it is not needed.
> Provide one of the two modes ActionUpdateThread.EDT or ActionUpdateThread.BGT by overriding the getActionUpdateThread() method.


![image](https://github.com/user-attachments/assets/444c53e0-5c80-489f-8b3e-82419cb18b1b)


---

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
