### PR TITLE
Update dev channel documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 
 - Resolved a "Slow operations are prohibited on EDT" exception on Flutter Project creation (#8446, #8447, #8448)
+- Made dev release daily instead of weekly
 
 ## 87.1.0
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Please note the following known issues:
 ## Dev channel
 
 If you like getting new features as soon as they've been added to the code then you
-might want to try out the dev channel. It is updated weekly with the latest contents
+might want to try out the dev channel. It is updated daily with the latest contents
 from the "master" branch. It has minimal testing. Set up instructions are in the wiki's
 [dev channel page](./docs/Dev-Channel.md).
 

--- a/docs/Dev-Channel.md
+++ b/docs/Dev-Channel.md
@@ -1,21 +1,32 @@
-We have an early-access version of the plugin, called the dev channel. This version will be updated weekly, containing all changes made in the previous week. To use it you need to configure IntelliJ or Android Studio to look for plugins on the dev channel repository.
+We have an early-access version of the plugin, called the dev channel. This version is updated daily, containing all changes made to the
+main branch at the time of the build. To use it, you need to configure your settings to look for plugins on the dev channel
+repository.
 
-NOTE: If you already have the Flutter plugin installed, please uninstall it before proceeding. Once you have the plugin installed from one channel it will not be available on other channels.
+## Configuring settings for the dev release
 
-Open the Plugins preference page (macOS) or settings page (Windows, Linux). Click the gear at the top-right and select _Manage Plugin Repositories_.
+NOTE: If you already have the Flutter plugin installed, please uninstall it before proceeding. Once you have the plugin installed from one
+channel it will not be available on other channels.
 
+Open the Plugins preference page (macOS) or settings page (Windows, Linux). Click the gear at the top-right and select _Manage Plugin
+Repositories_.
 
 ![Screen shot of repositories page](https://lh4.googleusercontent.com/zo9vANXp01YXJC_tQGuiLJxgbdtRFWV-VXViIx_MnqCphGi8PhhQbNTa7H-8ogl0AxIpU7enEQpAs3FZ8lSd0eUw4FpSkxXRkDoQj9uCpvs93D4pTdIrjyK0--q9xBPXTQ0MN7PB)
-
 
 A list editor will pop up that allows you to edit custom plugin repositories. Add this to the list:
 [https://plugins.jetbrains.com/plugins/dev/list](https://plugins.jetbrains.com/plugins/dev/list)
 
-
 ![Screen shot of repositories](https://lh3.googleusercontent.com/W4o9xr8IAx0ROAc5NLeTFMbV8b_0ONukXiQdbU9nPbsY3l1eYsqPhyRMU5GkCA93JgqEensjFHSP_AFY0UAGLtZF2epZmH-GoDNlK0okegrF-jsdpy0GuPPEt4CnqzwalWJVril3)
-
 
 Then click OK. The version of the Flutter plugin you see in the Marketplace list will be the dev channel version.
 
-
 ![Screen shot of plugins](https://lh6.googleusercontent.com/q8L3R4Rqyjb9gbrKui1SK7YvVLejBXg4TLE0Nif28nxRj69pxrgQY4cwFGiCHuBEegar5MvUgCWY2ETn2lABzG2HjZznPNAtprQRGoUenFrbxpsPNRM-gnxMCAkOpGcI3bGJtRwz)
+
+## Revert to stable releases
+
+To revert to stable releases, access "Manage Plugin Repositories" as described above, then remove the dev URL. This will prevent the IDE
+from suggesting the dev releases in the future.
+
+Go to the [Flutter plugin versions](https://plugins.jetbrains.com/plugin/9212-flutter/versions/stable) and download the stable release you'd
+like to use.
+
+Install the downloaded plugin by going to the Plugin page and clicking on the gear icon, then selecting "Install plugin from disk".


### PR DESCRIPTION
Th is is mainly to let people know the dev release will be daily instead of weekly. I also added instructions on how to stop using the dev release.