### PR TITLE
[infra] Flutter SDK version checking/updating automation

### DIFF
--- a/.github/workflows/update_flutter.yaml
+++ b/.github/workflows/update_flutter.yaml
@@ -28,7 +28,7 @@ jobs:
           echo "Current pinned version: $CURRENT_VERSION"
 
           # 2. Retrieve the latest stable version from Flutter's official releases manifest
-          LATEST_VERSION=$(curl -s https://storage.googleapis.com/flutter_infra_release/releases/releases_linux.json | jq -r '.current_release.stable')
+          LATEST_VERSION=$(curl -s https://storage.googleapis.com/flutter_infra_release/releases/releases_linux.json | jq -r '.releases | map(select(.channel == "stable"))[0].version')
           echo "Latest stable version: $LATEST_VERSION"
 
           # 3. Compare and update if a newer version is available

--- a/.github/workflows/update_flutter.yaml
+++ b/.github/workflows/update_flutter.yaml
@@ -1,0 +1,61 @@
+# Copyright 2026 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+name: Update Flutter SDK Pin
+
+on:
+  schedule:
+    - cron: '0 0 * * 1' # Run every Monday at midnight UTC
+  workflow_dispatch: # Allow manual execution from the Actions tab
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  check-and-update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Check for New Flutter stable version
+        id: check-version
+        run: |
+          # 1. Retrieve the current pinned version from the shared script
+          CURRENT_VERSION=$(grep -E 'FLUTTER_VERSION="[0-9.]+"' tool/provision_flutter.sh | head -n 1 | cut -d'"' -f2)
+          echo "Current pinned version: $CURRENT_VERSION"
+
+          # 2. Retrieve the latest stable version from Flutter's official releases manifest
+          LATEST_VERSION=$(curl -s https://storage.googleapis.com/flutter_infra_release/releases/releases_linux.json | jq -r '.current_release.stable')
+          echo "Latest stable version: $LATEST_VERSION"
+
+          # 3. Compare and update if a newer version is available
+          if [ "$CURRENT_VERSION" != "$LATEST_VERSION" ]; then
+            echo "New Flutter stable version detected: $LATEST_VERSION"
+            sed -i -e "s/FLUTTER_VERSION=\"$CURRENT_VERSION\"/FLUTTER_VERSION=\"$LATEST_VERSION\"/g" tool/provision_flutter.sh
+            echo "updated=true" >> $GITHUB_OUTPUT
+            echo "latest_version=$LATEST_VERSION" >> $GITHUB_OUTPUT
+          else
+            echo "Flutter SDK is already up to date."
+            echo "updated=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create Pull Request for Version Bump
+        if: steps.check-version.outputs.updated == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "ci: bump pinned Flutter SDK to version ${{ steps.check-version.outputs.latest_version }}"
+          title: "ci: bump pinned Flutter SDK to version ${{ steps.check-version.outputs.latest_version }}"
+          body: |
+            An automated check has detected a new stable release of the Flutter SDK.
+            
+            * **New Pinned Version**: `${{ steps.check-version.outputs.latest_version }}`
+            
+            This Pull Request updates our shared provisioning script (`tool/provision_flutter.sh`) to target this version. All presubmit tests will be run against this version to verify compatibility.
+          branch: "auto-update-flutter-sdk"
+          delete-branch: true
+          labels: |
+            dependencies
+            ci

--- a/testSrc/unit/io/flutter/CIIntegrityTest.java
+++ b/testSrc/unit/io/flutter/CIIntegrityTest.java
@@ -46,9 +46,9 @@ public class CIIntegrityTest {
 
     // Ensure the shell script declares the version constant in a predictable pattern:
     // E.g. FLUTTER_VERSION="3.41.0"
-    Pattern versionPattern = Pattern.compile("FLUTTER_VERSION=\"\\d+\\.\\d+\\.\\d+\"");
+    Pattern versionPattern = Pattern.compile("FLUTTER_VERSION=\"[0-9.]+\"");
     assertTrue(
-      "provision_flutter.sh must define a constant FLUTTER_VERSION matching semver format (e.g., FLUTTER_VERSION=\"3.41.0\"). " +
+      "provision_flutter.sh must define a constant FLUTTER_VERSION matching the expected format (e.g., FLUTTER_VERSION=\"3.41.0\"). " +
       "This constant is critical because the automated GitHub Actions updater searches for this exact pattern to bump the version.",
       versionPattern.matcher(content).find()
     );

--- a/testSrc/unit/io/flutter/CIIntegrityTest.java
+++ b/testSrc/unit/io/flutter/CIIntegrityTest.java
@@ -69,11 +69,13 @@ public class CIIntegrityTest {
 
     String content = Files.readString(workflowFile.toPath());
 
-    // The workflow must use the exact same constant name in its grep/sed matching regex
+    // The workflow must use the constant name followed by a flexible regex query in single or double quotes.
+    // E.g., matches 'FLUTTER_VERSION="[0-9.]+"' or 'FLUTTER_VERSION="[0-9.]*"' or "FLUTTER_VERSION='[0-9.]+'"
+    Pattern regexPattern = Pattern.compile("FLUTTER_VERSION=['\"].+?['\"]");
     assertTrue(
-      "update_flutter.yaml must reference the 'FLUTTER_VERSION=\"[0-9.]+\"' constant in its search-and-replace step. " +
-      "If you renamed this constant in tool/provision_flutter.sh, you must also update it inside update_flutter.yaml.",
-      content.contains("FLUTTER_VERSION=\"[0-9.]+\"")
+      "update_flutter.yaml must reference the 'FLUTTER_VERSION' constant with a regex pattern (e.g. 'FLUTTER_VERSION=\"[0-9.]+\"') " +
+      "in its search-and-replace logic.",
+      regexPattern.matcher(content).find()
     );
   }
 }

--- a/testSrc/unit/io/flutter/CIIntegrityTest.java
+++ b/testSrc/unit/io/flutter/CIIntegrityTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2026 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter;
+
+import org.junit.Test;
+import java.io.File;
+import java.nio.file.Files;
+import java.util.regex.Pattern;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Integrity tests for the CI/CD automation pipeline.
+ * <p>
+ * <b>Why this exists:</b>
+ * Our CI/CD scripts rely on a shared bash script to provision the Flutter SDK, and a
+ * scheduled GitHub Actions workflow to automatically check for new Flutter stable releases
+ * and submit version-bumping Pull Requests.
+ * <p>
+ * If a developer modifies the provisioning script (e.g., renaming the constant FLUTTER_VERSION)
+ * or alters the regex search format without updating the GitHub Actions workflow, the automation
+ * will fail silently in production.
+ * <p>
+ * This class acts as a "meta-test" or "integrity-check" that runs during standard project
+ * compilations (`./gradlew test`) to give developers an immediate early warning of synchronization
+ * failures before code is merged.
+ */
+public class CIIntegrityTest {
+
+  /**
+   * Verifies that the Flutter SDK provisioning script exists at the expected path
+   * and defines the `FLUTTER_VERSION` constant in the exact semver format required.
+   * <p>
+   * If this test fails, it means `tool/provision_flutter.sh` was moved, deleted, or
+   * the `FLUTTER_VERSION` constant definition was formatted incorrectly (or renamed).
+   */
+  @Test
+  public void testFlutterProvisioningScriptIntegrity() throws Exception {
+    // The JVM's Current Working Directory (CWD) during unit tests is the repository root.
+    File scriptFile = new File("tool/provision_flutter.sh");
+    assertTrue("provision_flutter.sh must exist at the repository root 'tool/' directory", scriptFile.exists());
+
+    String content = Files.readString(scriptFile.toPath());
+
+    // Ensure the shell script declares the version constant in a predictable pattern:
+    // E.g. FLUTTER_VERSION="3.41.0"
+    Pattern versionPattern = Pattern.compile("FLUTTER_VERSION=\"\\d+\\.\\d+\\.\\d+\"");
+    assertTrue(
+      "provision_flutter.sh must define a constant FLUTTER_VERSION matching semver format (e.g., FLUTTER_VERSION=\"3.41.0\"). " +
+      "This constant is critical because the automated GitHub Actions updater searches for this exact pattern to bump the version.",
+      versionPattern.matcher(content).find()
+    );
+  }
+
+  /**
+   * Verifies that the automated GitHub Actions updater workflow is synchronized
+   * with the provisioning script.
+   * <p>
+   * Specifically, it ensures the workflow searches for the exact constant pattern
+   * `FLUTTER_VERSION="[0-9.]+"` to perform its automated string replacement. If a developer
+   * renames the constant in the script, they MUST also update the workflow, otherwise this test fails.
+   */
+  @Test
+  public void testGitHubWorkflowRegexSync() throws Exception {
+    File workflowFile = new File(".github/workflows/update_flutter.yaml");
+    assertTrue("update_flutter.yaml workflow must exist in the '.github/workflows/' directory", workflowFile.exists());
+
+    String content = Files.readString(workflowFile.toPath());
+
+    // The workflow must use the exact same constant name in its grep/sed matching regex
+    assertTrue(
+      "update_flutter.yaml must reference the 'FLUTTER_VERSION=\"[0-9.]+\"' constant in its search-and-replace step. " +
+      "If you renamed this constant in tool/provision_flutter.sh, you must also update it inside update_flutter.yaml.",
+      content.contains("FLUTTER_VERSION=\"[0-9.]+\"")
+    );
+  }
+}

--- a/tool/provision_flutter.sh
+++ b/tool/provision_flutter.sh
@@ -9,7 +9,7 @@ set -e
 # Provision the pinned Flutter SDK if not present
 if [ ! -d "../flutter" ]; then
   OS_NAME=$(uname -s | tr '[:upper:]' '[:lower:]')
-  FLUTTER_VERSION="3.41.0"
+  FLUTTER_VERSION="3.22.0"
   
   echo "Provisioning Flutter SDK version ${FLUTTER_VERSION} for ${OS_NAME}..."
   if [ "$OS_NAME" = "darwin" ]; then

--- a/tool/provision_flutter.sh
+++ b/tool/provision_flutter.sh
@@ -9,7 +9,7 @@ set -e
 # Provision the pinned Flutter SDK if not present
 if [ ! -d "../flutter" ]; then
   OS_NAME=$(uname -s | tr '[:upper:]' '[:lower:]')
-  FLUTTER_VERSION="3.22.0"
+  FLUTTER_VERSION="3.38.0"
   
   echo "Provisioning Flutter SDK version ${FLUTTER_VERSION} for ${OS_NAME}..."
   if [ "$OS_NAME" = "darwin" ]; then

--- a/tool/provision_flutter.sh
+++ b/tool/provision_flutter.sh
@@ -9,7 +9,9 @@ set -e
 # Provision the pinned Flutter SDK if not present
 if [ ! -d "../flutter" ]; then
   OS_NAME=$(uname -s | tr '[:upper:]' '[:lower:]')
-  FLUTTER_VERSION="3.38.0"
+  # Pinned Flutter SDK version. This constant is automatically checked and updated weekly
+  # by the .github/workflows/update_flutter.yaml GitHub Actions workflow.
+  FLUTTER_VERSION="3.41.0"
   
   echo "Provisioning Flutter SDK version ${FLUTTER_VERSION} for ${OS_NAME}..."
   if [ "$OS_NAME" = "darwin" ]; then


### PR DESCRIPTION
## CI/CD Automation: Automated Flutter SDK Version Bumping & Integrity Verification

### Why This Matters

To ensure stable and reproducible builds, our CI/CD scripts are pinned to a specific stable version of the Flutter SDK in `tool/provision_flutter.sh` (see: #8951). Manually monitoring and upgrading this pin is tedious, while a rolling pin risks introducing silent test breakages.

This PR automates the maintenance of our pinned Flutter SDK version with safe, presubmit-verified upgrades, backed by compile-time integrity checks to prevent syntax or synchronization bugs.

Fixes: https://github.com/flutter/flutter-intellij/issues/8953

---

### Proposed Changes

#### 1. Automated Version-Pin Bumping
* **[NEW] [.github/workflows/update_flutter.yaml](file:///+github/workflows/update_flutter.yaml)**: Added a scheduled weekly GitHub Actions workflow (running every Monday at midnight) that:
  * Queries the official Flutter GCS manifest API for new stable releases.
  * Extracts and compares the latest version with our current pin inside `tool/provision_flutter.sh`.
  * If a newer version is available, it automatically edits the version constant in the script and opens a structured Pull Request so that standard presubmit checks run against the new version prior to merging.

#### 2. Compile-Time Integrity Verification
* **[NEW] [testSrc/unit/io/flutter/CIIntegrityTest.java](file:///testSrc/unit/io/flutter/CIIntegrityTest.java)**: Added a custom JUnit meta-test to enforce synchronization between the provisioning script and the GitHub Action:
  * `testFlutterProvisioningScriptIntegrity()`: Asserts `tool/provision_flutter.sh` exists and contains a valid semver-formatted `FLUTTER_VERSION="..."` constant.
  * `testGitHubWorkflowRegexSync()`: Asserts `.github/workflows/update_flutter.yaml` matches the exact constant pattern used in its search-and-replace step.
  * *Why this is here*: Prevents silent setup failures if a developer renames or reformats the version constant in the future.

---

### Verification Results

1. **JUnit Integrity Tests**: Ran the integrity suite locally:
   ```bash
   ./gradlew test --tests io.flutter.CIIntegrityTest

Result: BUILD SUCCESSFUL (Both assertions compiled and passed successfully in 4 seconds).


2. **Local Run**:

Until this is landed the action can't be tested on GH but this verifies that it should work:

```
☁  flutter-intellij [infra_flutterSdkWorkflow] ⚡  # 1. Read the current pinned version from the script (should print 3.41.0)
CURRENT_VERSION=$(grep -E 'FLUTTER_VERSION="[0-9.]+"' tool/provision_flutter.sh | head -n 1 | cut -d'"' -f2)
echo "Current pinned version: $CURRENT_VERSION"
# 2. Query the live Flutter API for the latest stable release version (should print 3.41.9+)
LATEST_VERSION=$(curl -s https://storage.googleapis.com/flutter_infra_release/releases/releases_linux.json | jq -r '.releases | map(select(.channel == "stable"))[0].version')
echo "Latest stable version: $LATEST_VERSION"
# 3. Run the comparison and update logic
if [ "$CURRENT_VERSION" != "$LATEST_VERSION" ]; then
  echo "New stable version detected: $LATEST_VERSION. Updating script..."

  # Perform the replacement (cross-compatible sed for macOS)
  sed -i "" "s/FLUTTER_VERSION=\"$CURRENT_VERSION\"/FLUTTER_VERSION=\"$LATEST_VERSION\"/g" tool/provision_flutter.sh

  echo "Successfully updated! Checking file content:"
  grep "FLUTTER_VERSION=" tool/provision_flutter.sh
else
  echo "Flutter SDK is already up to date."
fi
Current pinned version: 3.41.0
Latest stable version: 3.41.9
New stable version detected: 3.41.9. Updating script...
Successfully updated! Checking file content:
  FLUTTER_VERSION="3.41.9"
```




---

Review the contribution guidelines below:

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] I've included the required information in the description above.
- [x] My up-to-date information is in the `AUTHORS` file.
- [x] I've updated `CHANGELOG.md` if appropriate.

<details>
  <summary>Contribution guidelines:</summary><br>

- See
  our [contributor guide](../CONTRIBUTING.md) and
  the [Flutter organization contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md)
  for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use
  `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best
  practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).

</details>