### PR TITLE
Refactor PubRootCache to use SmartList usage patterns

### DIFF
--- a/src/io/flutter/pub/PubRootCache.java
+++ b/src/io/flutter/pub/PubRootCache.java
@@ -13,6 +13,7 @@ import io.flutter.utils.OpenApiUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import com.intellij.util.SmartList;
 import java.util.*;
 
 /**
@@ -61,7 +62,7 @@ public class PubRootCache {
 
   @NotNull
   public List<@NotNull PubRoot> getRoots(@NotNull Module module) {
-    final List<PubRoot> result = new ArrayList<>();
+    final List<PubRoot> result = new SmartList<>();
 
     for (VirtualFile dir : OpenApiUtils.getContentRoots(module)) {
       PubRoot root = cache.get(dir);
@@ -81,7 +82,7 @@ public class PubRootCache {
 
   @NotNull
   public List<PubRoot> getRoots(@NotNull Project project) {
-    final List<PubRoot> result = new ArrayList<>();
+    final List<PubRoot> result = new SmartList<>();
     for (Module module : OpenApiUtils.getModules(project)) {
       result.addAll(getRoots(module));
     }


### PR DESCRIPTION
Updates getRoots methods to use SmartList for collecting results. PubRoots are typically found in small numbers per module/project, making this memory optimization appropriate.

SmartList is a memory-efficient List implementation in the IntelliJ Platform, optimized for collections that typically contain 0 or 1 element.
