### PR TITLE
[fix] unsafe debugToolWindow access

### DIFF
--- a/src/io/flutter/toolwindow/ToolWindowBadgeUpdater.java
+++ b/src/io/flutter/toolwindow/ToolWindowBadgeUpdater.java
@@ -42,9 +42,12 @@ public class ToolWindowBadgeUpdater {
     }
     else if (app.getMode() == RunMode.DEBUG) {
       manager.invokeLater(() -> {
-        Icon baseIcon = AllIcons.Toolwindows.ToolWindowDebugger;
-        BadgeIcon iconWithBadge = new BadgeIcon(baseIcon, BADGE_PAINT);
-        Objects.requireNonNull(debugToolWindow).setIcon(iconWithBadge);
+        // https://github.com/flutter/flutter-intellij/issues/8391
+        if (debugToolWindow != null) {
+          Icon baseIcon = AllIcons.Toolwindows.ToolWindowDebugger;
+          BadgeIcon iconWithBadge = new BadgeIcon(baseIcon, BADGE_PAINT);
+          runToolWindow.setIcon(iconWithBadge);
+        }
       });
     }
   }


### PR DESCRIPTION
It's not safe to assume that the debug window is visible when running/debugging, so we need to add a check. (Note that something similar is already done for the run window.)


Fixes: https://github.com/flutter/flutter-intellij/issues/8391

---

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
