### PR TITLE
Fix dev build by using version 2025.2.1.5

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@
 # found in the LICENSE file.
 #
 
-ideaVersion=2025.2.1.3
+ideaVersion=2025.2.1.5
 dartPluginVersion= 252.25557.23
 sinceBuild=243
 untilBuild=253.*


### PR DESCRIPTION
The dev build was not able to pull down the previous version of Android Studio (2025.2.1.3) and there are newer versions now at https://plugins.jetbrains.com/docs/intellij/android-studio-releases-list.html. I checked that this works from a local invocation of the dev build.