### PR TITLE
[CQ] remove forbidden companion object from IDE extension

### DIFF
--- a/src/io/flutter/project/FlutterProjectOpenProcessor.kt
+++ b/src/io/flutter/project/FlutterProjectOpenProcessor.kt
@@ -5,9 +5,6 @@
  */
 package io.flutter.project
 
-import com.intellij.openapi.application.ApplicationInfo
-import com.intellij.openapi.application.writeAction
-import com.intellij.openapi.module.Module
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.projectImport.ProjectOpenProcessor
@@ -16,7 +13,7 @@ import io.flutter.FlutterBundle
 import io.flutter.FlutterUtils
 import io.flutter.pub.PubRoot
 import io.flutter.utils.FlutterModuleUtils
-import java.util.Objects
+import java.util.*
 import javax.swing.Icon
 
 /**
@@ -37,7 +34,6 @@ open class FlutterProjectOpenProcessor : ProjectOpenProcessor() {
   }
 
   override fun canOpenProject(file: VirtualFile): Boolean {
-    val info = ApplicationInfo.getInstance()
     if (FlutterUtils.isAndroidStudio()) {
       return false
     }
@@ -94,21 +90,18 @@ open class FlutterProjectOpenProcessor : ProjectOpenProcessor() {
       )
     }.findFirst().orElse(null)
   }
+}
 
-
-  companion object {
-    /**
-     * Sets up a project that doesn't have any Flutter modules.
-     *
-     *
-     * (It probably wasn't created with "flutter create" and probably didn't have any IntelliJ configuration before.)
-     */
-    private fun convertToFlutterProject(project: Project) {
-      for (module in FlutterModuleUtils.getModules(project)) {
-        if (FlutterModuleUtils.declaresFlutter(module) && !FlutterModuleUtils.isFlutterModule(module)) {
-          FlutterModuleUtils.setFlutterModuleAndReload(module, project)
-        }
-      }
+/**
+ * Sets up a project that doesn't have any Flutter modules.
+ *
+ *
+ * (It probably wasn't created with "flutter create" and probably didn't have any IntelliJ configuration before.)
+ */
+private fun convertToFlutterProject(project: Project) {
+  for (module in FlutterModuleUtils.getModules(project)) {
+    if (FlutterModuleUtils.declaresFlutter(module) && !FlutterModuleUtils.isFlutterModule(module)) {
+      FlutterModuleUtils.setFlutterModuleAndReload(module, project)
     }
   }
 }


### PR DESCRIPTION
Addresses warning:

    Companion objects in IDE extension implementations may only contain a logger and constants.

by moving the companion object function declaration to a top-level function.

(Also opportunistically removes an unused local -- interestingly this initialization theoretically causes the `ApplicationInfo` service to get loaded but I imagine it would be already. If not, this is an odd side effect. And probably unintended.)

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>