### PR TITLE
[logging] Use PluginLogger for bazel doctor and analytics

### DIFF
--- a/src/io/flutter/actions/FlutterDoctorAction.java
+++ b/src/io/flutter/actions/FlutterDoctorAction.java
@@ -16,6 +16,7 @@ import com.intellij.openapi.util.io.FileUtil;
 import io.flutter.FlutterUtils;
 import io.flutter.bazel.Workspace;
 import io.flutter.console.FlutterConsoles;
+import io.flutter.logging.PluginLogger;
 import io.flutter.pub.PubRoot;
 import io.flutter.sdk.FlutterSdk;
 import org.jetbrains.annotations.NotNull;
@@ -25,7 +26,7 @@ import java.nio.charset.StandardCharsets;
 
 public class FlutterDoctorAction extends FlutterSdkAction {
 
-  private static final @NotNull Logger LOG = Logger.getInstance(FlutterDoctorAction.class);
+  private static final @NotNull Logger LOG = PluginLogger.createLogger(FlutterDoctorAction.class);
 
   public void startCommand(@NotNull Project project, @NotNull FlutterSdk sdk, @Nullable PubRoot root) {
     sdk.flutterDoctor().startInConsole(project);

--- a/src/io/flutter/analytics/UnifiedAnalytics.java
+++ b/src/io/flutter/analytics/UnifiedAnalytics.java
@@ -17,6 +17,7 @@ import com.intellij.openapi.project.Project;
 import com.jetbrains.lang.dart.ide.toolingDaemon.DartToolingDaemonService;
 import de.roderick.weberknecht.WebSocketException;
 import io.flutter.dart.DtdUtils;
+import io.flutter.logging.PluginLogger;
 import io.flutter.sdk.FlutterSdkUtil;
 import io.flutter.utils.OpenApiUtils;
 import org.jetbrains.annotations.NotNull;
@@ -28,7 +29,7 @@ import java.util.concurrent.CompletableFuture;
  * Facilitates sending information to unified analytics.
  */
 public class UnifiedAnalytics {
-  private static final @NotNull Logger LOG = Logger.getInstance(UnifiedAnalytics.class);
+  private static final @NotNull Logger LOG = PluginLogger.createLogger(UnifiedAnalytics.class);
 
   @Nullable Boolean enabled = null;
   final Project project;


### PR DESCRIPTION
I'm just looking through the code and checking that paths aren't going to be logged. Bazel path for flutter doctor probably is used very little (if at all) and analytics isn't used at all (will probably be moved to dart plugin?).

Related to https://github.com/flutter/flutter-intellij/issues/8369