### PR TITLE
Change JX Browser file management to plugin logger

### DIFF
--- a/flutter-idea/src/io/flutter/jxbrowser/JxBrowserManager.java
+++ b/flutter-idea/src/io/flutter/jxbrowser/JxBrowserManager.java
@@ -23,6 +23,7 @@ import com.intellij.util.download.DownloadableFileService;
 import com.intellij.util.download.FileDownloader;
 import com.teamdev.jxbrowser.browser.UnsupportedRenderingModeException;
 import com.teamdev.jxbrowser.engine.RenderingMode;
+import io.flutter.logging.PluginLogger;
 import io.flutter.settings.FlutterSettings;
 import io.flutter.utils.FileUtils;
 import io.flutter.utils.JxBrowserUtils;
@@ -81,7 +82,7 @@ public class JxBrowserManager {
   @NotNull
   private static final AtomicBoolean listeningForSetting = new AtomicBoolean(false);
   @NotNull
-  private static final Logger LOG = Logger.getInstance(JxBrowserManager.class);
+  private static final Logger LOG = PluginLogger.createLogger(JxBrowserManager.class);
   @NotNull
   public static CompletableFuture<JxBrowserStatus> installation = new CompletableFuture<>();
   @NotNull
@@ -261,7 +262,7 @@ public class JxBrowserManager {
       assert fileName != null;
       final String filePath = getFilePath(fileName);
       if (!fileUtils.deleteFile(filePath)) {
-        LOG.info(projectName + ": Existing file could not be deleted - " + filePath);
+        LOG.info(projectName + ": Existing file could not be deleted - " + fileName);
       }
     }
     downloadJxBrowser(fileNames);
@@ -311,7 +312,7 @@ public class JxBrowserManager {
                 ContainerUtil.getFirstItem(downloader.download(new File(DOWNLOAD_PATH)));
               final File file = download != null ? download.first : null;
               if (file != null) {
-                LOG.info(project.getName() + ": JxBrowser file downloaded: " + file.getAbsolutePath());
+                LOG.info(project.getName() + ": JxBrowser file downloaded: " + file.getName());
               }
             }
 
@@ -344,11 +345,11 @@ public class JxBrowserManager {
         fileUtils.loadPaths(this.getClass().getClassLoader(), paths);
       }
       catch (Exception ex) {
-        LOG.info("Failed to load JxBrowser file", ex);
+        LOG.info("Failed to load JxBrowser paths");
         setStatusFailed(new InstallationFailedReason(FailureType.CLASS_LOAD_FAILED));
         return;
       }
-      LOG.info("Loaded JxBrowser files successfully: " + paths);
+      LOG.info("Loaded JxBrowser files successfully");
 
       try {
         final Class<?> clazz = Class.forName("com.teamdev.jxbrowser.browser.UnsupportedRenderingModeException");


### PR DESCRIPTION
I was planning to change over classes that are logging to using the plugin logger. In this case there were some file paths being logged and I removed those; however, now I'm thinking about whether it would make sense to allow logs with file paths to help users debug on their own (perhaps as a setting that's off by default?). Anyway, that's more a topic for a doc. In this case, I think our JX Browser download process is fairly stable and does not require file details.