### PR TITLE
[CQ] migrate off deprecated `PropertiesComponent.getValues` invocations

### DIFF
--- a/src/io/flutter/sdk/FlutterSdkUtil.java
+++ b/src/io/flutter/sdk/FlutterSdkUtil.java
@@ -78,9 +78,9 @@ public class FlutterSdkUtil {
     final PropertiesComponent props = PropertiesComponent.getInstance();
 
     // Add the existing known paths.
-    final String[] oldPaths = props.getValues(propertyKey);
+    final List<String> oldPaths = props.getList(propertyKey);
     if (oldPaths != null) {
-      allPaths.addAll(Arrays.asList(oldPaths));
+      allPaths.addAll(oldPaths);
     }
 
     // Store the values back.
@@ -131,9 +131,9 @@ public class FlutterSdkUtil {
     }
 
     // use the list of paths they've entered in the past
-    final String[] knownPaths = PropertiesComponent.getInstance().getValues(FLUTTER_SDK_KNOWN_PATHS);
+    final List<String> knownPaths = PropertiesComponent.getInstance().getList(FLUTTER_SDK_KNOWN_PATHS);
     if (knownPaths != null) {
-      paths.addAll(Arrays.asList(knownPaths));
+      paths.addAll(knownPaths);
     }
 
     // search the user's path


### PR DESCRIPTION
`PropertiesComponent.getValues` is deprecated in favor of `PropertiesComponent.getList`.

Verifier output:

```
      #Deprecated method com.intellij.ide.util.PropertiesComponent.getValues(String) invocation
          Deprecated method com.intellij.ide.util.PropertiesComponent.getValues(java.lang.String arg0) : java.lang.String[] is invoked in io.flutter.sdk.FlutterSdkUtil.updateKnownPaths(String, String) : void
          Deprecated method com.intellij.ide.util.PropertiesComponent.getValues(java.lang.String arg0) : java.lang.String[] is invoked in io.flutter.sdk.FlutterSdkUtil.getKnownFlutterSdkPaths() : String[]
```

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
