### PR TITLE
[infra] include Android Studio in release printing

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -397,9 +397,11 @@ tasks {
       productsReleases.get().max()
       println()
       println("Mapping printProductsReleases output to ideV:")
-      println(" - The prefix (e.g., IU-, IC-) maps to -Pide (Ultimate, IntelliJ).")
+      println(" - The prefix (e.g., IU-, IC-, AI-) maps to -Pide (Ultimate, IntelliJ, Android Studio).")
       println(" - The number part (e.g., 261.23567.71) maps to -PideV.")
       println(" - Example: IU-261.23567.71 -> -Pide=Ultimate -PideV=261.23567.71")
+      println(" - Example: AI-2025.3.3.6 -> -Pide=AndroidStudio -PideV=2025.3.3.6")
+
       println()
     }
   }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -390,7 +390,7 @@ tasks {
 tasks {
   printProductsReleases {
     channels = listOf(ProductRelease.Channel.RELEASE, ProductRelease.Channel.EAP)
-    types = listOf(IntelliJPlatformType.IntellijIdeaCommunity, IntelliJPlatformType.IntellijIdeaUltimate)
+    types = listOf(IntelliJPlatformType.IntellijIdeaCommunity, IntelliJPlatformType.IntellijIdeaUltimate, IntelliJPlatformType.AndroidStudio)
     untilBuild = provider { null }
 
     doLast {


### PR DESCRIPTION
Added Android Studio to the release printing. Android studio releases are prefixed with "AI"

IU-261.23567.71
IU-2025.3.4
IC-2025.2.6.1
IU-2025.2.6.1
IC-2025.1.7
IU-2025.1.7
AI-2025.3.3.6
AI-2025.2.3.9
AI-2025.1.4.8