### PR TITLE
[revert] removal of `BagdeIcon`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,16 +6,15 @@
 
 import okhttp3.internal.immutableListOf
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+import org.jetbrains.changelog.Changelog
 import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
 import org.jetbrains.intellij.platform.gradle.models.ProductRelease
 import org.jetbrains.intellij.platform.gradle.tasks.VerifyPluginTask
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
-import java.io.File
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
-import org.jetbrains.changelog.Changelog
 
 // Specify UTF-8 for all compilations so we avoid Windows-1252.
 allprojects {
@@ -186,7 +185,8 @@ intellijPlatform {
       VerifyPluginTask.FailureLevel.COMPATIBILITY_PROBLEMS,
 //      VerifyPluginTask.FailureLevel.DEPRECATED_API_USAGES, // https://github.com/flutter/flutter-intellij/issues/7718
 //      VerifyPluginTask.FailureLevel.SCHEDULED_FOR_REMOVAL_API_USAGES,
-      VerifyPluginTask.FailureLevel.EXPERIMENTAL_API_USAGES,
+// `BadgeIcon`:
+//      VerifyPluginTask.FailureLevel.EXPERIMENTAL_API_USAGES,
 //      VerifyPluginTask.FailureLevel.INTERNAL_API_USAGES,
 //      VerifyPluginTask.FailureLevel.OVERRIDE_ONLY_API_USAGES,
       VerifyPluginTask.FailureLevel.NON_EXTENDABLE_API_USAGES,
@@ -197,7 +197,7 @@ intellijPlatform {
     )
     verificationReportsFormats = VerifyPluginTask.VerificationReportsFormats.ALL
     subsystemsToCheck = VerifyPluginTask.Subsystems.ALL
-    
+
     ides {
       recommended()
     }

--- a/src/io/flutter/toolwindow/ToolWindowBadgeUpdater.java
+++ b/src/io/flutter/toolwindow/ToolWindowBadgeUpdater.java
@@ -10,6 +10,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowId;
 import com.intellij.openapi.wm.ToolWindowManager;
+import com.intellij.ui.BadgeIcon;
 import io.flutter.run.common.RunMode;
 import io.flutter.run.daemon.FlutterApp;
 
@@ -49,45 +50,6 @@ public class ToolWindowBadgeUpdater {
           debugToolWindow.setIcon(iconWithBadge);
         }
       });
-    }
-  }
-
-  private static class BadgeIcon implements Icon {
-    private final Icon baseIcon;
-    private final Color overlayColor;
-    private static final float alpha = 1.0F;
-
-    public BadgeIcon(Icon baseIcon, Color overlayColor) {
-      this.baseIcon = baseIcon;
-      this.overlayColor = overlayColor;
-    }
-
-    @Override
-    public void paintIcon(Component c, Graphics g, int x, int y) {
-      baseIcon.paintIcon(c, g, x, y);
-
-      Graphics2D g2d = (Graphics2D)g.create();
-      try {
-        g2d.translate(x, y);
-
-        g2d.setComposite(AlphaComposite.SrcOver.derive(alpha));
-
-        g2d.setColor(overlayColor);
-        g2d.fillRect(0, 0, getIconWidth(), getIconHeight());
-      }
-      finally {
-        g2d.dispose();
-      }
-    }
-
-    @Override
-    public int getIconWidth() {
-      return baseIcon.getIconWidth();
-    }
-
-    @Override
-    public int getIconHeight() {
-      return baseIcon.getIconHeight();
     }
   }
 }


### PR DESCRIPTION
Reverts https://github.com/flutter/flutter-intellij/pull/8365.

Fixes: https://github.com/flutter/flutter-intellij/issues/8422

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
