### PR TITLE
[cq] suppress invalid `DialogTitleCapitalization` inspection

### DIFF
--- a/src/io/flutter/actions/RestartFlutterDaemonAction.java
+++ b/src/io/flutter/actions/RestartFlutterDaemonAction.java
@@ -23,6 +23,7 @@ public class RestartFlutterDaemonAction extends AnAction {
    * Create a `RestartFlutterDaemonAction` for presentation in the device selector.
    */
   public static RestartFlutterDaemonAction forDeviceSelector() {
+    //noinspection DialogTitleCapitalization
     return new RestartFlutterDaemonAction("Restart Flutter Daemon", "Restart Flutter Daemon", FlutterIcons.Flutter);
   }
 


### PR DESCRIPTION
Dialog title capitalization isn't right for `Flutter Daemon`.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>
