### PR TITLE
Refactor DiagnosticsNode to use SmartList usage patterns

### DIFF
--- a/src/io/flutter/logging/DiagnosticsNode.java
+++ b/src/io/flutter/logging/DiagnosticsNode.java
@@ -17,8 +17,11 @@ import org.dartlang.vm.service.element.InstanceRef;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import com.intellij.util.SmartList;
+
 import javax.swing.*;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -50,7 +53,7 @@ public class DiagnosticsNode {
 
   private CompletableFuture<String> propertyDocFuture;
 
-  private ArrayList<DiagnosticsNode> cachedProperties;
+  private List<DiagnosticsNode> cachedProperties;
 
   public DiagnosticsNode(JsonObject json,
                          boolean isProperty,
@@ -286,12 +289,12 @@ public class DiagnosticsNode {
    * <p>
    * Only applies to IterableProperty.
    */
-  public ArrayList<String> getValues() {
+  public List<String> getValues() {
     if (!json.has("values")) {
       return null;
     }
     final JsonArray rawValues = json.getAsJsonArray("values");
-    final ArrayList<String> values = new ArrayList<>(rawValues.size());
+    final List<String> values = new ArrayList<>(rawValues.size());
     for (int i = 0; i < rawValues.size(); ++i) {
       values.add(rawValues.get(i).getAsString());
     }
@@ -452,7 +455,7 @@ public class DiagnosticsNode {
    */
   private final JsonObject json;
 
-  private CompletableFuture<ArrayList<DiagnosticsNode>> children;
+  private CompletableFuture<List<DiagnosticsNode>> children;
 
   private CompletableFuture<Map<String, InstanceRef>> valueProperties;
 
@@ -554,11 +557,11 @@ public class DiagnosticsNode {
     return json.has("children") || (children != null && children.isDone());
   }
 
-  public CompletableFuture<ArrayList<DiagnosticsNode>> getChildren() {
+  public CompletableFuture<List<DiagnosticsNode>> getChildren() {
     if (children == null) {
       if (json.has("children")) {
         final JsonArray jsonArray = json.get("children").getAsJsonArray();
-        final ArrayList<DiagnosticsNode> nodes = new ArrayList<>();
+        final List<DiagnosticsNode> nodes = new SmartList<>();
         for (JsonElement element : jsonArray) {
           final DiagnosticsNode child = new DiagnosticsNode(element.getAsJsonObject(), false, parent);
           child.setParent(this);
@@ -568,7 +571,7 @@ public class DiagnosticsNode {
       }
       else {
         // Known to have no children so we can provide the children immediately.
-        children = CompletableFuture.completedFuture(new ArrayList<>());
+        children = CompletableFuture.completedFuture(new SmartList<>());
       }
     }
     return children;
@@ -593,9 +596,9 @@ public class DiagnosticsNode {
   /**
    * Properties to show inline in the widget tree.
    */
-  public ArrayList<DiagnosticsNode> getInlineProperties() {
+  public List<DiagnosticsNode> getInlineProperties() {
     if (cachedProperties == null) {
-      cachedProperties = new ArrayList<>();
+      cachedProperties = new SmartList<>();
       if (json.has("properties")) {
         final JsonArray jsonArray = json.get("properties").getAsJsonArray();
         for (JsonElement element : jsonArray) {

--- a/src/io/flutter/logging/FlutterConsoleLogManager.java
+++ b/src/io/flutter/logging/FlutterConsoleLogManager.java
@@ -43,8 +43,8 @@ import org.dartlang.vm.service.element.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
@@ -186,7 +186,7 @@ public class FlutterConsoleLogManager {
   private static final int errorSeparatorLength = 100;
   private static final String errorSeparatorChar = "=";
 
-  private static final ArrayList<DiagnosticsNode> emptyList = new ArrayList<>();
+  private static final List<DiagnosticsNode> emptyList = Collections.emptyList();
 
   /**
    * Pretty print the error using the available console syling attributes.
@@ -256,9 +256,9 @@ public class FlutterConsoleLogManager {
     if (property.getLevel() == DiagnosticLevel.summary) {
       skip = false;
     }
-    else if (property.hasChildren()) {
-      final CompletableFuture<ArrayList<DiagnosticsNode>> future = property.getChildren();
-      final ArrayList<DiagnosticsNode> children = future.getNow(emptyList);
+    if (property.hasChildren()) {
+      final CompletableFuture<List<DiagnosticsNode>> future = property.getChildren();
+      final List<DiagnosticsNode> children = future.getNow(emptyList);
       if (children.stream().noneMatch(DiagnosticsNode::hasChildren)) {
         skip = false;
       }
@@ -292,8 +292,8 @@ public class FlutterConsoleLogManager {
     }
 
     if (property.hasChildren()) {
-      final CompletableFuture<ArrayList<DiagnosticsNode>> future = property.getChildren();
-      final ArrayList<DiagnosticsNode> children = future.getNow(emptyList);
+      final CompletableFuture<List<DiagnosticsNode>> future = property.getChildren();
+      final List<DiagnosticsNode> children = future.getNow(emptyList);
 
       for (DiagnosticsNode child : children) {
         printDiagnosticsNodeProperty(console, childIndent, child, contentType, false);
@@ -342,8 +342,8 @@ public class FlutterConsoleLogManager {
     }
 
     if (property.hasChildren()) {
-      final CompletableFuture<ArrayList<DiagnosticsNode>> future = property.getChildren();
-      final ArrayList<DiagnosticsNode> children = future.getNow(emptyList);
+      final CompletableFuture<List<DiagnosticsNode>> future = property.getChildren();
+      final List<DiagnosticsNode> children = future.getNow(emptyList);
 
       // Don't collapse children if it's just a flat list of children.
       if (!isInChild && children.stream().noneMatch(DiagnosticsNode::hasChildren)) {


### PR DESCRIPTION
SmartList is a memory-efficient List implementation in the IntelliJ Platform, optimized for collections that typically contain 0 or 1 element.

This change updates DiagnosticsNode to use List interface and SmartList implementation for properties and children, optimizing memory usage for tree nodes.
