### PR TITLE
[infra] use (caching) gradle and java actions

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -19,6 +19,15 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
       - name: build
         run: ./tool/github.sh
   checker:
@@ -30,6 +39,15 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
       - name: Linux ${{ matrix.bot }}
         run: ./tool/github.sh
         env:


### PR DESCRIPTION
Currently we're doing a bunch of redundant work across jobs where caching could help.

This hopes to improve that.

---

Here's how Gemini sells these action changes:

### 1. Eliminating Redundant Downloads Across the 4 Matrix Bots
The `checker` job runs 4 bots in parallel (`CHECK_BOT`, `DART_BOT`, `UNIT_TEST_BOT`, `VERIFY_BOT`) on 4 separate virtual machines.
* **Before**: Each of the 4 VMs had to download the Gradle distribution, the IntelliJ Platform SDK dependencies, and all project plugins/dependencies from scratch over the network.
* **After**: They retrieve the Gradle wrapper, cached dependencies, and SDK artifacts directly from the GitHub Actions local runner cache. This saves several minutes of network and disk I/O setup time on every bot.

### 2. Skipping Unchanged Tasks via the Gradle Build Cache
* **Before**: Every pull request check compiled the plugin and ran task targets entirely from scratch.
* **After**: The build cache stores the output of compilation and verification tasks. If a pull request only changes a Dart file (e.g. triggering `DART_BOT` checks), the other bots (`UNIT_TEST_BOT`, `VERIFY_BOT`) will fetch their task outputs directly from the cache (`FROM-CACHE`) and finish almost instantly.

### 3. Caching Gradle Configuration
* By restoring the Configuration Cache state, Gradle skips the project evaluation phase (evaluating plugins, dependency resolution, task-graph creation) at the start of the build, accelerating task initiation on every bot.




---

Review the contribution guidelines below:

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] I've included the required information in the description above.
- [x] My up-to-date information is in the `AUTHORS` file.
- [x] I've updated `CHANGELOG.md` if appropriate.

<details>
  <summary>Contribution guidelines:</summary><br>

- See
  our [contributor guide](../CONTRIBUTING.md) and
  the [Flutter organization contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md)
  for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use
  `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best
  practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).

</details>