### PR TITLE
[friction] ignore `bin`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 .vscode/
 .sandbox/
 artifacts/
+bin/
 build/
 flutter-gui-tests/.gradle/
 flutter-gui-tests/guitest.log

--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@
 .vscode/
 .sandbox/
 artifacts/
-bin/
+/bin/
 build/
 flutter-gui-tests/.gradle/
 flutter-gui-tests/guitest.log


### PR DESCRIPTION
Agents love to create stuff in `bin` which we have to manually ignore. The right thing to do is to git ignore the directory.



---

Review the contribution guidelines below:

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] I've included the required information in the description above.
- [x] My up-to-date information is in the `AUTHORS` file.
- [x] I've updated `CHANGELOG.md` if appropriate.

<details>
  <summary>Contribution guidelines:</summary><br>

- See
  our [contributor guide](../CONTRIBUTING.md) and
  the [Flutter organization contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md)
  for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use
  `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best
  practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).

</details>