### PR TITLE
[CQ] migrate off deprecated `ComboBoxAction.createPopupActionGroup`

### DIFF
--- a/src/io/flutter/actions/DeviceSelectorAction.java
+++ b/src/io/flutter/actions/DeviceSelectorAction.java
@@ -45,9 +45,8 @@ public class DeviceSelectorAction extends ComboBoxAction implements DumbAware {
     return ActionUpdateThread.BGT;
   }
 
-  @NotNull
   @Override
-  protected DefaultActionGroup createPopupActionGroup(JComponent button) {
+  protected @NotNull DefaultActionGroup createPopupActionGroup(@NotNull JComponent button, @NotNull DataContext dataContext) {
     final DefaultActionGroup group = new DefaultActionGroup();
     group.addAll(actions);
     return group;


### PR DESCRIPTION
Migrate to preferred `createPopupActionGroup` override.

```
 /** @deprecated override {@link #createPopupActionGroup(JComponent, DataContext)} instead */
```
https://github.com/JetBrains/intellij-community/blob/01fab1c57cbe692a1e7f8df0f819386890abf6cc/platform/platform-api/src/com/intellij/openapi/actionSystem/ex/ComboBoxAction.java#L123


---

For superstition, I tested to make sure this is behavior preserving:


<img width="634" height="404" alt="image" src="https://github.com/user-attachments/assets/ac4c617b-8760-46ed-a4cc-fedad02ed738" />


---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
