### PR TITLE
Upgrade gradle to 9.3.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,7 +43,7 @@ plugins {
   id("org.jetbrains.intellij.platform") version "2.10.5" // IntelliJ Platform Gradle Plugin
   id("org.jetbrains.kotlin.jvm") version "2.2.0" // Kotlin support
   id("org.jetbrains.changelog") version "2.2.0" // Gradle Changelog Plugin
-  id("org.jetbrains.kotlinx.kover") version "0.9.0"
+  id("org.jetbrains.kotlinx.kover") version "0.9.4"
   idea // IntelliJ IDEA support
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Our CI environment is using Java 25 and I suspect it is easier and better to upgrade gradle than to specify a older version of Java. This isn't ready to merge yet - making a PR to check the presubmits.

Although, to be clear, I didn't change the java version setting in `gradle.properties` (Java 21). I think this means that the CI environment can run gradle with Java 25, but gradle then uses Java 21 to build our plugin, so our plugin should stay the same (hopefully).