### PR TITLE
Update env for calling tools

### DIFF
--- a/src/io/flutter/run/SdkFields.java
+++ b/src/io/flutter/run/SdkFields.java
@@ -18,6 +18,7 @@ import com.intellij.util.xmlb.annotations.OptionTag;
 import com.intellij.util.xmlb.annotations.XMap;
 import com.jetbrains.lang.dart.sdk.DartConfigurable;
 import com.jetbrains.lang.dart.sdk.DartSdk;
+import com.jetbrains.lang.dart.analytics.Analytics;
 import io.flutter.FlutterBundle;
 import io.flutter.FlutterUtils;
 import io.flutter.dart.DartPlugin;
@@ -240,7 +241,9 @@ public class SdkFields {
     command = flutterSdk.flutterRun(root, main.getFile(), device, runMode, flutterLaunchMode, project, args);
     final GeneralCommandLine commandLine = command.createGeneralCommandLine(project);
     commandLine.getEnvironment().putAll(getEnvs());
+    Analytics.updateEnvironment(commandLine);
     commandLine.withParentEnvironmentType(GeneralCommandLine.ParentEnvironmentType.CONSOLE);
+
     return commandLine;
   }
 

--- a/src/io/flutter/run/SdkFields.java
+++ b/src/io/flutter/run/SdkFields.java
@@ -243,7 +243,6 @@ public class SdkFields {
     commandLine.getEnvironment().putAll(getEnvs());
     Analytics.updateEnvironment(commandLine);
     commandLine.withParentEnvironmentType(GeneralCommandLine.ParentEnvironmentType.CONSOLE);
-
     return commandLine;
   }
 

--- a/src/io/flutter/run/SdkFields.java
+++ b/src/io/flutter/run/SdkFields.java
@@ -241,7 +241,6 @@ public class SdkFields {
     command = flutterSdk.flutterRun(root, main.getFile(), device, runMode, flutterLaunchMode, project, args);
     final GeneralCommandLine commandLine = command.createGeneralCommandLine(project);
     commandLine.getEnvironment().putAll(getEnvs());
-    Analytics.updateEnvironment(commandLine);
     commandLine.withParentEnvironmentType(GeneralCommandLine.ParentEnvironmentType.CONSOLE);
     return commandLine;
   }

--- a/src/io/flutter/run/bazel/BazelFields.java
+++ b/src/io/flutter/run/bazel/BazelFields.java
@@ -22,6 +22,7 @@ import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.jetbrains.lang.dart.sdk.DartConfigurable;
 import com.jetbrains.lang.dart.sdk.DartSdk;
+import com.jetbrains.lang.dart.analytics.Analytics;
 import io.flutter.FlutterBundle;
 import io.flutter.FlutterMessages;
 import io.flutter.bazel.Workspace;
@@ -343,6 +344,8 @@ public class BazelFields {
     }
 
     commandLine.addParameter(target);
+
+    Analytics.updateEnvironment(commandLine);
 
     return commandLine;
   }

--- a/src/io/flutter/run/daemon/DevToolsServerTask.java
+++ b/src/io/flutter/run/daemon/DevToolsServerTask.java
@@ -30,6 +30,7 @@ import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.util.registry.Registry;
 import com.jetbrains.lang.dart.ide.devtools.DartDevToolsService;
 import com.jetbrains.lang.dart.ide.toolingDaemon.DartToolingDaemonService;
+import com.jetbrains.lang.dart.analytics.Analytics;
 import io.flutter.FlutterMessages;
 import io.flutter.FlutterUtils;
 import io.flutter.bazel.WorkspaceCache;
@@ -259,6 +260,8 @@ class DevToolsServerTask extends Task.Backgroundable {
     for (String argument : arguments) {
       result.addParameter(argument);
     }
+
+    Analytics.updateEnvironment(result);
 
     return result;
   }

--- a/src/io/flutter/sdk/FlutterCommand.java
+++ b/src/io/flutter/sdk/FlutterCommand.java
@@ -24,6 +24,7 @@ import io.flutter.FlutterMessages;
 import io.flutter.android.IntelliJAndroidSdk;
 import io.flutter.console.FlutterConsoles;
 import io.flutter.dart.DartPlugin;
+import com.jetbrains.lang.dart.analytics.Analytics;
 import io.flutter.logging.PluginLogger;
 import io.flutter.settings.FlutterSettings;
 import io.flutter.utils.MostlySilentColoredProcessHandler;
@@ -315,6 +316,9 @@ public class FlutterCommand {
     }
     line.addParameters(type.subCommand);
     line.addParameters(args);
+
+    Analytics.updateEnvironment(line);
+
     return line;
   }
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter-intellij/issues/8850

I verified by putting `System.out.println(commandLine.getEnvironment());` in `SdkFields` and checking that the new values are present, i.e.:

```
{DASH__SUPPRESS_ANALYTICS=>false, DASH__IDE_VERSION=>Panda 4 | 2025.3.4, DASH__PLUGIN_VERSION=>505.0.0, DASH__PLUGIN_NAME=>Dart, FLUTTER_HOST=>Android-Studio, DASH__IDE_NAME=>Android Studio, DASH__TOOL=>android-studio-plugins}
```