### PR TITLE
Update links to main

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ name and contact info to the [AUTHORS](AUTHORS) file.
     - `flutter run`
 3. Fork `https://github.com/flutter/flutter-intellij` into your own GitHub account.
    If you already have a fork and are now installing a development environment on a new machine,
-   make sure you've updated your fork with the master branch
+   make sure you've updated your fork with the main branch
    so that you don't use stale configuration options from long ago.
 4. `git clone https://github.com/<your_name_here>/flutter-intellij`
 5. `cd flutter-intellij`

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # <img src="https://raw.githubusercontent.com/dart-lang/site-shared/refs/heads/main/src/_assets/image/flutter/icon/64.png" alt="Flutter" width="26" height="26"/> Flutter Plugin for IntelliJ
 
 [![Latest plugin version](https://img.shields.io/jetbrains/plugin/v/9212)](https://plugins.jetbrains.com/plugin/9212-flutter)
-[![Build Status](https://github.com/flutter/flutter-intellij/workflows/presubmit/badge.svg)](https://github.com/flutter/flutter-intellij/actions?query=branch%3Amaster+workflow%3Apresubmit)
+[![Build Status](https://github.com/flutter/flutter-intellij/workflows/presubmit/badge.svg)](https://github.com/flutter/flutter-intellij/actions?query=branch%3Amain+workflow%3Apresubmit)
 
 An IntelliJ plugin for [Flutter](https://flutter.dev/) development. Flutter is a multi-platform
 app SDK to help developers and designers build modern apps for iOS, Android and the web.
@@ -66,7 +66,7 @@ Please note the following known issues:
 
 If you like getting new features as soon as they've been added to the code then you
 might want to try out the dev channel. It is updated daily with the latest contents
-from the "master" branch. It has minimal testing. Set up instructions are in the wiki's
+from the "main" branch. It has minimal testing. Set up instructions are in the wiki's
 [dev channel page](./docs/Dev-Channel.md).
 
 ## Flutter SDK compatibility

--- a/docs/Milestones.md
+++ b/docs/Milestones.md
@@ -3,6 +3,6 @@
 - we're using monthly [milestones](https://github.com/flutter/flutter-intellij/milestones)
 - at the beginning of a milestone, we triage issues from the [Backlog](https://github.com/flutter/flutter-intellij/milestone/10) and [On Deck](https://github.com/flutter/flutter-intellij/milestone/11) milestones into the new milestone
 - any work done or issues fixed should be assigned to the current milestone
-- at the end of the milestone, we run through the [testing plan](https://github.com/flutter/flutter-intellij/blob/master/docs/testing.md) and validate the candidate release
-- before releasing, we update the [changelog](https://github.com/flutter/flutter-intellij/blob/master/resources/META-INF/plugin.xml#L22) (based on the work tracking in the milestone)
+- at the end of the milestone, we run through the [testing plan](https://github.com/flutter/flutter-intellij/blob/main/docs/testing.md) and validate the candidate release
+- before releasing, we update the [changelog](https://github.com/flutter/flutter-intellij/blob/main/resources/META-INF/plugin.xml#L22) (based on the work tracking in the milestone)
 - we then [build and release](../docs/building.md), and iterate

--- a/docs/Release-testing.md
+++ b/docs/Release-testing.md
@@ -1,2 +1,2 @@
 The following use cases should be tested on all new releases:
-[https://github.com/flutter/flutter-intellij/blob/master/testing.md](https://github.com/flutter/flutter-intellij/blob/master/docs/testing.md)
+[https://github.com/flutter/flutter-intellij/blob/main/testing.md](https://github.com/flutter/flutter-intellij/blob/main/docs/testing.md)

--- a/docs/Triaging.md
+++ b/docs/Triaging.md
@@ -8,7 +8,7 @@ The [Inbox Query](https://github.com/flutter/flutter-intellij/issues?q=is%3Aissu
 The inbox tracker should do the following initial triage:
 
 * Is the issue invalid? Close it, with a brief explanation.
-* Is the issue a general question, like _"How can I make a blinking button?"_ Close it and redirect to [discord](https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md); fodder for a redirecting response can be harvested from this [message](https://gist.github.com/pq/9c8293516b055b369e34e7410c52d2d8).
+* Is the issue a general question, like _"How can I make a blinking button?"_ Close it and redirect to [discord](https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md); fodder for a redirecting response can be harvested from this [message](https://gist.github.com/pq/9c8293516b055b369e34e7410c52d2d8).
 * Is the issue better filed against Flutter?  Move it using the GitHub [issue transfer UI](https://docs.github.com/en/issues/tracking-your-work-with-issues/administering-issues/transferring-an-issue-to-another-repository#transferring-an-open-issue-to-another-repository).
 * Is the issue better filed against the Dart SDK? Consider creating a new issue on the [Dart SDK](https://github.com/dart-lang/sdk/issues) or ask the author to do so (and close the original issue).
 * Is the issue an obvious duplicate?  Close it with a pointer to the duplicated issue.

--- a/src/io/flutter/run/daemon/DevToolsServerTask.java
+++ b/src/io/flutter/run/daemon/DevToolsServerTask.java
@@ -89,7 +89,7 @@ class DevToolsServerTask extends Task.Backgroundable {
 
       // This is only for development to check integration with a locally run DevTools server.
       // To enable, follow the instructions in:
-      // https://github.com/flutter/flutter-intellij/blob/master/CONTRIBUTING.md#developing-with-local-devtools
+      // https://github.com/flutter/flutter-intellij/blob/main/CONTRIBUTING.md#developing-with-local-devtools
       final String localDevToolsDir = Registry.stringValue(LOCAL_DEVTOOLS_DIR);
       if (!localDevToolsDir.isEmpty()) {
         LOG.info("Starting local DevTools server at: " + localDevToolsDir);


### PR DESCRIPTION
I think this is what we all need to do to set upstream to main:
```
git branch -m master main
git fetch upstream
git branch -u upstream/main main
git remote set-head upstream -a
```

(The default instructions on the repo assume we are cloning this repo but we are all probably working on our own forks)