### PR TITLE
[CQ] remove reflective support for olde 4.1 API

### DIFF
--- a/src/io/flutter/utils/GradleUtils.java
+++ b/src/io/flutter/utils/GradleUtils.java
@@ -213,29 +213,7 @@ public class GradleUtils {
 
   @SuppressWarnings("rawtypes")
   private static BuildModelContext makeBuildModelContext(Project project) {
-    // return BuildModelContext.create(project);
-    Method method = ReflectionUtil.getDeclaredMethod(BuildModelContext.class, "create", Project.class);
-    if (method != null) {
-      try {
-        return (BuildModelContext)method.invoke(null, project);
-      }
-      catch (IllegalAccessException | InvocationTargetException e) {
-        throw new RuntimeException(e);
-      }
-    }
-    // If we get here we're using the 4.1 API.
-    // return BuildModelContext.create(project, new AndroidLocationProvider());
-    Class locationProviderClass = AndroidLocationProvider.class.getInterfaces()[0];
-    // Class.forName("com.android.tools.idea.gradle.dsl.model.BuildModelContext.ResolvedConfigurationFileLocationProvider");
-    // does not work in the debugger. That's why we get it from the interfaces of AndroidLocationProvider.
-    method = ReflectionUtil.getDeclaredMethod(BuildModelContext.class, "create", Project.class, locationProviderClass);
-    assert method != null;
-    try {
-      return (BuildModelContext)method.invoke(null, project, new AndroidLocationProvider());
-    }
-    catch (IllegalAccessException | InvocationTargetException e) {
-      throw new RuntimeException(e);
-    }
+    return BuildModelContext.create(project, new AndroidLocationProvider());
   }
 
   // The project is an Android project that contains a Flutter module.


### PR DESCRIPTION
Remove stale reflective logic introduced in  https://github.com/flutter/flutter-intellij/commit/24812e6f8b336bd917e0f018cf75725efa610ccf

See: https://github.com/flutter/flutter-intellij/issues/8352

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
