### PR TITLE
[perf] `FlutterNewProjectAction` stop eager presentation instantiation

### DIFF
--- a/src/io/flutter/FlutterBundle.properties
+++ b/src/io/flutter/FlutterBundle.properties
@@ -158,7 +158,6 @@ settings.enable.logs.preserve.during.hot.reload.and.restart=Preserve console log
 settings.enable.file.path.logging=Allow logging of full file paths
 settings.enable.file.path.logging.tooltip=Logs full file paths that could show private user information
 
-action.new.project.title=New Flutter Project...
 welcome.new.project.compact=New Flutter Project
 
 npw_platform_android=Android

--- a/src/io/flutter/actions/FlutterNewProjectAction.kt
+++ b/src/io/flutter/actions/FlutterNewProjectAction.kt
@@ -16,11 +16,7 @@ import com.intellij.openapi.roots.ui.configuration.ModulesProvider
 import com.intellij.openapi.wm.impl.welcomeScreen.NewWelcomeScreen
 import io.flutter.FlutterBundle
 import io.flutter.FlutterUtils
-import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.*
 
 /**
  * This classes was re-implemented with Kotlin from FlutterNewProjectAction.java to resolve the New Flutter Project action from hanging,
@@ -28,7 +24,7 @@ import kotlinx.coroutines.withContext
  *
  * See https://github.com/JetBrains/intellij-community/blob/master/java/idea-ui/src/com/intellij/ide/impl/NewProjectUtil.kt
  */
-class FlutterNewProjectAction : AnAction(FlutterBundle.message("action.new.project.title")), DumbAware {
+class FlutterNewProjectAction : AnAction(), DumbAware {
   override fun update(e: AnActionEvent) {
     if (NewWelcomeScreen.isNewWelcomeScreen(e)) {
       e.presentation.setText(FlutterBundle.message("welcome.new.project.compact"))


### PR DESCRIPTION
Stop eager presentation instantiation

<img width="1226" height="152" alt="image" src="https://github.com/user-attachments/assets/00d94eb7-d289-4555-a932-30a8b15fe150" />

From the inspection:

> Any of the constructors of AnAction with parameters instantiate the Presentation object. However, instantiating the Presentation object in constructor results in allocating resources, which may not be necessary. Instead of creating an instance of Presentation that stores text, description, or icon, it is more efficient to utilize no-argument constructors of AnAction and other base classes and follow the convention for setting the text, description, and icon in plugin.xml. The IDE will load text, description, and icon only when the action is actually displayed in the UI.

Confirmed that the label set in `plugin.xml` is sufficient:

<img width="1002" height="364" alt="image" src="https://github.com/user-attachments/assets/84b0586f-c4ab-4039-8881-5eb725b995ed" />



---

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
