### PR TITLE
Fix startNotify double-call crash during app launch

### DIFF
--- a/src/io/flutter/run/daemon/DaemonApi.java
+++ b/src/io/flutter/run/daemon/DaemonApi.java
@@ -169,7 +169,6 @@ public class DaemonApi {
     });
 
     // All hooked up and ready to receive events.
-    process.startNotify();
   }
 
   /**

--- a/src/io/flutter/run/daemon/DeviceDaemon.java
+++ b/src/io/flutter/run/daemon/DeviceDaemon.java
@@ -228,6 +228,7 @@ class DeviceDaemon {
         final DaemonApi api = new DaemonApi(process);
         final Listener listener = new Listener(daemonId, api, devices, deviceChanged, processStopped);
         api.listen(process, listener);
+        process.startNotify();
 
         final Future<Void> ready = listener.connected.thenCompose((Void ignored) -> api.enableDeviceEvents());
 


### PR DESCRIPTION
Run app was causing the error (pasted below) in 2026.1 because the process calls `startNotify` twice. `startNotify` had to be added to `DeviceDaemon` startup since that daemon was depending on the `DaemonApi` class calling it.

To test, start running (not debug) an app and make sure this error doesn't happen.

```
java.lang.Throwable: startNotify called already
	at com.intellij.openapi.diagnostic.Logger.error(Logger.java:375)
	at com.intellij.execution.process.ProcessHandler.startNotify(ProcessHandler.java:72)
	at com.intellij.execution.process.BaseOSProcessHandler.startNotify(BaseOSProcessHandler.java:92)
	at com.intellij.xdebugger.impl.XDebuggerManagerImpl.startSession(XDebuggerManagerImpl.java:234)
	at com.intellij.xdebugger.impl.XDebugSessionBuilderImpl.startSession(XDebugSessionBuilderImpl.kt:80)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
	at java.base/java.lang.reflect.Method.invoke(Method.java:565)
	at io.flutter.run.FlutterDebugSessionUtils.startBuilderSession(FlutterDebugSessionUtils.java:116)
	at io.flutter.run.FlutterDebugSessionUtils.startSessionAndGetDescriptor(FlutterDebugSessionUtils.java:58)
	at io.flutter.run.FlutterDebugSessionUtils.startSessionAndGetDescriptor(FlutterDebugSessionUtils.java:46)
	at io.flutter.run.LaunchState.createDebugSession(LaunchState.java:237)
	at io.flutter.run.LaunchState.launch(LaunchState.java:164)
	at io.flutter.run.LaunchState$Runner.doExecute(LaunchState.java:438)
	at com.intellij.execution.runners.GenericProgramRunner.execute$lambda$0(GenericProgramRunner.kt:20)
	at com.intellij.execution.impl.ExecutionManagerImpl.startRunProfile$lambda$0(ExecutionManagerImpl.kt:275)
	at com.intellij.execution.impl.ExecutionManagerImpl.doStartRunProfile$lambda$1(ExecutionManagerImpl.kt:342)
	at com.intellij.openapi.application.TransactionGuardImpl.runWithWritingAllowed(TransactionGuardImpl.java:236)
	at com.intellij.openapi.application.TransactionGuardImpl.access$100(TransactionGuardImpl.java:22)
	at com.intellij.openapi.application.TransactionGuardImpl$1.run(TransactionGuardImpl.java:198)
	at com.intellij.openapi.application.impl.AppImplKt$runnableUnitFunction$1.invoke(appImpl.kt:124)
	at com.intellij.openapi.application.impl.AppImplKt$runnableUnitFunction$1.invoke(appImpl.kt:124)
	at com.intellij.platform.locking.impl.NestedLocksThreadingSupport.runWriteIntentReadAction(NestedLocksThreadingSupport.kt:705)
	at com.intellij.openapi.application.impl.ApplicationImpl.runIntendedWriteActionOnCurrentThread(ApplicationImpl.java:1094)
	at com.intellij.openapi.application.impl.ApplicationImpl$7.lambda$run$0(ApplicationImpl.java:648)
	at com.intellij.concurrency.ThreadContext.installThreadContext(threadContext.kt:305)
	at com.intellij.openapi.application.impl.ApplicationImpl$7.run(ApplicationImpl.java:646)
	at com.intellij.util.concurrency.ChildContext$runInChildContext$1.invoke(propagation.kt:192)
	at com.intellij.util.concurrency.ChildContext$runInChildContext$1.invoke(propagation.kt:192)
	at com.intellij.util.concurrency.ChildContext.runInChildContext(propagation.kt:198)
	at com.intellij.util.concurrency.ChildContext.runInChildContext(propagation.kt:192)
	at com.intellij.util.concurrency.ContextRunnable.lambda$run$0(ContextRunnable.java:26)
	at com.intellij.concurrency.ThreadContext.resetThreadContext(threadContext.kt:294)
	at com.intellij.util.concurrency.ContextRunnable.run(ContextRunnable.java:25)
	at com.intellij.openapi.application.impl.NonBlockingFlushQueue.runNextEvent$lambda$1$1$0(NonBlockingFlushQueue.kt:334)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computePrioritized(CoreProgressManager.java:928)
	at com.intellij.openapi.application.impl.NonBlockingFlushQueue.runNextEvent$lambda$1$1(NonBlockingFlushQueue.kt:333)
	at com.intellij.concurrency.ThreadContext.resetThreadContext(threadContext.kt:294)
	at com.intellij.openapi.application.impl.NonBlockingFlushQueue.runNextEvent$lambda$1(NonBlockingFlushQueue.kt:330)
	at com.intellij.platform.locking.impl.NestedLocksThreadingSupport.tryRunWriteIntentReadAction(NestedLocksThreadingSupport.kt:747)
	at com.intellij.openapi.application.impl.NonBlockingFlushQueue.runNextEvent(NonBlockingFlushQueue.kt:326)
	at com.intellij.openapi.application.impl.NonBlockingFlushQueue.flushNow(NonBlockingFlushQueue.kt:305)
	at com.intellij.openapi.application.impl.NonBlockingFlushQueue.FLUSH_NOW$lambda$0(NonBlockingFlushQueue.kt:167)
	at java.desktop/java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:323)
	at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:732)
	at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:711)
	at com.intellij.ide.IdeEventQueue.defaultDispatchEvent(IdeEventQueue.kt:720)
	at com.intellij.ide.IdeEventQueue._dispatchEvent(IdeEventQueue.kt:573)
	at com.intellij.ide.IdeEventQueue.dispatchEvent$lambda$0$0$0(IdeEventQueue.kt:377)
	at com.intellij.ide.IdeEventQueueKt.performActivity$lambda$0(IdeEventQueue.kt:1110)
	at com.intellij.openapi.application.TransactionGuardImpl.performActivity(TransactionGuardImpl.java:106)
	at com.intellij.ide.IdeEventQueueKt.performActivity(IdeEventQueue.kt:1110)
	at com.intellij.ide.IdeEventQueue.dispatchEvent$lambda$0(IdeEventQueue.kt:375)
	at com.intellij.ide.IdeEventQueue.dispatchEvent(IdeEventQueue.kt:415)
	at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:207)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:128)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:117)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:113)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:105)
	at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:92)

```