### PR TITLE
Expose Flutter debug toolbar extension group

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -30,3 +30,4 @@ Kazuya Chikamatsu <kazu.chika.shima@gmail.com>
 Dustin Feucht <code.nopjar@gmail.com>
 Nico Mexis <nicomexis.nm@gmail.com>
 Luke Memet <lukememet@gmail.com>
+Diandian Liang <hlxsmail@gmail.com>

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -76,6 +76,9 @@
       <add-to-group anchor="before" group-id="ToolbarRunGroup" relative-to-action="RunConfiguration"/>
     </group>
 
+    <!-- Allows dependent plugins to contribute inline actions to Flutter run/debug content toolbars. -->
+    <group id="Flutter.DebugProcess.TopToolbar" popup="false"/>
+
     <!--suppress PluginXmlCapitalization -->
     <group id="FlutterToolsActionGroup" class="io.flutter.actions.FlutterToolsActionGroup" popup="true"
            text="Flutter" description="Flutter Tools" icon="FlutterIcons.Flutter">

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -74,6 +74,9 @@
       <add-to-group anchor="before" group-id="ToolbarRunGroup" relative-to-action="RunConfiguration"/>
     </group>
 
+    <!-- Allows dependent plugins to contribute inline actions to Flutter run/debug content toolbars. -->
+    <group id="Flutter.DebugProcess.TopToolbar" popup="false"/>
+
     <!--suppress PluginXmlCapitalization -->
     <group id="FlutterToolsActionGroup" class="io.flutter.actions.FlutterToolsActionGroup" popup="true"
            text="Flutter" description="Flutter Tools" icon="FlutterIcons.Flutter">

--- a/src/io/flutter/run/FlutterDebugProcess.java
+++ b/src/io/flutter/run/FlutterDebugProcess.java
@@ -111,6 +111,7 @@ public class FlutterDebugProcess extends DartVmServiceDebugProcess {
     topToolbar.addAction(new RestartFlutterApp(app, canReload));
     topToolbar.addSeparator();
     topToolbar.addAction(new OpenDevToolsAction(app, debugUrlAvailable));
+    FlutterDebugProcessActions.addTopToolbarExtensionActions(topToolbar);
 
     settings.addAction(new ReloadAllFlutterApps(app, canReload));
     settings.addAction(new RestartAllFlutterApps(app, canReload));

--- a/src/io/flutter/run/FlutterDebugProcessActions.java
+++ b/src/io/flutter/run/FlutterDebugProcessActions.java
@@ -24,14 +24,21 @@ public final class FlutterDebugProcessActions {
   private FlutterDebugProcessActions() {
   }
 
+  /**
+   * Appends toolbar actions contributed by downstream dependent plugins.
+   *
+   * <p>{@link ActionManager#getAction(String)} returns {@link AnAction} because action groups are
+   * actions too. The extension id resolves to an inline {@link ActionGroup}, which can contain
+   * multiple contributed child actions.
+   */
   public static void addTopToolbarExtensionActions(@NotNull DefaultActionGroup topToolbar) {
-    final AnAction action = ActionManager.getInstance().getAction(TOP_TOOLBAR_EXTENSION_GROUP_ID);
-    if (!(action instanceof ActionGroup actionGroup) || isEmpty(actionGroup)) {
+    final AnAction extensionGroupAction = ActionManager.getInstance().getAction(TOP_TOOLBAR_EXTENSION_GROUP_ID);
+    if (!(extensionGroupAction instanceof ActionGroup actionGroup) || isEmpty(actionGroup)) {
       return;
     }
 
     topToolbar.addSeparator();
-    topToolbar.addAction(action);
+    topToolbar.addAction(extensionGroupAction);
   }
 
   private static boolean isEmpty(@NotNull ActionGroup actionGroup) {

--- a/src/io/flutter/run/FlutterDebugProcessActions.java
+++ b/src/io/flutter/run/FlutterDebugProcessActions.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.run;
+
+import com.intellij.openapi.actionSystem.ActionGroup;
+import com.intellij.openapi.actionSystem.ActionManager;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.DefaultActionGroup;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Shared action groups for Flutter-specific run and debug toolbars.
+ */
+public final class FlutterDebugProcessActions {
+  /**
+   * Third-party plugins can contribute inline toolbar actions with:
+   * {@code <add-to-group group-id="Flutter.DebugProcess.TopToolbar" anchor="last" />}.
+   */
+  public static final @NotNull String TOP_TOOLBAR_EXTENSION_GROUP_ID = "Flutter.DebugProcess.TopToolbar";
+
+  private FlutterDebugProcessActions() {
+  }
+
+  public static void addTopToolbarExtensionActions(@NotNull DefaultActionGroup topToolbar) {
+    final AnAction action = ActionManager.getInstance().getAction(TOP_TOOLBAR_EXTENSION_GROUP_ID);
+    if (!(action instanceof ActionGroup actionGroup) || isEmpty(actionGroup)) {
+      return;
+    }
+
+    topToolbar.addSeparator();
+    topToolbar.addAction(action);
+  }
+
+  private static boolean isEmpty(@NotNull ActionGroup actionGroup) {
+    if (actionGroup instanceof DefaultActionGroup defaultActionGroup) {
+      return defaultActionGroup.getChildActionsOrStubs().length == 0;
+    }
+
+    return actionGroup.getChildren(null).length == 0;
+  }
+}

--- a/src/io/flutter/run/FlutterDebugProcessActions.java
+++ b/src/io/flutter/run/FlutterDebugProcessActions.java
@@ -5,7 +5,6 @@
  */
 package io.flutter.run;
 
-import com.intellij.openapi.actionSystem.ActionGroup;
 import com.intellij.openapi.actionSystem.ActionManager;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.DefaultActionGroup;
@@ -33,19 +32,13 @@ public final class FlutterDebugProcessActions {
    */
   public static void addTopToolbarExtensionActions(@NotNull DefaultActionGroup topToolbar) {
     final AnAction extensionGroupAction = ActionManager.getInstance().getAction(TOP_TOOLBAR_EXTENSION_GROUP_ID);
-    if (!(extensionGroupAction instanceof ActionGroup actionGroup) || isEmpty(actionGroup)) {
+    if (!(extensionGroupAction instanceof DefaultActionGroup extensionGroup) ||
+        extensionGroup.getChildActionsOrStubs().length == 0) {
       return;
     }
 
     topToolbar.addSeparator();
-    topToolbar.addAction(extensionGroupAction);
+    topToolbar.addAction(extensionGroup);
   }
 
-  private static boolean isEmpty(@NotNull ActionGroup actionGroup) {
-    if (actionGroup instanceof DefaultActionGroup defaultActionGroup) {
-      return defaultActionGroup.getChildActionsOrStubs().length == 0;
-    }
-
-    return actionGroup.getChildren(null).length == 0;
-  }
 }

--- a/src/io/flutter/run/bazelTest/BazelTestDebugProcess.java
+++ b/src/io/flutter/run/bazelTest/BazelTestDebugProcess.java
@@ -11,6 +11,7 @@ import com.intellij.openapi.actionSystem.DefaultActionGroup;
 import com.intellij.xdebugger.XDebugSession;
 import com.jetbrains.lang.dart.util.DartUrlResolver;
 import io.flutter.ObservatoryConnector;
+import io.flutter.run.FlutterDebugProcessActions;
 import io.flutter.run.FlutterPopFrameAction;
 import io.flutter.run.OpenDevToolsAction;
 import io.flutter.vmService.DartVmServiceDebugProcess;
@@ -40,6 +41,7 @@ public class BazelTestDebugProcess extends DartVmServiceDebugProcess {
     topToolbar.addSeparator();
     topToolbar.addAction(new FlutterPopFrameAction());
     topToolbar.addAction(new OpenDevToolsAction(connector, this::isActive));
+    FlutterDebugProcessActions.addTopToolbarExtensionActions(topToolbar);
   }
 
   private boolean isActive() {

--- a/src/io/flutter/run/test/TestDebugProcess.java
+++ b/src/io/flutter/run/test/TestDebugProcess.java
@@ -11,6 +11,7 @@ import com.intellij.openapi.actionSystem.DefaultActionGroup;
 import com.intellij.xdebugger.XDebugSession;
 import com.jetbrains.lang.dart.util.DartUrlResolver;
 import io.flutter.ObservatoryConnector;
+import io.flutter.run.FlutterDebugProcessActions;
 import io.flutter.run.FlutterPopFrameAction;
 import io.flutter.run.OpenDevToolsAction;
 import io.flutter.vmService.DartVmServiceDebugProcess;
@@ -40,6 +41,7 @@ public class TestDebugProcess extends DartVmServiceDebugProcess {
     topToolbar.addSeparator();
     topToolbar.addAction(new FlutterPopFrameAction());
     topToolbar.addAction(new OpenDevToolsAction(connector, this::isActive));
+    FlutterDebugProcessActions.addTopToolbarExtensionActions(topToolbar);
   }
 
   private boolean isActive() {


### PR DESCRIPTION
## What changed
- exposed a new public action group id: `Flutter.DebugProcess.TopToolbar`
- appended that group after Flutter's built-in debug toolbar actions in `FlutterDebugProcess`
- applied the same hook to Flutter test and Bazel test debug toolbars
- kept the group hidden when no downstream plugin contributes actions

## Why
`FlutterDebugProcess.registerAdditionalActions()` currently builds the top run/debug toolbar directly from code by mutating the runtime `DefaultActionGroup`. That makes the toolbar effectively closed to dependent plugins: there is no public action group id and no extension point they can target from `plugin.xml`.

Exposing a dedicated inline `ActionGroup` is the smallest platform-native way to make this extensible. Downstream plugins can now contribute with standard IntelliJ action registration, for example:

```xml
<action id="..." class="...">
  <add-to-group group-id="Flutter.DebugProcess.TopToolbar" anchor="last"/>
</action>
```

This avoids adding a new custom EP just to append toolbar actions, keeps the existing toolbar construction intact, and preserves current behavior when nobody contributes anything.

## Validation
- `./gradlew buildPlugin`
