### PR TITLE
[infra] gradle retries for deployment

### DIFF
--- a/tool/kokoro/build.sh
+++ b/tool/kokoro/build.sh
@@ -4,36 +4,6 @@ setup
 
 echo "kokoro build start"
 
-MAX_RETRIES=3
-RETRY_DELAY_SECS=15
-ATTEMPT=1
-
-# Retry the build a few times to address transient failures.
-# See: https://github.com/flutter/flutter-intellij/issues/9009
-while [[ $ATTEMPT -le $MAX_RETRIES ]]; do
-  echo "Running buildPlugin (Attempt $ATTEMPT of $MAX_RETRIES)..."
-  
-  if ./gradlew buildPlugin; then
-    echo "Gradle build completed successfully."
-    break
-  else
-    exit_code=$?
-    if [[ $exit_code -ge 128 ]]; then
-      echo "Build interrupted. Exiting."
-      exit $exit_code
-    fi
-  fi
-
-  echo "Build failed on attempt $ATTEMPT."
-  
-  if [[ $ATTEMPT -eq $MAX_RETRIES ]]; then
-    echo "All $MAX_RETRIES attempts failed. Exiting."
-    exit $exit_code
-  fi
-
-  echo "Waiting $RETRY_DELAY_SECS seconds before retrying..."
-  sleep $RETRY_DELAY_SECS
-  ATTEMPT=$((ATTEMPT + 1))
-done
+run_gradle_with_retry buildPlugin
 
 echo "kokoro build finished"

--- a/tool/kokoro/deploy.sh
+++ b/tool/kokoro/deploy.sh
@@ -8,7 +8,7 @@ setup
 
 echo "kokoro build start"
 
-./gradlew buildPlugin -Pdev --no-configuration-cache
+run_gradle_with_retry buildPlugin -Pdev --no-configuration-cache
 
 echo "kokoro build finished"
 

--- a/tool/kokoro/setup.sh
+++ b/tool/kokoro/setup.sh
@@ -1,9 +1,83 @@
 #!/bin/bash
 
+# Run a gradle command with retries to handle transient errors.
+# See:
+# - https://github.com/flutter/flutter-intellij/issues/9009
+# - https://github.com/flutter/flutter-intellij/issues/9021
+# Usage: run_gradle_with_retry [--max-retries N] [--delay-secs N] <gradle_args...>
+run_gradle_with_retry() {
+  local max_retries=2
+  local delay_secs=15
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --max-retries)
+        if [[ $# -lt 2 ]]; then
+          echo "Error: --max-retries requires an argument." >&2
+          return 1
+        fi
+        max_retries="$2"
+        shift 2
+        ;;
+      --delay-secs)
+        if [[ $# -lt 2 ]]; then
+          echo "Error: --delay-secs requires an argument." >&2
+          return 1
+        fi
+        delay_secs="$2"
+        shift 2
+        ;;
+      *)
+        break
+        ;;
+    esac
+  done
+
+  local gradle_args=("$@")
+  local total_attempts=$((1 + ${max_retries:-0}))
+  local ATTEMPT=1
+  local exit_code=0
+
+  local gradlew_cmd="./gradlew"
+  if [[ ! -x "$gradlew_cmd" ]]; then
+    gradlew_cmd="./third_party/gradlew"
+  fi
+
+  echo "Gradle retry config: max_retries=$max_retries, total_attempts=$total_attempts, delay_secs=$delay_secs" >&2
+
+  while [[ $ATTEMPT -le $total_attempts ]]; do
+    echo "Running $gradlew_cmd ${gradle_args[*]} (Attempt $ATTEMPT of $total_attempts)..." >&2
+    
+    if "$gradlew_cmd" "${gradle_args[@]}"; then
+      echo "Gradle command completed successfully." >&2
+      return 0
+    else
+      exit_code=$?
+      if [[ $exit_code -ge 128 ]]; then
+        echo "Gradle command interrupted. Exiting." >&2
+        return $exit_code
+      fi
+    fi
+
+    echo "Gradle command failed on attempt $ATTEMPT." >&2
+    
+    if [[ $ATTEMPT -eq $total_attempts ]]; then
+      echo "All $total_attempts attempts failed." >&2
+      return $exit_code
+    fi
+
+    echo "Waiting $delay_secs seconds before retrying..." >&2
+    sleep $delay_secs
+    ATTEMPT=$((ATTEMPT + 1))
+  done
+}
+
 # Initialize everything required by the plugin tool.
 setup() {
   # Fail on any error.
   set -e
+  # Prevent pipeline failures from being masked (e.g. printVersion | tail).
+  set -o pipefail
 
   # Display commands being run. Only do this while debugging and be careful
   # that no confidential information is displayed.
@@ -45,5 +119,5 @@ setup() {
   export NO_FS_ROOTS_ACCESS_CHECK=true
 
   (cd tool/plugin; echo "dart pub get `pwd`"; dart pub get --no-precompile)
-  ./gradlew --version
+  run_gradle_with_retry --version
 }

--- a/tool/kokoro/setup.sh
+++ b/tool/kokoro/setup.sh
@@ -16,12 +16,20 @@ run_gradle_with_retry() {
           echo "Error: --max-retries requires an argument." >&2
           return 1
         fi
+        if [[ ! "$2" =~ ^[0-9]+$ ]]; then
+          echo "Error: --max-retries requires a non-negative integer." >&2
+          return 1
+        fi
         max_retries="$2"
         shift 2
         ;;
       --delay-secs)
         if [[ $# -lt 2 ]]; then
           echo "Error: --delay-secs requires an argument." >&2
+          return 1
+        fi
+        if [[ ! "$2" =~ ^[0-9]+$ ]]; then
+          echo "Error: --delay-secs requires a non-negative integer." >&2
           return 1
         fi
         delay_secs="$2"

--- a/tool/kokoro/test.sh
+++ b/tool/kokoro/test.sh
@@ -6,6 +6,6 @@ setup
 (cd testData/sample_tests; echo "dart pub get `pwd`"; dart pub get --no-precompile)
 
 echo "kokoro test start"
-./gradlew test
+run_gradle_with_retry --max-retries 0 test
 
 echo "kokoro test finished"


### PR DESCRIPTION
Adds retries to the release script and does a bit of general tidying up.

Fixes: https://github.com/flutter/flutter-intellij/issues/9021.

See also: https://github.com/flutter/dart-intellij-third-party/pull/496.

---

Review the contribution guidelines below:

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] I've included the required information in the description above.
- [x] My up-to-date information is in the `AUTHORS` file.
- [x] I've updated `CHANGELOG.md` if appropriate.

<details>
  <summary>Contribution guidelines:</summary><br>

- See
  our [contributor guide](../CONTRIBUTING.md) and
  the [Flutter organization contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md)
  for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use
  `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best
  practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).

</details>