### PR TITLE
Remove query flutter channel during settings apply

### DIFF
--- a/src/io/flutter/sdk/FlutterSettingsConfigurable.java
+++ b/src/io/flutter/sdk/FlutterSettingsConfigurable.java
@@ -250,18 +250,6 @@ public class FlutterSettingsConfigurable implements SearchableConfigurable {
       OpenApiUtils.safeRunWriteAction(() -> {
         FlutterSdkUtil.setFlutterSdkPath(myProject, sdkHomePath);
         FlutterSdkUtil.enableDartSdk(myProject);
-
-        ApplicationManager.getApplication().executeOnPooledThread(() -> {
-          final FlutterSdk sdk = FlutterSdk.forPath(sdkHomePath);
-          if (sdk != null) {
-            try {
-              sdk.queryFlutterChannel(false);
-            }
-            catch (Exception ignored) {
-              // ignore exceptions during channel query
-            }
-          }
-        });
       });
     }
 


### PR DESCRIPTION
I believe this query was previously used to warm up the Flutter SDK cache to prepare for updating the SDK, but it wasn't working anyway, so in the past it was throwing an error (see https://github.com/flutter/flutter-intellij/issues/9007 for some more context).

In a previous SDK-related change, I caught an exception resulting from this query, so the issue above was already gone. However, this is a reasonable cleanup step to make the SDK update process a little clearer:
- When a user selects a new SDK, an `onVersionChanged` function updates the version of the SDK and displays it in the settings view.
- When apply is clicked, the Flutter SDK (and associated Dart SDK) is saved. (And with this change, there will no longer be an attempt to do the failing git query.)
- When OK is clicked, flutter pub get will run to update packages.

To manually verify, check that the steps above still work.

---

Review the contribution guidelines below:

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] I've included the required information in the description above.
- [x] My up-to-date information is in the `AUTHORS` file.
- ~[ ] I've updated `CHANGELOG.md` if appropriate.~ (no user-facing change)

<details>
  <summary>Contribution guidelines:</summary><br>

- See
  our [contributor guide](../CONTRIBUTING.md) and
  the [Flutter organization contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md)
  for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use
  `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best
  practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).

</details>