### PR TITLE
Fix ProcessAdapter deprecation warnings

### DIFF
--- a/src/io/flutter/actions/OpenInAppCodeAction.java
+++ b/src/io/flutter/actions/OpenInAppCodeAction.java
@@ -8,7 +8,7 @@ package io.flutter.actions;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configurations.GeneralCommandLine;
 import com.intellij.execution.process.ColoredProcessHandler;
-import com.intellij.execution.process.ProcessAdapter;
+import com.intellij.execution.process.ProcessListener;
 import com.intellij.execution.process.ProcessEvent;
 import com.intellij.execution.process.ProcessOutputTypes;
 import com.intellij.openapi.actionSystem.ActionUpdateThread;
@@ -46,12 +46,24 @@ public class OpenInAppCodeAction extends AnAction {
         final GeneralCommandLine cmd = new GeneralCommandLine().withExePath("/bin/bash")
           .withParameters("-c", "mdfind \"kMDItemContentType == 'com.apple.application-bundle'\" | grep AppCode.app");
         final ColoredProcessHandler handler = new ColoredProcessHandler(cmd);
-        handler.addProcessListener(new ProcessAdapter() {
+        handler.addProcessListener(new ProcessListener() {
           @Override
           public void onTextAvailable(@NotNull ProcessEvent event, @NotNull Key outputType) {
             if (outputType == ProcessOutputTypes.STDOUT) {
               IS_APPCODE_INSTALLED = true;
             }
+          }
+
+          @Override
+          public void processTerminated(@NotNull ProcessEvent event) {
+          }
+
+          @Override
+          public void startNotified(@NotNull ProcessEvent event) {
+          }
+
+          @Override
+          public void processWillTerminate(@NotNull ProcessEvent event, boolean willBeDestroyed) {
           }
         });
         handler.startNotify();
@@ -110,12 +122,24 @@ public class OpenInAppCodeAction extends AnAction {
     try {
       final GeneralCommandLine cmd = new GeneralCommandLine().withExePath("open").withParameters("-a", "AppCode.app", path);
       final ColoredProcessHandler handler = new ColoredProcessHandler(cmd);
-      handler.addProcessListener(new ProcessAdapter() {
+      handler.addProcessListener(new ProcessListener() {
         @Override
         public void processTerminated(@NotNull final ProcessEvent event) {
           if (event.getExitCode() != 0) {
             FlutterMessages.showError("Error Opening", path, project);
           }
+        }
+
+        @Override
+        public void startNotified(@NotNull ProcessEvent event) {
+        }
+
+        @Override
+        public void processWillTerminate(@NotNull ProcessEvent event, boolean willBeDestroyed) {
+        }
+
+        @Override
+        public void onTextAvailable(@NotNull ProcessEvent event, @NotNull com.intellij.openapi.util.Key outputType) {
         }
       });
       handler.startNotify();

--- a/src/io/flutter/actions/OpenInXcodeAction.java
+++ b/src/io/flutter/actions/OpenInXcodeAction.java
@@ -8,11 +8,12 @@ package io.flutter.actions;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configurations.GeneralCommandLine;
 import com.intellij.execution.process.ColoredProcessHandler;
-import com.intellij.execution.process.ProcessAdapter;
+import com.intellij.execution.process.ProcessListener;
 import com.intellij.execution.process.ProcessEvent;
 import com.intellij.openapi.actionSystem.*;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectUtil;
+import com.intellij.openapi.util.Key;
 import com.intellij.openapi.util.SystemInfo;
 import com.intellij.openapi.vfs.VirtualFile;
 import io.flutter.FlutterMessages;
@@ -81,7 +82,7 @@ public class OpenInXcodeAction extends AnAction {
         FlutterMessages.showError("Error Opening Xcode", "unable to run `flutter build`", project);
       }
       else {
-        processHandler.addProcessListener(new ProcessAdapter() {
+        processHandler.addProcessListener(new ProcessListener() {
           @Override
           public void processTerminated(@NotNull ProcessEvent event) {
             progressHelper.done();
@@ -93,6 +94,18 @@ public class OpenInXcodeAction extends AnAction {
             }
 
             openWithXcode(project, file.getPath());
+          }
+
+          @Override
+          public void startNotified(@NotNull ProcessEvent event) {
+          }
+
+          @Override
+          public void processWillTerminate(@NotNull ProcessEvent event, boolean willBeDestroyed) {
+          }
+
+          @Override
+          public void onTextAvailable(@NotNull ProcessEvent event, @NotNull com.intellij.openapi.util.Key outputType) {
           }
         });
       }
@@ -117,12 +130,24 @@ public class OpenInXcodeAction extends AnAction {
     try {
       final GeneralCommandLine cmd = new GeneralCommandLine().withExePath("open").withParameters(path);
       final ColoredProcessHandler handler = new ColoredProcessHandler(cmd);
-      handler.addProcessListener(new ProcessAdapter() {
+      handler.addProcessListener(new ProcessListener() {
         @Override
         public void processTerminated(@NotNull final ProcessEvent event) {
           if (event.getExitCode() != 0) {
             FlutterMessages.showError("Error Opening", path, project);
           }
+        }
+
+        @Override
+        public void startNotified(@NotNull ProcessEvent event) {
+        }
+
+        @Override
+        public void processWillTerminate(@NotNull ProcessEvent event, boolean willBeDestroyed) {
+        }
+
+        @Override
+        public void onTextAvailable(@NotNull ProcessEvent event, @NotNull com.intellij.openapi.util.Key outputType) {
         }
       });
       handler.startNotify();

--- a/src/io/flutter/console/FlutterConsole.java
+++ b/src/io/flutter/console/FlutterConsole.java
@@ -8,7 +8,8 @@ package io.flutter.console;
 import com.intellij.execution.filters.TextConsoleBuilder;
 import com.intellij.execution.filters.TextConsoleBuilderFactory;
 import com.intellij.execution.process.ColoredProcessHandler;
-import com.intellij.execution.process.ProcessAdapter;
+
+import com.intellij.execution.process.ProcessListener;
 import com.intellij.execution.process.ProcessEvent;
 import com.intellij.execution.ui.ConsoleView;
 import com.intellij.execution.ui.ConsoleViewContentType;
@@ -81,7 +82,7 @@ class FlutterConsole {
     view.attachToProcess(process);
 
     // Print exit code.
-    final ProcessAdapter listener = new ProcessAdapter() {
+    final ProcessListener listener = new ProcessListener() {
       @Override
       public void processTerminated(final @NotNull ProcessEvent event) {
         view.print(

--- a/src/io/flutter/console/FlutterConsoleFilter.java
+++ b/src/io/flutter/console/FlutterConsoleFilter.java
@@ -12,10 +12,12 @@ import com.intellij.execution.filters.Filter;
 import com.intellij.execution.filters.HyperlinkInfo;
 import com.intellij.execution.filters.OpenFileHyperlinkInfo;
 import com.intellij.execution.process.ColoredProcessHandler;
-import com.intellij.execution.process.ProcessAdapter;
+import com.intellij.execution.process.ProcessListener;
+import com.intellij.execution.process.ProcessOutputTypes;
 import com.intellij.execution.process.ProcessEvent;
 import com.intellij.openapi.editor.markup.EffectType;
 import com.intellij.openapi.editor.markup.TextAttributes;
+import com.intellij.openapi.util.Key;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.Messages;
@@ -54,12 +56,24 @@ public class FlutterConsoleFilter implements Filter {
       try {
         final GeneralCommandLine cmd = new GeneralCommandLine().withExePath("open").withParameters(myPath);
         final ColoredProcessHandler handler = new ColoredProcessHandler(cmd);
-        handler.addProcessListener(new ProcessAdapter() {
+        handler.addProcessListener(new ProcessListener() {
+          @Override
+          public void startNotified(@NotNull ProcessEvent event) {
+          }
+
           @Override
           public void processTerminated(@NotNull final ProcessEvent event) {
             if (event.getExitCode() != 0) {
               FlutterMessages.showError("Error Opening ", myPath, project);
             }
+          }
+
+          @Override
+          public void processWillTerminate(@NotNull ProcessEvent event, boolean willBeDestroyed) {
+          }
+
+          @Override
+          public void onTextAvailable(@NotNull ProcessEvent event, @NotNull Key outputType) {
           }
         });
         handler.startNotify();

--- a/src/io/flutter/run/bazelTest/BazelTestRunner.java
+++ b/src/io/flutter/run/bazelTest/BazelTestRunner.java
@@ -125,7 +125,7 @@ public class BazelTestRunner extends GenericProgramRunner {
       Workspace workspace = WorkspaceCache.getInstance(project).get();
       assert (workspace != null);
       String configWarningPrefix = workspace.getConfigWarningPrefix();
-      listener = new ProcessAdapter() {
+      listener = new ProcessListener() {
         @Override
         public void onTextAvailable(@NotNull ProcessEvent event, @NotNull Key outputType) {
           final String text = event.getText();

--- a/src/io/flutter/run/coverage/FlutterCoverageProgramRunner.java
+++ b/src/io/flutter/run/coverage/FlutterCoverageProgramRunner.java
@@ -13,7 +13,8 @@ import com.intellij.execution.configurations.RunProfile;
 import com.intellij.execution.configurations.RunProfileState;
 import com.intellij.execution.configurations.RunnerSettings;
 import com.intellij.execution.configurations.coverage.CoverageEnabledConfiguration;
-import com.intellij.execution.process.ProcessAdapter;
+
+import com.intellij.execution.process.ProcessListener;
 import com.intellij.execution.process.ProcessEvent;
 import com.intellij.execution.process.ProcessHandler;
 import com.intellij.execution.runners.DefaultProgramRunnerKt;
@@ -42,7 +43,7 @@ public class FlutterCoverageProgramRunner extends GenericProgramRunner<RunnerSet
 
   private static final String ID = "FlutterCoverageProgramRunner";
   private ProcessHandler handler;
-  private ProcessAdapter listener;
+  private ProcessListener listener;
 
   @Override
   public @NotNull
@@ -71,7 +72,7 @@ public class FlutterCoverageProgramRunner extends GenericProgramRunner<RunnerSet
     }
     handler = result.getProcessHandler();
     if (handler != null) {
-      listener = new ProcessAdapter() {
+      listener = new ProcessListener() {
         @Override
         public void processTerminated(@NotNull ProcessEvent event) {
           OpenApiUtils.safeInvokeLater(() -> processCoverage(env));

--- a/src/io/flutter/run/daemon/DaemonApi.java
+++ b/src/io/flutter/run/daemon/DaemonApi.java
@@ -12,9 +12,10 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSyntaxException;
-import com.intellij.execution.process.ProcessAdapter;
+
 import com.intellij.execution.process.ProcessEvent;
 import com.intellij.execution.process.ProcessHandler;
+import com.intellij.execution.process.ProcessListener;
 import com.intellij.execution.process.ProcessOutputTypes;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.util.Key;
@@ -120,7 +121,7 @@ public class DaemonApi {
    * Receive responses and events from a process until it shuts down.
    */
   void listen(@NotNull ProcessHandler process, @NotNull DaemonEvent.Listener listener) {
-    process.addProcessListener(new ProcessAdapter() {
+    process.addProcessListener(new ProcessListener() {
       @Override
       public void onTextAvailable(@NotNull ProcessEvent event, @NotNull Key outputType) {
         if (outputType.equals(ProcessOutputTypes.STDERR)) {

--- a/src/io/flutter/run/daemon/DevToolsServerTask.java
+++ b/src/io/flutter/run/daemon/DevToolsServerTask.java
@@ -11,7 +11,9 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonSyntaxException;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configurations.GeneralCommandLine;
-import com.intellij.execution.process.ProcessAdapter;
+
+import com.intellij.execution.process.ProcessListener;
+import com.intellij.execution.process.ProcessOutputTypes;
 import com.intellij.execution.process.ProcessEvent;
 import com.intellij.execution.process.ProcessHandler;
 import com.intellij.notification.Notification;
@@ -139,7 +141,7 @@ class DevToolsServerTask extends Task.Backgroundable {
   private void setUpInDevMode(@NotNull GeneralCommandLine command) {
     try {
       this.process = new MostlySilentColoredProcessHandler(command);
-      this.process.addProcessListener(new ProcessAdapter() {
+      this.process.addProcessListener(new ProcessListener() {
         @Override
         public void onTextAvailable(@NotNull ProcessEvent event, @NotNull Key outputType) {
           final String text = event.getText().trim();
@@ -159,7 +161,17 @@ class DevToolsServerTask extends Task.Backgroundable {
   private void setUpWithDart(GeneralCommandLine command) {
     try {
       this.process = new MostlySilentColoredProcessHandler(command);
-      this.process.addProcessListener(new ProcessAdapter() {
+      this.process.addProcessListener(new ProcessListener() {
+        @Override
+        public void startNotified(@NotNull ProcessEvent event) {
+        }
+
+        @Override
+        public void processTerminated(@NotNull ProcessEvent event) {
+          DevToolsServerTask.this.process.removeProcessListener(this);
+          DevToolsServerTask.this.process = null;
+        }
+
         @Override
         public void onTextAvailable(@NotNull ProcessEvent event, @NotNull Key outputType) {
           tryParseStartupText(event.getText().trim());

--- a/src/io/flutter/run/daemon/FlutterApp.java
+++ b/src/io/flutter/run/daemon/FlutterApp.java
@@ -10,9 +10,10 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configurations.GeneralCommandLine;
-import com.intellij.execution.process.ProcessAdapter;
+
 import com.intellij.execution.process.ProcessEvent;
 import com.intellij.execution.process.ProcessHandler;
+import com.intellij.execution.process.ProcessListener;
 import com.intellij.execution.runners.ExecutionEnvironment;
 import com.intellij.execution.ui.ConsoleView;
 import com.intellij.execution.ui.ConsoleViewContentType;
@@ -257,7 +258,7 @@ public class FlutterApp implements Disposable {
     final DaemonApi api = new DaemonApi(process);
     final FlutterApp app = new FlutterApp(project, mode, device, process, env, api, command);
 
-    process.addProcessListener(new ProcessAdapter() {
+    process.addProcessListener(new ProcessListener() {
       @Override
       public void processTerminated(@NotNull ProcessEvent event) {
         LOG.info(analyticsStop + " " + project.getName() + " (" + mode.mode() + ")");

--- a/src/io/flutter/run/test/FlutterTestRunner.java
+++ b/src/io/flutter/run/test/FlutterTestRunner.java
@@ -226,7 +226,15 @@ public class FlutterTestRunner extends GenericProgramRunner {
     private String observatoryUri;
 
     public Connector(ProcessHandler handler) {
-      listener = new ProcessAdapter() {
+      listener = new ProcessListener() {
+        @Override
+        public void startNotified(@NotNull ProcessEvent event) {
+        }
+
+        @Override
+        public void processTerminated(@NotNull ProcessEvent event) {
+        }
+
         @Override
         public void onTextAvailable(@NotNull ProcessEvent event, @NotNull Key outputType) {
           if (!outputType.equals(ProcessOutputTypes.STDOUT)) {

--- a/src/io/flutter/sdk/FlutterCommand.java
+++ b/src/io/flutter/sdk/FlutterCommand.java
@@ -8,7 +8,11 @@ package io.flutter.sdk;
 import com.google.common.collect.ImmutableList;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configurations.GeneralCommandLine;
-import com.intellij.execution.process.*;
+import com.intellij.execution.process.CapturingProcessAdapter;
+import com.intellij.execution.process.ColoredProcessHandler;
+import com.intellij.execution.process.ProcessEvent;
+import com.intellij.execution.process.ProcessListener;
+import com.intellij.execution.process.ProcessOutput;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
@@ -187,7 +191,7 @@ public class FlutterCommand {
     if (processListener != null) {
       handler.addProcessListener(processListener);
     }
-    handler.addProcessListener(new ProcessAdapter() {
+    handler.addProcessListener(new ProcessListener() {
       @Override
       public void processTerminated(@NotNull ProcessEvent event) {
         if (onDone != null) {
@@ -244,7 +248,7 @@ public class FlutterCommand {
       final GeneralCommandLine commandLine = createGeneralCommandLine(project);
       LOG.info(safeCommandLog(commandLine));
       handler = new MostlySilentColoredProcessHandler(commandLine);
-      handler.addProcessListener(new ProcessAdapter() {
+      handler.addProcessListener(new ProcessListener() {
         @Override
         public void processTerminated(@NotNull final ProcessEvent event) {
           if (isPubRelatedCommand()) {


### PR DESCRIPTION
Replaces deprecated ProcessAdapter with ProcessListener. Reduces deprecated API usages by 33 in 2025.2 (future-proofing for when check is enabled).

https://github.com/JetBrains/intellij-community/blob/master/platform/util/src/com/intellij/execution/process/ProcessAdapter.java
