### PR TITLE
Add test asserting display name setter is accessible on current IntelliJ build

### DIFF
--- a/testSrc/unit/io/flutter/run/LaunchStateTest.java
+++ b/testSrc/unit/io/flutter/run/LaunchStateTest.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2026 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.run;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+
+public class LaunchStateTest {
+
+  @Test
+  public void displaySetterIsAvailable() {
+    assertNotNull(
+      "setDisplayName not found on RunContentDescriptor — JetBrains may have removed or renamed it",
+      LaunchState.getDisplaySetter()
+    );
+  }
+}


### PR DESCRIPTION
Follow-up to #8796.

Extracts the reflection lookup into a `@VisibleForTesting getDisplaySetter()` method and adds a test asserting it returns non-null. This serves as a regression guard: if JetBrains removes or renames `setDisplayName` in a future build, the test will fail loudly rather than the feature silently breaking for users (which was the original failure mode in #8795).

Verified locally by running the test against the real SDK (passes), then temporarily corrupting the method name to `setDisplayName_doesNotExist` (fails with the expected assertion message).

 I've reviewed the contributor guide and applied the relevant portions to this PR.