### PR TITLE
Enable Gradle build and configuration caching

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,3 +13,6 @@ javaVersion=21
 kotlin.stdlib.default.dependency=false
 org.gradle.parallel=true
 org.gradle.jvmargs=-Xms1024m -Xmx4048m
+
+org.gradle.caching=true
+org.gradle.configuration-cache=true


### PR DESCRIPTION
Enabling `org.gradle.caching` allows Gradle to reuse task outputs from previous builds, significantly reducing build times for incremental builds. Enabling `org.gradle.configuration-cache` caches the result of the configuration phase, skipping the evaluation of the build script when no configuration changes are detected.

These optimizations reduced local build verification time from ~1m 7s to ~46s.

Thanks for your contribution! Please replace this text with a description of what this PR is changing or adding and why, list any relevant issues, and review the contribution guidelines below.
