### PR TITLE
Prevent console from auto-scrolling to bottom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- Scrolling the first of multiple errors to the top of the run console and holding that position, instead of auto-scrolling to the bottom. (#9008)
+
 ### Removed
 
 ### Fixed

--- a/src/io/flutter/run/daemon/DaemonConsoleView.java
+++ b/src/io/flutter/run/daemon/DaemonConsoleView.java
@@ -12,9 +12,17 @@ import com.intellij.execution.impl.ConsoleViewImpl;
 import com.intellij.execution.runners.ExecutionEnvironment;
 import com.intellij.execution.ui.ConsoleView;
 import com.intellij.execution.ui.ConsoleViewContentType;
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.editor.ScrollingModel;
+import com.intellij.openapi.editor.ex.EditorEx;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
+import java.util.Locale;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import com.intellij.psi.search.ExecutionSearchScopes;
 import com.intellij.psi.search.GlobalSearchScope;
 import com.jetbrains.lang.dart.ide.runner.DartRelativePathsConsoleFilter;
@@ -22,6 +30,7 @@ import io.flutter.logging.PluginLogger;
 import io.flutter.settings.FlutterSettings;
 import io.flutter.utils.FlutterModuleUtils;
 import io.flutter.utils.StdoutJsonParser;
+import java.awt.Rectangle;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -55,6 +64,35 @@ public class DaemonConsoleView extends ConsoleViewImpl {
   private final StdoutJsonParser stdoutParser = new StdoutJsonParser();
   private boolean hasPrintedText;
 
+  // Whether the console was scrolled to the end before the most recent batch of output.
+  // Defaults to true so that the first output auto-scrolls normally.
+  private volatile boolean wasAtScrollEnd = true;
+
+  // Prevents scheduling redundant EDT scroll-checks during rapid output bursts.
+  private final AtomicBoolean scrollCheckPending = new AtomicBoolean(false);
+
+  // Running count of the characters written to the underlying console document. Used to
+  // locate the offset at which an error begins so its first line can be scrolled into
+  // view. This tracks 1:1 with document offsets (filters and folding do not change the
+  // underlying text length).
+  private final AtomicLong printedCharCount = new AtomicLong(0);
+
+  // Document offset of the first error line to scroll into view, or -1 when there is no
+  // pending error. Written on the output thread in print(), consumed on the EDT in
+  // scrollToEnd().
+  private volatile int pendingErrorStartOffset = -1;
+
+  // True once we have pinned the viewport to an error and frozen auto-follow, so that
+  // later errors do not steal focus from the first one. Reset when the user scrolls back
+  // to the bottom, allowing a subsequent error to become a fresh target.
+  private volatile boolean pinnedToError = false;
+
+  // Guards against the transient "at end" that our own pin-scroll produces on a still-short
+  // document: after pinning we wait for the viewport to move away from the end (as the
+  // stack trace streams in) before a later return to the end is treated as the user asking
+  // to resume following.
+  private volatile boolean awaitingScrollAwayFromEnd = false;
+
   public DaemonConsoleView(@NotNull final Project project, @NotNull final GlobalSearchScope searchScope) {
     super(project, searchScope, true, false);
   }
@@ -65,18 +103,169 @@ public class DaemonConsoleView extends ConsoleViewImpl {
       return;
     }
     if (FlutterSettings.getInstance().isVerboseLogging()) {
-      super.print(text, contentType);
+      printCounted(text, contentType);
       return;
     }
 
+    // Capture scroll position before queuing new output so scrollToEnd() can
+    // honour it once the editor flushes the pending text. Editor geometry must
+    // be read on the EDT; if we're already there do it inline, otherwise
+    // schedule once (throttled by scrollCheckPending to avoid flooding the EDT
+    // during rapid output bursts).
+    if (ApplicationManager.getApplication().isDispatchThread()) {
+      updateScrollEndState();
+    } else if (scrollCheckPending.compareAndSet(false, true)) {
+      ApplicationManager.getApplication().invokeLater(() -> {
+        scrollCheckPending.set(false);
+        updateScrollEndState();
+      }, ModalityState.any());
+    }
+
     if (contentType != ConsoleViewContentType.NORMAL_OUTPUT) {
+      // Flush any buffered normal output first so the error is appended after it; the
+      // character count now points at the offset where this text will begin.
       writeAvailableLines();
-      super.print(text, contentType);
+      maybeCaptureErrorStart(text, ConsoleViewContentType.ERROR_OUTPUT.equals(contentType));
+      printCounted(text, contentType);
     }
     else {
       stdoutParser.appendOutput(text);
       writeAvailableLines();
     }
+  }
+
+  /**
+   * Records the current document offset as the scroll target when {@code text} marks the
+   * start of an error. We only pin to the first error (until the user returns to the
+   * bottom) and only when they were following output at the end; if they have scrolled up
+   * to read something, their position is left alone.
+   */
+  private void maybeCaptureErrorStart(@NotNull String text, boolean isErrorContentType) {
+    if (pinnedToError || !wasAtScrollEnd || !isErrorStart(text, isErrorContentType)) {
+      return;
+    }
+    pendingErrorStartOffset = (int)Math.min(printedCharCount.get(), Integer.MAX_VALUE);
+    pinnedToError = true;
+    awaitingScrollAwayFromEnd = true;
+  }
+
+  /**
+   * Whether {@code line} marks the beginning of an error. Content routed to the error
+   * stream always qualifies; framework exceptions are printed to stdout, so we also match
+   * the Flutter error banner text (e.g. "======== Exception caught by rendering library").
+   */
+  static boolean isErrorStart(@NotNull String line, boolean isErrorContentType) {
+    if (isErrorContentType) {
+      return true;
+    }
+    final String lower = line.toLowerCase(Locale.ROOT);
+    return lower.contains("exception caught by")
+           || lower.contains("another exception was thrown");
+  }
+
+  private void printCounted(@NotNull String text, @NotNull ConsoleViewContentType contentType) {
+    super.print(text, contentType);
+    printedCharCount.addAndGet(text.length());
+  }
+
+  /**
+   * The console is cleared on hot reload/restart. Reset our character count and pin state
+   * so document offsets stay valid and a fresh error can be tracked afterwards.
+   */
+  @Override
+  public void clear() {
+    super.clear();
+    printedCharCount.set(0);
+    pendingErrorStartOffset = -1;
+    pinnedToError = false;
+    awaitingScrollAwayFromEnd = false;
+  }
+
+  /**
+   * Called by the platform after flushing queued text to the editor.
+   *
+   * <p>When a new error burst has just arrived, scroll its first line to the top of the
+   * viewport and freeze auto-follow so the root-cause error stays visible while the rest
+   * of the stack traces stream in below. Otherwise, only scroll to the end when the user
+   * was already there; if they have scrolled up, preserve their position.
+   */
+  @Override
+  public void scrollToEnd() {
+    final int errorStart = pendingErrorStartOffset;
+    if (errorStart >= 0) {
+      pendingErrorStartOffset = -1;
+      if (scrollErrorStartIntoView(errorStart)) {
+        // Freeze auto-follow; the user can resume it by scrolling back to the bottom.
+        wasAtScrollEnd = false;
+        return;
+      }
+    }
+    if (wasAtScrollEnd) {
+      super.scrollToEnd();
+    }
+  }
+
+  /**
+   * Scrolls the editor so that the line containing {@code offset} sits at the top of the
+   * visible area. Returns false when there is no editor yet to scroll.
+   */
+  private boolean scrollErrorStartIntoView(int offset) {
+    final Editor rawEditor = getEditor();
+    final EditorEx editor = rawEditor instanceof EditorEx ? (EditorEx)rawEditor : null;
+    if (editor == null) {
+      return false;
+    }
+    final int clampedOffset = Math.min(offset, editor.getDocument().getTextLength());
+    final int targetY = editor.logicalPositionToXY(editor.offsetToLogicalPosition(clampedOffset)).y;
+    editor.getScrollingModel().scrollVertically(targetY);
+    return true;
+  }
+
+  private void updateScrollEndState() {
+    final Editor rawEditor = getEditor();
+    final EditorEx editor = rawEditor instanceof EditorEx ? (EditorEx) rawEditor : null;
+    if (editor == null) {
+      return;
+    }
+    final boolean atEnd = isAtScrollEnd(editor);
+    if (!pinnedToError) {
+      wasAtScrollEnd = atEnd;
+      return;
+    }
+    // While pinned we stay frozen (wasAtScrollEnd == false) until the user genuinely
+    // returns to the bottom. The first move away from the end clears the guard so that a
+    // later return counts as a real request to resume following.
+    if (!atEnd) {
+      awaitingScrollAwayFromEnd = false;
+    }
+    else if (shouldReleasePin(atEnd, awaitingScrollAwayFromEnd)) {
+      pinnedToError = false;
+      wasAtScrollEnd = true;
+    }
+  }
+
+  /**
+   * Whether a pinned error should be released, resuming auto-follow. Only true once the
+   * viewport has moved away from the end at least once (so the transient "at end" produced
+   * by our own pin-scroll does not immediately release the pin).
+   */
+  static boolean shouldReleasePin(boolean atEnd, boolean awaitingScrollAwayFromEnd) {
+    return atEnd && !awaitingScrollAwayFromEnd;
+  }
+
+  static boolean isAtScrollEnd(@NotNull EditorEx editor) {
+    final ScrollingModel scrollingModel = editor.getScrollingModel();
+    final Rectangle visibleArea = scrollingModel.getVisibleArea();
+    return isAtScrollEnd(
+      scrollingModel.getVerticalScrollOffset(),
+      visibleArea.height,
+      editor.getContentSize().height,
+      editor.getLineHeight()
+    );
+  }
+
+  static boolean isAtScrollEnd(int scrollOffset, int visibleHeight, int totalHeight, int lineHeight) {
+    return scrollOffset + visibleHeight >= totalHeight - lineHeight;
   }
 
   private void writeAvailableLines() {
@@ -95,7 +284,10 @@ public class DaemonConsoleView extends ConsoleViewImpl {
 
         hasPrintedText = true;
 
-        super.print(line, ConsoleViewContentType.NORMAL_OUTPUT);
+        // Framework exceptions arrive here as normal stdout; detect their banner so the
+        // first error can be scrolled into view.
+        maybeCaptureErrorStart(line, false);
+        printCounted(line, ConsoleViewContentType.NORMAL_OUTPUT);
       }
     }
   }

--- a/testSrc/unit/io/flutter/run/daemon/DaemonConsoleViewTest.java
+++ b/testSrc/unit/io/flutter/run/daemon/DaemonConsoleViewTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2026 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package io.flutter.run.daemon;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class DaemonConsoleViewTest {
+
+  @Test
+  public void isAtScrollEnd_returnsTrueWhenScrolledToBottom() {
+    // scrollOffset(900) + visibleHeight(100) == totalHeight(1000)
+    assertTrue(DaemonConsoleView.isAtScrollEnd(900, 100, 1000, 15));
+  }
+
+  @Test
+  public void isAtScrollEnd_returnsTrueWhenWithinOneLineOfBottom() {
+    // One line above the very bottom — treated as "at end" to avoid jitter.
+    assertTrue(DaemonConsoleView.isAtScrollEnd(890, 100, 1000, 15));
+  }
+
+  @Test
+  public void isAtScrollEnd_returnsFalseWhenScrolledToTop() {
+    assertFalse(DaemonConsoleView.isAtScrollEnd(0, 100, 1000, 15));
+  }
+
+  @Test
+  public void isAtScrollEnd_returnsFalseWhenInMiddle() {
+    assertFalse(DaemonConsoleView.isAtScrollEnd(400, 100, 1000, 15));
+  }
+
+  @Test
+  public void isAtScrollEnd_returnsTrueWhenContentShorterThanViewport() {
+    // Nothing to scroll — treat as "at end" so normal output still auto-scrolls.
+    assertTrue(DaemonConsoleView.isAtScrollEnd(0, 500, 200, 15));
+  }
+
+  @Test
+  public void isErrorStart_trueForErrorContentType() {
+    // Anything routed to the error stream qualifies regardless of its text.
+    assertTrue(DaemonConsoleView.isErrorStart("Finished with error: exited abnormally", true));
+  }
+
+  @Test
+  public void isErrorStart_trueForFlutterExceptionBanner() {
+    // Framework exceptions are printed to stdout (not the error stream), so we match the
+    // banner text instead.
+    assertTrue(DaemonConsoleView.isErrorStart(
+      "======== Exception caught by rendering library =====================================", false));
+  }
+
+  @Test
+  public void isErrorStart_matchesBannerCaseInsensitively() {
+    assertTrue(DaemonConsoleView.isErrorStart("══╡ EXCEPTION CAUGHT BY WIDGETS LIBRARY ╞══", false));
+  }
+
+  @Test
+  public void isErrorStart_trueForAnotherExceptionBanner() {
+    assertTrue(DaemonConsoleView.isErrorStart("Another exception was thrown: Bad state", false));
+  }
+
+  @Test
+  public void isErrorStart_falseForOrdinaryStdout() {
+    // Ordinary log lines must not trigger a scroll jump.
+    assertFalse(DaemonConsoleView.isErrorStart("Reloaded 1 of 512 libraries in 240ms.", false));
+  }
+
+  @Test
+  public void isErrorStart_falseForStackFrameLine() {
+    // A line from within a stack trace is not itself the start of an error.
+    assertFalse(DaemonConsoleView.isErrorStart("#0      RenderViewport.performResize (package:flutter/...)", false));
+  }
+
+  @Test
+  public void shouldReleasePin_falseForTransientAtEndRightAfterPinning() {
+    // Immediately after pinning, our own scroll can look "at end" on a short document;
+    // the guard must keep the pin so we do not jump to a later error.
+    assertFalse(DaemonConsoleView.shouldReleasePin(true, true));
+  }
+
+  @Test
+  public void shouldReleasePin_falseWhileViewportIsAwayFromEnd() {
+    assertFalse(DaemonConsoleView.shouldReleasePin(false, false));
+  }
+
+  @Test
+  public void shouldReleasePin_trueWhenUserReturnsToEndAfterScrollingAway() {
+    // The guard has cleared (viewport moved away), and now the user is back at the bottom.
+    assertTrue(DaemonConsoleView.shouldReleasePin(true, false));
+  }
+}


### PR DESCRIPTION
#### PR Description
Scroll the run console to the first of multiple errors instead of auto-scrolling to the bottom.

When a Flutter app throws a cascade of errors (e.g. an unbounded viewport), the logging console floods with hundreds of lines and auto-scrolls to the bottom, burying the root-cause error at the top. The reporter had to manually scroll back up to find it.

This changes `DaemonConsoleView` so that when the first error of a burst arrives (detected either from error-stream output or from the Flutter error banner `Exception caught by …`), the console scrolls that first error to the **top** of the viewport and freezes auto-follow. The root-cause error stays visible while the rest of the stack traces stream in below. Normal auto-follow resumes once the user scrolls back to the bottom.

Details:
- Reading editor geometry to determine scroll position happens only on the EDT (scheduled via `invokeLater`, throttled with an `AtomicBoolean`) to respect the platform threading model.
- A guard prevents the transient "at end" produced by our own pin-scroll (on a still-short document) from releasing the pin, so focus stays on the *first* error rather than a later one.
- If the user is still viewing the pinned error, a subsequent error cascade does not steal focus; following (and re-pinning to a new cascade's first error) resumes only after they scroll back to the bottom.
- Console state resets on `clear()` (hot reload/restart).

Fixes #3778

**To verify:**
1. Run the reproduction app: https://github.com/InMatrix/flutter_error_studies
2. Tap "Unbounded Viewport"
3. Before: console jumps to the bottom showing `hasSize` assertion failures
4. After: console holds on "Vertical viewport was given unbounded height" (the root cause). Scroll to the bottom to resume normal following. 

A before/after demo video is attached in the comments.

---

Review the contribution guidelines below:

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] I've included the required information in the description above.
- [ ] My up-to-date information is in the `AUTHORS` file.
- [x] I've updated `CHANGELOG.md` if appropriate.

<details>
  <summary>Contribution guidelines:</summary><br>

- See
  our [contributor guide](../CONTRIBUTING.md) and
  the [Flutter organization contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md)
  for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use
  `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best
  practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).

</details>
