### PR TITLE
[fix] target device selector updates

### DIFF
--- a/src/io/flutter/actions/DeviceSelectorAction.java
+++ b/src/io/flutter/actions/DeviceSelectorAction.java
@@ -6,7 +6,6 @@
 package io.flutter.actions;
 
 import com.intellij.icons.AllIcons;
-import com.intellij.ide.ActivityTracker;
 import com.intellij.ide.DataManager;
 import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
@@ -46,6 +45,7 @@ import io.flutter.logging.PluginLogger;
 import io.flutter.run.FlutterDevice;
 import io.flutter.run.daemon.DeviceService;
 import io.flutter.sdk.AndroidEmulatorManager;
+import io.flutter.utils.AsyncUtils;
 import io.flutter.utils.FlutterModuleUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -390,9 +390,10 @@ public class DeviceSelectorAction extends AnAction implements CustomComponentAct
     final Collection<FlutterDevice> devices = deviceService.getConnectedDevices();
 
     final String text;
-    Icon icon = DEFAULT_DEVICE_ICON;
+    Icon icon;
 
     if (devices.isEmpty()) {
+      icon = DEFAULT_DEVICE_ICON;
       final boolean isLoading = deviceService.getStatus() == DeviceService.State.LOADING;
       if (isLoading) {
         text = FlutterBundle.message("devicelist.loading");
@@ -402,6 +403,7 @@ public class DeviceSelectorAction extends AnAction implements CustomComponentAct
       }
     }
     else if (selectedDevice == null) {
+      icon = DEFAULT_DEVICE_ICON;
       text = FlutterBundle.message("devicelist.noDeviceSelected");
     }
     else {
@@ -416,25 +418,27 @@ public class DeviceSelectorAction extends AnAction implements CustomComponentAct
     // Update the custom component if it exists
     final JButton customComponent = presentation.getClientProperty(CUSTOM_COMPONENT_KEY);
     if (customComponent != null) {
-      final @Nullable JBLabel iconLabel = (JBLabel)customComponent.getClientProperty(ICON_LABEL_KEY);
-      final @Nullable JBLabel textLabel = (JBLabel)customComponent.getClientProperty(TEXT_LABEL_KEY);
+      AsyncUtils.invokeLater(() -> {
+        final @Nullable JBLabel iconLabel = (JBLabel)customComponent.getClientProperty(ICON_LABEL_KEY);
+        final @Nullable JBLabel textLabel = (JBLabel)customComponent.getClientProperty(TEXT_LABEL_KEY);
 
-      if (iconLabel != null) {
-        iconLabel.setIcon(icon);
-      }
-      if (textLabel != null) {
-        textLabel.setText(text);
-        // Update the foreground color to adapt to theme changes.
-        textLabel.setForeground(getToolbarForegroundColor());
-        customComponent.invalidate();
-        Container parent = customComponent.getParent();
-        while (parent != null) {
-          parent.invalidate();
-          parent = parent.getParent();
+        if (iconLabel != null) {
+          iconLabel.setIcon(icon);
         }
-        customComponent.revalidate();
-        customComponent.repaint();
-      }
+        if (textLabel != null) {
+          textLabel.setText(text);
+          // Update the foreground color to adapt to theme changes.
+          textLabel.setForeground(getToolbarForegroundColor());
+          customComponent.invalidate();
+          Container parent = customComponent.getParent();
+          while (parent != null) {
+            parent.invalidate();
+            parent = parent.getParent();
+          }
+          customComponent.revalidate();
+          customComponent.repaint();
+        }
+      });
     }
   }
 

--- a/src/io/flutter/actions/DeviceSelectorAction.java
+++ b/src/io/flutter/actions/DeviceSelectorAction.java
@@ -381,6 +381,10 @@ public class DeviceSelectorAction extends AnAction implements CustomComponentAct
       update(project, presentation);
     }
 
+    updateComponent(project, presentation);
+  }
+
+  private void updateComponent(@NotNull Project project, @NotNull Presentation presentation) {
     final DeviceService deviceService = DeviceService.getInstance(project);
     final FlutterDevice selectedDevice = deviceService.getSelectedDevice();
     final Collection<FlutterDevice> devices = deviceService.getConnectedDevices();
@@ -447,6 +451,7 @@ public class DeviceSelectorAction extends AnAction implements CustomComponentAct
     }
     updateActions(project, presentation);
     updateVisibility(project, presentation);
+    updateComponent(project, presentation);
   }
 
   private static void updateVisibility(final Project project, final @NotNull Presentation presentation) {
@@ -531,11 +536,6 @@ public class DeviceSelectorAction extends AnAction implements CustomComponentAct
     // Atomically replace the action list
     LOG.debug("[" + projectName + "] Replacing device selector actions");
     this.actions = newActions;
-
-    var tracker = ActivityTracker.getInstance();
-    if (tracker != null) {
-      tracker.inc();
-    }
   }
 
   private static class SelectDeviceAction extends AnAction {

--- a/src/io/flutter/run/daemon/DeviceService.java
+++ b/src/io/flutter/run/daemon/DeviceService.java
@@ -191,7 +191,6 @@ public class DeviceService {
       if (project.isDisposed()) return;
       deviceDaemon.refresh(this::chooseNextDaemon);
       refreshInProgress = false;
-      ActivityTracker.getInstance().inc();
     });
   }
 


### PR DESCRIPTION
In #8853, users are reporting an exception in Android Studio thanks to excessive toolbar updates. This is caused by the Flutter plugin triggering frequent global toolbar updates via a call to `ActivityTracker.getInstance().inc()` whenever the device or emulator lists change.

**The Fix.** To reduce update frequency, this change makes the updates targeted, removing  the (global)`ActivityTracker.getInstance().inc()` calls from `DeviceSelectorAction.updateActions()` and `DeviceService.refreshDeviceDaemon()`, invoking a newly extracted `updateComponent` method in `DeviceSelectorAction` instead. This ensures that the Flutter device selector UI still updates immediately when devices are connected or disconnected, but without forcing a global re-query of all actions on the toolbar.

**Verification.** Verified manually and  `io.flutter.actions.DeviceSelectorActionTest` still passes.

Fixes #8853 



---

Review the contribution guidelines below:

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] I've included the required information in the description above.
- [x] My up-to-date information is in the `AUTHORS` file.
- [x] I've updated `CHANGELOG.md` if appropriate.

<details>
  <summary>Contribution guidelines:</summary><br>

- See
  our [contributor guide](../CONTRIBUTING.md) and
  the [Flutter organization contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md)
  for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use
  `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best
  practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).

</details>