### PR TITLE
Add newlines to triage printout for markdown viewing

### DIFF
--- a/tool/triage/bin/triage.dart
+++ b/tool/triage/bin/triage.dart
@@ -50,11 +50,11 @@ void printCreationTimeCounts(Iterable<Issue> issues, {required int issueCount, r
     }
   }
 
-  print('issues: $issueCount (+ $prCount PRs)');
+  print('issues: $issueCount (+ $prCount PRs)\n');
   var unprioritizedPercentage = '${(unpriortizedCount / issueCount).toStringAsFixed(2).substring(2)}%';
   print(
-      'unprioritized: $unpriortizedCount ($unprioritizedPercentage)');
-  print('created within ...');
+      'unprioritized: $unpriortizedCount ($unprioritizedPercentage)\n');
+  print('created within ...\n');
 
   var timeData = [seven, fourteen, twentyEight, ninety, threeSixty, tenEighty, beyond];
 


### PR DESCRIPTION
I often run this triage report at the beginning of my triage week and paste it into a markdown document, so I added newlines to make the paste automatically markdown-friendly. Without the newlines the table doesn't show up and the lines get collapsed into a single paragraph.