### PR TITLE
Fix freeze when settings panel closed quickly

### DIFF
--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.java
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.java
@@ -100,7 +100,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
    * Semaphore used to synchronize flutter commands so we don't try to do two at once.
    */
   private final Semaphore lock = new Semaphore(1, true);
-  private Process updater;
+  private volatile @org.jspecify.annotations.Nullable Process updater;
 
   FlutterSettingsConfigurable(@NotNull Project project) {
     this.myProject = project;
@@ -428,13 +428,15 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
           try {
             updater = null;
             updater = sdk.flutterVersion().start((ProcessOutput output) -> {
+              if (updater != null) {
+                updater = null;
+                lock.release();
+              }
               fullVersionString = output.getStdout();
               final String[] lines = StringUtil.splitByLines(fullVersionString);
               final String singleLineVersion = lines.length > 0 ? lines[0] : "";
 
               OpenApiUtils.safeInvokeLater(() -> {
-                updater = null;
-                lock.release();
                 updateVersionTextIfCurrent(sdk, singleLineVersion);
               }, modalityState);
             }, null);

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.java
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.java
@@ -100,7 +100,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
    * Semaphore used to synchronize flutter commands so we don't try to do two at once.
    */
   private final Semaphore lock = new Semaphore(1, true);
-  private volatile @org.jspecify.annotations.Nullable Process updater;
+  private volatile @Nullable Process updater;
 
   FlutterSettingsConfigurable(@NotNull Project project) {
     this.myProject = project;


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter-intellij/issues/9013

I was able to reproduce the initial bug by changing the Flutter SDK directory, then clicking "Apply" very quickly (before the Flutter version check finished).

Both changing the SDK field and "Apply" start off flutter version checks that request the lock. "Apply" is happening on the UI thread and it will wait to acquire the lock before relinquishing the UI thread. So if we try to click "Apply" too quickly, the SDK field change still has the lock and wasn't releasing it until it could run on the UI thread (not possible because apply wasn't relinquishing). The fix is to check whether another flutter version check has started before we try to get the UI thread.

I had a hard time (or, am still having a hard time) making sense of this change, so I'm pasting the gemini output that finally made me confident I understood what's happening.

------

### Why it Froze Before (The Deadlock)

  In the previous code,  lock.release()  was placed inside  OpenApiUtils.safeInvokeLater(...) .

  1. Background Thread: Runs  flutter --version  while holding the  lock .
  2. User clicks Apply: The UI thread (EDT) runs  reset() , which hits  lock.acquire() . Because the background thread holds the lock, the EDT freezes completely, waiting for the lock to be released.
  3. Background Thread finishes: It tries to release the lock by calling  safeInvokeLater(() -> lock.release()) .
      • The Catch:  safeInvokeLater  puts the code in a queue and says, "Run this on the EDT as soon as the EDT is free."
  4. Permanent Freeze: The EDT is frozen waiting for  lock.release() , but  lock.release()  is stuck in the queue waiting for the EDT to unfreeze. Neither can ever proceed!
  ──────
  ### How Our Change Fixes It

  We moved  lock.release()  outside of  safeInvokeLater  so it runs directly on the background process-listener thread as soon as the command finishes:

    updater = sdk.flutterVersion().start((ProcessOutput output) -> {
      if (updater != null) {
        updater = null;
        lock.release(); // <-- NOW RUNS DIRECTLY ON THE BACKGROUND THREAD!
      }
      ...
      OpenApiUtils.safeInvokeLater(() -> {
        updateVersionTextIfCurrent(sdk, singleLineVersion);
      }, modalityState);
    }, null);

  Now, when  flutter --version  finishes in the background, it calls  lock.release()  immediately on the background thread without asking permission from the EDT.

  As soon as that happens, the frozen EDT instantly gets the lock, unblocks from  lock.acquire() , and smoothly finishes applying your settings!

  (Note: The  if (updater != null)  check just ensures that if you typed rapidly and a newer query already canceled this process, the canceled process won't accidentally release the lock a second time.)
