### PR TITLE
[fix] coalesce `FlutterPluginsLibraryManager` read actions

### DIFF
--- a/src/io/flutter/sdk/FlutterPluginsLibraryManager.java
+++ b/src/io/flutter/sdk/FlutterPluginsLibraryManager.java
@@ -112,6 +112,7 @@ public class FlutterPluginsLibraryManager extends AbstractLibraryManager<Flutter
 
     ReadAction.nonBlocking(() -> getFlutterPluginPaths(PubRoots.forProject(project)))
       .expireWith(FlutterDartAnalysisServer.getInstance(project))
+      .coalesceBy(this)
       .finishOnUiThread(ModalityState.nonModal(), flutterPluginPaths -> {
         final Set<String> flutterPluginUrls = new HashSet<>();
         for (String path : flutterPluginPaths) {


### PR DESCRIPTION
`FlutterPluginsLibraryManager` was piling up read actions thanks to lots of successive calls to `updateFlutterPluginsImpl`. Adding this call to `coalesceBy` merges these calls (which is the right thing to do).

This should help with if not fully address https://github.com/flutter/flutter-intellij/issues/8242.

(Should also address b/479127477.)

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>