### PR TITLE
[tool] plugin dependency update

### DIFF
--- a/tool/plugin/pubspec.yaml
+++ b/tool/plugin/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   git: ^2.0.0
   markdown: ^7.1.1
   path: ^1.8.0
-  string_validator: 1.1.0
+  string_validator: ^1.1.0
 
 dev_dependencies:
   lints: ^6.0.0


### PR DESCRIPTION
`string_validator` was pinned for (I expect) no good reason. Opening the version range gets the latest (and quiets an "outdated package" warning in the build.

<img width="544" height="153" alt="image" src="https://github.com/user-attachments/assets/860d4696-3afe-47e1-b4cb-e298faea87af" />


---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>