### PR TITLE
[perf] mark extension points dynamic

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -260,8 +260,8 @@
   </actions>
 
   <extensionPoints>
-    <extensionPoint name="gradleSyncProvider" interface="io.flutter.android.GradleSyncProvider"/>
-    <extensionPoint name="colorPickerProvider" interface="io.flutter.editor.ColorPickerProvider"/>
+    <extensionPoint name="gradleSyncProvider" interface="io.flutter.android.GradleSyncProvider" dynamic="true"/>
+    <extensionPoint name="colorPickerProvider" interface="io.flutter.editor.ColorPickerProvider" dynamic="true"/>
   </extensionPoints>
 
   <extensions defaultExtensionNs="io.flutter">


### PR DESCRIPTION
<img width="1474" height="160" alt="image" src="https://github.com/user-attachments/assets/26d02d31-540c-41dc-ae63-4eb03acbdf31" />

Since we support the usage rules detailed in the [Dynamic Extension Point docs](https://plugins.jetbrains.com/docs/intellij/plugin-extension-points.html?from=PluginXmlDynamicPlugin#dynamic-extension-points), marking this dynamic should allow hot reloading of the plugin.

---

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
