### PR TITLE
[docs] fix sandbox location in dev notes

### DIFF
--- a/docs/Development.md
+++ b/docs/Development.md
@@ -2,7 +2,10 @@
 
 ### Simulating a fresh install
 
-To simulate a fresh install, you need to delete any accrued application state.  To do this, you'll want to delete select folders in your plugin sandbox (location found in the `Sandbox Home` field in `Project structure | SDKs | [your IntelliJ IDEA plugin SDK]`.
+To simulate a fresh install, you need to delete any accrued application state.  To do this, you'll want to delete select folders in your plugin sandbox.
+(To find your sandbox, launch the `runIde` run/debug configuration and in this newly launched IDE instance, open `Help > Show Log in Finder` (macOS) or 
+`Help > Show Log in Explorer` (Windows), or `Help > Show Log in Files` (Linux). The log directory is usually inside a system folder, which itself is
+inside your sandbox.)
 
 * **config** folder contains IDE app-level configuration, including app-level libraries, SDKs, recent projects, etc.
 * **system** folder contains indexes and caches, deleting it is similar to File | Invalidate Caches action.


### PR DESCRIPTION
At some point, the `"Sandbox Home"` field stopped being explicitly displayed in the Plugin SDK settings and we need to get more adventurous to find it.

---

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
