### PR TITLE
Avoid project.save() on the EDT during Flutter module setup

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -31,3 +31,4 @@ Dustin Feucht <code.nopjar@gmail.com>
 Nico Mexis <nicomexis.nm@gmail.com>
 Luke Memet <lukememet@gmail.com>
 Diandian Liang <hlxsmail@gmail.com>
+Mehmet Emre Sezer <sezermehmetemre@gmail.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Removed
 
 ### Fixed
+- IDE deadlock on project open when the Flutter SDK path is invalid. (#9093)
 
 ## 95.0.0
 

--- a/src/io/flutter/utils/FlutterModuleUtils.java
+++ b/src/io/flutter/utils/FlutterModuleUtils.java
@@ -346,8 +346,11 @@ public class FlutterModuleUtils {
     ApplicationManager.getApplication().invokeLater(() -> {
       ApplicationManager.getApplication().runWriteAction(() -> setFlutterModuleType(module));
       enableDartSDK(module);
-      project.save();
 
+      // Do not call project.save() here. On the EDT it enters a nested modal pump while the
+      // document save it dispatches invokes back into the EDT, which deadlocks project open.
+      // The platform persists the module type on its own schedule.
+      // See https://github.com/flutter/flutter-intellij/issues/9093
       EditorNotifications.getInstance(project).updateAllNotifications();
     });
   }


### PR DESCRIPTION
## What and why

`FlutterModuleUtils.setFlutterModuleWithoutReload()` called `project.save()` from
an `invokeLater` block on the EDT. `ProjectImpl.save()` enters a nested modal
progress pump on the EDT, while the document save it dispatches calls back into
the EDT via `invokeAndWait` for `beforeAllDocumentsSaving`. Neither side can
proceed and the wait has no timeout, so opening a project whose Flutter SDK path
does not resolve hangs the IDE permanently — the user cannot even reach Settings
to correct the path.

The call was also redundant. It was left behind by #8903, which removed the
`ProjectManager.reloadProject(project)` that used to follow it. Its only purpose
was to flush the module type to disk before that reload read it back; with the
reload gone, the platform persists the module type on its own schedule.

This PR removes the call and leaves a comment explaining why it must not come
back, following the existing convention in this file (see the comment
referencing #8480 a few lines below).

One small correction to the issue report: the deadlock does not require the
write lock. `runWriteAction` on the preceding line has already exited by the
time `save()` runs — `runIntendedWriteActionOnCurrentThread` in the stack trace
is `invokeLater`'s write-intent wrapper, not a held write lock. Being on the EDT
is sufficient to reproduce it. This does not change the fix.

## Related issues

Fixes https://github.com/flutter/flutter-intellij/issues/9093

Same EDT re-entrancy class as #9013 and #9055, different call site.

## How to verify

1. Point a Flutter project's SDK path at something that does not resolve (a
   dangling symlink, e.g. from an FVM `cachePath` change).
2. Open the project in IntelliJ IDEA.
3. Before this change the IDE hangs permanently after logging "Fixing Flutter
   module configuration". After it, project open completes and the IDE stays
   responsive.

The full unit test suite passes locally (32 classes, 160 tests, 0 failures),
including `FlutterModuleUtilsTest` and `FlutterInitializerTest`.

## On testing

I did not add a regression test. The deadlock needs a real modal progress pump
and the document-save listener chain, neither of which the headless test fixture
sets up, so a test around `setFlutterModuleWithoutReload()` would pass against
the old code too and guard nothing. The method also reaches
`FlutterSdkUtil.locateSdkFromPath()`, which makes any test of it dependent on
the host's PATH. I opted for the explanatory comment instead, but I'm happy to
add a test if you see an angle I missed.

---

Review the contribution guidelines below:

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
- [x] I've included the required information in the description above.
- [x] My up-to-date information is in the `AUTHORS` file.
- [x] I've updated `CHANGELOG.md` if appropriate.

<details>
  <summary>Contribution guidelines:</summary><br>

- See
  our [contributor guide](../CONTRIBUTING.md) and
  the [Flutter organization contributor guide]([https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md)
  for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Dart contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use
  `dart format`.
- Java and Kotlin contributions should strive to follow Java and Kotlin best
  practices ([discussion](https://github.com/flutter/flutter-intellij/issues/8098)).

</details>