### PR TITLE
Turn off automatic gemini summary and code review of PRs

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -6,8 +6,8 @@ code_review:
   max_review_comments: -1
   pull_request_opened:
     help: false
-    summary: true
-    code_review: true
+    summary: false
+    code_review: false
     include_drafts: true
 ignore_patterns: []
 


### PR DESCRIPTION
We can do this locally in gemini CLI if desired without cluttering up PR comments. 