### PR TITLE
[CQ] migrate off deprecated `ListCellRendererWrapper`

### DIFF
--- a/src/io/flutter/run/bazelTest/FlutterBazelTestConfigurationEditorForm.java
+++ b/src/io/flutter/run/bazelTest/FlutterBazelTestConfigurationEditorForm.java
@@ -12,7 +12,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.TextFieldWithBrowseButton;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.util.text.StringUtil;
-import com.intellij.ui.ListCellRendererWrapper;
+import com.intellij.ui.SimpleListCellRenderer;
 import com.jetbrains.lang.dart.ide.runner.server.ui.DartCommandLineConfigurationEditorForm;
 import io.flutter.run.bazelTest.BazelTestFields.Scope;
 import io.flutter.settings.FlutterSettings;
@@ -62,7 +62,7 @@ public class FlutterBazelTestConfigurationEditorForm extends SettingsEditor<Baze
       updateFields(next);
       render(next);
     });
-    scope.setRenderer(new ListCellRendererWrapper<>() {
+    scope.setRenderer(new SimpleListCellRenderer<>() {
       @Override
       public void customize(final JList list,
                             final Scope value,

--- a/src/io/flutter/run/test/TestForm.java
+++ b/src/io/flutter/run/test/TestForm.java
@@ -9,7 +9,7 @@ import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory;
 import com.intellij.openapi.options.SettingsEditor;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.TextFieldWithBrowseButton;
-import com.intellij.ui.ListCellRendererWrapper;
+import com.intellij.ui.SimpleListCellRenderer;
 import io.flutter.run.test.TestFields.Scope;
 import org.jetbrains.annotations.NotNull;
 
@@ -51,7 +51,7 @@ public class TestForm extends SettingsEditor<TestConfig> {
       updateFields(next);
       render(next);
     });
-    scope.setRenderer(new ListCellRendererWrapper<>() {
+    scope.setRenderer(new SimpleListCellRenderer<>() {
       @Override
       public void customize(final JList list,
                             final Scope value,


### PR DESCRIPTION
`ListCellRendererWrapper` is deprecated, with favor given to `SimpleListCellRenderer`:

https://github.com/JetBrains/intellij-community/blob/8e46815dd140357c19061ceba77416d40d81866d/platform/platform-api/src/com/intellij/ui/ListCellRendererWrapper.java#L18-L24

Verifier ouput:

```
      #Deprecated class com.intellij.ui.ListCellRendererWrapper reference
          Deprecated class com.intellij.ui.ListCellRendererWrapper is referenced in io.flutter.run.bazelTest.FlutterBazelTestConfigurationEditorForm$1.<init>(FlutterBazelTestConfigurationEditorForm)
          Deprecated class com.intellij.ui.ListCellRendererWrapper is referenced in io.flutter.run.bazelTest.FlutterBazelTestConfigurationEditorForm$1
          Deprecated class com.intellij.ui.ListCellRendererWrapper is referenced in io.flutter.run.test.TestForm$1.<init>(TestForm)
          Deprecated class com.intellij.ui.ListCellRendererWrapper is referenced in io.flutter.run.test.TestForm$1
```

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
