### PR TITLE
🐛 Fix `DeviceSelectorAction` `NoSuchElementException` in the toolbar layout

### DIFF
--- a/src/io/flutter/FlutterBundle.properties
+++ b/src/io/flutter/FlutterBundle.properties
@@ -74,6 +74,8 @@ flutter.io.gettingStarted.IDE.url=https://docs.flutter.dev/tools/android-studio
 flutter.io.runAndDebug.url=https://docs.flutter.dev/tools/android-studio#running-and-debugging
 
 devicelist.loading=Loading...
+devicelist.noDevices=<no devices>
+devicelist.noDeviceSelected=<no device selected>
 
 flutter.pop.frame.action.text=Drop Frame (Flutter)
 flutter.pop.frame.action.description=Pop the current frame off the stack

--- a/src/io/flutter/actions/DeviceSelectorAction.java
+++ b/src/io/flutter/actions/DeviceSelectorAction.java
@@ -286,11 +286,11 @@ public class DeviceSelectorAction extends AnAction implements CustomComponentAct
         text = FlutterBundle.message("devicelist.loading");
       }
       else {
-        text = "<no devices>";
+        text = FlutterBundle.message("devicelist.noDevices");
       }
     }
     else if (selectedDevice == null) {
-      text = "<no device selected>";
+      text = FlutterBundle.message("devicelist.noDeviceSelected");
     }
     else {
       text = selectedDevice.presentationName();

--- a/src/io/flutter/actions/DeviceSelectorAction.java
+++ b/src/io/flutter/actions/DeviceSelectorAction.java
@@ -47,6 +47,8 @@ public class DeviceSelectorAction extends AnAction implements CustomComponentAct
   private static final Key<JBLabel> ICON_LABEL_KEY = Key.create("iconLabel");
   private static final Key<JBLabel> TEXT_LABEL_KEY = Key.create("textLabel");
   private static final Key<JBLabel> ARROW_LABEL_KEY = Key.create("arrowLabel");
+  private static final @NotNull Icon DEFAULT_DEVICE_ICON = FlutterIcons.Mobile;
+  private static final @NotNull Icon DEFAULT_ARROW_ICON = IconUtil.scale(AllIcons.General.ChevronDown, null, 1.2f);
 
   private final List<AnAction> actions = new ArrayList<>();
   private final List<Project> knownProjects = Collections.synchronizedList(new ArrayList<>());
@@ -87,9 +89,9 @@ public class DeviceSelectorAction extends AnAction implements CustomComponentAct
 
   @Override
   public @NotNull JComponent createCustomComponent(@NotNull Presentation presentation, @NotNull String place) {
-    final JBLabel iconLabel = new JBLabel(FlutterIcons.Mobile);
+    final JBLabel iconLabel = new JBLabel(DEFAULT_DEVICE_ICON);
     final JBLabel textLabel = new JBLabel();
-    final JBLabel arrowLabel = new JBLabel(IconUtil.scale(AllIcons.General.ChevronDown, null, 1.2f));
+    final JBLabel arrowLabel = new JBLabel(DEFAULT_ARROW_ICON);
 
     // Create a wrapper button for hover effects
     final JButton button = new JButton() {
@@ -119,16 +121,38 @@ public class DeviceSelectorAction extends AnAction implements CustomComponentAct
           width += icon.getIconWidth();
           height = Math.max(height, icon.getIconHeight());
         }
+        else {
+          // Fallback: use the default mobile icon size when the component is not fully initialized
+          Icon defaultIcon = DEFAULT_DEVICE_ICON;
+          width += defaultIcon.getIconWidth();
+          height = Math.max(height, defaultIcon.getIconHeight());
+        }
 
+        final @Nullable FontMetrics fm;
+        final @NotNull String textLabelText;
         if (textLabel instanceof JBLabel label && label.getText() instanceof String text && !text.isEmpty()) {
-          final FontMetrics fm = label.getFontMetrics(label.getFont());
-          width += Objects.requireNonNull(fm).stringWidth(text);
+          fm = label.getFontMetrics(label.getFont());
+          textLabelText = text;
+        }
+        else {
+          // Fallback: estimate width for typical device name length
+          fm = getFontMetrics(getFont());
+          textLabelText = FlutterBundle.message("devicelist.noDevices");
+        }
+        if (fm != null) {
+          width += fm.stringWidth(textLabelText);
           height = Math.max(height, fm.getHeight());
         }
 
         if (arrowLabel instanceof JBLabel label && label.getIcon() instanceof Icon icon) {
           width += icon.getIconWidth();
           height = Math.max(height, icon.getIconHeight());
+        }
+        else {
+          // Fallback: use the default arrow icon size
+          Icon defaultArrow = DEFAULT_ARROW_ICON;
+          width += defaultArrow.getIconWidth();
+          height = Math.max(height, defaultArrow.getIconHeight());
         }
 
         width += JBUI.scale(24);
@@ -278,7 +302,7 @@ public class DeviceSelectorAction extends AnAction implements CustomComponentAct
     final Collection<FlutterDevice> devices = deviceService.getConnectedDevices();
 
     final String text;
-    Icon icon = FlutterIcons.Mobile;
+    Icon icon = DEFAULT_DEVICE_ICON;
 
     if (devices.isEmpty()) {
       final boolean isLoading = deviceService.getStatus() == DeviceService.State.LOADING;


### PR DESCRIPTION
(originally #8496)

This PR fixes a `NoSuchElementException` that occurs in the `DeviceSelectorAction` when IntelliJ's toolbar layout system tries to calculate component widths.

## Problem

The error manifested as:
```
java.util.NoSuchElementException: Key io.flutter.actions.DeviceSelectorAction$1[...] is missing in the map.
	at kotlin.collections.MapsKt__MapWithDefaultKt.getOrImplicitDefaultNullable(MapWithDefault.kt:24)
	at kotlin.collections.MapsKt__MapsKt.getValue(Maps.kt:369)
	at com.intellij.openapi.actionSystem.toolbarLayout.CompressingLayoutStrategyKt.calculateComponentWidths(CompressingLayoutStrategy.kt:200)
```

## Root Cause

The `getPreferredSize()` method in the anonymous JButton class was being called by IntelliJ's layout system **before** the client properties (`ICON_LABEL_KEY`, `TEXT_LABEL_KEY`, `ARROW_LABEL_KEY`) were set during component initialization. This caused the layout system to fail when trying to register the component in its internal maps because:

1. The method accessed null client properties without proper fallback handling
2. Used unsafe `Objects.requireNonNull(fm)` calls that could throw exceptions
3. The layout system couldn't determine proper component dimensions during initialization

## Solution

Enhanced the `getPreferredSize()` method with defensive programming:

- **Added fallback logic**: When client properties are null (during initialization), use the same default icons and text that would normally be used
- **Safe null checking**: Replaced `Objects.requireNonNull(fm)` with proper null checks
- **Reasonable defaults**: Provide sensible sizing estimates using `FlutterIcons.Mobile`, chevron down icon, and "No device selected" text width

```java
// Before: Unsafe access
width += Objects.requireNonNull(fm).stringWidth(text);

// After: Defensive with fallback
if (fm != null) {
  width += fm.stringWidth(text);
  height = Math.max(height, fm.getHeight());
}
```

## Impact

- Eliminates `NoSuchElementException` during toolbar initialization
- Maintains exact same functionality once component is fully initialized
- No performance impact - fallback logic only runs during the brief initialization phase
- More robust component that gracefully handles IntelliJ's layout timing

Fixes #8494.
