### PR TITLE
Remove test and compile only dependencies on artifacts dir

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -131,49 +131,6 @@ dependencies {
   // TODO(helin24): The rest in this block was pulled over from flutter-idea; potentially parts could be deleted.
   compileOnly("org.jetbrains:annotations:24.0.0")
   testImplementation("org.jetbrains:annotations:24.0.0")
-
-  testRuntimeOnly(
-    fileTree(
-      mapOf(
-        "dir" to "${project.rootDir}/artifacts/android-studio/plugins",
-        "include" to listOf("**/*.jar"),
-        "exclude" to listOf("**/kotlin-compiler.jar", "**/kotlin-plugin.jar", "**/kotlin-stdlib-jdk8.jar")
-      )
-    )
-  )
-  compileOnly(
-    fileTree(
-      mapOf(
-        "dir" to "${project.rootDir}/artifacts/android-studio/lib",
-        "include" to listOf("*.jar"),
-        "exclude" to listOf("**/annotations.jar")
-      )
-    )
-  )
-  testRuntimeOnly(
-    fileTree(
-      mapOf(
-        "dir" to "${project.rootDir}/artifacts/android-studio/lib",
-        "include" to listOf("*.jar")
-      )
-    )
-  )
-  compileOnly(
-    fileTree(
-      mapOf(
-        "dir" to "${project.rootDir}/artifacts/android-studio/plugins/git4idea/lib",
-        "include" to listOf("*.jar")
-      )
-    )
-  )
-  testImplementation(
-    fileTree(
-      mapOf(
-        "dir" to "${project.rootDir}/artifacts/android-studio/plugins/git4idea/lib",
-        "include" to listOf("*.jar")
-      )
-    )
-  )
   compileOnly("com.google.guava:guava:32.0.1-android")
   compileOnly("com.google.code.gson:gson:2.10.1")
   testImplementation("com.google.guava:guava:32.0.1-jre")
@@ -200,41 +157,6 @@ dependencies {
       mapOf(
         "dir" to "${project.rootDir}/third_party/lib/jxbrowser",
         "include" to listOf("*.jar")
-      )
-    )
-  )
-
-  compileOnly(
-    fileTree(
-      mapOf(
-        "dir" to "${project.rootDir}/artifacts/android-studio/lib",
-        "include" to listOf("*.jar")
-      )
-    )
-  )
-  testImplementation(
-    fileTree(
-      mapOf(
-        "dir" to "${project.rootDir}/artifacts/android-studio/lib",
-        "include" to listOf("*.jar")
-      )
-    )
-  )
-  compileOnly(
-    fileTree(
-      mapOf(
-        "dir" to "${project.rootDir}/artifacts/android-studio/plugins",
-        "include" to listOf("**/*.jar"),
-        "exclude" to listOf("**/kotlin-compiler.jar", "**/kotlin-plugin.jar")
-      )
-    )
-  )
-  testImplementation(
-    fileTree(
-      mapOf(
-        "dir" to "${project.rootDir}/artifacts/android-studio/plugins",
-        "include" to listOf("**/*.jar"),
-        "exclude" to listOf("**/kotlin-compiler.jar", "**/kotlin-plugin.jar")
       )
     )
   )


### PR DESCRIPTION
This could break something I'm not aware of, but the plugin seems to build successfully (both from `bin/plugin make` and on sandbox) and `bin/plugin test` also runs successfully.

My suspicion is that the artifacts directory used to exist but no longer exists.