### PR TITLE
Fix the FlutterDependencyInspection for the analyzer workspaces

### DIFF
--- a/src/io/flutter/FlutterUtils.java
+++ b/src/io/flutter/FlutterUtils.java
@@ -16,6 +16,7 @@ import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
 import com.intellij.openapi.roots.*;
+import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -61,6 +62,7 @@ public class FlutterUtils {
 
     private boolean flutter = false;
     private boolean plugin = false;
+    private boolean resolutionWorkspace = false;
 
     FlutterPubspecInfo(long modificationStamp) {
       this.modificationStamp = modificationStamp;
@@ -72,6 +74,10 @@ public class FlutterUtils {
 
     public boolean isFlutterPlugin() {
       return plugin;
+    }
+
+    public boolean isResolutionWorkspace() {
+      return resolutionWorkspace;
     }
 
     public long getModificationStamp() {
@@ -359,6 +365,13 @@ public class FlutterUtils {
         final Object flutterEntry = yamlMap.get("flutter");
         if (flutterEntry instanceof Map) {
           info.plugin = ((Map<?, ?>)flutterEntry).containsKey("plugin");
+        }
+
+        // Check for resolution configuration.
+        //  https://dart.dev/tools/pub/workspaces
+        final Object resolutionEntry = yamlMap.get("resolution");
+        if (resolutionEntry instanceof String) {
+          info.resolutionWorkspace = StringUtil.equals((String)resolutionEntry, "workspace");
         }
       }
     }

--- a/src/io/flutter/inspections/FlutterDependencyInspection.java
+++ b/src/io/flutter/inspections/FlutterDependencyInspection.java
@@ -38,9 +38,8 @@ import java.util.Set;
 public class FlutterDependencyInspection extends LocalInspectionTool {
   private final Set<String> myIgnoredPubspecPaths = new HashSet<>(); // remember for the current session only, do not serialize
 
-  @Nullable
   @Override
-  public ProblemDescriptor[] checkFile(@NotNull final PsiFile psiFile, @NotNull final InspectionManager manager, final boolean isOnTheFly) {
+  public ProblemDescriptor @Nullable [] checkFile(@NotNull final PsiFile psiFile, @NotNull final InspectionManager manager, final boolean isOnTheFly) {
     if (!isOnTheFly) return null;
 
     if (!(psiFile instanceof DartFile)) return null;

--- a/src/io/flutter/pub/PubRoot.java
+++ b/src/io/flutter/pub/PubRoot.java
@@ -246,6 +246,15 @@ public class PubRoot {
   }
 
   /**
+   * Returns true if the pubspec declares "resolution: workspace".
+   */
+  public boolean declaresResolutionWorkspace() {
+    validateUpdateCachedPubspecInfo();
+    assert cachedPubspecInfo != null;
+    return cachedPubspecInfo.isResolutionWorkspace();
+  }
+
+  /**
    * Check if the cache needs to be updated.
    */
   private void validateUpdateCachedPubspecInfo() {
@@ -274,7 +283,15 @@ public class PubRoot {
 
   @Nullable
   public VirtualFile getPackageConfigFile() {
-    final VirtualFile tools = root.findChild(DOT_DART_TOOL);
+    VirtualFile rootToExpectToolsDirectory = root;
+
+    // If this package.yaml file has resolution:workspace declared, check in the parent directory for
+    //  the .dart_tool/ directory.
+    //   https://github.com/flutter/flutter-intellij/issues/7623
+    if (cachedPubspecInfo.isResolutionWorkspace()) {
+      rootToExpectToolsDirectory = root.getParent();
+    }
+    final VirtualFile tools = rootToExpectToolsDirectory.findChild(DOT_DART_TOOL);
     if (tools == null || !tools.isDirectory()) {
       return null;
     }


### PR DESCRIPTION
This resolves https://github.com/flutter/flutter-intellij/issues/7623

Additional work may be needed for non-flutter pubspecs (i.e. the Dart IJ plugin)
