### PR TITLE
Remove resources folders in subdirectories

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -300,7 +300,7 @@ sourceSets {
     resources.srcDirs(
       listOf(
         "flutter-idea/src",
-        "flutter-idea/resources"
+        "resources"
       )
     )
     java.srcDirs(
@@ -320,7 +320,7 @@ sourceSets {
     )
     resources.srcDirs(
       listOf(
-        "flutter-idea/resources",
+        "resources",
         "flutter-idea/testData",
         "flutter-idea/testSrc/unit"
       )

--- a/flutter-idea/resources
+++ b/flutter-idea/resources
@@ -1,1 +1,0 @@
-../resources

--- a/flutter-studio/resources
+++ b/flutter-studio/resources
@@ -1,1 +1,0 @@
-../resources


### PR DESCRIPTION
The `resources` directories in `flutter-idea` and `flutter-studio` were symlinks to the main-level directory, and I think this isn't needed with a flat structure. The classes in the generated `flutter-intellij.jar` file seem to include the same ones as the old jar and the plugin installs correctly.