### PR TITLE
Convert utility classes to use PluginLogger

### DIFF
--- a/src/io/flutter/utils/FileWatch.java
+++ b/src/io/flutter/utils/FileWatch.java
@@ -20,7 +20,7 @@ import com.intellij.openapi.vfs.VirtualFileManager;
 import com.intellij.openapi.vfs.newvfs.BulkFileListener;
 import com.intellij.openapi.vfs.newvfs.events.VFileEvent;
 import com.intellij.util.messages.MessageBusConnection;
-import io.flutter.FlutterUtils;
+import io.flutter.logging.PluginLogger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -131,7 +131,7 @@ public class FileWatch {
       callback.run();
     }
     catch (Exception e) {
-      FlutterUtils.warn(LOG, "Uncaught exception in FileWatch callback", e);
+      LOG.warn("Uncaught exception in FileWatch callback", e);
       unsubscribe(); // avoid further errors
     }
   }
@@ -269,5 +269,5 @@ public class FileWatch {
     }
   }
 
-  private static final @NotNull Logger LOG = Logger.getInstance(FileWatch.class);
+  private static final @NotNull Logger LOG = PluginLogger.createLogger(FileWatch.class);
 }

--- a/src/io/flutter/utils/IconPreviewGenerator.java
+++ b/src/io/flutter/utils/IconPreviewGenerator.java
@@ -8,6 +8,7 @@ package io.flutter.utils;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.util.TripleFunction;
 import io.flutter.FlutterUtils;
+import io.flutter.logging.PluginLogger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -24,7 +25,7 @@ import java.util.Properties;
 
 @SuppressWarnings("UseJBColor")
 public class IconPreviewGenerator {
-  private static final @NotNull Logger LOG = Logger.getInstance(IconPreviewGenerator.class);
+  private static final @NotNull Logger LOG = PluginLogger.createLogger(IconPreviewGenerator.class);
 
   @NotNull final String fontFilePath;
   int iconSize = 16;

--- a/src/io/flutter/utils/Refreshable.java
+++ b/src/io/flutter/utils/Refreshable.java
@@ -14,6 +14,7 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.util.Disposer;
 import com.intellij.util.concurrency.AppExecutorUtil;
 import io.flutter.FlutterUtils;
+import io.flutter.logging.PluginLogger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -122,7 +123,7 @@ public class Refreshable<T> implements Closeable {
       refreshDone.get();
     }
     catch (Exception e) {
-      FlutterUtils.warn(LOG, "Unexpected exception waiting for refresh task to finish", e);
+      FlutterUtils.warn(LOG, "Unexpected exception waiting for refresh task to finish", e, true);
     }
     return getNow();
   }
@@ -167,7 +168,7 @@ public class Refreshable<T> implements Closeable {
    */
   public void refresh(@NotNull Callback<T> callback) {
     if (publisher.isClosing()) {
-      FlutterUtils.warn(LOG, "attempted to update closed Refreshable");
+      LOG.warn("attempted to update closed Refreshable");
       return;
     }
     schedule.reschedule(new Request<>(this, callback));
@@ -228,7 +229,7 @@ public class Refreshable<T> implements Closeable {
         }
         catch (Exception e) {
           if (!Objects.equal(e.getMessage(), "expected failure in test")) {
-            FlutterUtils.warn(LOG, "Callback threw an exception while updating a Refreshable", e);
+            FlutterUtils.warn(LOG, "Callback threw an exception while updating a Refreshable", e, true);
           }
         }
         finally {
@@ -247,7 +248,7 @@ public class Refreshable<T> implements Closeable {
           });
         }
         catch (Exception e) {
-          FlutterUtils.warn(LOG, "Unable to publish a value while updating a Refreshable", e);
+          FlutterUtils.warn(LOG, "Unable to publish a value while updating a Refreshable", e, true);
         }
       }
     }
@@ -257,7 +258,7 @@ public class Refreshable<T> implements Closeable {
     }
   }
 
-  private static final @NotNull Logger LOG = Logger.getInstance(Refreshable.class);
+  private static final @NotNull Logger LOG = PluginLogger.createLogger(Refreshable.class);
 
   /**
    * A value indicating whether the Refreshable is being updated or not.
@@ -520,7 +521,7 @@ public class Refreshable<T> implements Closeable {
         unpublishCallback.accept(discarded);
       }
       catch (Exception e) {
-        FlutterUtils.warn(LOG, "An unpublish callback threw an exception while updating a Refreshable", e);
+        FlutterUtils.warn(LOG, "An unpublish callback threw an exception while updating a Refreshable", e, true);
       }
     }
 
@@ -534,7 +535,7 @@ public class Refreshable<T> implements Closeable {
         SwingUtilities.invokeAndWait(() -> doSetState(newState));
       }
       catch (Exception e) {
-        FlutterUtils.warn(LOG, "Unable to change state of Refreshable", e);
+        FlutterUtils.warn(LOG, "Unable to change state of Refreshable", e, true);
       }
     }
 
@@ -552,7 +553,7 @@ public class Refreshable<T> implements Closeable {
         }
         catch (Exception e) {
           if (!Objects.equal(e.getMessage(), "expected failure in test")) {
-            FlutterUtils.warn(LOG, "A subscriber to a Refreshable threw an exception", e);
+            FlutterUtils.warn(LOG, "A subscriber to a Refreshable threw an exception", e, true);
           }
         }
       }
@@ -569,7 +570,7 @@ public class Refreshable<T> implements Closeable {
         initialized.get();
       }
       catch (Exception e) {
-        FlutterUtils.warn(LOG, "Unexpected exception waiting for Refreshable to initialize", e);
+        FlutterUtils.warn(LOG, "Unexpected exception waiting for Refreshable to initialize", e, true);
       }
     }
 


### PR DESCRIPTION
Part of https://github.com/flutter/flutter-intellij/issues/8369

`FileWatch` is only used in bazel contexts, so I'm not using the path checking there.