### PR TITLE
Update Android Studio version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
-## Unreleased
+## 88.0.0
 
 ### Added
+
+- Support for Android Studio 2025.2
 
 ### Removed
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -152,9 +152,7 @@ sourceSets {
   test {
     java.srcDirs(
       listOf(
-        "src",
-        "testSrc/unit",
-        "third_party/vmServiceDrivers"
+        "testSrc/unit"
       )
     )
     resources.srcDirs(

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,8 +4,8 @@
 # found in the LICENSE file.
 #
 
-ideaVersion=2025.1.3.4
-dartPluginVersion= 251.27623.5
+ideaVersion=2025.2.1.3
+dartPluginVersion= 252.25557.23
 sinceBuild=243
 untilBuild=253.*
 javaVersion=21

--- a/src/io/flutter/utils/AndroidLocationProvider.java
+++ b/src/io/flutter/utils/AndroidLocationProvider.java
@@ -23,10 +23,14 @@ public class AndroidLocationProvider implements BuildModelContext.ResolvedConfig
   @Nullable
   @Override
   public VirtualFile getGradleBuildFile(@NotNull Module module) {
-    GradleModuleModel moduleModel = GradleProjectSystemUtil.getGradleModuleModel(module);
-    if (moduleModel != null) {
-      return moduleModel.getBuildFile();
-    }
+    // TODO(helin24): Delete this code (and potentially related code) if commenting out has no negative impact on Android editing.
+    // I believe this is to make gradle files show up nicely when a flutter project is opened, but this functionality already does not work
+    // and is not needed if we are recommending users edit Android files in a separate project window.
+
+    //GradleModuleModel moduleModel = GradleProjectSystemUtil.getGradleModuleModel(module);
+    //if (moduleModel != null) {
+    //  return moduleModel.getBuildFile();
+    //}
     return null;
   }
 

--- a/src/io/flutter/utils/AndroidLocationProvider.java
+++ b/src/io/flutter/utils/AndroidLocationProvider.java
@@ -9,10 +9,12 @@ import com.android.tools.idea.gradle.dsl.model.BuildModelContext;
 import com.android.tools.idea.gradle.project.model.GradleModuleModel;
 import com.android.tools.idea.gradle.util.GradleProjectSystemUtil;
 import com.android.tools.idea.projectsystem.AndroidProjectRootUtil;
+import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectUtil;
 import com.intellij.openapi.vfs.VirtualFile;
+import io.flutter.logging.PluginLogger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.SystemIndependent;
@@ -20,6 +22,8 @@ import org.jetbrains.annotations.SystemIndependent;
 // Copied from GradleModelSource.ResolvedConfigurationFileLocationProviderImpl
 // This file must be ignored in pre-4.1 builds.
 public class AndroidLocationProvider implements BuildModelContext.ResolvedConfigurationFileLocationProvider {
+  final static private Logger LOG = PluginLogger.createLogger(AndroidLocationProvider.class);
+
   @Nullable
   @Override
   public VirtualFile getGradleBuildFile(@NotNull Module module) {
@@ -31,6 +35,7 @@ public class AndroidLocationProvider implements BuildModelContext.ResolvedConfig
     //if (moduleModel != null) {
     //  return moduleModel.getBuildFile();
     //}
+    LOG.info("getGradleBuildFile attempted for module " + module.getName() + " but will return null");
     return null;
   }
 


### PR DESCRIPTION
I removed code that seems to be related to making gradle files editable within a Flutter project window as the Android Studio code has changed. I will record some additional details in my internal notes.

There were also test compilation failures that suggested the annotations library wasn't required correctly. (see https://stackoverflow.com/questions/62066166/string-notnull-syntax-causes-notnull-not-applicable-to-type-use-in-in - thanks @pq). When I asked gemini about this, it suggested that we were compiling production source code twice for tests, because the test source sets included `src` as well. I guess it turns out that this isn't needed and the dependency on the production source code is implied; additionally, compiling the production source during test is bad because it can be compiled in the wrong environment. I think this is documentation that includes this info if we want to investigate further at a later time: https://docs.gradle.org/current/userguide/building_java_projects.html#sec:java_source_sets