### PR TITLE
[fix] remove `DotPackagesFileUtil` references

### DIFF
--- a/src/io/flutter/sdk/FlutterPluginsLibraryManager.java
+++ b/src/io/flutter/sdk/FlutterPluginsLibraryManager.java
@@ -13,9 +13,12 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ModuleRootEvent;
 import com.intellij.openapi.roots.ModuleRootListener;
 import com.intellij.openapi.roots.libraries.PersistentLibraryKind;
-import com.intellij.openapi.vfs.*;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VfsUtilCore;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.openapi.vfs.VirtualFileContentsChangedAdapter;
+import com.intellij.openapi.vfs.VirtualFileManager;
 import com.intellij.util.concurrency.AppExecutorUtil;
-import com.jetbrains.lang.dart.util.DotPackagesFileUtil;
 import io.flutter.dart.FlutterDartAnalysisServer;
 import io.flutter.pub.PubRoot;
 import io.flutter.pub.PubRoots;
@@ -25,8 +28,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
-
-import static com.jetbrains.lang.dart.util.PubspecYamlUtil.PUBSPEC_YAML;
 
 /**
  * Manages the Flutter Plugins library, which hooks the packages used by plugins referenced in a project
@@ -77,21 +78,8 @@ public class FlutterPluginsLibraryManager extends AbstractLibraryManager<Flutter
   protected PersistentLibraryKind<FlutterPluginLibraryProperties> getLibraryKind() {
     return FlutterPluginLibraryType.LIBRARY_KIND;
   }
-
-  private boolean isPackagesFile(@NotNull final VirtualFile file) {
-    final VirtualFile parent = file.getParent();
-    return file.getName().equals(DotPackagesFileUtil.DOT_PACKAGES) && parent != null && parent.findChild(PUBSPEC_YAML) != null;
-  }
-
-  private boolean isPackageConfigFile(@NotNull final VirtualFile file) {
-    final VirtualFile parent = file.getParent();
-    return file.getName().equals(DotPackagesFileUtil.PACKAGE_CONFIG_JSON)
-           && parent != null
-           && parent.getName().equals(DotPackagesFileUtil.DART_TOOL_DIR);
-  }
-
+  
   private void fileChanged(@NotNull final Project project, @NotNull final VirtualFile file) {
-    if (!isPackageConfigFile(file) && !isPackagesFile(file)) return;
     if (LocalFileSystem.getInstance() != file.getFileSystem() && !ApplicationManager.getApplication().isUnitTestMode()) return;
 
     scheduleUpdate();


### PR DESCRIPTION
The dot-packages convention was retired many years ago so this code has been effectively dead for a good while. Removing it is good house-keeping (and will avoid runtime class not found exceptions when a new Dart Plugin with the class removed is published).

Fixes: #8699 

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>