### PR TITLE
[verifier] remove unneeded verification muting

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,13 +5,13 @@
  */
 
 import okhttp3.internal.immutableListOf
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
 import org.jetbrains.intellij.platform.gradle.models.ProductRelease
 import org.jetbrains.intellij.platform.gradle.tasks.VerifyPluginTask
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
-import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 
 // Specify UTF-8 for all compilations so we avoid Windows-1252.
 allprojects {
@@ -106,19 +106,21 @@ dependencies {
     // Plugin dependency documentation:
     // https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-dependencies-extension.html#plugins
     // https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html#project-setup
-    bundledPlugins(immutableListOf(
-      "com.google.tools.ij.aiplugin",
-      "com.intellij.java",
-      "com.intellij.properties",
-      "JUnit",
-      "Git4Idea",
-      "org.jetbrains.kotlin",
-      "org.jetbrains.plugins.gradle",
-      "org.jetbrains.plugins.yaml",
-      "org.intellij.intelliLang",
-      "org.jetbrains.android",
-      "com.android.tools.idea.smali"
-    ))
+    bundledPlugins(
+      immutableListOf(
+        "com.google.tools.ij.aiplugin",
+        "com.intellij.java",
+        "com.intellij.properties",
+        "JUnit",
+        "Git4Idea",
+        "org.jetbrains.kotlin",
+        "org.jetbrains.plugins.gradle",
+        "org.jetbrains.plugins.yaml",
+        "org.intellij.intelliLang",
+        "org.jetbrains.android",
+        "com.android.tools.idea.smali"
+      )
+    )
     plugin("Dart:$dartPluginVersion")
 
     if (sinceBuildInput == "243" || sinceBuildInput == "251") {
@@ -180,13 +182,7 @@ intellijPlatform {
     )
     verificationReportsFormats = VerifyPluginTask.VerificationReportsFormats.ALL
     subsystemsToCheck = VerifyPluginTask.Subsystems.ALL
-    // Mute and freeArgs documentation
-    // https://github.com/JetBrains/intellij-plugin-verifier/?tab=readme-ov-file#specific-options
-    // https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-faq.html#mutePluginVerifierProblems
-    freeArgs = listOf(
-      "-mute",
-      "TemplateWordInPluginId,ForbiddenPluginIdPrefix,TemplateWordInPluginName"
-    )
+    
     ides {
       recommended()
     }


### PR DESCRIPTION
These `freeArgs` were added in https://github.com/jwren/flutter-intellij/commit/37686087ddde8ad21621e39ae63c1f29adb0c659 but seem to be muting failures that don't occur.



---

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
