### PR TITLE
[perf] prefer primitive over wrapped `int`s

### DIFF
--- a/src/io/flutter/run/daemon/DevToolsServerTask.java
+++ b/src/io/flutter/run/daemon/DevToolsServerTask.java
@@ -216,7 +216,7 @@ class DevToolsServerTask extends Task.Backgroundable {
 
     String[] parts = dartPluginUri.split(":");
     String host = parts[0];
-    Integer port = Integer.parseInt(parts[1]);
+    int port = Integer.parseInt(parts[1]);
     if (host == null) {
       return null;
     }


### PR DESCRIPTION

**TL;DR:** no need for the wrapper type and it just gets unboxed a few lines later anyway.

Detected by a project inspection.

<img width="1572" height="272" alt="image" src="https://github.com/user-attachments/assets/4b8810c5-7ef9-4916-bd59-230c63c343e2" />


---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
