### PR TITLE
Remove semaphore and instead use cancelable process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Bazel run and test configurations.
 
 ### Fixed
+- IDE freeze when applying Flutter SDK path changes in Settings. (#9058)
 
 ## 94.0.0
 

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.java
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.java
@@ -54,7 +54,7 @@ import javax.swing.text.JTextComponent;
 import java.awt.datatransfer.StringSelection;
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicReference;
 
 // Note: when updating the settings here, update FlutterSearchableOptionContributor as well.
 
@@ -90,11 +90,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
   private String fullVersionString;
   private FlutterSdkVersion previousSdkVersion;
 
-  /**
-   * Semaphore used to synchronize flutter commands so we don't try to do two at once.
-   */
-  private final Semaphore lock = new Semaphore(1, true);
-  private Process updater;
+  private final AtomicReference<Process> activeVersionProcess = new AtomicReference<>();
 
   FlutterSettingsConfigurable(@NotNull Project project) {
     this.myProject = project;
@@ -256,12 +252,10 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
           final FlutterSdk sdk = FlutterSdk.forPath(sdkHomePath);
           if (sdk != null) {
             try {
-              lock.acquire();
               sdk.queryFlutterChannel(false);
-              lock.release();
             }
-            catch (InterruptedException e) {
-              // do nothing
+            catch (Throwable ignored) {
+              // ignore exceptions during channel query
             }
           }
         });
@@ -311,16 +305,11 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
       if (previousSdkVersion != null) {
         if (previousSdkVersion.compareTo(sdk.getVersion()) != 0) {
           final List<PubRoot> roots = PubRoots.forProject(myProject);
-          try {
-            lock.acquire();
+          ApplicationManager.getApplication().executeOnPooledThread(() -> {
             for (PubRoot root : roots) {
               sdk.startPubGet(root, myProject);
             }
-            lock.release();
-          }
-          catch (InterruptedException e) {
-            // do nothing
-          }
+          });
           previousSdkVersion = sdk.getVersion();
         }
       }
@@ -352,8 +341,17 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     myEnableFilePathLogging.setSelected(settings.isFilePathLoggingEnabled());
   }
 
+  private void cancelActiveVersionProcess() {
+    final Process previous = activeVersionProcess.getAndSet(null);
+    if (previous != null && previous.isAlive()) {
+      previous.destroy();
+    }
+  }
+
   private void onVersionChanged() {
     mySdkCombo.setEnabled(true);
+    cancelActiveVersionProcess();
+
     final FlutterSdk sdk = FlutterSdk.forPath(getSdkPathText());
     if (sdk == null) {
       // Clear the label out with a non-empty string, so that the layout doesn't give this element 0 height.
@@ -362,40 +360,32 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
       return;
     }
 
-    // Moved launching the version updater to a background thread to avoid deadlock
-    // when the semaphone was locked for a long time on the EDT.
     final ModalityState modalityState = ModalityState.current();
     ApplicationManager.getApplication().executeOnPooledThread(() -> {
-      try {
-        if (updater != null) {
-          // If we get back here before the previous one finished then just kill it.
-          // This isn't perfect, but does help avoid printing this message most times:
-          // Waiting for another flutter command to release the startup lock...
-          updater.destroy();
-          lock.release();
-        }
-        Thread.sleep(100L);
-        lock.acquire();
+      // "flutter --version" can take a long time on a slow network.
+      final Process[] processHolder = new Process[1];
+      processHolder[0] = sdk.flutterVersion().start((ProcessOutput output) -> {
+        fullVersionString = output.getStdout();
+        final String[] lines = StringUtil.splitByLines(fullVersionString);
+        final String singleLineVersion = lines.length > 0 ? lines[0] : "";
 
         OpenApiUtils.safeInvokeLater(() -> {
-          // "flutter --version" can take a long time on a slow network.
-          updater = sdk.flutterVersion().start((ProcessOutput output) -> {
-            fullVersionString = output.getStdout();
-            final String[] lines = StringUtil.splitByLines(fullVersionString);
-            final String singleLineVersion = lines.length > 0 ? lines[0] : "";
-
-            OpenApiUtils.safeInvokeLater(() -> {
-              updater = null;
-              lock.release();
-              updateVersionTextIfCurrent(sdk, singleLineVersion);
-            }, modalityState);
-          }, null);
+          if (processHolder[0] != null) {
+            activeVersionProcess.compareAndSet(processHolder[0], null);
+          }
+          updateVersionTextIfCurrent(sdk, singleLineVersion);
         }, modalityState);
-      }
-      catch (InterruptedException e) {
-        // do nothing
+      }, null);
+
+      if (processHolder[0] != null) {
+        activeVersionProcess.set(processHolder[0]);
       }
     });
+  }
+
+  @Override
+  public void disposeUIResources() {
+    cancelActiveVersionProcess();
   }
 
   /***

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.java
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.java
@@ -5,6 +5,8 @@
  */
 package io.flutter.sdk;
 
+import com.intellij.execution.process.CapturingProcessAdapter;
+import com.intellij.execution.process.ColoredProcessHandler;
 import com.intellij.execution.process.ProcessOutput;
 import com.intellij.icons.AllIcons;
 import com.intellij.ide.actions.ShowSettingsUtilImpl;
@@ -254,7 +256,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
             try {
               sdk.queryFlutterChannel(false);
             }
-            catch (Throwable ignored) {
+            catch (Exception ignored) {
               // ignore exceptions during channel query
             }
           }
@@ -363,23 +365,28 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     final ModalityState modalityState = ModalityState.current();
     ApplicationManager.getApplication().executeOnPooledThread(() -> {
       // "flutter --version" can take a long time on a slow network.
-      final Process[] processHolder = new Process[1];
-      processHolder[0] = sdk.flutterVersion().start((ProcessOutput output) -> {
-        fullVersionString = output.getStdout();
-        final String[] lines = StringUtil.splitByLines(fullVersionString);
-        final String singleLineVersion = lines.length > 0 ? lines[0] : "";
-
-        OpenApiUtils.safeInvokeLater(() -> {
-          if (processHolder[0] != null) {
-            activeVersionProcess.compareAndSet(processHolder[0], null);
-          }
-          updateVersionTextIfCurrent(sdk, singleLineVersion);
-        }, modalityState);
-      }, null);
-
-      if (processHolder[0] != null) {
-        activeVersionProcess.set(processHolder[0]);
+      final Process process = sdk.flutterVersion().start();
+      if (process == null) {
+        return;
       }
+      activeVersionProcess.set(process);
+
+      final ColoredProcessHandler handler = new ColoredProcessHandler(process, null);
+      final CapturingProcessAdapter listener = new CapturingProcessAdapter();
+      handler.addProcessListener(listener);
+      handler.startNotify();
+      handler.waitFor();
+
+      final ProcessOutput output = listener.getOutput();
+      final String stdout = output.getStdout();
+      final String[] lines = StringUtil.splitByLines(stdout);
+      final String singleLineVersion = lines.length > 0 ? lines[0] : "";
+
+      OpenApiUtils.safeInvokeLater(() -> {
+        activeVersionProcess.compareAndSet(process, null);
+        fullVersionString = stdout;
+        updateVersionTextIfCurrent(sdk, singleLineVersion);
+      }, modalityState);
     });
   }
 


### PR DESCRIPTION
The semaphore lock was causing problems because of this kind of situation:
- The plugin got the lock and started `flutter --version` on a background thread, then it waits for the process to finish to execute something on the UI thread, then release the lock.
- The UI thread would request the lock but find it's not available (flutter process is running), and wait.
- This resulted in a stuck state since the background thread is waiting for access to the UI thread to release the lock.

Previously, I was trying to fix this by making sure we release the semaphore lock in all the places it should be released, e.g. (https://github.com/flutter/flutter-intellij/pull/9016), but this is more confusing.

A semaphore is not the right solution for this case; it makes more sense to use a cancelable process. (In a later PR, this may change into a queue. I'm not sure yet.) `flutter --version` is run just to show the version in the settings panel, so if a user closes the settings panel, then we can cancel the version check. (Another version check will run later anyway as we save the version. Although, this is also an open issue about saving the version, which still needs to be fixed: https://github.com/flutter/flutter-intellij/issues/8641).

How to verify this change:
- Go to settings > (languages and frameworks) Flutter
- Choose a Flutter SDK at a new file location
- Click apply (quickly, or slowly) - neither should result in a crash.
- (Note that you may still get the wrong SDK file path when you open the settings again. I believe this is part of #8641) 

This hopefully fixes https://github.com/flutter/flutter-intellij/issues/9013

---

Review the contribution guidelines below:

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] I've included the required information in the description above.
- [x] My up-to-date information is in the `AUTHORS` file.
- [x] I've updated `CHANGELOG.md` if appropriate.

<details>
  <summary>Contribution guidelines:</summary><br>

- See
  our [contributor guide](../CONTRIBUTING.md) and
  the [Flutter organization contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md)
  for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use
  `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best
  practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).

</details>