### PR TITLE
[CQ] migrate off deprecated `URL` constructor invocations

### DIFF
--- a/src/io/flutter/utils/UrlUtils.java
+++ b/src/io/flutter/utils/UrlUtils.java
@@ -1,22 +1,25 @@
 package io.flutter.utils;
 
 import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 
 public class UrlUtils {
-    public static String generateHtmlFragmentWithHrefTags(String input) {
-        StringBuilder builder = new StringBuilder();
-        for (String token : input.split(" ")) {
-            if (!builder.isEmpty()) {
-                builder.append(" ");
-            }
-            try {
-                URL url = new URL(token);
-                builder.append("<a href=\"").append(url).append("\">").append(url).append("</a>");
-            } catch(MalformedURLException e) {
-                builder.append(token);
-            }
-        }
-        return builder.toString();
+  public static String generateHtmlFragmentWithHrefTags(String input) {
+    StringBuilder builder = new StringBuilder();
+    for (String token : input.split(" ")) {
+      if (!builder.isEmpty()) {
+        builder.append(" ");
+      }
+      try {
+        URL url = new URI(token).toURL();
+        builder.append("<a href=\"").append(url).append("\">").append(url).append("</a>");
+      }
+      catch (IllegalArgumentException | MalformedURLException | URISyntaxException e) {
+        builder.append(token);
+      }
     }
+    return builder.toString();
+  }
 }


### PR DESCRIPTION
As of Java 20, `URL(uri)` is deprecated in favor of `URI(uri).toURL()`.

See: https://bugs.openjdk.org/browse/JDK-8296385?jql=parent%3DJDK-8294241



---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
