### PR TITLE
[CQ] remove experimental `BadgeIcon` dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,13 +5,13 @@
  */
 
 import okhttp3.internal.immutableListOf
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
 import org.jetbrains.intellij.platform.gradle.models.ProductRelease
 import org.jetbrains.intellij.platform.gradle.tasks.VerifyPluginTask
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
-import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 
 // Specify UTF-8 for all compilations so we avoid Windows-1252.
 allprojects {
@@ -106,19 +106,21 @@ dependencies {
     // Plugin dependency documentation:
     // https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-dependencies-extension.html#plugins
     // https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html#project-setup
-    bundledPlugins(immutableListOf(
-      "com.google.tools.ij.aiplugin",
-      "com.intellij.java",
-      "com.intellij.properties",
-      "JUnit",
-      "Git4Idea",
-      "org.jetbrains.kotlin",
-      "org.jetbrains.plugins.gradle",
-      "org.jetbrains.plugins.yaml",
-      "org.intellij.intelliLang",
-      "org.jetbrains.android",
-      "com.android.tools.idea.smali"
-    ))
+    bundledPlugins(
+      immutableListOf(
+        "com.google.tools.ij.aiplugin",
+        "com.intellij.java",
+        "com.intellij.properties",
+        "JUnit",
+        "Git4Idea",
+        "org.jetbrains.kotlin",
+        "org.jetbrains.plugins.gradle",
+        "org.jetbrains.plugins.yaml",
+        "org.intellij.intelliLang",
+        "org.jetbrains.android",
+        "com.android.tools.idea.smali"
+      )
+    )
     plugin("Dart:$dartPluginVersion")
 
     if (sinceBuildInput == "243" || sinceBuildInput == "251") {
@@ -169,7 +171,7 @@ intellijPlatform {
       VerifyPluginTask.FailureLevel.COMPATIBILITY_PROBLEMS,
 //      VerifyPluginTask.FailureLevel.DEPRECATED_API_USAGES, // https://github.com/flutter/flutter-intellij/issues/7718
 //      VerifyPluginTask.FailureLevel.SCHEDULED_FOR_REMOVAL_API_USAGES,
-//      VerifyPluginTask.FailureLevel.EXPERIMENTAL_API_USAGES,
+      VerifyPluginTask.FailureLevel.EXPERIMENTAL_API_USAGES,
 //      VerifyPluginTask.FailureLevel.INTERNAL_API_USAGES,
 //      VerifyPluginTask.FailureLevel.OVERRIDE_ONLY_API_USAGES,
       VerifyPluginTask.FailureLevel.NON_EXTENDABLE_API_USAGES,

--- a/src/io/flutter/toolwindow/ToolWindowBadgeUpdater.java
+++ b/src/io/flutter/toolwindow/ToolWindowBadgeUpdater.java
@@ -10,22 +10,20 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowId;
 import com.intellij.openapi.wm.ToolWindowManager;
-import com.intellij.ui.BadgeIcon;
 import io.flutter.run.common.RunMode;
 import io.flutter.run.daemon.FlutterApp;
 
-import java.awt.Color;
-import java.awt.Paint;
+import javax.swing.*;
+import java.awt.*;
 import java.util.Objects;
-import javax.swing.Icon;
 
 public class ToolWindowBadgeUpdater {
-  public static final Paint BADGE_PAINT = Color.decode("#5ca963");
+  public static final Color BADGE_PAINT = Color.decode("#5ca963");
 
   /**
    * Updates the tool window icons for RUN or DEBUG mode with a green badge.
    *
-   * @param app The FlutterApp instance running in a given mode.
+   * @param app     The FlutterApp instance running in a given mode.
    * @param project The current IntelliJ project context.
    */
   public static void updateBadgedIcon(FlutterApp app, Project project) {
@@ -33,24 +31,60 @@ public class ToolWindowBadgeUpdater {
     final ToolWindow runToolWindow = manager.getToolWindow(ToolWindowId.RUN);
     final ToolWindow debugToolWindow = manager.getToolWindow(ToolWindowId.DEBUG);
 
-    if(Objects.requireNonNull(app).getMode() == RunMode.RUN) {
+    if (Objects.requireNonNull(app).getMode() == RunMode.RUN) {
       if (runToolWindow != null) {
         manager.invokeLater(() -> {
           Icon baseIcon = AllIcons.Toolwindows.ToolWindowRun;
           BadgeIcon iconWithBadge = new BadgeIcon(baseIcon, BADGE_PAINT);
-
           runToolWindow.setIcon(iconWithBadge);
         });
       }
     }
-    else if(app.getMode() == RunMode.DEBUG) {
+    else if (app.getMode() == RunMode.DEBUG) {
       manager.invokeLater(() -> {
         Icon baseIcon = AllIcons.Toolwindows.ToolWindowDebugger;
         BadgeIcon iconWithBadge = new BadgeIcon(baseIcon, BADGE_PAINT);
-
         Objects.requireNonNull(debugToolWindow).setIcon(iconWithBadge);
       });
     }
+  }
 
+  private static class BadgeIcon implements Icon {
+    private final Icon baseIcon;
+    private final Color overlayColor;
+    private static final float alpha = 1.0F;
+
+    public BadgeIcon(Icon baseIcon, Color overlayColor) {
+      this.baseIcon = baseIcon;
+      this.overlayColor = overlayColor;
+    }
+
+    @Override
+    public void paintIcon(Component c, Graphics g, int x, int y) {
+      baseIcon.paintIcon(c, g, x, y);
+
+      Graphics2D g2d = (Graphics2D)g.create();
+      try {
+        g2d.translate(x, y);
+
+        g2d.setComposite(AlphaComposite.SrcOver.derive(alpha));
+
+        g2d.setColor(overlayColor);
+        g2d.fillRect(0, 0, getIconWidth(), getIconHeight());
+      }
+      finally {
+        g2d.dispose();
+      }
+    }
+
+    @Override
+    public int getIconWidth() {
+      return baseIcon.getIconWidth();
+    }
+
+    @Override
+    public int getIconHeight() {
+      return baseIcon.getIconHeight();
+    }
   }
 }


### PR DESCRIPTION
The class `com.intellij.ui.BadgeIcon` is marked `@experimental` and is flagged by the verifier:

```
  Experimental API usages (4): 
      #Experimental API class com.intellij.ui.BadgeIcon reference
          Experimental API class com.intellij.ui.BadgeIcon is referenced in io.flutter.toolwindow.ToolWindowBadgeUpdater.lambda$updateBadgedIcon$1(ToolWindow) : void. This class can be changed in a future release leading to incompatibilities
          Experimental API class com.intellij.ui.BadgeIcon is referenced in io.flutter.toolwindow.ToolWindowBadgeUpdater.lambda$updateBadgedIcon$0(ToolWindow) : void. This class can be changed in a future release leading to incompatibilities
      #Experimental API constructor com.intellij.ui.BadgeIcon.<init>(Icon, Paint) invocation
          Experimental API constructor com.intellij.ui.BadgeIcon.<init>(javax.swing.Icon icon, java.awt.Paint paint) is invoked in io.flutter.toolwindow.ToolWindowBadgeUpdater.lambda$updateBadgedIcon$1(ToolWindow) : void. This constructor can be changed in a future release leading to incompatibilities
          Experimental API constructor com.intellij.ui.BadgeIcon.<init>(javax.swing.Icon icon, java.awt.Paint paint) is invoked in io.flutter.toolwindow.ToolWindowBadgeUpdater.lambda$updateBadgedIcon$0(ToolWindow) : void. This constructor can be changed in a future release leading to incompatibilities
```

This change introduces a lightweight replacement, allowing us to remove the dependency and enable `VerifyPluginTask.FailureLevel.EXPERIMENTAL_API_USAGES` failure checking in the verifier (see: https://github.com/flutter/flutter-intellij/issues/8361).

---
Behavior is preserved w/ the replacement:

Default:

<img width="1056" height="76" alt="image" src="https://github.com/user-attachments/assets/ecbe93f7-6f71-4862-abda-49434cbea405" />


with badge:

<img width="1124" height="84" alt="image" src="https://github.com/user-attachments/assets/ddda5bc5-6e79-4866-b2a5-07d1a4d466b1" />




---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
