### PR TITLE
Keep Flutter SDK cache entries distinct for symlinked paths

### DIFF
--- a/src/io/flutter/sdk/FlutterSdk.java
+++ b/src/io/flutter/sdk/FlutterSdk.java
@@ -157,7 +157,11 @@ public class FlutterSdk {
 
   @NotNull
   private static FlutterSdk saveSdkInCache(@NotNull VirtualFile home) {
-    final String cacheKey = home.getCanonicalPath();
+    // Keep SDKs selected through distinct symlink paths separate. FVM changes the
+    // target of a project-local symlink, so using its canonical path makes one
+    // project's SDK instance leak into another project that currently uses the
+    // same Flutter version.
+    final String cacheKey = home.getPath();
     synchronized (projectSdkCache) {
       if (!projectSdkCache.containsKey(cacheKey)) {
         projectSdkCache.put(cacheKey, new FlutterSdk(home, FlutterSdkVersion.readFromSdk(home)));


### PR DESCRIPTION
## Summary

Prevent `FlutterSdk` cache entries from collapsing distinct configured SDK paths that resolve to the same canonical target. This preserves each project's selected path, including project-local FVM symlinks, when resolving its SDK instance.

This addresses the cache-identity aspect of #6616. It does not change IntelliJ's SDK-directory chooser behavior.

## Verification

Manual verification still needed:

1. Configure projects with distinct SDK symlink paths that resolve to the same Flutter SDK.
2. Verify each project retains and resolves its configured SDK path independently.

Automated verification:

- `git diff --check` passed.
- OpenJDK 21 installed locally.
- `./gradlew --no-configuration-cache --no-daemon --console=plain -Dkotlin.compiler.execution.strategy=in-process test` reached successful Java compilation (one pre-existing deprecated API warning), but did not reach test execution: Gradle remained waiting on an included build after compilation and produced no test-result XML. This draft remains pending a completed test run.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] I've included the required information in the description above.
- [ ] My up-to-date information is in the `AUTHORS` file.
- [x] I've updated `CHANGELOG.md` if appropriate. This bug fix does not add a user-facing release-note entry.