### PR TITLE
Update Android Studio version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,8 +4,8 @@
 # found in the LICENSE file.
 #
 
-ideaVersion=2025.1.3.4
-dartPluginVersion= 251.27623.5
+ideaVersion=2025.2.1.3
+dartPluginVersion= 252.25557.23
 sinceBuild=243
 untilBuild=253.*
 javaVersion=21

--- a/src/io/flutter/FlutterErrorReportSubmitter.java
+++ b/src/io/flutter/FlutterErrorReportSubmitter.java
@@ -53,7 +53,7 @@ public class FlutterErrorReportSubmitter extends ErrorReportSubmitter {
   }
 
   //@Override
-  public boolean submit(@NotNull IdeaLoggingEvent @NotNull [] events,
+  public boolean submit(@NotNull IdeaLoggingEvent[] events,
                         @Nullable String additionalInfo,
                         @NotNull Component parentComponent,
                         @NotNull Consumer<? super SubmittedReportInfo> consumer) {

--- a/src/io/flutter/actions/AttachDebuggerAction.java
+++ b/src/io/flutter/actions/AttachDebuggerAction.java
@@ -174,7 +174,7 @@ public class AttachDebuggerAction extends FlutterSdkAction {
     return count == 1 ? sdkConfig : null;
   }
 
-  private static void onAttachTermination(@NotNull Project project, @NotNull Consumer<@NotNull Project> runner) {
+  private static void onAttachTermination(@NotNull Project project, @NotNull Consumer<Project> runner) {
     final MessageBusConnection connection = project.getMessageBus().connect();
 
     // Need an ExecutionListener to clean up project-scoped state when the Stop button is clicked.

--- a/src/io/flutter/actions/FlutterRetargetAppAction.java
+++ b/src/io/flutter/actions/FlutterRetargetAppAction.java
@@ -33,7 +33,7 @@ public abstract class FlutterRetargetAppAction extends DumbAwareAction {
   FlutterRetargetAppAction(@NotNull String actionId,
                            @Nullable String text,
                            @Nullable String description,
-                           @SuppressWarnings("SameParameterValue") @NotNull String @NotNull ... places) {
+                           @SuppressWarnings("SameParameterValue") @NotNull String ... places) {
     super(text, description, null);
     myActionId = actionId;
     myPlaces.addAll(Arrays.asList(places));

--- a/src/io/flutter/bazel/WorkspaceCache.java
+++ b/src/io/flutter/bazel/WorkspaceCache.java
@@ -38,7 +38,7 @@ public class WorkspaceCache {
 
   private boolean refreshScheduled = false;
 
-  private final @NotNull Set<@NotNull Runnable> subscribers = new LinkedHashSet<>();
+  private final @NotNull Set<Runnable> subscribers = new LinkedHashSet<>();
 
   private WorkspaceCache(@NotNull final Project project) {
     this.project = project;
@@ -157,7 +157,7 @@ public class WorkspaceCache {
     notifyListeners();
   }
 
-  private Set<@NotNull Runnable> getSubscribers() {
+  private Set<Runnable> getSubscribers() {
     synchronized (subscribers) {
       return ImmutableSet.copyOf(subscribers);
     }

--- a/src/io/flutter/dart/FlutterRequestUtilities.java
+++ b/src/io/flutter/dart/FlutterRequestUtilities.java
@@ -47,7 +47,7 @@ public class FlutterRequestUtilities {
    * </pre>
    */
   public static JsonObject generateAnalysisSetSubscriptions(@NotNull String id,
-                                                            Map<String, @NotNull List<String>> subscriptions) {
+                                                            Map<String, List<String>> subscriptions) {
     final JsonObject params = new JsonObject();
     params.add(SUBSCRIPTIONS, buildJsonElement(subscriptions));
     return buildJsonObjectRequest(id, METHOD_FLUTTER_SET_SUBSCRIPTIONS, params);

--- a/src/io/flutter/editor/FlutterPubspecNotificationProvider.java
+++ b/src/io/flutter/editor/FlutterPubspecNotificationProvider.java
@@ -26,7 +26,7 @@ import java.util.function.Function;
 public final class FlutterPubspecNotificationProvider implements EditorNotificationProvider {
   @Nullable
   @Override
-  public Function<? super @NotNull FileEditor, ? extends @Nullable JComponent> collectNotificationData(@NotNull Project project,
+  public Function<? super FileEditor, ? extends JComponent> collectNotificationData(@NotNull Project project,
                                                                                                        @NotNull VirtualFile file) {
     // We only show this notification inside of local pubspec files.
     if (!PubRoot.isPubspec(file) || !file.isInLocalFileSystem()) {

--- a/src/io/flutter/editor/NativeEditorNotificationProvider.java
+++ b/src/io/flutter/editor/NativeEditorNotificationProvider.java
@@ -34,7 +34,7 @@ public class NativeEditorNotificationProvider implements EditorNotificationProvi
   }
 
   @Override
-  public @Nullable Function<? super @NotNull FileEditor, ? extends @Nullable JComponent> collectNotificationData(@NotNull Project project,
+  public @Nullable Function<? super FileEditor, ? extends JComponent> collectNotificationData(@NotNull Project project,
                                                                                                                  @NotNull VirtualFile file) {
     if (!file.isInLocalFileSystem() || !showNotification) {
       return null;

--- a/src/io/flutter/inspections/SdkConfigurationNotificationProvider.java
+++ b/src/io/flutter/inspections/SdkConfigurationNotificationProvider.java
@@ -36,7 +36,7 @@ public class SdkConfigurationNotificationProvider implements EditorNotificationP
   }
 
   @Override
-  public @Nullable Function<? super @NotNull FileEditor, ? extends @Nullable JComponent> collectNotificationData(@NotNull Project project,
+  public @Nullable Function<? super FileEditor, ? extends JComponent> collectNotificationData(@NotNull Project project,
                                                                                                                  @NotNull VirtualFile file) {
     // If this is a Bazel configured Flutter project, exit immediately, neither of the notifications should be shown for this project type.
     if (FlutterModuleUtils.isFlutterBazelProject(project)) return null;

--- a/src/io/flutter/jxbrowser/JxBrowserManager.java
+++ b/src/io/flutter/jxbrowser/JxBrowserManager.java
@@ -245,7 +245,7 @@ public class JxBrowserManager {
     downloadJxBrowser(fileNames);
   }
 
-  protected void downloadJxBrowser(@NotNull String @NotNull [] fileNames) {
+  protected void downloadJxBrowser(@NotNull String[] fileNames) {
     // The FileDownloader API is used by other plugins - e.g.
     // https://github.com/JetBrains/intellij-community/blob/b09f8151e0d189d70363266c3bb6edb5f6bfeca4/plugins/markdown/src/org/intellij/plugins/markdown/ui/preview/javafx/JavaFXInstallator.java#L48
     final List<FileDownloader> fileDownloaders = new ArrayList<>();
@@ -309,7 +309,7 @@ public class JxBrowserManager {
     }
   }
 
-  private void loadClasses(@NotNull String @NotNull [] fileNames) {
+  private void loadClasses(@NotNull String[] fileNames) {
     final List<Path> paths = new ArrayList<>();
     final ClassLoader current = Thread.currentThread().getContextClassLoader();
     try {

--- a/src/io/flutter/project/FlutterIconProvider.java
+++ b/src/io/flutter/project/FlutterIconProvider.java
@@ -77,7 +77,7 @@ public class FlutterIconProvider extends IconProvider {
   }
 
   @NotNull
-  private static Icon overlayIcons(@NotNull Icon @NotNull ... icons) {
+  private static Icon overlayIcons(@NotNull Icon ... icons) {
     final LayeredIcon result = new LayeredIcon(icons.length);
 
     for (int layer = 0; layer < icons.length; layer++) {

--- a/src/io/flutter/pub/PubRoot.java
+++ b/src/io/flutter/pub/PubRoot.java
@@ -182,7 +182,7 @@ public class PubRoot {
     return path.substring(root.length() + 1);
   }
 
-  private static final String @NotNull [] TEST_DIRS = new String[]{ // TODO 2022.1
+  private static final String [] TEST_DIRS = new String[]{ // TODO 2022.1
     "/test/",
     "/integration_test/",
     "/test_driver/",

--- a/src/io/flutter/pub/PubRootCache.java
+++ b/src/io/flutter/pub/PubRootCache.java
@@ -60,7 +60,7 @@ public class PubRootCache {
   }
 
   @NotNull
-  public List<@NotNull PubRoot> getRoots(@NotNull Module module) {
+  public List<PubRoot> getRoots(@NotNull Module module) {
     final List<PubRoot> result = new ArrayList<>();
 
     for (VirtualFile dir : OpenApiUtils.getContentRoots(module)) {

--- a/src/io/flutter/pub/PubRoots.java
+++ b/src/io/flutter/pub/PubRoots.java
@@ -28,7 +28,7 @@ public class PubRoots {
    * (Based on the filesystem cache; doesn't refresh anything.)
    */
   @NotNull
-  public static List<@NotNull PubRoot> forModule(@NotNull Module module) {
+  public static List<PubRoot> forModule(@NotNull Module module) {
     final List<PubRoot> result = new ArrayList<>();
     if (module.isDisposed()) return result;
 
@@ -47,7 +47,7 @@ public class PubRoots {
    * (Based on the filesystem cache; doesn't refresh anything.)
    */
   @NotNull
-  public static List<@NotNull PubRoot> forProject(@NotNull Project project) {
+  public static List<PubRoot> forProject(@NotNull Project project) {
     final List<PubRoot> result = new ArrayList<>();
     if (project.isDisposed()) return result;
 

--- a/src/io/flutter/samples/FlutterSampleNotificationProvider.java
+++ b/src/io/flutter/samples/FlutterSampleNotificationProvider.java
@@ -43,7 +43,7 @@ public class FlutterSampleNotificationProvider implements EditorNotificationProv
 
   @Nullable
   @Override
-  public Function<? super @NotNull FileEditor, ? extends @Nullable JComponent> collectNotificationData(@NotNull Project project,
+  public Function<? super FileEditor, ? extends JComponent> collectNotificationData(@NotNull Project project,
                                                                                                        @NotNull VirtualFile file) {
     final FlutterSdk sdk = FlutterSdk.getFlutterSdk(project);
     if (sdk == null) {

--- a/src/io/flutter/sdk/AndroidEmulatorManager.java
+++ b/src/io/flutter/sdk/AndroidEmulatorManager.java
@@ -61,7 +61,7 @@ public class AndroidEmulatorManager {
 
   private CompletableFuture<List<AndroidEmulator>> inProgressRefresh;
 
-  public CompletableFuture<@NotNull List<AndroidEmulator>> refresh() {
+  public CompletableFuture<List<AndroidEmulator>> refresh() {
     // We don't need to refresh if one is in progress.
     synchronized (this) {
       if (inProgressRefresh != null) {
@@ -98,7 +98,7 @@ public class AndroidEmulatorManager {
     return future;
   }
 
-  public @NotNull List<@NotNull AndroidEmulator> getCachedEmulators() {
+  public @NotNull List<AndroidEmulator> getCachedEmulators() {
     return cachedEmulators;
   }
 

--- a/src/io/flutter/sdk/FlutterPluginsLibraryManager.java
+++ b/src/io/flutter/sdk/FlutterPluginsLibraryManager.java
@@ -134,7 +134,7 @@ public class FlutterPluginsLibraryManager extends AbstractLibraryManager<Flutter
       .submit(AppExecutorUtil.getAppExecutorService());
   }
 
-  private static @NotNull Set<@NotNull String> getFlutterPluginPaths(@NotNull List<@NotNull PubRoot> roots) {
+  private static @NotNull Set<String> getFlutterPluginPaths(@NotNull List<PubRoot> roots) {
     final Set<String> paths = new HashSet<>();
 
     for (PubRoot pubRoot : roots) {

--- a/src/io/flutter/sdk/FlutterSdk.java
+++ b/src/io/flutter/sdk/FlutterSdk.java
@@ -582,7 +582,7 @@ public class FlutterSdk {
 
   @NotNull
   @NonNls
-  private static final String @NotNull [] PLATFORMS =
+  private static final String[] PLATFORMS =
     new String[]{"enable-android", "enable-ios", "enable-web", "enable-linux-desktop", "enable-macos-desktop", "enable-windows-desktop"};
 
   @NotNull

--- a/src/io/flutter/utils/AndroidLocationProvider.java
+++ b/src/io/flutter/utils/AndroidLocationProvider.java
@@ -23,10 +23,14 @@ public class AndroidLocationProvider implements BuildModelContext.ResolvedConfig
   @Nullable
   @Override
   public VirtualFile getGradleBuildFile(@NotNull Module module) {
-    GradleModuleModel moduleModel = GradleProjectSystemUtil.getGradleModuleModel(module);
-    if (moduleModel != null) {
-      return moduleModel.getBuildFile();
-    }
+    // TODO(helin24): Delete this code (and potentially related code) if commenting out has no negative impact on Android editing.
+    // I believe this is to make gradle files show up nicely when a flutter project is opened, but this functionality already does not work
+    // and is not needed if we are recommending users edit Android files in a separate project window.
+
+    //GradleModuleModel moduleModel = GradleProjectSystemUtil.getGradleModuleModel(module);
+    //if (moduleModel != null) {
+    //  return moduleModel.getBuildFile();
+    //}
     return null;
   }
 

--- a/src/io/flutter/utils/FlutterModuleUtils.java
+++ b/src/io/flutter/utils/FlutterModuleUtils.java
@@ -201,7 +201,7 @@ public class FlutterModuleUtils {
   }
 
 
-  public static @NotNull Module @NotNull [] getModules(@NotNull Project project) {
+  public static @NotNull Module[] getModules(@NotNull Project project) {
     // A disposed project has no modules.
     if (project.isDisposed()) return Module.EMPTY_ARRAY;
 

--- a/src/io/flutter/utils/OpenApiUtils.java
+++ b/src/io/flutter/utils/OpenApiUtils.java
@@ -23,7 +23,7 @@ import org.jetbrains.annotations.Nullable;
 
 public class OpenApiUtils {
 
-  public static @NotNull VirtualFile @NotNull [] getContentRoots(@NotNull Module module) {
+  public static @NotNull VirtualFile[] getContentRoots(@NotNull Module module) {
     var moduleRootManager = ModuleRootManager.getInstance(module);
     return moduleRootManager == null ? VirtualFile.EMPTY_ARRAY : moduleRootManager.getContentRoots();
   }
@@ -33,7 +33,7 @@ public class OpenApiUtils {
     return registrar == null ? null : registrar.getLibraryTable(project);
   }
 
-  public static @NotNull Module @NotNull [] getModules(@NotNull Project project) {
+  public static @NotNull Module[] getModules(@NotNull Project project) {
     var modules = ModuleManager.getInstance(project).getModules();
     return modules == null ? Module.EMPTY_ARRAY : modules;
   }

--- a/src/io/flutter/view/EmbeddedBrowser.java
+++ b/src/io/flutter/view/EmbeddedBrowser.java
@@ -50,7 +50,7 @@ public abstract class EmbeddedBrowser {
 
   public static final String ANALYTICS_CATEGORY = "embedded-browser";
 
-  protected final Map<@NotNull String, Map<@NotNull String, @NotNull BrowserTab>> windows = new HashMap<>();
+  protected final Map<String, Map<String, BrowserTab>> windows = new HashMap<>();
 
   public abstract @NotNull Logger logger();
 

--- a/src/io/flutter/vmService/DartVmServiceDebugProcess.java
+++ b/src/io/flutter/vmService/DartVmServiceDebugProcess.java
@@ -279,7 +279,7 @@ public abstract class DartVmServiceDebugProcess extends XDebugProcess {
 
   @Override
   @NotNull
-  public XBreakpointHandler<?> @NotNull [] getBreakpointHandlers() {
+  public XBreakpointHandler<?> [] getBreakpointHandlers() {
     return myBreakpointHandlers;
   }
 

--- a/src/io/flutter/vmService/frame/DartVmServiceValue.java
+++ b/src/io/flutter/vmService/frame/DartVmServiceValue.java
@@ -426,7 +426,7 @@ public class DartVmServiceValue extends XNamedValue {
 
     if (instance.getBytes() != null) { // true for typed data
       //noinspection ConstantConditions
-      byte @NotNull [] bytes = Base64.getDecoder().decode(instance.getBytes());
+      byte[] bytes = Base64.getDecoder().decode(instance.getBytes());
       TypedDataList data = getTypedDataList(bytes);
       XValueChildrenList childrenList = new XValueChildrenList(data.size());
       for (int i = 0; i < data.size(); i++) {
@@ -469,7 +469,7 @@ public class DartVmServiceValue extends XNamedValue {
     return new InstanceRef(ref);
   }
 
-  private TypedDataList getTypedDataList(byte @NotNull [] bytes) {
+  private TypedDataList getTypedDataList(byte[] bytes) {
     ByteBuffer buffer = ByteBuffer.wrap(bytes);
     //noinspection ConstantConditions
     return switch (myInstanceRef.getKind()) {


### PR DESCRIPTION
I removed code that seems to be related to making gradle files editable within a Flutter project window as the Android Studio code has changed. I will record some additional details in my internal notes.

I also removed nullability annotations that caused errors during `./gradlew test`. These are mostly complaints that we are adding an annotation like `String @NotNull []` or `List<@NotNull Runnable>`. I'm not sure why these are considered invalid with the new platform version - AI suggests it is due to default JDK difference, but I'm also not sure how to update my IDE settings to reflect this supposed difference. In my view, all of these instances with errors are still relevant annotations (e.g. you want to know that the container is not null as well as all of the items within it). 🤷 