### PR TITLE
[verifier] migrate from to-be-removed `SystemInfo.getOsNameAndVersion`

### DIFF
--- a/src/io/flutter/jxbrowser/JxBrowserManager.java
+++ b/src/io/flutter/jxbrowser/JxBrowserManager.java
@@ -15,7 +15,6 @@ import com.intellij.openapi.progress.impl.BackgroundableProcessIndicator;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
 import com.intellij.openapi.util.Pair;
-import com.intellij.openapi.util.SystemInfo;
 import com.intellij.util.containers.ContainerUtil;
 import com.intellij.util.download.DownloadableFileDescription;
 import com.intellij.util.download.DownloadableFileService;
@@ -26,6 +25,7 @@ import io.flutter.logging.PluginLogger;
 import io.flutter.settings.FlutterSettings;
 import io.flutter.utils.FileUtils;
 import io.flutter.utils.JxBrowserUtils;
+import io.flutter.utils.SystemUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -36,7 +36,12 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -211,8 +216,8 @@ public class JxBrowserManager {
       platformFileName = jxBrowserUtils.getPlatformFileName();
     }
     catch (FileNotFoundException e) {
-      LOG.info(projectName + ": Unable to find JxBrowser platform file for " + SystemInfo.getOsNameAndVersion());
-      setStatusFailed(new InstallationFailedReason(FailureType.MISSING_PLATFORM_FILES, SystemInfo.getOsNameAndVersion()));
+      LOG.info(projectName + ": Unable to find JxBrowser platform file for " + SystemUtils.getOsNameAndVersion());
+      setStatusFailed(new InstallationFailedReason(FailureType.MISSING_PLATFORM_FILES, SystemUtils.getOsNameAndVersion()));
       return;
     }
 

--- a/src/io/flutter/run/daemon/DeviceDaemon.java
+++ b/src/io/flutter/run/daemon/DeviceDaemon.java
@@ -16,7 +16,6 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.DialogWrapper;
 import com.intellij.openapi.ui.Messages;
-import com.intellij.openapi.util.SystemInfo;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.util.text.StringUtil;
 import io.flutter.FlutterMessages;
@@ -32,10 +31,13 @@ import io.flutter.settings.FlutterSettings;
 import io.flutter.utils.FlutterModuleUtils;
 import io.flutter.utils.MostlySilentColoredProcessHandler;
 import io.flutter.utils.OpenApiUtils;
+import io.flutter.utils.SystemUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import javax.swing.*;
+import javax.swing.JComponent;
+import javax.swing.JPanel;
+import javax.swing.JTextPane;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -452,7 +454,7 @@ class DeviceDaemon {
       setTitle("Flutter Device Daemon Crash");
       myPanel = new JPanel();
       myTextPane = new JTextPane();
-      final String os = SystemInfo.getOsNameAndVersion();
+      final String os = SystemUtils.getOsNameAndVersion();
       final String link = "https://www.google.com/search?q=increase maximum file handles " + os;
       Messages.installHyperlinkSupport(myTextPane);
       final String message =

--- a/src/io/flutter/utils/JxBrowserUtils.java
+++ b/src/io/flutter/utils/JxBrowserUtils.java
@@ -45,7 +45,7 @@ public class JxBrowserUtils {
     }
 
     if (name.isEmpty()) {
-      throw new FileNotFoundException("Unable to find matching JxBrowser platform file for: " + SystemInfo.getOsNameAndVersion());
+      throw new FileNotFoundException("Unable to find matching JxBrowser platform file for: " + SystemUtils.getOsNameAndVersion());
     }
 
     return String.format("%s-%s-%s.%s", JXBROWSER_FILE_PREFIX, name, JXBROWSER_FILE_VERSION, JXBROWSER_FILE_SUFFIX);

--- a/src/io/flutter/utils/SystemUtils.java
+++ b/src/io/flutter/utils/SystemUtils.java
@@ -12,12 +12,18 @@ import com.intellij.execution.process.ProcessOutput;
 import com.intellij.execution.util.ExecUtil;
 import com.intellij.openapi.util.SystemInfo;
 import com.intellij.util.concurrency.AppExecutorUtil;
+import com.intellij.util.system.OS;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
 import java.util.concurrent.CompletableFuture;
 
 public class SystemUtils {
+  
+  // Replaces slated-for-removal `com.intellij.openapi.util.SystemInfo.getOsNameAndVersion()`.
+  public static String getOsNameAndVersion() {
+    return OS.CURRENT.name() + ' ' + OS.CURRENT.version;
+  }
 
   /**
    * Locate a given command-line tool given its name.


### PR DESCRIPTION
Scheduled from removal as of 2026.1.

See: #8764

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>