### PR TITLE
[skill] gather conext before invoking code-review subagent

### DIFF
--- a/.agents/skills/code-review/SKILL.md
+++ b/.agents/skills/code-review/SKILL.md
@@ -44,10 +44,19 @@ Perform a multi-pass analysis of the diff:
 ## Step-by-Step Execution
 1. **Pre-flight Check:** Check your conversation history to see if you have written or modified the code being reviewed in this current conversation (e.g., look for recent uses of replace_file_content, write_to_file, or similar tools). If so, and you are in an interactive session, pause and ask the user:
    > "I noticed we wrote this code in our current conversation. Should I spin up a sub-agent for an unbiased review?"
-   - If they agree, invoke a subagent to perform the rest of this skill.
+   - If they agree: **Before** invoking the subagent, you (the parent agent) must gather the required context (by executing the context-gathering steps below yourself). This avoids the subagent stalling on permission prompts. Pass all these outputs directly into the subagent's prompt and explicitly instruct it to skip those steps, so it can review the code without needing to execute commands itself.
    - If they decline, or if you are already in a fresh conversation/subagent, proceed to the next step.
-   If you are in a non-interactive environment, automatically invoke a subagent to perform the review.
+   If you are in a non-interactive environment, gather the context as described above and automatically invoke a subagent, passing the context and instructing it to skip the context-gathering steps.
+   
+    > [!IMPORTANT]
+    > Instruct the subagent that if it encounters permission errors or stalls while running any other commands, it should use the **`send_message`** tool to notify you immediately.
+
+### Context-Gathering Steps
 2. Retrieve the current changes (using `git diff`).
 3. Read `.gemini/styleguide.md` if present.
+
+   *(Note for subagents: If context was not provided by your parent and you are executing the context-gathering steps yourself, the system may pause to ask the user for permission. If you get stuck waiting, use the **`send_message`** tool to notify your parent agent.)*
+
+### Analysis & Review
 4. Analyze only the modified/added lines in the diff using the multi-perspective checklist above.
 5. Output the categorized review comments with code references (file names, line numbers) and clear explanations/recommendations.

--- a/.agents/skills/code-review/SKILL.md
+++ b/.agents/skills/code-review/SKILL.md
@@ -55,7 +55,7 @@ Perform a multi-pass analysis of the diff:
 2. Retrieve the current changes (using `git diff`).
 3. Read `.gemini/styleguide.md` if present.
 
-   *(Note for subagents: If context was not provided by your parent and you are executing the context-gathering steps yourself, the system may pause to ask the user for permission. If you get stuck waiting, use the **`send_message`** tool to notify your parent agent.)*
+   *(Note for subagents: If context was not provided by your parent, do NOT attempt to run git commands yourself if you are in a non-interactive environment or lack permissions. Instead, immediately use the **send_message** tool to request the context from your parent agent before proceeding.)*
 
 ### Analysis & Review
 4. Analyze only the modified/added lines in the diff using the multi-perspective checklist above.


### PR DESCRIPTION
Addresses the stalled code-review subagent SNAFU.

Analog to: https://github.com/flutter/dart-intellij-third-party/pull/583

---

Review the contribution guidelines below:

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] I've included the required information in the description above.
- [x] My up-to-date information is in the `AUTHORS` file.
- [x] I've updated `CHANGELOG.md` if appropriate.

<details>
  <summary>Contribution guidelines:</summary><br>

- See
  our [contributor guide](../CONTRIBUTING.md) and
  the [Flutter organization contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md)
  for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use
  `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best
  practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).

</details>