### PR TITLE
Remove verify and test from deploy (dev build)

### DIFF
--- a/tool/kokoro/deploy.sh
+++ b/tool/kokoro/deploy.sh
@@ -3,21 +3,6 @@
 source ./tool/kokoro/setup.sh
 setup
 
-echo "kokoro verify start"
-
-./gradlew verifyPluginProjectConfiguration
-./gradlew verifyPluginStructure
-./gradlew verifyPluginSignature
-./gradlew verifyPlugin
-
-echo "kokoro verify finished"
-
-echo "kokoro test start"
-
-./gradlew test
-
-echo "kokoro test finished"
-
 echo "kokoro build start"
 
 ./gradlew buildPlugin -Pdev


### PR DESCRIPTION
`./gradlew verifyPlugin` is broken currently (see https://github.com/jetbrains/intellij-platform-gradle-plugin/issues/2087)

I think it would make sense to remove verify and testing from the dev build deploy process, especially since verify has been blocking dev build pretty frequently. We run both on presubmit already so we're not getting additional information here. We also have verification results on the jetbrains site.