### PR TITLE
[CQ] migrate off deprecated `Logger.error` API

### DIFF
--- a/src/io/flutter/vmService/VmServiceWrapper.java
+++ b/src/io/flutter/vmService/VmServiceWrapper.java
@@ -600,7 +600,7 @@ public class VmServiceWrapper implements Disposable {
 
         @Override
         public void onError(RPCError error) {
-          LOG.error(error);
+          LOG.error(error.toString());
           LOG.error(error.getMessage());
           LOG.error(error.getRequest());
           LOG.error(error.getDetails());


### PR DESCRIPTION
`Logger.error(object)` is deprecated and the `String` API is preferred.

https://github.com/JetBrains/intellij-community/blob/8e46815dd140357c19061ceba77416d40d81866d/platform/util/src/com/intellij/openapi/diagnostic/Logger.java#L378

(This logging isn't awesome and maybe we'll revisit but at least the API calls are clean.)

Verifier output:

```
      #Deprecated method com.intellij.openapi.diagnostic.Logger.error(Object) invocation
          Deprecated method com.intellij.openapi.diagnostic.Logger.error(java.lang.Object message) : void is invoked in io.flutter.vmService.VmServiceWrapper$10.onError(RPCError) : void
```
---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
