### PR TITLE
Update and fix SDK support table

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,11 @@ These are the versions of Flutter SDK that current and previous Flutter plugins 
 
 | Flutter SDK version | Flutter plugin version |
 |---------------------|------------------------|
-| up to v3.7          | 85.3.2 and earlier     |
-| v3.10 and above     | Currently supported    |
+| up to v3.7.12       | 83.0.4 and earlier     |
+| v3.10.0 to v3.10.2  | 85.3.2 and earlier     |
+| v3.10.3 to v3.10.6  | 86.0.2 and earlier     |
+| v3.13.0 to v3.13.9  | 88.1.0 and earlier     |
+| v3.16.0 and above   | Currently supported    |
 
 Here is more information on the Flutter plugin's support for Flutter
 SDKs: https://docs.flutter.dev/tools/sdk#sdk-support-for-flutter-developer-tools.


### PR DESCRIPTION
I forgot to update this table for some previous changes to the min SDK supported setting, and the first row was inaccurate because I probably forgot to account for https://github.com/flutter/flutter-intellij/pull/7883 back when I first made the table.

Here's the timeline if anyone needs to recreate the logic for updating the table (it was more arduous than I expected):

```
Release 85.3.2: May 12 2025
- min SDK supported was 3.10.0 (Jan 8 2025)

Release 86.0.1/2: June 13 2025
- min SDK supported was 3.10.3 (from May 29)

Release 87.0: August 5 2025
- min SDK supported was 3.13 (from June 24)

Release 87.1: August 11 2025
- unchanged

Release 88.0.0: October 5 2025
- unchanged

Release 88.1.0: November 13 2025
- unchanged

Release 89.0.0: upcoming
- min SDK supported was 3.16 (from Dec 8)
```