### PR TITLE
Change the message sent to IntelliJ when starting the test suites to the correct one

### DIFF
--- a/flutter-idea/src/io/flutter/test/DartTestEventsConverterZ.java
+++ b/flutter-idea/src/io/flutter/test/DartTestEventsConverterZ.java
@@ -401,7 +401,7 @@ public class DartTestEventsConverterZ extends OutputToGeneralTestEventsConverter
     mySuiteData.clear();
     mySuitCount = 0;
 
-    return doProcessServiceMessages(ServiceMessageBuilder.testStarted("").toString());
+    return doProcessServiceMessages(ServiceMessageBuilder.testsStarted().toString());
   }
 
   @SuppressWarnings("RedundantThrows")


### PR DESCRIPTION
This is the cause of the error mentioned in #8325.
Previously, the correct message was being sent hard-coded and was supposed to be replaced by `ServiceMessageBuilder.testsStarted()` once the method was available. Instead, `ServiceMessageBuilder.testStarted("")` was used which changes the message to `##teamcity[testStarted name='']` from `##teamcity[enteredtheMatrix]` (hence the error).

This one-liner just replaces the erroneous call to the correct one.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
