### PR TITLE
[fix] `RestartFlutterDaemonAction` menu item rendering in the device selector

### DIFF
--- a/flutter-idea/src/io/flutter/actions/DeviceSelectorAction.java
+++ b/flutter-idea/src/io/flutter/actions/DeviceSelectorAction.java
@@ -202,7 +202,7 @@ public class DeviceSelectorAction extends ComboBoxAction implements DumbAware {
     }
     if (!FlutterModuleUtils.hasInternalDartSdkPath(project)) {
       actions.add(new Separator());
-      actions.add(new RestartFlutterDaemonAction());
+      actions.add(RestartFlutterDaemonAction.forDeviceSelector());
     }
     ActivityTracker.getInstance().inc();
   }

--- a/flutter-idea/src/io/flutter/actions/RestartFlutterDaemonAction.java
+++ b/flutter-idea/src/io/flutter/actions/RestartFlutterDaemonAction.java
@@ -9,10 +9,38 @@ import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.NlsActions;
+import icons.FlutterIcons;
 import io.flutter.run.daemon.DeviceService;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
 
 public class RestartFlutterDaemonAction extends AnAction {
+
+  /**
+   * Create a `RestartFlutterDaemonAction` for presentation in the device selector.
+   */
+  public static RestartFlutterDaemonAction forDeviceSelector() {
+    return new RestartFlutterDaemonAction("Restart Flutter Daemon", FlutterIcons.Flutter);
+  }
+
+  /**
+   * A default constructor, invoked by plugin.xml contributions.
+   */
+  RestartFlutterDaemonAction() {
+    super();
+  }
+
+  /**
+   * A constructor for dynamic invocation.
+   */
+  private RestartFlutterDaemonAction(@Nullable @NlsActions.ActionText String text,
+                                     @Nullable Icon icon) {
+    super(text, text, icon);
+  }
+
   @Override
   public void actionPerformed(AnActionEvent event) {
     final Project project = event.getProject();


### PR DESCRIPTION
Programmatic invocation of the default constructor was creating an instance that didn't have the benefit of having text and icon set by the `plugin.xml` contribution. This adds a new "factory" method (kinda) for dynamic creations.

![image](https://github.com/user-attachments/assets/11a1eb80-8b92-4be2-95f5-cef375bcefea)

Fixes: https://github.com/flutter/flutter-intellij/issues/8264

---

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
