### PR TITLE
[CQ] fix nullability problems for `flutter/pub`

### DIFF
--- a/flutter-idea/src/io/flutter/pub/PubRoot.java
+++ b/flutter-idea/src/io/flutter/pub/PubRoot.java
@@ -177,7 +177,7 @@ public class PubRoot {
     return path.substring(root.length() + 1);
   }
 
-  private static final String /*@NotNull*/[] TEST_DIRS = new String[]{ // TODO 2022.1
+  private static final String @NotNull [] TEST_DIRS = new String[]{ // TODO 2022.1
     "/test/",
     "/integration_test/",
     "/test_driver/",
@@ -237,6 +237,7 @@ public class PubRoot {
    */
   public boolean declaresFlutter() {
     validateUpdateCachedPubspecInfo();
+    assert cachedPubspecInfo != null;
     return cachedPubspecInfo.declaresFlutter();
   }
 
@@ -444,7 +445,10 @@ public class PubRoot {
     if (project.isDisposed()) {
       return null;
     }
-    return ProjectRootManager.getInstance(project).getFileIndex().getModuleForFile(pubspec);
+    var manager = ProjectRootManager.getInstance(project);
+    if (manager == null) return null;
+
+    return manager.getFileIndex().getModuleForFile(pubspec);
   }
 
   @Override


### PR DESCRIPTION
Fix nullability problems in `src/io/flutter/pub/`.

See https://github.com/flutter/flutter-intellij/issues/8291.

If we pursue https://github.com/flutter/flutter-intellij/issues/8292, we could mark `src/io/flutter/pub/` as null-"clean".


---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
