### PR TITLE
Migrate String.join to StringUtil.join

### DIFF
--- a/src/io/flutter/devtools/DevToolsUrl.java
+++ b/src/io/flutter/devtools/DevToolsUrl.java
@@ -8,6 +8,7 @@ package io.flutter.devtools;
 import io.flutter.bazel.WorkspaceCache;
 import io.flutter.sdk.FlutterSdkUtil;
 import io.flutter.sdk.FlutterSdkVersion;
+import com.intellij.openapi.util.text.StringUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -211,7 +212,8 @@ public class DevToolsUrl {
     if (widgetId != null) {
       params.add("inspectorRef=" + widgetId);
     }
-    return "http://" + devToolsHost + ":" + devToolsPort + "/" + (page != null ? page : "") + "?" + String.join("&", params);
+    return "http://" + devToolsHost + ":" + devToolsPort + "/" + (page != null ? page : "") + "?"
+        + StringUtil.join(params, "&");
   }
 
   public boolean maybeUpdateColor() {

--- a/src/io/flutter/run/daemon/DaemonApi.java
+++ b/src/io/flutter/run/daemon/DaemonApi.java
@@ -18,6 +18,7 @@ import com.intellij.execution.process.ProcessHandler;
 import com.intellij.execution.process.ProcessOutputTypes;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.util.Key;
+import com.intellij.openapi.util.text.StringUtil;
 import io.flutter.logging.PluginLogger;
 import io.flutter.utils.JsonUtils;
 import io.flutter.utils.StdoutJsonParser;
@@ -236,7 +237,7 @@ public class DaemonApi {
    */
   public String getStderrTail() {
     final String[] lines = stderr.toArray(new String[]{ });
-    return String.join("", lines);
+    return StringUtil.join(lines, "");
   }
 
   /**

--- a/src/io/flutter/run/test/TestFields.java
+++ b/src/io/flutter/run/test/TestFields.java
@@ -13,6 +13,7 @@ import com.intellij.openapi.util.InvalidDataException;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VfsUtilCore;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.util.execution.ParametersListUtil;
 import io.flutter.pub.PubRoot;
 import io.flutter.run.FlutterDevice;
@@ -299,7 +300,7 @@ public class TestFields {
     }
     args.add(0, "-d");
     args.add(1, device.deviceId());
-    return String.join(" ", args);
+    return StringUtil.join(args, " ");
   }
 
   private void checkSdk(@NotNull Project project) throws RuntimeConfigurationError {

--- a/src/io/flutter/sdk/FlutterCommand.java
+++ b/src/io/flutter/sdk/FlutterCommand.java
@@ -13,6 +13,7 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.io.FileUtil;
+import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import io.flutter.FlutterBundle;
 import io.flutter.FlutterMessages;
@@ -69,7 +70,7 @@ public class FlutterCommand {
     words.add("flutter");
     words.addAll(type.subCommand);
     words.addAll(args);
-    return String.join(" ", words);
+    return StringUtil.join(words, " ");
   }
 
   /**
@@ -93,7 +94,7 @@ public class FlutterCommand {
     }
 
     words.addAll(newArgs);
-    return String.join(" ", words);
+    return StringUtil.join(words, " ");
   }
 
   protected boolean isPubRelatedCommand() {


### PR DESCRIPTION
Replaces standard Java String.join with IntelliJ's StringUtil.join across the codebase (FlutterCommand, DaemonApi, TestFields, DevToolsUrl) to improve consistency with the platform API usage.
