### PR TITLE
[tool] add `triage` report generation

### DIFF
--- a/tool/triage/README.md
+++ b/tool/triage/README.md
@@ -1,0 +1,10 @@
+
+# Triage Reporting Utilities
+
+To get generate a report on untriaged issues, run:
+
+```
+dart bin/triage.dart
+```
+
+(Optionally pass an auth token as an argument.)

--- a/tool/triage/analysis_options.yaml
+++ b/tool/triage/analysis_options.yaml
@@ -1,0 +1,6 @@
+include: package:lints/recommended.yaml
+
+analyzer:
+  language:
+    strict-casts: true
+

--- a/tool/triage/bin/triage.dart
+++ b/tool/triage/bin/triage.dart
@@ -1,0 +1,23 @@
+// Copyright 2025 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:github/github.dart';
+import 'package:triage/github.dart';
+
+/// Print a simple triage report.
+Future<void> main(List<String> args) async {
+  var auth = args.isNotEmpty ? Authentication.withToken(args[0]) : null;
+  var issues = await getFlutterPluginIssues(auth: auth);
+  var filtered = issues.where((issue) => issue.isIssue);
+  var prCount = issues.length - filtered.length;
+  var issueCount = filtered.length;
+  var unprioritized = filtered.where((issue) => !issue.prioritized);
+  var unpriortizedCount = unprioritized.length;
+
+  print('issues: $issueCount (+ $prCount PRs)');
+  print(
+      'unprioritized: $unpriortizedCount (${(unpriortizedCount / issueCount).toStringAsFixed(2).substring(2)}%)');
+  print('created within ...');
+  printCreationTimeCounts(unprioritized);
+}

--- a/tool/triage/lib/github.dart
+++ b/tool/triage/lib/github.dart
@@ -1,0 +1,63 @@
+// Copyright 2025 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:github/github.dart';
+
+Future<List<Issue>> getFlutterPluginIssues({Authentication? auth}) async {
+  var github = auth != null ? GitHub(auth: auth) : GitHub();
+  var slug = RepositorySlug('flutter', 'flutter-intellij');
+  try {
+    return github.issues.listByRepo(slug).toList();
+  } on Exception catch (e) {
+    print(e);
+    return Future.value(<Issue>[]);
+  }
+}
+
+void printCreationTimeCounts(Iterable<Issue> issues) {
+  var seven = 0;
+  var fourteen = 0;
+  var twentyEight = 0;
+  var ninety = 0;
+  var threeSixty = 0;
+  var tenEighty = 0;
+  var beyond = 0;
+
+  var now = DateTime.timestamp();
+  for (var issue in issues) {
+    var updated = issue.createdAt!;
+    var daysSinceUpdate = now.difference(updated).inDays;
+    switch (daysSinceUpdate) {
+      case <= 7:
+        ++seven;
+      case > 7 && <= 14:
+        ++fourteen;
+      case > 14 && <= 28:
+        ++twentyEight;
+      case > 28 && <= 90:
+        ++ninety;
+      case > 90 && <= 360:
+        ++threeSixty;
+      case > 360 && <= 1080:
+        ++tenEighty;
+      case _:
+        ++beyond;
+    }
+  }
+
+  print(
+      '| 1 week | 2 weeks | 1 month | 3 months | 1 year | 3 years | longer |');
+  print('| --- | --- | --- | --- | --- | --- | --- |');
+  print(
+      '| $seven | $fourteen | $twentyEight | $ninety | $threeSixty | $tenEighty | $beyond |');
+}
+
+extension IssueExtension on Issue {
+  bool get prioritized =>
+      labels.map((l) => l.name).any((n) => n.startsWith('P'));
+
+  bool get isPR => pullRequest != null;
+
+  bool get isIssue => !isPR;
+}

--- a/tool/triage/pubspec.yaml
+++ b/tool/triage/pubspec.yaml
@@ -1,0 +1,14 @@
+name: triage
+description: Triage report tools
+version: 0.0.1
+publish_to: none
+
+environment:
+  sdk: ^3.5.0
+
+dependencies:
+  github: ^9.0.0
+
+dev_dependencies:
+  lints: ^6.0.0
+  test: ^1.22.0


### PR DESCRIPTION
In support of https://github.com/flutter/flutter-intellij/issues/8101.

Sample run:

```
☁  flutter-intellij [master] ⚡  dart tool/triage/bin/triage.dart
```

produces:

issues: 769 (+ 6 PRs)
unprioritized: 734 (95%)
created within ...
| 1 week | 2 weeks | 1 month | 3 months | 1 year | 3 years | longer |
| --- | --- | --- | --- | --- | --- | --- |
| 5 | 6 | 5 | 17 | 75 | 183 | 443 |

---

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
