### PR TITLE
[verifier] migrate off deprecated Java Lexer

### DIFF
--- a/src/io/flutter/utils/AndroidUtils.java
+++ b/src/io/flutter/utils/AndroidUtils.java
@@ -70,10 +70,12 @@ public class AndroidUtils {
     if (string.isEmpty()) {
       return "Package segments must be of non-zero length";
     }
-    if (SourceVersion.isKeyword(string)) {
+
+    SourceVersion javaSource = SourceVersion.latest();
+    if (javaSource.isKeyword(string)) {
       return "Package names cannot contain Java keywords like '" + string + "'";
     }
-    if (!SourceVersion.isIdentifier(string)) {
+    if (!javaSource.isIdentifier(string)) {
       return string + " is not a valid identifier";
     }
     return null;


### PR DESCRIPTION
The JDK has it's own support for lexing so we can use that and get off the deprecated IntelliJ APIs.

See: https://docs.oracle.com/javase/8/docs/api/javax/lang/model/SourceVersion.html

See: https://github.com/flutter/flutter-intellij/issues/8764


---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>