### PR TITLE
[fix] allow nullable `fileOrDir` for client compatibility

### DIFF
--- a/src/io/flutter/pub/PubRoot.java
+++ b/src/io/flutter/pub/PubRoot.java
@@ -118,9 +118,13 @@ public class PubRoot {
    * Based on the filesystem cache; doesn't refresh anything.
    */
   @Nullable
-  public static PubRoot forDescendant(@NotNull VirtualFile fileOrDir, @NotNull Project project) {
+  public static PubRoot forDescendant(@Nullable VirtualFile fileOrDir, @NotNull Project project) {
+    // To be compatible w/ `flutter_enhancement_suite`, we allow a null `fileOrDir`.
+    // https://github.com/flutter/flutter-intellij/issues/8399
+    if (fileOrDir == null) return null;
     ProjectRootManager manager = ProjectRootManager.getInstance(project);
     if (manager == null) return null;
+    
     final ProjectFileIndex index = manager.getFileIndex();
     return OpenApiUtils.safeRunReadAction(() -> {
       final VirtualFile root = index.getContentRootForFile(fileOrDir);


### PR DESCRIPTION
The `flutter_enhancement_suite` uses `PubRoot.forDescendant` but does not ensure null safety. Since the plugin is not being actively maintained (but still adding value), this adjusts the API to be defensive.

Fixes https://github.com/flutter/flutter-intellij/issues/8399

---

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
