### PR TITLE
[ai] add a subagent check to keep reviews unbiased

### DIFF
--- a/.agents/skills/code-review/SKILL.md
+++ b/.agents/skills/code-review/SKILL.md
@@ -22,11 +22,13 @@ You are a Senior Staff Engineer performing a rigorous code review on the develop
 
 Perform a multi-pass analysis of the diff:
 
+### Pass 0: Repository & Structure Restrictions
+- **Third-Party Sources:** Check for any modifications to files under the `third_party/thirdPartySrc/` directory. These files are periodically bulk-copied from upstream, and any direct changes will be lost. Reject such modifications with a `[MUST-FIX]` comment (unless explicitly requested as an override).
+
 ### Pass 1: Correctness & Logic
 - **Edge cases:** Check boundary conditions (empty lists, null values, division by zero, empty strings).
 - **Concurrency & State:** Look for potential race conditions, thread-safety issues, or improper handling of shared mutable state.
 - **Control Flow:** Verify boolean logic, loop termination criteria, and exception handling (ensure catch blocks are not silently swallowing errors).
-- **Parameter & Argument Validation:** Ensure that command-line options or input arguments expecting specific formats (like numbers/integers) are validated early (e.g. using regex `^[0-9]+$` for non-negative integers in bash) to prevent arithmetic or execution errors later.
 
 ### Pass 2: Resource Management & Efficiency
 - **Leaks:** Check if opened streams, database connections, files, socket connections, or timers/subscriptions are properly closed or disposed of (even in failure paths).
@@ -42,10 +44,11 @@ Perform a multi-pass analysis of the diff:
 - **API Design:** Are new functions/methods single-responsibility? Do the parameters make sense? Are visibility modifiers (public, private, protected) used correctly?
 
 ## Step-by-Step Execution
-1. **Pre-flight Check:** Check your conversation history to see if you have written or modified the code being reviewed in this current conversation (e.g., look for recent uses of `replace_file_content`, `write_to_file`, or similar tools). If so, pause and ask the user:
+1. **Pre-flight Check:** Check your conversation history to see if you have written or modified the code being reviewed in this current conversation (e.g., look for recent uses of replace_file_content, write_to_file, or similar tools). If so, and you are in an interactive session, pause and ask the user:
    > "I noticed we wrote this code in our current conversation. Should I spin up a sub-agent for an unbiased review?"
    - If they agree, invoke a subagent to perform the rest of this skill.
    - If they decline, or if you are already in a fresh conversation/subagent, proceed to the next step.
+   If you are in a non-interactive environment, automatically invoke a subagent to perform the review.
 2. Retrieve the current changes (using `git diff`).
 3. Read `.gemini/styleguide.md` if present.
 4. Analyze only the modified/added lines in the diff using the multi-perspective checklist above.

--- a/.agents/skills/code-review/SKILL.md
+++ b/.agents/skills/code-review/SKILL.md
@@ -22,13 +22,11 @@ You are a Senior Staff Engineer performing a rigorous code review on the develop
 
 Perform a multi-pass analysis of the diff:
 
-### Pass 0: Repository & Structure Restrictions
-- **Third-Party Sources:** Check for any modifications to files under the `third_party/thirdPartySrc/` directory. These files are periodically bulk-copied from upstream, and any direct changes will be lost. Reject such modifications with a `[MUST-FIX]` comment (unless explicitly requested as an override).
-
 ### Pass 1: Correctness & Logic
 - **Edge cases:** Check boundary conditions (empty lists, null values, division by zero, empty strings).
 - **Concurrency & State:** Look for potential race conditions, thread-safety issues, or improper handling of shared mutable state.
 - **Control Flow:** Verify boolean logic, loop termination criteria, and exception handling (ensure catch blocks are not silently swallowing errors).
+- **Parameter & Argument Validation:** Ensure that command-line options or input arguments expecting specific formats (like numbers/integers) are validated early (e.g. using regex `^[0-9]+$` for non-negative integers in bash) to prevent arithmetic or execution errors later.
 
 ### Pass 2: Resource Management & Efficiency
 - **Leaks:** Check if opened streams, database connections, files, socket connections, or timers/subscriptions are properly closed or disposed of (even in failure paths).

--- a/.agents/skills/code-review/SKILL.md
+++ b/.agents/skills/code-review/SKILL.md
@@ -42,7 +42,11 @@ Perform a multi-pass analysis of the diff:
 - **API Design:** Are new functions/methods single-responsibility? Do the parameters make sense? Are visibility modifiers (public, private, protected) used correctly?
 
 ## Step-by-Step Execution
-1. Retrieve the current changes (using `git diff`).
-2. Read `.gemini/styleguide.md` if present.
-3. Analyze only the modified/added lines in the diff using the multi-perspective checklist above.
-4. Output the categorized review comments with code references (file names, line numbers) and clear explanations/recommendations.
+1. **Pre-flight Check:** Check your conversation history to see if you have written or modified the code being reviewed in this current conversation (e.g., look for recent uses of `replace_file_content`, `write_to_file`, or similar tools). If so, pause and ask the user:
+   > "I noticed we wrote this code in our current conversation. Should I spin up a sub-agent for an unbiased review?"
+   - If they agree, invoke a subagent to perform the rest of this skill.
+   - If they decline, or if you are already in a fresh conversation/subagent, proceed to the next step.
+2. Retrieve the current changes (using `git diff`).
+3. Read `.gemini/styleguide.md` if present.
+4. Analyze only the modified/added lines in the diff using the multi-perspective checklist above.
+5. Output the categorized review comments with code references (file names, line numbers) and clear explanations/recommendations.


### PR DESCRIPTION
Reviews can be biased by conversation history so this updates the review skill to check and offer to run in a sub-agent (with a clear head).


Analog to: https://github.com/flutter/dart-intellij-third-party/pull/568

---

Review the contribution guidelines below:

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] I've included the required information in the description above.
- [x] My up-to-date information is in the `AUTHORS` file.
- [x] I've updated `CHANGELOG.md` if appropriate.

<details>
  <summary>Contribution guidelines:</summary><br>

- See
  our [contributor guide](../CONTRIBUTING.md) and
  the [Flutter organization contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md)
  for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use
  `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best
  practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).

</details>