### PR TITLE
Remove Bazel settings and analytics telemetry

### DIFF
--- a/src/io/flutter/FlutterBundle.properties
+++ b/src/io/flutter/FlutterBundle.properties
@@ -127,7 +127,6 @@ settings.organize.imports.on.save=Organize imports on save
 settings.flutter.version=Version:
 settings.open.inspector.on.launch=Open Flutter Inspector view on app launch
 settings.hot.reload.on.save=Perform hot reload on save
-settings.enable.bazel.hot.restart=Enable Bazel hot restart (refreshes generated files)
 settings.allow.tests.in.sources=<html>Allow files ending with <b>_test.dart</b> to be recognized as tests
 settings.allow.tests.tooltip=The directory must be marked as a sources root, such as <b>lib</b>.
 settings.font.packages=Font Packages

--- a/src/io/flutter/actions/FlutterSdkAction.java
+++ b/src/io/flutter/actions/FlutterSdkAction.java
@@ -43,7 +43,6 @@ public abstract class FlutterSdkAction extends DumbAwareAction {
       if (workspace != null) {
         FileDocumentManager.getInstance().saveAllDocuments();
         startCommandInBazelContext(project, workspace, event);
-        analyticsData.add(AnalyticsConstants.IN_BAZEL_CONTEXT, true);
         Analytics.report(analyticsData);
         return;
       }

--- a/src/io/flutter/actions/RestartFlutterApp.java
+++ b/src/io/flutter/actions/RestartFlutterApp.java
@@ -18,8 +18,6 @@ import icons.FlutterIcons;
 import io.flutter.FlutterBundle;
 import io.flutter.FlutterConstants;
 import io.flutter.FlutterMessages;
-import io.flutter.analytics.AnalyticsConstants;
-import io.flutter.bazel.WorkspaceCache;
 import io.flutter.run.FlutterReloadManager;
 import io.flutter.run.daemon.FlutterApp;
 import io.flutter.settings.FlutterSettings;
@@ -54,24 +52,6 @@ public class RestartFlutterApp extends FlutterAppAction {
     }
 
     var analyticsData = AnalyticsData.forAction(this, e);
-
-    if (WorkspaceCache.getInstance(project).isBazel() &&
-        FlutterSettings.getInstance().isShowBazelHotRestartWarning() &&
-        !FlutterSettings.getInstance().isEnableBazelHotRestart()) {
-      final Notification notification = new Notification(
-        FlutterMessages.FLUTTER_NOTIFICATION_GROUP_ID,
-        "Hot restart is not google3-specific",
-        "Hot restart now disables google3-specific support by default. This makes hot restart faster and more robust, but hot " +
-        "restart will not update generated files. To enable google3 hot restart, go to Settings > Flutter.",
-        NotificationType.INFORMATION);
-      Notifications.Bus.notify(notification, project);
-
-      analyticsData.add(AnalyticsConstants.GOOGLE3, true);
-
-      // We only want to show this notification once.
-      FlutterSettings.getInstance().setShowBazelHotRestartWarning(false);
-    }
-
     Analytics.report(analyticsData);
   }
 }

--- a/src/io/flutter/analytics/Analytics.kt
+++ b/src/io/flutter/analytics/Analytics.kt
@@ -27,12 +27,6 @@ object AnalyticsConstants {
   val GOOGLE3 = BooleanValue("google3")
 
   /**
-   * Indicates if the project is in a Bazel context.
-   */
-  @JvmField
-  val IN_BAZEL_CONTEXT = BooleanValue("inBazelContext")
-
-  /**
    * Indicates if the Flutter SDK is missing.
    */
   @JvmField
@@ -46,8 +40,6 @@ object AnalyticsConstants {
 
   const val MECHANISM_FLUTTER_ATTACH = "flutter_attach"
   const val MECHANISM_FLUTTER_APP = "flutter_app"
-  const val MECHANISM_BAZEL_APP = "bazel_app"
-  const val MECHANISM_BAZEL_TEST = "bazel_test"
   const val MECHANISM_FLUTTER_TESTS = "flutter_tests"
 
   const val DEBUG_SESSION_TYPE = "debug_session"

--- a/src/io/flutter/sdk/FlutterSearchableOptionContributor.java
+++ b/src/io/flutter/sdk/FlutterSearchableOptionContributor.java
@@ -24,7 +24,6 @@ public class FlutterSearchableOptionContributor extends SearchableOptionContribu
     add(processor, FlutterBundle.message("settings.flutter.version"));
     add(processor, FlutterBundle.message("settings.open.inspector.on.launch"));
     add(processor, FlutterBundle.message("settings.hot.reload.on.save"));
-    add(processor, FlutterBundle.message("settings.enable.bazel.hot.restart"));
     add(processor, FlutterBundle.message("settings.allow.tests.in.sources"));
     add(processor, FlutterBundle.message("settings.allow.tests.tooltip"));
     add(processor, FlutterBundle.message("settings.font.packages"));

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.form
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.form
@@ -128,6 +128,7 @@
             <properties>
               <text value="Show structured errors for Flutter framework issues"/>
             </properties>
+          </component>
           <component id="6cf1f" class="javax.swing.JCheckBox" binding="myIncludeAllStackTraces">
             <constraints>
               <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="3" use-parent-layout="false"/>

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.form
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.form
@@ -128,15 +128,6 @@
             <properties>
               <text value="Show structured errors for Flutter framework issues"/>
             </properties>
-          </component>
-          <component id="475be" class="javax.swing.JCheckBox" binding="myEnableBazelHotRestartCheckBox">
-            <constraints>
-              <grid row="4" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
-            </constraints>
-            <properties>
-              <text resource-bundle="io/flutter/FlutterBundle" key="settings.enable.bazel.hot.restart"/>
-            </properties>
-          </component>
           <component id="6cf1f" class="javax.swing.JCheckBox" binding="myIncludeAllStackTraces">
             <constraints>
               <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="3" use-parent-layout="false"/>

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.java
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.java
@@ -38,8 +38,6 @@ import icons.FlutterIcons;
 import io.flutter.FlutterBundle;
 import io.flutter.FlutterConstants;
 import io.flutter.FlutterMessages;
-import io.flutter.bazel.Workspace;
-import io.flutter.bazel.WorkspaceCache;
 import io.flutter.font.FontPreviewProcessor;
 import io.flutter.pub.PubRoot;
 import io.flutter.pub.PubRoots;
@@ -75,10 +73,8 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
   private JCheckBox myOrganizeImportsOnSaveCheckBox;
   private JCheckBox myShowStructuredErrors;
   private JCheckBox myIncludeAllStackTraces;
-  private JCheckBox myEnableBazelHotRestartCheckBox;
 
   private JCheckBox myEnableJcefBrowserCheckBox;
-
   private JCheckBox myShowBuildMethodGuides;
   private JCheckBox myShowClosingLabels;
   private FixedSizeButton myCopyButton;
@@ -89,10 +85,8 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
   private @NotNull JCheckBox myEnableFilePathLogging;
 
   private final @NotNull Project myProject;
-  private final WorkspaceCache workspaceCache;
 
   private boolean ignoringSdkChanges = false;
-
   private String fullVersionString;
   private FlutterSdkVersion previousSdkVersion;
 
@@ -104,7 +98,6 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
 
   FlutterSettingsConfigurable(@NotNull Project project) {
     this.myProject = project;
-    workspaceCache = WorkspaceCache.getInstance(project);
     init();
     myVersionLabel.setText(" ");
   }
@@ -133,13 +126,10 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
         }
       }
     });
-    workspaceCache.subscribe(this::onVersionChanged);
     myFormatCodeOnSaveCheckBox.addChangeListener(
       (e) -> myOrganizeImportsOnSaveCheckBox.setEnabled(myFormatCodeOnSaveCheckBox.isSelected()));
     myShowStructuredErrors.addChangeListener(
       (e) -> myIncludeAllStackTraces.setEnabled(myShowStructuredErrors.isSelected()));
-
-    myEnableBazelHotRestartCheckBox.setVisible(WorkspaceCache.getInstance(myProject).isBazel());
   }
 
   private void createUIComponents() {
@@ -234,10 +224,6 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
       return true;
     }
 
-    if (settings.isEnableBazelHotRestart() != myEnableBazelHotRestartCheckBox.isSelected()) {
-      return true;
-    }
-
     if (settings.isAllowTestsInSourcesRoot() != myAllowTestsInSourcesRoot.isSelected()) {
       return true;
     }
@@ -255,36 +241,31 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
 
   @Override
   public void apply() throws ConfigurationException {
-    // Bazel workspaces do not specify a sdk path so we do not need to update the sdk path if using
-    // a bazel workspace.
-    if (!workspaceCache.isBazel()) {
-      final String errorMessage = FlutterSdkUtil.getErrorMessageIfWrongSdkRootPath(getSdkPathText());
-      if (errorMessage != null) {
-        throw new ConfigurationException(errorMessage);
-      }
+    final String errorMessage = FlutterSdkUtil.getErrorMessageIfWrongSdkRootPath(getSdkPathText());
+    if (errorMessage != null) {
+      throw new ConfigurationException(errorMessage);
+    }
 
-      final String sdkHomePath = getSdkPathText();
-      if (FlutterSdkUtil.isFlutterSdkHome(sdkHomePath)) {
+    final String sdkHomePath = getSdkPathText();
+    if (FlutterSdkUtil.isFlutterSdkHome(sdkHomePath)) {
+      OpenApiUtils.safeRunWriteAction(() -> {
+        FlutterSdkUtil.setFlutterSdkPath(myProject, sdkHomePath);
+        FlutterSdkUtil.enableDartSdk(myProject);
 
-        OpenApiUtils.safeRunWriteAction(() -> {
-          FlutterSdkUtil.setFlutterSdkPath(myProject, sdkHomePath);
-          FlutterSdkUtil.enableDartSdk(myProject);
-
-          ApplicationManager.getApplication().executeOnPooledThread(() -> {
-            final FlutterSdk sdk = FlutterSdk.forPath(sdkHomePath);
-            if (sdk != null) {
-              try {
-                lock.acquire();
-                sdk.queryFlutterChannel(false);
-                lock.release();
-              }
-              catch (InterruptedException e) {
-                // do nothing
-              }
+        ApplicationManager.getApplication().executeOnPooledThread(() -> {
+          final FlutterSdk sdk = FlutterSdk.forPath(sdkHomePath);
+          if (sdk != null) {
+            try {
+              lock.acquire();
+              sdk.queryFlutterChannel(false);
+              lock.release();
             }
-          });
+            catch (InterruptedException e) {
+              // do nothing
+            }
+          }
         });
-      }
+      });
     }
 
     final FlutterSettings settings = FlutterSettings.getInstance();
@@ -300,7 +281,6 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     settings.setOpenInspectorOnAppLaunch(myOpenInspectorOnAppLaunchCheckBox.isSelected());
     settings.setPerserveLogsDuringHotReloadAndRestart(myEnableLogsPreserveAfterHotReloadOrRestart.isSelected());
     settings.setVerboseLogging(myEnableVerboseLoggingCheckBox.isSelected());
-    settings.setEnableBazelHotRestart(myEnableBazelHotRestartCheckBox.isSelected());
     settings.setAllowTestsInSourcesRoot(myAllowTestsInSourcesRoot.isSelected());
     settings.setFontPackages(myFontPackagesTextArea.getText());
     settings.setEnableJcefBrowser(myEnableJcefBrowserCheckBox.isSelected());
@@ -355,7 +335,6 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     myOrganizeImportsOnSaveCheckBox.setSelected(settings.isOrganizeImportsOnSave());
 
     myShowBuildMethodGuides.setSelected(settings.isShowBuildMethodGuides());
-
     myShowClosingLabels.setSelected(settings.isShowClosingLabels());
 
     myShowStructuredErrors.setSelected(settings.isShowStructuredErrors());
@@ -364,9 +343,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     myEnableLogsPreserveAfterHotReloadOrRestart.setSelected(settings.isPerserveLogsDuringHotReloadAndRestart());
     myEnableVerboseLoggingCheckBox.setSelected(settings.isVerboseLogging());
 
-    myEnableBazelHotRestartCheckBox.setSelected(settings.isEnableBazelHotRestart());
     myAllowTestsInSourcesRoot.setSelected(settings.isAllowTestsInSourcesRoot());
-
     myOrganizeImportsOnSaveCheckBox.setEnabled(myFormatCodeOnSaveCheckBox.isSelected());
     myIncludeAllStackTraces.setEnabled(myShowStructuredErrors.isSelected());
 
@@ -376,21 +353,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
   }
 
   private void onVersionChanged() {
-    final Workspace workspace = workspaceCache.get();
-    if (workspaceCache.isBazel()) {
-      if (mySdkCombo.isEnabled()) {
-        // The workspace is not null if workspaceCache.isBazel() is true.
-        assert (workspace != null);
-
-        mySdkCombo.setEnabled(false);
-        mySdkCombo.getEditor()
-          .setItem(workspace.getRoot().getPath() + '/' + workspace.getSdkHome() + " <set by bazel project>");
-      }
-    }
-    else {
-      mySdkCombo.setEnabled(true);
-    }
-
+    mySdkCombo.setEnabled(true);
     final FlutterSdk sdk = FlutterSdk.forPath(getSdkPathText());
     if (sdk == null) {
       // Clear the label out with a non-empty string, so that the layout doesn't give this element 0 height.

--- a/src/io/flutter/settings/FlutterSettings.java
+++ b/src/io/flutter/settings/FlutterSettings.java
@@ -27,12 +27,9 @@ public class FlutterSettings {
   private static final String showStructuredErrorsKey = "io.flutter.showStructuredErrors";
   private static final String includeAllStackTracesKey = "io.flutter.includeAllStackTraces";
   private static final String showBuildMethodGuidesKey = "io.flutter.editor.showBuildMethodGuides";
-  private static final String enableBazelHotRestartKey = "io.flutter.editor.enableBazelHotRestart";
-  private static final String showBazelHotRestartWarningKey = "io.flutter.showBazelHotRestartWarning";
   private static final String enableJcefBrowserKey = "io.flutter.enableJcefBrowser";
   private static final String fontPackagesKey = "io.flutter.fontPackages";
   private static final String allowTestsInSourcesRootKey = "io.flutter.allowTestsInSources";
-  private static final String showBazelIosRunNotificationKey = "io.flutter.hideBazelIosRunNotification";
   private static final String sdkVersionOutdatedWarningAcknowledgedKey = "io.flutter.sdkVersionOutdatedWarningAcknowledged";
   private static final String androidStudioBotAcknowledgedKey = "io.flutter.androidStudioBotAcknowledgedKey";
   private static final String enableFilePathLoggingKey = "io.flutter.enableFilePathLogging";
@@ -194,24 +191,6 @@ public class FlutterSettings {
     dispatcher.getMulticaster().settingsChanged();
   }
 
-  public boolean isEnableBazelHotRestart() {
-    return getPropertiesComponent().getBoolean(enableBazelHotRestartKey, false);
-  }
-
-  public void setEnableBazelHotRestart(boolean value) {
-    getPropertiesComponent().setValue(enableBazelHotRestartKey, value, false);
-    fireEvent();
-  }
-
-  public boolean isShowBazelHotRestartWarning() {
-    return getPropertiesComponent().getBoolean(showBazelHotRestartWarningKey, true);
-  }
-
-  public void setShowBazelHotRestartWarning(boolean value) {
-    getPropertiesComponent().setValue(showBazelHotRestartWarningKey, value, true);
-    fireEvent();
-  }
-
   public boolean isAllowTestsInSourcesRoot() {
     return getPropertiesComponent().getBoolean(allowTestsInSourcesRootKey, false);
   }
@@ -221,14 +200,7 @@ public class FlutterSettings {
     fireEvent();
   }
 
-  public boolean isShowBazelIosRunNotification() {
-    return getPropertiesComponent().getBoolean(showBazelIosRunNotificationKey, true);
-  }
 
-  public void setShowBazelIosRunNotification(boolean value) {
-    getPropertiesComponent().setValue(showBazelIosRunNotificationKey, value, true);
-    fireEvent();
-  }
 
   /**
    * See {FlutterSdkVersion#MIN_SDK_SUPPORTED}.


### PR DESCRIPTION
To manually test this:
- Check flutter settings panel - bazel-related checkbox should be removed, but other things should still be changeable. SDK should be changeable (though there are some bugs here that are unrelated to this change, mostly from clicking around quickly during SDK changes)
- Hot reload and hot restart should still work
- Pub commands should still work, e.g. try running flutter doctor