### PR TITLE
[CQ] RestartFlutterDaemonAction: ignore spurious perf warning

### DIFF
--- a/src/io/flutter/actions/RestartFlutterDaemonAction.java
+++ b/src/io/flutter/actions/RestartFlutterDaemonAction.java
@@ -36,6 +36,7 @@ public class RestartFlutterDaemonAction extends AnAction {
   /**
    * A constructor for dynamic invocation.
    */
+  @SuppressWarnings("ActionPresentationInstantiatedInCtor")
   private RestartFlutterDaemonAction(@Nullable @NlsActions.ActionText String text,
                                      @Nullable Icon icon) {
     super(text, text, icon);


### PR DESCRIPTION
This inspection guards against eager presentation creation for actions that are referenced in `plugin.xml` but not used. This particular constructor is only used dynamically so there's nothing eager about it -- it will only be invoked on use.



---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
