### PR TITLE
[logging] Use separate log for FlutterCommand

### DIFF
--- a/flutter-idea/src/io/flutter/FlutterBundle.properties
+++ b/flutter-idea/src/io/flutter/FlutterBundle.properties
@@ -157,6 +157,8 @@ settings.report.analytics.tooltip=Report anonymized usage information to Google 
 settings.enable.verbose.logging.tooltip=Enables verbose logging (this can be useful for diagnostic purposes).
 # suppress inspection "UnusedProperty" (used in a `FlutterSettingsConfigurable.form`)
 settings.enable.logs.preserve.during.hot.reload.and.restart=Preserve console logs during Hot Reload and Hot Restart
+settings.enable.file.path.logging=Allow logging of full file paths
+settings.enable.file.path.logging.tooltip=Logs full file paths that could show private user information
 
 action.new.project.title=New Flutter Project...
 welcome.new.project.compact=New Flutter Project

--- a/flutter-idea/src/io/flutter/sdk/FlutterSettingsConfigurable.form
+++ b/flutter-idea/src/io/flutter/sdk/FlutterSettingsConfigurable.form
@@ -59,7 +59,7 @@
           </component>
         </children>
       </grid>
-      <grid id="e885c" layout-manager="GridLayoutManager" row-count="2" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="e885c" layout-manager="GridLayoutManager" row-count="3" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -83,6 +83,15 @@
             <properties>
               <text resource-bundle="io/flutter/FlutterBundle" key="settings.allow.tests.in.sources"/>
               <toolTipText resource-bundle="io/flutter/FlutterBundle" key="settings.allow.tests.tooltip"/>
+            </properties>
+          </component>
+          <component id="1a5b8" class="javax.swing.JCheckBox" binding="myEnableFilePathLogging">
+            <constraints>
+              <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text resource-bundle="io/flutter/FlutterBundle" key="settings.enable.file.path.logging"/>
+              <toolTipText resource-bundle="io/flutter/FlutterBundle" key="settings.enable.file.path.logging.tooltip"/>
             </properties>
           </component>
         </children>

--- a/flutter-idea/src/io/flutter/sdk/FlutterSettingsConfigurable.java
+++ b/flutter-idea/src/io/flutter/sdk/FlutterSettingsConfigurable.java
@@ -86,6 +86,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
   private JCheckBox myAllowTestsInSourcesRoot;
   private ActionLink settingsLink;
   private JCheckBox myEnableLogsPreserveAfterHotReloadOrRestart;
+  private @NotNull JCheckBox myEnableFilePathLogging;
 
   private final @NotNull Project myProject;
   private final WorkspaceCache workspaceCache;
@@ -245,6 +246,10 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
       return true;
     }
 
+    if (settings.isFilePathLoggingEnabled() != myEnableFilePathLogging.isSelected()) {
+      return true;
+    }
+
     return settings.isEnableJcefBrowser() != myEnableJcefBrowserCheckBox.isSelected();
   }
 
@@ -299,6 +304,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     settings.setAllowTestsInSourcesRoot(myAllowTestsInSourcesRoot.isSelected());
     settings.setFontPackages(myFontPackagesTextArea.getText());
     settings.setEnableJcefBrowser(myEnableJcefBrowserCheckBox.isSelected());
+    settings.setFilePathLoggingEnabled(myEnableFilePathLogging.isSelected());
 
     reset(); // because we rely on remembering initial state
     checkFontPackages(settings.getFontPackages(), oldFontPackages);
@@ -366,6 +372,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
 
     myEnableJcefBrowserCheckBox.setSelected(settings.isEnableJcefBrowser());
     myFontPackagesTextArea.setText(settings.getFontPackages());
+    myEnableFilePathLogging.setSelected(settings.isFilePathLoggingEnabled());
   }
 
   private void onVersionChanged() {

--- a/flutter-idea/src/io/flutter/settings/FlutterSettings.java
+++ b/flutter-idea/src/io/flutter/settings/FlutterSettings.java
@@ -35,6 +35,7 @@ public class FlutterSettings {
   private static final String showBazelIosRunNotificationKey = "io.flutter.hideBazelIosRunNotification";
   private static final String sdkVersionOutdatedWarningAcknowledgedKey = "io.flutter.sdkVersionOutdatedWarningAcknowledged";
   private static final String androidStudioBotAcknowledgedKey = "io.flutter.androidStudioBotAcknowledgedKey";
+  private static final String enableFilePathLoggingKey = "io.flutter.enableFilePathLogging";
 
   private static @Nullable FlutterSettings testInstance;
 
@@ -260,5 +261,13 @@ public class FlutterSettings {
 
   public void setAndroidStudioBotAcknowledgedKey(boolean value) {
     getPropertiesComponent().setValue(androidStudioBotAcknowledgedKey, value);
+  }
+
+  public boolean isFilePathLoggingEnabled() {
+    return getPropertiesComponent().getBoolean(enableFilePathLoggingKey, false);
+  }
+
+  public void setFilePathLoggingEnabled(boolean value) {
+    getPropertiesComponent().setValue(enableFilePathLoggingKey, value);
   }
 }


### PR DESCRIPTION
I added an option (default off) to record full file paths in logs. Originally I was thinking that we shouldn't record any file paths, but it seems reasonable to have them sometimes for debugging setup issues since these are recorded on a user's machine rather than to somewhere centralized that we receive by default.