### PR TITLE
Suppress IDE stack trace for setLevel failure

### DIFF
--- a/src/io/flutter/logging/PluginLogger.java
+++ b/src/io/flutter/logging/PluginLogger.java
@@ -45,13 +45,18 @@ public class PluginLogger {
 
   public static void updateLogLevel() {
     final Logger rootLoggerInstance = Logger.getInstance("io.flutter");
+    // Workaround for https://github.com/flutter/flutter-intellij/issues/8631
+    if (rootLoggerInstance.getClass().getName().equals("com.haulmont.jmixstudio.logger.JmixLoggerWrapper")) {
+      return;
+    }
     try {
       rootLoggerInstance.setLevel(FlutterSettings.getInstance().isVerboseLogging() ? LogLevel.ALL : LogLevel.INFO);
     }
     catch (Throwable e) {
-      // This can happen if the logger is wrapped by a 3rd party plugin that doesn't correctly implement setLevel.
+      // This can happen if the logger is wrapped by a 3rd party plugin that doesn't
+      // correctly implement setLevel.
       // See https://github.com/flutter/flutter-intellij/issues/8631
-      Logger.getInstance(PluginLogger.class).warn("Failed to set log level", e);
+      Logger.getInstance(PluginLogger.class).info("Failed to set log level");
     }
   }
 


### PR DESCRIPTION
The stack trace is effectively just the log message being excessively loud because of how IntelliJ handles exceptions passed to the logger.

This is a follow up on https://github.com/flutter/flutter-intellij/issues/8631
