### PR TITLE
[infra] support local dev-channel uploads

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,6 +15,10 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
+import org.gradle.api.DefaultTask
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
 
 // Specify UTF-8 for all compilations so we avoid Windows-1252.
 allprojects {
@@ -50,12 +54,16 @@ plugins {
 // By default (e.g. when we call `runIde` during development), the plugin version is SNAPSHOT
 var flutterPluginVersion = "SNAPSHOT"
 
+val isRelease = providers.gradleProperty("release").isPresent
+val isDev = providers.gradleProperty("dev").isPresent
+val singleIdeVersionProvider = providers.gradleProperty("singleIdeVersion")
+
 // Otherwise, we will decide on the proper semver-formatted version from the CHANGELOG.
 // Note: The CHANGELOG follows the style from https://keepachangelog.com/en/1.0.0/ so that we can use the gradle changelog plugin.
-if (project.hasProperty("release")) {
+if (isRelease) {
   // If we are building for a release, the changelog should be updated with the latest version.
   flutterPluginVersion = changelog.getLatest().version
-} else if (project.hasProperty("dev")) {
+} else if (isDev) {
   // If we are building the dev version, the version label will increment the latest version from the changelog and append the date.
   val latestVersion = changelog.getLatest().version
   val majorVersion = latestVersion.substringBefore('.').toInt()
@@ -63,8 +71,17 @@ if (project.hasProperty("release")) {
   val datestamp = DateTimeFormatter.ofPattern("yyyyMMdd").format(LocalDate.now())
   flutterPluginVersion = "$nextMajorVersion.0.0-dev.$datestamp"
 
-  val commitHash = System.getenv("KOKORO_GIT_COMMIT")
-  if (commitHash is String) {
+  val commitHash = System.getenv("KOKORO_GIT_COMMIT") ?: try {
+    providers.exec {
+      commandLine("git", "rev-parse", "--short", "HEAD")
+    }.standardOutput.asText.get().trim()
+  } catch (e: Exception) {
+    // Catching all exceptions here is intentional: if git is not installed, or if this is built
+    // outside of a git repository clone (e.g. from a source zip release), we want the build
+    // to gracefully proceed with an empty hash instead of crashing.
+    ""
+  }
+  if (commitHash.isNotEmpty()) {
     val shortCommitHash = commitHash.take(7)
     flutterPluginVersion += "-$shortCommitHash"
   }
@@ -305,8 +322,8 @@ intellijPlatform {
 
     ides {
       // `singleIdeVersion` is only intended for use by GitHub actions to enable deleting instances of IDEs after testing.
-      if (project.hasProperty("singleIdeVersion")) {
-        val singleIdeVersion = project.property("singleIdeVersion") as String
+      if (singleIdeVersionProvider.isPresent) {
+        val singleIdeVersion = singleIdeVersionProvider.get()
         select {
           types = listOf(IntelliJPlatformType.AndroidStudio)
           channels = listOf(ProductRelease.Channel.RELEASE)
@@ -322,7 +339,7 @@ intellijPlatform {
 
 // If we don't delete old versions of the IDE during `verifyPlugin`, then GitHub action bots can run out of space.
 tasks.withType<VerifyPluginTask> {
-  if (project.hasProperty("singleIdeVersion")) {
+  if (singleIdeVersionProvider.isPresent) {
     doLast {
       ides.forEach { ide ->
         if (ide.exists()) {
@@ -522,4 +539,18 @@ tasks.withType<ProcessResources>().configureEach {
     // The context here is unambiguously the task itself.
     exclude("jxbrowser/jxbrowser.properties")
   }
+}
+
+abstract class PrintVersionTask : DefaultTask() {
+  @get:Input
+  abstract val pluginVersion: Property<String>
+
+  @TaskAction
+  fun action() {
+    println(pluginVersion.get())
+  }
+}
+
+tasks.register<PrintVersionTask>("printVersion") {
+  pluginVersion.set(intellijPlatform.pluginConfiguration.version)
 }

--- a/tool/kokoro/deploy.sh
+++ b/tool/kokoro/deploy.sh
@@ -1,31 +1,43 @@
 #!/bin/bash
 
+# To run this script locally from the repository root:
+# JB_MARKETPLACE_TOKEN="your_real_token" ./tool/kokoro/deploy.sh
+
 source ./tool/kokoro/setup.sh
 setup
 
 echo "kokoro build start"
 
-./gradlew buildPlugin -Pdev
+./gradlew buildPlugin -Pdev --no-configuration-cache
 
 echo "kokoro build finished"
 
 echo "kokoro deploy start"
 
-KOKORO_TOKEN_FILE="${KOKORO_KEYSTORE_DIR}/${FLUTTER_KEYSTORE_ID}_${FLUTTER_KEYSTORE_NAME}"
-if [ ! -f "$KOKORO_TOKEN_FILE" ]; then
-  echo "Error: Keystore token file not found at $KOKORO_TOKEN_FILE"
-  exit 1
+if [ -n "$JB_MARKETPLACE_TOKEN" ]; then
+  TOKEN="$JB_MARKETPLACE_TOKEN"
+  echo "Using token from JB_MARKETPLACE_TOKEN environment variable."
+else
+  KOKORO_TOKEN_FILE="${KOKORO_KEYSTORE_DIR}/${FLUTTER_KEYSTORE_ID}_${FLUTTER_KEYSTORE_NAME}"
+  if [ ! -f "$KOKORO_TOKEN_FILE" ]; then
+    echo "Error: Keystore token file not found at $KOKORO_TOKEN_FILE"
+    echo "Please set JB_MARKETPLACE_TOKEN or ensure KOKORO_KEYSTORE_DIR is set correctly."
+    exit 1
+  fi
+  TOKEN=$(cat "$KOKORO_TOKEN_FILE")
 fi
-TOKEN=$(cat "$KOKORO_TOKEN_FILE")
 
 ZIP_FILE="build/distributions/flutter-intellij-kokoro.zip"
+if [ ! -f "$ZIP_FILE" ]; then
+  ZIP_FILE="build/distributions/flutter-intellij.zip"
+fi
 if [ ! -f "$ZIP_FILE" ]; then
   echo "Error: Zip file not found at $ZIP_FILE"
   exit 1
 fi
 
 echo "Uploading $ZIP_FILE to JetBrains Marketplace..."
-curl -if --fail \
+curl -i \
   --header "Authorization: Bearer $TOKEN" \
   -F pluginId=9212 \
   -F file=@"$ZIP_FILE" \

--- a/tool/kokoro/deploy.sh
+++ b/tool/kokoro/deploy.sh
@@ -37,7 +37,7 @@ if [ ! -f "$ZIP_FILE" ]; then
 fi
 
 echo "Uploading $ZIP_FILE to JetBrains Marketplace..."
-curl -i \
+curl -if \
   --header "Authorization: Bearer $TOKEN" \
   -F pluginId=9212 \
   -F file=@"$ZIP_FILE" \

--- a/tool/kokoro/setup.sh
+++ b/tool/kokoro/setup.sh
@@ -32,8 +32,12 @@ setup() {
 
   export JAVA_OPTS=" -Djava.net.preferIPv4Stack=false -Djava.net.preferIPv6Addresses=true"
 
-  # Clone and configure Flutter to the latest stable release
-  git clone --depth 1 https://github.com/flutter/flutter.git ../flutter
+  # Clone and configure Flutter to the latest stable release if not present
+  if [ ! -d "../flutter" ]; then
+    git clone --depth 1 https://github.com/flutter/flutter.git ../flutter
+  else
+    echo "../flutter already exists, skipping clone."
+  fi
   export PATH="$PATH":`pwd`/../flutter/bin:`pwd`/../flutter/bin/cache/dart-sdk/bin
   flutter config --no-analytics
   flutter doctor


### PR DESCRIPTION
Adds support for local `dev` channel builds and deployments to the JetBrains Marketplace for `flutter-intellij`, comparable to what we did for the Dart plugin: https://github.com/flutter/dart-intellij-third-party/pull/340.

Along the way we found some gradle issues and curl failures and added safeguards for Gradle Configuration Cache invalidation and more verbose local diagnostics.

Fixes: https://github.com/flutter/flutter-intellij/issues/8925


---

### Key Changes

#### 1. Gradle Build & Versioning (`build.gradle.kts`)
- **Dynamic Git Hash Fallback**: Dynamically resolves the Git commit hash prefix (`git rev-parse --short HEAD`) as part of the `dev` channel version calculation if the `KOKORO_GIT_COMMIT` environment variable is absent.
- **Configuration-Cache Safety**: Refactored the `dev`, `release`, and `singleIdeVersion` project property lookups to use the modern Gradle `providers.gradleProperty(...)` API. This registers properties as configuration inputs, ensuring correct cache invalidation when switching project parameters.
- **Dynamic Version Inspection**: Registered a new, configuration-cache safe `printVersion` task to easily query the calculated plugin version from the command line.
- **Robust Catching**: Handled potential compilation/CLI environment crashes gracefully (e.g., if git is not present or executing outside of a git clone) with comprehensive code comments.

#### 2. Kokoro Deployment Pipeline (`tool/kokoro/deploy.sh`)
- **Token Injection**: Added support for the `JB_MARKETPLACE_TOKEN` environment variable to allow local authorization token injection.
- **Visible Debugging**: Removed the `--fail` option and replaced it with `curl -i` to ensure full JetBrains Marketplace error payloads are printed directly to standard output on error rather than hidden behind generic curl exit codes.
- **Robust Zip Path Matching**: Fallback to `flutter-intellij.zip` automatically if not running inside the Kokoro pipeline directory structure.
- **Local Setup Quality-of-Life**: Updated `setup.sh` to bypass cloning the Flutter SDK if `../flutter` is already present locally, making local pipeline test runs pain-free.

---

### Verification & Testing

#### 1. Version calculation matches local Git state:
```bash
$ ./gradlew printVersion -Pdev
flutterPluginVersion: 93.0.0-dev.20260506-9a1a847
...
> Task :printVersion
93.0.0-dev.20260506-9a1a847
```

**Verified deployment** 👍 : 

<img width="2314" height="772" alt="image" src="https://github.com/user-attachments/assets/0059bb70-31a7-4401-bcd1-20077f56431b" />

---

Review the contribution guidelines below:

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] I've included the required information in the description above.
- [x] My up-to-date information is in the `AUTHORS` file.
- [x] I've updated `CHANGELOG.md` if appropriate.

<details>
  <summary>Contribution guidelines:</summary><br>

- See
  our [contributor guide](../CONTRIBUTING.md) and
  the [Flutter organization contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md)
  for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use
  `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best
  practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).

</details>