### PR TITLE
[CQ] migrate from deprecated `LayeredIcon` constructor

### DIFF
--- a/src/io/flutter/vmService/frame/DartVmServiceValue.java
+++ b/src/io/flutter/vmService/frame/DartVmServiceValue.java
@@ -30,11 +30,12 @@ import java.util.Base64;
 // See https://youtrack.jetbrains.com/issue/WEB-17629.
 
 public class DartVmServiceValue extends XNamedValue {
-
-  private static final LayeredIcon FINAL_FIELD_ICON = new LayeredIcon(AllIcons.Nodes.Field, AllIcons.Nodes.FinalMark);
-  private static final LayeredIcon STATIC_FIELD_ICON = new LayeredIcon(AllIcons.Nodes.Field, AllIcons.Nodes.StaticMark);
+  private static final LayeredIcon FINAL_FIELD_ICON =
+    new LayeredIcon().layeredIcon(() -> new Icon[]{AllIcons.Nodes.Field, AllIcons.Nodes.FinalMark});
+  private static final LayeredIcon STATIC_FIELD_ICON =
+    new LayeredIcon().layeredIcon(() -> new Icon[]{AllIcons.Nodes.Field, AllIcons.Nodes.StaticMark});
   private static final LayeredIcon STATIC_FINAL_FIELD_ICON =
-    new LayeredIcon(AllIcons.Nodes.Field, AllIcons.Nodes.StaticMark, AllIcons.Nodes.FinalMark);
+    new LayeredIcon().layeredIcon(() -> new Icon[]{AllIcons.Nodes.Field, AllIcons.Nodes.StaticMark, AllIcons.Nodes.FinalMark});
   private static final String JSON_STRING_TEMPLATE =
     "'{'\"type\":\"@Instance\",\"class\":'{'\"type\":\"@Class\",\"fixedId\":\"true\",\"id\":\"classes/91\"," +
     "\"name\":\"_OneByteString\"'}',\"kind\":\"String\",\"length\":\"{0}\",\"valueAsString\":\"{1}\"'}'";


### PR DESCRIPTION
`LayeredIcon(...)` has been deprecated in favor of a version that uses a supplier. 


<img width="985" height="282" alt="image" src="https://github.com/user-attachments/assets/3ad44485-94fd-4d46-bf5e-d9c5b84a8954" />

https://github.com/JetBrains/intellij-community/blob/5c3b582e154b720700a8f133fcb9513543682824/platform/core-ui/src/ui/LayeredIcon.kt#L63

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
