### PR TITLE
[ai] add Claude config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,12 @@
+# Flutter IntelliJ Plugin — Claude Code Guide
+
+@.gemini/styleguide.md
+
+## Additional Rules
+
+- No I/O or heavy computation on the EDT (IntelliJ Threading Model).
+- All `AnAction` subclasses must be stateless (no mutable instance fields).
+- Use `io.flutter.logging.PluginLogger` (or IntelliJ's `Logger`) for all logging; never `System.out`.
+- All new files must include the standard Chromium Authors copyright header.
+- Zero-Formatting Policy: do not comment on indentation, spacing, or brace placement.
+- Categorize code suggestions with `[MUST-FIX]`, `[CONCERN]`, or `[NIT]` severity prefixes.


### PR DESCRIPTION
See: https://github.com/flutter/flutter-intellij/issues/8895

Adds `Claude.md` config.

The `@.gemini/styleguide.md` import pulls in the full styleguide automatically, and the additional rules below it mirror the key generation rules for Gemini from `.aiconfig`.

---

Review the contribution guidelines below:

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] I've included the required information in the description above.
- [x] My up-to-date information is in the `AUTHORS` file.
- [x] I've updated `CHANGELOG.md` if appropriate.

<details>
  <summary>Contribution guidelines:</summary><br>

- See
  our [contributor guide](../CONTRIBUTING.md) and
  the [Flutter organization contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md)
  for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use
  `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best
  practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).

</details>