### PR TITLE
[CQ] fix nullability problems for `flutter/actions`

### DIFF
--- a/flutter-idea/src/io/flutter/actions/AttachDebuggerAction.java
+++ b/flutter-idea/src/io/flutter/actions/AttachDebuggerAction.java
@@ -125,7 +125,7 @@ public class AttachDebuggerAction extends FlutterSdkAction {
   }
 
   @Override
-  public void update(AnActionEvent e) {
+  public void update(@NotNull AnActionEvent e) {
     final Project project = e.getProject();
     if (project == null || project.isDefault()) {
       super.update(e);
@@ -159,7 +159,7 @@ public class AttachDebuggerAction extends FlutterSdkAction {
   }
 
   @Nullable
-  public static RunConfiguration findRunConfig(Project project) {
+  public static RunConfiguration findRunConfig(@NotNull Project project) {
     // Look for a Flutter run config. If exactly one is found then return it otherwise return null.
     final RunManagerEx mgr = RunManagerEx.getInstanceEx(project);
     final List<RunConfiguration> configs = mgr.getAllConfigurationsList();
@@ -174,7 +174,7 @@ public class AttachDebuggerAction extends FlutterSdkAction {
     return count == 1 ? sdkConfig : null;
   }
 
-  private static void onAttachTermination(@NotNull Project project, @NotNull Consumer<Project> runner) {
+  private static void onAttachTermination(@NotNull Project project, @NotNull Consumer<@NotNull Project> runner) {
     final MessageBusConnection connection = project.getMessageBus().connect();
 
     // Need an ExecutionListener to clean up project-scoped state when the Stop button is clicked.
@@ -221,7 +221,9 @@ public class AttachDebuggerAction extends FlutterSdkAction {
                                   "module was created. See <a href=\"" +
                                   FlutterConstants.URL_RUN_AND_DEBUG +
                                   "\">the Flutter documentation</a> for more information.</body></html>";
+      //noinspection DataFlowIssue
       myTextPane.setText(selectConfig);
+      //noinspection DataFlowIssue
       myPanel.add(myTextPane);
       init();
       //noinspection ConstantConditions

--- a/flutter-idea/src/io/flutter/actions/ExtractWidgetAction.java
+++ b/flutter-idea/src/io/flutter/actions/ExtractWidgetAction.java
@@ -31,11 +31,15 @@ import java.awt.*;
 
 public class ExtractWidgetAction extends DumbAwareAction {
   @Override
-  public void actionPerformed(AnActionEvent event) {
+  public void actionPerformed(@NotNull AnActionEvent event) {
     final DataContext dataContext = event.getDataContext();
+    //noinspection DataFlowIssue
     final Project project = dataContext.getData(PlatformDataKeys.PROJECT);
+    //noinspection DataFlowIssue
     final VirtualFile file = dataContext.getData(PlatformDataKeys.VIRTUAL_FILE);
+    //noinspection DataFlowIssue
     final Editor editor = dataContext.getData(PlatformDataKeys.EDITOR);
+    //noinspection DataFlowIssue
     final Caret caret = dataContext.getData(PlatformDataKeys.CARET);
 
     if (project != null && file != null && editor != null && caret != null) {
@@ -51,7 +55,9 @@ public class ExtractWidgetAction extends DumbAwareAction {
       if (initialStatus.hasError()) {
         final String message = initialStatus.getMessage();
         assert message != null;
-        CommonRefactoringUtil.showErrorHint(project, editor, message, CommonBundle.getErrorTitle(), null);
+        String title = CommonBundle.getErrorTitle();
+        assert title != null;
+        CommonRefactoringUtil.showErrorHint(project, editor, message, title, null);
         return;
       }
 
@@ -60,7 +66,7 @@ public class ExtractWidgetAction extends DumbAwareAction {
   }
 
   @Override
-  public void update(AnActionEvent e) {
+  public void update(@NotNull AnActionEvent e) {
     e.getPresentation().setVisible(isVisibleFor(e));
     super.update(e);
   }
@@ -70,17 +76,17 @@ public class ExtractWidgetAction extends DumbAwareAction {
     return ActionUpdateThread.BGT;
   }
 
-  protected static boolean isVisibleFor(AnActionEvent e) {
+  protected static boolean isVisibleFor(@NotNull AnActionEvent e) {
     final DataContext dataContext = e.getDataContext();
-    final Project project = dataContext.getData(PlatformDataKeys.PROJECT);
+    //noinspection DataFlowIssue
     final VirtualFile file = dataContext.getData(PlatformDataKeys.VIRTUAL_FILE);
     return file != null && FlutterUtils.isDartFile(file);
   }
 }
 
 class ExtractWidgetDialog extends ServerRefactoringDialog<ExtractWidgetRefactoring> {
-  @NotNull final ExtractWidgetRefactoring myRefactoring;
-  private final JTextField myNameField = new JTextField();
+  final @NotNull ExtractWidgetRefactoring myRefactoring;
+  private final @NotNull JTextField myNameField = new JTextField();
 
   public ExtractWidgetDialog(@NotNull Project project,
                              @Nullable Editor editor,
@@ -92,17 +98,21 @@ class ExtractWidgetDialog extends ServerRefactoringDialog<ExtractWidgetRefactori
 
     myNameField.setText("NewWidget");
     myNameField.selectAll();
-    myNameField.getDocument().addDocumentListener(new DocumentAdapter() {
-      @Override
-      protected void textChanged(@NotNull DocumentEvent event) {
-        updateRefactoringOptions();
-      }
-    });
+    var document = myNameField.getDocument();
+    if (document != null) {
+      document.addDocumentListener(new DocumentAdapter() {
+        @Override
+        protected void textChanged(@NotNull DocumentEvent event) {
+          updateRefactoringOptions();
+        }
+      });
+    }
 
     updateRefactoringOptions();
   }
 
   private void updateRefactoringOptions() {
+    //noinspection DataFlowIssue
     myRefactoring.setName(myNameField.getText());
     myRefactoring.sendOptions();
   }
@@ -137,6 +147,7 @@ class ExtractWidgetDialog extends ServerRefactoringDialog<ExtractWidgetRefactori
     gbConstraints.fill = GridBagConstraints.BOTH;
     gbConstraints.anchor = GridBagConstraints.WEST;
     panel.add(myNameField, gbConstraints);
+    //noinspection DataFlowIssue
     myNameField.setPreferredSize(new Dimension(200, myNameField.getPreferredSize().height));
 
     return panel;

--- a/flutter-idea/src/io/flutter/actions/FlutterBuildActionGroup.java
+++ b/flutter-idea/src/io/flutter/actions/FlutterBuildActionGroup.java
@@ -24,15 +24,13 @@ import io.flutter.utils.ProgressHelper;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.List;
-
 public class FlutterBuildActionGroup extends DefaultActionGroup {
 
   public static void build(@NotNull Project project,
-                                       @NotNull PubRoot pubRoot,
-                                       @NotNull FlutterSdk sdk,
-                                       @NotNull BuildType buildType,
-                                       @Nullable String desc) {
+                           @NotNull PubRoot pubRoot,
+                           @NotNull FlutterSdk sdk,
+                           @NotNull BuildType buildType,
+                           @Nullable String desc) {
     final ProgressHelper progressHelper = new ProgressHelper(project);
     progressHelper.start(desc == null ? "building" : desc);
     ProcessAdapter processAdapter = new ProcessAdapter() {
@@ -105,7 +103,12 @@ public class FlutterBuildActionGroup extends DefaultActionGroup {
       return module;
     }
     // We may get here if the file is in the Android module of a Flutter module project.
-    final VirtualFile parent = OpenApiUtils.getContentRoots(module)[0].getParent();
+    var root = OpenApiUtils.getContentRoots(module)[0];
+    if (root == null) return null;
+
+    final VirtualFile parent = root.getParent();
+    if (parent == null) return null;
+
     module = ModuleUtilCore.findModuleForFile(parent, project);
     if (module == null) {
       return null;
@@ -135,7 +138,7 @@ public class FlutterBuildActionGroup extends DefaultActionGroup {
         build(project, pubRoot, sdk, buildType, presentation.getDescription());
       }
       else {
-        List<PubRoot> roots = PubRoots.forProject(project);
+        var roots = PubRoots.forProject(project);
         for (PubRoot sub : roots) {
           build(project, sub, sdk, buildType, presentation.getDescription());
         }

--- a/flutter-idea/src/io/flutter/actions/FlutterExternalIdeActionGroup.java
+++ b/flutter-idea/src/io/flutter/actions/FlutterExternalIdeActionGroup.java
@@ -18,8 +18,8 @@ import org.jetbrains.annotations.Nullable;
  * See https://github.com/flutter/flutter-intellij/issues/7103
  */
 public class FlutterExternalIdeActionGroup extends DefaultActionGroup {
-  private static boolean isExternalIdeFile(AnActionEvent e) {
-    final VirtualFile file = e.getData(CommonDataKeys.VIRTUAL_FILE);
+  private static boolean isExternalIdeFile(@NotNull AnActionEvent e) {
+    @SuppressWarnings("DataFlowIssue") final VirtualFile file = e.getData(CommonDataKeys.VIRTUAL_FILE);
     if (file == null || !file.exists()) {
       return false;
     }
@@ -86,7 +86,7 @@ public class FlutterExternalIdeActionGroup extends DefaultActionGroup {
   }
 
   @Override
-  public void update(AnActionEvent event) {
+  public void update(@NotNull AnActionEvent event) {
     final Presentation presentation = event.getPresentation();
     final boolean enabled = isExternalIdeFile(event);
     presentation.setEnabled(enabled);

--- a/flutter-idea/src/io/flutter/actions/FlutterPackagesExplorerActionGroup.java
+++ b/flutter-idea/src/io/flutter/actions/FlutterPackagesExplorerActionGroup.java
@@ -14,7 +14,7 @@ import org.jetbrains.annotations.NotNull;
 public class FlutterPackagesExplorerActionGroup extends DefaultActionGroup {
 
   private static boolean isFlutterPubspec(@NotNull AnActionEvent e) {
-    final VirtualFile file = CommonDataKeys.VIRTUAL_FILE.getData(e.getDataContext());
+    @SuppressWarnings("DataFlowIssue") final VirtualFile file = CommonDataKeys.VIRTUAL_FILE.getData(e.getDataContext());
     final PubRoot root = file == null ? null : PubRoot.forDirectory(file.getParent());
     return root != null && root.getPubspec().equals(file) && root.declaresFlutter();
   }

--- a/flutter-idea/src/io/flutter/actions/FlutterRetargetAppAction.java
+++ b/flutter-idea/src/io/flutter/actions/FlutterRetargetAppAction.java
@@ -33,7 +33,7 @@ public abstract class FlutterRetargetAppAction extends DumbAwareAction {
   FlutterRetargetAppAction(@NotNull String actionId,
                            @Nullable String text,
                            @Nullable String description,
-                           @SuppressWarnings("SameParameterValue") @NotNull String... places) {
+                           @SuppressWarnings("SameParameterValue") @NotNull String @NotNull ... places) {
     super(text, description, null);
     myActionId = actionId;
     myPlaces.addAll(Arrays.asList(places));
@@ -44,7 +44,7 @@ public abstract class FlutterRetargetAppAction extends DumbAwareAction {
   }
 
   @Override
-  public void actionPerformed(AnActionEvent e) {
+  public void actionPerformed(@NotNull AnActionEvent e) {
     final AnAction action = getAction(e.getProject());
     if (action != null) {
       action.actionPerformed(e);
@@ -52,7 +52,7 @@ public abstract class FlutterRetargetAppAction extends DumbAwareAction {
   }
 
   @Override
-  public void update(AnActionEvent e) {
+  public void update(@NotNull AnActionEvent e) {
     final Presentation presentation = e.getPresentation();
 
     final Project project = e.getProject();
@@ -76,7 +76,7 @@ public abstract class FlutterRetargetAppAction extends DumbAwareAction {
     }
   }
 
-  private AnAction getAction(@Nullable Project project) {
+  private @Nullable AnAction getAction(@Nullable Project project) {
     return project == null ? null : ProjectActions.getAction(project, myActionId);
   }
 }

--- a/flutter-idea/src/io/flutter/actions/FlutterSdkAction.java
+++ b/flutter-idea/src/io/flutter/actions/FlutterSdkAction.java
@@ -82,7 +82,7 @@ public abstract class FlutterSdkAction extends DumbAwareAction {
     return false;
   }
 
-  public static void showMissingSdkDialog(Project project) {
+  public static void showMissingSdkDialog(@Nullable Project project) {
     final int response = FlutterMessages.showDialog(project, FlutterBundle.message("flutter.sdk.notAvailable.message"),
                                                     FlutterBundle.message("flutter.sdk.notAvailable.title"),
                                                     new String[]{"Yes, configure", "No, thanks"}, -1);

--- a/flutter-idea/src/io/flutter/actions/OpenEmulatorAction.java
+++ b/flutter-idea/src/io/flutter/actions/OpenEmulatorAction.java
@@ -15,6 +15,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import static java.util.stream.Collectors.toList;
 
@@ -33,12 +34,12 @@ public class OpenEmulatorAction extends AnAction {
     final AndroidEmulatorManager emulatorManager = AndroidEmulatorManager.getInstance(project);
 
     final List<AndroidEmulator> emulators = emulatorManager.getCachedEmulators();
-    return emulators.stream().map(OpenEmulatorAction::new).collect(toList());
+    return emulators.stream().filter(Objects::nonNull).map(OpenEmulatorAction::new).collect(toList());
   }
 
-  final AndroidEmulator emulator;
+  final @NotNull AndroidEmulator emulator;
 
-  public OpenEmulatorAction(AndroidEmulator emulator) {
+  public OpenEmulatorAction(@NotNull AndroidEmulator emulator) {
     super("Open Android Emulator: " + emulator.getName());
 
     this.emulator = emulator;

--- a/flutter-idea/src/io/flutter/actions/OpenInAppCodeAction.java
+++ b/flutter-idea/src/io/flutter/actions/OpenInAppCodeAction.java
@@ -102,7 +102,10 @@ public class OpenInAppCodeAction extends AnAction {
       FlutterSdkAction.showMissingSdkDialog(project);
       return;
     }
-    openInAppCode(project, file.getParent().getPath());
+    var parent = file.getParent();
+    if (parent != null) {
+      openInAppCode(project, parent.getPath());
+    }
   }
 
   private static void openInAppCode(@Nullable Project project, @NotNull String path) {

--- a/flutter-idea/src/io/flutter/actions/OpenInXcodeAction.java
+++ b/flutter-idea/src/io/flutter/actions/OpenInXcodeAction.java
@@ -28,7 +28,7 @@ public class OpenInXcodeAction extends AnAction {
 
   @Nullable
   static VirtualFile findProjectFile(@NotNull AnActionEvent event) {
-    final VirtualFile file = event.getData(CommonDataKeys.VIRTUAL_FILE);
+    @SuppressWarnings("DataFlowIssue") final VirtualFile file = event.getData(CommonDataKeys.VIRTUAL_FILE);
     final Project project = event.getProject();
     if (file != null && file.exists()) {
       if (FlutterUtils.isXcodeFileName(file.getName())) {
@@ -113,7 +113,7 @@ public class OpenInXcodeAction extends AnAction {
     return sdk.isOlderThanToolsStamp(gen);
   }
 
-  private static void openWithXcode(@Nullable Project project, String path) {
+  private static void openWithXcode(@Nullable Project project, @NotNull String path) {
     try {
       final GeneralCommandLine cmd = new GeneralCommandLine().withExePath("open").withParameters(path);
       final ColoredProcessHandler handler = new ColoredProcessHandler(cmd);

--- a/flutter-idea/src/io/flutter/actions/ReloadAllFlutterApps.java
+++ b/flutter-idea/src/io/flutter/actions/ReloadAllFlutterApps.java
@@ -29,7 +29,8 @@ public class ReloadAllFlutterApps extends FlutterAppAction {
   public ReloadAllFlutterApps(@NotNull FlutterApp app, @NotNull Computable<Boolean> isApplicable) {
     super(app, TEXT, DESCRIPTION, FlutterIcons.HotReload, isApplicable, ID);
     // Shortcut is associated with toolbar action.
-    copyShortcutFrom(Objects.requireNonNull(Objects.requireNonNull(ActionManager.getInstance()).getAction("Flutter.Toolbar.ReloadAllAction")));
+    copyShortcutFrom(
+      Objects.requireNonNull(Objects.requireNonNull(ActionManager.getInstance()).getAction("Flutter.Toolbar.ReloadAllAction")));
   }
 
   @Override
@@ -38,7 +39,9 @@ public class ReloadAllFlutterApps extends FlutterAppAction {
     if (project == null) {
       return;
     }
-    FlutterReloadManager.getInstance(project)
-      .saveAllAndReloadAll(FlutterApp.allFromProjectProcess(project), FlutterConstants.RELOAD_REASON_MANUAL);
+    FlutterReloadManager reloadManager = FlutterReloadManager.getInstance(project);
+    if (reloadManager != null) {
+      reloadManager.saveAllAndReloadAll(FlutterApp.allFromProjectProcess(project), FlutterConstants.RELOAD_REASON_MANUAL);
+    }
   }
 }

--- a/flutter-idea/src/io/flutter/actions/ReloadFlutterApp.java
+++ b/flutter-idea/src/io/flutter/actions/ReloadFlutterApp.java
@@ -26,7 +26,13 @@ public class ReloadFlutterApp extends FlutterAppAction {
   public ReloadFlutterApp(@NotNull FlutterApp app, @NotNull Computable<Boolean> isApplicable) {
     super(app, TEXT, DESCRIPTION, FlutterIcons.HotReload, isApplicable, ID);
     // Shortcut is associated with toolbar action.
-    copyShortcutFrom(ActionManager.getInstance().getAction("Flutter.Toolbar.ReloadAction"));
+    var actionManager = ActionManager.getInstance();
+    if (actionManager != null) {
+      var action = actionManager.getAction("Flutter.Toolbar.ReloadAction");
+      if (action != null) {
+        copyShortcutFrom(action);
+      }
+    }
   }
 
   @Override
@@ -40,12 +46,15 @@ public class ReloadFlutterApp extends FlutterAppAction {
     // 'GoToAction' dialog. If so, the modifiers are for the command that opened the go-to action dialog.
     final boolean shouldRestart = (e.getModifiers() & InputEvent.SHIFT_MASK) != 0 && !"GoToAction".equals(e.getPlace());
 
+    var reloadManager = FlutterReloadManager.getInstance(project);
+    if (reloadManager == null) return;
+
     if (shouldRestart) {
-      FlutterReloadManager.getInstance(project).saveAllAndRestart(getApp(), FlutterConstants.RELOAD_REASON_MANUAL);
+      reloadManager.saveAllAndRestart(getApp(), FlutterConstants.RELOAD_REASON_MANUAL);
     }
     else {
       // Else perform a hot reload.
-      FlutterReloadManager.getInstance(project).saveAllAndReload(getApp(), FlutterConstants.RELOAD_REASON_MANUAL);
+      reloadManager.saveAllAndReload(getApp(), FlutterConstants.RELOAD_REASON_MANUAL);
     }
   }
 

--- a/flutter-idea/src/io/flutter/actions/RestartAllFlutterApps.java
+++ b/flutter-idea/src/io/flutter/actions/RestartAllFlutterApps.java
@@ -27,7 +27,13 @@ public class RestartAllFlutterApps extends FlutterAppAction {
   public RestartAllFlutterApps(@NotNull FlutterApp app, @NotNull Computable<Boolean> isApplicable) {
     super(app, TEXT, DESCRIPTION, FlutterIcons.HotRestart, isApplicable, ID);
     // Shortcut is associated with toolbar action.
-    copyShortcutFrom(ActionManager.getInstance().getAction("Flutter.Toolbar.RestartAllAction"));
+    ActionManager actionManager = ActionManager.getInstance();
+    if (actionManager != null) {
+      var action = actionManager.getAction("Flutter.Toolbar.RestartAllAction");
+      if (action != null) {
+        copyShortcutFrom(action);
+      }
+    }
   }
 
   @Override
@@ -37,7 +43,10 @@ public class RestartAllFlutterApps extends FlutterAppAction {
       return;
     }
 
-    FlutterReloadManager.getInstance(project)
-      .saveAllAndRestartAll(FlutterApp.allFromProjectProcess(project), FlutterConstants.RELOAD_REASON_MANUAL);
+    var reloadManager = FlutterReloadManager.getInstance(project);
+    if (reloadManager != null) {
+      reloadManager
+        .saveAllAndRestartAll(FlutterApp.allFromProjectProcess(project), FlutterConstants.RELOAD_REASON_MANUAL);
+    }
   }
 }

--- a/flutter-idea/src/io/flutter/actions/RestartFlutterApp.java
+++ b/flutter-idea/src/io/flutter/actions/RestartFlutterApp.java
@@ -30,7 +30,13 @@ public class RestartFlutterApp extends FlutterAppAction {
   public RestartFlutterApp(@NotNull FlutterApp app, @NotNull Computable<Boolean> isApplicable) {
     super(app, TEXT, DESCRIPTION, FlutterIcons.HotRestart, isApplicable, ID);
     // Shortcut is associated with toolbar action.
-    copyShortcutFrom(ActionManager.getInstance().getAction("Flutter.Toolbar.RestartAction"));
+    ActionManager actionManager = ActionManager.getInstance();
+    if (actionManager != null) {
+      var action = actionManager.getAction("Flutter.Toolbar.RestartAction");
+      if (action != null) {
+        copyShortcutFrom(action);
+      }
+    }
   }
 
   @Override
@@ -39,8 +45,10 @@ public class RestartFlutterApp extends FlutterAppAction {
     if (project == null) {
       return;
     }
-
-    FlutterReloadManager.getInstance(project).saveAllAndRestart(getApp(), FlutterConstants.RELOAD_REASON_MANUAL);
+    var reloadManager = FlutterReloadManager.getInstance(project);
+    if (reloadManager != null) {
+      reloadManager.saveAllAndRestart(getApp(), FlutterConstants.RELOAD_REASON_MANUAL);
+    }
 
     if (WorkspaceCache.getInstance(project).isBazel() &&
         FlutterSettings.getInstance().isShowBazelHotRestartWarning() &&

--- a/flutter-idea/src/io/flutter/actions/RestartFlutterDaemonAction.java
+++ b/flutter-idea/src/io/flutter/actions/RestartFlutterDaemonAction.java
@@ -42,7 +42,7 @@ public class RestartFlutterDaemonAction extends AnAction {
   }
 
   @Override
-  public void actionPerformed(AnActionEvent event) {
+  public void actionPerformed(@NotNull AnActionEvent event) {
     final Project project = event.getProject();
     if (project == null) {
       return;

--- a/flutter-idea/src/io/flutter/run/daemon/DeviceService.java
+++ b/flutter-idea/src/io/flutter/run/daemon/DeviceService.java
@@ -133,7 +133,7 @@ public class DeviceService {
   /**
    * Returns the currently connected devices, sorted by device name.
    */
-  public Collection<FlutterDevice> getConnectedDevices() {
+  public @NotNull Collection<FlutterDevice> getConnectedDevices() {
     return deviceSelection.get().getDevices();
   }
 

--- a/flutter-idea/src/io/flutter/sdk/AndroidEmulatorManager.java
+++ b/flutter-idea/src/io/flutter/sdk/AndroidEmulatorManager.java
@@ -36,7 +36,7 @@ public class AndroidEmulatorManager {
   private final @NotNull Project project;
   private final AtomicReference<ImmutableSet<Runnable>> listeners = new AtomicReference<>(ImmutableSet.of());
 
-  private List<AndroidEmulator> cachedEmulators = new ArrayList<>();
+  private @NotNull List<AndroidEmulator> cachedEmulators = new ArrayList<>();
 
   private AndroidEmulatorManager(@NotNull Project project) {
     this.project = project;
@@ -60,7 +60,7 @@ public class AndroidEmulatorManager {
 
   private CompletableFuture<List<AndroidEmulator>> inProgressRefresh;
 
-  public CompletableFuture<List<AndroidEmulator>> refresh() {
+  public CompletableFuture<@NotNull List<AndroidEmulator>> refresh() {
     // We don't need to refresh if one is in progress.
     synchronized (this) {
       if (inProgressRefresh != null) {
@@ -97,11 +97,11 @@ public class AndroidEmulatorManager {
     return future;
   }
 
-  public List<AndroidEmulator> getCachedEmulators() {
+  public @NotNull List<@NotNull AndroidEmulator> getCachedEmulators() {
     return cachedEmulators;
   }
 
-  private void fireChangeEvent(final List<AndroidEmulator> newEmulators, final List<AndroidEmulator> oldEmulators) {
+  private void fireChangeEvent(final @NotNull List<AndroidEmulator> newEmulators, final List<AndroidEmulator> oldEmulators) {
     if (project.isDisposed()) return;
 
     // Don't fire if the list of devices is unchanged.

--- a/flutter-idea/src/io/flutter/view/EmbeddedBrowser.java
+++ b/flutter-idea/src/io/flutter/view/EmbeddedBrowser.java
@@ -262,7 +262,7 @@ public abstract class EmbeddedBrowser {
   // This will refresh all the browser tabs within a tool window (e.g. if there are multiple apps running and the inspector tool window is
   // refreshed, an inspector tab will refresh for each app.)
   // TODO(helin24): Consider allowing refresh for single browser tabs within tool windows.
-  public void refresh(String toolWindowId) {
+  public void refresh(@Nullable String toolWindowId) {
     Map<String, BrowserTab> tabs = windows.get(toolWindowId);
 
     if (tabs == null) {


### PR DESCRIPTION
Fix nullability problems for all the actions in `src/io/flutter/actions/`.

See https://github.com/flutter/flutter-intellij/issues/8291.

If we pursue https://github.com/flutter/flutter-intellij/issues/8292, we could mark `src/io/flutter/actions/` as null-"clean".

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
