### PR TITLE
Warn before Flutter upgrade on Windows

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -31,3 +31,4 @@ Dustin Feucht <code.nopjar@gmail.com>
 Nico Mexis <nicomexis.nm@gmail.com>
 Luke Memet <lukememet@gmail.com>
 Diandian Liang <hlxsmail@gmail.com>
+LyViolz <kahramanberke2001@gmail.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Removed
 
 ### Fixed
+- Prevent Flutter upgrades from running inside the IDE on Windows when Dart SDK files may be locked. (#9092)
 
 ## 96.0.0
 

--- a/src/io/flutter/FlutterBundle.properties
+++ b/src/io/flutter/FlutterBundle.properties
@@ -188,5 +188,5 @@ widget.preview.choose_pubroot=Choose module and try again
 widget.preview.choose_pubroot.title=Select Flutter Project
 widget.preview.choose_pubroot.description=Select the Flutter project to use for Flutter Widget Preview.
 flutter.upgrade.windows.title=Flutter Upgrade on Windows
-flutter.upgrade.windows.message=Flutter upgrades can fail on Windows while the IDE is running because the Dart SDK may be locked by IDE processes. Close the IDE and run ''flutter upgrade'' from a terminal instead.
+flutter.upgrade.windows.message=Flutter upgrades can fail on Windows while the IDE is running because the Dart SDK may be locked by IDE processes. Close the IDE and run 'flutter upgrade' from a terminal instead.
 flutter.sdk.not.found=Flutter SDK not found.

--- a/src/io/flutter/FlutterBundle.properties
+++ b/src/io/flutter/FlutterBundle.properties
@@ -187,4 +187,6 @@ widget.preview.retry=Reload and try again
 widget.preview.choose_pubroot=Choose module and try again
 widget.preview.choose_pubroot.title=Select Flutter Project
 widget.preview.choose_pubroot.description=Select the Flutter project to use for Flutter Widget Preview.
+flutter.upgrade.windows.title=Flutter Upgrade on Windows
+flutter.upgrade.windows.message=Flutter upgrades can fail on Windows while the IDE is running because the Dart SDK may be locked by IDE processes. Close the IDE and run ''flutter upgrade'' from a terminal instead.
 flutter.sdk.not.found=Flutter SDK not found.

--- a/src/io/flutter/actions/FlutterUpgradeAction.java
+++ b/src/io/flutter/actions/FlutterUpgradeAction.java
@@ -5,14 +5,32 @@
  */
 package io.flutter.actions;
 
+import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.SystemInfo;
+import io.flutter.FlutterBundle;
+import io.flutter.FlutterMessages;
 import io.flutter.pub.PubRoot;
 import io.flutter.sdk.FlutterSdk;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class FlutterUpgradeAction extends FlutterSdkAction {
+  @Override
+  public void actionPerformed(@NotNull AnActionEvent event) {
+    final Project project = event.getProject();
+    if (SystemInfo.isWindows && project != null && FlutterSdk.getFlutterSdk(project) != null) {
+      FlutterMessages.showDialog(project,
+                                 FlutterBundle.message("flutter.upgrade.windows.message"),
+                                 FlutterBundle.message("flutter.upgrade.windows.title"),
+                                 new String[]{"OK"}, 0);
+      return;
+    }
+
+    super.actionPerformed(event);
+  }
+
   @Override
   public void startCommand(@NotNull Project project, @NotNull FlutterSdk sdk, @Nullable PubRoot root, @NotNull DataContext context) {
     sdk.flutterUpgrade().startInConsole(project);

--- a/src/io/flutter/actions/FlutterUpgradeAction.java
+++ b/src/io/flutter/actions/FlutterUpgradeAction.java
@@ -9,6 +9,8 @@ import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.SystemInfo;
+import com.jetbrains.lang.dart.analytics.Analytics;
+import com.jetbrains.lang.dart.analytics.AnalyticsData;
 import io.flutter.FlutterBundle;
 import io.flutter.FlutterMessages;
 import io.flutter.pub.PubRoot;
@@ -25,6 +27,7 @@ public class FlutterUpgradeAction extends FlutterSdkAction {
                                  FlutterBundle.message("flutter.upgrade.windows.message"),
                                  FlutterBundle.message("flutter.upgrade.windows.title"),
                                  new String[]{"OK"}, 0);
+      Analytics.report(AnalyticsData.forAction(this, event));
       return;
     }
 


### PR DESCRIPTION
Addresses #7668.

On Windows, running `flutter upgrade` from inside the IDE can fail because Dart SDK files may still be locked by IDE processes.

This change prevents the upgrade action from starting on Windows and instead shows a message instructing users to close the IDE and run `flutter upgrade` from a terminal.

Linux and macOS behavior is unchanged.

### Testing

- `./gradlew compileJava`
- `./gradlew test --tests 'io.flutter.actions.*'`

Both completed successfully.

The Windows-specific runtime behavior was not tested locally.