### PR TITLE
[build] inline dev-build upload in `deploy.sh`

### DIFF
--- a/tool/kokoro/deploy.sh
+++ b/tool/kokoro/deploy.sh
@@ -25,10 +25,10 @@ if [ ! -f "$ZIP_FILE" ]; then
 fi
 
 echo "Uploading $ZIP_FILE to JetBrains Marketplace..."
-curl -i \
+curl -if --fail \
   --header "Authorization: Bearer $TOKEN" \
   -F pluginId=9212 \
-  -F file=@$ZIP_FILE \
+  -F file=@"$ZIP_FILE" \
   -F channel=dev \
   https://plugins.jetbrains.com/plugin/uploadPlugin
 


### PR DESCRIPTION
Removes the call to `plugin..dart deploy` in favor of a bash implementation inline.

Fixes: #8866 .


---

Review the contribution guidelines below:

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] I've included the required information in the description above.
- [x] My up-to-date information is in the `AUTHORS` file.
- [x] I've updated `CHANGELOG.md` if appropriate.

<details>
  <summary>Contribution guidelines:</summary><br>

- See
  our [contributor guide](../CONTRIBUTING.md) and
  the [Flutter organization contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md)
  for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use
  `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best
  practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).

</details>