### PR TITLE
[fix] push `FlutterInitializer` slow init off the EDT

### DIFF
--- a/src/io/flutter/FlutterInitializer.java
+++ b/src/io/flutter/FlutterInitializer.java
@@ -135,6 +135,7 @@ public class FlutterInitializer extends FlutterProjectActivity {
 
     // Lambdas need final vars.
     boolean finalHasFlutterModule = hasFlutterModule;
+    boolean finalIsBazel = WorkspaceCache.getInstance(project).isBazel();
     ReadAction.nonBlocking(() -> {
         for (var root : roots) {
           // Set up a default run configuration for 'main.dart' (if it's not there already and the file exists).
@@ -144,7 +145,7 @@ public class FlutterInitializer extends FlutterProjectActivity {
       })
       .expireWith(FlutterDartAnalysisServer.getInstance(project))
       .finishOnUiThread(ModalityState.defaultModalityState(), result -> {
-        edtInitialization(finalHasFlutterModule, project);
+        edtInitialization(finalHasFlutterModule, finalIsBazel, project);
       })
       .submit(AppExecutorUtil.getAppExecutorService());
   }
@@ -152,8 +153,8 @@ public class FlutterInitializer extends FlutterProjectActivity {
   /***
    * Initialization that needs to complete on the EDT thread.
    */
-  private void edtInitialization(boolean hasFlutterModule, @NotNull Project project) {
-    if (hasFlutterModule || WorkspaceCache.getInstance(project).isBazel()) {
+  private void edtInitialization(boolean hasFlutterModule, boolean isBazel, @NotNull Project project) {
+    if (hasFlutterModule || isBazel) {
       initializeToolWindows(project);
     }
     else {


### PR DESCRIPTION
Move service init off the EDT dispatch.

Fixes: https://github.com/flutter/flutter-intellij/issues/8760

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>