### PR TITLE
Add release skill and point to it

### DIFF
--- a/.agents/skills/release-plugin/SKILL.md
+++ b/.agents/skills/release-plugin/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: release-plugin
+description: Prepare and execute a new release for the flutter-intellij plugin, including updating dependencies, compatibility bounds, changelogs, and verification.
+---
+
+# Skill: Release Plugin
+
+You are tasked with preparing a new version release of the `flutter-intellij` plugin (e.g., releasing `95.0.0`).
+
+## Objective
+Systematically update plugin dependencies, compatibility parameters, and `CHANGELOG.md`, verify tests and plugin structure, and build the release zip artifact.
+
+---
+
+## Workflow Instructions
+
+### 1. Update Platform & Dependency Parameters
+- **`gradle.properties`**:
+  - Update `dartPluginVersion` to the target Dart plugin release version (e.g. `dartPluginVersion= 507.0.0`).
+  - If dropping support for older platform versions, update `sinceBuild` to the new lower bound (e.g., `sinceBuild=252`). Note: `untilBuild` is omitted for open-ended platform compatibility.
+- **New Platform Version Compatibility & Baselines**:
+  - When supporting/verifying a new platform release (e.g., IntelliJ 2026.3 / build `263`):
+    - Update the verification loop in `tool/github.sh` (`for version in ...; do`).
+    - Run `./tool/update_baselines.sh` to generate or update the plugin verifier baseline files in `tool/baseline/<version>/verifier-baseline.txt`.
+- **JxBrowser License Key**:
+  - Ensure `resources/jxbrowser/jxbrowser.properties` is present (copy from local environment if creating a new git worktree).
+
+### 2. Fix API & Dependency Compatibility
+- Check for compilation errors or API signature changes introduced by the updated dependencies (e.g., websocket/DTD exception handling changes in `FlutterInitializer.java` and `FlutterApp.java`).
+- Run `./gradlew testClasses` to confirm the codebase compiles against updated dependencies.
+
+### 3. Update Changelog (`CHANGELOG.md`)
+- **Compatibility Changes PR**:
+  - Document compatibility updates under `### Changed` in `CHANGELOG.md` with the PR reference (e.g., `- Removed upper build constraint (\`untilBuild\`) for open-ended platform compatibility. (#9063)`).
+- **Release Version Bump**:
+  - Rename `## Unreleased` to `## <VERSION>.0.0` (e.g., `## 95.0.0`).
+  - Ensure all user-facing changes since the last release are categorized and tagged with PR numbers.
+  - Insert a fresh empty `## Unreleased` block at the top with:
+    ```markdown
+    ## Unreleased
+
+    ### Added
+
+    ### Changed
+
+    ### Removed
+
+    ### Fixed
+    ```
+
+### 4. Build & Validation
+- Run `./gradlew testClasses` to verify Java/Kotlin compilation.
+- Run `./gradlew verifyPluginStructure` to validate `plugin.xml` structure.
+- Run `./gradlew test` to ensure all unit tests pass.
+- Run `./gradlew buildPlugin -Prelease -PversionedName` to build the prospective release plugin zip artifact (`Flutter-<VERSION>-<COMMIT>.zip`) in `build/distributions/`.
+- **Upload Prospective Zip**: Manually upload the generated release zip (`Flutter-<VERSION>-<COMMIT>.zip`) from `build/distributions/` to the team's Google Drive folder (e.g. DevExp Flutter Releases) for team-wide manual testing prior to public publishing.
+
+### 5. Manual Testing Checklist
+Perform manual sanity checks across **every supported platform version** (e.g. IntelliJ IDEA 2025.3, 2026.1, 2026.2 and Android Studio 2025.3 / Meerkat):
+- [ ] **Create New Project**: Verify new Flutter project wizard succeeds.
+- [ ] **Open Existing Project**: Verify existing Flutter project opens cleanly.
+- [ ] **Run & Debug**: Run app, hit breakpoints, and inspect variables.
+- [ ] **Hot Reload & Hot Restart**: Perform **Hot Reload** (⚡) and **Hot Restart** on a running app.
+- [ ] **DevTools**: Open DevTools tool windows (Inspector, Memory, Network, etc.).
+- [ ] **Version-Specific Features**: Verify any release-specific fixes or changes (e.g. Flutter SDK path changes in Settings, DTD theme synchronization, EAP installation compatibility).

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ These skills are located in the [.agents/skills/](.agents/skills/) directory. Th
 * **[Code Review](.agents/skills/code-review/SKILL.md):** Performs a pedantic, multi-perspective code review (covering logic, correctness, resource safety, design, and styleguide compliance) on your uncommitted changes.
 * **[Migrate IntelliJ Util](.agents/skills/migrate-intellij-util/SKILL.md):** Optimize memory usage, consistency, and performance by migrating standard Java/Kotlin classes to IntelliJ's specialized `com.intellij.util` implementations.
 * **[Remove Platform Version](.agents/skills/remove-platform-version/SKILL.md):** Remove support for an older IntelliJ Platform / Android Studio version from the project and clean up obsolete code, baselines, and CI configurations.
+* **[Release Plugin](.agents/skills/release-plugin/SKILL.md):** Prepare and execute a new release for the flutter-intellij plugin, including updating dependencies, compatibility bounds, changelogs, and verification.
 * **[Resolve Verification Issues](.agents/skills/resolve-verification-issues/SKILL.md):** Eliminate plugin verification warnings and errors identified by `./gradlew verifyPlugin`.
 * **[Verify EAP Compatibility](.agents/skills/verify-eap-compatibility/SKILL.md):** Ensure the plugin remains compatible with the latest IntelliJ Platform releases and EAP (Early Access Program) builds.
 

--- a/docs/Release-testing.md
+++ b/docs/Release-testing.md
@@ -1,2 +1,3 @@
-The following use cases should be tested on all new releases:
-[https://github.com/flutter/flutter-intellij/blob/main/testing.md](https://github.com/flutter/flutter-intellij/blob/main/docs/testing.md)
+# Release Testing
+
+For manual release verification and testing checklists, see the [`release-plugin` skill](../.agents/skills/release-plugin/SKILL.md#5-manual-testing-checklist).

--- a/docs/building.md
+++ b/docs/building.md
@@ -1,5 +1,8 @@
 ## Building the plugin for release
 
+> [!NOTE]
+> For the complete step-by-step workflow for preparing and executing a plugin release (including dependency updates, changelog management, building versioned zip artifacts, and manual testing checklists), see the [`release-plugin` skill](../.agents/skills/release-plugin/SKILL.md).
+
 Update the `gradle.properties` file
 
 - IntelliJ IDEA versions can be found here: https://www.jetbrains.com/idea/download/other.html
@@ -18,7 +21,7 @@ with the `<KEY>` replaced with a valid JXBrowser key to be used in the built Flu
 Run gradle:
 
 - Check that `$JAVA_HOME` is set (see CONTRIBUTING.md for instructions if not set)
-- Run `./gradlew buildPlugin -Prelease` to build the plugin for the settings specified in `gradle.properties`
+- Run `./gradlew buildPlugin -Prelease -PversionedName` to build the plugin for the settings specified in `gradle.properties`
 - The output .zip file will be in `<flutter-intellij root>/build/distributions`
 
 ### Test and upload to the JetBrains Servers

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,5 +1,8 @@
 # Plugin Smoke Testing
 
+> [!WARNING]
+> **Outdated Documentation**: This smoke testing document contains legacy manual test procedures. For up-to-date release verification instructions and the active manual testing checklist, refer to the [`release-plugin` skill](../.agents/skills/release-plugin/SKILL.md#5-manual-testing-checklist).
+
 Manual tests to execute before plugin releases.
 
 ## Setup


### PR DESCRIPTION
I asked for a release skill to capture steps as I was preparing v95. (Probably a further discussion how we can test that this is useful)

---

Review the contribution guidelines below:

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] I've included the required information in the description above.
- [x] My up-to-date information is in the `AUTHORS` file.
- ~[ ] I've updated `CHANGELOG.md` if appropriate.~

<details>
  <summary>Contribution guidelines:</summary><br>

- See
  our [contributor guide](../CONTRIBUTING.md) and
  the [Flutter organization contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md)
  for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use
  `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best
  practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).

</details>