### PR TITLE
[CQ] remove pre-2024 reflective support for `myDisplayName`

### DIFF
--- a/src/io/flutter/run/LaunchState.java
+++ b/src/io/flutter/run/LaunchState.java
@@ -168,33 +168,19 @@ public class LaunchState extends CommandLineState {
     // The descriptor shows the run configuration name (e.g., `main.dart`) by default;
     // adding the device name will help users identify the instance when trying to operate a specific one.
     final String nameWithDeviceName = descriptor.getDisplayName() + " (" + device.deviceName() + ")";
-    boolean displayNameUpdated = false;
+
     try {
-      // Find "myDisplayNameView" for 2024+ builds.
-      // https://github.com/JetBrains/intellij-community/blob/idea/241.14494.240/platform/execution/src/com/intellij/execution/ui/RunContentDescriptor.java#L33
+      // There is no public way to set display name so we resort to reflection.
       final Field f = descriptor.getClass().getDeclaredField("myDisplayNameView");
       f.setAccessible(true);
       Object viewInstance = f.get(descriptor);
       if (viewInstance != null) {
         final Method setValueMethod = viewInstance.getClass().getMethod("setValue", Object.class);
         setValueMethod.invoke(viewInstance, nameWithDeviceName);
-        displayNameUpdated = true;
       }
     }
     catch (IllegalAccessException | InvocationTargetException | NoSuchFieldException | NoSuchMethodException e) {
       LOG.info(e);
-    }
-    if (!displayNameUpdated) {
-      try {
-        // Find "myDisplayName" for 2023 builds.
-        // https://github.com/JetBrains/intellij-community/blob/idea/231.8109.175/platform/execution/src/com/intellij/execution/ui/RunContentDescriptor.java#L30
-        final Field f = descriptor.getClass().getDeclaredField("myDisplayName");
-        f.setAccessible(true);
-        f.set(descriptor, nameWithDeviceName);
-      }
-      catch (IllegalAccessException | NoSuchFieldException e) {
-        LOG.info(e);
-      }
     }
 
     return descriptor;


### PR DESCRIPTION
Ideally there'd be no reflection here but at least this gets rid of the conditional support for 2023.

See: https://github.com/flutter/flutter-intellij/issues/8352

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
