### PR TITLE
WIP add integration test (not working)

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="17" />
+    <bytecodeTargetLevel target="17">
+      <module name="flutter-intellij" target="21" />
+      <module name="flutter-intellij.main" target="21" />
+      <module name="flutter-intellij.test" target="21" />
+    </bytecodeTargetLevel>
   </component>
 </project>

--- a/flutter-idea/src/io/flutter/logging/FlutterConsoleLogManager.java
+++ b/flutter-idea/src/io/flutter/logging/FlutterConsoleLogManager.java
@@ -177,7 +177,7 @@ public class FlutterConsoleLogManager {
   private static final ArrayList<DiagnosticsNode> emptyList = new ArrayList<>();
 
   /**
-   * Pretty print the error using the available console syling attributes.
+   * Pretty print the error using the available console styling attributes.
    */
   private void processFlutterErrorEvent(@NotNull DiagnosticsNode diagnosticsNode) {
     final String description = " " + diagnosticsNode + " ";

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -23,7 +23,7 @@
   <category>Custom Languages</category>
   <version>SNAPSHOT</version>
   <!--suppress PluginXmlValidity -->
-  <idea-version since-build="243" until-build="243.*"/>
+  <idea-version since-build="251" until-build="253.*"/>
 
   <depends>com.intellij.modules.platform</depends>
   <depends>com.intellij.modules.lang</depends>
@@ -45,7 +45,7 @@
 
   <!-- Contributes Android Studio-specific features and implementations. -->
   <!--suppress PluginXmlValidity -->
-  <depends optional="true" config-file="studio-contribs.xml">com.intellij.modules.androidstudio</depends>
+  <depends optional="true" config-file="studio-contribs.xml">com.android.tools.apk</depends>
 
 
   <change-notes>

--- a/src/integrationTest/kotlin/PluginTest.kt
+++ b/src/integrationTest/kotlin/PluginTest.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2025 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+import com.intellij.ide.starter.ci.CIServer
+import com.intellij.ide.starter.ci.NoCIServer
+import com.intellij.ide.starter.di.di
+import com.intellij.ide.starter.driver.engine.runIdeWithDriver
+import com.intellij.ide.starter.ide.IdeProductProvider
+import com.intellij.ide.starter.models.TestCase
+import com.intellij.ide.starter.plugins.PluginConfigurator
+import com.intellij.ide.starter.project.GitHubProject
+import com.intellij.ide.starter.runner.Starter
+import org.junit.Test
+
+class PluginTest {
+  @Test
+  fun simpleTestWithoutProject() {
+    println("In integration test")
+//    Starter.newContext(
+//      testName = "testExample",
+//      TestCase(IdeProductProvider.IC, projectInfo = NoProject)
+//        .withVersion("2024.3")
+//    ).apply {
+//      val pathToPlugin = System.getProperty("path.to.build.plugin")
+//      PluginConfigurator(this).installPluginFromFolder(File(pathToPlugin))
+//    }.runIdeWithDriver().useDriverAndCloseIde {
+//    }
+  }
+}


### PR DESCRIPTION
From following https://plugins.jetbrains.com/docs/intellij/integration-tests-intro.html and https://blog.jetbrains.com/platform/2025/02/integration-tests-for-plugin-developers-intro-dependencies-and-first-integration-test/ and asking Gemini a lot of questions

The `PluginTest` file doesn't seem to see all of the `com.intellij.ide...` imports it needs. For example, it gets stuck on `TestCase` despite my trying to import all of the classpaths that we have for normal tests and trying to add specific Starter framework libraries.

I added printouts of paths visible at compile time to try to see what's included. There may be other debugging steps like this I'm not aware of when working on gradle issues.

@jwren 