### PR TITLE
[fix] digit separator handling in Color parsing

### DIFF
--- a/src/io/flutter/editor/ExpressionParsingUtils.java
+++ b/src/io/flutter/editor/ExpressionParsingUtils.java
@@ -21,6 +21,8 @@ public class ExpressionParsingUtils {
         val = val.substring(0, index);
       }
       try {
+        // Handle digit-separators.
+        val = val.replaceAll("_", "");
         return val.startsWith("0x")
                ? Integer.parseUnsignedInt(val.substring(2), 16)
                : Integer.parseUnsignedInt(val);

--- a/testSrc/unit/io/flutter/editor/FlutterColorProviderTest.java
+++ b/testSrc/unit/io/flutter/editor/FlutterColorProviderTest.java
@@ -43,9 +43,32 @@ public class FlutterColorProviderTest extends AbstractDartElementTest {
   }
 
   @Test
+  public void locatesColorCtor_digitSeparators() throws Exception {
+    run(() -> {
+      final PsiElement testIdentifier = setUpDartElement("main() { Color(0xFF_E3_F2_FD); }", "Color", LeafPsiElement.class);
+      final Color color = new FlutterColorProvider().getColorFrom(testIdentifier);
+      assertNotNull(color);
+      final DartCallExpression element = DartSyntax.findEnclosingFunctionCall(testIdentifier, "Color");
+      assertNotNull(element);
+    });
+  }
+
+
+  @Test
   public void locatesConstColorCtor() throws Exception {
     run(() -> {
       final PsiElement testIdentifier = setUpDartElement("main() { const Color(0xFFE3F2FD); }", "Color", LeafPsiElement.class);
+      final Color color = new FlutterColorProvider().getColorFrom(testIdentifier);
+      assertNotNull(color);
+      final DartNewExpression element = DartSyntax.findEnclosingNewExpression(testIdentifier);
+      assertNotNull(element);
+    });
+  }
+
+  @Test
+  public void locatesConstColorCtor_digitSeparators() throws Exception {
+    run(() -> {
+      final PsiElement testIdentifier = setUpDartElement("main() { const Color(0xFF_E3_F2_FD); }", "Color", LeafPsiElement.class);
       final Color color = new FlutterColorProvider().getColorFrom(testIdentifier);
       assertNotNull(color);
       final DartNewExpression element = DartSyntax.findEnclosingNewExpression(testIdentifier);
@@ -144,7 +167,8 @@ public class FlutterColorProviderTest extends AbstractDartElementTest {
   @Test
   public void locatesCuppertinoColorReference() throws Exception {
     run(() -> {
-      final PsiElement testIdentifier = setUpDartElement("main() { CupertinoColors.systemGreen; }", "CupertinoColors", LeafPsiElement.class);
+      final PsiElement testIdentifier =
+        setUpDartElement("main() { CupertinoColors.systemGreen; }", "CupertinoColors", LeafPsiElement.class);
       final Color color = new FlutterColorProvider().getColorFrom(testIdentifier);
       assertNotNull(color);
       final DartReferenceExpression element = DartSyntax.findEnclosingReferenceExpression(testIdentifier);
@@ -155,7 +179,8 @@ public class FlutterColorProviderTest extends AbstractDartElementTest {
   @Test
   public void locatesColorReferenceWithComment() throws Exception {
     run(() -> {
-      final PsiElement testIdentifier = setUpDartElement("main() { Colors . blue . /* darkish */ shade700; }", "shade700", LeafPsiElement.class);
+      final PsiElement testIdentifier =
+        setUpDartElement("main() { Colors . blue . /* darkish */ shade700; }", "shade700", LeafPsiElement.class);
       final Color color = new FlutterColorProvider().getColorFrom(testIdentifier);
       assertNotNull(color);
       final DartReferenceExpression element = DartSyntax.findEnclosingReferenceExpression(testIdentifier);
@@ -166,7 +191,8 @@ public class FlutterColorProviderTest extends AbstractDartElementTest {
   @Test
   public void locatesCuppertinoColorReferenceWithWitespace() throws Exception {
     run(() -> {
-      final PsiElement testIdentifier = setUpDartElement("main() { CupertinoColors . systemGreen; }", "CupertinoColors", LeafPsiElement.class);
+      final PsiElement testIdentifier =
+        setUpDartElement("main() { CupertinoColors . systemGreen; }", "CupertinoColors", LeafPsiElement.class);
       final Color color = new FlutterColorProvider().getColorFrom(testIdentifier);
       assertNotNull(color);
       final DartReferenceExpression element = DartSyntax.findEnclosingReferenceExpression(testIdentifier);
@@ -177,12 +203,12 @@ public class FlutterColorProviderTest extends AbstractDartElementTest {
   @Test
   public void locatesCuppertinoColorReferenceWithLineEndComment() throws Exception {
     run(() -> {
-      final PsiElement testIdentifier = setUpDartElement("main() { CupertinoColors . // comment\n systemGreen; }", "CupertinoColors", LeafPsiElement.class);
+      final PsiElement testIdentifier =
+        setUpDartElement("main() { CupertinoColors . // comment\n systemGreen; }", "CupertinoColors", LeafPsiElement.class);
       final Color color = new FlutterColorProvider().getColorFrom(testIdentifier);
       assertNotNull(color);
       final DartReferenceExpression element = DartSyntax.findEnclosingReferenceExpression(testIdentifier);
       assertNotNull(element);
     });
   }
-
 }


### PR DESCRIPTION
Add digit separator support to Color-parsing.

Fixes: #8510.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
