### PR TITLE
Remove multiple loads of widget preview

### DIFF
--- a/src/io/flutter/widgetpreview/WidgetPreviewListener.java
+++ b/src/io/flutter/widgetpreview/WidgetPreviewListener.java
@@ -29,15 +29,10 @@ public class WidgetPreviewListener implements ProcessListener {
   private static final @NotNull Logger LOG = PluginLogger.createLogger(WidgetPreviewListener.class);
   @NotNull private final CompletableFuture<String> urlFuture;
   boolean isVerboseMode;
-  @NotNull private final Consumer<String> onError;
-  @NotNull private final Consumer<String> onSuccess;
 
-  public WidgetPreviewListener(@NotNull CompletableFuture<String> urlFuture, boolean isVerboseMode, @NotNull Consumer<String> onError,
-                               Consumer<@NotNull String> onSuccess) {
+  public WidgetPreviewListener(@NotNull CompletableFuture<String> urlFuture, boolean isVerboseMode) {
     this.urlFuture = urlFuture;
     this.isVerboseMode = isVerboseMode;
-    this.onError = onError;
-    this.onSuccess = onSuccess;
   }
 
   private static final Pattern URL_PATTERN = Pattern.compile("http://localhost:\\d+/?");
@@ -80,24 +75,6 @@ public class WidgetPreviewListener implements ProcessListener {
         }
       }
     }
-
-    urlFuture.whenComplete((url, ex) -> {
-      if (ex != null) {
-        LOG.error("Error getting widget preview URL", ex);
-        final String message = ex.getMessage();
-        this.onError.accept(message);
-        return;
-      }
-
-      ApplicationManager.getApplication().invokeLater(() -> {
-        if (url == null) {
-          this.onError.accept("No URL found");
-          return;
-        }
-
-        this.onSuccess.accept(url);
-      });
-    });
   }
 
   @Override


### PR DESCRIPTION
Follow up to https://github.com/flutter/flutter-intellij/pull/8701

The widget preview was loading multiple times because the `whenComplete` listener was being added for each line from the widget preview server output.

To verify this is working, check `dash.log` and ensure that this only appears once, not multiple times:
```
2026-01-08 08:44:28 io.flutter.widgetpreview.WidgetPreviewPanel [INFO   ] Widget preview URL received: http://localhost:62494  
2026-01-08 08:44:28 io.flutter.widgetpreview.WidgetPreviewPanel [INFO   ] Embedded browser is available: true  
```