### PR TITLE
Add warning about "docked unpinned" state

### DIFF
--- a/flutter-idea/src/io/flutter/propertyeditor/PropertyEditorViewFactory.java
+++ b/flutter-idea/src/io/flutter/propertyeditor/PropertyEditorViewFactory.java
@@ -6,7 +6,12 @@
 package io.flutter.propertyeditor;
 
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Disposer;
 import com.intellij.openapi.wm.ToolWindow;
+import com.intellij.openapi.wm.ToolWindowManager;
+import com.intellij.openapi.wm.ToolWindowType;
+import com.intellij.openapi.wm.ex.ToolWindowManagerListener;
+import com.intellij.util.messages.MessageBusConnection;
 import io.flutter.bazel.WorkspaceCache;
 import io.flutter.dart.DartPlugin;
 import io.flutter.dart.DartPluginVersion;
@@ -15,14 +20,18 @@ import io.flutter.devtools.DevToolsIdeFeature;
 import io.flutter.devtools.DevToolsUrl;
 import io.flutter.run.daemon.DevToolsInstance;
 import io.flutter.sdk.FlutterSdkVersion;
+import kotlin.coroutines.Continuation;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
+import javax.tools.*;
 import java.util.List;
 
 public class PropertyEditorViewFactory extends AbstractDevToolsViewFactory {
   @NotNull public static String TOOL_WINDOW_ID = "Flutter Property Editor";
 
   @NotNull public static String DEVTOOLS_PAGE_ID = "propertyEditor";
+  @Nullable private static Boolean PREVIOUS_DOCKED_UNPINNED = null;
 
   @Override
   public boolean versionSupportsThisTool(@NotNull final FlutterSdkVersion flutterSdkVersion) {
@@ -65,6 +74,38 @@ public class PropertyEditorViewFactory extends AbstractDevToolsViewFactory {
                                                         "newer version of the Dart plugin."));
       return;
     }
-    super.createToolWindowContent(project, toolWindow);
+
+    checkDockedUnpinnedAndCreateContent(project, toolWindow);
+
+    final PropertyEditorViewFactory self = this;
+    MessageBusConnection connection = project.getMessageBus().connect();
+    connection.subscribe(ToolWindowManagerListener.TOPIC, new ToolWindowManagerListener() {
+      @Override
+      public void toolWindowShown(@NotNull ToolWindow activatedToolWindow) {
+        if (activatedToolWindow.getId().equals(getToolWindowId())) {
+          checkDockedUnpinnedAndCreateContent(project, toolWindow);
+        }
+      }
+
+      @Override
+      public void stateChanged(@NotNull ToolWindowManager toolWindowManager, @NotNull ToolWindowManagerEventType changeType) {
+        if (changeType.equals(ToolWindowManagerEventType.SetToolWindowAutoHide) || changeType.equals(ToolWindowManagerEventType.SetToolWindowType)) {
+          checkDockedUnpinnedAndCreateContent(project, toolWindow);
+        }
+      }
+    });
+    Disposer.register(toolWindow.getDisposable(), connection);
+  }
+
+  private void checkDockedUnpinnedAndCreateContent(@NotNull Project project, ToolWindow toolWindow) {
+    final Boolean isDockedUnpinned = toolWindow.getType().equals(ToolWindowType.DOCKED) && toolWindow.isAutoHide();
+    if (!isDockedUnpinned.equals(PREVIOUS_DOCKED_UNPINNED)) {
+      PREVIOUS_DOCKED_UNPINNED = isDockedUnpinned;
+      super.createToolWindowContent(project, toolWindow, isDockedUnpinned
+                                                         ? "This tool window is in \"Docked Unpinned\" mode, which means it will " +
+                                                           "disappear during normal use of the property editor. Select Options (three dots) >"
+                                                           + " View Mode > Docked Pinned instead."
+                                                         : null);
+    }
   }
 }

--- a/flutter-idea/src/io/flutter/propertyeditor/PropertyEditorViewFactory.java
+++ b/flutter-idea/src/io/flutter/propertyeditor/PropertyEditorViewFactory.java
@@ -20,18 +20,16 @@ import io.flutter.devtools.DevToolsIdeFeature;
 import io.flutter.devtools.DevToolsUrl;
 import io.flutter.run.daemon.DevToolsInstance;
 import io.flutter.sdk.FlutterSdkVersion;
-import kotlin.coroutines.Continuation;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import javax.tools.*;
 import java.util.List;
 
 public class PropertyEditorViewFactory extends AbstractDevToolsViewFactory {
-  @NotNull public static String TOOL_WINDOW_ID = "Flutter Property Editor";
+  @NotNull public final static String TOOL_WINDOW_ID = "Flutter Property Editor";
 
-  @NotNull public static String DEVTOOLS_PAGE_ID = "propertyEditor";
-  @Nullable private static Boolean PREVIOUS_DOCKED_UNPINNED = null;
+  @NotNull public final static String DEVTOOLS_PAGE_ID = "propertyEditor";
+  @Nullable private static Boolean previousDockedUnpinned = null;
 
   @Override
   public boolean versionSupportsThisTool(@NotNull final FlutterSdkVersion flutterSdkVersion) {
@@ -100,8 +98,8 @@ public class PropertyEditorViewFactory extends AbstractDevToolsViewFactory {
 
   private void checkDockedUnpinnedAndCreateContent(@NotNull Project project, ToolWindow toolWindow) {
     final Boolean isDockedUnpinned = toolWindow.getType().equals(ToolWindowType.DOCKED) && toolWindow.isAutoHide();
-    if (!isDockedUnpinned.equals(PREVIOUS_DOCKED_UNPINNED)) {
-      PREVIOUS_DOCKED_UNPINNED = isDockedUnpinned;
+    if (!isDockedUnpinned.equals(previousDockedUnpinned)) {
+      previousDockedUnpinned = isDockedUnpinned;
       super.createToolWindowContent(project, toolWindow, isDockedUnpinned
                                                          ? "This tool window is in \"Docked Unpinned\" mode, which means it will disappear "
                                                            + "during normal use of the property editor. Select Options (three dots) > View "

--- a/flutter-idea/src/io/flutter/propertyeditor/PropertyEditorViewFactory.java
+++ b/flutter-idea/src/io/flutter/propertyeditor/PropertyEditorViewFactory.java
@@ -89,7 +89,8 @@ public class PropertyEditorViewFactory extends AbstractDevToolsViewFactory {
 
       @Override
       public void stateChanged(@NotNull ToolWindowManager toolWindowManager, @NotNull ToolWindowManagerEventType changeType) {
-        if (changeType.equals(ToolWindowManagerEventType.SetToolWindowAutoHide) || changeType.equals(ToolWindowManagerEventType.SetToolWindowType)) {
+        if (changeType.equals(ToolWindowManagerEventType.SetToolWindowAutoHide) ||
+            changeType.equals(ToolWindowManagerEventType.SetToolWindowType)) {
           checkDockedUnpinnedAndCreateContent(project, toolWindow);
         }
       }
@@ -102,9 +103,9 @@ public class PropertyEditorViewFactory extends AbstractDevToolsViewFactory {
     if (!isDockedUnpinned.equals(PREVIOUS_DOCKED_UNPINNED)) {
       PREVIOUS_DOCKED_UNPINNED = isDockedUnpinned;
       super.createToolWindowContent(project, toolWindow, isDockedUnpinned
-                                                         ? "This tool window is in \"Docked Unpinned\" mode, which means it will " +
-                                                           "disappear during normal use of the property editor. Select Options (three dots) >"
-                                                           + " View Mode > Docked Pinned instead."
+                                                         ? "This tool window is in \"Docked Unpinned\" mode, which means it will disappear "
+                                                           + "during normal use of the property editor. Select Options (three dots) > View "
+                                                           + "Mode > Docked Pinned instead."
                                                          : null);
     }
   }

--- a/flutter-idea/src/io/flutter/run/daemon/DevToolsServerTask.java
+++ b/flutter-idea/src/io/flutter/run/daemon/DevToolsServerTask.java
@@ -80,7 +80,7 @@ class DevToolsServerTask extends Task.Backgroundable {
       progressIndicator.setFraction(30);
       progressIndicator.setText2("Init");
 
-      // If DevTools is not supported, start the daemon instead.
+      // If the `dart devtools` command is not supported, start the daemon instead.
       final boolean dartDevToolsSupported = dartSdkSupportsDartDevTools();
       if (!dartDevToolsSupported) {
         LOG.info("Starting the DevTools daemon.");

--- a/flutter-idea/src/io/flutter/view/EmbeddedBrowser.java
+++ b/flutter-idea/src/io/flutter/view/EmbeddedBrowser.java
@@ -78,11 +78,18 @@ public abstract class EmbeddedBrowser {
     });
   }
 
-  public void openPanel(ToolWindow toolWindow, String tabName, DevToolsUrl devToolsUrl, Consumer<String> onBrowserUnavailable) {
+  public void openPanel(@NotNull ToolWindow toolWindow,
+                        @NotNull String tabName,
+                        @NotNull DevToolsUrl devToolsUrl,
+                        @NotNull Consumer<String> onBrowserUnavailable) {
     openPanel(toolWindow, tabName, devToolsUrl, onBrowserUnavailable, null);
   }
 
-  public void openPanel(ToolWindow toolWindow, String tabName, DevToolsUrl devToolsUrl, Consumer<String> onBrowserUnavailable, @Nullable String warningMessage) {
+  public void openPanel(@NotNull ToolWindow toolWindow,
+                        @NotNull String tabName,
+                        @NotNull DevToolsUrl devToolsUrl,
+                        @NotNull Consumer<String> onBrowserUnavailable,
+                        @Nullable String warningMessage) {
     this.url = devToolsUrl;
     Map<String, BrowserTab> tabs = windows.computeIfAbsent(toolWindow.getId(), k -> new HashMap<>());
 

--- a/flutter-idea/src/io/flutter/view/ViewUtils.java
+++ b/flutter-idea/src/io/flutter/view/ViewUtils.java
@@ -22,7 +22,7 @@ import java.awt.*;
 import java.util.List;
 
 public class ViewUtils {
-  public @NotNull JBLabel warningLabel(String warning) {
+  public @NotNull JBLabel warningLabel(@NotNull String warning) {
     final JBLabel descriptionLabel = new JBLabel(wrapWithHtml(warning));
     descriptionLabel.setBorder(JBUI.Borders.empty(5));
     descriptionLabel.setHorizontalAlignment(SwingConstants.CENTER);

--- a/flutter-idea/src/io/flutter/view/ViewUtils.java
+++ b/flutter-idea/src/io/flutter/view/ViewUtils.java
@@ -22,6 +22,14 @@ import java.awt.*;
 import java.util.List;
 
 public class ViewUtils {
+  public @NotNull JBLabel warningLabel(String warning) {
+    final JBLabel descriptionLabel = new JBLabel(wrapWithHtml(warning));
+    descriptionLabel.setBorder(JBUI.Borders.empty(5));
+    descriptionLabel.setHorizontalAlignment(SwingConstants.CENTER);
+    descriptionLabel.setForeground(Color.RED);
+    return descriptionLabel;
+  }
+
   public void presentLabel(ToolWindow toolWindow, String text) {
     final JBLabel label = new JBLabel(wrapWithHtml(text), SwingConstants.CENTER);
     label.setForeground(UIUtil.getLabelDisabledForeground());


### PR DESCRIPTION
This threads a potential warning message from an individual tool window (specifically property editor) to an embedded browser tab. There's probably a better way to structure this code, but I've already spent an embarrassing amount of time on shuffling around the UI pieces. 🙃  Suggestions welcome though.

Fixes https://github.com/flutter/flutter-intellij/issues/8181

<img width="519" alt="Screenshot 2025-06-05 at 3 47 54 PM" src="https://github.com/user-attachments/assets/53809ba7-9e15-46b5-90a6-222e070b976e" />
