### PR TITLE
Convert to reading changelog with gradle plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
-# 87
+## 87
+
 - Fixes to Flutter test execution (#8233, #8325)
 - Make Android dependencies optional, allowing the plugin to be used in more Jetbrains products (Rider, etc) (#7949, #8375)
 - Internal: support for logging to a dedicated plugin log file (#8253)
 - Fixes to ensure the Property Editor loads on all project opens (#8268)
 - Fix the hang after opening a new project in Android Studio (#8390)
 
-# 86
+## 86
+
 - New message in DevTools windows for "Dock unpinned" IntelliJ feature (#8181)
 - Fixes for Slow Operation notifications in the IDEA platform (#7792)
 - Fix in Flutter project creation flow (#8259)
@@ -13,22 +15,26 @@
 - Migration of deprecated API usages (#7718)
 - Fix for empty menu item in the device selector (#8264)
 
-# 85.3
+## 85.3
+
 - Add Property Editor side panel (#7957)
 - Support removed for IDEA 2024.1 (Koala) and 2024.2 (Ladybug) (#8073)
 - Various cleanups including migrating slow operations to non-blocking calls (#8089)
 
-# 85.2
+## 85.2
+
 - Fix broken devtools inspector source navigation (#8041)
 
-# 85.1
+## 85.1
+
 - Fix the disappearance of the New Flutter Project menu item (#8040)
 - Add back the device name with the running tab (#7948)
 - Update the `org.jetbrains.intellij.platform` version to `2.5.0` (#8038)
 - Replace deprecated ComboBoxWithBrowserButton (#7931)
 - Fix Flutter Outline View event over-subscriptions (#7980)
 
-# 85
+## 85
+
 - Restored Test with coverage run configuration feature (#7810)
 - Upgrade `org.jetbrains.intellij.platform` to 2.2.1 from 2.1.0 (#7936)
 - Fix for DevTool windows not appearing (#8029)
@@ -40,35 +46,42 @@
 - Cleanup: removal of the deprecated Performance page window (#7816)
 - Migrated all instances of EditorNotifications.Provider to the new API (#7830)
 
-# 84
+## 84
+
 - This version was not shipped due to issue #7968
 
-# 83
+## 83
+
 - First version for Meerkat, Android Studio 2024.3 (#7799)
 - Message in the Flutter Outline window that the window is now deprecated (#7778)
 - Testing and cleanup now that the code is migrated to the new Gradle Plugin (#7670)
 
-# 82.2
+## 82.2
+
 - Release of the plugin for 2024.3 (#7670)
 - Migration to IntelliJ Platform Gradle Plugin (2.x) (#7670)
 - The Flutter coverage runner support has been removed (#7670)
 
-# 82.1
+## 82.1
+
 - Fix for Cannot invoke "com.intellij.openapi.wm.ToolWindow.setAvailable(boolean)" issue -- thanks to @parlough (#7691)
 - New SDK notification to notify of old Flutter SDK usage (#7763)
 - Progress on migrating off of old IDEA APIs (#7718)
 - Significant code cleanup
 
-# 82
+## 82
+
 - Various DevTools integration improvements (#7626) (#7621)
 - Removal of the old Performance page, now replaced by DevTools (#7624)
 - Add an option to reload a DevTools window (#7617)
 - Fix to the developer build (#7625)
 
-# 81.1
+## 81.1
+
 - Initial support 2024.2 & Android Studio Ladybug Canary 6 (#7595)
 
-# 81
+## 81
+
 - New icons to match "New UI" features in IntelliJ and Android Studio (#6595)
 - Restore Flutter test icons in the editor gutter (#7505)
 - Fix widget tree highlighting in the editor (#7522)
@@ -78,7 +91,8 @@
 - Configure the Project view for Flutter in AS, when creating a new Flutter project (#4470)
 - Migrate to Kotlin UI DSL Version 2 (#7310)
 
-# 80
+## 80
+
 - Resolve debugger issue with the new Dart macro file uri format (#7449)
 - Hide deep links window when insufficient SDK version (#7478)
 - Fix exceptions out of FlutterSampleNotificationProvider (#5634)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,18 +15,7 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import java.io.File
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
-import org.intellij.markdown.flavours.gfm.GFMFlavourDescriptor
-import org.intellij.markdown.html.HtmlGenerator
-import org.intellij.markdown.parser.MarkdownParser
-
-buildscript {
-  repositories {
-    mavenCentral()
-  }
-  dependencies {
-    classpath("org.jetbrains:markdown:0.7.1")
-  }
-}
+import org.jetbrains.changelog.Changelog
 
 // Specify UTF-8 for all compilations so we avoid Windows-1252.
 allprojects {
@@ -52,6 +41,7 @@ plugins {
   id("java") // Java support
   id("org.jetbrains.intellij.platform") version "2.7.0" // IntelliJ Platform Gradle Plugin
   id("org.jetbrains.kotlin.jvm") version "2.2.0" // Kotlin support
+  id("org.jetbrains.changelog") version "2.2.0" // Gradle Changelog Plugin
 }
 
 var flutterPluginVersion = providers.gradleProperty("flutterPluginVersion").get()
@@ -166,6 +156,9 @@ dependencies {
   )
 }
 
+changelog {
+  headerParserRegex = """(\d+(\.\d+)*)""".toRegex()
+}
 
 intellijPlatform {
   pluginConfiguration {
@@ -175,13 +168,7 @@ intellijPlatform {
       untilBuild = untilBuildInput
     }
     changeNotes = provider {
-      // This is gemini-provided code to turn the changelog into HTML. Without it, the changelog will display properly on the jetbrains
-      // site, but not in the Plugins settings view.
-      val flavour = GFMFlavourDescriptor()
-      val parser = MarkdownParser(flavour)
-      val markdownText = file("CHANGELOG.md").readText(Charsets.UTF_8)
-      val parsedTree = parser.buildMarkdownTreeFromString(markdownText)
-      HtmlGenerator(markdownText, parsedTree, flavour).generateHtml()
+      project.changelog.render(Changelog.OutputType.HTML)
     }
   }
 


### PR DESCRIPTION
This follows how the IJ plugin template is doing things, see https://github.com/JetBrains/intellij-platform-plugin-template/blob/main/build.gradle.kts (forgot to look there when I created https://github.com/flutter/flutter-intellij/pull/8393!)