### PR TITLE
[CQ] RestartFlutterDaemonAction: fix action description contract

### DIFF
--- a/src/io/flutter/actions/RestartFlutterDaemonAction.java
+++ b/src/io/flutter/actions/RestartFlutterDaemonAction.java
@@ -23,7 +23,7 @@ public class RestartFlutterDaemonAction extends AnAction {
    * Create a `RestartFlutterDaemonAction` for presentation in the device selector.
    */
   public static RestartFlutterDaemonAction forDeviceSelector() {
-    return new RestartFlutterDaemonAction("Restart Flutter Daemon", FlutterIcons.Flutter);
+    return new RestartFlutterDaemonAction("Restart Flutter Daemon", "Restart Flutter Daemon", FlutterIcons.Flutter);
   }
 
   /**
@@ -38,8 +38,9 @@ public class RestartFlutterDaemonAction extends AnAction {
    */
   @SuppressWarnings("ActionPresentationInstantiatedInCtor")
   private RestartFlutterDaemonAction(@Nullable @NlsActions.ActionText String text,
+                                     @Nullable @NlsActions.ActionDescription String description,
                                      @Nullable Icon icon) {
-    super(text, text, icon);
+    super(text, description, icon);
   }
 
   @Override


### PR DESCRIPTION
The same sentence is legitimately a title and a sentence but we still need annotations to ensure the inspection sees we're respecting the contract.

<img width="1516" height="206" alt="image" src="https://github.com/user-attachments/assets/56aebbbb-a403-458e-998c-af429fd9fb7e" />




---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
