### PR TITLE
[CQ] migrate off slated-for-removal `SystemInfo` access

### DIFF
--- a/src/io/flutter/utils/JxBrowserUtils.java
+++ b/src/io/flutter/utils/JxBrowserUtils.java
@@ -25,18 +25,22 @@ public class JxBrowserUtils {
     String name = "";
     final boolean is64Bit = Objects.requireNonNull(CpuArch.CURRENT).width == 64;
     if (SystemInfo.isMac) {
-      if (SystemInfo.isAarch64){
+      if (CpuArch.isArm64()) {
         name = "mac-arm";
-      } else {
+      }
+      else {
         name = "mac";
       }
-    } else if (SystemInfo.isWindows) {
+    }
+    else if (SystemInfo.isWindows) {
       if (CpuArch.is32Bit()) {
         name = "win32";
-      } else if (is64Bit) {
+      }
+      else if (is64Bit) {
         name = "win64";
       }
-    } else if (SystemInfo.isLinux && is64Bit) {
+    }
+    else if (SystemInfo.isLinux && is64Bit) {
       name = "linux64";
     }
 


### PR DESCRIPTION
<img width="2706" height="244" alt="image" src="https://github.com/user-attachments/assets/5c9bf160-0793-4943-94ea-eef30a713580" />

https://plugins.jetbrains.com/plugin/9212-flutter/edit/versions/dev/909537#verification-results


I'm pretty sure this is behavior-preserving but could use another set of eyes.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>