### PR TITLE
Remove Weberknecht from the project

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -321,8 +321,6 @@ intellijPlatform {
     )
     verificationReportsFormats = VerifyPluginTask.VerificationReportsFormats.ALL
     subsystemsToCheck = VerifyPluginTask.Subsystems.ALL
-    ignoredProblemsFile.set(project.file("verify-ignore-problems.txt"))
-
     ides {
       // `singleIdeVersion` is only intended for use by GitHub actions to enable deleting instances of IDEs after testing.
       if (singleIdeVersionProvider.isPresent) {

--- a/flutter-intellij-community.iml
+++ b/flutter-intellij-community.iml
@@ -138,15 +138,6 @@
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/third_party/lib/dart-plugin/deps/weberknecht-0.1.5.jar!/" />
-        </CLASSES>
-        <JAVADOC />
-        <SOURCES />
-      </library>
-    </orderEntry>
-    <orderEntry type="module-library">
-      <library>
-        <CLASSES>
           <root url="jar://$MODULE_DIR$/third_party/lib/java-string-similarity-2.0.0.jar!/" />
         </CLASSES>
         <JAVADOC />

--- a/src/io/flutter/FlutterInitializer.java
+++ b/src/io/flutter/FlutterInitializer.java
@@ -29,7 +29,6 @@ import com.intellij.openapi.roots.ProjectRootManager;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.util.concurrency.AppExecutorUtil;
 import com.intellij.util.messages.MessageBusConnection;
-import de.roderick.weberknecht.WebSocketException;
 import io.flutter.android.IntelliJAndroidSdk;
 import io.flutter.dart.DtdUtils;
 import io.flutter.dart.FlutterDartAnalysisServer;
@@ -313,7 +312,9 @@ public class FlutterInitializer extends FlutterProjectActivity {
               }
             });
           }
-          catch (WebSocketException e) {
+          // The Dart plugin changed its checked WebSocket exception type when it replaced
+          // Weberknecht. Catching the common base type keeps this call compatible with both APIs.
+          catch (Exception e) {
             log().error("Unable to send theme changed event", e);
           }
         })

--- a/src/io/flutter/run/daemon/FlutterApp.java
+++ b/src/io/flutter/run/daemon/FlutterApp.java
@@ -28,7 +28,6 @@ import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.util.EventDispatcher;
 import com.intellij.util.concurrency.AppExecutorUtil;
 import com.jetbrains.lang.dart.ide.toolingDaemon.DartToolingDaemonService;
-import de.roderick.weberknecht.WebSocketException;
 import io.flutter.FlutterUtils;
 import io.flutter.ObservatoryConnector;
 import io.flutter.dart.DtdRequest;
@@ -841,7 +840,10 @@ class FlutterAppDaemonEventListener implements DaemonEvent.Listener {
         }
       });
     }
-    catch (InterruptedException | java.util.concurrent.ExecutionException | WebSocketException e) {
+    // The Dart plugin changed its checked WebSocket exception type when it replaced
+    // Weberknecht. Catching the common base type keeps this call compatible with both APIs.
+    // We can potnetitaly catch WebSocketException in the future from Dart plugin, but since it's only used for logging, the general exception is ok
+    catch (Exception e) {
       LOG.error("Exception while sending DTD request", e);
     }
   }

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/VmServiceBase.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/VmServiceBase.java
@@ -17,15 +17,15 @@ import com.google.common.collect.Maps;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
-import de.roderick.weberknecht.WebSocket;
-import de.roderick.weberknecht.WebSocketEventHandler;
-import de.roderick.weberknecht.WebSocketException;
-import de.roderick.weberknecht.WebSocketMessage;
 import org.dartlang.vm.service.consumer.*;
 import org.dartlang.vm.service.element.*;
 import org.dartlang.vm.service.internal.RequestSink;
 import org.dartlang.vm.service.internal.VmServiceConst;
 import org.dartlang.vm.service.internal.WebSocketRequestSink;
+import org.dartlang.vm.service.internal.websocket.WebSocket;
+import org.dartlang.vm.service.internal.websocket.WebSocketEventHandler;
+import org.dartlang.vm.service.internal.websocket.WebSocketException;
+import org.dartlang.vm.service.internal.websocket.WebSocketMessage;
 import org.dartlang.vm.service.logging.Logging;
 
 import java.io.IOException;
@@ -63,13 +63,7 @@ abstract class VmServiceBase implements VmServiceConst {
     }
 
     // Create web socket and observatory
-    WebSocket webSocket;
-    try {
-      webSocket = new WebSocket(uri);
-    }
-    catch (WebSocketException e) {
-      throw new IOException("Failed to create websocket: " + url, e);
-    }
+    WebSocket webSocket = new WebSocket(uri);
     final VmService vmService = new VmService();
 
     // Setup event handler for forwarding responses
@@ -113,11 +107,6 @@ abstract class VmServiceBase implements VmServiceConst {
       webSocket.connect();
     }
     catch (WebSocketException e) {
-      throw new IOException("Failed to connect: " + url, e);
-    }
-    catch (ArrayIndexOutOfBoundsException e) {
-      // The weberknecht can occasionally throw an array index exception if a connect terminates on initial connect
-      // (de.roderick.weberknecht.WebSocket.connect, WebSocket.java:126).
       throw new IOException("Failed to connect: " + url, e);
     }
     vmService.requestSink = new WebSocketRequestSink(webSocket);

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/internal/WebSocketRequestSink.java
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/internal/WebSocketRequestSink.java
@@ -14,8 +14,8 @@
 package org.dartlang.vm.service.internal;
 
 import com.google.gson.JsonObject;
-import de.roderick.weberknecht.WebSocket;
-import de.roderick.weberknecht.WebSocketException;
+import org.dartlang.vm.service.internal.websocket.WebSocket;
+import org.dartlang.vm.service.internal.websocket.WebSocketException;
 import org.dartlang.vm.service.logging.Logging;
 
 /**

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/internal/websocket/WebSocket.kt
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/internal/websocket/WebSocket.kt
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2026 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+package org.dartlang.vm.service.internal.websocket
+
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.WebSocket as JdkWebSocket
+import java.nio.ByteBuffer
+import java.util.concurrent.CompletionStage
+import java.util.concurrent.TimeUnit
+
+/**
+ * A thin wrapper around the JDK [java.net.http.WebSocket] that originally mirrored the API of the
+ * Weberknecht library's WebSocket to ease replacement.
+ */
+class WebSocket(private val uri: URI) {
+
+    @Volatile
+    private var jdkWebSocket: JdkWebSocket? = null
+
+    @Volatile
+    var eventHandler: WebSocketEventHandler? = null
+
+    @Throws(WebSocketException::class)
+    fun connect() {
+        val listener = JdkListener()
+        val future = try {
+            httpClient.newWebSocketBuilder().buildAsync(uri, listener).toCompletableFuture()
+        } catch (e: Exception) {
+            throw WebSocketException("Failed to start WebSocket handshake to $uri", e)
+        }
+        try {
+            future.get(CONNECT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        } catch (e: Exception) {
+            future.cancel(true)
+            if (e is InterruptedException) {
+                Thread.currentThread().interrupt()
+            }
+            throw WebSocketException("WebSocket handshake to $uri failed", e)
+        }
+    }
+
+    @Synchronized
+    @Throws(WebSocketException::class)
+    fun send(text: String) {
+        val webSocket = jdkWebSocket ?: throw WebSocketException("WebSocket is not connected")
+        val future = webSocket.sendText(text, true).toCompletableFuture()
+        try {
+            future.get(SEND_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        } catch (e: Exception) {
+            future.cancel(true)
+            if (e is InterruptedException) {
+                Thread.currentThread().interrupt()
+            }
+            throw WebSocketException("Failed to send WebSocket message", e)
+        }
+    }
+
+    @Synchronized
+    @Throws(WebSocketException::class)
+    fun close() {
+        val webSocket = jdkWebSocket ?: return
+        val future = webSocket.sendClose(JdkWebSocket.NORMAL_CLOSURE, "Normal Closure").toCompletableFuture()
+        try {
+            future.get(CLOSE_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        } catch (e: Exception) {
+            future.cancel(true)
+            if (e is InterruptedException) {
+                Thread.currentThread().interrupt()
+            }
+            throw WebSocketException("Failed to close WebSocket gracefully", e)
+        } finally {
+            jdkWebSocket = null
+        }
+    }
+
+    private inner class JdkListener : JdkWebSocket.Listener {
+        private val pendingText = StringBuilder()
+
+        override fun onOpen(webSocket: JdkWebSocket) {
+            jdkWebSocket = webSocket
+            webSocket.request(Long.MAX_VALUE)
+            eventHandler?.onOpen()
+        }
+
+        override fun onText(webSocket: JdkWebSocket, data: CharSequence, last: Boolean): CompletionStage<*>? {
+            pendingText.append(data)
+            if (last) {
+                val complete = pendingText.toString()
+                pendingText.setLength(0)
+                eventHandler?.onMessage(WebSocketMessage(complete))
+            }
+            return null
+        }
+
+        // We could use the statusCode and the reason for logging purposes
+        override fun onClose(webSocket: JdkWebSocket, statusCode: Int, reason: String): CompletionStage<*>? {
+            pendingText.clear()
+            jdkWebSocket = null
+            eventHandler?.onClose()
+            return null
+        }
+
+        override fun onError(webSocket: JdkWebSocket, error: Throwable) {
+            pendingText.clear()
+            jdkWebSocket = null
+            eventHandler?.onClose()
+        }
+
+        override fun onPing(webSocket: JdkWebSocket, message: ByteBuffer): CompletionStage<*>? {
+            eventHandler?.onPing()
+            return null
+        }
+
+        override fun onPong(webSocket: JdkWebSocket, message: ByteBuffer): CompletionStage<*>? {
+            eventHandler?.onPong()
+            return null
+        }
+    }
+
+    private companion object {
+        const val CONNECT_TIMEOUT_SECONDS = 10L
+        const val SEND_TIMEOUT_SECONDS = 10L
+        const val CLOSE_TIMEOUT_SECONDS = 10L
+        private val httpClient: HttpClient = HttpClient.newHttpClient()
+    }
+}

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/internal/websocket/WebSocketEventHandler.kt
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/internal/websocket/WebSocketEventHandler.kt
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2026 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+package org.dartlang.vm.service.internal.websocket
+
+interface WebSocketEventHandler {
+  fun onOpen()
+  fun onMessage(message: WebSocketMessage)
+  fun onClose()
+  fun onPing()
+  fun onPong()
+}

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/internal/websocket/WebSocketException.kt
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/internal/websocket/WebSocketException.kt
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2026 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+package org.dartlang.vm.service.internal.websocket
+
+class WebSocketException : Exception {
+  constructor(message: String) : super(message)
+  constructor(message: String, cause: Throwable) : super(message, cause)
+}

--- a/third_party/vmServiceDrivers/org/dartlang/vm/service/internal/websocket/WebSocketMessage.kt
+++ b/third_party/vmServiceDrivers/org/dartlang/vm/service/internal/websocket/WebSocketMessage.kt
@@ -1,0 +1,9 @@
+/*
+ * Copyright 2026 The Chromium Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+package org.dartlang.vm.service.internal.websocket
+
+data class WebSocketMessage(val text: String)

--- a/verify-ignore-problems.txt
+++ b/verify-ignore-problems.txt
@@ -1,6 +1,0 @@
-# This is a known false positive. The de.roderick.weberknecht package is provided
-# by the Dart plugin at runtime, but the verifier's static analysis of
-# class loader visibility is flawed in this case.
-# See more context in https://github.com/flutter/flutter-intellij/pull/8590
-::Package 'de.roderick' is not found.*
-


### PR DESCRIPTION
## Summary

This pull request copies the Jdk's WebSocket into `third_party/vmServiceDrivers/org/dartlang/vm/service/internal`.
And replaces it with the Weberknecht.

Note about FlutterApp.java:
Since the new version of dart plugin is no longer throwing weberknecht.WebSocketException, we need to migrate the exception handling to the new Exception as well. But because we are only logging the exception here generalizing is a good idea to keep the compatibiity with both old and new dart plugin. 