### PR TITLE
[CQ] analyze `triage` source in presubmit

### DIFF
--- a/tool/github.sh
+++ b/tool/github.sh
@@ -47,7 +47,7 @@ if [ "DART_BOT" = "$BOT" ] ; then
   echo "dart analyze"
   (cd flutter-idea/src; dart analyze)
   (cd tool/plugin; dart analyze)
-  (cd tool/triage; dart analyze)
+  (cd tool/triage; dart pub upgrade && dart analyze)
 
   # Ensure that the edits have been applied to template files (and their target
   # files have been regenerated).


### PR DESCRIPTION
Following up from a conversation w/ @jwren. Enables analysis on `triage` tools as part of our presubmit.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
