### PR TITLE
[infra] authenticate version-updater via flutteractionsbot

### DIFF
--- a/.github/workflows/update_flutter.yaml
+++ b/.github/workflows/update_flutter.yaml
@@ -49,6 +49,7 @@ jobs:
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.FLUTTERACTIONSBOT_CP_TOKEN }}
+          push-to-fork: flutteractionsbot/flutter-intellij
           committer: flutteractionsbot <flutter-actions-bot@google.com>
           author: flutteractionsbot <flutter-actions-bot@google.com>
           commit-message: "ci: bump pinned Flutter SDK to version ${{ steps.check-version.outputs.latest_version }}"

--- a/.github/workflows/update_flutter.yaml
+++ b/.github/workflows/update_flutter.yaml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.FLUTTERACTIONSBOT_CP_TOKEN }}
 
       - name: Check for New Flutter stable version
         id: check-version
@@ -46,6 +48,9 @@ jobs:
         if: steps.check-version.outputs.updated == 'true'
         uses: peter-evans/create-pull-request@v6
         with:
+          token: ${{ secrets.FLUTTERACTIONSBOT_CP_TOKEN }}
+          committer: flutteractionsbot <flutter-actions-bot@google.com>
+          author: flutteractionsbot <flutter-actions-bot@google.com>
           commit-message: "ci: bump pinned Flutter SDK to version ${{ steps.check-version.outputs.latest_version }}"
           title: "ci: bump pinned Flutter SDK to version ${{ steps.check-version.outputs.latest_version }}"
           body: |


### PR DESCRIPTION
Our automated Flutter SDK version-bump presubmit was failing to trigger subsequent CI/CD test workflows and was getting blocked by Google's CLA check.  (See for example: #8955.) 

* Standard `GITHUB_TOKEN` creations do not trigger downstream actions on PR creation (preventing presubmit tests from running on the PR).
* system `github-actions[bot]` commits are not registered with Google's CLA bot, blocking the merge path.

This PR configures the workflow to authenticate using our organization's pre-approved `flutteractionsbot` credentials, enabling instant CLA compliance and automatic presubmit test execution. (Note I had to create a fork of this repo for `flutteractionsbot` behind the scenes, explaining some action failures leading up to the success below).

I verified this works by manually kicking off the action, which produced this PR:

https://github.com/flutter/flutter-intellij/pull/8958

which has the right CLA credentials:

<img width="1832" height="534" alt="image" src="https://github.com/user-attachments/assets/c39b2e4c-910b-4399-9d81-cd743b80cf9b" />

Completes the work started in #8953. 

🚀 🚀 🚀 

---

### Proposed Changes

* **[Modified] [.github/workflows/update_flutter.yaml](file:///+github/workflows/update_flutter.yaml)**: 
  * Configured the `Checkout` and `Create Pull Request` steps to authenticate via the organization's `secrets.FLUTTERACTIONSBOT_CP_TOKEN` PAT.
  * Explicitly overrode `committer` and `author` git metadata to match `flutteractionsbot <flutter-actions-bot@google.com>` to pass Google's CLA checks automatically.
  * Configured `push-to-fork: flutteractionsbot/flutter-intellij` to push the PR branch to the bot's fork, bypassing upstream main-branch push restrictions.

---

### Verification Results
* **JUnit Integrity Tests**: Checked locally using `./gradlew test --tests io.flutter.CIIntegrityTest` — **BUILD SUCCESSFUL** (all meta-tests compile and pass).
* **YAML Syntax Vetted**: Validated structured parameters against the latest `peter-evans/create-pull-request` specifications.

Replaces https://github.com/flutter/flutter-intellij/pull/8956

---

Review the contribution guidelines below:

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] I've included the required information in the description above.
- [x] My up-to-date information is in the `AUTHORS` file.
- [x] I've updated `CHANGELOG.md` if appropriate.

<details>
  <summary>Contribution guidelines:</summary><br>

- See
  our [contributor guide](../CONTRIBUTING.md) and
  the [Flutter organization contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md)
  for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use
  `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best
  practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).

</details>