### PR TITLE
Clean up new project integration test

### DIFF
--- a/testSrc/integration/io/flutter/integrationTest/DeepLinksToolWindowTest.kt
+++ b/testSrc/integration/io/flutter/integrationTest/DeepLinksToolWindowTest.kt
@@ -60,7 +60,7 @@ class DeepLinksToolWindowTest {
   fun testDeepLinksToolWindow() {
     println("Initializing IDE test context")
     val projectPath = Paths.get(System.getProperty("java.io.tmpdir"), testProjectName)
-    run = Setup.setupTestContextIC("DeepLinksToolWindowTest", LocalProjectInfo(projectPath)).runIdeWithDriver()
+    run = Setup.setupTestContextIC(javaClass.simpleName, LocalProjectInfo(projectPath)).runIdeWithDriver()
 
     run.driver.withContext {
       ideFrame {

--- a/testSrc/integration/io/flutter/integrationTest/NewProjectUITest.kt
+++ b/testSrc/integration/io/flutter/integrationTest/NewProjectUITest.kt
@@ -73,7 +73,7 @@ class NewProjectUITest {
   fun newProjectIC() {
     println("Initializing IDE test context")
     println("Test project will be created as: $testProjectName")
-    run = Setup.setupTestContextIC("NewProjectUITest").runIdeWithDriver()
+    run = Setup.setupTestContextIC(javaClass.simpleName).runIdeWithDriver()
 
     newProjectWelcomeScreen(run, testProjectName)
     newProjectInProjectView()
@@ -84,7 +84,7 @@ class NewProjectUITest {
   fun newProjectUE() {
     println("Initializing IDE test context")
     println("Test project will be created as: $testProjectName")
-    run = Setup.setupTestContextUE("NewProjectUITest").runIdeWithDriver()
+    run = Setup.setupTestContextUE(javaClass.simpleName).runIdeWithDriver()
 
     newProjectWelcomeScreen(run, testProjectName)
     run.driver.withContext {
@@ -101,7 +101,7 @@ class NewProjectUITest {
   fun newProjectWS() {
     println("Initializing IDE test context")
     println("Test project will be created as: $testProjectName")
-    run = Setup.setupTestContextWS("NewProjectUITest").runIdeWithDriver()
+    run = Setup.setupTestContextWS(javaClass.simpleName).runIdeWithDriver()
 
     newProjectWelcomeScreen(run, testProjectName)
     newProjectInProjectView()


### PR DESCRIPTION
After adding a clean up utility function to the deep links integration test, it makes sense to clean up the original integration test to use that. I'm also retitling the class to match the file.

Continue to run with `./gradlew clean`, then `./gradlew integration`.