### PR TITLE
[logging] Convert FlutterSdk class to using PluginLogger

### DIFF
--- a/src/io/flutter/sdk/FlutterCommand.java
+++ b/src/io/flutter/sdk/FlutterCommand.java
@@ -72,6 +72,30 @@ public class FlutterCommand {
     return String.join(" ", words);
   }
 
+  /**
+   * Returns a displayable version of the command, with potential file paths redacted if path logging is disabled.
+   */
+  public String getSanitizedDisplayCommand() {
+    if (FlutterSettings.getInstance().isFilePathLoggingEnabled()) {
+      return getDisplayCommand();
+    }
+
+    final List<String> words = new ArrayList<>();
+    words.add("flutter");
+    words.addAll(type.subCommand);
+
+    final List<String> newArgs = new ArrayList<>(args);
+    // For run, attach, and test commands, the last argument is typically a file path.
+    // We redact it to avoid logging user-specific information.
+    if (!newArgs.isEmpty() && (type == Type.RUN || type == Type.ATTACH || type == Type.TEST)) {
+      final int lastIndex = newArgs.size() - 1;
+      newArgs.set(lastIndex, "<path>");
+    }
+
+    words.addAll(newArgs);
+    return String.join(" ", words);
+  }
+
   protected boolean isPubRelatedCommand() {
     return pubRelatedCommands.contains(type);
   }

--- a/src/io/flutter/sdk/FlutterCommand.java
+++ b/src/io/flutter/sdk/FlutterCommand.java
@@ -64,7 +64,7 @@ public class FlutterCommand {
   /**
    * Returns a displayable version of the command that will be run.
    */
-  public String getDisplayCommand() {
+  public @NotNull String getDisplayCommand() {
     final List<String> words = new ArrayList<>();
     words.add("flutter");
     words.addAll(type.subCommand);
@@ -310,10 +310,11 @@ public class FlutterCommand {
     TEST("Flutter test", "test");
 
     final public String title;
-    final ImmutableList<String> subCommand;
+    final @NotNull ImmutableList<String> subCommand;
 
-    Type(String title, String... subCommand) {
+    Type(String title, @NotNull String... subCommand) {
       this.title = title;
+      assert subCommand != null;
       this.subCommand = ImmutableList.copyOf(subCommand);
     }
   }


### PR DESCRIPTION
I'm not sure if the `FlutterSdk` class actually gets asked to call `flutter run`, `flutter attach`, or `flutter test`, but seems reasonable to check in case.