### PR TITLE
[CQ] migrate off deprecated `InputEvent` bitmasks

### DIFF
--- a/src/io/flutter/actions/OpenAndroidModule.java
+++ b/src/io/flutter/actions/OpenAndroidModule.java
@@ -21,7 +21,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.plugins.gradle.util.GradleConstants;
 
-import java.awt.event.InputEvent;
+import java.awt.event.ActionEvent;
 import java.nio.file.Path;
 
 import static com.android.tools.idea.gradle.project.ProjectImportUtil.findGradleTarget;
@@ -42,8 +42,8 @@ public class OpenAndroidModule extends OpenInAndroidStudioAction implements Dumb
     }
     final int modifiers = e.getModifiers();
     // From ReopenProjectAction.
-    final boolean forceOpenInNewFrame = BitUtil.isSet(modifiers, InputEvent.CTRL_MASK)
-                                        || BitUtil.isSet(modifiers, InputEvent.SHIFT_MASK)
+    final boolean forceOpenInNewFrame = BitUtil.isSet(modifiers, ActionEvent.CTRL_MASK)
+                                        || BitUtil.isSet(modifiers, ActionEvent.SHIFT_MASK)
                                         || e.getPlace() == ActionPlaces.WELCOME_SCREEN;
 
     VirtualFile sourceFile = e.getData(CommonDataKeys.VIRTUAL_FILE);


### PR DESCRIPTION
`InputEvent` is deprecated in favor of `ActionEvent`s for bitmasks.

<img width="1242" height="150" alt="image" src="https://github.com/user-attachments/assets/2161a117-c1d4-4644-a594-e8058cf0bc5f" />

---

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
