### PR TITLE
[verifier] don't warn artifact upload if there are no reports

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -43,4 +43,5 @@ jobs:
          name: build-${{ matrix.bot }}
          path: |
            **/build/reports/
-           **/build/test-results/     
+           **/build/test-results/
+         if-no-files-found: ignore  


### PR DESCRIPTION
A few of the actions do not produce artifacts and currently generate a warning that's just noise:


<img width="1398" height="1340" alt="image" src="https://github.com/user-attachments/assets/3fd20a1a-939a-4457-bb92-56d022e72e99" />

`if-no-files-found:` is the ticket:

<img width="664" height="494" alt="image" src="https://github.com/user-attachments/assets/af92082d-605b-4de4-b7e8-6889e6f6bdc1" />



---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>