### PR TITLE
Update skill to depend on latest public Dart plugin version

### DIFF
--- a/.agents/skills/release-plugin/SKILL.md
+++ b/.agents/skills/release-plugin/SKILL.md
@@ -16,7 +16,7 @@ Systematically update plugin dependencies, compatibility parameters, and `CHANGE
 
 ### 1. Update Platform & Dependency Parameters
 - **`gradle.properties`**:
-  - Update `dartPluginVersion` to the latest public Dart plugin release version. Fetch the latest version from JetBrains Marketplace (e.g. via `curl -s "https://plugins.jetbrains.com/api/plugins/6351/updates?size=1"` or by checking [JetBrains Marketplace Dart Plugin](https://plugins.jetbrains.com/plugin/6351-dart)) and set `dartPluginVersion` in `gradle.properties` to that version (e.g., `dartPluginVersion= 508.0.0`).
+  - Update `dartPluginVersion` to the latest public Dart plugin release version. Fetch the latest version from JetBrains Marketplace (e.g. via `curl -s "https://plugins.jetbrains.com/api/plugins/6351/updates?size=1" | jq -r '.[0].version'` or by checking [JetBrains Marketplace Dart Plugin](https://plugins.jetbrains.com/plugin/6351-dart)) and set `dartPluginVersion` in `gradle.properties` to that version (e.g., `dartPluginVersion= 508.0.0`).
   - If dropping support for older platform versions, update `sinceBuild` to the new lower bound (e.g., `sinceBuild=252`). Note: `untilBuild` is omitted for open-ended platform compatibility.
 - **New Platform Version Compatibility & Baselines**:
   - When supporting/verifying a new platform release (e.g., IntelliJ 2026.3 / build `263`):

--- a/.agents/skills/release-plugin/SKILL.md
+++ b/.agents/skills/release-plugin/SKILL.md
@@ -16,7 +16,7 @@ Systematically update plugin dependencies, compatibility parameters, and `CHANGE
 
 ### 1. Update Platform & Dependency Parameters
 - **`gradle.properties`**:
-  - Update `dartPluginVersion` to the target Dart plugin release version (e.g. `dartPluginVersion= 507.0.0`).
+  - Update `dartPluginVersion` to the latest public Dart plugin release version. Fetch the latest version from JetBrains Marketplace (e.g. via `curl -s "https://plugins.jetbrains.com/api/plugins/6351/updates?size=1"` or by checking [JetBrains Marketplace Dart Plugin](https://plugins.jetbrains.com/plugin/6351-dart)) and set `dartPluginVersion` in `gradle.properties` to that version (e.g., `dartPluginVersion= 508.0.0`).
   - If dropping support for older platform versions, update `sinceBuild` to the new lower bound (e.g., `sinceBuild=252`). Note: `untilBuild` is omitted for open-ended platform compatibility.
 - **New Platform Version Compatibility & Baselines**:
   - When supporting/verifying a new platform release (e.g., IntelliJ 2026.3 / build `263`):


### PR DESCRIPTION
This is a follow up to https://github.com/flutter/flutter-intellij/pull/9072. After testing the release skill on commit before I started making release-related changes, I saw that it wasn't suggesting an update to the Dart plugin version.

---

Review the contribution guidelines below:

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] I've included the required information in the description above.
- [x] My up-to-date information is in the `AUTHORS` file.
- ~[ ] I've updated `CHANGELOG.md` if appropriate.~

<details>
  <summary>Contribution guidelines:</summary><br>

- See
  our [contributor guide](../CONTRIBUTING.md) and
  the [Flutter organization contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md)
  for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use
  `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best
  practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).

</details>