### PR TITLE
[fix] `OpenInAppCodeAction` forbidden initialization service dependency

### DIFF
--- a/flutter-idea/src/io/flutter/actions/OpenInAppCodeAction.java
+++ b/flutter-idea/src/io/flutter/actions/OpenInAppCodeAction.java
@@ -22,19 +22,23 @@ import com.intellij.openapi.util.SystemInfo;
 import com.intellij.openapi.vfs.VirtualFile;
 import io.flutter.FlutterMessages;
 import io.flutter.sdk.FlutterSdk;
+import io.flutter.utils.OpenApiUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import static io.flutter.actions.OpenInXcodeAction.findProjectFile;
 
 public class OpenInAppCodeAction extends AnAction {
+  OpenInAppCodeAction() {
+    // Schedule initialization so that we can discover if `AppCode` is installed *before* we
+    // need to decide whether to make the action menu visible.
+    OpenApiUtils.safeInvokeLater(() -> {
+      initialize();
+    });
+  }
 
   private static boolean IS_INITIALIZED = false;
   private static boolean IS_APPCODE_INSTALLED = false;
-
-  static {
-    initialize();
-  }
 
   private static void initialize() {
     if (SystemInfo.isMac) {
@@ -78,6 +82,7 @@ public class OpenInAppCodeAction extends AnAction {
   public @NotNull ActionUpdateThread getActionUpdateThread() {
     return ActionUpdateThread.BGT;
   }
+
   @Override
   public void actionPerformed(@NotNull AnActionEvent event) {
     final VirtualFile projectFile = findProjectFile(event);


### PR DESCRIPTION
Schedule initialization in a runnable rather than doing service calls in the class initializer.

Fixes: https://github.com/flutter/flutter-intellij/issues/8180

---

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
