### PR TITLE
Rename "observatoryUri" to "vmServiceUri" for test.startedProcess

### DIFF
--- a/flutter-idea/src/io/flutter/run/test/FlutterTestEventsConverter.java
+++ b/flutter-idea/src/io/flutter/run/test/FlutterTestEventsConverter.java
@@ -54,8 +54,10 @@ public class FlutterTestEventsConverter extends DartTestEventsConverterZ {
 
   @Override
   protected boolean process(@NotNull JsonArray array) {
-    // Consume (and don't print) vmServiceUri output, e.g.,
-    //     [{"event":"test.startedProcess","params":{"vmServiceUri":"http://127.0.0.1:51770/"}}]
+    // Consume (and don't print) observatoryUri/vmServiceUri output, e.g.,
+    //     [{"event":"test.startedProcess","params":{"vmServiceUri":"http://127.0.0.1:62047/VFPfi0PrluM=/"}}]
+    //     [{"event":"test.startedProcess","params":{"observatoryUri":"http://127.0.0.1:51770/"}}] (deprecated)
+    // Both fields may be present on Flutter versions older than 3.34.
     if (array.size() == 1) {
       final JsonElement element = array.get(0);
       final JsonElement event = getValue(element, "event");
@@ -63,8 +65,8 @@ public class FlutterTestEventsConverter extends DartTestEventsConverterZ {
         if (Objects.equals(event.getAsString(), "test.startedProcess")) {
           final JsonElement params = getValue(element, "params");
           if (params != null) {
-            final JsonElement uri = getValue(params, "vmServiceUri");
-            return uri != null;
+            return getValue(params, "vmServiceUri") != null
+                || getValue(params, "observatoryUri") != null;
           }
         }
       }

--- a/flutter-idea/src/io/flutter/run/test/FlutterTestRunner.java
+++ b/flutter-idea/src/io/flutter/run/test/FlutterTestRunner.java
@@ -323,9 +323,20 @@ public class FlutterTestRunner extends GenericProgramRunner {
       }
 
       if (eventName.equals("test.startedProcess")) {
-        final JsonPrimitive primUri = params.getAsJsonPrimitive("vmServiceUri");
-        if (primUri != null) {
-          observatoryUri = primUri.getAsString();
+        // Since Flutter release 3.34, "observatoryUri" is no longer available due to the removal of
+        // Observatory in favor of DevTools/VM Service.
+        // Since then, only the field "vmServiceUri" is given in this event (contrary to both fields
+        // on earlier versions).
+        final JsonPrimitive primVmServiceUri = params.getAsJsonPrimitive("vmServiceUri");
+
+        if (primVmServiceUri != null) {
+          observatoryUri = primVmServiceUri.getAsString();
+        } else {
+          final JsonPrimitive primObservatoryUri = params.getAsJsonPrimitive("observatoryUri");
+
+          if (primObservatoryUri != null) {
+            observatoryUri = primObservatoryUri.getAsString();
+          }
         }
       }
     }


### PR DESCRIPTION
This is due to the removal of Observatory support from Dart SDKs and Flutter which made the tests never unpause on recent versions of Flutter. This fixes #8233.

The URI pointing to Observatory is no longer given in `test.startedProcess`. Now, the URI to the VM Service for DevTools is present and can be used as a drop-in replacement to achieve the same functionality.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
