### PR TITLE
[CQ] migrate off deprecated `LOG.error(object)` call

### DIFF
--- a/src/io/flutter/vmService/VmServiceWrapper.java
+++ b/src/io/flutter/vmService/VmServiceWrapper.java
@@ -493,7 +493,7 @@ public class VmServiceWrapper implements Disposable {
     if (WorkspaceCache.getInstance(myDebugProcess.getSession().getProject()).isBazel()) {
       return true;
     }
-    
+
     return VmServiceVersion.hasMapping(version);
   }
 
@@ -621,7 +621,7 @@ public class VmServiceWrapper implements Disposable {
         public void onError(RPCError error) {
           LOG.error(error.toString());
           LOG.error(error.getMessage());
-          LOG.error(error.getRequest());
+          LOG.error(Objects.toString(error.getRequest()));
           LOG.error(error.getDetails());
           errorResponses.add(error);
           consumer.received(breakpointResponses, errorResponses);


### PR DESCRIPTION
`LOG.error(string)` is preferred.

<img width="2104" height="108" alt="image" src="https://github.com/user-attachments/assets/f610075d-fc57-4819-aefd-29cef3db21f7" />

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
