### PR TITLE
Show Run window during run mode in 2026.1

### DIFF
--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -67,6 +67,7 @@ enforce standard modern Java/Kotlin coding conventions, but strictly police the 
 - Prefer **Composition over Inheritance** for plugin components.
 - Avoid using reflection without a strong justification.
 - Avoid stray `TODO` or `FIXME` comments without justification.
+- Use imports instead of fully qualified names.
 
 ## 4. Code Quality & Maintainability
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 - Restored device labels on split-debugger run tabs in IntelliJ IDEA 2025.3+. (#8908)
+- Debug window opening for run app in 2026.1. (#8985)
 
 ## 92.0.0
 

--- a/src/io/flutter/run/FlutterDebugProcess.java
+++ b/src/io/flutter/run/FlutterDebugProcess.java
@@ -127,7 +127,7 @@ public class FlutterDebugProcess extends DartVmServiceDebugProcess {
       // AND we are using the new named tab hooks.
       // For other non-debug modes (like PROFILE), the tab is still visible in the Debug window,
       // so we must suppress the empty debugger panels.
-      final boolean isHeadlessRunMode = app.getMode() == RunMode.RUN && FlutterDebugSessionUtils.useNamedTab();
+      final boolean isHeadlessRunMode = app.getMode() == RunMode.RUN && FlutterDebugSessionUtils.USE_NAMED_TAB;
       if (!isHeadlessRunMode) {
         suppressDebugViews(getSession().getUI());
       }

--- a/src/io/flutter/run/FlutterDebugProcess.java
+++ b/src/io/flutter/run/FlutterDebugProcess.java
@@ -6,9 +6,9 @@
 package io.flutter.run;
 
 import com.intellij.execution.ExecutionResult;
+import com.intellij.execution.filters.TextConsoleBuilderFactory;
 import com.intellij.execution.runners.ExecutionEnvironment;
 import com.intellij.execution.ui.ExecutionConsole;
-import com.intellij.execution.filters.TextConsoleBuilderFactory;
 import com.intellij.execution.ui.RunnerLayoutUi;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.DefaultActionGroup;

--- a/src/io/flutter/run/FlutterDebugProcess.java
+++ b/src/io/flutter/run/FlutterDebugProcess.java
@@ -7,6 +7,8 @@ package io.flutter.run;
 
 import com.intellij.execution.ExecutionResult;
 import com.intellij.execution.runners.ExecutionEnvironment;
+import com.intellij.execution.ui.ExecutionConsole;
+import com.intellij.execution.filters.TextConsoleBuilderFactory;
 import com.intellij.execution.ui.RunnerLayoutUi;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.DefaultActionGroup;
@@ -121,8 +123,25 @@ public class FlutterDebugProcess extends DartVmServiceDebugProcess {
   @Override
   public void sessionInitialized() {
     if (app.getMode() != RunMode.DEBUG) {
-      suppressDebugViews(getSession().getUI());
+      // Only skip suppressDebugViews if we are in RUN mode (where the tab is headless/hidden)
+      // AND we are using the new named tab hooks.
+      // For other non-debug modes (like PROFILE), the tab is still visible in the Debug window,
+      // so we must suppress the empty debugger panels.
+      final boolean isHeadlessRunMode = app.getMode() == RunMode.RUN && FlutterDebugSessionUtils.useNamedTab();
+      if (!isHeadlessRunMode) {
+        suppressDebugViews(getSession().getUI());
+      }
     }
+  }
+
+  @NotNull
+  @Override
+  public ExecutionConsole createConsole() {
+    if (app.getMode() == RunMode.RUN) {
+      return TextConsoleBuilderFactory.getInstance()
+        .createBuilder(getSession().getProject()).getConsole();
+    }
+    return super.createConsole();
   }
 
   /**

--- a/src/io/flutter/run/FlutterDebugSessionUtils.java
+++ b/src/io/flutter/run/FlutterDebugSessionUtils.java
@@ -174,7 +174,6 @@ public class FlutterDebugSessionUtils {
         return null;
     }
 
-
     @VisibleForTesting
     static final class BuilderHooks {
         final Method newSessionBuilderMethod;

--- a/src/io/flutter/run/FlutterDebugSessionUtils.java
+++ b/src/io/flutter/run/FlutterDebugSessionUtils.java
@@ -6,6 +6,7 @@
 package io.flutter.run;
 
 import com.intellij.execution.ExecutionException;
+import com.intellij.execution.executors.DefaultRunExecutor;
 import com.intellij.execution.runners.ExecutionEnvironment;
 import com.intellij.execution.ui.RunContentDescriptor;
 import com.intellij.xdebugger.XDebugProcessStarter;
@@ -24,6 +25,7 @@ import java.lang.reflect.Method;
 public class FlutterDebugSessionUtils {
 
     private static final @Nullable BuilderHooks builderHooks = findBuilderHooks();
+    private static final boolean USE_NAMED_TAB = builderHooks != null && getNamedTabSupportError() == null;
 
     public static @NotNull RunContentDescriptor startSessionAndGetDescriptor(
             @NotNull XDebuggerManager manager,
@@ -129,7 +131,8 @@ public class FlutterDebugSessionUtils {
             builder = hooks.sessionNameMethod.invoke(builder, sessionName);
         }
         if (hooks.showTabMethod != null) {
-            builder = hooks.showTabMethod.invoke(builder, true);
+            boolean showTab = !env.getExecutor().getId().equals(DefaultRunExecutor.EXECUTOR_ID);
+            builder = hooks.showTabMethod.invoke(builder, showTab);
         }
         return builder;
     }
@@ -169,6 +172,10 @@ public class FlutterDebugSessionUtils {
             return "showTab not found on XDebugSessionBuilder";
         }
         return null;
+    }
+
+    public static boolean useNamedTab() {
+        return USE_NAMED_TAB;
     }
 
     @VisibleForTesting

--- a/src/io/flutter/run/FlutterDebugSessionUtils.java
+++ b/src/io/flutter/run/FlutterDebugSessionUtils.java
@@ -25,7 +25,7 @@ import java.lang.reflect.Method;
 public class FlutterDebugSessionUtils {
 
     private static final @Nullable BuilderHooks builderHooks = findBuilderHooks();
-    private static final boolean USE_NAMED_TAB = builderHooks != null && getNamedTabSupportError() == null;
+    public static final boolean USE_NAMED_TAB = builderHooks != null && getNamedTabSupportError() == null;
 
     public static @NotNull RunContentDescriptor startSessionAndGetDescriptor(
             @NotNull XDebuggerManager manager,
@@ -174,9 +174,6 @@ public class FlutterDebugSessionUtils {
         return null;
     }
 
-    public static boolean useNamedTab() {
-        return USE_NAMED_TAB;
-    }
 
     @VisibleForTesting
     static final class BuilderHooks {

--- a/src/io/flutter/run/LaunchState.java
+++ b/src/io/flutter/run/LaunchState.java
@@ -44,6 +44,8 @@ import com.jetbrains.lang.dart.ide.runner.DartExecutionHelper;
 import com.jetbrains.lang.dart.util.DartUrlResolver;
 import io.flutter.FlutterConstants;
 import io.flutter.FlutterUtils;
+import io.flutter.actions.ReloadFlutterApp;
+import io.flutter.actions.RestartFlutterApp;
 import io.flutter.dart.DartPlugin;
 import io.flutter.logging.PluginLogger;
 import io.flutter.run.bazel.BazelRunConfig;
@@ -303,8 +305,8 @@ public class LaunchState extends CommandLineState {
                                                          app.getFlutterDebugProcess().getVmConnected() &&
                                                          !app.getProcessHandler().isProcessTerminated();
       final Computable<Boolean> canReload = () -> isSessionActive.compute() && !app.isReloading();
-      actions.add(new io.flutter.actions.ReloadFlutterApp(app, canReload));
-      actions.add(new io.flutter.actions.RestartFlutterApp(app, canReload));
+      actions.add(new ReloadFlutterApp(app, canReload));
+      actions.add(new RestartFlutterApp(app, canReload));
     }
 
     return new DefaultExecutionResult(console, app.getProcessHandler(), actions.toArray(new AnAction[0]));

--- a/src/io/flutter/run/LaunchState.java
+++ b/src/io/flutter/run/LaunchState.java
@@ -158,14 +158,7 @@ public class LaunchState extends CommandLineState {
 
     final String nameWithDeviceName = device.withRunConfigurationName(env.getRunProfile().getName());
     final FlutterLaunchMode launchMode = FlutterLaunchMode.fromEnv(env);
-    final RunContentDescriptor descriptor;
-    if (launchMode.supportsDebugConnection()) {
-      ToolWindowBadgeUpdater.updateBadgedIcon(app, project);
-      descriptor = createDebugSession(env, app, result, nameWithDeviceName);
-    }
-    else {
-      descriptor = new RunContentBuilder(result, env).showRunContent(env.getContentToReuse());
-    }
+    final RunContentDescriptor descriptor = getRunContentDescriptor(env, app, result, nameWithDeviceName, launchMode, project);
 
     // Add the device name for the run descriptor.
     // The descriptor shows the run configuration name (e.g., `main.dart`) by default;
@@ -179,6 +172,29 @@ public class LaunchState extends CommandLineState {
     }
 
     return descriptor;
+  }
+
+  private @Nullable RunContentDescriptor getRunContentDescriptor(
+      @NotNull ExecutionEnvironment env,
+      @NotNull FlutterApp app,
+      @NotNull ExecutionResult result,
+      @NotNull String nameWithDeviceName,
+      @NotNull FlutterLaunchMode launchMode,
+      @NotNull Project project) throws ExecutionException {
+    if (launchMode.supportsDebugConnection()) {
+      ToolWindowBadgeUpdater.updateBadgedIcon(app, project);
+
+      // We must always create a debug session here (even in Run mode) because the debug connection
+      // is what connects to the Dart VM Service and powers background Hot Reload / Hot Restart.
+      final RunContentDescriptor debugDescriptor = createDebugSession(env, app, result, nameWithDeviceName);
+
+      if (app.getMode() == RunMode.RUN) {
+        // In Run mode, we discard the debug descriptor UI and instead render a standard Run console tab.
+        return new RunContentBuilder(result, env).showRunContent(env.getContentToReuse());
+      }
+      return debugDescriptor;
+    }
+    return new RunContentBuilder(result, env).showRunContent(env.getContentToReuse());
   }
 
   /**
@@ -280,6 +296,16 @@ public class LaunchState extends CommandLineState {
       super.createActions(console, app.getProcessHandler(), getEnvironment().getExecutor())));
     actions.add(new Separator());
     actions.add(new OpenDevToolsAction(app, observatoryAvailable));
+
+    if (app.getMode() == RunMode.RUN && app.getLaunchMode().supportsReload()) {
+      final Computable<Boolean> isSessionActive = () -> app.isStarted() &&
+                                                         app.getFlutterDebugProcess() != null &&
+                                                         app.getFlutterDebugProcess().getVmConnected() &&
+                                                         !app.getProcessHandler().isProcessTerminated();
+      final Computable<Boolean> canReload = () -> isSessionActive.compute() && !app.isReloading();
+      actions.add(new io.flutter.actions.ReloadFlutterApp(app, canReload));
+      actions.add(new io.flutter.actions.RestartFlutterApp(app, canReload));
+    }
 
     return new DefaultExecutionResult(console, app.getProcessHandler(), actions.toArray(new AnAction[0]));
   }

--- a/testSrc/unit/io/flutter/run/FlutterDebugSessionUtilsTest.java
+++ b/testSrc/unit/io/flutter/run/FlutterDebugSessionUtilsTest.java
@@ -34,6 +34,9 @@ public class FlutterDebugSessionUtilsTest {
   @Test
   public void splitDebugSessionUsesDeviceQualifiedBuilderTitle() throws Exception {
     final ExecutionEnvironment env = mock(ExecutionEnvironment.class);
+    final com.intellij.execution.Executor executor = mock(com.intellij.execution.Executor.class);
+    when(executor.getId()).thenReturn("Debug");
+    when(env.getExecutor()).thenReturn(executor);
     final RunContentDescriptor contentToReuse = mock(RunContentDescriptor.class);
     when(env.getContentToReuse()).thenReturn(contentToReuse);
 
@@ -69,6 +72,42 @@ public class FlutterDebugSessionUtilsTest {
       List.of("newSessionBuilder", "environment", "contentToReuse", "sessionName", "showTab", "startSession"),
       builder.calls
     );
+  }
+
+  @Test
+  public void splitDebugSessionMutesTabInRunMode() throws Exception {
+    final ExecutionEnvironment env = mock(ExecutionEnvironment.class);
+    final com.intellij.execution.Executor executor = mock(com.intellij.execution.Executor.class);
+    when(executor.getId()).thenReturn("Run");
+    when(env.getExecutor()).thenReturn(executor);
+    final RunContentDescriptor contentToReuse = mock(RunContentDescriptor.class);
+    when(env.getContentToReuse()).thenReturn(contentToReuse);
+
+    final RunContentDescriptor descriptor = mock(RunContentDescriptor.class);
+    final XDebugSession session = mock(XDebugSession.class);
+    final RecordingSessionBuilder builder = new RecordingSessionBuilder(session, descriptor);
+    final RecordingManager manager = new RecordingManager(builder);
+    final XDebugProcessStarter starter = mock(XDebugProcessStarter.class);
+    final FlutterDebugSessionUtils.BuilderHooks hooks = new FlutterDebugSessionUtils.BuilderHooks(
+      RecordingManager.class.getMethod("newSessionBuilder", XDebugProcessStarter.class),
+      RecordingSessionBuilder.class.getMethod("environment", ExecutionEnvironment.class),
+      RecordingSessionBuilder.class.getMethod("sessionName", String.class),
+      RecordingSessionBuilder.class.getMethod("contentToReuse", RunContentDescriptor.class),
+      RecordingSessionBuilder.class.getMethod("showTab", boolean.class),
+      RecordingSessionBuilder.class.getMethod("startSession")
+    );
+
+    final RunContentDescriptor result = FlutterDebugSessionUtils.startSessionAndGetDescriptor(
+      hooks,
+      manager,
+      env,
+      starter,
+      "main.dart (macOS)",
+      true
+    );
+
+    assertSame(descriptor, result);
+    assertEquals(Boolean.FALSE, builder.showTab);
   }
 
   private static final class RecordingManager {

--- a/testSrc/unit/io/flutter/run/FlutterDebugSessionUtilsTest.java
+++ b/testSrc/unit/io/flutter/run/FlutterDebugSessionUtilsTest.java
@@ -5,6 +5,7 @@
  */
 package io.flutter.run;
 
+import com.intellij.execution.Executor;
 import com.intellij.execution.runners.ExecutionEnvironment;
 import com.intellij.execution.ui.RunContentDescriptor;
 import com.intellij.xdebugger.XDebugProcessStarter;
@@ -34,7 +35,7 @@ public class FlutterDebugSessionUtilsTest {
   @Test
   public void splitDebugSessionUsesDeviceQualifiedBuilderTitle() throws Exception {
     final ExecutionEnvironment env = mock(ExecutionEnvironment.class);
-    final com.intellij.execution.Executor executor = mock(com.intellij.execution.Executor.class);
+    final Executor executor = mock(Executor.class);
     when(executor.getId()).thenReturn("Debug");
     when(env.getExecutor()).thenReturn(executor);
     final RunContentDescriptor contentToReuse = mock(RunContentDescriptor.class);
@@ -77,7 +78,7 @@ public class FlutterDebugSessionUtilsTest {
   @Test
   public void splitDebugSessionMutesTabInRunMode() throws Exception {
     final ExecutionEnvironment env = mock(ExecutionEnvironment.class);
-    final com.intellij.execution.Executor executor = mock(com.intellij.execution.Executor.class);
+    final Executor executor = mock(Executor.class);
     when(executor.getId()).thenReturn("Run");
     when(env.getExecutor()).thenReturn(executor);
     final RunContentDescriptor contentToReuse = mock(RunContentDescriptor.class);


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter-intellij/issues/8890

This change routes the Flutter app console to the native Run tool window when running in "Run" mode (not debugging), while still starting a headless debug session in the background to support Hot Reload.

We achieve this by:
1. Muting the debug tab in the Debug window via XDebugSessionBuilder.showTab(false) in Run mode.
2. Returning a standard run descriptor via RunContentBuilder in LaunchState.launch() for Run mode.
3. Manually injecting the Reload and Restart actions directly into this Run console toolbar.
4. Overriding XDebugProcess.createConsole() to return a dummy console in Run mode, completely avoiding a Swing parent hierarchy conflict (which previously caused a blank console).
5. Skipping deprecated suppressDebugViews calls in sessionInitialized() when the new reflective hooks are active to avoid platform warnings.

I'm pasting a description of the run and debug lifecycle below, in case this is helpful context for any future changes.

---

## Step-by-Step Lifecycle Description

### 1. Shared Startup Phase
No matter which button the user clicks, the plugin first prepares the environment:
1. **Process Preparation:** `FlutterApp.start()` is invoked. It creates the `MostlySilentColoredProcessHandler` which wraps the native `flutter` command line.
2. **API Hookup:** `DaemonApi.listen(process, listener)` is called. This registers the JSON parser to handle the stdin/stdout streams of the process. **Crucially, `process.startNotify()` is not called yet.**
3. **Console Creation:** `setUpConsoleAndActions(app)` creates the `DaemonConsoleView` and attaches it to the process. It also prepares the toolbar actions (like DevTools).

---

### 2. Debug Workflow Lifecycle
If the user clicked **"Debug"**:
1. **Configure Builder:** The plugin uses reflection to call `XDebugSessionBuilder.showTab(true)` on the session builder.
2. **Initialize Session:** `XDebuggerManager.startSession` is called.
3. **UI Bindings:** Because `showTab` is `true`, the platform creates `XDebugSessionTab` and automatically registers it with the **Debug Tool Window** (`ToolWindowId.DEBUG`). This opens the Debug window and shows the debugger panels (Variables, Frames, Threads) alongside the Console.
4. **Process Boot:** Immediately after UI initialization, `XDebuggerManagerImpl` calls `processHandler.startNotify()`. This boots the OS process.
5. **Connection:** The background thread (`scheduleConnect()`) detects the VM Service URI printed by the process and connects the debugger.

---

### 3. Run Workflow Lifecycle
If the user clicked **"Run"** (which still needs a headless debug connection for Hot Reload):
1. **Configure Headless Builder:** The plugin calls `XDebugSessionBuilder.showTab(false)` on the builder.
2. **Headless Initialization:** `XDebuggerManager.startSession` is called.
   * Because `showTab` is `false`, the platform enters a **headless path**.
   * It completely skips creating the `XDebugSessionTab` UI and does **not** open the Debug tool window.
   * It also **skips calling `processHandler.startNotify()`** inside `XDebuggerManager`.
3. **Run UI Creation:** In `LaunchState.launch()`, the plugin discards the headless debug descriptor. Instead, it passes the console `ExecutionResult` to `RunContentBuilder(result, env).showRunContent()`.
   * Since this is a standard run builder executed under the `"Run"` executor, it registers the console tab with the **Run Tool Window** (`ToolWindowId.RUN`).
4. **Process Boot:** `LaunchState.launch()` returns this native Run descriptor to the platform `ExecutionManager`.
5. **Single `startNotify`:** The platform `ExecutionManager` renders the tab in the Run tool window and calls `processHandler.startNotify()`. This boots the OS process exactly once.
6. **Headless Connection:** The background thread (`scheduleConnect()`) connects the debugger silently in the background. The user gets their console and Hot Reload buttons in the Run window, while the Debug window remains completely closed.