### PR TITLE
[CQ] fix nullability problems for `flutter/propertyEditor`

### DIFF
--- a/flutter-idea/src/io/flutter/propertyeditor/PropertyEditorViewFactory.java
+++ b/flutter-idea/src/io/flutter/propertyeditor/PropertyEditorViewFactory.java
@@ -96,7 +96,7 @@ public class PropertyEditorViewFactory extends AbstractDevToolsViewFactory {
     Disposer.register(toolWindow.getDisposable(), connection);
   }
 
-  private void checkDockedUnpinnedAndCreateContent(@NotNull Project project, ToolWindow toolWindow, boolean forceLoad) {
+  private void checkDockedUnpinnedAndCreateContent(@NotNull Project project, @NotNull ToolWindow toolWindow, boolean forceLoad) {
     final Boolean isDockedUnpinned = toolWindow.getType().equals(ToolWindowType.DOCKED) && toolWindow.isAutoHide();
 
     // If this is the first time we are loading the content, force a load even if docked unpinned state matches.


### PR DESCRIPTION
Fix nullability problems in `src/io/flutter/propertyEditor/`.

See https://github.com/flutter/flutter-intellij/issues/8291.

If we pursue https://github.com/flutter/flutter-intellij/issues/8292, we could mark `src/io/flutter/propertyEditor/` as null-"clean".


---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
