### PR TITLE
[CQ] migrate off deprecated org.junit `assertThat`

### DIFF
--- a/testSrc/unit/io/flutter/utils/RefreshableTest.java
+++ b/testSrc/unit/io/flutter/utils/RefreshableTest.java
@@ -6,6 +6,7 @@
 package io.flutter.utils;
 
 import com.google.common.collect.ImmutableList;
+import org.hamcrest.MatcherAssert;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Before;
 import org.junit.Test;
@@ -362,7 +363,7 @@ public class RefreshableTest {
   }
 
   private void checkLog(String... expectedEntries) {
-    assertThat("logEntries entries are different", getLogEntries(), is(ImmutableList.copyOf(expectedEntries)));
+    MatcherAssert.assertThat("logEntries entries are different", getLogEntries(), is(ImmutableList.copyOf(expectedEntries)));
     logEntries.clear();
   }
 }


### PR DESCRIPTION
The junit `assertThat` has been deprecated in favor of the one from `org.hamcrest.MatcherAssert`.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
