### PR TITLE
[CQ] remove deprecated `Disposer.isDisposed` invocation

### DIFF
--- a/src/io/flutter/vmService/VMServiceManager.java
+++ b/src/io/flutter/vmService/VMServiceManager.java
@@ -9,7 +9,6 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.intellij.openapi.Disposable;
-import com.intellij.openapi.util.Disposer;
 import com.intellij.openapi.util.text.StringUtil;
 import io.flutter.run.daemon.FlutterApp;
 import io.flutter.utils.EventStream;
@@ -412,12 +411,6 @@ public class VMServiceManager implements FlutterApp.FlutterAppListener, Disposab
     synchronized (serviceExtensions) {
       final EventStream<Boolean> stream = serviceExtensions.get(name);
       return stream != null && stream.getValue() == Boolean.TRUE;
-    }
-  }
-
-  public void hasServiceExtension(String name, Consumer<Boolean> onData, Disposable parentDisposable) {
-    if (!Disposer.isDisposed(parentDisposable)) {
-      Disposer.register(parentDisposable, hasServiceExtension(name, onData));
     }
   }
 


### PR DESCRIPTION
Removes deprecated `Disposer.isDisposed` invocation. (Invoking method is unused.)

Verifier output:

```
     #Deprecated method com.intellij.openapi.util.Disposer.isDisposed(Disposable) invocation
          Deprecated method com.intellij.openapi.util.Disposer.isDisposed(com.intellij.openapi.Disposable disposable) : boolean is invoked in io.flutter.vmService.VMServiceManager.hasServiceExtension(String, Consumer, Disposable) : void
```

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
