### PR TITLE
[fix] open the `FlutterModuleBuilder` error dialog on the EDT

### DIFF
--- a/flutter-idea/src/io/flutter/module/FlutterModuleBuilder.java
+++ b/flutter-idea/src/io/flutter/module/FlutterModuleBuilder.java
@@ -258,7 +258,9 @@ public class FlutterModuleBuilder extends ModuleBuilder {
   public boolean validate(@Nullable Project current, @NotNull Project dest) {
     final String settingsValidation = validateSettings(getAdditionalSettings());
     if (settingsValidation != null) {
-      Messages.showErrorDialog(settingsValidation, "Error");
+      OpenApiUtils.safeInvokeLater(() -> {
+        Messages.showErrorDialog(settingsValidation, "Error");
+      });
       try {
         Files.deleteIfExists(Path.of(dest.getBasePath()));
       }


### PR DESCRIPTION
`FlutterModuleBuilder` settings validation happens off the `EDT`, which is great for performance but it means we need to take an extra step when wanting to display dialogs.

Fixes: https://github.com/flutter/flutter-intellij/issues/8243

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
