### PR TITLE
[CQ] migrate off deprecated `Class.newInstance()` invocation

### DIFF
--- a/src/io/flutter/actions/OpenInAndroidStudioAction.java
+++ b/src/io/flutter/actions/OpenInAndroidStudioAction.java
@@ -32,6 +32,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
+import java.lang.reflect.InvocationTargetException;
 
 /**
  * This action has been removed from the plugin.xml as a required dependent method call {GradleProjectImporter.importAndOpenProjectCore()
@@ -63,10 +64,11 @@ public class OpenInAndroidStudioAction extends AnAction {
         //noinspection unchecked
         final Class<OpenInAndroidStudioAction> opener =
           (Class<OpenInAndroidStudioAction>)Class.forName("io.flutter.actions.OpenAndroidModule");
-        opener.newInstance().actionPerformed(event);
+        opener.getDeclaredConstructor().newInstance().actionPerformed(event);
         return;
       }
-      catch (ClassNotFoundException | IllegalAccessException | InstantiationException ignored) {
+      catch (ClassNotFoundException | IllegalAccessException | InstantiationException | NoSuchMethodException |
+             InvocationTargetException ignored) {
       }
     }
 


### PR DESCRIPTION
Replaces  `clazz.newInstance()` with the preferred  `clazz.getDeclaredConstructor().newInstance()` and updates exception handling appropriately.


Relevant verifier output:

```
      #Deprecated method java.lang.Class.newInstance() invocation
          Deprecated method java.lang.Class.newInstance() : T is invoked in io.flutter.actions.OpenInAndroidStudioAction.actionPerformed(AnActionEvent) : void
```


---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
