### PR TITLE
Handle IndexOutOfBoundsException in FlutterColorProvider

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -31,3 +31,4 @@ Dustin Feucht <code.nopjar@gmail.com>
 Nico Mexis <nicomexis.nm@gmail.com>
 Luke Memet <lukememet@gmail.com>
 Diandian Liang <hlxsmail@gmail.com>
+LyViolz <kahramanberke2001@gmail.com>

--- a/src/io/flutter/editor/FlutterColorProvider.java
+++ b/src/io/flutter/editor/FlutterColorProvider.java
@@ -193,7 +193,7 @@ public class FlutterColorProvider implements ElementColorProvider {
         return ExpressionParsingUtils.parseColor(code);
       }
     }
-    catch (StringIndexOutOfBoundsException e) {
+    catch (IndexOutOfBoundsException e) {
       // This is rare but possible in 2023.3, see https://github.com/flutter/flutter-intellij/issues/7285
       // from the call to AstBufferUtil.getTextSkippingWhitespaceComments()
       return null;


### PR DESCRIPTION
Fixes #8505

`FlutterColorProvider` already guards against `StringIndexOutOfBoundsException` thrown by `AstBufferUtil.getTextSkippingWhitespaceComments()`. IntelliJ 2025.2 can surface the same failure path as an `ArrayIndexOutOfBoundsException`.

This broadens the existing guard to `IndexOutOfBoundsException`, covering both cases while preserving the existing behavior of returning `null` when the PSI buffer is temporarily inconsistent.

Tested with:

```
./gradlew test --tests io.flutter.editor.FlutterColorProviderTest
```

Result: `BUILD SUCCESSFUL`.