### PR TITLE
Convert markdown to html for changelog

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,6 +15,18 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import java.io.File
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
+import org.intellij.markdown.flavours.gfm.GFMFlavourDescriptor
+import org.intellij.markdown.html.HtmlGenerator
+import org.intellij.markdown.parser.MarkdownParser
+
+buildscript {
+  repositories {
+    mavenCentral()
+  }
+  dependencies {
+    classpath("org.jetbrains:markdown:0.7.1")
+  }
+}
 
 // Specify UTF-8 for all compilations so we avoid Windows-1252.
 allprojects {
@@ -163,7 +175,13 @@ intellijPlatform {
       untilBuild = untilBuildInput
     }
     changeNotes = provider {
-      file("CHANGELOG.md").readText(Charsets.UTF_8)
+      // This is gemini-provided code to turn the changelog into HTML. Without it, the changelog will display properly on the jetbrains
+      // site, but not in the Plugins settings view.
+      val flavour = GFMFlavourDescriptor()
+      val parser = MarkdownParser(flavour)
+      val markdownText = file("CHANGELOG.md").readText(Charsets.UTF_8)
+      val parsedTree = parser.buildMarkdownTreeFromString(markdownText)
+      HtmlGenerator(markdownText, parsedTree, flavour).generateHtml()
     }
   }
 


### PR DESCRIPTION
This is annoying - the plugin view in IJ settings doesn't show markdown text properly, only HTML (otoh, the jetbrains web site shows markdown from the changelog properly). So we have to convert the markdown to HTML ourselves. Perhaps I can file this as a feature request for jetbrains, since I'm pretty sure having a CHANGELOG.md file is recommended for plugins.