### PR TITLE
Fix SDK settings window not showing current SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Fixed
 - IDE freeze when applying Flutter SDK path changes in Settings. (#9058)
+- Fixed issue with saving the Flutter SDK path in Settings. ([#9074](https://github.com/flutter/flutter-intellij/pull/9074))
 
 ## 94.0.0
 

--- a/src/io/flutter/sdk/FlutterSdk.java
+++ b/src/io/flutter/sdk/FlutterSdk.java
@@ -118,7 +118,11 @@ public class FlutterSdk {
       return null;
     }
 
-    final String dartPath = FileUtil.toSystemIndependentName(dartSdk.getHomePath());
+    final String homePath = dartSdk.getHomePath();
+    if (homePath == null) {
+      return null;
+    }
+    final String dartPath = FileUtil.toSystemIndependentName(homePath);
     if (!dartPath.endsWith(DART_SDK_SUFFIX)) {
       return null;
     }

--- a/src/io/flutter/sdk/FlutterSdk.java
+++ b/src/io/flutter/sdk/FlutterSdk.java
@@ -118,7 +118,7 @@ public class FlutterSdk {
       return null;
     }
 
-    final String dartPath = dartSdk.getHomePath();
+    final String dartPath = FileUtil.toSystemIndependentName(dartSdk.getHomePath());
     if (!dartPath.endsWith(DART_SDK_SUFFIX)) {
       return null;
     }

--- a/src/io/flutter/sdk/FlutterSdkUtil.java
+++ b/src/io/flutter/sdk/FlutterSdkUtil.java
@@ -101,14 +101,15 @@ public class FlutterSdkUtil {
    */
   public static void addKnownSDKPathsToCombo(@NotNull JComboBox combo) {
     // First, get the current path from the combo box on the EDT.
-    final String currentPath = combo.getEditor().getItem().toString().trim();
-    final Set<String> pathsToShow = new LinkedHashSet<>();
+    final Object initialItem = combo.getEditor().getItem();
+    final String currentPath = initialItem != null ? initialItem.toString().trim() : "";
+    final Set<String> initialPaths = new LinkedHashSet<>();
     if (!currentPath.isEmpty()) {
-      pathsToShow.add(currentPath);
+      initialPaths.add(currentPath);
     }
 
     // Now, run the slow operation (finding valid SDK paths) on a background thread.
-    ApplicationManager.getApplication().executeOnPooledThread(() -> {
+    OpenApiUtils.safeExecuteOnPooledThread(() -> {
       final String[] knownPaths = getKnownFlutterSdkPaths();
       final Set<String> validPaths = new LinkedHashSet<>();
       for (String path : knownPaths) {
@@ -119,16 +120,27 @@ public class FlutterSdkUtil {
       }
 
       // After the slow operation is complete, switch back to the EDT to update the UI.
-      ApplicationManager.getApplication().invokeLater(() -> {
+      OpenApiUtils.safeInvokeLater(() -> {
         // This code runs on the EDT.
+        final Object currentEditorItem = combo.getEditor().getItem();
+        final String activePath = currentEditorItem != null ? currentEditorItem.toString().trim() : "";
+
+        final Set<String> pathsToShow = new LinkedHashSet<>();
+        if (!activePath.isEmpty()) {
+          pathsToShow.add(activePath);
+        }
+        pathsToShow.addAll(initialPaths);
         pathsToShow.addAll(validPaths);
 
         // Update the combo box model with the new paths.
         //noinspection unchecked
         combo.setModel(new DefaultComboBoxModel<>(ArrayUtil.toStringArray(pathsToShow)));
 
-        // Select the first item if none is selected.
-        if (combo.getSelectedIndex() == -1 && combo.getItemCount() > 0) {
+        // Preserve active editor content or select the first item if none is selected.
+        if (!activePath.isEmpty()) {
+          combo.getEditor().setItem(activePath);
+        }
+        else if (combo.getSelectedIndex() == -1 && combo.getItemCount() > 0) {
           combo.setSelectedIndex(0);
         }
       });

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.java
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.java
@@ -295,8 +295,8 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     // (This can happen if the user changed the Dart SDK.)
     try {
       ignoringSdkChanges = true;
-      FlutterSdkUtil.addKnownSDKPathsToCombo(mySdkCombo);
       mySdkCombo.getEditor().setItem(FileUtil.toSystemDependentName(path));
+      FlutterSdkUtil.addKnownSDKPathsToCombo(mySdkCombo);
     }
     finally {
       ignoringSdkChanges = false;
@@ -307,7 +307,7 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
       if (previousSdkVersion != null) {
         if (previousSdkVersion.compareTo(sdk.getVersion()) != 0) {
           final List<PubRoot> roots = PubRoots.forProject(myProject);
-          ApplicationManager.getApplication().executeOnPooledThread(() -> {
+          OpenApiUtils.safeInvokeLater(() -> {
             for (PubRoot root : roots) {
               sdk.startPubGet(root, myProject);
             }
@@ -424,7 +424,8 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
 
   @NotNull
   private String getSdkPathText() {
-    return FileUtilRt.toSystemIndependentName(mySdkCombo.getEditor().getItem().toString().trim());
+    final Object item = mySdkCombo.getEditor().getItem();
+    return item != null ? FileUtilRt.toSystemIndependentName(item.toString().trim()) : "";
   }
 
   private void checkFontPackages(String value, String previous) {

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.java
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.java
@@ -21,6 +21,7 @@ import com.intellij.openapi.fileChooser.FileChooser;
 import com.intellij.openapi.fileChooser.FileChooserDescriptor;
 import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory;
 import com.intellij.openapi.ide.CopyPasteManager;
+import com.intellij.openapi.module.Module;
 import com.intellij.openapi.options.ConfigurationException;
 import com.intellij.openapi.options.SearchableConfigurable;
 import com.intellij.openapi.project.Project;
@@ -340,9 +341,12 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
 
     if (previousSdkVersion != null && previousSdkVersion.compareTo(sdk.getVersion()) != 0) {
       final List<PubRoot> roots = PubRoots.forProject(myProject);
-      OpenApiUtils.safeInvokeLater(() -> {
+      OpenApiUtils.safeExecuteOnPooledThread(() -> {
         for (PubRoot root : roots) {
-          sdk.startPubGet(root, myProject);
+          final Module module = OpenApiUtils.<Module>safeRunReadAction(() -> root.getModule(myProject));
+          if (module != null) {
+            sdk.startPubGet(root, myProject);
+          }
         }
       });
       previousSdkVersion = sdk.getVersion();

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.java
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.java
@@ -286,39 +286,11 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     checkFontPackages(settings.getFontPackages(), oldFontPackages);
   }
 
+  // Reset is run when opening settings, clicking cancel, or right after apply.
   @Override
   public void reset() {
     final FlutterSdk sdk = FlutterSdk.getFlutterSdk(myProject);
-    final String path = sdk != null ? sdk.getHomePath() : "";
-
-    // Set this after populating the combo box to display correctly when the Flutter SDK is unset.
-    // (This can happen if the user changed the Dart SDK.)
-    try {
-      ignoringSdkChanges = true;
-      mySdkCombo.getEditor().setItem(FileUtil.toSystemDependentName(path));
-      FlutterSdkUtil.addKnownSDKPathsToCombo(mySdkCombo);
-    }
-    finally {
-      ignoringSdkChanges = false;
-    }
-
-    onVersionChanged();
-    if (sdk != null) {
-      if (previousSdkVersion != null) {
-        if (previousSdkVersion.compareTo(sdk.getVersion()) != 0) {
-          final List<PubRoot> roots = PubRoots.forProject(myProject);
-          OpenApiUtils.safeInvokeLater(() -> {
-            for (PubRoot root : roots) {
-              sdk.startPubGet(root, myProject);
-            }
-          });
-          previousSdkVersion = sdk.getVersion();
-        }
-      }
-    }
-    else {
-      previousSdkVersion = null;
-    }
+    resetSdkSelection(sdk);
 
     final FlutterSettings settings = FlutterSettings.getInstance();
     myHotReloadOnSaveCheckBox.setSelected(settings.isReloadOnSave());
@@ -341,6 +313,40 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
     myEnableJcefBrowserCheckBox.setSelected(settings.isEnableJcefBrowser());
     myFontPackagesTextArea.setText(settings.getFontPackages());
     myEnableFilePathLogging.setSelected(settings.isFilePathLoggingEnabled());
+  }
+
+  private void resetSdkSelection(@Nullable FlutterSdk sdk) {
+    final String path = sdk != null ? sdk.getHomePath() : "";
+
+    try {
+      ignoringSdkChanges = true;
+      mySdkCombo.getEditor().setItem(FileUtil.toSystemDependentName(path));
+      FlutterSdkUtil.addKnownSDKPathsToCombo(mySdkCombo);
+    }
+    finally {
+      ignoringSdkChanges = false;
+    }
+
+    // This is to show the version below the SDK selection box.
+    onVersionChanged();
+    updatePubGetOnSdkChange(sdk);
+  }
+
+  private void updatePubGetOnSdkChange(@Nullable FlutterSdk sdk) {
+    if (sdk == null) {
+      previousSdkVersion = null;
+      return;
+    }
+
+    if (previousSdkVersion != null && previousSdkVersion.compareTo(sdk.getVersion()) != 0) {
+      final List<PubRoot> roots = PubRoots.forProject(myProject);
+      OpenApiUtils.safeInvokeLater(() -> {
+        for (PubRoot root : roots) {
+          sdk.startPubGet(root, myProject);
+        }
+      });
+      previousSdkVersion = sdk.getVersion();
+    }
   }
 
   private void cancelActiveVersionProcess() {

--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.java
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.java
@@ -341,12 +341,9 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
 
     if (previousSdkVersion != null && previousSdkVersion.compareTo(sdk.getVersion()) != 0) {
       final List<PubRoot> roots = PubRoots.forProject(myProject);
-      OpenApiUtils.safeExecuteOnPooledThread(() -> {
+      OpenApiUtils.safeInvokeLater(() -> {
         for (PubRoot root : roots) {
-          final Module module = OpenApiUtils.<Module>safeRunReadAction(() -> root.getModule(myProject));
-          if (module != null) {
-            sdk.startPubGet(root, myProject);
-          }
+          sdk.startPubGet(root, myProject);
         }
       });
       previousSdkVersion = sdk.getVersion();

--- a/testSrc/unit/io/flutter/sdk/FlutterSdkUtilsTest.java
+++ b/testSrc/unit/io/flutter/sdk/FlutterSdkUtilsTest.java
@@ -79,4 +79,15 @@ public class FlutterSdkUtilsTest {
       assertEquals("/Users/user/flutter", result);
     }
   }
+
+  @Test
+  public void addKnownSDKPathsToCombo_preservesActiveItem() {
+    final javax.swing.JComboBox<String> combo = new javax.swing.JComboBox<>();
+    combo.setEditable(true);
+    combo.getEditor().setItem("/path/to/custom/sdk");
+
+    FlutterSdkUtil.addKnownSDKPathsToCombo(combo);
+
+    assertEquals("/path/to/custom/sdk", combo.getEditor().getItem());
+  }
 }


### PR DESCRIPTION
Fixes #8641

This changes how the combo box that contains SDK file locations is refreshed so that the chosen SDK displays correctly after updates. It seems that before, the selected SDK file location was being overwritten by the first item in the list of retrieved SDK options, so it was often incorrect.

While touching these files I also refactored a little to separate the SDK field setup of the reset funciton.

To test these changes:
- Go to Settings > Flutter
- Change the Flutter SDK location and click apply/okay
- Open the Flutter settings again and make sure that the SDK location reflects your latest selection.

https://github.com/user-attachments/assets/efbf5efa-bbb3-4669-809d-e49980cb0ed0

---

Review the contribution guidelines below:

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] I've included the required information in the description above.
- [x] My up-to-date information is in the `AUTHORS` file.
- [x] I've updated `CHANGELOG.md` if appropriate.

<details>
  <summary>Contribution guidelines:</summary><br>

- See
  our [contributor guide](../CONTRIBUTING.md) and
  the [Flutter organization contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md)
  for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use
  `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best
  practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).

</details>