### PR TITLE
[verifier] migrate off to-be-removed `Messages` API

### DIFF
--- a/src/io/flutter/FlutterMessages.java
+++ b/src/io/flutter/FlutterMessages.java
@@ -9,7 +9,7 @@ import com.intellij.notification.Notification;
 import com.intellij.notification.NotificationType;
 import com.intellij.notification.Notifications;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.ui.Messages;
+import com.intellij.openapi.ui.messages.MessagesService;
 import icons.FlutterIcons;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
@@ -54,8 +54,9 @@ public class FlutterMessages {
                                @NotNull @Nls String title,
                                @NotNull String[] options,
                                int defaultOptionIndex) {
-    return Messages.showIdeaMessageDialog(project, message, title,
-                                          options, defaultOptionIndex,
-                                          FlutterIcons.Flutter_2x, null);
+    return MessagesService.getInstance()
+      .showMessageDialog(project, null, message, title,
+                         options, defaultOptionIndex, -1,
+                         FlutterIcons.Flutter_2x, null, true, null);
   }
 }


### PR DESCRIPTION
Slated for removal as of 2026.1.

In this case we can just go right to the `MessagesService` API this convenience wrapper was delegating to.

<img width="1936" height="606" alt="image" src="https://github.com/user-attachments/assets/72e03f46-f86f-4176-8377-0bd1110118e0" />

See: #8764



---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>