### PR TITLE
Change build to not having version in zip file by default

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -567,10 +567,14 @@ tasks.register<PrintVersionTask>("printVersion") {
 tasks.named<Zip>("buildPlugin") {
   val v = intellijPlatform.pluginConfiguration.version
   archiveFileName.set(v.map { versionStr ->
-    if (commitHash.isNotEmpty() && !versionStr.contains(commitHash)) {
-      "Flutter-$versionStr-$commitHash.zip"
+    if (project.hasProperty("versionedName")) {
+      if (commitHash.isNotEmpty() && !versionStr.contains(commitHash)) {
+        "Flutter-$versionStr-$commitHash.zip"
+      } else {
+        "Flutter-$versionStr.zip"
+      }
     } else {
-      "Flutter-$versionStr.zip"
+      "Flutter.zip"
     }
   })
 }


### PR DESCRIPTION
Similar to https://github.com/flutter/dart-intellij-third-party/pull/434

### Build Instructions

*   **Default Build**
    *   **Command:** `./gradlew buildPlugin`
    *   **Output File:** `build/distributions/Flutter.zip`
    *   **Plugin Version:** `SNAPSHOT` (default, or release version from CHANGELOG if `-Prelease` is used)
    *   **Description:** Builds the plugin with the default version and the default filename.

*   **Dev Build (Default filename)**
    *   **Command:** `./gradlew buildPlugin -Pdev`
    *   **Output File:** `build/distributions/Flutter.zip`
    *   **Plugin Version:** `94.0.0-dev.20260604-213d2c9` (example)
    *   **Description:** Builds the plugin with a development version (including timestamp and commit hash) but keeps the default filename.

*   **Default Build with Versioned Filename**
    *   **Command:** `./gradlew buildPlugin -PversionedName`
    *   **Output File:** `build/distributions/Flutter-SNAPSHOT-213d2c9.zip` (example)
    *   **Plugin Version:** `SNAPSHOT` (default)
    *   **Description:** Builds the plugin with the default version and includes the version and commit hash in the filename.

*   **Dev Build with Versioned Filename**
    *   **Command:** `./gradlew buildPlugin -Pdev -PversionedName`
    *   **Output File:** `build/distributions/Flutter-94.0.0-dev.20260604-213d2c9.zip` (example)
    *   **Plugin Version:** `94.0.0-dev.20260604-213d2c9` (example)
    *   **Description:** Builds the plugin with a development version and includes that version info in the filename.
