### PR TITLE
Open project view for flutter projects

### DIFF
--- a/src/io/flutter/FlutterStudioStartupActivity.java
+++ b/src/io/flutter/FlutterStudioStartupActivity.java
@@ -28,7 +28,7 @@ public class FlutterStudioStartupActivity extends FlutterProjectActivity {
   private static final String PROJECT_VIEW_ID = "ProjectPane";
 
   private static Void doNonBlockingStartup(@NotNull Project project) {
-    LOG.info("Project " + project.getName() + ": Executing Studio startup");
+    LOG.info("Project " + project.getName() + ": Executing non-blocking Studio startup");
 
     if (AndroidUtils.isAndroidProject(project)) {
       GradleUtils.addGradleListeners(project);
@@ -54,11 +54,15 @@ public class FlutterStudioStartupActivity extends FlutterProjectActivity {
       .submit(AppExecutorUtil.getAppExecutorService());
 
     if (!FlutterModuleUtils.declaresFlutter(project)) {
-      LOG.info("Project " + project.getName() + ": does not declare Flutter; exiting Studio startup before setting project view");
+      LOG.info("Project " + project.getName() + ": does not declare Flutter; exiting Studio startup before checking project view");
       return;
     }
 
     // Set project tool window to show the project on first open (Android Studio sometimes opens android view instead).
+    // See https://github.com/flutter/flutter-intellij/issues/8556.
+    // Note: After showing the project view, subsequent opens should go to the project view also. However, if the android subdirectory is
+    // opened, it seems the full project settings will be modified to open to the Android view instead. See
+    // https://github.com/flutter/flutter-intellij/pull/8573 for more details.
     PropertiesComponent properties = PropertiesComponent.getInstance(project);
     if (properties == null) return;
     if (!properties.isValueSet(IS_FIRST_OPEN_KEY)) {
@@ -66,7 +70,7 @@ public class FlutterStudioStartupActivity extends FlutterProjectActivity {
         ProjectView projectView = ProjectView.getInstance(project);
         if (projectView == null) return;
         if (projectView.getPaneIds().contains(PROJECT_VIEW_ID)) {
-          LOG.info("Project " + project.getName() + ": Setting project tool window to be project view");
+          LOG.info("Project " + project.getName() + ": Setting project tool window to be project view on first open");
           projectView.changeView(PROJECT_VIEW_ID);
         }
       });


### PR DESCRIPTION
This shows the project view for flutter projects on first open:
<img width="509" height="312" alt="Screenshot 2025-10-09 at 9 45 30 AM" src="https://github.com/user-attachments/assets/5f4d2fbc-4a55-42cf-9286-e392fb3548c2" />

There's a problem with this fix though, in this scenario:
1. Open the flutter project (this will open to the project view correctly)
2. Close the project
3. Open the project's Android subdirectory (this will open to the android view correctly)
4. Open the top-level flutter project again - this will open to the android view, which isn't what we want

So I don't even know if I want to commit this code, because it feels like we are trying to manipulate a mechanism that's already pretty complicated. Any opinions are welcome.


(mostly) Fixes [8556](https://github.com/flutter/flutter-intellij/issues/8556)