### PR TITLE
Change editor directory files to use PluginLogger

### DIFF
--- a/.idea/runConfigurations/flutter_intellij__runIde_.xml
+++ b/.idea/runConfigurations/flutter_intellij__runIde_.xml
@@ -1,6 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="flutter-intellij [runIde]" type="GradleRunConfiguration" factoryName="Gradle">
-    <log_file alias="flutter" path="$PROJECT_DIR$/build/idea-sandbox/AI-AI-251.23774.16.2511.13338727/log/flutter.log" />
+    <!--  TODO(helin24): This doesn't seem to work for now; even reading in idea.log doesn't work as expected. Further investigation needed.  -->
+    <log_file alias="flutter" path="$PROJECT_DIR$/build/idea-sandbox/*/log/flutter.log" show_all="true" skipped="false" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />

--- a/src/io/flutter/editor/FlutterColors.java
+++ b/src/io/flutter/editor/FlutterColors.java
@@ -7,6 +7,7 @@ package io.flutter.editor;
 
 import com.intellij.openapi.diagnostic.Logger;
 import io.flutter.FlutterUtils;
+import io.flutter.logging.PluginLogger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -17,7 +18,7 @@ import java.util.Map;
 import java.util.Properties;
 
 public class FlutterColors {
-  private static final @NotNull Logger LOG = Logger.getInstance(FlutterColors.class);
+  private static final @NotNull Logger LOG = PluginLogger.createLogger(FlutterColors.class);
 
   public static class FlutterColor {
     @NotNull

--- a/src/io/flutter/editor/FlutterCupertinoColors.java
+++ b/src/io/flutter/editor/FlutterCupertinoColors.java
@@ -7,6 +7,7 @@ package io.flutter.editor;
 
 import com.intellij.openapi.diagnostic.Logger;
 import io.flutter.FlutterUtils;
+import io.flutter.logging.PluginLogger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -17,7 +18,7 @@ import java.util.Map;
 import java.util.Properties;
 
 public class FlutterCupertinoColors {
-  private static final @NotNull Logger LOG = Logger.getInstance(FlutterCupertinoColors.class);
+  private static final @NotNull Logger LOG = PluginLogger.createLogger(FlutterCupertinoColors.class);
 
   private static final Properties colors;
 

--- a/src/io/flutter/editor/FlutterCupertinoIcons.java
+++ b/src/io/flutter/editor/FlutterCupertinoIcons.java
@@ -8,6 +8,7 @@ package io.flutter.editor;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.util.IconLoader;
 import io.flutter.FlutterUtils;
+import io.flutter.logging.PluginLogger;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
@@ -15,7 +16,7 @@ import java.io.IOException;
 import java.util.Properties;
 
 public class FlutterCupertinoIcons {
-  private static final @NotNull Logger LOG = Logger.getInstance(FlutterCupertinoIcons.class);
+  private static final @NotNull Logger LOG = PluginLogger.createLogger(FlutterCupertinoIcons.class);
 
   private static final Properties icons;
 

--- a/src/io/flutter/editor/FlutterIconLineMarkerProvider.java
+++ b/src/io/flutter/editor/FlutterIconLineMarkerProvider.java
@@ -30,6 +30,7 @@ import com.jetbrains.lang.dart.util.DartPsiImplUtil;
 import com.jetbrains.lang.dart.util.DartResolveUtil;
 import info.debatty.java.stringsimilarity.JaroWinkler;
 import io.flutter.FlutterBundle;
+import io.flutter.logging.PluginLogger;
 import io.flutter.sdk.FlutterSdk;
 import io.flutter.sdk.FlutterSdkUtil;
 import io.flutter.utils.IconPreviewGenerator;
@@ -49,7 +50,7 @@ public class FlutterIconLineMarkerProvider extends LineMarkerProviderDescriptor 
 
   public static final Map<String, Set<String>> KnownPaths = new HashMap<>();
   private static final Map<String, String> BuiltInPaths = new HashMap<>();
-  private static final @NotNull Logger LOG = Logger.getInstance(FlutterIconLineMarkerProvider.class);
+  private static final @NotNull Logger LOG = PluginLogger.createLogger(FlutterIconLineMarkerProvider.class);
   private static final String MaterialRelativeAssetPath = "/bin/cache/artifacts/material_fonts/MaterialIcons-Regular.otf";
   private static final String MaterialRelativeIconsPath = "/packages/flutter/lib/src/material/icons.dart";
   private static final String CupertinoRelativeAssetPath = "/assets/CupertinoIcons.ttf";

--- a/src/io/flutter/editor/FlutterMaterialIcons.java
+++ b/src/io/flutter/editor/FlutterMaterialIcons.java
@@ -8,6 +8,7 @@ package io.flutter.editor;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.util.IconLoader;
 import io.flutter.FlutterUtils;
+import io.flutter.logging.PluginLogger;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
@@ -15,7 +16,7 @@ import java.io.IOException;
 import java.util.Properties;
 
 public class FlutterMaterialIcons {
-  private static final @NotNull Logger LOG = Logger.getInstance(FlutterMaterialIcons.class);
+  private static final @NotNull Logger LOG = PluginLogger.createLogger(FlutterMaterialIcons.class);
 
   private static final Properties icons;
 


### PR DESCRIPTION
Related to https://github.com/flutter/flutter-intellij/issues/8369

I also attempted to make the flutter.log file viewable in sandbox mode with a generic file path, but this doesn't work for now - I get an empty file. Oddly this file path will work for `idea.log`, but seems to skip some lines. As the note says, this topic needs further investigation to understand how to optimize this part of setup.