### PR TITLE
[CQ] prefer Darcula-aware JBColor

### DIFF
--- a/src/io/flutter/view/ViewUtils.java
+++ b/src/io/flutter/view/ViewUtils.java
@@ -7,6 +7,7 @@ package io.flutter.view;
 
 import com.intellij.openapi.ui.VerticalFlowLayout;
 import com.intellij.openapi.wm.ToolWindow;
+import com.intellij.ui.JBColor;
 import com.intellij.ui.components.JBLabel;
 import com.intellij.ui.components.labels.LinkLabel;
 import com.intellij.ui.content.Content;
@@ -26,7 +27,7 @@ public class ViewUtils {
     final JBLabel descriptionLabel = new JBLabel(wrapWithHtml(warning));
     descriptionLabel.setBorder(JBUI.Borders.empty(5));
     descriptionLabel.setHorizontalAlignment(SwingConstants.CENTER);
-    descriptionLabel.setForeground(Color.RED);
+    descriptionLabel.setForeground(JBColor.RED);
     return descriptionLabel;
   }
 


### PR DESCRIPTION
Prefer `JBColor` over `java.awt.Color` which doesn't play nice with dark themes.

<img width="441" height="78" alt="image" src="https://github.com/user-attachments/assets/f53f8acd-da9c-4512-a703-ab24806b7e6b" />

https://www.jetbrains.com/help/inspectopedia/UseJBColor.html

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
