### PR TITLE
Resolves a "Slow operations are prohibited on EDT" exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## Unreleased
+
+### Added
+
+### Removed
+
+### Changed
+
+- Resolved a "Slow operations are prohibited on EDT" exception on Flutter Project creation (#8446, #8447, #8448)
+
 ## 87.1
 
 - Register VM service with DTD (#8436)


### PR DESCRIPTION
This resolves https://github.com/flutter/flutter-intellij/issues/8447 and https://github.com/flutter/flutter-intellij/issues/8446

Additional work may be needed to limit the number of read actions by the plugin, see https://github.com/flutter/flutter-intellij/issues/8242
