### PR TITLE
Add dashTool and dashIdeName params

### DIFF
--- a/src/io/flutter/devtools/DevToolsUrl.java
+++ b/src/io/flutter/devtools/DevToolsUrl.java
@@ -9,6 +9,7 @@ import io.flutter.bazel.WorkspaceCache;
 import io.flutter.sdk.FlutterSdkUtil;
 import io.flutter.sdk.FlutterSdkVersion;
 import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.openapi.application.ApplicationInfo;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -180,6 +181,8 @@ public class DevToolsUrl {
 
     String ideValue = sdkUtil.getFlutterHostEnvValue();
     params.add("ide=" + (ideValue == null ? "IntelliJPluginUnknown" : ideValue));
+    params.add("dashTool=intellij-plugins");
+    params.add("dashIdeName=" + URLEncoder.encode(getIdeName(), StandardCharsets.UTF_8));
     if (colorHexCode != null) {
       params.add("backgroundColor=" + colorHexCode);
     }
@@ -214,6 +217,17 @@ public class DevToolsUrl {
     }
     return "http://" + devToolsHost + ":" + devToolsPort + "/" + (page != null ? page : "") + "?"
         + StringUtil.join(params, "&");
+  }
+
+  private String getIdeName() {
+    ApplicationInfo appInfo = ApplicationInfo.getInstance();
+    if (appInfo != null) {
+      String versionName = appInfo.getVersionName();
+      if (versionName != null) {
+        return versionName;
+      }
+    }
+    return "IntelliJ - Unknown";
   }
 
   public boolean maybeUpdateColor() {

--- a/src/io/flutter/devtools/DevToolsUrl.java
+++ b/src/io/flutter/devtools/DevToolsUrl.java
@@ -37,6 +37,7 @@ public class DevToolsUrl {
   private final boolean canUseMultiEmbed;
 
   public final DevToolsIdeFeature ideFeature;
+  private final String ideName;
 
   @NotNull private final DevToolsUtils devToolsUtils;
 
@@ -53,6 +54,7 @@ public class DevToolsUrl {
     private @Nullable FlutterSdkVersion flutterSdkVersion;
     private WorkspaceCache workspaceCache;
     private DevToolsIdeFeature ideFeature;
+    private String ideName;
 
     private DevToolsUtils devToolsUtils;
 
@@ -134,6 +136,12 @@ public class DevToolsUrl {
     }
 
     @NotNull
+    public Builder setIdeName(String ideName) {
+      this.ideName = ideName;
+      return this;
+    }
+
+    @NotNull
     public DevToolsUrl build() {
       if (devToolsUtils == null) {
         devToolsUtils = new DevToolsUtils();
@@ -164,6 +172,7 @@ public class DevToolsUrl {
     this.flutterSdkVersion = builder.flutterSdkVersion;
     this.ideFeature = builder.ideFeature;
     this.sdkUtil = builder.flutterSdkUtil;
+    this.ideName = builder.ideName != null ? builder.ideName : getIdeName();
 
     if (builder.workspaceCache != null && builder.workspaceCache.isBazel()) {
       this.canUseMultiEmbed = true;
@@ -182,9 +191,10 @@ public class DevToolsUrl {
     final List<String> params = new ArrayList<>();
 
     String ideValue = sdkUtil.getFlutterHostEnvValue();
-    params.add("ide=" + (ideValue == null ? UNKNOWN_INTELLIJ_NAME : ideValue));
+    String ideParamValue = ideValue == null ? UNKNOWN_INTELLIJ_NAME : ideValue;
+    params.add("ide=" + URLEncoder.encode(ideParamValue, StandardCharsets.UTF_8));
     params.add("dashTool=intellij-plugins");
-    params.add("dashIdeName=" + URLEncoder.encode(getIdeName(), StandardCharsets.UTF_8));
+    params.add("dashIdeName=" + URLEncoder.encode(this.ideName, StandardCharsets.UTF_8));
     if (colorHexCode != null) {
       params.add("backgroundColor=" + colorHexCode);
     }

--- a/src/io/flutter/devtools/DevToolsUrl.java
+++ b/src/io/flutter/devtools/DevToolsUrl.java
@@ -5,6 +5,7 @@
  */
 package io.flutter.devtools;
 
+import com.intellij.openapi.application.ApplicationManager;
 import io.flutter.bazel.WorkspaceCache;
 import io.flutter.sdk.FlutterSdkUtil;
 import io.flutter.sdk.FlutterSdkVersion;
@@ -20,6 +21,7 @@ import java.util.List;
 import java.util.Objects;
 
 public class DevToolsUrl {
+  public static final String UNKNOWN_INTELLIJ_NAME = "IntelliJ - Unknown";
   private String devToolsHost;
   private int devToolsPort;
   public String vmServiceUri;
@@ -180,7 +182,7 @@ public class DevToolsUrl {
     final List<String> params = new ArrayList<>();
 
     String ideValue = sdkUtil.getFlutterHostEnvValue();
-    params.add("ide=" + (ideValue == null ? "IntelliJPluginUnknown" : ideValue));
+    params.add("ide=" + (ideValue == null ? UNKNOWN_INTELLIJ_NAME : ideValue));
     params.add("dashTool=intellij-plugins");
     params.add("dashIdeName=" + URLEncoder.encode(getIdeName(), StandardCharsets.UTF_8));
     if (colorHexCode != null) {
@@ -219,7 +221,10 @@ public class DevToolsUrl {
         + StringUtil.join(params, "&");
   }
 
-  private String getIdeName() {
+  private @NotNull String getIdeName() {
+    if (ApplicationManager.getApplication() == null) {
+      return UNKNOWN_INTELLIJ_NAME;
+    }
     ApplicationInfo appInfo = ApplicationInfo.getInstance();
     if (appInfo != null) {
       String versionName = appInfo.getVersionName();
@@ -227,7 +232,7 @@ public class DevToolsUrl {
         return versionName;
       }
     }
-    return "IntelliJ - Unknown";
+    return UNKNOWN_INTELLIJ_NAME;
   }
 
   public boolean maybeUpdateColor() {

--- a/testSrc/unit/io/flutter/devtools/DevToolsUrlTest.java
+++ b/testSrc/unit/io/flutter/devtools/DevToolsUrlTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.devtools;
+
+import io.flutter.sdk.FlutterSdkUtil;
+import org.junit.Test;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertTrue;
+
+public class DevToolsUrlTest {
+
+  @Test
+  public void testGetUrlString() {
+    DevToolsUrl.Builder builder = new DevToolsUrl.Builder()
+      .setDevToolsHost("127.0.0.1")
+      .setDevToolsPort(9100)
+      .setVmServiceUri("http://127.0.0.1:12345/abc=");
+
+    // Mock FlutterSdkUtil to avoid calling real IntelliJ APIs which might fail in unit tests.
+    builder.setFlutterSdkUtil(new FlutterSdkUtil() {
+      @Override
+      public String getFlutterHostEnvValue() {
+        return "TestIDE";
+      }
+    });
+
+    DevToolsUrl devToolsUrl = builder.build();
+    String url = devToolsUrl.getUrlString();
+
+    assertTrue(url.contains("ide=TestIDE"));
+    assertTrue(url.contains("dashTool=intellij-plugins"));
+
+    // We check that dashIdeName is present. We don't assert the exact value because it depends on the environment
+    // (whether ApplicationInfo is initialized or returns null).
+    assertTrue(url.contains("dashIdeName="));
+  }
+}

--- a/testSrc/unit/io/flutter/devtools/DevToolsUrlTest.java
+++ b/testSrc/unit/io/flutter/devtools/DevToolsUrlTest.java
@@ -20,24 +20,25 @@ public class DevToolsUrlTest {
     DevToolsUrl.Builder builder = new DevToolsUrl.Builder()
       .setDevToolsHost("127.0.0.1")
       .setDevToolsPort(9100)
-      .setVmServiceUri("http://127.0.0.1:12345/abc=");
+      .setVmServiceUri("http://127.0.0.1:12345/abc=")
+      .setIdeName("Test IDE Name");
 
     // Mock FlutterSdkUtil to avoid calling real IntelliJ APIs which might fail in unit tests.
     builder.setFlutterSdkUtil(new FlutterSdkUtil() {
       @Override
       public String getFlutterHostEnvValue() {
-        return "TestIDE";
+        return "Test:IDE";
       }
     });
 
     DevToolsUrl devToolsUrl = builder.build();
     String url = devToolsUrl.getUrlString();
 
-    assertTrue(url.contains("ide=TestIDE"));
+    // Test:IDE encoded becomes Test%3AIDE
+    assertTrue(url.contains("ide=Test%3AIDE"));
     assertTrue(url.contains("dashTool=intellij-plugins"));
 
-    // We check that dashIdeName is present. We don't assert the exact value because it depends on the environment
-    // (whether ApplicationInfo is initialized or returns null).
-    assertTrue(url.contains("dashIdeName="));
+    // Test IDE Name encoded becomes Test+IDE+Name
+    assertTrue(url.contains("dashIdeName=Test+IDE+Name"));
   }
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter-intellij/issues/8968

An example DevTools URL: `http://127.0.0.1:9104/?ide=Android-Studio&dashTool=intellij-plugins&dashIdeName=Android+Studio&backgroundColor=191a1c&theme=dark&embedMode=many&hide=home,inspector,deep-links,extensions,debugger&ideFeature=toolWindow`