### PR TITLE
Add SDK design doc

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -3,7 +3,7 @@
 This directory contains workspace customizations, rules, skills, and design documentation for AI agents working on `flutter-intellij`.
 
 ## Rules
-- [`sdk-functionality.md`](file:///Users/helinx/Documents/flutter-intellij-doc/.agents/rules/sdk-functionality.md): Guidelines and intentions for Flutter SDK management.
+- [`sdk-functionality.md`](rules/sdk-functionality.md): Guidelines and intentions for Flutter SDK management.
 
 ## Design Documents
-- [`sdk-functionality.md`](file:///Users/helinx/Documents/flutter-intellij-doc/.agents/design-docs/sdk-functionality.md): Full architectural design document for SDK handling in IntelliJ plugins.
+- [`sdk-functionality.md`](design-docs/sdk-functionality.md): Full architectural design document for SDK handling in IntelliJ plugins.

--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -1,0 +1,9 @@
+# Workspace Agent Guidelines & Architecture Docs
+
+This directory contains workspace customizations, rules, skills, and design documentation for AI agents working on `flutter-intellij`.
+
+## Rules
+- [`sdk-functionality.md`](file:///Users/helinx/Documents/flutter-intellij-doc/.agents/rules/sdk-functionality.md): Guidelines and intentions for Flutter SDK management.
+
+## Design Documents
+- [`sdk-functionality.md`](file:///Users/helinx/Documents/flutter-intellij-doc/.agents/design-docs/sdk-functionality.md): Full architectural design document for SDK handling in IntelliJ plugins.

--- a/.agents/design-docs/sdk-functionality.md
+++ b/.agents/design-docs/sdk-functionality.md
@@ -1,0 +1,74 @@
+# SDK Functionality in IntelliJ Plugins (Flutter Focus)
+
+This design document details the expected functionality, intentional design choices, trade-offs, and architecture for Flutter SDK handling in the `flutter-intellij` plugin.
+
+---
+
+## 1. Objectives & Summary
+
+We define and agree on the desired plugin functionality for Flutter SDK management to facilitate refactoring, bug fixes, and maintenance.
+
+### Key Intentions & Design Decisions
+- **Flutter SDK Mandates the Dart SDK:** In a Flutter project, the Flutter SDK dictates the Dart SDK location (`<flutter-sdk>/bin/cache/dart-sdk`). A separate Dart SDK configuration for Flutter projects is disallowed because version skew between the Flutter engine/framework and the Dart compiler causes broken `.dill` builds, incompatible package resolution, and analyzer failures.
+- **`pub get` Triggering:** Changing the Flutter SDK path invalidates package mappings in `.dart_tool/package_config.json` (such as `package:flutter/...` pointing into the Flutter SDK). Therefore, Flutter SDK changes require running `flutter pub get`. Standard Dart SDK imports resolve against the global cache (`~/.pub-cache/`), making Flutter SDK changes uniquely dependent on `pub get`.
+- **UI Threading & `pub get` Execution:** Running `pub get` automatically on SDK save has historically caused IDE UI freezes when executed synchronously on the Event Dispatch Thread (EDT). The preferred design judgment is to run `pub get` asynchronously off the EDT or prompt the user to trigger it.
+- **Global Path Persistence & Hygiene:** Validated SDK paths are persisted globally in `FLUTTER_SDK_KNOWN_PATHS` so that subsequent projects and settings dialogs can suggest recently used SDKs. Upon saving, non-existent paths are pruned from persistent storage and the list is capped at a maximum of 5 recent valid paths.
+- **Single-Owner SDK Change Detection:** The Flutter plugin assumes total ownership of SDK update notifications in Flutter projects, explicitly setting `DartSdkUpdateOption.DoNotCheck` to suppress redundant Dart plugin SDK update checks.
+- **Symlink & Version Manager (FVM) Preservation:** Symlink paths (such as `.fvm/flutter_sdk`) are explicitly preserved as the configured path. In-memory `FlutterSdk` and `FlutterSdkVersion` caches must be invalidated when a symlink target change is detected.
+- **Project-Wide SDK Scoping (Single SDK Per Project):** Flutter SDK settings are strictly project-wide (1 SDK per IntelliJ `Project`). Multi-module SDK version skew and mixed standalone Dart + Flutter projects in a single workspace are explicitly unsupported non-goals (users should open separate projects).
+- **Scoped Editor Notifications:** SDK configuration banners ("Flutter SDK not configured") are strictly scoped to `.dart` and Flutter `pubspec.yaml` files. They must never appear on native Java, Kotlin, Swift, or other files.
+- **Active Debug Sessions & Processes:** Changing the SDK path leaves existing run/debug sessions and daemons untouched. Users are responsible for stopping and restarting debug sessions after an SDK change.
+- **Remote Development Non-Goal:** Remote Development (WSL, Remote SSH, Dev Containers) is currently not officially supported or tested.
+
+---
+
+## 2. Detailed Behavior & Validation Matrix
+
+### New Project Creation
+- Suggests previously used Flutter SDK paths or the `FLUTTER_SDK` environment variable.
+- After project creation, saves the Flutter SDK path and registers the nested Dart SDK path (`<flutter-sdk>/bin/cache/dart-sdk`) with the Dart plugin.
+
+### Changing SDK Location
+- Managed via **Settings > Languages & Frameworks > Flutter**.
+- In **Settings > Languages & Frameworks > Dart**, the Dart SDK path displays the nested path (`<flutter-sdk>/bin/cache/dart-sdk`) and is non-editable for Flutter projects.
+
+### Upgrading SDK & Symlink Version Switches
+- Upon detecting an SDK upgrade on disk (e.g., via CLI `flutter upgrade` or FVM version switch), the plugin invalidates cached SDK version info, restarts the Dart Analysis Server, and automatically triggers/prompts `pub get`.
+
+### Invalid SDK Validation Rules
+
+| Condition | IDE Action | Rationale |
+| :--- | :--- | :--- |
+| **SDK path is null or empty** | Block saving / proceeding. | Required setting. |
+| **SDK path does not exist on disk** | Show error, block saving / proceeding. | Invalid filesystem path. |
+| **Path exists, but missing Flutter binaries/packages** | Show error, block saving / proceeding. | Path must contain `/packages/flutter/pubspec.yaml` and `/bin/flutter`. |
+| **Flutter SDK present, but missing bundled Dart SDK** | Show error, block saving / proceeding. | Path must contain `/bin/cache/dart-sdk/lib`. Freshly cloned SDKs must be initialized via CLI before configuring in IDE (future work: analytics & auto-bootstrap). |
+| **SDK version too old for plugin** | Issue warning, allow proceed/save. | Warn that features may fail unpredictably; recommend upgrading SDK or downgrading plugin. |
+| **SDK version newer than plugin/pre-release** | Allow proceed/save silently. | No upper bound restriction enforced; bleeding-edge builds are assumed functional. |
+
+---
+
+## 3. General Code Locations
+
+When making changes to SDK functionality, refer to the following key components in the codebase:
+
+- **SDK Instance & Versioning:**
+  - [`FlutterSdk.java`](file:///Users/helinx/Documents/flutter-intellij-doc/src/io/flutter/sdk/FlutterSdk.java) - Per-project SDK instance, version querying, and running SDK tools.
+  - [`FlutterSdkVersion.java`](file:///Users/helinx/Documents/flutter-intellij-doc/src/io/flutter/sdk/FlutterSdkVersion.java) - Parses and compares SDK version strings against capability thresholds.
+
+- **SDK Discovery, Validation & Paths:**
+  - [`FlutterSdkUtil.java`](file:///Users/helinx/Documents/flutter-intellij-doc/src/io/flutter/sdk/FlutterSdkUtil.java) - Core validation (`isFlutterSdkHome`, `getErrorMessageIfWrongSdkRootPath`), configuring nested Dart SDK (`setFlutterSdkPath`), and known paths persistence (`getKnownFlutterSdkPaths`).
+
+- **Settings UI:**
+  - [`FlutterSettingsConfigurable.java`](file:///Users/helinx/Documents/flutter-intellij-doc/src/io/flutter/sdk/FlutterSettingsConfigurable.java) - **Settings > Languages & Frameworks > Flutter** UI, path selection, and applying changes.
+
+- **SDK Manager & Change Notifications:**
+  - [`FlutterSdkManager.java`](file:///Users/helinx/Documents/flutter-intellij-doc/src/io/flutter/sdk/FlutterSdkManager.java) - Listens for library table changes and fires `flutterSdkAdded` / `flutterSdkRemoved`.
+
+- **New Project Wizard:**
+  - [`FlutterModuleBuilder.java`](file:///Users/helinx/Documents/flutter-intellij-doc/src/io/flutter/module/FlutterModuleBuilder.java) - Handles project creation commit steps.
+  - [`FlutterGeneratorPeer.java`](file:///Users/helinx/Documents/flutter-intellij-doc/src/io/flutter/module/FlutterGeneratorPeer.java) - Manages SDK selection combo box and path validation in wizard.
+
+- **Editor Notifications:**
+  - [`SdkConfigurationNotificationProvider.java`](file:///Users/helinx/Documents/flutter-intellij-doc/src/io/flutter/inspections/SdkConfigurationNotificationProvider.java) - Banner prompting user to configure Flutter SDK when opening Dart files without an SDK set.
+

--- a/.agents/design-docs/sdk-functionality.md
+++ b/.agents/design-docs/sdk-functionality.md
@@ -53,22 +53,22 @@ We define and agree on the desired plugin functionality for Flutter SDK manageme
 When making changes to SDK functionality, refer to the following key components in the codebase:
 
 - **SDK Instance & Versioning:**
-  - [`FlutterSdk.java`](file:///Users/helinx/Documents/flutter-intellij-doc/src/io/flutter/sdk/FlutterSdk.java) - Per-project SDK instance, version querying, and running SDK tools.
-  - [`FlutterSdkVersion.java`](file:///Users/helinx/Documents/flutter-intellij-doc/src/io/flutter/sdk/FlutterSdkVersion.java) - Parses and compares SDK version strings against capability thresholds.
+  - [`FlutterSdk.java`](../../src/io/flutter/sdk/FlutterSdk.java) - Per-project SDK instance, version querying, and running SDK tools.
+  - [`FlutterSdkVersion.java`](../../src/io/flutter/sdk/FlutterSdkVersion.java) - Parses and compares SDK version strings against capability thresholds.
 
 - **SDK Discovery, Validation & Paths:**
-  - [`FlutterSdkUtil.java`](file:///Users/helinx/Documents/flutter-intellij-doc/src/io/flutter/sdk/FlutterSdkUtil.java) - Core validation (`isFlutterSdkHome`, `getErrorMessageIfWrongSdkRootPath`), configuring nested Dart SDK (`setFlutterSdkPath`), and known paths persistence (`getKnownFlutterSdkPaths`).
+  - [`FlutterSdkUtil.java`](../../src/io/flutter/sdk/FlutterSdkUtil.java) - Core validation (`isFlutterSdkHome`, `getErrorMessageIfWrongSdkRootPath`), configuring nested Dart SDK (`setFlutterSdkPath`), and known paths persistence (`getKnownFlutterSdkPaths`).
 
 - **Settings UI:**
-  - [`FlutterSettingsConfigurable.java`](file:///Users/helinx/Documents/flutter-intellij-doc/src/io/flutter/sdk/FlutterSettingsConfigurable.java) - **Settings > Languages & Frameworks > Flutter** UI, path selection, and applying changes.
+  - [`FlutterSettingsConfigurable.java`](../../src/io/flutter/sdk/FlutterSettingsConfigurable.java) - **Settings > Languages & Frameworks > Flutter** UI, path selection, and applying changes.
 
 - **SDK Manager & Change Notifications:**
-  - [`FlutterSdkManager.java`](file:///Users/helinx/Documents/flutter-intellij-doc/src/io/flutter/sdk/FlutterSdkManager.java) - Listens for library table changes and fires `flutterSdkAdded` / `flutterSdkRemoved`.
+  - [`FlutterSdkManager.java`](../../src/io/flutter/sdk/FlutterSdkManager.java) - Listens for library table changes and fires `flutterSdkAdded` / `flutterSdkRemoved`.
 
 - **New Project Wizard:**
-  - [`FlutterModuleBuilder.java`](file:///Users/helinx/Documents/flutter-intellij-doc/src/io/flutter/module/FlutterModuleBuilder.java) - Handles project creation commit steps.
-  - [`FlutterGeneratorPeer.java`](file:///Users/helinx/Documents/flutter-intellij-doc/src/io/flutter/module/FlutterGeneratorPeer.java) - Manages SDK selection combo box and path validation in wizard.
+  - [`FlutterModuleBuilder.java`](../../src/io/flutter/module/FlutterModuleBuilder.java) - Handles project creation commit steps.
+  - [`FlutterGeneratorPeer.java`](../../src/io/flutter/module/FlutterGeneratorPeer.java) - Manages SDK selection combo box and path validation in wizard.
 
 - **Editor Notifications:**
-  - [`SdkConfigurationNotificationProvider.java`](file:///Users/helinx/Documents/flutter-intellij-doc/src/io/flutter/inspections/SdkConfigurationNotificationProvider.java) - Banner prompting user to configure Flutter SDK when opening Dart files without an SDK set.
+  - [`SdkConfigurationNotificationProvider.java`](../../src/io/flutter/inspections/SdkConfigurationNotificationProvider.java) - Banner prompting user to configure Flutter SDK when opening Dart files without an SDK set.
 

--- a/.agents/rules/sdk-functionality.md
+++ b/.agents/rules/sdk-functionality.md
@@ -1,0 +1,3 @@
+# Flutter SDK Functionality Rule
+
+When working on SDK-related code, refactoring SDK management, or debugging SDK features in `flutter-intellij`, read and follow [`.agents/design-docs/sdk-functionality.md`](file:///Users/helinx/Documents/flutter-intellij-doc/.agents/design-docs/sdk-functionality.md).

--- a/.agents/rules/sdk-functionality.md
+++ b/.agents/rules/sdk-functionality.md
@@ -1,3 +1,3 @@
 # Flutter SDK Functionality Rule
 
-When working on SDK-related code, refactoring SDK management, or debugging SDK features in `flutter-intellij`, read and follow [`.agents/design-docs/sdk-functionality.md`](file:///Users/helinx/Documents/flutter-intellij-doc/.agents/design-docs/sdk-functionality.md).
+When working on SDK-related code, refactoring SDK management, or debugging SDK features in `flutter-intellij`, read and follow [`design-docs/sdk-functionality.md`](../design-docs/sdk-functionality.md).


### PR DESCRIPTION
This adds our SDK design doc as an agent-friendly summary of intentions. The rules directory is supposed to be always loaded, which is why the file there is a pointer to the design doc (only loaded if SDK work is being done).

I went through something like step 1 in https://drensin.medium.com/elephants-goldfish-and-the-new-golden-age-of-software-engineering-c33641a48874 to consider edge cases, though most are things where I didn't have an opinion (these items are added as open questions in the original doc, but I don't think they're worth examining much further right now).

I have not yet tested this documentation. 

---

Review the contribution guidelines below:

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] I've included the required information in the description above.
- [x] My up-to-date information is in the `AUTHORS` file.
- ~[ ] I've updated `CHANGELOG.md` if appropriate.~

<details>
  <summary>Contribution guidelines:</summary><br>

- See
  our [contributor guide](../CONTRIBUTING.md) and
  the [Flutter organization contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md)
  for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use
  `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best
  practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).

</details>