### PR TITLE
[infra] provision flutter from a gstore archive

### DIFF
--- a/tool/github.sh
+++ b/tool/github.sh
@@ -20,8 +20,24 @@ ls $JAVA_HOME
 echo "export PATH=$JAVA_HOME/bin:\$PATH"
 export PATH=$JAVA_HOME/bin:$PATH
 
-# Clone and configure Flutter to the latest stable release
-git clone --depth 1 https://github.com/flutter/flutter.git ../flutter
+# Download and configure Flutter to the pinned stable release if not present
+if [ ! -d "../flutter" ]; then
+  OS_NAME=$(uname -s | tr '[:upper:]' '[:lower:]')
+  FLUTTER_VERSION="3.22.0"
+  
+  echo "Provisioning Flutter SDK version ${FLUTTER_VERSION} for ${OS_NAME}..."
+  if [ "$OS_NAME" = "darwin" ]; then
+    curl -O "https://storage.googleapis.com/flutter_infra_release/releases/stable/macos/flutter_macos_${FLUTTER_VERSION}-stable.zip"
+    unzip -q "flutter_macos_${FLUTTER_VERSION}-stable.zip" -d ../
+    rm "flutter_macos_${FLUTTER_VERSION}-stable.zip"
+  else
+    curl -O "https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_${FLUTTER_VERSION}-stable.tar.xz"
+    tar xf "flutter_linux_${FLUTTER_VERSION}-stable.tar.xz" -C ../
+    rm "flutter_linux_${FLUTTER_VERSION}-stable.tar.xz"
+  fi
+else
+  echo "../flutter already exists, skipping download."
+fi
 export PATH="$PATH":`pwd`/../flutter/bin:`pwd`/../flutter/bin/cache/dart-sdk/bin
 flutter config --no-analytics
 flutter doctor

--- a/tool/github.sh
+++ b/tool/github.sh
@@ -23,7 +23,7 @@ export PATH=$JAVA_HOME/bin:$PATH
 # Download and configure Flutter to the pinned stable release if not present
 if [ ! -d "../flutter" ]; then
   OS_NAME=$(uname -s | tr '[:upper:]' '[:lower:]')
-  FLUTTER_VERSION="3.22.0"
+  FLUTTER_VERSION="3.41.0"
   
   echo "Provisioning Flutter SDK version ${FLUTTER_VERSION} for ${OS_NAME}..."
   if [ "$OS_NAME" = "darwin" ]; then

--- a/tool/github.sh
+++ b/tool/github.sh
@@ -21,23 +21,7 @@ echo "export PATH=$JAVA_HOME/bin:\$PATH"
 export PATH=$JAVA_HOME/bin:$PATH
 
 # Download and configure Flutter to the pinned stable release if not present
-if [ ! -d "../flutter" ]; then
-  OS_NAME=$(uname -s | tr '[:upper:]' '[:lower:]')
-  FLUTTER_VERSION="3.41.0"
-  
-  echo "Provisioning Flutter SDK version ${FLUTTER_VERSION} for ${OS_NAME}..."
-  if [ "$OS_NAME" = "darwin" ]; then
-    curl -O "https://storage.googleapis.com/flutter_infra_release/releases/stable/macos/flutter_macos_${FLUTTER_VERSION}-stable.zip"
-    unzip -q "flutter_macos_${FLUTTER_VERSION}-stable.zip" -d ../
-    rm "flutter_macos_${FLUTTER_VERSION}-stable.zip"
-  else
-    curl -O "https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_${FLUTTER_VERSION}-stable.tar.xz"
-    tar xf "flutter_linux_${FLUTTER_VERSION}-stable.tar.xz" -C ../
-    rm "flutter_linux_${FLUTTER_VERSION}-stable.tar.xz"
-  fi
-else
-  echo "../flutter already exists, skipping download."
-fi
+source ./tool/provision_flutter.sh
 export PATH="$PATH":`pwd`/../flutter/bin:`pwd`/../flutter/bin/cache/dart-sdk/bin
 flutter config --no-analytics
 flutter doctor

--- a/tool/kokoro/setup.sh
+++ b/tool/kokoro/setup.sh
@@ -32,8 +32,24 @@ setup() {
 
   export JAVA_OPTS=" -Djava.net.preferIPv4Stack=false -Djava.net.preferIPv6Addresses=true"
 
-  # Clone and configure Flutter to the latest stable release
-  git clone --depth 1 https://github.com/flutter/flutter.git ../flutter
+  # Download and configure Flutter to the pinned stable release if not present
+  if [ ! -d "../flutter" ]; then
+    OS_NAME=$(uname -s | tr '[:upper:]' '[:lower:]')
+    FLUTTER_VERSION="3.22.0"
+    
+    echo "Provisioning Flutter SDK version ${FLUTTER_VERSION} for ${OS_NAME}..."
+    if [ "$OS_NAME" = "darwin" ]; then
+      curl -O "https://storage.googleapis.com/flutter_infra_release/releases/stable/macos/flutter_macos_${FLUTTER_VERSION}-stable.zip"
+      unzip -q "flutter_macos_${FLUTTER_VERSION}-stable.zip" -d ../
+      rm "flutter_macos_${FLUTTER_VERSION}-stable.zip"
+    else
+      curl -O "https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_${FLUTTER_VERSION}-stable.tar.xz"
+      tar xf "flutter_linux_${FLUTTER_VERSION}-stable.tar.xz" -C ../
+      rm "flutter_linux_${FLUTTER_VERSION}-stable.tar.xz"
+    fi
+  else
+    echo "../flutter already exists, skipping download."
+  fi
   export PATH="$PATH":`pwd`/../flutter/bin:`pwd`/../flutter/bin/cache/dart-sdk/bin
   flutter config --no-analytics
   flutter doctor

--- a/tool/kokoro/setup.sh
+++ b/tool/kokoro/setup.sh
@@ -33,23 +33,7 @@ setup() {
   export JAVA_OPTS=" -Djava.net.preferIPv4Stack=false -Djava.net.preferIPv6Addresses=true"
 
   # Download and configure Flutter to the pinned stable release if not present
-  if [ ! -d "../flutter" ]; then
-    OS_NAME=$(uname -s | tr '[:upper:]' '[:lower:]')
-    FLUTTER_VERSION="3.22.0"
-    
-    echo "Provisioning Flutter SDK version ${FLUTTER_VERSION} for ${OS_NAME}..."
-    if [ "$OS_NAME" = "darwin" ]; then
-      curl -O "https://storage.googleapis.com/flutter_infra_release/releases/stable/macos/flutter_macos_${FLUTTER_VERSION}-stable.zip"
-      unzip -q "flutter_macos_${FLUTTER_VERSION}-stable.zip" -d ../
-      rm "flutter_macos_${FLUTTER_VERSION}-stable.zip"
-    else
-      curl -O "https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_${FLUTTER_VERSION}-stable.tar.xz"
-      tar xf "flutter_linux_${FLUTTER_VERSION}-stable.tar.xz" -C ../
-      rm "flutter_linux_${FLUTTER_VERSION}-stable.tar.xz"
-    fi
-  else
-    echo "../flutter already exists, skipping download."
-  fi
+  source ./tool/provision_flutter.sh
   export PATH="$PATH":`pwd`/../flutter/bin:`pwd`/../flutter/bin/cache/dart-sdk/bin
   flutter config --no-analytics
   flutter doctor

--- a/tool/provision_flutter.sh
+++ b/tool/provision_flutter.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Copyright 2026 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# Fail on any error.
+set -e
+
+# Provision the pinned Flutter SDK if not present
+if [ ! -d "../flutter" ]; then
+  OS_NAME=$(uname -s | tr '[:upper:]' '[:lower:]')
+  FLUTTER_VERSION="3.41.0"
+  
+  echo "Provisioning Flutter SDK version ${FLUTTER_VERSION} for ${OS_NAME}..."
+  if [ "$OS_NAME" = "darwin" ]; then
+    curl -fLO "https://storage.googleapis.com/flutter_infra_release/releases/stable/macos/flutter_macos_${FLUTTER_VERSION}-stable.zip"
+    unzip -q "flutter_macos_${FLUTTER_VERSION}-stable.zip" -d ../
+    rm "flutter_macos_${FLUTTER_VERSION}-stable.zip"
+  else
+    curl -fLO "https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_${FLUTTER_VERSION}-stable.tar.xz"
+    tar xf "flutter_linux_${FLUTTER_VERSION}-stable.tar.xz" -C ../
+    rm "flutter_linux_${FLUTTER_VERSION}-stable.tar.xz"
+  fi
+else
+  echo "../flutter already exists, skipping download."
+fi


### PR DESCRIPTION
Moves Flutter provisioning from a `git clone` to pulling down an archive which is **much faster**.

First run is coming in at just under 17 minutes; down from an hour:

<img width="949" height="254" alt="image" src="https://github.com/user-attachments/assets/37d3f816-0996-410d-91a5-caca882fd815" />

---

If this sticks, we'll be waiting 71.7% less time for builds to complete, and our deployment pipeline will be running 253% faster than it used to be. 🚀 

Fixes: https://github.com/flutter/flutter-intellij/issues/8950

---

Review the contribution guidelines below:

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] I've included the required information in the description above.
- [x] My up-to-date information is in the `AUTHORS` file.
- [x] I've updated `CHANGELOG.md` if appropriate.

<details>
  <summary>Contribution guidelines:</summary><br>

- See
  our [contributor guide](../CONTRIBUTING.md) and
  the [Flutter organization contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md)
  for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use
  `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best
  practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).

</details>