### PR TITLE
Attempting to make runIde work for multiple independent IDEs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -71,6 +71,8 @@ if (project.hasProperty("release")) {
 }
 
 val ideaVersion = providers.gradleProperty("ideaVersion").get()
+val intellijIdeaVersion = providers.gradleProperty("intellijIdeaVersion").get()
+val platformType = providers.gradleProperty("platformType").getOrElse("AS")
 val dartPluginVersion = providers.gradleProperty("dartPluginVersion").get()
 val sinceBuildInput = providers.gradleProperty("sinceBuild").get()
 val untilBuildInput = providers.gradleProperty("untilBuild").get()
@@ -79,7 +81,9 @@ group = "io.flutter"
 
 // For debugging purposes:
 println("flutterPluginVersion: $flutterPluginVersion")
+println("platformType: $platformType")
 println("ideaVersion: $ideaVersion")
+println("intellijIdeaVersion: $intellijIdeaVersion")
 println("dartPluginVersion: $dartPluginVersion")
 println("sinceBuild: $sinceBuildInput")
 println("untilBuild: $untilBuildInput")
@@ -142,6 +146,21 @@ sourceSets {
         "third_party/vmServiceDrivers"
       )
     )
+    if (platformType == "IC") {
+      // Option 1 experiment: keep AS-specific code in src and exclude for IC builds.
+      java.exclude(
+        listOf(
+          "io/flutter/FlutterStudioStartupActivity.java",
+          "io/flutter/actions/OpenAndroidModule.java",
+          "io/flutter/android/AndroidStudioGradleSyncProvider.java",
+          "io/flutter/utils/AddToAppUtils.java",
+          "io/flutter/utils/AndroidLocationProvider.java",
+          "io/flutter/utils/FlutterExternalSystemTaskNotificationListener.java",
+          "io/flutter/utils/GradleUtils.java",
+          "org/jetbrains/android/facet/AndroidFrameworkDetector.java"
+        )
+      )
+    }
     kotlin.srcDirs(
       listOf(
         "src",
@@ -201,8 +220,13 @@ dependencies {
     // Documentation on the default target platform methods:
     // https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-dependencies-extension.html#default-target-platforms
     // Android Studio versions can be found at: https://plugins.jetbrains.com/docs/intellij/android-studio-releases-list.html
+    // IntelliJ IDEA CE versions can be found at: https://www.jetbrains.com/idea/download/other.html
     try {
-      androidStudio(ideaVersion)
+      if (platformType == "IC") {
+        intellijIdeaCommunity(intellijIdeaVersion)
+      } else {
+        androidStudio(ideaVersion)
+      }
     } catch (e: Exception) {
       throw GradleException(
         "Failed to resolve Android Studio / IDEA download URL. This is likely due to a network issue blocking the download URL. Please check your internet connection or VPN.",
@@ -216,20 +240,21 @@ dependencies {
     // Plugin dependency documentation:
     // https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-dependencies-extension.html#plugins
     // https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html#project-setup
-    bundledPlugins(
-      immutableListOf(
-        "com.intellij.java",
-        "com.intellij.properties",
-        "JUnit",
-        "Git4Idea",
-        "org.jetbrains.kotlin",
-        "org.jetbrains.plugins.gradle",
-        "org.jetbrains.plugins.yaml",
-        "org.intellij.intelliLang",
-        "org.jetbrains.android",
-        "com.android.tools.idea.smali"
-      )
+    val commonPlugins = immutableListOf(
+      "com.intellij.java",
+      "com.intellij.properties",
+      "JUnit",
+      "Git4Idea",
+      "org.jetbrains.kotlin",
+      "org.jetbrains.plugins.gradle",
+      "org.jetbrains.plugins.yaml",
+      "org.intellij.intelliLang"
     )
+    if (platformType == "AS") {
+      bundledPlugins(commonPlugins + listOf("org.jetbrains.android", "com.android.tools.idea.smali"))
+    } else {
+      bundledPlugins(commonPlugins)
+    }
     plugin("Dart:$dartPluginVersion")
 
     if (sinceBuildInput == "243" || sinceBuildInput == "251") {

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,11 @@
 #
 
 ideaVersion=2025.2.3.9
+intellijIdeaVersion=2025.2.6.1
 dartPluginVersion= 503.0.0
+# Set to IC to run against IntelliJ IDEA Community instead of Android Studio.
+# Usage: .\gradlew runIde -PplatformType=IC
+platformType=AS
 # Also update the versions for verify checks in tool/github.sh.
 sinceBuild=251
 untilBuild=261.*

--- a/src/io/flutter/ProjectOpenActivity.java
+++ b/src/io/flutter/ProjectOpenActivity.java
@@ -7,7 +7,6 @@ package io.flutter;
 
 import com.intellij.framework.FrameworkType;
 import com.intellij.framework.detection.DetectionExcludesConfiguration;
-import com.intellij.ide.plugins.IdeaPluginDescriptor;
 import com.intellij.ide.plugins.PluginManagerCore;
 import com.intellij.notification.Notification;
 import com.intellij.notification.NotificationType;
@@ -29,7 +28,8 @@ import io.flutter.pub.PubRoots;
 import io.flutter.sdk.FlutterSdk;
 import io.flutter.utils.AndroidUtils;
 import io.flutter.utils.FlutterModuleUtils;
-import org.jetbrains.android.facet.AndroidFrameworkDetector;
+// AndroidFrameworkDetector is loaded reflectively to avoid a compile-time dependency on
+// org.jetbrains.android, which is only bundled in Android Studio (not IntelliJ IDEA CE).
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
@@ -93,20 +93,24 @@ public class ProjectOpenActivity extends FlutterProjectActivity implements DumbA
     if (FlutterUtils.isAndroidStudio()) {
       return;
     }
-    IdeaPluginDescriptor desc;
     if (PluginManagerCore.getPlugin(PluginId.getId("org.jetbrains.android")) == null) {
       return;
     }
     try {
       final DetectionExcludesConfiguration excludesConfiguration = DetectionExcludesConfiguration.getInstance(project);
       try {
-        final FrameworkType type = new AndroidFrameworkDetector().getFrameworkType();
+        final Class<?> detectorClass = Class.forName("org.jetbrains.android.facet.AndroidFrameworkDetector");
+        final Object detector = detectorClass.getDeclaredConstructor().newInstance();
+        final FrameworkType type = (FrameworkType)detectorClass.getMethod("getFrameworkType").invoke(detector);
         if (!excludesConfiguration.isExcludedFromDetection(type)) {
           excludesConfiguration.addExcludedFramework(type);
         }
       }
       catch (NullPointerException ignored) {
         // If the Android facet has not been configured then getFrameworkType() throws a NPE.
+      }
+      catch (ReflectiveOperationException ignored) {
+        // AndroidFrameworkDetector could not be loaded reflectively.
       }
     }
     catch (NoClassDefFoundError ignored) {


### PR DESCRIPTION
This PR attempts to allow users to runIde with either AS or IC (Intellij community) on the command line, allowing either IDE to be properly started to do testing. There is a minor change to a java file that loads an Android plugin class at runtime. This would normally fail silently, but due to Gradle compile time constraints, this will not compile correctly as written. So it has been updated with reflection to make the execution of the class a run time instead of a compile time thing.