### PR TITLE
[tool] triage report csv output

### DIFF
--- a/tool/triage/bin/triage.dart
+++ b/tool/triage/bin/triage.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:github/github.dart';
+import 'package:intl/intl.dart';
 import 'package:triage/github.dart';
 
 /// Print a simple triage report.
@@ -14,10 +15,55 @@ Future<void> main(List<String> args) async {
   var issueCount = filtered.length;
   var unprioritized = filtered.where((issue) => !issue.prioritized);
   var unpriortizedCount = unprioritized.length;
+  printCreationTimeCounts(unprioritized, issueCount: issueCount, prCount: prCount, unpriortizedCount: unpriortizedCount);
+}
+
+
+void printCreationTimeCounts(Iterable<Issue> issues, {required int issueCount, required int prCount, required int unpriortizedCount} ) {
+  var seven = 0;
+  var fourteen = 0;
+  var twentyEight = 0;
+  var ninety = 0;
+  var threeSixty = 0;
+  var tenEighty = 0;
+  var beyond = 0;
+
+  var now = DateTime.timestamp();
+  for (var issue in issues) {
+    var updated = issue.createdAt!;
+    var daysSinceUpdate = now.difference(updated).inDays;
+    switch (daysSinceUpdate) {
+      case <= 7:
+        ++seven;
+      case > 7 && <= 14:
+        ++fourteen;
+      case > 14 && <= 28:
+        ++twentyEight;
+      case > 28 && <= 90:
+        ++ninety;
+      case > 90 && <= 360:
+        ++threeSixty;
+      case > 360 && <= 1080:
+        ++tenEighty;
+      case _:
+        ++beyond;
+    }
+  }
 
   print('issues: $issueCount (+ $prCount PRs)');
+  var unprioritizedPercentage = '${(unpriortizedCount / issueCount).toStringAsFixed(2).substring(2)}%';
   print(
-      'unprioritized: $unpriortizedCount (${(unpriortizedCount / issueCount).toStringAsFixed(2).substring(2)}%)');
+      'unprioritized: $unpriortizedCount ($unprioritizedPercentage)');
   print('created within ...');
-  printCreationTimeCounts(unprioritized);
+
+  var timeData = [seven, fourteen, twentyEight, ninety, threeSixty, tenEighty, beyond];
+
+  print(
+      '| 1 week | 2 weeks | 1 month | 3 months | 1 year | 3 years | longer |');
+  print('| --- | --- | --- | --- | --- | --- | --- |');
+  print('| ${timeData.join(' | ')} |');
+  print('\n');
+
+  var today = DateFormat('MM/dd/yyyy').format(now);
+  print([today, ...timeData, '' /** empty column */,issueCount, unpriortizedCount].join(', '));
 }

--- a/tool/triage/lib/github.dart
+++ b/tool/triage/lib/github.dart
@@ -15,44 +15,6 @@ Future<List<Issue>> getFlutterPluginIssues({Authentication? auth}) async {
   }
 }
 
-void printCreationTimeCounts(Iterable<Issue> issues) {
-  var seven = 0;
-  var fourteen = 0;
-  var twentyEight = 0;
-  var ninety = 0;
-  var threeSixty = 0;
-  var tenEighty = 0;
-  var beyond = 0;
-
-  var now = DateTime.timestamp();
-  for (var issue in issues) {
-    var updated = issue.createdAt!;
-    var daysSinceUpdate = now.difference(updated).inDays;
-    switch (daysSinceUpdate) {
-      case <= 7:
-        ++seven;
-      case > 7 && <= 14:
-        ++fourteen;
-      case > 14 && <= 28:
-        ++twentyEight;
-      case > 28 && <= 90:
-        ++ninety;
-      case > 90 && <= 360:
-        ++threeSixty;
-      case > 360 && <= 1080:
-        ++tenEighty;
-      case _:
-        ++beyond;
-    }
-  }
-
-  print(
-      '| 1 week | 2 weeks | 1 month | 3 months | 1 year | 3 years | longer |');
-  print('| --- | --- | --- | --- | --- | --- | --- |');
-  print(
-      '| $seven | $fourteen | $twentyEight | $ninety | $threeSixty | $tenEighty | $beyond |');
-}
-
 extension IssueExtension on Issue {
   bool get prioritized =>
       labels.map((l) => l.name).any((n) => n.startsWith('P'));

--- a/tool/triage/pubspec.yaml
+++ b/tool/triage/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
 
 dependencies:
   github: ^9.0.0
+  intl: ^0.20.0
 
 dev_dependencies:
   lints: ^6.0.0


### PR DESCRIPTION
See #8101.

Adds CSV output to make importing into sheets easier:

```
☁  flutter-intellij [master] ⚡  dart tool/triage/bin/triage.dart

issues: 743 (+ 6 PRs)
unprioritized: 684 (92%)
created within ...
| 1 week | 2 weeks | 1 month | 3 months | 1 year | 3 years | longer |
| --- | --- | --- | --- | --- | --- | --- |
| 2 | 1 | 0 | 8 | 53 | 182 | 438 |


06/24/2025, 2, 1, 0, 8, 53, 182, 438, , 743, 684
```

---

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
