### PR TITLE
Fix device labels missing from run tabs on IntelliJ 2025.3+

### DIFF
--- a/src/io/flutter/run/LaunchState.java
+++ b/src/io/flutter/run/LaunchState.java
@@ -55,7 +55,6 @@ import io.flutter.toolwindow.ToolWindowBadgeUpdater;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -171,16 +170,12 @@ public class LaunchState extends CommandLineState {
     final String nameWithDeviceName = descriptor.getDisplayName() + " (" + device.deviceName() + ")";
 
     try {
-      // There is no public way to set display name so we resort to reflection.
-      final Field f = descriptor.getClass().getDeclaredField("myDisplayNameView");
-      f.setAccessible(true);
-      Object viewInstance = f.get(descriptor);
-      if (viewInstance != null) {
-        final Method setValueMethod = viewInstance.getClass().getMethod("setValue", Object.class);
-        setValueMethod.invoke(viewInstance, nameWithDeviceName);
-      }
+      // RunContentDescriptor.setDisplayName() is protected, so we use reflection to call it.
+      final Method setDisplayName = RunContentDescriptor.class.getDeclaredMethod("setDisplayName", String.class);
+      setDisplayName.setAccessible(true);
+      setDisplayName.invoke(descriptor, nameWithDeviceName);
     }
-    catch (IllegalAccessException | InvocationTargetException | NoSuchFieldException | NoSuchMethodException e) {
+    catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
       FlutterUtils.info(LOG, "Error setting display name", e, true);
     }
 


### PR DESCRIPTION
## Summary

- Fix `IllegalAccessException` that silently prevents device names from appearing in Run/Debug tab titles on IntelliJ 2025.3 (Android Studio Panda)
- Use `RunContentDescriptor.setDisplayName()` API instead of reaching into a private field's internal type

Fixes https://github.com/flutter/flutter-intellij/issues/8795

## Problem

In IntelliJ 2025.3, the `myDisplayNameView` field on `RunContentDescriptor` changed from `MutableReactiveProperty` (a public class) to `MutableStateFlow` (whose runtime class `StateFlowImpl` is package-private). The existing reflection code calls `Method.invoke()` on the `setValue` method found via `getMethod()`, which throws `IllegalAccessException` when the declaring class is not accessible — even though the method itself is public. The exception is caught silently, so run tabs show "main.dart" instead of "main.dart (macOS)".

Regression introduced by [JetBrains/intellij-community@`aaa88849ba4c`](https://github.com/JetBrains/intellij-community/commit/aaa88849ba4ceec53a0e65279e9ee79071f27451) (Jul 14, 2025).

## Fix

Replace the field-level reflection (`getDeclaredField("myDisplayNameView")` → `getMethod("setValue")` → `invoke()`) with a call to `RunContentDescriptor.setDisplayName()`, an existing protected method on `RunContentDescriptor`. This calls a stable API method on a public class rather than depending on the internal type of a private field.

An alternative minimal fix would be to add `setValueMethod.setAccessible(true)` before the existing `invoke()` call, but calling a stable API method on a public class is more resilient than depending on the internal type of a private field.

## Before & After

### Before fix
<img width="293" height="116" alt="Screenshot 2026-02-15 at 2 53 56 PM" src="https://github.com/user-attachments/assets/61f7d727-871a-438b-9735-7f51fc5a743e" />


### After fix:
<img width="321" height="128" alt="Screenshot 2026-02-15 at 2 52 38 PM" src="https://github.com/user-attachments/assets/efa559a1-1fa2-4d37-a94a-bdf9b544bf67" />

---

- [x] I've reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).
</details>