### PR TITLE
Add a table about SDK support in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,15 +27,17 @@ A brief summary of the [getting started guide](https://docs.flutter.dev/tools/an
 - install the [Flutter SDK](https://docs.flutter.dev/get-started/install)
 - run `flutter doctor` from the command line to verify your installation
 - ensure you have a supported IntelliJ development environment; either:
-  - the latest stable version of [IntelliJ](https://www.jetbrains.com/idea/download), Community or Ultimate Edition (EAP versions are not always supported)
-  - the latest stable version of [Android Studio](https://developer.android.com/studio) (note: Android Studio Canary versions are generally _not_ supported)
+    - the latest stable version of [IntelliJ](https://www.jetbrains.com/idea/download), Community or Ultimate Edition (EAP versions are not
+      always supported)
+    - the latest stable version of [Android Studio](https://developer.android.com/studio) (note: Android Studio Canary versions are
+      generally _not_ supported)
 - open the plugin preferences
-  - `Preferences > Plugins` on macOS, `File > Settings > Plugins` on Linux, select "Browse repositories…"
+    - `Preferences > Plugins` on macOS, `File > Settings > Plugins` on Linux, select "Browse repositories…"
 - search for and install the 'Flutter' plugin
 - choose the option to restart IntelliJ
 - configure the Flutter SDK setting
-  - `Preferences` on macOS, `File>Settings` on Linux, select `Languages & Frameworks > Flutter`, and set
-    the path to the root of your flutter repo
+    - `Preferences` on macOS, `File>Settings` on Linux, select `Languages & Frameworks > Flutter`, and set
+      the path to the root of your flutter repo
 
 ## Filing issues
 
@@ -53,10 +55,10 @@ Please note the following known issues:
 
 - [#601](https://github.com/flutter/flutter-intellij/issues/601): IntelliJ will
   read the PATH variable just once on startup. Thus, if you change PATH later to
-  include the Flutter SDK path, this will not have an affect in IntelliJ until you
+  include the Flutter SDK path, this will not have an effect in IntelliJ until you
   restart the IDE.
-- If you require network access to go through proxy settings, you will need to set the 
-  `https_proxy` variable in your environment as described in the 
+- If you require network access to go through proxy settings, you will need to set the
+  `https_proxy` variable in your environment as described in the
   [pub docs](https://dart.dev/tools/pub/troubleshoot#pub-get-fails-from-behind-a-corporate-firewall).
   (See also: [#2914](https://github.com/flutter/flutter-intellij/issues/2914).)
 
@@ -66,3 +68,15 @@ If you like getting new features as soon as they've been added to the code then 
 might want to try out the dev channel. It is updated weekly with the latest contents
 from the "master" branch. It has minimal testing. Set up instructions are in the wiki's
 [dev channel page](./docs/Dev-Channel.md).
+
+## Flutter SDK compatibility
+
+These are the versions of Flutter SDK that current and previous Flutter plugins support:
+
+| Flutter SDK version | Flutter plugin version |
+|---------------------|------------------------|
+| up to v3.7          | 85.3.2 and earlier     |
+| v3.10 and above     | Currently supported    |
+
+Here is more information on the Flutter plugin's support for Flutter
+SDKs: https://docs.flutter.dev/tools/sdk#sdk-support-for-flutter-developer-tools.


### PR DESCRIPTION
This links to the flutter.dev site and provides a table similar to what Danny added: https://dartcode.org/sdk-version-compatibility/