### PR TITLE
[infra] trigger kokoro builds w/ the “kokoro:run” label

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
       interval: "weekly"
     labels:
       - "autosubmit"
+      - "kokoro:run"
     # Updating patch versions for "github-actions" is too chatty.
     # See https://github.com/flutter/flutter/issues/158350.
     ignore:
@@ -18,3 +19,4 @@ updates:
       interval: "weekly"
     labels:
       - "autosubmit"
+      - "kokoro:run"


### PR DESCRIPTION
Auto apply the "kokoro:run" label to dependabot changes to get them to trigger kokoro builds so we can verify dependency updates.

See: https://github.com/flutter/dart-intellij-third-party/issues/369.



---

Review the contribution guidelines below:

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] I've included the required information in the description above.
- [x] My up-to-date information is in the `AUTHORS` file.
- [x] I've updated `CHANGELOG.md` if appropriate.

<details>
  <summary>Contribution guidelines:</summary><br>

- See
  our [contributor guide](../CONTRIBUTING.md) and
  the [Flutter organization contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md)
  for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use
  `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best
  practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).

</details>