### PR TITLE
[docs] fix `macOS` capitialization

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,7 +137,7 @@ name and contact info to the [AUTHORS](AUTHORS) file.
     - Select "Platform Settings > SDKs"
     - Click the "+" sign at the top, click "Add New SDK (Alt+Insert)", then select "Add JDK from disk...".
     - Select your IntelliJ application (most likely under `Applications`) and from there, select the `Contents/jbr/Contents/Home` directory
-    - **[For macos]** You won't be able to select the `Contents` directory from Finder without right-clicking on the IntelliJ application, and selecting "Quick Look" from the dropdown that opens. From there, you can select the `Contents` directory.
+    - **[For macOS]** You won't be able to select the `Contents` directory from Finder without right-clicking on the IntelliJ application, and selecting "Quick Look" from the dropdown that opens. From there, you can select the `Contents` directory.
     - Change the name so that you can easily identify it, e.g. `IDEA JBR 21`.
     - When you are done, your settings should look something like:
     ```
@@ -150,7 +150,7 @@ name and contact info to the [AUTHORS](AUTHORS) file.
     - Click the "+" sign at the top, click "Add New SDK (Alt+Insert)", then select "Add IntelliJ Platform Plugin SDK...".
     - **[Note]** If you don't see this option, ensure you have the DevKit plugin installed.
     - Select your IntelliJ application (most likely under `Applications`) and from there, select the `Contents` directory
-    - **[For macos]** You won't be able to select the `Contents` directory from Finder without right-clicking on the IntelliJ application, and selecting "Quick Look" from the dropdown that opens. 
+    - **[For macOS]** You won't be able to select the `Contents` directory from Finder without right-clicking on the IntelliJ application, and selecting "Quick Look" from the dropdown that opens. 
     - Remember the generated name (probably `IntelliJ IDEA IU-231.8109.175`) or change to name to a format like this.
     - Change the **Internal Java Platform** to the JBR you added in step 2. (e.g. `IDEA JBR 21`).
     - When you are done, your settings should look something like:


### PR DESCRIPTION
A nit, but `macOS` is how macs like to identify themselves. 

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
