### PR TITLE
[verifier] migrate off deprecated `Charsets.UTF_8`

### DIFF
--- a/src/io/flutter/FlutterUtils.java
+++ b/src/io/flutter/FlutterUtils.java
@@ -50,6 +50,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.util.Map;
 import java.util.Objects;
@@ -468,7 +469,7 @@ public class FlutterUtils {
     if (meta != null) {
       try {
         final Properties properties = new Properties();
-        properties.load(new InputStreamReader(meta.getInputStream(), Charsets.UTF_8));
+        properties.load(new InputStreamReader(meta.getInputStream(), StandardCharsets.UTF_8));
         final String value = properties.getProperty("project_type");
         if (value == null) {
           return null;

--- a/src/io/flutter/run/daemon/DaemonApi.java
+++ b/src/io/flutter/run/daemon/DaemonApi.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -314,7 +315,7 @@ public class DaemonApi {
   private static PrintWriter getStdin(ProcessHandler processHandler) {
     final OutputStream stdin = processHandler.getProcessInput();
     if (stdin == null) return null;
-    return new PrintWriter(new OutputStreamWriter(stdin, Charsets.UTF_8));
+    return new PrintWriter(new OutputStreamWriter(stdin, StandardCharsets.UTF_8));
   }
 
   public static class RestartResult {


### PR DESCRIPTION
Docs: https://docs.oracle.com/javase/8/docs/api/java/nio/charset/StandardCharsets.html

See: https://github.com/flutter/flutter-intellij/issues/8764

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>