### PR TITLE
[CQ] fix nullability problems for `flutter/project`

### DIFF
--- a/flutter-idea/src/io/flutter/project/FlutterIconProvider.java
+++ b/flutter-idea/src/io/flutter/project/FlutterIconProvider.java
@@ -27,7 +27,8 @@ import javax.swing.*;
 import java.util.Objects;
 
 public class FlutterIconProvider extends IconProvider {
-  private static final Icon TEST_FILE = overlayIcons(DartFileType.INSTANCE.getIcon(), AllIcons.Nodes.JunitTestMark);
+  @SuppressWarnings("DataFlowIssue") private static final @NotNull Icon TEST_FILE =
+    overlayIcons(DartFileType.INSTANCE.getIcon(), AllIcons.Nodes.JunitTestMark);
 
   @Nullable
   public Icon getIcon(@NotNull PsiElement element, @IconFlags int flags) {
@@ -76,7 +77,7 @@ public class FlutterIconProvider extends IconProvider {
   }
 
   @NotNull
-  private static Icon overlayIcons(@NotNull Icon... icons) {
+  private static Icon overlayIcons(@NotNull Icon @NotNull ... icons) {
     final LayeredIcon result = new LayeredIcon(icons.length);
 
     for (int layer = 0; layer < icons.length; layer++) {

--- a/flutter-idea/src/io/flutter/project/FlutterProjectOpenProcessor.java
+++ b/flutter-idea/src/io/flutter/project/FlutterProjectOpenProcessor.java
@@ -71,6 +71,7 @@ public class FlutterProjectOpenProcessor extends ProjectOpenProcessor {
 
   @Nullable
   protected ProjectOpenProcessor getDelegateImportProvider(@NotNull VirtualFile file) {
+    //noinspection DataFlowIssue
     return EXTENSION_POINT_NAME.getExtensionList().stream().filter(
       processor -> processor.canOpenProject(file) && !Objects.equals(processor.getName(), getName())
     ).findFirst().orElse(null);

--- a/flutter-idea/src/io/flutter/project/ProjectWatch.java
+++ b/flutter-idea/src/io/flutter/project/ProjectWatch.java
@@ -40,6 +40,7 @@ public class ProjectWatch implements Closeable {
     };
 
     final ProjectManager manager = ProjectManager.getInstance();
+    assert manager != null;
     manager.addProjectManagerListener(project, listener);
 
     final MessageBusConnection bus = project.getMessageBus().connect();

--- a/flutter-idea/src/io/flutter/pub/PubRootCache.java
+++ b/flutter-idea/src/io/flutter/pub/PubRootCache.java
@@ -43,7 +43,7 @@ public class PubRootCache {
   }
 
   @Nullable
-  public PubRoot getRoot(VirtualFile file) {
+  public PubRoot getRoot(@Nullable VirtualFile file) {
     file = findPubspecDir(file);
     if (file == null) {
       return null;


### PR DESCRIPTION
Fix nullability problems in `src/io/flutter/project/`.

See https://github.com/flutter/flutter-intellij/issues/8291.

If we pursue https://github.com/flutter/flutter-intellij/issues/8292, we could mark `src/io/flutter/project/` as null-"clean".


---

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
