### PR TITLE
[infra] upload build report artifacts

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-         name: build
+         name: build-${{ matrix.bot }}
          path: |
            **/build/reports/
            **/build/test-results/     


### PR DESCRIPTION
Uploads build artifacts (test and verifier reports) after all actions.

Artifact URLs can be found in the run output:

<img width="916" height="425" alt="image" src="https://github.com/user-attachments/assets/fd626ab2-a804-4f47-9b35-a6c94a9d322d" />

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>