### PR TITLE
Update Dart dependency, remove untilBuild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 ### Changed
+- Removed upper build constraint (`untilBuild`) for open-ended platform compatibility. (#9063)
 
 ### Removed
 - Support for platform version 2025.1.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -93,7 +93,6 @@ if (isRelease) {
 val androidStudioVersion = providers.gradleProperty("androidStudioVersion").get()
 val dartPluginVersion = providers.gradleProperty("dartPluginVersion").get()
 val sinceBuildInput = providers.gradleProperty("sinceBuild").get()
-val untilBuildInput = providers.gradleProperty("untilBuild").get()
 val javaVersion = providers.gradleProperty("javaVersion").get()
 group = "io.flutter"
 
@@ -102,7 +101,6 @@ println("flutterPluginVersion: $flutterPluginVersion")
 println("androidStudioVersion: $androidStudioVersion")
 println("dartPluginVersion: $dartPluginVersion")
 println("sinceBuild: $sinceBuildInput")
-println("untilBuild: $untilBuildInput")
 println("javaVersion: $javaVersion")
 println("group: $group")
 
@@ -289,7 +287,6 @@ intellijPlatform {
     version = flutterPluginVersion
     ideaVersion {
       sinceBuild = sinceBuildInput
-      untilBuild = untilBuildInput
     }
     changeNotes = provider {
       project.changelog.renderItem(project.changelog.getLatest(), Changelog.OutputType.HTML)

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,10 +7,9 @@
 # We try to use the stable Android Studio version here since most Flutter users are on Android Studio and not IntelliJ.
 # Meanwhile, Dart-only users are more likely to be on IntelliJ.
 androidStudioVersion=2026.1.2.8
-dartPluginVersion= 505.0.0
+dartPluginVersion= 507.0.0
 # Also update the versions for verify checks in tool/github.sh.
 sinceBuild=252
-untilBuild=262.*
 javaVersion=21
 kotlin.stdlib.default.dependency=false
 org.gradle.parallel=true

--- a/tool/plugin/lib/build_spec.dart
+++ b/tool/plugin/lib/build_spec.dart
@@ -30,7 +30,6 @@ class BuildSpec {
 
   // plugin.xml variables
   final String sinceBuild;
-  final String untilBuild;
   final String pluginId = 'io.flutter';
   final String? release;
   final List<String> filesToSkip;
@@ -48,7 +47,6 @@ class BuildSpec {
         androidPluginVersion = json['androidPluginVersion'] as String,
         dartPluginVersion = json['dartPluginVersion'] as String,
         sinceBuild = json['sinceBuild'] as String,
-        untilBuild = json['untilBuild'] as String,
         filesToSkip = json['filesToSkip'] as List<String>? ?? [],
         isUnitTestTarget = json['isUnitTestTarget'] == 'true',
         isTestTarget = json['isTestTarget'] == 'true',
@@ -110,7 +108,6 @@ class BuildSpec {
         'dartPluginVersion: $dartPluginVersion, '
         'javaVersion: $javaVersion, '
         'since: $sinceBuild, '
-        'until: $untilBuild, '
         'version: "$release")';
   }
 

--- a/tool/plugin/lib/runner.dart
+++ b/tool/plugin/lib/runner.dart
@@ -46,7 +46,6 @@ baseVersion=${spec.baseVersion}
 dartPluginVersion=${spec.dartPluginVersion}
 androidPluginVersion=${spec.androidPluginVersion}
 sinceBuild=${spec.sinceBuild}
-untilBuild=${spec.untilBuild}
 testing=$testing
 javaVersion=${spec.javaVersion}
 kotlin.stdlib.default.dependency=false


### PR DESCRIPTION
This is in preparation for upcoming v95.

I want to remove untilBuild because it's causing confusion on what the latest version we cover is, and this is recommended anyway. On the main branch, this plugin should be able to be installed to any newer version of IJ.

I'm updating to v507 just because the Flutter plugin should depend on a recent version of Dart. Dart v508 will be released pretty close to Flutter's release, so using v507 as dependency will make it easier to test Flutter. (i.e. I am not updating to 508 because in this upcoming Flutter release, we have no particular changes depending on Dart v508.)

(It would be nice if plugins were combined)

---

Review the contribution guidelines below:

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] I've included the required information in the description above.
- [x] My up-to-date information is in the `AUTHORS` file.
- [x] I've updated `CHANGELOG.md` if appropriate.

<details>
  <summary>Contribution guidelines:</summary><br>

- See
  our [contributor guide](../CONTRIBUTING.md) and
  the [Flutter organization contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md)
  for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use
  `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best
  practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).

</details>