### PR TITLE
[CQ] remove deprecated `createSingleFileDescriptor()` call

### DIFF
--- a/src/io/flutter/run/bazelTest/FlutterBazelTestConfigurationEditorForm.java
+++ b/src/io/flutter/run/bazelTest/FlutterBazelTestConfigurationEditorForm.java
@@ -5,8 +5,6 @@
  */
 package io.flutter.run.bazelTest;
 
-import com.intellij.openapi.fileChooser.FileChooserDescriptor;
-import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory;
 import com.intellij.openapi.options.SettingsEditor;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.TextFieldWithBrowseButton;
@@ -23,7 +21,9 @@ import javax.swing.*;
 import java.awt.event.ActionEvent;
 import java.util.Objects;
 
-import static io.flutter.run.bazelTest.BazelTestFields.Scope.*;
+import static io.flutter.run.bazelTest.BazelTestFields.Scope.FILE;
+import static io.flutter.run.bazelTest.BazelTestFields.Scope.NAME;
+import static io.flutter.run.bazelTest.BazelTestFields.Scope.TARGET_PATTERN;
 
 public class FlutterBazelTestConfigurationEditorForm extends SettingsEditor<BazelTestConfig> {
   private JPanel myMainPanel;
@@ -73,8 +73,6 @@ public class FlutterBazelTestConfigurationEditorForm extends SettingsEditor<Baze
       }
     });
     scope.setEnabled(true);
-
-    final FileChooserDescriptor descriptor = FileChooserDescriptorFactory.createSingleFileDescriptor();
 
     DartCommandLineConfigurationEditorForm.initDartFileTextWithBrowse(project, myEntryFile);
   }


### PR DESCRIPTION
`FileChooserDescriptorFactory.createSingleFileDescriptor()` is deprecated.

<img width="1776" height="90" alt="image" src="https://github.com/user-attachments/assets/24ff4d5d-e7e2-4b98-94f3-bb4febf9c7b0" />

The result of the call is also unused so we can safely remove it.

---

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
