### PR TITLE
Prevent crashes when 3rd party loggers do not implement `setLevel`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 88.2.0
+
+### Added
+
+### Changed
+
+### Removed
+
+### Fixed
+
+- Fixed crash when using 3rd party loggers that don't implement `setLevel`. (#8631)
+
 ## 88.1.0
 
 ### Added

--- a/src/io/flutter/logging/PluginLogger.java
+++ b/src/io/flutter/logging/PluginLogger.java
@@ -46,7 +46,14 @@ public class PluginLogger {
 
   public static void updateLogLevel() {
     final Logger rootLoggerInstance = Logger.getInstance("io.flutter");
-    rootLoggerInstance.setLevel(FlutterSettings.getInstance().isVerboseLogging() ? LogLevel.ALL : LogLevel.INFO);
+    try {
+      rootLoggerInstance.setLevel(FlutterSettings.getInstance().isVerboseLogging() ? LogLevel.ALL : LogLevel.INFO);
+    }
+    catch (Throwable e) {
+      // This can happen if the logger is wrapped by a 3rd party plugin that doesn't correctly implement setLevel.
+      // See https://github.com/flutter/flutter-intellij/issues/8631
+      Logger.getInstance(PluginLogger.class).warn("Failed to set log level", e);
+    }
   }
 
   public static @NotNull Logger createLogger(@NotNull Class<?> logClass) {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter-intellij/issues/8631

Thanks for your contribution! Please replace this text with a description of what this PR is changing or adding and why, list any relevant issues, and review the contribution guidelines below.
