### PR TITLE
Update contributing guidelines to ask for verification steps and screenshots

### DIFF
--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -70,5 +70,5 @@ enforce standard modern Java/Kotlin coding conventions, but strictly police the 
 - **Single Responsibility:** Methods should ideally be 10-20 lines. If a method exceeds 30 lines, suggest a refactor.
 - **DRY:** Identify blocks of code that are 90%+ identical to existing utility methods in this repo and flag them for duplication.
 - **Meaningful Naming:** Variables should describe their intent (e.g., `timeoutInMs` instead of `t`).
-- **Explanatory PR:** Contributors should include the information recommended in the pull request template (In
+- **Descriptive Pull Request:** Contributors should include the information recommended in the pull request template (In
   `.github/PULL_REQUEST_TEMPLATE.md`Ï)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,5 @@
 Thanks for your contribution! Please replace this text with:
+
 - a description of what this PR is changing and why
 - any relevant issues
 - a description of how to verify the change is working
@@ -7,14 +8,18 @@ Thanks for your contribution! Please replace this text with:
 ---
 
 Review the contribution guidelines below:
+
 - [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
 - [ ] I've included the required information in the description above.
+- [ ] My up-to-date information is in the `AUTHORS` file.
+- [ ] I've updated `CHANGELOG.md` if appropriate.
 
 <details>
   <summary>Contribution guidelines:</summary><br>
 
 - See
-  our [contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md)
+  our [contributor guide](../CONTRIBUTING.md) and
+  the [Flutter organization contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md)
   for general expectations for PRs.
 - Larger or significant changes should be discussed in an issue before creating a PR.
 - Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use


### PR DESCRIPTION
I added some additional checklist items to the PR template and added a note to the gemini styleguide (at the very bottom) to try to enforce those requirements. Most of the changes to styleguide are formatting updates (Cmd+Opt+L).