### PR TITLE
[CQ] fix nullability problems for `flutter/analytics`

### DIFF
--- a/flutter-idea/src/io/flutter/analytics/UnifiedAnalytics.java
+++ b/flutter-idea/src/io/flutter/analytics/UnifiedAnalytics.java
@@ -70,9 +70,9 @@ public class UnifiedAnalytics {
     }
   }
 
-  private CompletableFuture<JsonObject> makeUnifiedAnalyticsRequest(String requestName,
-                                                                    @NotNull DartToolingDaemonService service,
-                                                                    @NotNull JsonObject params) {
+  private @NotNull CompletableFuture<JsonObject> makeUnifiedAnalyticsRequest(String requestName,
+                                                                             @NotNull DartToolingDaemonService service,
+                                                                             @NotNull JsonObject params) {
     CompletableFuture<JsonObject> finalResult = new CompletableFuture<>();
     try {
       service.sendRequest("UnifiedAnalytics." + requestName, params, false, object -> {
@@ -90,7 +90,7 @@ public class UnifiedAnalytics {
     return finalResult;
   }
 
-  private @Nullable CompletableFuture<Boolean> telemetryEnabled(@NotNull DartToolingDaemonService service, @NotNull JsonObject params) {
+  private @NotNull CompletableFuture<Boolean> telemetryEnabled(@NotNull DartToolingDaemonService service, @NotNull JsonObject params) {
     return makeUnifiedAnalyticsRequest("telemetryEnabled", service, params).thenCompose(result -> {
       assert result != null;
       JsonPrimitive value = result.getAsJsonPrimitive("value");
@@ -104,7 +104,7 @@ public class UnifiedAnalytics {
     });
   }
 
-  private @Nullable CompletableFuture<Boolean> clientShowedMessage(@NotNull DartToolingDaemonService service, @NotNull JsonObject params) {
+  private @NotNull CompletableFuture<Boolean> clientShowedMessage(@NotNull DartToolingDaemonService service, @NotNull JsonObject params) {
     return makeUnifiedAnalyticsRequest("clientShowedMessage", service, params).thenCompose(result -> {
       assert result != null;
       JsonPrimitive type = result.getAsJsonPrimitive("type");
@@ -118,9 +118,9 @@ public class UnifiedAnalytics {
     });
   }
 
-  private @Nullable CompletableFuture<Boolean> setTelemetry(@NotNull DartToolingDaemonService service,
-                                                            @NotNull JsonObject params,
-                                                            Boolean canSendAnalytics) {
+  private @NotNull CompletableFuture<Boolean> setTelemetry(@NotNull DartToolingDaemonService service,
+                                                           @NotNull JsonObject params,
+                                                           Boolean canSendAnalytics) {
     params.addProperty("enable", canSendAnalytics);
     return makeUnifiedAnalyticsRequest("setTelemetry", service, params).thenCompose(result -> {
       assert result != null;
@@ -178,7 +178,7 @@ public class UnifiedAnalytics {
     }
   }
 
-  private @Nullable CompletableFuture<Boolean> shouldShowMessage(@NotNull DartToolingDaemonService service, @NotNull JsonObject params) {
+  private @NotNull CompletableFuture<Boolean> shouldShowMessage(@NotNull DartToolingDaemonService service, @NotNull JsonObject params) {
     return makeUnifiedAnalyticsRequest("shouldShowMessage", service, params).thenCompose(result -> {
       assert result != null;
       JsonPrimitive value = result.getAsJsonPrimitive("value");
@@ -192,7 +192,7 @@ public class UnifiedAnalytics {
     });
   }
 
-  private @Nullable CompletableFuture<String> getConsentMessage(@NotNull DartToolingDaemonService service, @NotNull JsonObject params) {
+  private @NotNull CompletableFuture<String> getConsentMessage(@NotNull DartToolingDaemonService service, @NotNull JsonObject params) {
     return makeUnifiedAnalyticsRequest("getConsentMessage", service, params).thenCompose(result -> {
       assert result != null;
       JsonPrimitive value = result.getAsJsonPrimitive("value");

--- a/flutter-idea/src/io/flutter/dart/DtdUtils.java
+++ b/flutter-idea/src/io/flutter/dart/DtdUtils.java
@@ -12,7 +12,7 @@ import org.jetbrains.annotations.NotNull;
 import java.util.concurrent.CompletableFuture;
 
 public class DtdUtils {
-  public CompletableFuture<DartToolingDaemonService> readyDtdService(@NotNull Project project) {
+  public @NotNull CompletableFuture<DartToolingDaemonService> readyDtdService(@NotNull Project project) {
     final DartToolingDaemonService dtdService = DartToolingDaemonService.getInstance(project);
     CompletableFuture<DartToolingDaemonService> readyService = new CompletableFuture<>();
     int attemptsRemaining = 10;


### PR DESCRIPTION
Fix nullability problems for `src/io/flutter/analytics/`.

See https://github.com/flutter/flutter-intellij/issues/8291.

If we pursue https://github.com/flutter/flutter-intellij/issues/8292, we could mark `src/io/flutter/analytics/` as null-"clean".

---

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
