### PR TITLE
Fix empty Flutter SDK dropdown in New Project wizard on IJ 2026.2

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -31,3 +31,4 @@ Dustin Feucht <code.nopjar@gmail.com>
 Nico Mexis <nicomexis.nm@gmail.com>
 Luke Memet <lukememet@gmail.com>
 Diandian Liang <hlxsmail@gmail.com>
+Akshat Vyas <akshatvyas0@gmail.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Removed
 
 ### Fixed
+- Empty Flutter SDK dropdown in the New Project wizard on IntelliJ Platform 2026.2. (#9106)
 
 ## 96.0.0
 

--- a/src/io/flutter/sdk/FlutterSdkUtil.java
+++ b/src/io/flutter/sdk/FlutterSdkUtil.java
@@ -14,6 +14,7 @@ import com.intellij.execution.ExecutionException;
 import com.intellij.ide.util.PropertiesComponent;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ApplicationNamesInfo;
+import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
@@ -143,7 +144,7 @@ public class FlutterSdkUtil {
         else if (combo.getSelectedIndex() == -1 && combo.getItemCount() > 0) {
           combo.setSelectedIndex(0);
         }
-      });
+      }, ModalityState.stateForComponent(combo));
     });
   }
 


### PR DESCRIPTION
Fixes #9106

## What this changes
The Flutter SDK combo box in the New Project wizard (and Settings page) is
populated asynchronously: known SDK paths are resolved on a background
thread, then the UI update is scheduled back onto the EDT via
`OpenApiUtils.safeInvokeLater()`.

On IntelliJ Platform 2026.2, this deferred update no longer runs while the
New Project wizard's modal dialog is open, leaving the SDK dropdown empty.
Passing `ModalityState.any()` ensures the update runs regardless of any
open modal dialog.

## How to verify
1. Run a 2026.2 sandbox: `./gradlew runTarget -Pide=AndroidStudio -PideV=2026.2.1.4`
2. Open New Project → Flutter
3. Confirm previously-used Flutter SDK paths appear in the SDK dropdown
   (before this fix, the dropdown was empty)

- [x] I've reviewed the contributor guide and applied the relevant portions to this PR.
- [x] I've included the required information in the description above.
- [x] My up-to-date information is in the `AUTHORS` file.
- [x] I've updated `CHANGELOG.md`.