### PR TITLE
fix: add jcef as dependency for Intellij 2026.2

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -26,6 +26,7 @@
   <depends>com.intellij.modules.platform</depends>
   <depends>com.intellij.modules.lang</depends>
   <depends>com.intellij.modules.xdebugger</depends>
+  <depends>com.intellij.modules.jcef</depends>
   <depends>org.jetbrains.plugins.yaml</depends>
   <depends>Dart</depends>
   <depends>Git4Idea</depends>


### PR DESCRIPTION
Since 2026.2, jcef should be declared explicitly, or Intellij will complain `java.lang.NoClassDefFoundError: com/intellij/ui/jcef/JBCefBrowser`

See: https://github.com/asciidoctor/asciidoctor-intellij-plugin/pull/2081

Review the contribution guidelines below:

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] I've included the required information in the description above.
- [ ] My up-to-date information is in the `AUTHORS` file.
- [ ] I've updated `CHANGELOG.md` if appropriate.