### PR TITLE
Move log level setup to initializer

### DIFF
--- a/src/io/flutter/FlutterInitializer.java
+++ b/src/io/flutter/FlutterInitializer.java
@@ -83,6 +83,10 @@ public class FlutterInitializer extends FlutterProjectActivity {
 
   @Override
   public void executeProjectStartup(@NotNull Project project) {
+    // This sets the correct log level and listens for future changes.
+    PluginLogger.updateLogLevel();
+    FlutterSettings.getInstance().addListener(PluginLogger::updateLogLevel);
+
     log().info("Executing Flutter plugin startup for project: " + project.getName());
     // Disable the 'Migrate Project to Gradle' notification.
     FlutterUtils.disableGradleProjectMigrationNotification(project);
@@ -143,10 +147,6 @@ public class FlutterInitializer extends FlutterProjectActivity {
         edtInitialization(finalHasFlutterModule, project);
       })
       .submit(AppExecutorUtil.getAppExecutorService());
-
-    // This sets the correct log level and listens for future changes.
-    PluginLogger.updateLogLevel();
-    FlutterSettings.getInstance().addListener(PluginLogger::updateLogLevel);
   }
 
   /***

--- a/src/io/flutter/FlutterInitializer.java
+++ b/src/io/flutter/FlutterInitializer.java
@@ -39,6 +39,7 @@ import io.flutter.devtools.DevToolsUtils;
 import io.flutter.devtools.RemainingDevToolsViewFactory;
 import io.flutter.editor.FlutterSaveActionsManager;
 import io.flutter.logging.FlutterConsoleLogManager;
+import io.flutter.logging.PluginLogger;
 import io.flutter.module.FlutterModuleBuilder;
 import io.flutter.pub.PubRoot;
 import io.flutter.pub.PubRoots;
@@ -142,6 +143,10 @@ public class FlutterInitializer extends FlutterProjectActivity {
         edtInitialization(finalHasFlutterModule, project);
       })
       .submit(AppExecutorUtil.getAppExecutorService());
+
+    // This sets the correct log level and listens for future changes.
+    PluginLogger.updateLogLevel();
+    FlutterSettings.getInstance().addListener(PluginLogger::updateLogLevel);
   }
 
   /***

--- a/src/io/flutter/logging/PluginLogger.java
+++ b/src/io/flutter/logging/PluginLogger.java
@@ -42,14 +42,9 @@ public class PluginLogger {
 
   static {
     rootLogger.addHandler(fileHandler);
-    // This check prevents trying to access settings in test context.
-    if (ApplicationManager.getApplication() != null) {
-      updateLogLevel();
-      FlutterSettings.getInstance().addListener(PluginLogger::updateLogLevel);
-    }
   }
 
-  private static void updateLogLevel() {
+  public static void updateLogLevel() {
     final Logger rootLoggerInstance = Logger.getInstance("io.flutter");
     rootLoggerInstance.setLevel(FlutterSettings.getInstance().isVerboseLogging() ? LogLevel.ALL : LogLevel.INFO);
   }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter-intellij/issues/8562

I'm realizing from this problem that logging at plugin startup may be tricky. E.g. with this change, I'm not totally sure what the setting will be at project initialization - probably with a level of INFO, or whatever is default in the IntelliJ logger. That's probably fine - if we are trying to log information from project startup, it would be reasonable to make the logs INFO or higher, as DEBUG level logs could be excluded even with a user setting of verbose.