### PR TITLE
Prevent IDE freeze during Flutter SDK change

### DIFF
--- a/src/io/flutter/sdk/FlutterSdk.java
+++ b/src/io/flutter/sdk/FlutterSdk.java
@@ -591,12 +591,14 @@ public class FlutterSdk {
     }
 
     final VirtualFile dir = LocalFileSystem.getInstance().findFileByPath(getHomePath());
-    assert dir != null;
+    if (dir == null) {
+      return FlutterSdkChannel.fromText("unknown");
+    }
     String branch;
     try {
       branch = git4idea.light.LightGitUtilKt.getLocation(dir, GitExecutableManager.getInstance().getExecutable((Project)null));
     }
-    catch (VcsException e) {
+    catch (Exception e) {
       final String stdout = returnOutputOfQuery(flutterChannel());
       if (stdout == null) {
         branch = "unknown";

--- a/src/io/flutter/sdk/FlutterSdk.java
+++ b/src/io/flutter/sdk/FlutterSdk.java
@@ -592,7 +592,7 @@ public class FlutterSdk {
 
     final VirtualFile dir = LocalFileSystem.getInstance().findFileByPath(getHomePath());
     if (dir == null) {
-      return FlutterSdkChannel.fromText("unknown");
+      return FlutterSdkChannel.fromId(FlutterSdkChannel.ID.UNKNOWN);
     }
     String branch;
     try {

--- a/src/io/flutter/sdk/FlutterSdkChannel.java
+++ b/src/io/flutter/sdk/FlutterSdkChannel.java
@@ -46,6 +46,11 @@ public class FlutterSdkChannel {
     return new FlutterSdkChannel(ID.fromText(text));
   }
 
+  @NotNull
+  public static FlutterSdkChannel fromId(@NotNull ID channelId) {
+    return new FlutterSdkChannel(channelId);
+  }
+
   private FlutterSdkChannel(@NotNull ID channel) {
     this.channel = channel;
   }

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.java
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.java
@@ -270,7 +270,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
           FlutterSdkUtil.setFlutterSdkPath(myProject, sdkHomePath);
           FlutterSdkUtil.enableDartSdk(myProject);
 
-          ApplicationManager.getApplication().executeOnPooledThread(() -> {
+          OpenApiUtils.safeExecuteOnPooledThread(() -> {
             final FlutterSdk sdk = FlutterSdk.forPath(sdkHomePath);
             if (sdk != null) {
               try {
@@ -417,6 +417,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
           // This isn't perfect, but does help avoid printing this message most times:
           // Waiting for another flutter command to release the startup lock...
           updater.destroy();
+          updater = null;
           lock.release();
         }
         Thread.sleep(100L);
@@ -425,6 +426,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
         OpenApiUtils.safeInvokeLater(() -> {
           // "flutter --version" can take a long time on a slow network.
           try {
+            updater = null;
             updater = sdk.flutterVersion().start((ProcessOutput output) -> {
               fullVersionString = output.getStdout();
               final String[] lines = StringUtil.splitByLines(fullVersionString);

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.java
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.java
@@ -275,8 +275,12 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
             if (sdk != null) {
               try {
                 lock.acquire();
-                sdk.queryFlutterChannel(false);
-                lock.release();
+                try {
+                  sdk.queryFlutterChannel(false);
+                }
+                finally {
+                  lock.release();
+                }
               }
               catch (InterruptedException e) {
                 // do nothing
@@ -333,10 +337,14 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
           final List<PubRoot> roots = PubRoots.forProject(myProject);
           try {
             lock.acquire();
-            for (PubRoot root : roots) {
-              sdk.startPubGet(root, myProject);
+            try {
+              for (PubRoot root : roots) {
+                sdk.startPubGet(root, myProject);
+              }
             }
-            lock.release();
+            finally {
+              lock.release();
+            }
           }
           catch (InterruptedException e) {
             // do nothing
@@ -416,17 +424,24 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
 
         OpenApiUtils.safeInvokeLater(() -> {
           // "flutter --version" can take a long time on a slow network.
-          updater = sdk.flutterVersion().start((ProcessOutput output) -> {
-            fullVersionString = output.getStdout();
-            final String[] lines = StringUtil.splitByLines(fullVersionString);
-            final String singleLineVersion = lines.length > 0 ? lines[0] : "";
+          try {
+            updater = sdk.flutterVersion().start((ProcessOutput output) -> {
+              fullVersionString = output.getStdout();
+              final String[] lines = StringUtil.splitByLines(fullVersionString);
+              final String singleLineVersion = lines.length > 0 ? lines[0] : "";
 
-            OpenApiUtils.safeInvokeLater(() -> {
-              updater = null;
+              OpenApiUtils.safeInvokeLater(() -> {
+                updater = null;
+                lock.release();
+                updateVersionTextIfCurrent(sdk, singleLineVersion);
+              }, modalityState);
+            }, null);
+          }
+          finally {
+            if (updater == null) {
               lock.release();
-              updateVersionTextIfCurrent(sdk, singleLineVersion);
-            }, modalityState);
-          }, null);
+            }
+          }
         }, modalityState);
       }
       catch (InterruptedException e) {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter-intellij/issues/9007

Summary of changes:
- Catch a more general exception when querying for Flutter SDK channel using git (when this happens, use flutter channel command instead).
- Wrap more of the queries in try/catch so that locks are released even during failure.

I believe this bug is new in 2026.1, because IntelliJ platform is throwing a new exception through git4idea. We were previously only catching a `VcsException` and the new exception is `IllegalStateException`.

Changing the setting for Flutter SDK triggers a query of what channel the SDK is on, and that's where the git exception occurs. Specifically, the exception occurs because IntelliJ is aware we are in a project context, but the git4idea utility does not record a project context anyway (even if we weren't sending `null` for project in `getExecutable`).

I asked gemini if we should instead skip checking git to get the SDK channel and always use the flutter channel query, but apparently this is not great either, because the git utility is to make finding the channel during new project creation significantly faster. I suppose we could still special case this path, but 🤷  - maybe not worth thinking about further.